### PR TITLE
docs: add comprehensive GitHub Wiki pages (13 pages)

### DIFF
--- a/wiki/API-Reference.md
+++ b/wiki/API-Reference.md
@@ -1,0 +1,384 @@
+# API Reference
+
+> Complete reference for the iHymns server-side API (`api.php`)
+
+---
+
+## Overview
+
+All API requests go through `api.php`. There are two request types:
+
+- **Page requests** (`?page=...`) — return HTML fragments for AJAX page loading
+- **Action requests** (`?action=...`) — return JSON data
+
+All JSON responses include:
+- `Content-Type: application/json; charset=UTF-8`
+- `X-Content-Type-Options: nosniff`
+- `Cache-Control: no-cache, must-revalidate`
+
+---
+
+## Page Endpoints
+
+These return HTML fragments loaded into the SPA content area.
+
+| Parameter | Description |
+|---|---|
+| `?page=home` | Home page |
+| `?page=songbooks` | Songbook grid |
+| `?page=songbook&id=CP` | Song list for songbook |
+| `?page=song&id=CP-0001` | Song lyrics |
+| `?page=search` | Search page |
+| `?page=favorites` | Favourites page |
+| `?page=setlist` | Setlist page |
+| `?page=setlist-shared` | Shared setlist import page |
+| `?page=settings` | Settings page |
+| `?page=stats` | Collection statistics |
+| `?page=writer&id=slug` | Writer/composer page |
+| `?page=help` | Help page |
+| `?page=terms` | Terms of use |
+| `?page=privacy` | Privacy policy |
+
+---
+
+## Song Data Endpoints
+
+### `GET ?action=search`
+
+Full-text fuzzy search across all fields.
+
+| Parameter | Required | Description |
+|---|---|---|
+| `q` | Yes | Search query string |
+| `songbook` | No | Filter by songbook abbreviation |
+| `limit` | No | Max results (default: 50) |
+
+**Response:**
+```json
+{
+  "results": [{ "id": "MP-0001", "number": 1, "title": "...", "songbook": "MP", ... }],
+  "total": 42,
+  "query": "amazing grace"
+}
+```
+
+### `GET ?action=search_num`
+
+Search by song number within a songbook.
+
+| Parameter | Required | Description |
+|---|---|---|
+| `songbook` | Yes | Songbook abbreviation |
+| `number` | Yes | Song number |
+
+### `GET ?action=random`
+
+Get a random song.
+
+| Parameter | Required | Description |
+|---|---|---|
+| `songbook` | No | Filter by songbook |
+
+**Response:**
+```json
+{ "song": { "id": "...", "title": "...", "components": [...], ... } }
+```
+
+### `GET ?action=song_data&id=CP-0001`
+
+Get full song data including lyrics/components.
+
+### `GET ?action=songbooks`
+
+Get all songbooks with metadata.
+
+### `GET ?action=songs`
+
+Get song list (summaries only, no lyrics).
+
+| Parameter | Required | Description |
+|---|---|---|
+| `songbook` | No | Filter by songbook |
+
+### `GET ?action=stats`
+
+Get collection statistics (song counts, songbook breakdown).
+
+### `GET ?action=songs_json`
+
+Stream the full `songs.json` file. Supports `ETag` and `If-Modified-Since` for conditional caching.
+
+---
+
+## Shared Setlist Endpoints
+
+### `POST ?action=setlist_share`
+
+Create or update a shared setlist.
+
+**Request body (JSON):**
+```json
+{
+  "name": "Sunday Service",
+  "songs": ["MP-0001", "CP-0042"],
+  "owner": "uuid-string",
+  "id": "abc12345",
+  "arrangements": {
+    "MP-0001": [0, 2, 1, 2]
+  }
+}
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `name` | Yes | Setlist name (max 200 chars) |
+| `songs` | Yes | Array of song IDs (max 200) |
+| `owner` | Yes | Owner UUID (for ownership verification) |
+| `id` | No | Existing share ID (for updates) |
+| `arrangements` | No | Map of song ID to component index arrays |
+
+**Response:**
+```json
+{ "id": "abc12345", "url": "/setlist/shared/abc12345" }
+```
+
+### `GET ?action=setlist_get&id=abc12345`
+
+Retrieve a shared setlist by its 8-character hex ID.
+
+**Response:**
+```json
+{
+  "id": "abc12345",
+  "name": "Sunday Service",
+  "songs": ["MP-0001", "CP-0042"],
+  "arrangements": { "MP-0001": [0, 2, 1, 2] },
+  "created": "2026-04-09T10:00:00+00:00",
+  "updated": "2026-04-09T10:00:00+00:00"
+}
+```
+
+---
+
+## Authentication Endpoints
+
+All auth endpoints use JSON request/response bodies. See [[User Accounts & Roles]] for the role hierarchy.
+
+### `POST ?action=auth_register`
+
+Register a new user account.
+
+**Request body:**
+```json
+{
+  "username": "john",
+  "password": "securepass123",
+  "display_name": "John Smith"
+}
+```
+
+**Validation:**
+- Username: min 3 chars, lowercase letters/numbers/`_`/`-`/`.` only
+- Password: min 8 characters
+- Display name: defaults to username if omitted
+
+**Response (201):**
+```json
+{
+  "token": "64-char-hex-bearer-token...",
+  "user": {
+    "id": 1,
+    "username": "john",
+    "display_name": "John Smith",
+    "role": "user"
+  }
+}
+```
+
+**Note:** The very first registered user is automatically assigned the `global_admin` role. All subsequent registrations get the `user` role.
+
+### `POST ?action=auth_login`
+
+Log in with existing credentials.
+
+**Request body:**
+```json
+{ "username": "john", "password": "securepass123" }
+```
+
+**Response (200):**
+```json
+{
+  "token": "64-char-hex-bearer-token...",
+  "user": {
+    "id": 1,
+    "username": "john",
+    "display_name": "John Smith",
+    "role": "editor"
+  }
+}
+```
+
+**Error (401):**
+```json
+{ "error": "Invalid username or password." }
+```
+
+### `POST ?action=auth_logout`
+
+Invalidate the current bearer token.
+
+**Headers:** `Authorization: Bearer <token>`
+
+**Response:**
+```json
+{ "ok": true }
+```
+
+### `GET ?action=auth_me`
+
+Get the currently authenticated user's info.
+
+**Headers:** `Authorization: Bearer <token>`
+
+**Response:**
+```json
+{
+  "user": {
+    "id": 1,
+    "username": "john",
+    "display_name": "John Smith",
+    "role": "editor"
+  }
+}
+```
+
+### `POST ?action=auth_forgot_password`
+
+Request a password reset token. Always returns 200 to prevent user enumeration.
+
+**Request body:**
+```json
+{ "username": "john" }
+```
+
+Accepts username or email address.
+
+**Response (200):**
+```json
+{
+  "ok": true,
+  "message": "If an account exists with that username or email, a reset link has been generated.",
+  "_dev_token": "48-char-hex-token..."
+}
+```
+
+**Note:** `_dev_token` is included for development/testing only. In production, the token should be delivered via email.
+
+### `POST ?action=auth_reset_password`
+
+Reset password using a valid reset token.
+
+**Request body:**
+```json
+{
+  "token": "48-char-hex-token...",
+  "password": "newSecurePass123"
+}
+```
+
+**Response (200):**
+```json
+{ "ok": true, "message": "Password reset successfully. Please sign in with your new password." }
+```
+
+**Side effects:** Invalidates all existing API tokens for the user (forces re-login on all devices).
+
+---
+
+## User Setlist Endpoints
+
+Require `Authorization: Bearer <token>` header.
+
+### `GET ?action=user_setlists`
+
+Get all setlists for the authenticated user.
+
+**Response:**
+```json
+{
+  "setlists": [
+    {
+      "id": "setlist-uuid",
+      "name": "Sunday Morning",
+      "songs": [
+        { "id": "MP-0001", "title": "...", "songbook": "MP", "number": 1 }
+      ],
+      "createdAt": "2026-04-09T10:00:00+00:00",
+      "updatedAt": "2026-04-09T10:00:00+00:00"
+    }
+  ]
+}
+```
+
+### `POST ?action=user_setlists_sync`
+
+Merge local setlists with server-side storage. New setlists are inserted; existing ones are updated. Server-only setlists are preserved.
+
+**Request body:**
+```json
+{
+  "setlists": [
+    {
+      "id": "setlist-uuid",
+      "name": "Sunday Morning",
+      "createdAt": "2026-04-09T10:00:00+00:00",
+      "songs": [
+        {
+          "id": "MP-0001",
+          "title": "A New Commandment",
+          "songbook": "MP",
+          "number": 1,
+          "arrangement": [0, 2, 1, 2]
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Limits:** Max 50 setlists per user, 200 songs per setlist.
+
+**Response:** Same format as `user_setlists` — returns the full merged result.
+
+---
+
+## Bearer Token Details
+
+| Property | Value |
+|---|---|
+| Format | 64-character lowercase hexadecimal string |
+| Expiry | 30 days from creation |
+| Storage | `api_tokens` table in SQLite |
+| Header | `Authorization: Bearer <token>` |
+| Fallback header | `REDIRECT_HTTP_AUTHORIZATION` (for Apache CGI/FCGI) |
+
+---
+
+## Error Responses
+
+All errors follow this format:
+
+```json
+{ "error": "Human-readable error message." }
+```
+
+| HTTP Code | Meaning |
+|---|---|
+| 400 | Bad request / validation error |
+| 401 | Not authenticated / invalid token |
+| 403 | Forbidden / insufficient role |
+| 404 | Resource not found |
+| 405 | Method not allowed (e.g. GET on POST-only endpoint) |
+| 409 | Conflict (e.g. username already taken) |
+| 500 | Server error |

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -1,0 +1,161 @@
+# Architecture
+
+> Technical architecture of the iHymns multiplatform application
+
+---
+
+## Project Structure
+
+```text
+iHymns/
+├── .claude/                  # Claude AI context & project brief
+├── .github/workflows/        # CI/CD: deploy, version bump, changelog, tests
+├── .SourceSongData/           # Raw song text files (source of truth — DO NOT MODIFY)
+├── tools/                    # Build tools & song data parser
+│   ├── parse-songs.js        #   Parses .SourceSongData/ → songs.json
+│   └── build-web.js          #   Web build/packaging script
+├── data/                     # Generated song data
+│   ├── songs.json            #   Canonical song database (single source of truth)
+│   └── songs.schema.json     #   JSON Schema (draft 2020-12) for validation
+├── tests/                    # 33 unit tests
+├── appWeb/                   # Web PWA application
+│   ├── public_html/          #   Deployed source (single source for all environments)
+│   │   ├── index.php         #     SPA shell — OG tags, CSP, JSON-LD
+│   │   ├── api.php           #     AJAX API — pages, search, auth, setlists
+│   │   ├── includes/         #     PHP components, pages, config
+│   │   ├── js/               #     ES modules architecture
+│   │   │   ├── app.js        #       Main app bootstrap (25+ modules)
+│   │   │   ├── modules/      #       Feature modules (router, search, setlist, etc.)
+│   │   │   └── utils/        #       Utilities (html.js, text.js, components.js)
+│   │   ├── css/              #     Stylesheets
+│   │   └── manage/           #     Admin area (editor, users, auth)
+│   ├── data_share/           #   Shared data (songs.json, setlists, SQLite DB)
+│   └── private_html/         #   Private admin tools (song editor — legacy)
+├── appApple/                 # Native Apple app (Swift 6.3 / SwiftUI)
+├── appAndroid/               # Native Android app (Kotlin 2.1 / Jetpack Compose)
+├── help/                     # User documentation (6 guides)
+└── wiki/                     # GitHub Wiki source pages
+```
+
+---
+
+## Web PWA Architecture
+
+### SPA Pattern
+
+The PWA is a single-page application served from `index.php`. All URLs are rewritten via `.htaccess` to `index.php`, which:
+
+1. Generates a unique CSP nonce per request
+2. Detects the URL path for Open Graph meta tags and JSON-LD structured data
+3. Renders the HTML shell (header, content area, footer)
+4. Loads the JS app which handles client-side routing via History API
+
+### JavaScript Module Architecture
+
+The app uses **ES modules** with a central `iHymnsApp` class that coordinates 25+ feature modules:
+
+```
+iHymnsApp
+├── Router          — History API routing, AJAX page loading
+├── Transitions     — Page transition animations
+├── Settings        — Theme, motion, font size, analytics consent
+├── Search          — Fuse.js search with TF-IDF related songs
+├── Favorites       — Favourite songs (localStorage)
+├── SetList         — Setlists with custom arrangements
+├── UserAuth        — Bearer token auth, cross-device sync
+├── PWA             — Install banner, service worker
+├── Audio           — MIDI playback
+├── SheetMusic      — PDF sheet music viewer
+├── History         — Recently viewed songs
+├── Display         — Presentation mode, font prefs
+├── Compare         — Side-by-side song comparison
+├── Shortcuts       — Keyboard shortcuts overlay
+├── Numpad          — Numeric keypad for song number search
+├── Share           — Song sharing (Web Share API)
+├── Shuffle         — Random song picker
+├── Transpose       — Capo/transpose indicator
+├── ReadingProgress — Scroll-linked progress bar
+├── SongbookIndex   — Alphabetical songbook index
+├── SearchHistory   — Recent search terms
+├── SongOfTheDay    — Daily featured song
+├── OfflineIndicator— Online/offline status
+├── StorageBridge   — Cross-domain localStorage sync
+├── SubdomainSync   — Subdomain cookie sync
+├── Gestures        — Touch swipe navigation
+├── Analytics       — GA4, Plausible, Clarity, Matomo, Fathom
+└── Request         — Missing song request form
+```
+
+### PHP Server Architecture
+
+```
+index.php           — SPA shell (OG tags, CSP nonce, JSON-LD)
+api.php             — AJAX API (pages, search, auth, setlists)
+├── includes/
+│   ├── config.php      — Centralised configuration
+│   ├── infoAppVer.php  — App version metadata
+│   ├── SongData.php    — Song data handler class
+│   ├── components/     — Reusable PHP components
+│   └── pages/          — Page templates (home, song, setlist, etc.)
+└── manage/
+    ├── includes/
+    │   ├── auth.php     — Authentication middleware (roles, sessions, CSRF)
+    │   └── db.php       — Database connection factory (SQLite/MySQL/SQL Server)
+    ├── editor/          — Song editor (requires editor+ role)
+    ├── users.php        — User management (requires admin+ role)
+    ├── setup.php        — First-run Global Admin setup
+    ├── login.php        — Admin login page
+    └── logout.php       — Admin logout
+```
+
+### Data Flow
+
+```
+.SourceSongData/ (raw text files)
+        │
+        ▼  tools/parse-songs.js
+data/songs.json (canonical, 5.22 MB)
+        │
+        ├──▶ appWeb/data_share/song_data/songs.json (deployed copy)
+        ├──▶ appApple/ (bundled in app)
+        └──▶ appAndroid/ (bundled in assets)
+```
+
+---
+
+## Native App Architecture
+
+### Apple (Swift 6.3 / SwiftUI)
+
+- **Pattern**: Observable object (`SongStore`) + SwiftUI views
+- **Data**: Bundled `songs.json` from app bundle
+- **Persistence**: UserDefaults for favorites
+- **Platforms**: Universal — iPhone, iPad, Mac, Apple TV, Vision Pro, Watch
+- **UI**: `TabView` (iPhone) / `NavigationSplitView` (iPad/Mac)
+
+### Android (Kotlin 2.1 / Jetpack Compose)
+
+- **Pattern**: MVVM with `SongViewModel` + StateFlow
+- **Data**: Bundled `songs.json` from assets
+- **Persistence**: SharedPreferences for favorites
+- **Platforms**: Phone, Tablet, Android TV, Fire OS
+- **UI**: Single-activity, NavHost navigation
+- **Compatibility**: Zero Google Play Services dependencies (Fire OS compatible)
+
+---
+
+## Database
+
+SQLite (default) with migration support for MySQL/MariaDB and SQL Server. See [[Database & Migrations]] for details.
+
+---
+
+## Security
+
+- Content Security Policy with per-request nonces
+- SRI hashes on all CDN resources
+- CSRF tokens for form submissions
+- BCRYPT password hashing (cost 12)
+- Bearer token auth for public API (64-char hex)
+- Session-based auth for admin panel
+- See [[Security]] for full details

--- a/wiki/Database-&-Migrations.md
+++ b/wiki/Database-&-Migrations.md
@@ -1,0 +1,163 @@
+# Database & Migrations
+
+> SQLite database, schema migrations, and multi-driver support
+
+---
+
+## Overview
+
+The iHymns admin backend uses a relational database for user accounts, API tokens, setlists, and password reset tokens. The default driver is **SQLite** (zero-configuration), with migration support for **MySQL/MariaDB** and **SQL Server**.
+
+---
+
+## Configuration
+
+Database configuration is in `appWeb/public_html/manage/includes/db.php`:
+
+```php
+define('DB_CONFIG', [
+    'driver' => 'sqlite',  // Change to 'mysql' or 'sqlsrv' to switch
+
+    'sqlite' => [
+        'path' => dirname(__DIR__, 3) . '/data_share/SQLite/ihymns.db',
+    ],
+
+    'mysql' => [
+        'host' => '127.0.0.1', 'port' => 3306,
+        'database' => 'ihymns', 'username' => '', 'password' => '',
+        'charset' => 'utf8mb4',
+    ],
+
+    'sqlsrv' => [
+        'host' => '127.0.0.1', 'port' => 1433,
+        'database' => 'ihymns', 'username' => '', 'password' => '',
+    ],
+]);
+```
+
+### SQLite File Location
+
+The SQLite database is stored at `appWeb/data_share/SQLite/ihymns.db` — **outside the public web root** for security. The directory is created automatically if it doesn't exist.
+
+**Important:** The `data_share/` directory is deployed **without** the `--delete` flag, so the database is preserved between deployments.
+
+---
+
+## Connection Factory
+
+The `getDb()` function returns a shared PDO instance (singleton per request):
+
+- Creates the connection on first call, reuses for subsequent calls
+- Automatically creates the SQLite file and directory if needed
+- Runs all pending migrations on every connection (idempotent)
+- Enables WAL journal mode and foreign keys for SQLite
+
+---
+
+## Schema Migrations
+
+Migrations are idempotent SQL statements tracked in a `migrations` table. New migrations are appended to the array and run in order.
+
+### Current Migrations
+
+| Migration | Table | Purpose |
+|---|---|---|
+| `001_create_users` | `users` | User accounts (username, password_hash, display_name, role, is_active) |
+| `002_create_sessions` | `sessions` | PHP sessions (for admin panel) |
+| `003_create_api_tokens` | `api_tokens` | Bearer tokens for public API auth |
+| `004_create_user_setlists` | `user_setlists` | Server-side setlist storage linked to user accounts |
+| `005_create_password_reset_tokens` | `password_reset_tokens` | Password reset tokens (48-char hex, 1hr expiry, single-use) |
+| `006_add_user_email` | `users` | Adds `email` column for password reset delivery |
+
+### Table Schemas
+
+#### `users`
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | INTEGER PK | Auto-increment user ID |
+| `username` | TEXT UNIQUE | Lowercase login name |
+| `password_hash` | TEXT | BCRYPT hash (cost 12) |
+| `display_name` | TEXT | Human-readable name |
+| `role` | TEXT | `global_admin`, `admin`, `editor`, or `user` |
+| `email` | TEXT | Email for password resets |
+| `is_active` | INTEGER | 1=active, 0=disabled |
+| `created_at` | TEXT | ISO 8601 timestamp |
+| `updated_at` | TEXT | ISO 8601 timestamp |
+
+#### `api_tokens`
+
+| Column | Type | Description |
+|---|---|---|
+| `token` | TEXT PK | 64-char hex bearer token |
+| `user_id` | INTEGER FK | References `users(id)` CASCADE |
+| `created_at` | TEXT | ISO 8601 timestamp |
+| `expires_at` | TEXT | Token expiry (30 days from creation) |
+
+#### `user_setlists`
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | INTEGER PK | Auto-increment |
+| `user_id` | INTEGER FK | References `users(id)` CASCADE |
+| `setlist_id` | TEXT | Client-generated setlist UUID |
+| `name` | TEXT | Setlist name |
+| `songs_json` | TEXT | JSON array of song entries |
+| `created_at` | TEXT | ISO 8601 timestamp |
+| `updated_at` | TEXT | ISO 8601 timestamp |
+| | UNIQUE | `(user_id, setlist_id)` — one per user per setlist |
+
+#### `password_reset_tokens`
+
+| Column | Type | Description |
+|---|---|---|
+| `token` | TEXT PK | 48-char hex reset token |
+| `user_id` | INTEGER FK | References `users(id)` CASCADE |
+| `created_at` | TEXT | ISO 8601 timestamp |
+| `expires_at` | TEXT | Token expiry (1 hour from creation) |
+| `used` | INTEGER | 0=unused, 1=used |
+
+#### `sessions`
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | TEXT PK | Session ID |
+| `user_id` | INTEGER FK | References `users(id)` CASCADE |
+| `ip_address` | TEXT | Client IP |
+| `user_agent` | TEXT | Client user agent |
+| `created_at` | TEXT | ISO 8601 timestamp |
+| `expires_at` | TEXT | Session expiry |
+
+---
+
+## Adding New Migrations
+
+To add a new migration, append to the `$migrations` array in `runMigrations()`:
+
+```php
+'007_your_migration_name' => '
+    CREATE TABLE IF NOT EXISTS your_table (
+        id INTEGER PRIMARY KEY ' . ($driver === 'sqlite' ? 'AUTOINCREMENT' : 'AUTO_INCREMENT') . ',
+        ...
+    )
+',
+```
+
+**Rules:**
+- Use standard SQL compatible with both SQLite and MySQL
+- Use the `$driver` variable for driver-specific syntax (e.g., `AUTOINCREMENT` vs `AUTO_INCREMENT`)
+- Migrations are idempotent — use `IF NOT EXISTS` for CREATE, `IF EXISTS` for DROP
+- Migration names must be unique — prefix with a sequential number
+- Never modify existing migrations — always add new ones
+
+---
+
+## Switching Database Drivers
+
+To switch from SQLite to MySQL:
+
+1. Change `'driver' => 'mysql'` in `DB_CONFIG`
+2. Fill in the MySQL connection details
+3. The migrations will run automatically on first connection, creating all tables
+
+The migrations use driver-conditional syntax for `AUTO_INCREMENT` vs `AUTOINCREMENT`.

--- a/wiki/Deployment-&-CI-CD.md
+++ b/wiki/Deployment-&-CI-CD.md
@@ -1,0 +1,154 @@
+# Deployment & CI/CD
+
+> Automated deployment pipelines, branch strategy, and secrets configuration
+
+---
+
+## Branch Strategy
+
+| Branch | Purpose | Deploys To |
+|---|---|---|
+| `alpha` | Experimental | `public_html/` to remote `public_html_dev/` |
+| `beta` | Active development | `public_html/` to remote `public_html_beta/` |
+| `main` | Production releases | `public_html/` to remote `public_html/` |
+
+All branches deploy from `appWeb/public_html/` — the branch determines the remote SFTP target path.
+
+---
+
+## Web Directory Structure
+
+| Directory | Purpose | Deployment |
+|---|---|---|
+| `appWeb/public_html/` | Single source directory | Deployed to all environments |
+| `appWeb/data_share/` | Shared data (songs.json, setlists, SQLite DB) | Deployed alongside public_html (without `--delete`) |
+| `appWeb/private_html/` | Private admin tools, song editor | Separate SFTP path (`SFTP_PRIVATE_PATH`) |
+
+---
+
+## GitHub Actions Workflows
+
+### 1. Deploy (`deploy.yml`)
+
+SFTP mirroring using `lftp`. Triggered on push to `alpha`, `beta`, or `main`.
+
+- Uses `lftp mirror --reverse` for one-way sync
+- `--exclude` uses **regex patterns** (NOT shell globs): e.g., `\.xcodeproj$` not `*.xcodeproj`
+- `appWeb/data_share/` deployed **without** `--delete` to preserve runtime data (SQLite DB, shared setlists)
+- `.env-channel` file injected by CI for server-side environment detection
+- `[deploy all]` in commit message forces full upload (ignores change detection)
+- `[skip ci]` in commit message skips all workflows
+- Kill switch: `vars.SFTP_ENABLED` must be `true`
+
+### 2. Version Bump (`version-bump.yml`)
+
+Auto-bumps version via conventional commits on push to `beta`.
+
+### 3. Changelog Generation (`changelog.yml`)
+
+Auto-generates `CHANGELOG.md` from conventional commit messages.
+
+### 4. GitHub Releases (`release.yml`)
+
+Creates GitHub Releases with tagged versions.
+
+### 5. CI Lint/Test (`test.yml`)
+
+Runs linting and the 33 unit tests.
+
+---
+
+## Secrets & Variables
+
+### Web/PWA — SFTP Deployment
+
+| Secret/Variable | Required | Type | Description |
+|---|---|---|---|
+| `SFTP_HOST` | Yes | Secret | SFTP server hostname |
+| `SFTP_PORT` | No | Secret | SFTP port (defaults to 22) |
+| `SFTP_USER` | Yes | Secret | SFTP username |
+| `SFTP_KEY` | * | Secret | SSH private key (preferred) |
+| `SFTP_PASSWORD` | * | Secret | SFTP password (fallback) |
+| `SFTP_LIVE_PATH` | Yes | Secret | Remote path for production |
+| `SFTP_BETA_PATH` | Yes | Secret | Remote path for beta |
+| `SFTP_DEV_PATH` | No | Secret | Remote path for alpha/dev |
+| `SFTP_PRIVATE_PATH` | No | Secret | Remote path for private_html |
+| `SFTP_ENABLED` | Yes | **Variable** | Kill switch (`true` to enable) |
+
+> \* Either `SFTP_KEY` or `SFTP_PASSWORD` is required. SSH key auth is preferred.
+
+#### SSH Key Setup
+
+```bash
+# Generate a dedicated deploy key (no passphrase)
+ssh-keygen -t ed25519 -C "github-deploy@ihymns.app" -f ~/.ssh/ihymns_deploy -N ""
+
+# Copy the public key to your server
+ssh-copy-id -i ~/.ssh/ihymns_deploy.pub user@ihymns.app
+
+# The PRIVATE key goes into the SFTP_KEY secret
+cat ~/.ssh/ihymns_deploy
+```
+
+### Apple — App Store, TestFlight, Direct
+
+| Secret | Required | Description |
+|---|---|---|
+| `APPLE_TEAM_ID` | Yes | Apple Developer Team ID (10-char alphanumeric) |
+| `ASC_KEY_ID` | Yes | App Store Connect API Key ID |
+| `ASC_ISSUER_ID` | Yes | App Store Connect API Issuer ID |
+| `ASC_API_KEY` | Yes | App Store Connect API Private Key (.p8 contents) |
+| `MATCH_GIT_URL` | Yes | Git repo URL for Fastlane Match certificate storage |
+| `MATCH_PASSWORD` | Yes | Encryption password for Fastlane Match |
+
+### Android — Google Play Store
+
+| Secret | Required | Description |
+|---|---|---|
+| `ANDROID_KEYSTORE_BASE64` | Yes | Release keystore, base64-encoded |
+| `ANDROID_KEYSTORE_PASSWORD` | Yes | Keystore password |
+| `ANDROID_KEY_ALIAS` | Yes | Signing key alias |
+| `ANDROID_KEY_PASSWORD` | Yes | Key password |
+| `PLAY_SERVICE_ACCOUNT_JSON` | No | Google Play Console service account JSON |
+| `PLAY_STORE_ENABLED` | No | Variable — `true` to enable Play Store upload |
+
+### Amazon Fire OS
+
+Uses the same Android release APK. Manual upload to Amazon Developer Console. No Google Play Services dependencies.
+
+---
+
+## Quick Setup Checklists
+
+### Minimum for Web/PWA
+
+- [ ] Set `SFTP_HOST`, `SFTP_USER` secrets
+- [ ] Set `SFTP_KEY` or `SFTP_PASSWORD` secret
+- [ ] Set `SFTP_LIVE_PATH`, `SFTP_BETA_PATH` secrets
+- [ ] Set `SFTP_ENABLED` **variable** to `true`
+
+### Minimum for Apple
+
+- [ ] Set `APPLE_TEAM_ID` secret
+- [ ] Set `ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_API_KEY` secrets
+- [ ] Set `MATCH_GIT_URL`, `MATCH_PASSWORD` secrets
+- [ ] Run `fastlane match appstore` locally once
+
+### Minimum for Android
+
+- [ ] Generate release keystore, set `ANDROID_KEYSTORE_BASE64`
+- [ ] Set `ANDROID_KEYSTORE_PASSWORD`, `ANDROID_KEY_ALIAS`, `ANDROID_KEY_PASSWORD`
+
+---
+
+## Environment Detection
+
+The CI pipeline injects a `.env-channel` file during deployment, allowing server-side PHP to detect which environment is running:
+
+| Channel | `.env-channel` content |
+|---|---|
+| Alpha/Dev | `alpha` |
+| Beta | `beta` |
+| Production | `main` |
+
+Alpha builds display a commit date timestamp (yyyymmddhhmmss) in the footer for deploy tracking.

--- a/wiki/Design.md
+++ b/wiki/Design.md
@@ -1,0 +1,128 @@
+# Design
+
+> Colour scheme, theming, and visual design guidelines
+
+---
+
+## Colour Scheme
+
+iHymns uses a clean, neutral slate/grey palette — professional and easy on the eyes. No bright or vivid colours on songbook cards.
+
+### Core Palette
+
+| Element | Colour | Hex |
+|---|---|---|
+| Navbar | Solid dark slate | `#1e293b` |
+| Accent | Muted teal | `#0d9488` |
+| Songbook cards | Soft grey gradient | (all same, no rainbow) |
+| Dark mode background | Charcoal blue | `#0f172a` |
+| Text (light mode) | Dark slate | `#1e293b` |
+| Text (dark mode) | Light slate | `#e2e8f0` |
+| Muted text | Slate grey | `#94a3b8` |
+| Admin amber | Warm amber | `#f59e0b` |
+| Admin amber hover | Dark amber | `#d97706` |
+| Admin background | Deep navy | `#1a1a2e` |
+| Admin surface | Dark navy | `#16213e` |
+
+### Theme Modes
+
+| Mode | Description |
+|---|---|
+| Light | Default — white background, dark text |
+| Dark | Charcoal blue `#0f172a` background, light text |
+| High Contrast | Maximum contrast for visual accessibility |
+| System | Follows OS `prefers-color-scheme` preference |
+
+### Colourblind Mode
+
+CVD-safe palette based on Wong 2011:
+- Uses colours distinguishable by people with protanopia, deuteranopia, and tritanopia
+- Applied automatically when enabled in settings
+- Affects songbook badges, component tags, and UI accents
+
+---
+
+## Component Tag Colours
+
+Used in the arrangement editor and song display:
+
+| Component | Colour | Hex |
+|---|---|---|
+| Verse | Blue | `#3b82f6` |
+| Chorus | Amber | `#f59e0b` |
+| Refrain | Amber | `#f59e0b` |
+| Pre-Chorus | Pink | `#ec4899` |
+| Bridge | Purple | `#8b5cf6` |
+| Tag | Grey | `#6b7280` |
+| Coda | Grey | `#6b7280` |
+| Intro | Green | `#10b981` |
+| Outro | Red | `#ef4444` |
+| Interlude | Cyan | `#06b6d4` |
+| Vamp | Orange | `#f97316` |
+| Ad-lib | Lime | `#84cc16` |
+
+---
+
+## Role Badge Colours (Admin Panel)
+
+| Role | Colour | Hex |
+|---|---|---|
+| Global Admin | Red | `#dc2626` |
+| Admin | Amber | `#f59e0b` |
+| Editor | Blue | `#3b82f6` |
+| User | Grey | `#6b7280` |
+
+---
+
+## Typography
+
+- **Body font:** System font stack (Bootstrap default)
+- **Monospace:** System monospace stack (for code, song numbers)
+- **Lyrics font size:** User-adjustable (14px–28px, default 18px)
+- **Line height:** 1.6 for lyrics readability
+
+---
+
+## Accessibility
+
+### Colour Contrast
+- All text meets **WCAG 2.1 AA** minimum contrast ratios (4.5:1 for normal text, 3:1 for large text)
+- Songbook badge text contrast is calculated automatically using relative luminance
+- Badge colours checked against both light and dark backgrounds
+
+### Focus Indicators
+- Visible focus outlines on all interactive elements
+- Custom focus ring colour matching the accent palette
+- Tab order follows logical reading order
+
+### Reduced Motion
+- All animations respect `prefers-reduced-motion: reduce`
+- Page transitions disabled when reduced motion is active
+- Toggle available in Settings
+
+### Reduced Transparency
+- Background blur and opacity effects removed when `prefers-reduced-transparency: reduce` is active
+
+---
+
+## Responsive Breakpoints
+
+Following Bootstrap 5.3 breakpoints:
+
+| Breakpoint | Width | Layout |
+|---|---|---|
+| xs | < 576px | Single column, compact header |
+| sm | >= 576px | Slightly wider content |
+| md | >= 768px | Two-column where appropriate |
+| lg | >= 992px | Full sidebar navigation |
+| xl | >= 1200px | Wide content area |
+| xxl | >= 1400px | Maximum content width |
+
+---
+
+## Icons
+
+- **Icon library:** Font Awesome 6 (Free, solid style)
+- **Admin panel:** Bootstrap Icons
+- **PWA icons:** Generated from `favicon.svg` (48px–512px PNGs)
+- **Favicon:** SVG with teal accent colour

--- a/wiki/Development-Setup.md
+++ b/wiki/Development-Setup.md
@@ -1,0 +1,167 @@
+# Development Setup
+
+> Prerequisites, local development, coding standards, and commit conventions
+
+---
+
+## Prerequisites
+
+| Tool | Version | Purpose |
+|---|---|---|
+| Node.js | v22+ (LTS) | Song parser, build tools, tests |
+| npm | v10+ | Package management |
+| PHP | 8.5+ | Web server (local or shared hosting) |
+| Git | Latest | Version control |
+| VS Code | Latest | Recommended editor |
+| Xcode | 16+ | Apple app development (macOS only) |
+| Android Studio | Latest | Android app development |
+
+---
+
+## Getting Started
+
+```bash
+# Clone the repository
+git clone https://github.com/MWBMPartners/iHymns.git
+cd iHymns
+
+# Install Node.js dependencies
+npm install
+
+# Parse song data (generates data/songs.json)
+npm run parse-songs
+
+# Run unit tests
+npm test
+```
+
+### Running the Web PWA Locally
+
+The PWA requires PHP 8.5+. Options for local development:
+
+```bash
+# Option 1: PHP built-in server
+cd appWeb/public_html
+php -S localhost:8080
+
+# Option 2: MAMP/XAMPP/Laragon
+# Point document root to appWeb/public_html/
+
+# Option 3: Docker (if configured)
+# docker-compose up
+```
+
+Ensure `appWeb/data_share/` exists alongside `public_html/` with a copy of `data/songs.json` at `data_share/song_data/songs.json`.
+
+---
+
+## Application IDs
+
+| Platform | Application ID |
+|---|---|
+| Web/PWA | `Ltd.MWBMPartners.iHymns.PWA` |
+| Apple | `Ltd.MWBMPartners.iHymns.Apple` |
+| Android | `Ltd.MWBMPartners.iHymns.Android` |
+
+---
+
+## Coding Standards
+
+### PHP
+
+- PHP 8.5+ with `declare(strict_types=1)` in every file
+- Modern syntax: `str_contains()`, `match` expressions, named arguments
+- Modular architecture: components in `includes/components/`, pages in `includes/pages/`
+- Direct-access prevention at top of every include file
+- Content Security Policy with per-request nonces
+
+### JavaScript
+
+- ES modules architecture (25+ modules in `js/modules/`, utilities in `js/utils/`)
+- No build step required — native ES module loading
+- `import`/`export` syntax, no CommonJS
+- All state in the central `iHymnsApp` class
+- Use `escapeHtml()` from `js/utils/html.js` for all dynamic content
+
+### CSS
+
+- Bootstrap 5.3.6 as the framework
+- Custom properties (CSS variables) for theming
+- Colour scheme: clean neutral slate/grey (see [[Design]])
+- Accent: muted teal `#0d9488`
+- Dark mode: charcoal blue `#0f172a`
+
+### General
+
+- **Detailed code annotations** — comments on every code block (ideally every line)
+- **Automated copyright year** — `2026-<current year>` resolved at runtime
+- **Accessibility** — WCAG 2.1 AA, skip-to-content, focus indicators, reduced motion
+- **Security** — CSP nonces, SRI hashes, CSRF tokens, input sanitisation
+- **Clean code** — all linting/security checks must pass with zero issues
+
+---
+
+## Commit Message Conventions
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### Types
+
+| Type | Use |
+|---|---|
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `refactor` | Code restructuring (no behaviour change) |
+| `docs` | Documentation only |
+| `style` | Formatting, whitespace (no code change) |
+| `test` | Tests |
+| `chore` | Maintenance, dependencies |
+| `ci` | CI/CD changes |
+
+### Scopes
+
+Common scopes: `pwa`, `api`, `editor`, `parser`, `apple`, `android`, `ci`, `docs`
+
+### Examples
+
+```
+feat(api): add password reset endpoints
+fix(pwa): correct setlist sync merge logic
+refactor(editor): use requireEditor() for access control
+docs: update wiki with API reference
+```
+
+### Special Commit Flags
+
+| Flag | Effect |
+|---|---|
+| `[deploy all]` | Forces full SFTP upload (ignores change detection) |
+| `[skip ci]` | Skips all GitHub Actions workflows |
+
+---
+
+## Project File Reference
+
+| File | Purpose |
+|---|---|
+| `data/songs.json` | Canonical song database (single source of truth) |
+| `data/songs.schema.json` | JSON Schema (draft 2020-12) for validation |
+| `tools/parse-songs.js` | Parses `.SourceSongData/` into songs.json |
+| `tools/build-web.js` | Web build/packaging script |
+| `appWeb/public_html/includes/infoAppVer.php` | App version metadata |
+| `appWeb/public_html/includes/config.php` | App configuration |
+| `appWeb/public_html/api.php` | Server-side API |
+| `appWeb/public_html/index.php` | SPA shell |
+| `appWeb/public_html/manage/includes/auth.php` | Auth middleware + roles |
+| `appWeb/public_html/manage/includes/db.php` | Database + migrations |
+| `appWeb/public_html/js/app.js` | Main app entry point |
+| `appWeb/public_html/js/constants.js` | localStorage key constants |
+| `tests/test-song-parser.js` | 33 unit tests |

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -1,0 +1,100 @@
+# Getting Started
+
+> Quick guide for users and developers
+
+---
+
+## For Users
+
+### Using the Web App
+
+1. Visit [iHymns.app](https://ihymns.app) in any modern browser
+2. Browse songbooks from the home page
+3. Tap a songbook to see its songs, then tap a song for lyrics
+4. Use the search icon to find songs by title, lyrics, or number
+
+### Installing as a PWA
+
+1. Visit [iHymns.app](https://ihymns.app) on your phone or computer
+2. Look for the "Install" or "Add to Home Screen" prompt
+3. Once installed, iHymns works like a native app — even offline
+
+### Creating an Account
+
+An account is optional but enables cross-device setlist sync:
+
+1. Click the user icon in the header
+2. Choose "Create Account"
+3. Enter a username (3+ chars), display name, and password (8+ chars)
+4. Your setlists will sync automatically across all your devices
+
+### Using Setlists
+
+1. Navigate to any song
+2. Click "Add to Set List" and choose or create a setlist
+3. Go to `/setlist` to manage your setlists
+4. Click "Arrange" on a song to customise the performance order
+5. Click "Share" to send a setlist to others
+
+### Keyboard Shortcuts
+
+| Key | Action |
+|---|---|
+| `/` | Open search |
+| `#` | Open numeric keypad |
+| `?` | Show keyboard shortcuts help |
+| `F` | Toggle favourite |
+| `P` | Toggle presentation mode |
+| `L` | Go to setlists |
+| `Left/Right` | Previous/next song |
+| `0-9` | Quick-jump to song number |
+
+---
+
+## For Developers
+
+### Prerequisites
+
+- Node.js v22+ and npm v10+
+- PHP 8.5+ (for local web server)
+- Git
+
+### Quick Start
+
+```bash
+# Clone
+git clone https://github.com/MWBMPartners/iHymns.git
+cd iHymns
+
+# Install dependencies
+npm install
+
+# Parse song data
+npm run parse-songs
+
+# Run tests
+npm test
+
+# Start local server
+cd appWeb/public_html
+php -S localhost:8080
+```
+
+### Key Files to Know
+
+| File | What it does |
+|---|---|
+| `data/songs.json` | All song data (generated, don't edit manually) |
+| `appWeb/public_html/index.php` | SPA shell |
+| `appWeb/public_html/api.php` | All API endpoints |
+| `appWeb/public_html/js/app.js` | JS app entry point |
+| `appWeb/public_html/manage/includes/auth.php` | Auth & role system |
+| `appWeb/public_html/manage/includes/db.php` | Database & migrations |
+
+### Further Reading
+
+- [[Architecture]] — how the codebase is structured
+- [[API Reference]] — all API endpoints
+- [[Development Setup]] — coding standards, commit conventions
+- [[Database & Migrations]] — schema and migration system
+- [[Security]] — CSP, auth, input sanitisation

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,95 @@
+# iHymns Wiki
+
+> A multiplatform Christian lyrics application for worship enhancement
+
+**Website**: [iHymns.app](https://ihymns.app) | **Repo**: [GitHub](https://github.com/MWBMPartners/iHymns) | **Version**: 0.1.7 (Phase 1 pre-release)
+
+---
+
+## About iHymns
+
+iHymns provides searchable hymn and worship song lyrics from multiple songbooks, designed to enhance Christian worship across all devices. Browse, search, and save your favourite hymns — online or offline.
+
+---
+
+## Song Library
+
+| Songbook | Abbr. | Songs | MIDI Audio | Sheet Music |
+|---|---|---|---|---|
+| Carol Praise | CP | 243 | Yes | Yes |
+| Junior Praise | JP | 617 | Yes | Yes |
+| Mission Praise | MP | 1,355 | Yes | Yes |
+| SDA Hymnal | SDAH | 695 | — | — |
+| The Church Hymnal | CH | 702 | — | — |
+| Miscellaneous | Misc | 0 | — | — |
+| **Total** | | **3,612** | | |
+
+---
+
+## Platforms
+
+| Platform | Technology | Status |
+|---|---|---|
+| Web PWA | PHP 8.5+, Bootstrap 5.3.6, Vanilla JS (ES modules), Fuse.js | Core + Enhanced complete |
+| Apple (iOS/iPadOS/tvOS/visionOS/macOS/watchOS) | Swift 6.3, SwiftUI | Code complete |
+| Android (+ Fire OS, Android TV) | Kotlin 2.1, Jetpack Compose | Code complete |
+
+---
+
+## Quick Links
+
+### For Users
+- [[Getting Started]]
+- [[PWA Features]]
+- [[User Accounts & Roles]]
+- [[Setlists & Arrangements]]
+- [[Troubleshooting & FAQ]]
+
+### For Developers
+- [[Architecture]]
+- [[Development Setup]]
+- [[API Reference]]
+- [[Song Data Format]]
+- [[Deployment & CI-CD]]
+- [[Native Apps (Apple & Android)]]
+- [[Database & Migrations]]
+- [[Security]]
+
+---
+
+## Two-Phase Approach
+
+### Phase ONE (Current) — v0.x.x / v1.x.x
+
+- Songs sourced from local `.SourceSongData/` text files
+- Parsed into structured JSON (`data/songs.json`) — single canonical copy
+- 6 songbooks, 3,612 songs across CP, JP, MP, SDAH, CH, Misc
+- Some songbooks include MIDI audio and PDF sheet music
+- Song Editor (admin tool) in `/manage/editor/`
+
+### Phase TWO (Future) — v2.x.x
+
+- Songs sourced from iLyrics dB API
+- MySQL backend, Christian songs only
+- Same frontend UI, different data source
+- Apple TV Remote Control: iPhone/iPad controls tvOS lyrics display over LAN
+
+---
+
+## Version Numbering
+
+| Range | Meaning |
+|---|---|
+| `v0.x.x` | Phase 1 pre-release (current) |
+| `v1.x.x` | Phase 1 stable |
+| `v2.x.x` | Phase 2 (iLyrics dB integration) |
+
+Auto-bumped via conventional commits on push to `beta` (single source of truth). Alpha builds display commit date timestamp in footer.
+
+---
+
+## Copyright
+
+Copyright 2026 MWBM Partners Ltd. All rights reserved.
+
+Proprietary software. Third-party components retain their respective licenses.

--- a/wiki/Native-Apps-(Apple-&-Android).md
+++ b/wiki/Native-Apps-(Apple-&-Android).md
@@ -1,0 +1,167 @@
+# Native Apps (Apple & Android)
+
+> Architecture, current state, and roadmap for the native applications
+
+---
+
+## Apple App
+
+### Overview
+
+| Property | Value |
+|---|---|
+| Language | Swift 6.3 |
+| Framework | SwiftUI |
+| Min deployment | iOS 17, macOS 14, tvOS 17, visionOS 1, watchOS 10 |
+| App ID | `Ltd.MWBMPartners.iHymns.Apple` |
+| Architecture | Observable object + SwiftUI views |
+| Status | Code complete (offline features) |
+| Issue | [#257](https://github.com/MWBMPartners/iHymns/issues/257) — user accounts & API integration |
+
+### Project Structure
+
+```
+appApple/iHymns/iHymns/
+├── iHymnsApp.swift              # App entry point
+├── Models/
+│   ├── Song.swift               # Song data model (Codable)
+│   ├── SongData.swift           # Song data container
+│   └── Songbook.swift           # Songbook metadata
+├── Services/
+│   ├── SongStore.swift          # Observable data store
+│   └── AppInfo.swift            # App metadata
+└── Views/
+    ├── ContentView.swift         # Root view (TabView/NavigationSplitView)
+    ├── SongbookListView.swift    # Songbook browser
+    ├── SongDetailView.swift      # Song lyrics
+    ├── FavoritesView.swift       # Favourites
+    ├── SearchView.swift          # Search
+    ├── HelpView.swift            # In-app help
+    └── WidgetViews.swift         # Widget UI
+```
+
+### Current Features
+- Songbook browsing and song detail views
+- Full-text search by title, lyrics, songbook, number
+- Favourites (UserDefaults persistence)
+- Adaptive UI: `TabView` (iPhone) / `NavigationSplitView` (iPad/Mac)
+- Apple TV and Vision Pro support
+- Home screen widgets (Song of the Day, Recent Favourites)
+
+### Planned (Issue #257)
+- Networking layer (URLSession async/await)
+- User authentication (Keychain token storage)
+- Setlist management with custom arrangements
+- Cross-device setlist sync via API
+- Password reset flow
+- Background App Refresh for periodic sync
+- Handoff support between Apple devices
+- Sign in with Apple (future)
+
+---
+
+## Android App
+
+### Overview
+
+| Property | Value |
+|---|---|
+| Language | Kotlin 2.1 |
+| Framework | Jetpack Compose |
+| Min SDK | 24 (Android 7.0) |
+| App ID | `Ltd.MWBMPartners.iHymns.Android` |
+| Architecture | MVVM (ViewModel + StateFlow) |
+| Status | Code complete (offline features) |
+| Issue | [#258](https://github.com/MWBMPartners/iHymns/issues/258) — user accounts & API integration |
+
+### Project Structure
+
+```
+appAndroid/app/src/main/java/ltd/mwbmpartners/ihymns/android/
+├── MainActivity.kt              # Single-activity entry point
+├── models/
+│   └── Song.kt                  # Song data class
+├── viewmodel/
+│   └── SongViewModel.kt        # MVVM ViewModel (StateFlow)
+└── ui/
+    ├── Navigation.kt            # NavHost routing
+    ├── Theme.kt                 # Material 3 theme
+    └── screens/
+        ├── HomeScreen.kt        # Home with songbook grid
+        ├── SongListScreen.kt    # Song list for a songbook
+        ├── SongDetailScreen.kt  # Song lyrics
+        ├── FavoritesScreen.kt   # Favourites
+        ├── SearchScreen.kt      # Search
+        └── HelpScreen.kt       # In-app help
+```
+
+### Current Features
+- Songbook browsing and song detail views
+- Full-text search by title, lyrics, number
+- Favourites (SharedPreferences persistence)
+- Material 3 theming
+- Android TV / Fire OS compatible (no Google Play Services)
+- Leanback launcher support for TV
+
+### Planned (Issue #258)
+- HTTP client (Ktor or Retrofit)
+- User authentication (EncryptedSharedPreferences)
+- Setlist management with custom arrangements
+- Cross-device setlist sync via API
+- Password reset flow
+- WorkManager for background sync
+- Glance widgets for home screen
+- Android TV lean-back UI for setlist browsing
+- Wear OS support (future)
+
+---
+
+## Shared API
+
+Both native apps will integrate with the same bearer token API as the PWA. See [[API Reference]] for all endpoints.
+
+### Key Integration Points
+
+| Feature | API Endpoint |
+|---|---|
+| Register | `POST ?action=auth_register` |
+| Login | `POST ?action=auth_login` |
+| Logout | `POST ?action=auth_logout` |
+| Verify token | `GET ?action=auth_me` |
+| Forgot password | `POST ?action=auth_forgot_password` |
+| Reset password | `POST ?action=auth_reset_password` |
+| Get setlists | `GET ?action=user_setlists` |
+| Sync setlists | `POST ?action=user_setlists_sync` |
+| Share setlist | `POST ?action=setlist_share` |
+| Get shared setlist | `GET ?action=setlist_get&id=...` |
+
+### Token Storage Recommendations
+
+| Platform | Storage | Notes |
+|---|---|---|
+| PWA | `localStorage` | Only option for web |
+| iOS | Keychain | More secure; survives app reinstall |
+| Android | EncryptedSharedPreferences | Backed by Android Keystore |
+
+---
+
+## Fire OS Compatibility
+
+The Android app has **zero Google Play Services dependencies**, making it fully compatible with Amazon Fire OS:
+
+- Fire tablets, Fire TV, Fire TV Stick
+- Uses the same APK as standard Android
+- `android.hardware.touchscreen` set to `required="false"` for TV remote navigation
+- `LEANBACK_LAUNCHER` intent filter in `AndroidManifest.xml`
+- Manual upload to Amazon Developer Console (automated API available for future integration)
+
+---
+
+## Phase 2 Roadmap
+
+In Phase 2 (v2.x.x), all platforms will migrate from bundled `songs.json` to the **iLyrics dB API**:
+
+- Song data fetched from MySQL backend via REST API
+- Search performed server-side
+- Real-time updates without app updates
+- Apple TV Remote Control: iPhone/iPad controls tvOS lyrics display over LAN

--- a/wiki/PWA-Features.md
+++ b/wiki/PWA-Features.md
@@ -1,0 +1,149 @@
+# PWA Features
+
+> Complete feature list for the iHymns Progressive Web App
+
+---
+
+## Core Features
+
+### Song Browsing
+- **Songbook grid** — visual cards for each songbook with song count badges
+- **Song list** — sortable by title (default), number, or songbook
+- **Song detail** — formatted lyrics with verse/chorus/bridge labels
+- **Writer/composer pages** — all songs by a given writer, grouped by songbook
+
+### Search
+- **Full-text search** — fuzzy search across titles, lyrics, writers, composers (Fuse.js)
+- **Number search** — jump to a song by number within a songbook
+- **Numeric keypad** — modal number pad for quick song lookup (`#` keyboard shortcut)
+- **Search history** — recent search terms with one-click re-search
+- **TF-IDF related songs** — content-based similarity for "Related Songs" on song pages
+
+### Favourites
+- **Save/unsave** songs with star button or `F` keyboard shortcut
+- **Favourites page** — browse all favourited songs
+- **Persistent** — stored in localStorage
+
+### Setlists
+- **Create setlists** — named playlists for worship services
+- **Add/remove/reorder** songs within a setlist
+- **Custom arrangements** — per-song arrangement editor (ProPresenter 7-style)
+  - Component pool: click to add components (V1, C, B, PC1, etc.)
+  - Arrangement strip: drag-and-drop to reorder, click to remove
+  - Live lyrics preview of the custom arrangement
+  - 12 component types with colour-coded short tags
+- **Share setlists** — generate shareable links with optional arrangements
+- **Import shared setlists** — import from shared links
+- **Cross-device sync** — merge local and server setlists when logged in
+
+### Audio & Sheet Music
+- **MIDI playback** — play MIDI audio files where available (CP, JP, MP)
+- **PDF sheet music** — view sheet music PDFs where available (CP, JP, MP)
+
+---
+
+## User Interface
+
+### Theme & Display
+- **Light mode** — default, clean neutral slate/grey
+- **Dark mode** — charcoal blue `#0f172a`
+- **High contrast mode** — for visual accessibility
+- **System mode** — follows OS preference
+- **Colourblind mode** — CVD-safe palette (Wong 2011)
+- **Adjustable font size** — lyrics font size slider in settings
+- **Presentation mode** — fullscreen lyrics display for projection
+
+### Navigation
+- **Clean URLs** — `/song/MP-0001`, `/songbook/CP`, `/setlist`
+- **History API routing** — SPA with pushState navigation
+- **Page transitions** — smooth animated transitions between pages
+- **Touch gestures** — swipe left/right for next/previous song
+- **Keyboard shortcuts** — `?` help overlay, `/` search, `#` numpad, `F` favourite, `P` present
+- **Quick-jump** — type a number to jump to that song in the current songbook
+- **Reading progress** — scroll-linked progress bar on song pages
+- **Alphabetical index** — quick letter-jump on songbook song lists
+
+### Responsive Design
+- **Mobile-first** — optimised for phones
+- **Tablet layout** — wider content area, sidebar navigation
+- **Desktop layout** — full-width with hover effects
+- **Print stylesheet** — clean lyrics-only print output
+
+---
+
+## PWA Capabilities
+
+### Offline Support
+- **Service worker** — caches all assets and song data for offline use
+- **Offline indicator** — shows connection status in UI
+- **Auto-update** — detects new service worker versions and prompts to refresh
+- **Songs cached** — full `songs.json` available offline via service worker
+
+### Installation
+- **Install banner** — dismissible prompt for PWA installation
+- **Cross-subdomain detection** — hides banner if already installed on another subdomain
+- **Manifest** — full PWA manifest with icons (48px–512px), theme colours, display mode
+
+---
+
+## User Accounts
+
+See [[User Accounts & Roles]] for full details.
+
+- **Sign In / Register** — modal in the header, available on all pages
+- **Role-based access** — Global Admin, Admin, Curator/Editor, User
+- **Setlist sync** — cross-device setlist synchronisation for logged-in users
+- **Password reset** — forgot password flow with secure token
+- **Header dropdown** — shows user info, role, sync, and sign out when logged in
+
+---
+
+## Analytics & Privacy
+
+### Analytics Providers
+- Google Analytics 4 (GA4)
+- Plausible Analytics
+- Microsoft Clarity
+- Matomo
+- Fathom Analytics
+
+### Privacy
+- **GDPR consent banner** — opt-in analytics consent with localStorage persistence
+- **Do Not Track (DNT)** — respects browser DNT header, anonymises IP addresses
+- **No cookies** (for analytics) — consent tracked in localStorage
+- **Privacy policy** — comprehensive 12-section policy at `/privacy`
+- **Terms of use** — 12-section terms at `/terms`
+
+---
+
+## Social Sharing
+
+### Open Graph Meta Tags
+- **Dynamic per-page** — customised title, description, and image for each song, songbook, and page
+- **Rich previews** — Facebook, Twitter, Slack, WhatsApp show song title, songbook, first lyrics lines
+- **Dynamic OG images** — generated via `og-image.php` (1200x630, contextual)
+
+### JSON-LD Structured Data
+- **WebSite schema** with SearchAction (home page)
+- **MusicComposition** schema for song pages (title, composers, lyricists)
+- **BreadcrumbList** for navigation context
+
+### SEO
+- **Canonical URLs** — prevents duplicate content
+- **Dynamic XML sitemap** — auto-generated from song database (`sitemap.xml.php`)
+- **Flexible permalinks** — `MP-1` normalises to `MP-0001`
+
+---
+
+## Accessibility
+
+- **WCAG 2.1 AA** compliant
+- **Skip-to-content** link for keyboard navigation
+- **Focus indicators** — visible focus outlines on all interactive elements
+- **Reduced motion** — respects `prefers-reduced-motion`, disables animations
+- **Reduced transparency** — respects `prefers-reduced-transparency`
+- **Screen reader** — ARIA labels, roles, and live regions
+- **Semantic HTML** — proper heading hierarchy, landmarks, lists
+- **Colour contrast** — automated badge contrast via relative luminance calculation
+- **Colourblind-safe palette** — Wong 2011 CVD-safe colours
+- **Keyboard shortcuts** — full keyboard navigation without mouse

--- a/wiki/Security.md
+++ b/wiki/Security.md
@@ -1,0 +1,138 @@
+# Security
+
+> Security measures, authentication, and best practices
+
+---
+
+## Content Security Policy (CSP)
+
+Every request generates a unique nonce for inline scripts. The CSP header includes:
+
+```
+default-src 'self';
+script-src 'self' 'nonce-<random>' https://cdn.jsdelivr.net ...;
+style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net ...;
+img-src 'self' data: https:;
+font-src 'self' https://cdn.jsdelivr.net ...;
+connect-src 'self' https://www.google-analytics.com ...;
+frame-ancestors 'self';
+base-uri 'self';
+form-action 'self';
+upgrade-insecure-requests;
+```
+
+All CDN resources include **Subresource Integrity (SRI)** hashes.
+
+---
+
+## Authentication Security
+
+### Password Hashing
+- Algorithm: **BCRYPT** (`PASSWORD_BCRYPT`)
+- Cost factor: **12** (higher than default for stronger protection)
+- PHP's `password_hash()` / `password_verify()` — timing-safe comparison
+
+### Bearer Tokens
+- 64-character lowercase hexadecimal (32 bytes of `random_bytes()`)
+- 30-day expiry with server-side validation
+- Stored in `api_tokens` table
+- Deleted on logout and password reset
+
+### Password Reset Tokens
+- 48-character lowercase hexadecimal (24 bytes of `random_bytes()`)
+- 1-hour expiry
+- Single-use (marked as `used` after consumption)
+- Previous tokens for the same user are deleted when a new one is generated
+- Password reset invalidates ALL API tokens (forces re-login on all devices)
+
+### Session Security (Admin Panel)
+- `httponly` flag — prevents JavaScript access to session cookie
+- `samesite=Strict` — prevents CSRF via cross-site requests
+- `secure` flag — when HTTPS is detected
+- `session_regenerate_id(true)` on login — prevents session fixation
+- Session cookie scoped to `/manage/` path only
+
+### CSRF Protection
+- Per-session CSRF token (64 hex chars via `random_bytes(32)`)
+- Validated with `hash_equals()` — timing-safe comparison
+- Required on all admin panel form submissions
+
+---
+
+## Input Sanitisation
+
+### API Inputs
+- Usernames: lowercased, trimmed, validated against `/^[a-z0-9_.\-]+$/`
+- Song IDs: validated against `/^[A-Za-z]+-\d+$/`
+- Setlist IDs: alphanumeric only (regex filtered)
+- Owner UUIDs: hex + hyphen only
+- Display names: trimmed, truncated to 100 chars
+- Setlist names: trimmed, truncated to 200 chars
+- Song counts: capped at 200 per setlist, 50 setlists per user
+- Arrangements: validated as arrays of non-negative integers
+
+### HTML Output
+- All dynamic content escaped with `htmlspecialchars()`
+- JavaScript uses `escapeHtml()` from `js/utils/html.js`
+- No raw HTML interpolation of user data
+
+---
+
+## File Security
+
+### Direct Access Prevention
+Every PHP include file starts with:
+```php
+if (basename($_SERVER['SCRIPT_FILENAME'] ?? '') === basename(__FILE__)) {
+    http_response_code(403);
+    exit('Access denied.');
+}
+```
+
+### SQLite Database Location
+- Stored in `appWeb/data_share/SQLite/` — **outside the public web root**
+- Not directly accessible via HTTP
+- `.htaccess` rules prevent access to `data_share/` if misconfigured
+
+### Shared Setlist Files
+- Stored in `appWeb/data_share/setlist_json/`
+- Setlist IDs are 8-character hex strings (4 bytes of randomness)
+- Atomic file creation with `fopen('x')` to prevent TOCTOU races
+- Ownership verified before updates (owner UUID must match)
+
+---
+
+## User Enumeration Prevention
+
+- `auth_forgot_password` always returns HTTP 200 with the same message, regardless of whether the user exists
+- Registration returns 409 for duplicate usernames (necessary for UX, acceptable trade-off)
+
+---
+
+## Rate Limiting
+
+Currently not implemented at the application level. Recommendations:
+- Use web server rate limiting (Apache `mod_ratelimit`, nginx `limit_req`)
+- Consider adding application-level rate limiting for auth endpoints
+- Rate limit password reset requests per IP
+
+---
+
+## Security Headers
+
+| Header | Value |
+|---|---|
+| `Content-Security-Policy` | Per-request with nonce (see above) |
+| `X-Content-Type-Options` | `nosniff` (on all JSON responses) |
+| `Cache-Control` | `no-cache, must-revalidate` (on API responses) |
+
+---
+
+## Recommendations for Production
+
+1. **Enable HTTPS** — the session cookie `secure` flag activates automatically
+2. **Set up rate limiting** at the web server level for `/api.php` auth endpoints
+3. **Remove `_dev_token`** from `auth_forgot_password` response in production
+4. **Implement email delivery** for password reset tokens
+5. **Monitor** `api_tokens` table size and clean up expired tokens periodically
+6. **Backup** the SQLite database regularly (it's in `data_share/SQLite/`)

--- a/wiki/Setlists-&-Arrangements.md
+++ b/wiki/Setlists-&-Arrangements.md
@@ -1,0 +1,112 @@
+# Setlists & Arrangements
+
+> Create worship setlists with custom song arrangements
+
+---
+
+## Overview
+
+Setlists (playlists) allow users to organise songs for worship services. Each setlist can contain up to 200 songs, and each song can have a custom arrangement that controls the order in which song components are performed.
+
+---
+
+## Creating a Setlist
+
+1. Navigate to any song page
+2. Click the **"Add to Set List"** button
+3. Choose an existing setlist or create a new one
+4. The song is added to the setlist
+
+Alternatively, navigate to `/setlist` to manage all setlists.
+
+---
+
+## Custom Song Arrangements
+
+Each song in a setlist can have a custom arrangement that overrides the default component order. This is modelled after **ProPresenter 7**'s arrangement system.
+
+### Arrangement Editor
+
+Click the **"Arrange"** button on a song within a setlist to open the arrangement editor.
+
+The editor has three sections:
+
+1. **Component Pool** — shows all available components for the song (e.g., V1, V2, C, B). Click a chip to add it to the arrangement.
+
+2. **Arrangement Strip** — shows the current custom order. Drag chips to reorder, click the x to remove.
+
+3. **Live Preview** — shows the lyrics in the current arrangement order, updating in real-time as you edit.
+
+### Quick Actions
+
+| Action | Description |
+|---|---|
+| **Auto-generate** | Creates a standard arrangement (e.g., V1, C, V2, C, V3, C) |
+| **Sequential** | Resets to the original component order (V1, V2, V3, C, etc.) |
+| **Song Default** | Removes the custom arrangement, uses the song's original order |
+
+### Component Tags
+
+Each component type has a short tag and colour:
+
+| Tag | Type | Colour |
+|---|---|---|
+| V1, V2... | Verse | Blue |
+| C, C1... | Chorus | Amber |
+| R | Refrain | Amber |
+| PC, PC1... | Pre-Chorus | Pink |
+| B, B1... | Bridge | Purple |
+| I | Intro | Green |
+| O | Outro | Red |
+| IL | Interlude | Cyan |
+| T | Tag | Grey |
+| CD | Coda | Grey |
+| VP | Vamp | Orange |
+| AL | Ad-lib | Lime |
+
+### How Arrangements Work
+
+Arrangements are stored as arrays of component indices. For example, if a song has:
+- Index 0: Verse 1
+- Index 1: Chorus
+- Index 2: Verse 2
+- Index 3: Bridge
+
+An arrangement of `[0, 1, 2, 1, 3, 1]` would produce: V1, C, V2, C, B, C.
+
+---
+
+## Sharing Setlists
+
+Click the **"Share"** button on a setlist to generate a shareable link. The link includes:
+- Setlist name
+- Song IDs
+- Custom arrangements (if any)
+
+Recipients can import the shared setlist via the link. Arrangements are preserved in the shared data.
+
+---
+
+## Cross-Device Sync
+
+Logged-in users can sync setlists across all their devices:
+
+1. **Sign in** on each device (PWA, iOS, Android)
+2. **Sync** — local setlists are merged with server-side storage
+3. **Automatic** — sync happens on login and can be triggered manually via the header menu
+
+### Merge Strategy
+
+- New setlists (by ID) are inserted on the server
+- Existing setlists are updated if the local version is newer
+- Server-only setlists are preserved and returned to the client
+- Maximum 50 setlists per user, 200 songs per setlist
+
+### Storage Locations
+
+| State | Storage |
+|---|---|
+| Anonymous (not logged in) | Browser localStorage only |
+| Logged in (PWA) | localStorage + server sync |
+| Logged in (iOS) | Local storage + server sync |
+| Logged in (Android) | Local storage + server sync |

--- a/wiki/Song-Data-Format.md
+++ b/wiki/Song-Data-Format.md
@@ -1,0 +1,165 @@
+# Song Data Format
+
+> Source song files, parsed JSON structure, and component types
+
+---
+
+## Source Files
+
+Songs are stored as plain text files in `.SourceSongData/`, organised by songbook:
+
+```
+.SourceSongData/
+├── Carol Praise [CP]/
+│   ├── 001 (CP) - A Baby Was Born In Bethlehem.txt
+│   ├── 001 (CP) - A Baby Was Born In Bethlehem_audio.mid
+│   └── 001 (CP) - A Baby Was Born In Bethlehem_music.pdf
+├── Junior Praise [JP]/
+├── Mission Praise [MP]/
+├── SDA Hymnal [SDAH]/
+└── The Church Hymnal [CH]/
+```
+
+> **WARNING:** The `.SourceSongData/` directory must NEVER be deleted or modified manually. It is the source of truth for all song data.
+
+### File Naming
+
+| Songbook | Pattern | Example |
+|---|---|---|
+| Carol Praise (CP) | `NNN (CP) - Title.txt` | `001 (CP) - A Baby Was Born In Bethlehem.txt` |
+| Junior Praise (JP) | `NNN (JP) - Title.txt` | `001 (JP) - A Boy Gave To Jesus.txt` |
+| Mission Praise (MP) | `NNNN (MP) - Title.txt` | `0001 (MP) - A New Commandment.txt` |
+| SDA Hymnal (SDAH) | `NNN (SDAH) - Title.txt` | `001 (SDAH) - Praise to the Lord.txt` |
+| Church Hymnal (CH) | `NNN (CH) - Title.txt` | `003 (CH) - Come, Thou Almighty King.txt` |
+
+**Companion files** (CP, JP, MP only):
+- `*_audio.mid` — MIDI audio file
+- `*_music.pdf` — Sheet music PDF
+
+### Text File Structure
+
+```text
+"Song Title"            ← Line 1: Title in double quotes
+
+1                       ← Verse number (standalone digit)
+First line of verse,
+Second line of verse,
+...
+
+Refrain                 ← Or "Chorus" — label on its own line
+First line of refrain,
+...
+
+2                       ← Next verse
+...
+
+Writers: Name1, Name2   ← "Writers:" prefix (lyricists)
+Composers: Name3        ← "Composers:" prefix (music)
+CCLI: 12345             ← Optional CCLI number
+```
+
+---
+
+## Parsed JSON (`data/songs.json`)
+
+The parser (`tools/parse-songs.js`) converts source files into structured JSON. The output `data/songs.json` is the single canonical copy used by all platforms.
+
+### Song Object
+
+```json
+{
+  "id": "MP-0001",
+  "number": 1,
+  "title": "A New Commandment",
+  "songbook": "MP",
+  "songbookName": "Mission Praise",
+  "writers": ["Author Name"],
+  "composers": ["Composer Name"],
+  "ccli": "12345",
+  "hasAudio": true,
+  "hasSheetMusic": true,
+  "components": [
+    {
+      "type": "verse",
+      "number": 1,
+      "lines": [
+        "First line of the verse,",
+        "Second line of the verse."
+      ]
+    },
+    {
+      "type": "chorus",
+      "number": null,
+      "lines": [
+        "This is the chorus line."
+      ]
+    }
+  ]
+}
+```
+
+### JSON Schema
+
+The structure is validated against `data/songs.schema.json` (JSON Schema draft 2020-12). Any changes to the song format must update the schema.
+
+---
+
+## Component Types
+
+Songs are divided into components, each with a `type` field. The 12 supported types:
+
+| Type | Short Tag | Colour | Label |
+|---|---|---|---|
+| `verse` | V | `#3b82f6` (blue) | Verse |
+| `chorus` | C | `#f59e0b` (amber) | Chorus |
+| `refrain` | R | `#f59e0b` (amber) | Refrain |
+| `pre-chorus` | PC | `#ec4899` (pink) | Pre-Chorus |
+| `bridge` | B | `#8b5cf6` (purple) | Bridge |
+| `tag` | T | `#6b7280` (grey) | Tag |
+| `coda` | CD | `#6b7280` (grey) | Coda |
+| `intro` | I | `#10b981` (green) | Intro |
+| `outro` | O | `#ef4444` (red) | Outro |
+| `interlude` | IL | `#06b6d4` (cyan) | Interlude |
+| `vamp` | VP | `#f97316` (orange) | Vamp |
+| `ad-lib` | AL | `#84cc16` (lime) | Ad-lib |
+
+### Short Tags
+
+Short tags use industry-standard abbreviations inspired by ProPresenter 7. Numbered variants are supported: `V1`, `V2`, `C1`, `PC1`, etc.
+
+The tag utility is defined in `appWeb/public_html/js/utils/components.js` and shared between the PWA and editor.
+
+---
+
+## Song ID Format
+
+Song IDs follow the pattern `<ABBR>-<NNNN>`:
+
+| Component | Description | Example |
+|---|---|---|
+| Abbreviation | Songbook abbreviation (uppercase) | `MP`, `CP`, `JP`, `SDAH`, `CH` |
+| Number | Zero-padded song number | `0001`, `0042`, `0695` |
+| Full ID | Combined | `MP-0001`, `CP-0042`, `SDAH-0695` |
+
+The router supports flexible input: `MP-1` is normalised to `MP-0001`.
+
+---
+
+## Parser
+
+Run the parser to regenerate `data/songs.json` from source files:
+
+```bash
+npm run parse-songs
+# or
+node tools/parse-songs.js
+```
+
+The parser:
+1. Scans `.SourceSongData/` subdirectories
+2. Parses each `.txt` file for title, components, writers, composers
+3. Detects companion `_audio.mid` and `_music.pdf` files
+4. Outputs structured JSON to `data/songs.json`
+5. Reports statistics (song count, songbook breakdown)
+
+**33 unit tests** validate the parser in `tests/test-song-parser.js`.

--- a/wiki/Troubleshooting-&-FAQ.md
+++ b/wiki/Troubleshooting-&-FAQ.md
@@ -1,0 +1,120 @@
+# Troubleshooting & FAQ
+
+> Common issues, solutions, and frequently asked questions
+
+---
+
+## Troubleshooting
+
+### PWA / Web App
+
+#### Songs not loading or showing "Unable to load song data"
+- **Cause:** The `songs.json` file is missing or inaccessible
+- **Fix:** Ensure `appWeb/data_share/song_data/songs.json` exists. Run `npm run parse-songs` to regenerate it
+
+#### Search returns no results
+- **Cause:** Fuse.js search index may not have loaded
+- **Fix:** Clear browser cache and reload. Check browser console for errors loading `songs.json`
+
+#### "Access denied" when accessing the Song Editor
+- **Cause:** Your user account doesn't have the `editor` role or above
+- **Fix:** Ask an admin or global admin to assign you the `editor` role via `/manage/users`
+
+#### Cannot log in to admin panel
+- **Cause:** Account may be disabled, or password incorrect
+- **Fix:** Use the "Forgot password" feature, or ask a global admin to check your account status
+
+#### Setlists not syncing
+- **Cause:** Not logged in, or bearer token expired (30-day limit)
+- **Fix:** Sign out and sign back in to get a fresh token. Check `/api.php?action=auth_me` for token validity
+
+#### Dark mode not applying
+- **Cause:** Theme setting may be stuck in localStorage
+- **Fix:** Go to Settings, manually select a theme. If the issue persists, clear `ihymns_theme` from localStorage
+
+#### PWA install banner not showing
+- **Cause:** Already installed, or browser doesn't support PWA installation
+- **Fix:** The banner is hidden if the app is detected as already installed (including cross-subdomain detection). Check the browser's "Install app" option in the address bar
+
+#### MIDI audio not playing
+- **Cause:** Browser may not support MIDI playback, or the MIDI file is missing
+- **Fix:** MIDI playback requires Web MIDI API support. Not all songbooks have MIDI files (only CP, JP, MP)
+
+### Database
+
+#### SQLite database gets wiped on deployment
+- **Cause:** The `data_share/` directory is being deleted during SFTP sync
+- **Fix:** Ensure the deploy script uses `--delete` only for `public_html/`, NOT for `data_share/`. The database path should be `dirname(__DIR__, 3) . '/data_share/SQLite/ihymns.db'`
+
+#### "Table not found" errors
+- **Cause:** Migrations haven't run yet
+- **Fix:** Migrations run automatically on first database connection. If the issue persists, check that the SQLite file path is correct and the directory is writable
+
+### Native Apps (iOS / Android)
+
+#### App shows no songs
+- **Cause:** The `songs.json` file may not be bundled correctly
+- **Fix:** Ensure `songs.json` is included in the app bundle (iOS: Copy Bundle Resources, Android: assets folder)
+
+---
+
+## FAQ
+
+### General
+
+**Q: Is iHymns free?**
+A: The web PWA is freely accessible at [iHymns.app](https://ihymns.app). Native apps may be distributed via app stores.
+
+**Q: Can I use iHymns offline?**
+A: Yes. The PWA caches all song data via a service worker. Once loaded, it works fully offline. Native apps bundle all data locally.
+
+**Q: What songbooks are included?**
+A: Carol Praise (CP), Junior Praise (JP), Mission Praise (MP), SDA Hymnal (SDAH), The Church Hymnal (CH), and Miscellaneous.
+
+**Q: Do I need an account to use iHymns?**
+A: No. You can browse, search, and save favourites without an account. An account is only needed for cross-device setlist sync.
+
+### User Accounts
+
+**Q: What's the difference between the account roles?**
+A: See [[User Accounts & Roles]]. In short: User = setlist sync, Editor = edit songs, Admin = manage users, Global Admin = full access.
+
+**Q: How do I become an editor?**
+A: Ask an Admin or Global Admin to assign you the `editor` role via `/manage/users`.
+
+**Q: I forgot my password. What do I do?**
+A: Click "Forgot password?" on the sign-in modal. Enter your username or email to receive a reset token. In the current version, the token is displayed directly (email delivery coming soon).
+
+**Q: Can I change my username?**
+A: Not currently. Usernames are permanent and lowercase.
+
+**Q: Who is the Global Admin?**
+A: The first person to create an account (either via `/manage/setup` or the public registration API) automatically becomes the Global Admin.
+
+### Setlists
+
+**Q: How many setlists can I have?**
+A: Up to 50 setlists per user account, with up to 200 songs per setlist.
+
+**Q: Can I share a setlist without an account?**
+A: Yes. The "Share" feature generates a public link that anyone can import, no account needed.
+
+**Q: What are custom arrangements?**
+A: They let you reorder song components (verses, choruses, bridges, etc.) for a specific performance. See [[Setlists & Arrangements]].
+
+**Q: Do shared setlists include custom arrangements?**
+A: Yes. Custom arrangements are included in shared setlist links and preserved when imported.
+
+### Technical
+
+**Q: What browsers are supported?**
+A: Any modern browser with ES module support: Chrome 80+, Firefox 78+, Safari 14+, Edge 80+.
+
+**Q: What PHP version is required?**
+A: PHP 8.5+ with `pdo_sqlite` extension (default). `pdo_mysql` or `pdo_sqlsrv` if using MySQL or SQL Server.
+
+**Q: Can I use MySQL instead of SQLite?**
+A: Yes. Change `'driver' => 'mysql'` in `db.php` and fill in the connection details. Migrations will run automatically. See [[Database & Migrations]].
+
+**Q: How do I run the song parser?**
+A: `npm run parse-songs` or `node tools/parse-songs.js`. This regenerates `data/songs.json` from the source files in `.SourceSongData/`.

--- a/wiki/User-Accounts-&-Roles.md
+++ b/wiki/User-Accounts-&-Roles.md
@@ -1,0 +1,164 @@
+# User Accounts & Roles
+
+> Role-based access control, authentication flows, and password reset
+
+---
+
+## Role Hierarchy
+
+iHymns uses a four-tier role hierarchy. Each role inherits the capabilities of all roles below it.
+
+| Role | Level | Label | Capabilities |
+|---|---|---|---|
+| `global_admin` | 4 | Global Admin | All powers. Auto-assigned to first registered user. Can assign any role to any user, including promoting others to Global Admin. |
+| `admin` | 3 | Admin | Manage users (create, assign roles up to `admin`). Cannot assign or demote `global_admin`. Full access to admin panel. |
+| `editor` | 2 | Curator / Editor | Edit songs via `/manage/editor/`. Can view admin panel but cannot manage users. |
+| `user` | 1 | User | Save setlists centrally. Cross-device setlist sync. No admin panel access. |
+| _(anonymous)_ | — | — | Local-only setlists (browser localStorage). No account required. |
+
+### Hierarchy Rules
+
+- **Cannot promote above your own level** — an `admin` cannot assign `global_admin`
+- **Cannot demote at or above your level** — an `admin` cannot demote another `admin` (unless you are `global_admin`)
+- **Only `global_admin` can assign `global_admin`**
+- **First registered user** automatically gets `global_admin` role (both via `/manage/setup` and via the public `auth_register` API)
+
+---
+
+## Two Authentication Systems
+
+iHymns has two separate authentication systems for different use cases:
+
+### 1. Admin Panel (Session-Based)
+
+Used by: `/manage/` area (editor, user management, setup)
+
+| Property | Detail |
+|---|---|
+| Mechanism | PHP sessions with secure cookies |
+| Cookie name | `ihymns_manage_session` |
+| Cookie path | `/manage/` |
+| Lifetime | 24 hours |
+| Cookie flags | `httponly`, `samesite=Strict`, `secure` (when HTTPS) |
+| CSRF | Per-session CSRF tokens |
+
+**Functions:**
+- `initSession()` — Start PHP session
+- `isAuthenticated()` — Check if logged in
+- `getCurrentUser()` — Get user row from DB
+- `requireAuth()` — Redirect to login if not authenticated
+- `requireEditor()` — Require editor+ role (403 otherwise)
+- `requireAdmin()` — Require admin+ role (403 otherwise)
+- `requireGlobalAdmin()` — Require global_admin only
+- `attemptLogin()` — Verify credentials, set session
+- `logout()` — Destroy session and cookie
+
+### 2. Public API (Bearer Token)
+
+Used by: PWA frontend, native iOS/Android apps
+
+| Property | Detail |
+|---|---|
+| Mechanism | Bearer tokens in `Authorization` header |
+| Token format | 64-character lowercase hex (32 random bytes) |
+| Token lifetime | 30 days |
+| Storage (server) | `api_tokens` table |
+| Storage (PWA) | `localStorage` (`ihymns_auth_token`) |
+| Storage (iOS) | Keychain (recommended) |
+| Storage (Android) | EncryptedSharedPreferences (recommended) |
+
+**API Endpoints:** See [[API Reference]] for full details.
+
+---
+
+## Authentication Flows
+
+### Registration Flow
+
+```
+User fills form → POST auth_register
+    ├── Validate username (3+ chars, alphanumeric)
+    ├── Validate password (8+ chars)
+    ├── Check username uniqueness
+    ├── Check if first user → assign global_admin, else user
+    ├── Hash password (BCRYPT, cost 12)
+    ├── Create user record
+    ├── Generate bearer token (64 hex, 30-day expiry)
+    └── Return { token, user: { id, username, display_name, role } }
+```
+
+### Login Flow
+
+```
+User enters credentials → POST auth_login
+    ├── Look up user by username
+    ├── Verify password hash
+    ├── Check is_active flag
+    ├── Generate new bearer token
+    └── Return { token, user: { id, username, display_name, role } }
+```
+
+### Password Reset Flow
+
+```
+1. User clicks "Forgot password?" → POST auth_forgot_password
+    ├── Look up user by username or email
+    ├── Generate reset token (48 hex chars, 1-hour expiry)
+    ├── Delete any existing tokens for this user
+    ├── Store new token in password_reset_tokens table
+    └── Return success (+ dev token in non-production)
+
+2. User enters token + new password → POST auth_reset_password
+    ├── Validate token (exists, not expired, not used)
+    ├── Hash new password (BCRYPT, cost 12)
+    ├── Update user's password_hash
+    ├── Mark token as used
+    ├── Delete ALL API tokens for this user (force re-login everywhere)
+    └── Return success
+```
+
+**Note:** In production, the reset token should be delivered via email. Currently, the token is returned in the API response (`_dev_token`) for development/testing purposes.
+
+---
+
+## Access Control Matrix
+
+| Resource | Anonymous | User | Editor | Admin | Global Admin |
+|---|---|---|---|---|---|
+| Browse songs | Yes | Yes | Yes | Yes | Yes |
+| Search | Yes | Yes | Yes | Yes | Yes |
+| Favourites (local) | Yes | Yes | Yes | Yes | Yes |
+| Setlists (local) | Yes | Yes | Yes | Yes | Yes |
+| Setlists (synced) | — | Yes | Yes | Yes | Yes |
+| Share setlists | Yes | Yes | Yes | Yes | Yes |
+| Song editor | — | — | Yes | Yes | Yes |
+| User management | — | — | — | Yes | Yes |
+| Assign global_admin | — | — | — | — | Yes |
+
+---
+
+## Header User Menu
+
+The site header on all pages includes a user dropdown:
+
+**Logged Out (Anonymous):**
+- Sign In button → opens auth modal in login mode
+- Create Account button → opens auth modal in register mode
+
+**Logged In:**
+- Display name (bold)
+- Role label (e.g., "Curator / Editor")
+- Divider
+- My Set Lists → navigates to `/setlist`
+- Sync Set Lists → triggers setlist sync
+- Account Settings → navigates to `/settings`
+- Divider
+- Sign Out → calls logout API, clears credentials
+
+The icon changes: `fa-user` (anonymous) → `fa-circle-user` (logged in).
+
+---
+
+## Future: SIGNula ID
+
+A future integration with the SIGNula ID single sign-on service is planned for Phase 2. This will provide unified authentication across all MWBM Partners products.

--- a/wiki/_Footer.md
+++ b/wiki/_Footer.md
@@ -1,0 +1,2 @@
+---
+Copyright 2026 MWBM Partners Ltd. All rights reserved. | [iHymns.app](https://ihymns.app) | [GitHub](https://github.com/MWBMPartners/iHymns)

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,0 +1,33 @@
+### iHymns Wiki
+
+**[[Home]]**
+
+---
+
+**User Guide**
+- [[Getting Started]]
+- [[PWA Features]]
+- [[Setlists & Arrangements]]
+- [[User Accounts & Roles]]
+- [[Troubleshooting & FAQ]]
+
+---
+
+**Developer Guide**
+- [[Architecture]]
+- [[Development Setup]]
+- [[API Reference]]
+- [[Song Data Format]]
+- [[Database & Migrations]]
+- [[Security]]
+- [[Deployment & CI-CD]]
+- [[Design]]
+
+---
+
+**Platform Reference**
+- [[Native Apps (Apple & Android)]]
+
+---
+
+[View on GitHub](https://github.com/MWBMPartners/iHymns)


### PR DESCRIPTION
Wiki pages covering all aspects of the iHymns project:
- Home, Getting Started — project overview and quick start
- Architecture — project structure, module system, data flow
- API Reference — all endpoints with request/response examples
- User Accounts & Roles — role hierarchy, auth flows, access control
- PWA Features — complete feature list (search, setlists, offline, etc.)
- Setlists & Arrangements — custom arrangements, sharing, sync
- Song Data Format — source files, JSON structure, component types
- Database & Migrations — SQLite schema, migration system
- Security — CSP, auth, input sanitisation, best practices
- Development Setup — prerequisites, coding standards, conventions
- Deployment & CI-CD — branch strategy, secrets, workflows
- Native Apps (Apple & Android) — architecture, roadmap, API integration
- Design — colour scheme, typography, accessibility
- Troubleshooting & FAQ — common issues and answers
- _Sidebar and _Footer navigation

https://claude.ai/code/session_019iLcFctpajfVnyEsGqZCvj