### PR TITLE
fix: Song of the Day async data race condition

### DIFF
--- a/appWeb/public_html/js/modules/search.js
+++ b/appWeb/public_html/js/modules/search.js
@@ -208,6 +208,12 @@ export class Search {
 
             console.log(`[Search] Fuse.js index built: ${this.songsData.length} songs`);
 
+            /* Re-render Song of the Day if home page is active (#108) —
+               the home page may have rendered before song data finished loading */
+            if (document.getElementById('song-of-the-day') && this.app.songOfTheDay) {
+                this.app.songOfTheDay.renderHomeSection();
+            }
+
         } catch (error) {
             console.warn('[Search] Fuse.js loading failed, using API fallback:', error);
             this.fuseFailed = true;


### PR DESCRIPTION
## Summary

- **Fix Song of the Day not rendering**: The home page rendered before `songs.json` finished loading asynchronously, so `songsData` was `null` and the Song of the Day card silently skipped. After `loadFuseIndex()` completes in `search.js`, it now re-renders the Song of the Day if the home page is active.

## Test plan

- [ ] Open home page — Song of the Day card should appear after songs load
- [ ] Refresh home page — card should still appear reliably
- [ ] Navigate away and back to home — card re-renders correctly
- [ ] Check that the correct themed song appears for today's date

https://claude.ai/code/session_019iLcFctpajfVnyEsGqZCvj