### PR TITLE
fix(pwa): share direction, empty banner HTML, hide on non-Safari iOS (#177)

### DIFF
--- a/.claude/ProjectBrief.md
+++ b/.claude/ProjectBrief.md
@@ -12,7 +12,7 @@ A multiplatform Christian lyrics application providing searchable hymn and worsh
 - **Copyright**: © 2026– MWBM Partners Ltd
 - **License**: Proprietary (third-party components retain their own licenses)
 - **GitHub Repo**: <https://github.com/MWBMPartners/iHymns>
-- **Current Version**: 0.1.6 (pre-release, Phase 1)
+- **Current Version**: 0.1.7 (pre-release, Phase 1)
 
 ---
 
@@ -71,6 +71,7 @@ A multiplatform Christian lyrics application providing searchable hymn and worsh
 ### Automated Deployment
 
 - GitHub Actions with `lftp` for SFTP mirroring (modelled on phpWhoIs)
+- lftp `--exclude` uses **regex patterns**, NOT shell globs (e.g. `\.xcodeproj$` not `*.xcodeproj`)
 - All branches deploy from `appWeb/public_html/`; branch determines remote SFTP path
 - `appWeb/data_share/` deployed alongside (without `--delete` to preserve runtime data)
 - `.env-channel` file injected by CI for server-side environment detection
@@ -83,7 +84,8 @@ A multiplatform Christian lyrics application providing searchable hymn and worsh
 - `v0.x.x` = Phase 1 pre-release (current)
 - `v1.x.x` = Phase 1 stable
 - `v2.x.x` = Phase 2 (iLyrics dB integration)
-- Auto-bumped via conventional commits on push to `beta`
+- Auto-bumped via conventional commits on push to `beta` (single source of truth)
+- Alpha builds display commit date timestamp (yyyymmddhhmmss) in footer
 
 ---
 
@@ -139,6 +141,8 @@ A multiplatform Christian lyrics application providing searchable hymn and worsh
 | `appWeb/public_html/js/utils/*.js` | JS utilities (html.js, text.js) |
 | `appWeb/public_html/js/constants.js` | Centralised localStorage key constants (#139) |
 | `appWeb/public_html/api.php` | Server-side API (songs, setlists, search) |
+| `appWeb/public_html/og-image.php` | Dynamic OG image generator (1200×630, contextual song images) |
+| `appWeb/public_html/sitemap.xml.php` | Dynamic XML sitemap from song database |
 | `appWeb/public_html/includes/config.php` | App configuration (analytics, features) |
 | `appWeb/private_html/editor/` | Song editor (dev tool) |
 | `appApple/iHymns/iHymns/Services/AppInfo.swift` | Apple app info |
@@ -160,4 +164,4 @@ See `DEV_NOTES.md` for full setup guide including Apple, Android, and Fire OS.
 
 ---
 
-Last updated: 2026-04-06
+Last updated: 2026-04-07

--- a/.claude/projects/-Users-lance-manasse-Projects-Coding-and-Development-MWBM-Partners-Ltd-GitHub-iHymns-iHymns/memory/MEMORY.md
+++ b/.claude/projects/-Users-lance-manasse-Projects-Coding-and-Development-MWBM-Partners-Ltd-GitHub-iHymns-iHymns/memory/MEMORY.md
@@ -7,3 +7,4 @@
 - [Clean neutral colours](feedback_colours.md) — Slate/grey neutral scheme, no bright/vivid colours on songbook cards
 - [Web app directory structure](feedback_appweb_dir.md) — appWeb/ with public_html (single source), data_share, private_html
 - [Phase 1 PWA enhancements](feedback_phase1_pwa_enhancements.md) — Analytics, gestures, writer pages, TF-IDF related songs, WCAG contrast, PWA icons
+- [Phase 1 SEO/PWA/Social](feedback_phase1_seo_pwa_social.md) — OG images, PWA install banners, editor arrangement, Song of the Day expansion, CI/CD lftp regex fix, sitemap

--- a/.claude/projects/-Users-lance-manasse-Projects-Coding-and-Development-MWBM-Partners-Ltd-GitHub-iHymns-iHymns/memory/feedback_phase1_seo_pwa_social.md
+++ b/.claude/projects/-Users-lance-manasse-Projects-Coding-and-Development-MWBM-Partners-Ltd-GitHub-iHymns-iHymns/memory/feedback_phase1_seo_pwa_social.md
@@ -1,0 +1,55 @@
+---
+name: Phase 1 PWA — SEO, social sharing, PWA install banners, editor arrangement, Song of the Day
+description: Major batch of enhancements on claude/rebuild-pwa-php-KjLJB including dynamic OG images, PWA install prompts, song editor arrangement, expanded Song of the Day, CI/CD fixes.
+type: feedback
+---
+
+Phase 1 PWA received another major batch of enhancements (session April 2026):
+
+**SEO & Social Sharing (#170, #172, #173):**
+- `og-image.php` — Dynamic PHP/GD OG image generator producing 1200×630 PNG
+- Centre-safe layout: critical content in 630×630 centre zone for iMessage square-crop
+- Contextual song images: `og-image.php?song=CP-0001` shows title, songbook badge with accent colour, writer, first verse lyrics
+- Per-songbook accent colours matching CSS variables (CP=indigo, JP=pink, MP=teal, SDAH=amber, CH=red, Misc=purple)
+- Generic image: app icon, name, tagline, accent line, domain
+- `index.php` OG tags: canonical URL, 1200×630, `summary_large_image` Twitter card
+- Song pages pass song ID to OG image URL automatically
+
+**PWA Install Banner (#174, #175):**
+- Safari on iOS: "Tap Share → Add to Home Screen" instructions
+- Safari on macOS: "File → Add to Dock" instructions
+- iOS Chrome/Edge/Firefox/Opera: "Open in Safari" guidance + Copy Link button
+- Platform detection: `detectPlatform()` returns ios-safari, ios-chrome, ios-edge, ios-firefox, ios-other, macos-safari, android, desktop
+- CSS fix: `!important` on `.d-none` prevents blank strip visual leak
+- iOS safe-area: `env(safe-area-inset-top)` for notch/Dynamic Island
+
+**Editor Arrangement (#161):**
+- Arrangement editor UI with coloured chips + text input
+- Human-readable labels (V1, V2, C, B, etc.) instead of raw indexes
+- Auto-generate arrangement (chorus after each verse)
+- Sequential arrangement option
+- Preview renders in arrangement order when set
+
+**Song of the Day (#163):**
+- Expanded from 7 to 16 calendar themes: Advent, Christmas, Epiphany, Palm Sunday, Holy Week, Good Friday, Easter, Ascension, Pentecost, Lent, New Year, Reformation, Harvest, Remembrance, Trinity Sunday
+- Title + first-verse lyrics keyword matching (title weighted higher)
+- Easter date calculation (Anonymous Gregorian algorithm)
+
+**Dynamic Sitemap:**
+- `sitemap.xml.php` — Dynamic XML sitemap from song database
+- Includes all static pages, songbook pages, 3,612 song pages, writer pages
+- `.htaccess` rewrite: sitemap.xml → sitemap.xml.php
+
+**CI/CD Fixes:**
+- lftp `--exclude` uses **regex patterns**, NOT shell globs — key lesson from CI failures
+- Job-level `env.LFTP_EXCLUDES` with YAML `>-` folding
+- Excludes: IDE files (.vscode, .idea, .xcodeproj, .sublime-*), repo files (.git, .github), OS files (.DS_Store, Thumbs.db)
+- CHANGELOG.md allowed to deploy (removed from exclusions)
+- Commit date format includes seconds for alpha build timestamps
+
+**Version Management:**
+- Version bumps only on `beta` branch (industry standard)
+- Alpha gets build timestamp (yyyymmddhhmmss) after version in footer
+- Timestamp injected at deploy time via commit date from CI
+
+**How to apply:** These features extend existing architecture. OG images use PHP/GD (no external dependencies). PWA install uses `pwa.js` module with platform detection. lftp excludes MUST use regex syntax.

--- a/.claude/projects/-Users-lance-manasse-Projects-Coding-and-Development-MWBM-Partners-Ltd-GitHub-iHymns-iHymns/memory/project_ihymns.md
+++ b/.claude/projects/-Users-lance-manasse-Projects-Coding-and-Development-MWBM-Partners-Ltd-GitHub-iHymns-iHymns/memory/project_ihymns.md
@@ -8,7 +8,7 @@ type: project
 
 **Domain**: iHymns.app | **Repo**: https://github.com/MWBMPartners/iHymns
 **Copyright**: MWBM Partners Ltd | **License**: Proprietary
-**Current version**: 0.1.6 (pre-release, Phase 1)
+**Current version**: 0.1.7 (pre-release, Phase 1)
 
 **Why:** Enhance worship by providing searchable hymn lyrics across platforms.
 
@@ -24,7 +24,9 @@ type: project
 - Security: CSP with per-request nonces, SRI hashes on all CDN resources
 - Analytics: GA4, Plausible, Clarity, Matomo, Fathom — GDPR consent required
 - Deployment: GitHub Actions + lftp SFTP (main→live, beta→beta, alpha→dev)
+- lftp `--exclude` uses **regex patterns**, NOT shell globs (critical: `\.xcodeproj$` not `*.xcodeproj`)
 - Working branch: `beta` (merge to `main` for production release)
+- Version bumps: only on `beta` branch (single source of truth); alpha uses build timestamps
 - Song editor (dev tool) in `appWeb/private_html/editor/` (HTTP Basic Auth protected)
 - Colour scheme: clean neutral slate/grey, NOT bright colours
 - WCAG contrast: Automated relative luminance calculation for songbook badges
@@ -38,7 +40,9 @@ type: project
 - `gestures.js` — Touch swipe navigation for song pages
 - `settings.js` — Theme, display prefs, analytics consent management
 - `transitions.js` — Page transition animations with loading bar
-- `favorites.js`, `setlists.js`, `search.js`, `song-of-day.js`, etc.
+- `pwa.js` — PWA install banner with platform detection (iOS Safari/Chrome/Edge/Firefox, macOS Safari, Android, desktop)
+- `song-of-the-day.js` — Deterministic date-seeded selection, 16 calendar themes, title + lyrics keyword matching
+- `favorites.js`, `setlists.js`, `search.js`, etc.
 
 **Key PHP Files:**
 - `index.php` — Main SPA shell, CSP headers, conditional analytics scripts
@@ -46,3 +50,5 @@ type: project
 - `includes/SongData.php` — Song data loading, flexible ID matching, alphabetical sort
 - `includes/config.php` — App configuration including analytics platform IDs
 - `includes/pages/*.php` — Page templates (song, writer, privacy, terms, settings, etc.)
+- `og-image.php` — Dynamic OG image generator (1200×630 PNG, centre-safe layout, contextual song images via ?song=ID)
+- `sitemap.xml.php` — Dynamic XML sitemap (all songs, songbooks, writers, static pages)

--- a/appWeb/public_html/index.php
+++ b/appWeb/public_html/index.php
@@ -498,17 +498,15 @@ if (!empty($breadcrumbItems)) {
          aria-label="Install application">
         <div class="container-fluid d-flex align-items-center justify-content-between py-2 px-3">
             <div class="d-flex align-items-center gap-2 flex-grow-1">
-                <i class="fa-solid fa-mobile-screen-button fa-lg" aria-hidden="true"></i>
-                <span class="pwa-install-text">
-                    Get the full <strong><?= htmlspecialchars($appName) ?></strong> experience!
-                </span>
+                <i class="pwa-banner-icon" aria-hidden="true"></i>
+                <span class="pwa-install-text"></span>
             </div>
             <button type="button"
-                    class="btn btn-sm btn-install-app me-2"
+                    class="btn btn-sm btn-install-app me-2 d-none"
                     id="pwa-install-btn"
                     aria-label="Install <?= htmlspecialchars($appName) ?> app">
-                <i class="fa-solid fa-download me-1" aria-hidden="true"></i>
-                <span>Install</span>
+                <i class="me-1" aria-hidden="true"></i>
+                <span></span>
             </button>
             <button type="button"
                     class="btn-close btn-close-white"

--- a/appWeb/public_html/js/modules/pwa.js
+++ b/appWeb/public_html/js/modules/pwa.js
@@ -11,8 +11,8 @@
  *   - Chrome/Edge/Samsung (Android & desktop): uses beforeinstallprompt API
  *   - Safari iOS:  "Tap Share below → Add to Home Screen" (iOS 15+ bottom bar)
  *   - Safari macOS: "File → Add to Dock" instructions
- *   - iOS non-Safari (Chrome, Edge, Firefox, Opera): guides user to open
- *     in Safari, since only Safari can install PWAs on iOS
+ *   - iOS non-Safari (Chrome, Edge, Firefox, Opera): banner hidden,
+ *     since only Safari can install PWAs on iOS
  *   - Native app stores: redirects to app store if configured
  *
  * The banner HTML starts empty (no default content) — all text, icons, and
@@ -92,15 +92,7 @@ export class PWA {
                 showButton: false,
             });
         } else if (platform.startsWith('ios-')) {
-            /* iOS non-Safari: Chrome, Edge, Firefox, Opera — guide to Safari */
-            this.showPlatformBanner({
-                icon: 'fa-brands fa-safari',
-                text: 'To install, open in <strong>Safari</strong> then tap <strong>Share</strong> → <strong>Add to Home Screen</strong>',
-                showButton: true,
-                buttonIcon: 'fa-solid fa-copy',
-                buttonText: 'Copy Link',
-                buttonAction: () => this.copyCurrentUrl(),
-            });
+            /* iOS non-Safari: cannot install PWAs — don't show banner */
         } else if (platform === 'macos-safari') {
             this.showPlatformBanner({
                 icon: 'fa-solid fa-display',
@@ -279,28 +271,6 @@ export class PWA {
             if (outcome === 'accepted') {
                 this.hideInstallBanner();
             }
-        }
-    }
-
-    /**
-     * Copy the current page URL to clipboard for pasting into Safari.
-     * Shows a toast confirmation.
-     */
-    async copyCurrentUrl() {
-        try {
-            await navigator.clipboard.writeText(window.location.href);
-            this.app.showToast('Link copied — open Safari and paste to install', 'success');
-        } catch {
-            /* Fallback for older browsers */
-            const textArea = document.createElement('textarea');
-            textArea.value = window.location.href;
-            textArea.style.position = 'fixed';
-            textArea.style.opacity = '0';
-            document.body.appendChild(textArea);
-            textArea.select();
-            document.execCommand('copy');
-            document.body.removeChild(textArea);
-            this.app.showToast('Link copied — open Safari and paste to install', 'success');
         }
     }
 

--- a/appWeb/public_html/js/modules/pwa.js
+++ b/appWeb/public_html/js/modules/pwa.js
@@ -9,11 +9,15 @@
  *
  * Platform handling:
  *   - Chrome/Edge/Samsung (Android & desktop): uses beforeinstallprompt API
- *   - Safari iOS:  "Tap Share → Add to Home Screen" instructions
+ *   - Safari iOS:  "Tap Share below → Add to Home Screen" (iOS 15+ bottom bar)
  *   - Safari macOS: "File → Add to Dock" instructions
  *   - iOS non-Safari (Chrome, Edge, Firefox, Opera): guides user to open
  *     in Safari, since only Safari can install PWAs on iOS
  *   - Native app stores: redirects to app store if configured
+ *
+ * The banner HTML starts empty (no default content) — all text, icons, and
+ * buttons are populated by JS based on platform detection. This prevents
+ * the old generic banner content from flashing before JS loads. (#177)
  *
  * Banner dismissal is remembered in localStorage.
  */
@@ -64,7 +68,7 @@ export class PWA {
             });
         }
 
-        /* Install button */
+        /* Install button — default handler for Chrome/Edge beforeinstallprompt */
         const installBtn = document.getElementById('pwa-install-btn');
         if (installBtn) {
             installBtn.addEventListener('click', () => this.handleInstallClick());
@@ -81,42 +85,17 @@ export class PWA {
         const platform = this.detectPlatform();
 
         if (platform === 'ios-safari') {
+            /* iOS 15+ moved the Share button to the bottom toolbar (#177) */
             this.showPlatformBanner({
                 icon: 'fa-solid fa-arrow-up-from-bracket',
-                text: 'Tap <strong><i class="fa-solid fa-arrow-up-from-bracket"></i> Share</strong>, then <strong>Add to Home Screen</strong>',
+                text: 'Tap <strong><i class="fa-solid fa-arrow-up-from-bracket"></i> Share</strong> below, then <strong>Add to Home Screen</strong>',
                 showButton: false,
             });
-        } else if (platform === 'ios-chrome') {
+        } else if (platform.startsWith('ios-')) {
+            /* iOS non-Safari: Chrome, Edge, Firefox, Opera — guide to Safari */
             this.showPlatformBanner({
                 icon: 'fa-brands fa-safari',
-                text: 'To install, open in <strong>Safari</strong> → <strong><i class="fa-solid fa-arrow-up-from-bracket"></i> Share</strong> → <strong>Add to Home Screen</strong>',
-                showButton: true,
-                buttonIcon: 'fa-solid fa-copy',
-                buttonText: 'Copy Link',
-                buttonAction: () => this.copyCurrentUrl(),
-            });
-        } else if (platform === 'ios-edge') {
-            this.showPlatformBanner({
-                icon: 'fa-brands fa-safari',
-                text: 'To install, open in <strong>Safari</strong> → <strong><i class="fa-solid fa-arrow-up-from-bracket"></i> Share</strong> → <strong>Add to Home Screen</strong>',
-                showButton: true,
-                buttonIcon: 'fa-solid fa-copy',
-                buttonText: 'Copy Link',
-                buttonAction: () => this.copyCurrentUrl(),
-            });
-        } else if (platform === 'ios-firefox') {
-            this.showPlatformBanner({
-                icon: 'fa-brands fa-safari',
-                text: 'To install, open in <strong>Safari</strong> → <strong><i class="fa-solid fa-arrow-up-from-bracket"></i> Share</strong> → <strong>Add to Home Screen</strong>',
-                showButton: true,
-                buttonIcon: 'fa-solid fa-copy',
-                buttonText: 'Copy Link',
-                buttonAction: () => this.copyCurrentUrl(),
-            });
-        } else if (platform === 'ios-other') {
-            this.showPlatformBanner({
-                icon: 'fa-brands fa-safari',
-                text: 'To install, open in <strong>Safari</strong> → <strong><i class="fa-solid fa-arrow-up-from-bracket"></i> Share</strong> → <strong>Add to Home Screen</strong>',
+                text: 'To install, open in <strong>Safari</strong> then tap <strong>Share</strong> → <strong>Add to Home Screen</strong>',
                 showButton: true,
                 buttonIcon: 'fa-solid fa-copy',
                 buttonText: 'Copy Link',
@@ -174,6 +153,7 @@ export class PWA {
 
     /**
      * Show a platform-specific install banner.
+     * Populates the empty banner HTML with platform-appropriate content.
      *
      * @param {Object} opts Banner options
      * @param {string} opts.icon FontAwesome class for the leading icon
@@ -189,37 +169,36 @@ export class PWA {
         const banner = document.getElementById('pwa-install-banner');
         if (!banner) return;
 
-        /* Update icon */
-        const iconEl = banner.querySelector('.pwa-install-banner i.fa-mobile-screen-button, .pwa-install-banner i.fa-arrow-up-from-bracket, .pwa-install-banner i.fa-display, .pwa-install-banner i.fa-brands');
+        /* Populate icon */
+        const iconEl = banner.querySelector('.pwa-banner-icon');
         if (iconEl) {
-            iconEl.className = opts.icon + ' fa-lg';
+            iconEl.className = 'pwa-banner-icon ' + opts.icon + ' fa-lg';
         }
 
-        /* Update text */
+        /* Populate text */
         const textEl = banner.querySelector('.pwa-install-text');
         if (textEl) {
             textEl.innerHTML = opts.text;
         }
 
-        /* Update button */
+        /* Populate button */
         const installBtn = document.getElementById('pwa-install-btn');
         if (installBtn) {
             if (opts.showButton && opts.buttonText) {
-                installBtn.style.display = '';
+                installBtn.classList.remove('d-none');
                 const icon = installBtn.querySelector('i');
                 const span = installBtn.querySelector('span');
                 if (icon) icon.className = (opts.buttonIcon || 'fa-solid fa-download') + ' me-1';
                 if (span) span.textContent = opts.buttonText;
 
                 if (opts.buttonAction) {
-                    /* Replace click handler */
+                    /* Replace click handler by cloning the button */
                     const newBtn = installBtn.cloneNode(true);
                     installBtn.parentNode.replaceChild(newBtn, installBtn);
                     newBtn.addEventListener('click', opts.buttonAction);
                 }
-            } else {
-                installBtn.style.display = 'none';
             }
+            /* If showButton is false, button stays hidden (d-none from HTML) */
         }
 
         banner.classList.remove('d-none');
@@ -227,16 +206,37 @@ export class PWA {
     }
 
     /**
-     * Show the default PWA install banner if not previously dismissed.
+     * Show the default PWA install banner (Chrome/Edge/Samsung beforeinstallprompt).
+     * Populates the empty banner HTML with default install content.
      */
     showInstallBanner() {
         if (localStorage.getItem(this.dismissKey)) return;
 
         const banner = document.getElementById('pwa-install-banner');
-        if (banner) {
-            banner.classList.remove('d-none');
-            document.body.classList.add('banner-visible');
+        if (!banner) return;
+
+        /* Populate default content for Chrome/Edge/Samsung */
+        const iconEl = banner.querySelector('.pwa-banner-icon');
+        if (iconEl) {
+            iconEl.className = 'pwa-banner-icon fa-solid fa-mobile-screen-button fa-lg';
         }
+
+        const textEl = banner.querySelector('.pwa-install-text');
+        if (textEl) {
+            textEl.innerHTML = 'Get the full <strong>iHymns</strong> experience!';
+        }
+
+        const installBtn = document.getElementById('pwa-install-btn');
+        if (installBtn) {
+            installBtn.classList.remove('d-none');
+            const icon = installBtn.querySelector('i');
+            const span = installBtn.querySelector('span');
+            if (icon) icon.className = 'fa-solid fa-download me-1';
+            if (span) span.textContent = 'Install';
+        }
+
+        banner.classList.remove('d-none');
+        document.body.classList.add('banner-visible');
     }
 
     /**
@@ -310,23 +310,19 @@ export class PWA {
 
     /**
      * Check if the current platform has a native app available.
-     * If so, update the banner button to redirect to the app store.
+     * If so, populate the banner and redirect to the app store.
      */
     checkNativeAppRedirect() {
         const nativeUrl = this.getNativeAppUrl();
         if (!nativeUrl) return;
 
-        const installBtn = document.getElementById('pwa-install-btn');
-        if (installBtn) {
-            const icon = installBtn.querySelector('i');
-            const span = installBtn.querySelector('span');
-            if (icon) icon.className = 'fa-solid fa-arrow-up-right-from-square me-1';
-            if (span) span.textContent = 'Open App';
-        }
-
-        if (!localStorage.getItem(this.dismissKey)) {
-            this.showInstallBanner();
-        }
+        this.showPlatformBanner({
+            icon: 'fa-solid fa-mobile-screen-button',
+            text: 'Get the full <strong>iHymns</strong> experience!',
+            showButton: true,
+            buttonIcon: 'fa-solid fa-arrow-up-right-from-square',
+            buttonText: 'Open App',
+        });
     }
 
     /**


### PR DESCRIPTION
## Summary

- **Fix share icon direction** (#177): iOS 15+ moved Safari's share button to the bottom toolbar. Banner now says "Tap Share **below**, then Add to Home Screen".
- **Empty default banner HTML** (#177): Banner HTML is now empty — all content (icon, text, button) populated by JS via platform detection. Install button starts hidden (`d-none`). Prevents old generic "Get the full iHymns experience!" text from flashing.
- **Hide banner on non-Safari iOS**: Edge/Chrome/Firefox/Opera on iOS cannot install PWAs, so the install banner is simply hidden. Removed unused `copyCurrentUrl()` method. Consolidated duplicate iOS browser configs into `platform.startsWith('ios-')`.
- **Claude context updates**: ProjectBrief.md, project_ihymns.md, MEMORY.md updated with latest session work (OG images, PWA banners, CI/CD, version management).

Closes #177

## Commits

1. `e5a26eb` — docs: update Claude context with SEO, PWA, and social sharing work
2. `f207727` — fix(pwa): share icon direction + empty default banner HTML (#177)
3. `c5ab226` — fix(pwa): hide install banner on non-Safari iOS browsers

## Test plan

- [ ] iOS Safari: banner says "Tap Share **below**, then Add to Home Screen"
- [ ] iOS Edge/Chrome/Firefox/Opera: **no** install banner shown
- [ ] macOS Safari: banner says "File → Add to Dock"
- [ ] Desktop Chrome: "Get the full iHymns experience!" + Install button (via `beforeinstallprompt`)
- [ ] No flash of old banner content on any platform
- [ ] Dismiss banner → stays dismissed across page loads
- [ ] Already installed as PWA → no banner
- [ ] CI deploy passes

https://claude.ai/code/session_019iLcFctpajfVnyEsGqZCvj