### PR TITLE
Fix: SQLite database wiped on every deploy (#253)

### DIFF
--- a/appWeb/public_html/manage/includes/db.php
+++ b/appWeb/public_html/manage/includes/db.php
@@ -43,7 +43,7 @@ define('DB_CONFIG', [
 
     /* SQLite — file-based, zero-configuration */
     'sqlite' => [
-        'path' => dirname(__DIR__, 2) . '/data_share/SQLite/ihymns.db',
+        'path' => dirname(__DIR__, 3) . '/data_share/SQLite/ihymns.db',
     ],
 
     /* MySQL / MariaDB — uncomment and configure when ready to migrate */


### PR DESCRIPTION
## Summary

- **Fix critical bug** where the SQLite database was placed inside `public_html/` due to incorrect `dirname(__DIR__, 2)` — changed to `dirname(__DIR__, 3)` so the DB lives in `data_share/` (sibling to `public_html/`)
- This caused the database to be wiped on every deploy because `lftp mirror --reverse --delete` removes files not in the source from `public_html/`
- Admins were forced to re-register after every push

Closes #253

## Test plan
- [ ] Deploy to alpha and verify admin accounts persist after subsequent deploys
- [ ] Verify the SQLite DB is created at `appWeb/data_share/SQLite/ihymns.db` (not inside `public_html/`)
- [ ] Confirm `/manage/editor` does not prompt for re-registration after a push

https://claude.ai/code/session_019iLcFctpajfVnyEsGqZCvj