### PR TITLE
fix(ci): use regex syntax for lftp exclude patterns

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,30 +70,28 @@ jobs:
     # glob-expand them (variable expansion within double quotes is safe).
     env:
       LFTP_EXCLUDES: >-
-        --exclude .DS_Store
-        --exclude Thumbs.db
-        --exclude .git/
-        --exclude .github/
-        --exclude .gitkeep
-        --exclude .gitignore
-        --exclude .gitattributes
-        --exclude README.md
-        --exclude DEV_NOTES.md
-        --exclude CLAUDE.md
-        --exclude .htpasswd
-        --exclude .htpasswd-*
-        --exclude .htpasswd.example
-        --exclude .vscode/
-        --exclude .idea/
-        --exclude *.xcodeproj
-        --exclude *.xcworkspace
-        --exclude .xcuserdata/
-        --exclude *.sublime-project
-        --exclude *.sublime-workspace
-        --exclude .editorconfig
-        --exclude *.swp
-        --exclude *.swo
-        --exclude *~
+        --exclude ^\.DS_Store$
+        --exclude ^Thumbs\.db$
+        --exclude ^\.git/
+        --exclude ^\.github/
+        --exclude ^\.gitkeep$
+        --exclude ^\.gitignore$
+        --exclude ^\.gitattributes$
+        --exclude ^README\.md$
+        --exclude ^DEV_NOTES\.md$
+        --exclude ^CLAUDE\.md$
+        --exclude ^\.htpasswd
+        --exclude ^\.vscode/
+        --exclude ^\.idea/
+        --exclude \.xcodeproj$
+        --exclude \.xcworkspace$
+        --exclude ^\.xcuserdata/
+        --exclude \.sublime-project$
+        --exclude \.sublime-workspace$
+        --exclude ^\.editorconfig$
+        --exclude \.swp$
+        --exclude \.swo$
+        --exclude ~$
 
     steps:
       # -- Checkout code --


### PR DESCRIPTION
## Summary

Fixes CI deploy failure (runs #26–#28). The error was:

```
mirror: regular expression `*.xcodeproj': Invalid preceding regular expression
```

**Root cause**: lftp `--exclude` takes **regex patterns**, not shell globs. `*.xcodeproj` is invalid regex because `*` is a quantifier with nothing preceding it.

**Fix**: Convert all exclude patterns to proper regex syntax — escape dots (`\.`), use anchors (`^`, `$`), remove invalid leading `*`.

## Test plan

- [ ] Verify CI deploy passes

https://claude.ai/code/session_019iLcFctpajfVnyEsGqZCvj