### PR TITLE
feat: editor fixes, admin user mgmt, language fields & schema

### DIFF
--- a/appWeb/public_html/manage/.htaccess
+++ b/appWeb/public_html/manage/.htaccess
@@ -29,6 +29,9 @@ RewriteRule ^logout$ logout.php [L]
 # /manage/setup → setup.php
 RewriteRule ^setup$ setup.php [L]
 
+# /manage/users → users.php (admin-only user management)
+RewriteRule ^users$ users.php [L]
+
 # /manage/ root → redirect to editor
 RewriteRule ^$ editor/ [R=302,L]
 

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -447,6 +447,7 @@ function selectSong(songId) {
     setVal('edit-number', song.number || '');
     setVal('edit-songbook', song.songbook || '');
     setVal('edit-ccli', song.ccli || '');
+    setVal('edit-language', song.language || 'en');
 
     /* Populate the boolean checkboxes (#222, #225). */
     setChecked('edit-verified', !!song.verified);
@@ -495,6 +496,7 @@ function bindMetadataListeners() {
         { elId: 'edit-number',   key: 'number' },
         { elId: 'edit-songbook', key: 'songbook' },
         { elId: 'edit-ccli',     key: 'ccli' },
+        { elId: 'edit-language', key: 'language' },
         { elId: 'edit-copyright', key: 'copyright' }
     ];
 
@@ -1745,6 +1747,7 @@ function clearEditForm() {
     setVal('edit-number', '');
     setVal('edit-songbook', '');
     setVal('edit-ccli', '');
+    setVal('edit-language', 'en');
     setVal('edit-copyright', '');
 
     /* Clear boolean checkboxes (#222, #225). */
@@ -1880,6 +1883,7 @@ function addNewSong() {
         title: 'New Song',
         number: songData.songs.length + 1,
         songbook: '',
+        language: 'en',
         ccli: '',
         copyright: '',
         writers: [],

--- a/appWeb/public_html/manage/editor/index.php
+++ b/appWeb/public_html/manage/editor/index.php
@@ -518,7 +518,7 @@ $currentUser = getCurrentUser();
             <button
                 type="button"
                 class="btn btn-sm btn-amber"
-                id="btnLoadJson"
+                id="btn-load-file"
                 title="Load a songs.json file from disk"
             >
                 <i class="bi bi-folder2-open me-1"></i>Load JSON
@@ -528,7 +528,7 @@ $currentUser = getCurrentUser();
             <button
                 type="button"
                 class="btn btn-sm btn-amber-solid"
-                id="btnSaveJson"
+                id="btn-save"
                 title="Download the current songs as a JSON file"
             >
                 <i class="bi bi-download me-1"></i>Save JSON
@@ -549,13 +549,13 @@ $currentUser = getCurrentUser();
                 <ul class="dropdown-menu dropdown-menu-dark" aria-labelledby="dropdownExport">
                     <!-- Export as JSON — full data export -->
                     <li>
-                        <a class="dropdown-item" href="#" id="exportJson">
+                        <a class="dropdown-item" href="#" id="btn-export-json">
                             <i class="bi bi-filetype-json me-2"></i>Export as JSON
                         </a>
                     </li>
                     <!-- Export as CSV — tabular export for spreadsheets -->
                     <li>
-                        <a class="dropdown-item" href="#" id="exportCsv">
+                        <a class="dropdown-item" href="#" id="btn-export-csv">
                             <i class="bi bi-filetype-csv me-2"></i>Export as CSV
                         </a>
                     </li>
@@ -566,15 +566,22 @@ $currentUser = getCurrentUser();
             <button
                 type="button"
                 class="btn btn-sm btn-amber"
-                id="btnImport"
+                id="btn-import"
                 title="Import songs from an external JSON or CSV file"
             >
                 <i class="bi bi-box-arrow-in-down me-1"></i>Import
             </button>
 
-            <!-- Separator + User / Logout -->
+            <!-- Separator + Admin links / Logout -->
             <span class="text-muted mx-1">|</span>
-            <span class="text-muted small d-none d-md-inline"><?= htmlspecialchars($currentUser['display_name'] ?? $currentUser['username'] ?? '') ?></span>
+            <?php if (($currentUser['role'] ?? '') === 'admin'): ?>
+            <a href="/manage/users"
+               class="btn btn-sm btn-outline-secondary me-1"
+               title="User management">
+                <i class="bi bi-people me-1"></i>Users
+            </a>
+            <?php endif; ?>
+            <span class="text-muted small d-none d-md-inline me-1"><?= htmlspecialchars($currentUser['display_name'] ?? $currentUser['username'] ?? '') ?></span>
             <a href="/manage/logout"
                class="btn btn-sm btn-outline-secondary"
                title="Sign out">
@@ -608,7 +615,7 @@ $currentUser = getCurrentUser();
                 <div class="mb-2">
                     <select
                         class="form-select form-select-sm"
-                        id="filterSongbook"
+                        id="songbook-filter"
                         aria-label="Filter by songbook"
                         title="Filter songs by songbook"
                     >
@@ -626,7 +633,7 @@ $currentUser = getCurrentUser();
                     <input
                         type="text"
                         class="form-control"
-                        id="searchSongs"
+                        id="song-search"
                         placeholder="Search songs..."
                         aria-label="Search songs by title"
                     >
@@ -634,7 +641,7 @@ $currentUser = getCurrentUser();
             </div>
 
             <!-- Song list — scrollable container; each song is a clickable row -->
-            <div class="song-list-container" id="songList">
+            <div class="song-list-container" id="song-list">
                 <!--
                      Song list items are rendered dynamically by editor.js.
                      Each item follows this structure:
@@ -655,7 +662,7 @@ $currentUser = getCurrentUser();
 
             <!-- Sidebar Footer — Song count display -->
             <div class="sidebar-footer">
-                <span id="songCount">0 songs</span>
+                <span id="song-count">0 songs</span>
                 <!-- Filtered count shown when a filter is active -->
                 <span id="songCountFiltered" style="display: none;"> (showing <span id="filteredCount">0</span>)</span>
             </div>
@@ -930,7 +937,7 @@ $currentUser = getCurrentUser();
                             <button
                                 type="button"
                                 class="btn btn-sm btn-amber"
-                                id="btnAddComponent"
+                                id="btn-add-component"
                                 title="Add a new song component (verse, chorus, etc.)"
                             >
                                 <i class="bi bi-plus-circle me-1"></i>Add Component
@@ -1034,7 +1041,7 @@ $currentUser = getCurrentUser();
                             </label>
 
                             <!-- Dynamic list of writer input rows -->
-                            <div id="writersList">
+                            <div id="writers-container">
                                 <!--
                                      Each writer row is rendered by editor.js:
                                      <div class="dynamic-list-row">
@@ -1045,16 +1052,7 @@ $currentUser = getCurrentUser();
                                      </div>
                                 -->
                             </div>
-
-                            <!-- Add Writer button -->
-                            <button
-                                type="button"
-                                class="btn btn-sm btn-amber mt-1"
-                                id="btnAddWriter"
-                                title="Add another writer"
-                            >
-                                <i class="bi bi-plus me-1"></i>Add Writer
-                            </button>
+                            <!-- Add Writer button is dynamically rendered by editor.js inside writers-container -->
                         </div>
 
                         <!-- Composers Section — list of music composer names -->
@@ -1064,7 +1062,7 @@ $currentUser = getCurrentUser();
                             </label>
 
                             <!-- Dynamic list of composer input rows -->
-                            <div id="composersList">
+                            <div id="composers-container">
                                 <!--
                                      Each composer row is rendered by editor.js:
                                      <div class="dynamic-list-row">
@@ -1075,16 +1073,7 @@ $currentUser = getCurrentUser();
                                      </div>
                                 -->
                             </div>
-
-                            <!-- Add Composer button -->
-                            <button
-                                type="button"
-                                class="btn btn-sm btn-amber mt-1"
-                                id="btnAddComposer"
-                                title="Add another composer"
-                            >
-                                <i class="bi bi-plus me-1"></i>Add Composer
-                            </button>
+                            <!-- Add Composer button is dynamically rendered by editor.js inside composers-container -->
                         </div>
 
                         <!-- Copyright Text — free-text copyright notice -->
@@ -1119,7 +1108,7 @@ $currentUser = getCurrentUser();
                         role="tabpanel"
                         aria-labelledby="tab-preview"
                     >
-                        <div class="preview-container" id="previewContainer">
+                        <div class="preview-container" id="preview-container">
                             <!-- Preview content is rendered by editor.js.
                                  The structure will look like:
 
@@ -1172,21 +1161,25 @@ $currentUser = getCurrentUser();
         <!-- Left section — save status -->
         <div class="me-auto d-flex align-items-center">
             <!-- Coloured dot indicator — class toggled by editor.js -->
-            <span class="status-indicator saved" id="statusIndicator"></span>
+            <span class="status-indicator saved" id="status-indicator"></span>
             <!-- Status text (e.g., "All changes saved" or "Unsaved changes") -->
-            <span id="statusText">Ready</span>
+            <span id="status-text">Ready</span>
+            <!-- Unsaved changes warning badge -->
+            <span id="status-unsaved-warning" class="badge bg-warning text-dark ms-2" style="display: none;">
+                <span id="status-modified">0</span> unsaved
+            </span>
         </div>
 
         <!-- Centre section — total songs loaded -->
         <div class="mx-3">
             <i class="bi bi-collection me-1"></i>
-            <span id="statusTotalSongs">0</span> songs loaded
+            <span id="status-total">0</span> songs loaded
         </div>
 
         <!-- Right section — last saved timestamp -->
         <div>
             <i class="bi bi-clock me-1"></i>
-            Last saved: <span id="statusLastSaved">Never</span>
+            Last saved: <span id="status-save-time">Never</span>
         </div>
     </footer>
 
@@ -1326,6 +1319,9 @@ $currentUser = getCurrentUser();
          Bootstrap 5.3 JS bundle (includes Popper for dropdowns) loaded
          from CDN, followed by the editor's own JavaScript module.
          ================================================================= -->
+
+    <!-- Toast notification container — dynamically populated by editor.js -->
+    <div id="toast-container" class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1090;"></div>
 
     <!-- Bootstrap 5.3 JavaScript bundle — required for tabs, dropdowns, and other interactive components -->
     <script

--- a/appWeb/public_html/manage/editor/index.php
+++ b/appWeb/public_html/manage/editor/index.php
@@ -660,11 +660,20 @@ $currentUser = getCurrentUser();
                 </div>
             </div>
 
-            <!-- Sidebar Footer — Song count display -->
-            <div class="sidebar-footer">
-                <span id="song-count">0 songs</span>
-                <!-- Filtered count shown when a filter is active -->
-                <span id="songCountFiltered" style="display: none;"> (showing <span id="filteredCount">0</span>)</span>
+            <!-- Sidebar Footer — Song count + Add/Delete buttons -->
+            <div class="sidebar-footer d-flex align-items-center justify-content-between">
+                <span>
+                    <span id="song-count">0 songs</span>
+                    <span id="songCountFiltered" style="display: none;"> (showing <span id="filteredCount">0</span>)</span>
+                </span>
+                <span>
+                    <button type="button" class="btn btn-sm btn-amber py-0 px-1" id="btn-add-song" title="Add new song">
+                        <i class="bi bi-plus-lg"></i>
+                    </button>
+                    <button type="button" class="btn btn-sm btn-outline-danger py-0 px-1" id="btn-delete-song" title="Delete selected song">
+                        <i class="bi bi-trash"></i>
+                    </button>
+                </span>
             </div>
         </aside>
 
@@ -827,6 +836,35 @@ $currentUser = getCurrentUser();
                             >
                             <div class="form-text" style="color: var(--ih-text-muted); font-size: 0.75rem;">
                                 The CCLI song number for licensing and reporting purposes.
+                            </div>
+                        </div>
+
+                        <!-- Language — IETF BCP 47 language tag for the song lyrics -->
+                        <div class="mb-3">
+                            <label for="edit-language" class="form-label">Language</label>
+                            <input
+                                type="text"
+                                class="form-control"
+                                id="edit-language"
+                                placeholder="e.g. en, en-GB, fr-FR, de-DE"
+                                list="language-suggestions"
+                            >
+                            <datalist id="language-suggestions">
+                                <option value="en">English</option>
+                                <option value="en-GB">English (United Kingdom)</option>
+                                <option value="en-US">English (United States)</option>
+                                <option value="fr-FR">French (France)</option>
+                                <option value="de-DE">German (Germany)</option>
+                                <option value="es-ES">Spanish (Spain)</option>
+                                <option value="it-IT">Italian (Italy)</option>
+                                <option value="pt-BR">Portuguese (Brazil)</option>
+                                <option value="la">Latin</option>
+                                <option value="cy-GB">Welsh (United Kingdom)</option>
+                                <option value="gd-GB">Scottish Gaelic (United Kingdom)</option>
+                                <option value="ga-IE">Irish (Ireland)</option>
+                            </datalist>
+                            <div class="form-text" style="color: var(--ih-text-muted); font-size: 0.75rem;">
+                                IETF BCP 47 language tag (language, region, script). Defaults to "en".
                             </div>
                         </div>
 

--- a/appWeb/public_html/manage/users.php
+++ b/appWeb/public_html/manage/users.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Admin User Management (#229)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Allows admins to create new user accounts. Only accessible to
+ * authenticated users with the 'admin' role. The public setup page
+ * is disabled after the first admin is created — all subsequent
+ * user creation goes through this page.
+ */
+
+require_once __DIR__ . '/includes/auth.php';
+requireAdmin();
+
+$currentUser = getCurrentUser();
+
+/* Handle form submission */
+$error   = '';
+$success = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $token       = $_POST['csrf_token'] ?? '';
+    $username    = $_POST['username'] ?? '';
+    $displayName = $_POST['display_name'] ?? '';
+    $password    = $_POST['password'] ?? '';
+    $confirm     = $_POST['password_confirm'] ?? '';
+    $role        = $_POST['role'] ?? 'editor';
+
+    if (!validateCsrf($token)) {
+        $error = 'Invalid form submission. Please try again.';
+    } elseif (strlen(trim($username)) < 3) {
+        $error = 'Username must be at least 3 characters.';
+    } elseif (strlen($password) < 8) {
+        $error = 'Password must be at least 8 characters.';
+    } elseif ($password !== $confirm) {
+        $error = 'Passwords do not match.';
+    } elseif (!in_array($role, ['admin', 'editor'], true)) {
+        $error = 'Invalid role.';
+    } else {
+        try {
+            createUser($username, $password, $displayName ?: $username, $role);
+            $success = 'User "' . htmlspecialchars($username) . '" created successfully.';
+        } catch (\RuntimeException $e) {
+            $error = $e->getMessage();
+        }
+    }
+}
+
+/* Fetch existing users for the list */
+$db = getDb();
+$users = $db->query('SELECT id, username, display_name, role, is_active, created_at FROM users ORDER BY created_at ASC')->fetchAll(PDO::FETCH_ASSOC);
+
+$csrf = csrfToken();
+?>
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Users — iHymns Admin</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+          rel="stylesheet"
+          integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+          crossorigin="anonymous">
+    <link rel="stylesheet"
+          href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
+          integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+"
+          crossorigin="anonymous">
+    <style>
+        :root {
+            --ih-bg: #1a1a2e;
+            --ih-surface: #16213e;
+            --ih-amber: #f59e0b;
+            --ih-amber-hover: #d97706;
+            --ih-text: #e2e8f0;
+            --ih-text-muted: #94a3b8;
+            --ih-border: #334155;
+        }
+        body { background: var(--ih-bg); color: var(--ih-text); }
+        .card-admin { background: var(--ih-surface); border: 1px solid var(--ih-border); border-radius: 12px; }
+        .btn-amber { background: var(--ih-amber); border-color: var(--ih-amber); color: #1a1a2e; font-weight: 600; }
+        .btn-amber:hover { background: var(--ih-amber-hover); border-color: var(--ih-amber-hover); color: #1a1a2e; }
+        .form-control:focus, .form-select:focus { border-color: var(--ih-amber); box-shadow: 0 0 0 0.2rem rgba(245, 158, 11, 0.25); }
+        .navbar-admin { background: var(--ih-surface); border-bottom: 1px solid var(--ih-border); padding: 0.75rem 1rem; }
+        .navbar-admin .nav-link { color: var(--ih-text-muted); }
+        .navbar-admin .nav-link:hover { color: var(--ih-amber); }
+        .table { color: var(--ih-text); }
+        .badge-admin { background: var(--ih-amber); color: #1a1a2e; }
+        .badge-editor { background: #3b82f6; }
+    </style>
+</head>
+<body>
+    <!-- Navigation -->
+    <nav class="navbar-admin d-flex align-items-center">
+        <a href="/manage/editor/" class="text-decoration-none me-auto d-flex align-items-center gap-2" style="color: var(--ih-amber);">
+            <i class="bi bi-music-note-beamed"></i>
+            <strong>iHymns Admin</strong>
+        </a>
+        <a href="/manage/editor/" class="nav-link d-inline"><i class="bi bi-pencil-square me-1"></i>Editor</a>
+        <span class="text-muted mx-2">|</span>
+        <span class="text-muted small"><?= htmlspecialchars($currentUser['display_name'] ?? $currentUser['username']) ?></span>
+        <a href="/manage/logout" class="btn btn-sm btn-outline-secondary ms-2">
+            <i class="bi bi-box-arrow-right me-1"></i>Logout
+        </a>
+    </nav>
+
+    <div class="container py-4" style="max-width: 800px;">
+
+        <h1 class="h4 mb-4"><i class="bi bi-people me-2"></i>User Management</h1>
+
+        <!-- Existing users -->
+        <div class="card-admin p-3 mb-4">
+            <h2 class="h6 mb-3">Existing Users</h2>
+            <table class="table table-sm table-borderless mb-0">
+                <thead>
+                    <tr class="text-muted small">
+                        <th>Username</th>
+                        <th>Display Name</th>
+                        <th>Role</th>
+                        <th>Status</th>
+                        <th>Created</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($users as $u): ?>
+                    <tr>
+                        <td><code><?= htmlspecialchars($u['username']) ?></code></td>
+                        <td><?= htmlspecialchars($u['display_name']) ?></td>
+                        <td>
+                            <span class="badge <?= $u['role'] === 'admin' ? 'badge-admin' : 'badge-editor' ?>">
+                                <?= htmlspecialchars($u['role']) ?>
+                            </span>
+                        </td>
+                        <td><?= $u['is_active'] ? '<span class="text-success">Active</span>' : '<span class="text-danger">Disabled</span>' ?></td>
+                        <td class="text-muted small"><?= htmlspecialchars($u['created_at']) ?></td>
+                    </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+
+        <!-- Create new user form -->
+        <div class="card-admin p-3">
+            <h2 class="h6 mb-3">Create New User</h2>
+
+            <?php if ($success): ?>
+                <div class="alert alert-success py-2"><?= $success ?></div>
+            <?php endif; ?>
+            <?php if ($error): ?>
+                <div class="alert alert-danger py-2"><i class="bi bi-exclamation-triangle me-1"></i><?= htmlspecialchars($error) ?></div>
+            <?php endif; ?>
+
+            <form method="POST">
+                <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+
+                <div class="row mb-3">
+                    <div class="col-md-6">
+                        <label for="username" class="form-label">Username <span class="text-danger">*</span></label>
+                        <input type="text" class="form-control" id="username" name="username"
+                               value="<?= htmlspecialchars($_POST['username'] ?? '') ?>" minlength="3" required>
+                    </div>
+                    <div class="col-md-6">
+                        <label for="display_name" class="form-label">Display Name</label>
+                        <input type="text" class="form-control" id="display_name" name="display_name"
+                               value="<?= htmlspecialchars($_POST['display_name'] ?? '') ?>" placeholder="Defaults to username">
+                    </div>
+                </div>
+
+                <div class="row mb-3">
+                    <div class="col-md-6">
+                        <label for="password" class="form-label">Password <span class="text-danger">*</span></label>
+                        <input type="password" class="form-control" id="password" name="password" minlength="8" required>
+                    </div>
+                    <div class="col-md-6">
+                        <label for="password_confirm" class="form-label">Confirm Password <span class="text-danger">*</span></label>
+                        <input type="password" class="form-control" id="password_confirm" name="password_confirm" minlength="8" required>
+                    </div>
+                </div>
+
+                <div class="mb-3">
+                    <label for="role" class="form-label">Role</label>
+                    <select class="form-select" id="role" name="role">
+                        <option value="editor">Editor — can edit songs</option>
+                        <option value="admin">Admin — full access including user management</option>
+                    </select>
+                </div>
+
+                <button type="submit" class="btn btn-amber">
+                    <i class="bi bi-person-plus me-1"></i>Create User
+                </button>
+            </form>
+        </div>
+    </div>
+</body>
+</html>

--- a/data/songs.schema.json
+++ b/data/songs.schema.json
@@ -79,7 +79,7 @@
       "type": "object",
       "required": [
         "id", "number", "title", "songbook", "songbookName",
-        "writers", "composers", "copyright", "ccli",
+        "language", "writers", "composers", "copyright", "ccli",
         "verified", "lyricsPublicDomain", "musicPublicDomain",
         "hasAudio", "hasSheetMusic", "components"
       ],
@@ -109,6 +109,12 @@
           "description": "Full display name of the songbook (denormalised for convenience).",
           "type": "string",
           "minLength": 1
+        },
+        "language": {
+          "description": "IETF BCP 47 language tag for the song lyrics (e.g. 'en', 'en-GB', 'fr-FR'). Identifies language, regional locale, and optionally script.",
+          "type": "string",
+          "pattern": "^[a-z]{2,3}(-[A-Z][a-z]{3})?(-[A-Z]{2})?(-[a-zA-Z0-9]+)*$",
+          "default": "en"
         },
         "writers": {
           "description": "Lyricists / authors. Empty array if unknown.",

--- a/tools/parse-songs.js
+++ b/tools/parse-songs.js
@@ -652,6 +652,7 @@ function parseSongFile(filePath, filename, songbookConfig) {
     title: title,
     songbook: songbookConfig.id,
     songbookName: songbookConfig.name,
+    language: 'en',
     writers: writers,
     composers: composers,
     copyright: copyright,


### PR DESCRIPTION
## Summary

- **Fix editor HTML-to-JS ID mismatches** — 20+ element IDs in `index.php` now match the kebab-case IDs expected by `editor.js`, restoring all toolbar, sidebar, preview, and status bar functionality (#235)
- **Add .htaccess rules for /manage/** — passthrough rule before SPA catch-all prevents 404s on admin pages; clean URL rewrites hide .php extensions (#227, #232)
- **Admin-only user management** — new `/manage/users` page restricted to admin role; user registration closed after initial admin setup (#236)
- **Add IETF BCP 47 language field** — split into three sub-fields (Language, Script, Region) with datalists that compose the IETF tag automatically (#237, #240)
- **Add/Delete song buttons** — missing sidebar buttons wired up to existing JS functionality (#238)
- **JSON schema updates** — `songs.schema.json` updated with language field pattern, nullable component numbers

## Commits
- `2f0ccf1` — fix: add .htaccess rules for /manage/ and use clean URLs (#227)
- `bb1fe9c` — fix: editor HTML-to-JS ID mismatches + admin-only user management
- `b9acc2f` — feat: add language field (IETF BCP 47) + Add/Delete song buttons
- `7953cd5` — feat: split language into Language, Script, Region fields (#240)

## Files changed (12)
- `appWeb/public_html/.htaccess` — manage/ passthrough rule
- `appWeb/public_html/manage/.htaccess` — clean URL rewrites
- `appWeb/public_html/manage/editor/index.php` — fixed 20+ element IDs, language sub-fields, add/delete buttons
- `appWeb/public_html/manage/editor/editor.js` — IETF parse/compose helpers, checkbox helpers, language binding
- `appWeb/public_html/manage/includes/auth.php` — admin role check
- `appWeb/public_html/manage/login.php` — clean URL redirects
- `appWeb/public_html/manage/logout.php` — clean URL redirects
- `appWeb/public_html/manage/setup.php` — clean URL redirects
- `appWeb/public_html/manage/users.php` — admin-only user management page
- `data/songs.json` — regenerated with language, verified, publicDomain fields
- `data/songs.schema.json` — language pattern, nullable component number
- `tools/parse-songs.js` — language field in song parser

## Test plan
- [ ] Browse to `/manage/` — should redirect to `/manage/editor/`
- [ ] Setup admin account at `/manage/setup` — verify setup page disables after first user
- [ ] Login at `/manage/login` — verify redirect to editor
- [ ] Editor: load songs, search, filter by songbook, edit metadata fields
- [ ] Editor: verify checkboxes for verified, lyricsPublicDomain, musicPublicDomain
- [ ] Editor: verify Language, Script, Region fields compose IETF tag in preview
- [ ] Editor: add new song, delete song
- [ ] `/manage/users` — verify only admin role can access
- [ ] Non-admin user — verify /manage/users returns forbidden

Closes #235, closes #236, closes #237, closes #238, closes #240

https://claude.ai/code/session_019iLcFctpajfVnyEsGqZCvj