### PR TITLE
feat: split language fields + protect SQLite directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,6 +202,7 @@ sftp-config.json
 # The runtime copy in data_share/ and deploy copies are excluded.
 appWeb/data_share/song_data/songs.json
 appWeb/data_share/setlist_json/*.json
+appWeb/data_share/SQLite/*.db
 appWeb/data/songs.json
 appWeb/public_html/data/songs.json
 appWeb/private_html/data/songs.json

--- a/appWeb/data_share/SQLite/.htaccess
+++ b/appWeb/data_share/SQLite/.htaccess
@@ -1,0 +1,11 @@
+# ==========================================================================
+# iHymns — SQLite Database Storage
+#
+# This directory stores the SQLite database file (ihymns.db) used by the
+# /manage/ admin area for authentication and session management.
+#
+# SECURITY: Defence-in-depth to prevent direct access to database files.
+# ==========================================================================
+
+# Deny all direct access
+Deny from all

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -447,7 +447,12 @@ function selectSong(songId) {
     setVal('edit-number', song.number || '');
     setVal('edit-songbook', song.songbook || '');
     setVal('edit-ccli', song.ccli || '');
-    setVal('edit-language', song.language || 'en');
+    /* Parse IETF BCP 47 tag into sub-fields (#240). */
+    var ietf = parseIetfTag(song.language || 'en');
+    setVal('edit-lang-language', ietf.language);
+    setVal('edit-lang-script', ietf.script);
+    setVal('edit-lang-region', ietf.region);
+    composeIetfTag();
 
     /* Populate the boolean checkboxes (#222, #225). */
     setChecked('edit-verified', !!song.verified);
@@ -496,7 +501,6 @@ function bindMetadataListeners() {
         { elId: 'edit-number',   key: 'number' },
         { elId: 'edit-songbook', key: 'songbook' },
         { elId: 'edit-ccli',     key: 'ccli' },
-        { elId: 'edit-language', key: 'language' },
         { elId: 'edit-copyright', key: 'copyright' }
     ];
 
@@ -543,6 +547,24 @@ function bindMetadataListeners() {
             /* Write the boolean value back to the song object. */
             song[field.key] = el.checked;
             markModified(song.id);
+        });
+    });
+
+    /* Language sub-fields — compose IETF BCP 47 tag on change (#240). */
+    ['edit-lang-language', 'edit-lang-script', 'edit-lang-region'].forEach(function (elId) {
+        var el = document.getElementById(elId);
+        if (!el) return;
+
+        ['input', 'change'].forEach(function (eventType) {
+            el.addEventListener(eventType, function () {
+                if (!currentSongId) return;
+                var song = findSongById(currentSongId);
+                if (!song) return;
+
+                /* Compose the three fields into a single IETF tag and store it. */
+                song.language = composeIetfTag();
+                markModified(song.id);
+            });
         });
     });
 }
@@ -1736,6 +1758,76 @@ function setChecked(elementId, checked) {
 }
 
 /**
+ * parseIetfTag(tag)
+ * -----------------
+ * Splits an IETF BCP 47 language tag into its constituent parts.
+ * Format: language[-Script][-REGION]
+ *   - language: 2-3 lowercase letters (ISO 639)
+ *   - Script:   4 letters, title-case (ISO 15924) — optional
+ *   - REGION:   2 uppercase letters (ISO 3166-1) — optional
+ *
+ * @param {string} tag - e.g. "en", "en-GB", "zh-Hant-TW"
+ * @returns {{ language: string, script: string, region: string }}
+ */
+function parseIetfTag(tag) {
+    var parts = (tag || 'en').split('-');
+    var result = { language: parts[0] || 'en', script: '', region: '' };
+
+    for (var i = 1; i < parts.length; i++) {
+        var p = parts[i];
+        /* Script: exactly 4 chars, first uppercase (e.g. Latn, Cyrl) */
+        if (p.length === 4 && /^[A-Z][a-z]{3}$/.test(p)) {
+            result.script = p;
+        /* Region: exactly 2 uppercase chars (e.g. GB, US) */
+        } else if (p.length === 2 && /^[A-Z]{2}$/.test(p)) {
+            result.region = p;
+        }
+    }
+    return result;
+}
+
+/**
+ * composeIetfTag()
+ * ----------------
+ * Reads the three language sub-fields from the DOM and composes
+ * the IETF BCP 47 tag. Updates the hidden edit-language field
+ * and the preview element.
+ *
+ * @returns {string} The composed IETF tag (e.g. "en-Latn-GB")
+ */
+function composeIetfTag() {
+    var lang   = (getVal('edit-lang-language') || 'en').trim().toLowerCase();
+    var script = (getVal('edit-lang-script') || '').trim();
+    var region = (getVal('edit-lang-region') || '').trim().toUpperCase();
+
+    /* Normalise script to title case (e.g. "latn" → "Latn") */
+    if (script.length > 0) {
+        script = script.charAt(0).toUpperCase() + script.slice(1).toLowerCase();
+    }
+
+    var tag = lang;
+    if (script) tag += '-' + script;
+    if (region) tag += '-' + region;
+
+    /* Update the hidden field and preview. */
+    setVal('edit-language', tag);
+    var preview = document.getElementById('edit-lang-preview');
+    if (preview) preview.textContent = tag;
+
+    return tag;
+}
+
+/**
+ * getVal(elementId)
+ * -----------------
+ * Returns the value of a form element by ID, or empty string if not found.
+ */
+function getVal(elementId) {
+    var el = document.getElementById(elementId);
+    return el ? el.value : '';
+}
+
+/**
  * clearEditForm()
  * ---------------
  * Resets all edit form fields to empty / default values.
@@ -1747,7 +1839,10 @@ function clearEditForm() {
     setVal('edit-number', '');
     setVal('edit-songbook', '');
     setVal('edit-ccli', '');
-    setVal('edit-language', 'en');
+    setVal('edit-lang-language', 'en');
+    setVal('edit-lang-script', '');
+    setVal('edit-lang-region', '');
+    composeIetfTag();
     setVal('edit-copyright', '');
 
     /* Clear boolean checkboxes (#222, #225). */

--- a/appWeb/public_html/manage/editor/index.php
+++ b/appWeb/public_html/manage/editor/index.php
@@ -839,32 +839,120 @@ $currentUser = getCurrentUser();
                             </div>
                         </div>
 
-                        <!-- Language — IETF BCP 47 language tag for the song lyrics -->
+                        <!-- Language — IETF BCP 47 composed from Language + Script + Region (#240) -->
                         <div class="mb-3">
-                            <label for="edit-language" class="form-label">Language</label>
-                            <input
-                                type="text"
-                                class="form-control"
-                                id="edit-language"
-                                placeholder="e.g. en, en-GB, fr-FR, de-DE"
-                                list="language-suggestions"
-                            >
-                            <datalist id="language-suggestions">
-                                <option value="en">English</option>
-                                <option value="en-GB">English (United Kingdom)</option>
-                                <option value="en-US">English (United States)</option>
-                                <option value="fr-FR">French (France)</option>
-                                <option value="de-DE">German (Germany)</option>
-                                <option value="es-ES">Spanish (Spain)</option>
-                                <option value="it-IT">Italian (Italy)</option>
-                                <option value="pt-BR">Portuguese (Brazil)</option>
-                                <option value="la">Latin</option>
-                                <option value="cy-GB">Welsh (United Kingdom)</option>
-                                <option value="gd-GB">Scottish Gaelic (United Kingdom)</option>
-                                <option value="ga-IE">Irish (Ireland)</option>
-                            </datalist>
-                            <div class="form-text" style="color: var(--ih-text-muted); font-size: 0.75rem;">
-                                IETF BCP 47 language tag (language, region, script). Defaults to "en".
+                            <label class="form-label"><i class="bi bi-translate me-1"></i>Language (IETF BCP 47)</label>
+                            <div class="row g-2">
+                                <!-- Language (required) — ISO 639 -->
+                                <div class="col-4">
+                                    <label for="edit-lang-language" class="form-label" style="font-size:0.75rem;">Language</label>
+                                    <input type="text" class="form-control form-control-sm" id="edit-lang-language"
+                                        placeholder="e.g. en" list="lang-language-list" required>
+                                    <datalist id="lang-language-list">
+                                        <option value="en">English</option>
+                                        <option value="fr">French</option>
+                                        <option value="de">German</option>
+                                        <option value="es">Spanish</option>
+                                        <option value="it">Italian</option>
+                                        <option value="pt">Portuguese</option>
+                                        <option value="la">Latin</option>
+                                        <option value="cy">Welsh</option>
+                                        <option value="gd">Scottish Gaelic</option>
+                                        <option value="ga">Irish</option>
+                                        <option value="nl">Dutch</option>
+                                        <option value="sv">Swedish</option>
+                                        <option value="no">Norwegian</option>
+                                        <option value="da">Danish</option>
+                                        <option value="fi">Finnish</option>
+                                        <option value="pl">Polish</option>
+                                        <option value="cs">Czech</option>
+                                        <option value="hu">Hungarian</option>
+                                        <option value="ro">Romanian</option>
+                                        <option value="ko">Korean</option>
+                                        <option value="ja">Japanese</option>
+                                        <option value="zh">Chinese</option>
+                                        <option value="ar">Arabic</option>
+                                        <option value="he">Hebrew</option>
+                                        <option value="hi">Hindi</option>
+                                        <option value="sw">Swahili</option>
+                                        <option value="zu">Zulu</option>
+                                        <option value="xh">Xhosa</option>
+                                        <option value="af">Afrikaans</option>
+                                        <option value="tl">Tagalog</option>
+                                    </datalist>
+                                </div>
+                                <!-- Script (optional) — ISO 15924 -->
+                                <div class="col-4">
+                                    <label for="edit-lang-script" class="form-label" style="font-size:0.75rem;">Script</label>
+                                    <input type="text" class="form-control form-control-sm" id="edit-lang-script"
+                                        placeholder="e.g. Latn" list="lang-script-list">
+                                    <datalist id="lang-script-list">
+                                        <option value="Latn">Latin</option>
+                                        <option value="Cyrl">Cyrillic</option>
+                                        <option value="Arab">Arabic</option>
+                                        <option value="Hebr">Hebrew</option>
+                                        <option value="Deva">Devanagari</option>
+                                        <option value="Hans">Simplified Chinese</option>
+                                        <option value="Hant">Traditional Chinese</option>
+                                        <option value="Hang">Hangul</option>
+                                        <option value="Kana">Katakana</option>
+                                        <option value="Grek">Greek</option>
+                                        <option value="Geor">Georgian</option>
+                                        <option value="Armn">Armenian</option>
+                                        <option value="Thai">Thai</option>
+                                        <option value="Ethi">Ethiopic</option>
+                                    </datalist>
+                                </div>
+                                <!-- Region (optional) — ISO 3166-1 alpha-2 -->
+                                <div class="col-4">
+                                    <label for="edit-lang-region" class="form-label" style="font-size:0.75rem;">Region</label>
+                                    <input type="text" class="form-control form-control-sm" id="edit-lang-region"
+                                        placeholder="e.g. GB" list="lang-region-list">
+                                    <datalist id="lang-region-list">
+                                        <option value="GB">United Kingdom</option>
+                                        <option value="US">United States</option>
+                                        <option value="AU">Australia</option>
+                                        <option value="NZ">New Zealand</option>
+                                        <option value="CA">Canada</option>
+                                        <option value="IE">Ireland</option>
+                                        <option value="ZA">South Africa</option>
+                                        <option value="FR">France</option>
+                                        <option value="DE">Germany</option>
+                                        <option value="AT">Austria</option>
+                                        <option value="CH">Switzerland</option>
+                                        <option value="ES">Spain</option>
+                                        <option value="MX">Mexico</option>
+                                        <option value="IT">Italy</option>
+                                        <option value="PT">Portugal</option>
+                                        <option value="BR">Brazil</option>
+                                        <option value="NL">Netherlands</option>
+                                        <option value="SE">Sweden</option>
+                                        <option value="NO">Norway</option>
+                                        <option value="DK">Denmark</option>
+                                        <option value="FI">Finland</option>
+                                        <option value="PL">Poland</option>
+                                        <option value="CZ">Czechia</option>
+                                        <option value="HU">Hungary</option>
+                                        <option value="RO">Romania</option>
+                                        <option value="KR">South Korea</option>
+                                        <option value="JP">Japan</option>
+                                        <option value="CN">China</option>
+                                        <option value="TW">Taiwan</option>
+                                        <option value="IN">India</option>
+                                        <option value="PH">Philippines</option>
+                                        <option value="KE">Kenya</option>
+                                        <option value="NG">Nigeria</option>
+                                        <option value="GH">Ghana</option>
+                                    </datalist>
+                                </div>
+                            </div>
+                            <!-- Composed IETF tag preview -->
+                            <div class="mt-1 d-flex align-items-center gap-2">
+                                <span class="form-text" style="color: var(--ih-text-muted); font-size: 0.75rem;">
+                                    IETF tag:
+                                </span>
+                                <code id="edit-lang-preview" style="font-size: 0.8rem;">en</code>
+                                <input type="hidden" id="edit-language">
                             </div>
                         </div>
 


### PR DESCRIPTION
## Summary

- **Split language into Language, Script, Region fields** — replaces the single IETF BCP 47 text input with three separate fields (ISO 639 language, ISO 15924 script, ISO 3166-1 region) that auto-compose the tag with live preview. Includes datalists with 30 languages, 14 scripts, and 34 regions (#240)
- **Protect SQLite directory** — adds `.gitkeep` (so directory persists across deployments), `.htaccess` (blocks direct web access to `.db` files), and `.gitignore` entry (prevents git from overwriting the live database). Fixes admin account being wiped on deployment (#242)

## Commits
- `7953cd5` — feat: split language into Language, Script, Region fields (#240)
- `a53ef35` — fix: preserve SQLite directory and protect DB from git/web access (#242)

## Files changed (5)
- `appWeb/public_html/manage/editor/index.php` — three language sub-fields with datalists + composed tag preview
- `appWeb/public_html/manage/editor/editor.js` — `parseIetfTag()` / `composeIetfTag()` / `getVal()` helpers; updated `selectSong()`, `clearEditForm()`, `bindMetadataListeners()`
- `appWeb/data_share/SQLite/.gitkeep` — preserves directory in git
- `appWeb/data_share/SQLite/.htaccess` — denies direct web access
- `.gitignore` — excludes `appWeb/data_share/SQLite/*.db`

## Test plan
- [ ] Editor: select a song — verify Language, Script, Region fields populate from existing IETF tag
- [ ] Editor: change Language/Script/Region — verify composed IETF tag updates in preview
- [ ] Editor: verify composed tag is saved to song object (check JSON output)
- [ ] Deploy: verify `data_share/SQLite/` directory persists and `.db` file is not overwritten
- [ ] Verify `.htaccess` blocks direct access to `data_share/SQLite/ihymns.db`

Closes #240, closes #242

https://claude.ai/code/session_019iLcFctpajfVnyEsGqZCvj