### PR TITLE
fix(ci): use job-level env var for lftp exclude flags

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,6 +63,38 @@ jobs:
     runs-on: ubuntu-latest
     if: vars.SFTP_ENABLED == 'true'
 
+    # Shared lftp exclude flags — available to all steps via $LFTP_EXCLUDES.
+    # IMPORTANT: patterns with wildcards MUST be single-quoted here in YAML
+    # so they are passed as literal strings to the shell env, and then
+    # referenced inside double-quoted heredocs/commands where bash won't
+    # glob-expand them (variable expansion within double quotes is safe).
+    env:
+      LFTP_EXCLUDES: >-
+        --exclude .DS_Store
+        --exclude Thumbs.db
+        --exclude .git/
+        --exclude .github/
+        --exclude .gitkeep
+        --exclude .gitignore
+        --exclude .gitattributes
+        --exclude README.md
+        --exclude DEV_NOTES.md
+        --exclude CLAUDE.md
+        --exclude .htpasswd
+        --exclude .htpasswd-*
+        --exclude .htpasswd.example
+        --exclude .vscode/
+        --exclude .idea/
+        --exclude *.xcodeproj
+        --exclude *.xcworkspace
+        --exclude .xcuserdata/
+        --exclude *.sublime-project
+        --exclude *.sublime-workspace
+        --exclude .editorconfig
+        --exclude *.swp
+        --exclude *.swo
+        --exclude *~
+
     steps:
       # -- Checkout code --
       - name: Checkout code
@@ -87,36 +119,6 @@ jobs:
             echo "remote_path=${{ secrets.SFTP_DEV_PATH }}" >> $GITHUB_OUTPUT
             echo "channel=alpha" >> $GITHUB_OUTPUT
           fi
-
-      # -- Build shared lftp exclude flags for all mirror commands --
-      # Excludes repo metadata, IDE/editor files, OS artefacts, and
-      # documentation that should never be deployed to SFTP servers.
-      # NOTE: No shell quotes around glob patterns — these are stored in
-      # GITHUB_OUTPUT and interpolated by GitHub Actions, then passed
-      # directly to lftp which handles its own glob expansion.
-      - name: Build SFTP exclude flags
-        id: excludes
-        run: |
-          EXCLUDES=""
-          # OS artefacts
-          EXCLUDES+=" --exclude .DS_Store --exclude Thumbs.db"
-          # Git / GitHub
-          EXCLUDES+=" --exclude .git/ --exclude .github/ --exclude .gitkeep --exclude .gitignore --exclude .gitattributes"
-          # Documentation
-          EXCLUDES+=" --exclude README.md --exclude DEV_NOTES.md --exclude CLAUDE.md"
-          # Apache auth (server-managed, never overwrite)
-          EXCLUDES+=" --exclude .htpasswd --exclude .htpasswd-* --exclude .htpasswd.example"
-          # VS Code
-          EXCLUDES+=" --exclude .vscode/"
-          # JetBrains IDEs (IntelliJ, WebStorm, PhpStorm)
-          EXCLUDES+=" --exclude .idea/"
-          # Xcode
-          EXCLUDES+=" --exclude *.xcodeproj --exclude *.xcworkspace --exclude .xcuserdata/"
-          # Sublime Text
-          EXCLUDES+=" --exclude *.sublime-project --exclude *.sublime-workspace"
-          # Editor config & temp files
-          EXCLUDES+=" --exclude .editorconfig --exclude *.swp --exclude *.swo --exclude *~"
-          echo "flags=$EXCLUDES" >> $GITHUB_OUTPUT
 
       # -- Check if deployable files changed in the last 5 commits --
       - name: Get changed files
@@ -305,7 +307,7 @@ jobs:
           cat > /tmp/lftp_script.txt <<LFTP_EOF
           set sftp:connect-program "ssh -o StrictHostKeyChecking=no -i $HOME/.ssh/deploy_key -p ${SFTP_PORT}"
           open sftp://${SFTP_USER}@${SFTP_HOST}:${SFTP_PORT}
-          mirror --reverse --delete --verbose --only-newer --no-empty-dirs ${{ steps.excludes.outputs.flags }} ${SOURCE_DIR} ${REMOTE_PATH}
+          mirror --reverse --delete --verbose --only-newer --no-empty-dirs $LFTP_EXCLUDES ${SOURCE_DIR} ${REMOTE_PATH}
           bye
           LFTP_EOF
           lftp -f /tmp/lftp_script.txt
@@ -324,7 +326,7 @@ jobs:
           lftp -u "${SFTP_USER},${SFTP_PASS}" \
             -e "set sftp:auto-confirm yes; set ssl:verify-certificate no; \
             mirror --reverse --delete --verbose --only-newer --no-empty-dirs \
-            ${{ steps.excludes.outputs.flags }} \
+            $LFTP_EXCLUDES \
             ${SOURCE_DIR} ${REMOTE_PATH}; bye" \
             "sftp://${SFTP_HOST}:${SFTP_PORT}"
 
@@ -381,7 +383,7 @@ jobs:
           cat > /tmp/lftp_private.txt <<LFTP_EOF
           set sftp:connect-program "ssh -o StrictHostKeyChecking=no -i $HOME/.ssh/deploy_key -p ${SFTP_PORT}"
           open sftp://${SFTP_USER}@${SFTP_HOST}:${SFTP_PORT}
-          mirror --reverse --delete --verbose --only-newer --no-empty-dirs ${{ steps.excludes.outputs.flags }} appWeb/private_html/ ${REMOTE_PATH}
+          mirror --reverse --delete --verbose --only-newer --no-empty-dirs $LFTP_EXCLUDES appWeb/private_html/ ${REMOTE_PATH}
           bye
           LFTP_EOF
           lftp -f /tmp/lftp_private.txt
@@ -407,7 +409,7 @@ jobs:
           lftp -u "${SFTP_USER},${SFTP_PASS}" \
             -e "set sftp:auto-confirm yes; set ssl:verify-certificate no; \
             mirror --reverse --delete --verbose --only-newer --no-empty-dirs \
-            ${{ steps.excludes.outputs.flags }} \
+            $LFTP_EXCLUDES \
             appWeb/private_html/ ${REMOTE_PATH}; bye" \
             "sftp://${SFTP_HOST}:${SFTP_PORT}"
           echo "Private HTML deployed to ${REMOTE_PATH}"
@@ -437,7 +439,7 @@ jobs:
           cat > /tmp/lftp_datashare.txt <<LFTP_EOF
           set sftp:connect-program "ssh -o StrictHostKeyChecking=no -i $HOME/.ssh/deploy_key -p ${SFTP_PORT}"
           open sftp://${SFTP_USER}@${SFTP_HOST}:${SFTP_PORT}
-          mirror --reverse --verbose --only-newer --no-empty-dirs ${{ steps.excludes.outputs.flags }} appWeb/data_share/ ${DATA_SHARE_PATH}
+          mirror --reverse --verbose --only-newer --no-empty-dirs $LFTP_EXCLUDES appWeb/data_share/ ${DATA_SHARE_PATH}
           bye
           LFTP_EOF
           lftp -f /tmp/lftp_datashare.txt
@@ -458,7 +460,7 @@ jobs:
           lftp -u "${SFTP_USER},${SFTP_PASS}" \
             -e "set sftp:auto-confirm yes; set ssl:verify-certificate no; \
             mirror --reverse --verbose --only-newer --no-empty-dirs \
-            ${{ steps.excludes.outputs.flags }} \
+            $LFTP_EXCLUDES \
             appWeb/data_share/ ${DATA_SHARE_PATH}; bye" \
             "sftp://${SFTP_HOST}:${SFTP_PORT}"
           echo "Data share deployed to ${DATA_SHARE_PATH}"


### PR DESCRIPTION
## Summary

Fixes CI deploy failures (runs #26, #27) caused by lftp exclude flag handling.

**Root cause**: The `GITHUB_OUTPUT` approach for passing exclude flags between steps caused glob patterns (`*.swp`, `*~`, `.htpasswd-*`) to be expanded or mangled by bash during heredoc processing.

**Fix**: Moved exclude flags to a job-level `env` variable (`LFTP_EXCLUDES`) defined directly in YAML using `>-` folding. The env var is set by the runner before any step runs and is safely expanded within shell contexts without glob expansion issues.

## Test plan

- [ ] Verify CI deploy workflow passes after merge

https://claude.ai/code/session_019iLcFctpajfVnyEsGqZCvj