### PR TITLE
feat: sortable song list, title formatting, PWA install detection

### DIFF
--- a/appWeb/public_html/js/modules/pwa.js
+++ b/appWeb/public_html/js/modules/pwa.js
@@ -38,10 +38,17 @@ export class PWA {
     /**
      * Initialise PWA module — listen for install prompt and set up banner.
      */
-    init() {
-        /* If running as installed PWA, don't show banner */
+    async init() {
+        /* If running as installed PWA, set the cross-subdomain cookie and exit */
         if (window.matchMedia('(display-mode: standalone)').matches ||
             window.navigator.standalone === true) {
+            this._setPwaInstalledCookie();
+            return;
+        }
+
+        /* Check if PWA is already installed (cross-subdomain) before proceeding (#248) */
+        const alreadyInstalled = await this._isAlreadyInstalled();
+        if (alreadyInstalled) {
             return;
         }
 
@@ -56,6 +63,7 @@ export class PWA {
         window.addEventListener('appinstalled', () => {
             this.deferredPrompt = null;
             this.hideInstallBanner();
+            this._setPwaInstalledCookie();
             this.app.showToast('App installed successfully!', 'success');
         });
 
@@ -243,6 +251,91 @@ export class PWA {
     }
 
     /* =====================================================================
+     * INSTALLED DETECTION (#248)
+     *
+     * Two strategies for cross-subdomain detection:
+     * 1. navigator.getInstalledRelatedApps() — Chromium API, matches by
+     *    manifest id. Requires "platform": "webapp" in related_applications.
+     * 2. Shared parent-domain cookie — set when running in standalone mode,
+     *    readable from any subdomain (e.g. dev., alpha., www.).
+     * ===================================================================== */
+
+    /**
+     * Check if the PWA is already installed, using all available methods.
+     *
+     * @returns {Promise<boolean>} True if the PWA appears to be installed.
+     */
+    async _isAlreadyInstalled() {
+        /* Strategy 1: getInstalledRelatedApps() — Chromium browsers */
+        if ('getInstalledRelatedApps' in navigator) {
+            try {
+                const apps = await navigator.getInstalledRelatedApps();
+                if (apps.length > 0) {
+                    return true;
+                }
+            } catch (e) {
+                /* API not available or failed — fall through to cookie check */
+            }
+        }
+
+        /* Strategy 2: shared parent-domain cookie */
+        if (this._getPwaInstalledCookie()) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Set a cookie on the parent domain indicating the PWA is installed.
+     * Called when running in standalone mode or after a successful install.
+     * The cookie is set on the highest-level domain that isn't a public
+     * suffix (e.g. .ihymns.app), so all subdomains can read it.
+     */
+    _setPwaInstalledCookie() {
+        const domain = this._getParentDomain();
+        const maxAge = 365 * 24 * 60 * 60; /* 1 year */
+        let cookie = 'ihymns_pwa_installed=1; path=/; max-age=' + maxAge + '; SameSite=Lax';
+        if (domain) {
+            cookie += '; domain=' + domain;
+        }
+        document.cookie = cookie;
+    }
+
+    /**
+     * Read the shared PWA-installed cookie.
+     *
+     * @returns {boolean} True if the cookie exists.
+     */
+    _getPwaInstalledCookie() {
+        return document.cookie.split(';').some(c => c.trim().startsWith('ihymns_pwa_installed='));
+    }
+
+    /**
+     * Determine the parent domain for cross-subdomain cookies.
+     * e.g. "dev.ihymns.app" → ".ihymns.app"
+     *       "ihymns.app"     → ".ihymns.app"
+     *       "localhost"      → null (no parent domain)
+     *
+     * @returns {string|null} Parent domain with leading dot, or null.
+     */
+    _getParentDomain() {
+        const host = window.location.hostname;
+
+        /* Skip for localhost / IP addresses */
+        if (host === 'localhost' || /^\d+\.\d+\.\d+\.\d+$/.test(host)) {
+            return null;
+        }
+
+        const parts = host.split('.');
+        /* Need at least 2 parts (e.g. ihymns.app) */
+        if (parts.length < 2) return null;
+
+        /* Use the last two parts as the parent domain */
+        return '.' + parts.slice(-2).join('.');
+    }
+
+    /* =====================================================================
      * INSTALL ACTIONS
      * ===================================================================== */
 
@@ -270,6 +363,7 @@ export class PWA {
 
             if (outcome === 'accepted') {
                 this.hideInstallBanner();
+                this._setPwaInstalledCookie();
             }
         }
     }

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -343,17 +343,26 @@ function renderSongList(filter) {
             li.classList.add('active');
         }
 
-        /* Build the display text: "number — title". */
+        /* Build the display text: "number - Title Case Title" (#249). */
         var label = document.createElement('span');
-        label.textContent = (song.number || '?') + ' \u2014 ' + (song.title || 'Untitled');
+        label.textContent = (song.number || '?') + ' - ' + toTitleCase(song.title || 'Untitled');
 
-        /* Append a small badge if the song has been modified. */
+        /* Right-side badges: songbook abbreviation + modified indicator (#249). */
         var badges = document.createElement('span');
+        badges.className = 'd-flex align-items-center gap-1 flex-shrink-0';
         if (modifiedSongIds.has(song.id)) {
-            var badge = document.createElement('span');
-            badge.className = 'badge bg-warning text-dark ms-2';
-            badge.textContent = 'modified';
-            badges.appendChild(badge);
+            var modBadge = document.createElement('span');
+            modBadge.className = 'badge bg-warning text-dark';
+            modBadge.style.fontSize = '0.65rem';
+            modBadge.textContent = 'modified';
+            badges.appendChild(modBadge);
+        }
+        if (song.songbook) {
+            var sbBadge = document.createElement('span');
+            sbBadge.className = 'badge rounded-pill';
+            sbBadge.style.cssText = 'background-color: rgba(245,158,11,0.15); color: #f59e0b; font-size: 0.65rem; font-weight: 600;';
+            sbBadge.textContent = song.songbook;
+            badges.appendChild(sbBadge);
         }
 
         li.appendChild(label);
@@ -1845,6 +1854,29 @@ function composeIetfTag() {
 function getVal(elementId) {
     var el = document.getElementById(elementId);
     return el ? el.value : '';
+}
+
+/**
+ * toTitleCase(str)
+ * ----------------
+ * Converts a string to Title Case. Common small words (a, an, the, and,
+ * but, or, for, nor, in, on, at, to, by, of, with) stay lowercase unless
+ * they are the first or last word.
+ *
+ * @param {string} str - The input string.
+ * @returns {string} The title-cased string.
+ */
+function toTitleCase(str) {
+    var smallWords = /^(a|an|the|and|but|or|for|nor|in|on|at|to|by|of|with)$/i;
+    var words = str.replace(/\s+/g, ' ').trim().split(' ');
+
+    return words.map(function (word, i, arr) {
+        /* Always capitalise first and last word */
+        if (i === 0 || i === arr.length - 1 || !smallWords.test(word)) {
+            return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+        }
+        return word.toLowerCase();
+    }).join(' ');
 }
 
 /**

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -55,6 +55,9 @@ var modifiedSongIds = new Set();
 /** Timestamp (Date object) of the most recent save/download action, or null. */
 var lastSaveTime = null;
 
+/** Current sort mode for the song list: 'title', 'number', or 'songbook' (#251). */
+var currentSortMode = 'title';
+
 /* ========================================================================
  *  SECTION 2 — Data Management (#53, #58)
  * ======================================================================== */
@@ -313,8 +316,22 @@ function renderSongList(filter) {
     /* Count how many songs pass the filters (for the badge). */
     var visibleCount = 0;
 
-    /* Iterate over every song in the data set. */
-    songData.songs.forEach(function (song) {
+    /* Sort songs according to the current sort mode (#251). */
+    var sortedSongs = songData.songs.slice().sort(function (a, b) {
+        if (currentSortMode === 'title') {
+            return (a.title || '').localeCompare(b.title || '', undefined, { sensitivity: 'base' });
+        } else if (currentSortMode === 'number') {
+            return (Number(a.number) || 0) - (Number(b.number) || 0);
+        } else if (currentSortMode === 'songbook') {
+            var sbCmp = (a.songbook || '').localeCompare(b.songbook || '', undefined, { sensitivity: 'base' });
+            if (sbCmp !== 0) return sbCmp;
+            return (Number(a.number) || 0) - (Number(b.number) || 0);
+        }
+        return 0;
+    });
+
+    /* Iterate over sorted songs. */
+    sortedSongs.forEach(function (song) {
         /* ---- Songbook filter ---- */
         if (songbookFilter && song.songbook !== songbookFilter) {
             return; // skip songs not in the selected songbook
@@ -2130,6 +2147,15 @@ function bindGlobalEventListeners() {
     if (searchEl) {
         /* Re-render the song list on every keystroke for instant filtering. */
         searchEl.addEventListener('input', function () {
+            renderSongList();
+        });
+    }
+
+    /* ---- Sort order dropdown (#251) ---- */
+    var sortEl = document.getElementById('song-sort');
+    if (sortEl) {
+        sortEl.addEventListener('change', function () {
+            currentSortMode = sortEl.value;
             renderSongList();
         });
     }

--- a/appWeb/public_html/manage/editor/index.php
+++ b/appWeb/public_html/manage/editor/index.php
@@ -626,7 +626,7 @@ $currentUser = getCurrentUser();
                 </div>
 
                 <!-- Search input — live text search across song titles -->
-                <div class="input-group input-group-sm">
+                <div class="input-group input-group-sm mb-2">
                     <span class="input-group-text" style="background-color: var(--ih-bg-input); border-color: var(--ih-border); color: var(--ih-text-muted);">
                         <i class="bi bi-search"></i>
                     </span>
@@ -638,6 +638,19 @@ $currentUser = getCurrentUser();
                         aria-label="Search songs by title"
                     >
                 </div>
+
+                <!-- Sort order toggle (#251) -->
+                <select
+                    class="form-select form-select-sm"
+                    id="song-sort"
+                    aria-label="Sort songs by"
+                    title="Sort order"
+                    style="font-size: 0.75rem;"
+                >
+                    <option value="title" selected>Sort by Title (A–Z)</option>
+                    <option value="number">Sort by Number</option>
+                    <option value="songbook">Sort by Songbook, then Number</option>
+                </select>
             </div>
 
             <!-- Song list — scrollable container; each song is a clickable row -->

--- a/appWeb/public_html/manifest.json
+++ b/appWeb/public_html/manifest.json
@@ -37,6 +37,10 @@
     "prefer_related_applications": false,
     "related_applications": [
         {
+            "platform": "webapp",
+            "url": "https://ihymns.app/manifest.json"
+        },
+        {
             "platform": "play",
             "id": "ltd.mwbmpartners.ihymns",
             "url": "https://play.google.com/store/apps/details?id=ltd.mwbmpartners.ihymns"


### PR DESCRIPTION
## Summary

- **Sortable song list** — dropdown with three sort modes: Title A–Z (default), Number, Songbook then Number. Uses locale-aware comparison (#251)
- **Song list format** — `number - Title Case Title` with amber songbook badge on the right. Added `toTitleCase()` helper with proper small-word handling (#249)
- **PWA install banner detection** — hides banner when PWA already installed, cross-subdomain via `getInstalledRelatedApps()` API + shared parent-domain cookie on `.ihymns.app` (#248)

## Commits
- `0dec2a4` — feat: sortable song list — title (default), number, songbook (#251)
- `e02d2e0` — feat: editor song list — title case + songbook badge (#249)
- `26af33d` — feat: hide PWA install banner when already installed cross-subdomain (#248)

## Files changed
- `appWeb/public_html/manage/editor/editor.js` — sort logic, `toTitleCase()`, songbook badge, sort mode global
- `appWeb/public_html/manage/editor/index.php` — sort dropdown in sidebar header
- `appWeb/public_html/js/modules/pwa.js` — installed detection with `_isAlreadyInstalled()`, cookie helpers
- `appWeb/public_html/manifest.json` — added `"platform": "webapp"` to `related_applications`

## Test plan
- [ ] Editor: songs default to alphabetical title order
- [ ] Editor: sort dropdown switches between title / number / songbook+number
- [ ] Editor: titles display in Title Case with songbook badge on right
- [ ] Editor: small words (a, the, of, in, etc.) lowercase except at start/end
- [ ] PWA: install banner hidden when PWA already installed from any subdomain
- [ ] PWA: cookie set when running in standalone mode

Closes #248, closes #249, closes #251

https://claude.ai/code/session_019iLcFctpajfVnyEsGqZCvj