### PR TITLE
fix: .htaccess passthrough for /manage/ admin area

### DIFF
--- a/appWeb/public_html/.htaccess
+++ b/appWeb/public_html/.htaccess
@@ -21,11 +21,21 @@
 RewriteEngine On
 
 # ==========================================================================
+# ADMIN AREA PASSTHROUGH (/manage/)
+#
+# The /manage/ directory has its own PHP authentication system and does
+# not use the SPA router. All requests to /manage/ are served directly
+# by PHP — they must bypass the .php blocking rule and the SPA catch-all.
+# ==========================================================================
+
+RewriteRule ^manage/ - [L]
+
+# ==========================================================================
 # BLOCK DIRECT ACCESS TO PHP FILES
 #
 # Security measure: prevents revealing that the server uses PHP.
 # All PHP files must be accessed through clean URL rewrites.
-# Exceptions: none — all PHP access goes through rewritten paths.
+# Exceptions: /manage/ (handled above, has its own auth).
 # ==========================================================================
 
 # Block direct access to any .php file (except internal rewrites)

--- a/appWeb/public_html/manage/.htaccess
+++ b/appWeb/public_html/manage/.htaccess
@@ -1,0 +1,36 @@
+# ==========================================================================
+# iHymns — Admin Area (.htaccess)
+#
+# Copyright (c) 2026 iHymns. All rights reserved.
+#
+# PURPOSE:
+# Handles routing for the /manage/ admin area. This directory is
+# excluded from the main SPA rewrite rules and has its own auth system.
+#
+# ROUTING:
+#   /manage/              → /manage/editor/ (default redirect)
+#   /manage/login         → /manage/login.php
+#   /manage/logout        → /manage/logout.php
+#   /manage/setup         → /manage/setup.php
+#   /manage/editor/       → /manage/editor/index.php (DirectoryIndex)
+# ==========================================================================
+
+# Enable the rewrite engine
+RewriteEngine On
+
+# ---- Clean URL rewrites (hide .php extensions) ----
+
+# /manage/login → login.php
+RewriteRule ^login$ login.php [L]
+
+# /manage/logout → logout.php
+RewriteRule ^logout$ logout.php [L]
+
+# /manage/setup → setup.php
+RewriteRule ^setup$ setup.php [L]
+
+# /manage/ root → redirect to editor
+RewriteRule ^$ editor/ [R=302,L]
+
+# ---- Ensure DirectoryIndex works for /manage/editor/ ----
+DirectoryIndex index.php

--- a/appWeb/public_html/manage/editor/index.php
+++ b/appWeb/public_html/manage/editor/index.php
@@ -575,7 +575,7 @@ $currentUser = getCurrentUser();
             <!-- Separator + User / Logout -->
             <span class="text-muted mx-1">|</span>
             <span class="text-muted small d-none d-md-inline"><?= htmlspecialchars($currentUser['display_name'] ?? $currentUser['username'] ?? '') ?></span>
-            <a href="/manage/logout.php"
+            <a href="/manage/logout"
                class="btn btn-sm btn-outline-secondary"
                title="Sign out">
                 <i class="bi bi-box-arrow-right me-1"></i>Logout

--- a/appWeb/public_html/manage/includes/auth.php
+++ b/appWeb/public_html/manage/includes/auth.php
@@ -96,7 +96,7 @@ function requireAuth(): void
 {
     /* If no users exist yet, redirect to setup */
     if (needsSetup()) {
-        header('Location: /manage/setup.php');
+        header('Location: /manage/setup');
         exit;
     }
 
@@ -104,7 +104,7 @@ function requireAuth(): void
         /* Store the requested URL so we can redirect back after login */
         initSession();
         $_SESSION['redirect_after_login'] = $_SERVER['REQUEST_URI'] ?? '/manage/';
-        header('Location: /manage/login.php');
+        header('Location: /manage/login');
         exit;
     }
 
@@ -112,7 +112,7 @@ function requireAuth(): void
     $user = getCurrentUser();
     if ($user === null) {
         logout();
-        header('Location: /manage/login.php');
+        header('Location: /manage/login');
         exit;
     }
 }

--- a/appWeb/public_html/manage/login.php
+++ b/appWeb/public_html/manage/login.php
@@ -12,7 +12,7 @@ require_once __DIR__ . '/includes/auth.php';
 
 /* Redirect to setup if no users exist */
 if (needsSetup()) {
-    header('Location: /manage/setup.php');
+    header('Location: /manage/setup');
     exit;
 }
 

--- a/appWeb/public_html/manage/logout.php
+++ b/appWeb/public_html/manage/logout.php
@@ -11,5 +11,5 @@ declare(strict_types=1);
 require_once __DIR__ . '/includes/auth.php';
 
 logout();
-header('Location: /manage/login.php');
+header('Location: /manage/login');
 exit;

--- a/appWeb/public_html/manage/setup.php
+++ b/appWeb/public_html/manage/setup.php
@@ -16,7 +16,7 @@ require_once __DIR__ . '/includes/auth.php';
 
 /* If users already exist, setup is disabled — redirect to login */
 if (!needsSetup()) {
-    header('Location: /manage/login.php');
+    header('Location: /manage/login');
     exit;
 }
 
@@ -122,7 +122,7 @@ $csrf = csrfToken();
             <div class="alert alert-success" role="alert">
                 <i class="bi bi-check-circle me-1"></i>Admin account created successfully.
             </div>
-            <a href="/manage/login.php" class="btn btn-amber w-100">
+            <a href="/manage/login" class="btn btn-amber w-100">
                 <i class="bi bi-box-arrow-in-right me-1"></i>Go to Login
             </a>
         <?php else: ?>


### PR DESCRIPTION
## Summary

- Fix 404 on `/manage/` admin pages caused by SPA `.htaccess` rewrite rules (#232)
- Add `manage/.htaccess` with clean URL rewrites for login, logout, setup
- Update all PHP redirects to use clean URLs (no `.php` extensions)

## Details

The main `.htaccess` had two rules blocking `/manage/`:
1. PHP file blocking rule returned 404 for any `.php` URL
2. SPA catch-all rewrote everything to `index.php`

Added `RewriteRule ^manage/ - [L]` before both rules so Apache serves `/manage/` files directly.

## Test plan

- [ ] Browse to `dev.ihymns.app/manage/` — should redirect to `/manage/editor/`
- [ ] First visit with no users → redirects to `/manage/setup`
- [ ] Create admin account → redirects to `/manage/login`
- [ ] Login → redirects to `/manage/editor/`
- [ ] Logout button → returns to `/manage/login`
- [ ] Main PWA routes (/, /songbooks, /song/CP-0001) still work normally

https://claude.ai/code/session_019iLcFctpajfVnyEsGqZCvj