### PR TITLE
fix(ci): add beta→dev sync for alpha branch deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,12 +107,60 @@ jobs:
           git push origin main
 
   # ===========================================================================
+  # JOB 1b: Sync beta files to dev directory on alpha branch pushes
+  # This ensures public_html_dev/ always mirrors public_html_beta/ for alpha
+  # ===========================================================================
+  sync-beta-to-dev:
+    runs-on: ubuntu-latest
+    if: github.ref_name == 'alpha' && !contains(github.event.head_commit.message, '[skip sync]')
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # -- Rsync public_html_beta/ → public_html_dev/ --
+      - name: Sync public_html_beta → public_html_dev
+        id: sync
+        run: |
+          rsync -a --delete \
+            --exclude='.DS_Store' \
+            --exclude='.gitkeep' \
+            --exclude='CHANGELOG.md' \
+            --exclude='README.md' \
+            --exclude='DEV_NOTES.md' \
+            appWeb/public_html_beta/ appWeb/public_html_dev/
+
+          git add appWeb/public_html_dev/
+
+          if git diff --cached --quiet appWeb/public_html_dev/; then
+            echo "synced=false" >> $GITHUB_OUTPUT
+            echo "Dev files already in sync"
+            git reset HEAD appWeb/public_html_dev/ > /dev/null 2>&1 || true
+          else
+            echo "synced=true" >> $GITHUB_OUTPUT
+            echo "Files synced — changes detected:"
+            git diff --cached --stat appWeb/public_html_dev/
+          fi
+
+      - name: Commit synced files
+        if: steps.sync.outputs.synced == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add appWeb/public_html_dev/
+          git commit -m "build: auto-sync public_html_dev from public_html_beta [skip sync]"
+          git push origin alpha
+
+  # ===========================================================================
   # JOB 2: Deploy to server via SFTP
   # Runs after sync (if applicable), deploys the appropriate directory
   # ===========================================================================
   deploy:
     runs-on: ubuntu-latest
-    needs: [sync-beta-to-production]
+    needs: [sync-beta-to-production, sync-beta-to-dev]
     # Always run (even if sync was skipped), but only if SFTP is enabled
     if: always() && vars.SFTP_ENABLED == 'true'
 
@@ -124,10 +172,10 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.ref_name }}
 
-      # -- Pull latest if main (in case sync job pushed new commits) --
+      # -- Pull latest if sync job may have pushed new commits --
       - name: Pull latest (in case sync job pushed new commits)
-        if: github.ref_name == 'main'
-        run: git pull origin main
+        if: github.ref_name == 'main' || github.ref_name == 'alpha'
+        run: git pull origin ${{ github.ref_name }}
 
       # -- Determine which directory to deploy based on branch --
       - name: Determine deployment target


### PR DESCRIPTION
## Summary

- **Fix alpha deployments** — Add `sync-beta-to-dev` CI/CD job that rsyncs `public_html_beta/` → `public_html_dev/` on alpha branch pushes, mirroring the existing `sync-beta-to-production` pattern. Without this, `public_html_dev/` was empty and alpha deploys uploaded nothing.
- **Pull latest for alpha** — Deploy job now pulls latest after sync for both `main` and `alpha` branches.

## Test Plan
- [ ] Merge this PR, then verify the deploy workflow runs the sync step
- [ ] Confirm `public_html_dev/` is populated and SFTP uploads to the dev server

https://claude.ai/code/session_019iLcFctpajfVnyEsGqZCvj