### PR TITLE
feat: admin dashboard & enhanced user management (#260)

### DIFF
--- a/appWeb/public_html/manage/.htaccess
+++ b/appWeb/public_html/manage/.htaccess
@@ -8,10 +8,11 @@
 # excluded from the main SPA rewrite rules and has its own auth system.
 #
 # ROUTING:
-#   /manage/              → /manage/editor/ (default redirect)
+#   /manage/              → /manage/index.php (admin dashboard)
 #   /manage/login         → /manage/login.php
 #   /manage/logout        → /manage/logout.php
 #   /manage/setup         → /manage/setup.php
+#   /manage/users         → /manage/users.php
 #   /manage/editor/       → /manage/editor/index.php (DirectoryIndex)
 # ==========================================================================
 
@@ -32,8 +33,8 @@ RewriteRule ^setup$ setup.php [L]
 # /manage/users → users.php (admin-only user management)
 RewriteRule ^users$ users.php [L]
 
-# /manage/ root → redirect to editor
-RewriteRule ^$ editor/ [R=302,L]
+# /manage/ root → serve dashboard (index.php via DirectoryIndex)
+# No rewrite needed — DirectoryIndex handles it
 
 # ---- Ensure DirectoryIndex works for /manage/editor/ ----
 DirectoryIndex index.php

--- a/appWeb/public_html/manage/includes/admin-nav.php
+++ b/appWeb/public_html/manage/includes/admin-nav.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Admin Navbar Component
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Shared navigation bar for all /manage/ pages. Shows links
+ * appropriate to the current user's role.
+ *
+ * USAGE:
+ *   $currentUser = getCurrentUser();
+ *   $activePage  = 'dashboard'; // 'dashboard', 'editor', 'users'
+ *   require __DIR__ . '/includes/admin-nav.php';
+ */
+
+/* Prevent direct access */
+if (basename($_SERVER['SCRIPT_FILENAME'] ?? '') === basename(__FILE__)) {
+    http_response_code(403);
+    exit('Access denied.');
+}
+?>
+<nav class="navbar-admin d-flex align-items-center flex-wrap gap-2">
+    <a href="/manage/" class="text-decoration-none me-auto d-flex align-items-center gap-2" style="color: var(--ih-amber);">
+        <i class="bi bi-music-note-beamed"></i>
+        <strong>iHymns Admin</strong>
+    </a>
+
+    <a href="/manage/" class="nav-link d-inline <?= ($activePage ?? '') === 'dashboard' ? 'active' : '' ?>">
+        <i class="bi bi-speedometer2 me-1"></i>Dashboard
+    </a>
+
+    <?php if (hasRole($currentUser['role'], 'editor')): ?>
+    <a href="/manage/editor/" class="nav-link d-inline <?= ($activePage ?? '') === 'editor' ? 'active' : '' ?>">
+        <i class="bi bi-pencil-square me-1"></i>Editor
+    </a>
+    <?php endif; ?>
+
+    <?php if (hasRole($currentUser['role'], 'admin')): ?>
+    <a href="/manage/users" class="nav-link d-inline <?= ($activePage ?? '') === 'users' ? 'active' : '' ?>">
+        <i class="bi bi-people me-1"></i>Users
+    </a>
+    <?php endif; ?>
+
+    <span class="text-muted mx-1 d-none d-sm-inline">|</span>
+    <span class="text-muted small d-none d-sm-inline">
+        <?= htmlspecialchars($currentUser['display_name'] ?? $currentUser['username']) ?>
+        <span class="badge ms-1 <?= match($currentUser['role']) {
+            'global_admin' => 'bg-danger',
+            'admin'        => 'bg-warning text-dark',
+            'editor'       => 'bg-primary',
+            default        => 'bg-secondary',
+        } ?>" style="font-size: 0.65rem;">
+            <?= htmlspecialchars(roleLabel($currentUser['role'])) ?>
+        </span>
+    </span>
+    <a href="/manage/logout" class="btn btn-sm btn-outline-secondary ms-1">
+        <i class="bi bi-box-arrow-right me-1"></i>Logout
+    </a>
+</nav>

--- a/appWeb/public_html/manage/includes/auth.php
+++ b/appWeb/public_html/manage/includes/auth.php
@@ -493,3 +493,96 @@ function validateCsrf(string $token): bool
     initSession();
     return isset($_SESSION['csrf_token']) && hash_equals($_SESSION['csrf_token'], $token);
 }
+
+/* =========================================================================
+ * USER PROFILE MANAGEMENT
+ * ========================================================================= */
+
+/**
+ * Change a user's password (by user ID).
+ * Invalidates all existing API tokens for the user.
+ *
+ * @param int    $userId      Target user ID
+ * @param string $newPassword New plaintext password
+ * @return bool
+ */
+function changeUserPassword(int $userId, string $newPassword): bool
+{
+    $db = getDb();
+    $hash = password_hash($newPassword, PASSWORD_BCRYPT, ['cost' => 12]);
+    $stmt = $db->prepare('UPDATE users SET password_hash = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?');
+    $stmt->execute([$hash, $userId]);
+
+    /* Invalidate all API tokens (force re-login) */
+    $stmt = $db->prepare('DELETE FROM api_tokens WHERE user_id = ?');
+    $stmt->execute([$userId]);
+
+    return true;
+}
+
+/**
+ * Update a user's profile fields (display name, email).
+ *
+ * @param int    $userId      Target user ID
+ * @param string $displayName New display name
+ * @param string $email       New email address
+ * @return bool
+ */
+function updateUserProfile(int $userId, string $displayName, string $email): bool
+{
+    $db = getDb();
+    $stmt = $db->prepare('UPDATE users SET display_name = ?, email = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?');
+    $stmt->execute([trim($displayName), trim($email), $userId]);
+    return true;
+}
+
+/**
+ * Activate or deactivate a user account.
+ *
+ * @param int  $userId   Target user ID
+ * @param bool $isActive True to activate, false to deactivate
+ * @return bool
+ */
+function setUserActive(int $userId, bool $isActive): bool
+{
+    $db = getDb();
+    $stmt = $db->prepare('UPDATE users SET is_active = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?');
+    $stmt->execute([$isActive ? 1 : 0, $userId]);
+
+    /* If deactivating, invalidate all their tokens */
+    if (!$isActive) {
+        $stmt = $db->prepare('DELETE FROM api_tokens WHERE user_id = ?');
+        $stmt->execute([$userId]);
+    }
+
+    return true;
+}
+
+/**
+ * Delete a user account permanently.
+ * Foreign key cascades will remove tokens, setlists, etc.
+ *
+ * @param int $userId Target user ID
+ * @return bool
+ */
+function deleteUser(int $userId): bool
+{
+    $db = getDb();
+    $stmt = $db->prepare('DELETE FROM users WHERE id = ?');
+    $stmt->execute([$userId]);
+    return (int)$stmt->rowCount() > 0;
+}
+
+/**
+ * Get a user by ID.
+ *
+ * @param int $userId User ID
+ * @return array|null User row or null
+ */
+function getUserById(int $userId): ?array
+{
+    $db = getDb();
+    $stmt = $db->prepare('SELECT * FROM users WHERE id = ?');
+    $stmt->execute([$userId]);
+    return $stmt->fetch(PDO::FETCH_ASSOC) ?: null;
+}

--- a/appWeb/public_html/manage/index.php
+++ b/appWeb/public_html/manage/index.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Admin Dashboard (#260)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Central admin dashboard showing system overview, quick stats,
+ * and navigation. Accessible to editor role and above.
+ */
+
+require_once __DIR__ . '/includes/auth.php';
+requireEditor();
+
+$currentUser = getCurrentUser();
+$activePage  = 'dashboard';
+
+/* Gather stats */
+$db = getDb();
+$totalUsers   = (int)$db->query('SELECT COUNT(*) FROM users')->fetchColumn();
+$activeUsers  = (int)$db->query('SELECT COUNT(*) FROM users WHERE is_active = 1')->fetchColumn();
+
+/* User counts by role */
+$roleStmt = $db->query('SELECT role, COUNT(*) as cnt FROM users WHERE is_active = 1 GROUP BY role');
+$roleCounts = [];
+while ($row = $roleStmt->fetch(PDO::FETCH_ASSOC)) {
+    $roleCounts[$row['role']] = (int)$row['cnt'];
+}
+
+/* Recent users (last 10) */
+$recentUsers = $db->query('SELECT id, username, display_name, role, is_active, created_at FROM users ORDER BY created_at DESC LIMIT 10')->fetchAll(PDO::FETCH_ASSOC);
+
+/* Active API tokens count */
+$activeTokens = (int)$db->prepare('SELECT COUNT(*) FROM api_tokens WHERE expires_at > ?')->execute([gmdate('c')]) ? (int)$db->query('SELECT COUNT(*) FROM api_tokens WHERE expires_at > \'' . gmdate('c') . '\'')->fetchColumn() : 0;
+
+/* Total setlists stored */
+$totalSetlists = 0;
+try {
+    $totalSetlists = (int)$db->query('SELECT COUNT(*) FROM user_setlists')->fetchColumn();
+} catch (\Exception $e) { /* table may not exist yet */ }
+
+$csrf = csrfToken();
+?>
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dashboard — iHymns Admin</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+          rel="stylesheet"
+          integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+          crossorigin="anonymous">
+    <link rel="stylesheet"
+          href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
+          integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+"
+          crossorigin="anonymous">
+    <style>
+        :root {
+            --ih-bg: #1a1a2e;
+            --ih-surface: #16213e;
+            --ih-amber: #f59e0b;
+            --ih-amber-hover: #d97706;
+            --ih-text: #e2e8f0;
+            --ih-text-muted: #94a3b8;
+            --ih-border: #334155;
+        }
+        body { background: var(--ih-bg); color: var(--ih-text); }
+        .navbar-admin { background: var(--ih-surface); border-bottom: 1px solid var(--ih-border); padding: 0.75rem 1rem; }
+        .navbar-admin .nav-link { color: var(--ih-text-muted); }
+        .navbar-admin .nav-link:hover, .navbar-admin .nav-link.active { color: var(--ih-amber); }
+        .card-admin { background: var(--ih-surface); border: 1px solid var(--ih-border); border-radius: 12px; }
+        .stat-card { text-align: center; padding: 1.25rem; }
+        .stat-card .stat-number { font-size: 2rem; font-weight: 700; color: var(--ih-amber); }
+        .stat-card .stat-label { font-size: 0.8rem; color: var(--ih-text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
+        .btn-amber { background: var(--ih-amber); border-color: var(--ih-amber); color: #1a1a2e; font-weight: 600; }
+        .btn-amber:hover { background: var(--ih-amber-hover); border-color: var(--ih-amber-hover); color: #1a1a2e; }
+        .table { color: var(--ih-text); }
+        .quick-link { display: block; padding: 1rem; border-radius: 8px; text-decoration: none; color: var(--ih-text); transition: background 0.2s; }
+        .quick-link:hover { background: rgba(245, 158, 11, 0.1); color: var(--ih-amber); }
+        .quick-link i { font-size: 1.5rem; color: var(--ih-amber); }
+    </style>
+</head>
+<body>
+    <?php require __DIR__ . '/includes/admin-nav.php'; ?>
+
+    <div class="container py-4" style="max-width: 960px;">
+
+        <h1 class="h4 mb-4"><i class="bi bi-speedometer2 me-2"></i>Dashboard</h1>
+
+        <!-- Stats Cards -->
+        <div class="row g-3 mb-4">
+            <div class="col-6 col-md-3">
+                <div class="card-admin stat-card">
+                    <div class="stat-number"><?= $activeUsers ?></div>
+                    <div class="stat-label">Active Users</div>
+                </div>
+            </div>
+            <div class="col-6 col-md-3">
+                <div class="card-admin stat-card">
+                    <div class="stat-number"><?= $totalUsers ?></div>
+                    <div class="stat-label">Total Users</div>
+                </div>
+            </div>
+            <div class="col-6 col-md-3">
+                <div class="card-admin stat-card">
+                    <div class="stat-number"><?= $activeTokens ?></div>
+                    <div class="stat-label">Active Tokens</div>
+                </div>
+            </div>
+            <div class="col-6 col-md-3">
+                <div class="card-admin stat-card">
+                    <div class="stat-number"><?= $totalSetlists ?></div>
+                    <div class="stat-label">Synced Setlists</div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Users by Role -->
+        <?php if (hasRole($currentUser['role'], 'admin')): ?>
+        <div class="card-admin p-3 mb-4">
+            <h2 class="h6 mb-3"><i class="bi bi-shield-check me-2"></i>Users by Role</h2>
+            <div class="row g-2">
+                <?php foreach (allRoles() as $role): ?>
+                <div class="col-6 col-md-3">
+                    <div class="d-flex align-items-center gap-2 p-2 rounded" style="background: rgba(255,255,255,0.03);">
+                        <span class="badge <?= match($role) {
+                            'global_admin' => 'bg-danger',
+                            'admin'        => 'bg-warning text-dark',
+                            'editor'       => 'bg-primary',
+                            default        => 'bg-secondary',
+                        } ?>"><?= htmlspecialchars(roleLabel($role)) ?></span>
+                        <strong><?= $roleCounts[$role] ?? 0 ?></strong>
+                    </div>
+                </div>
+                <?php endforeach; ?>
+            </div>
+        </div>
+        <?php endif; ?>
+
+        <!-- Quick Links -->
+        <div class="row g-3 mb-4">
+            <div class="col-md-4">
+                <div class="card-admin">
+                    <a href="/manage/editor/" class="quick-link">
+                        <i class="bi bi-pencil-square d-block mb-2"></i>
+                        <strong>Song Editor</strong>
+                        <div class="small text-muted">Edit songs, metadata, and arrangements</div>
+                    </a>
+                </div>
+            </div>
+            <?php if (hasRole($currentUser['role'], 'admin')): ?>
+            <div class="col-md-4">
+                <div class="card-admin">
+                    <a href="/manage/users" class="quick-link">
+                        <i class="bi bi-people d-block mb-2"></i>
+                        <strong>User Management</strong>
+                        <div class="small text-muted">Manage accounts, roles, and permissions</div>
+                    </a>
+                </div>
+            </div>
+            <?php endif; ?>
+            <div class="col-md-4">
+                <div class="card-admin">
+                    <a href="/" class="quick-link" target="_blank">
+                        <i class="bi bi-globe d-block mb-2"></i>
+                        <strong>View Website</strong>
+                        <div class="small text-muted">Open iHymns in a new tab</div>
+                    </a>
+                </div>
+            </div>
+        </div>
+
+        <!-- Recent Users (admin+ only) -->
+        <?php if (hasRole($currentUser['role'], 'admin')): ?>
+        <div class="card-admin p-3 mb-4">
+            <div class="d-flex align-items-center justify-content-between mb-3">
+                <h2 class="h6 mb-0"><i class="bi bi-clock-history me-2"></i>Recent Users</h2>
+                <a href="/manage/users" class="btn btn-sm btn-outline-secondary">View All</a>
+            </div>
+            <div class="table-responsive">
+                <table class="table table-sm table-borderless mb-0">
+                    <thead>
+                        <tr class="text-muted small">
+                            <th>Username</th>
+                            <th>Display Name</th>
+                            <th>Role</th>
+                            <th>Status</th>
+                            <th>Created</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($recentUsers as $u): ?>
+                        <tr>
+                            <td><code><?= htmlspecialchars($u['username']) ?></code></td>
+                            <td><?= htmlspecialchars($u['display_name']) ?></td>
+                            <td>
+                                <span class="badge <?= match($u['role']) {
+                                    'global_admin' => 'bg-danger',
+                                    'admin'        => 'bg-warning text-dark',
+                                    'editor'       => 'bg-primary',
+                                    default        => 'bg-secondary',
+                                } ?>" style="font-size: 0.7rem;">
+                                    <?= htmlspecialchars(roleLabel($u['role'])) ?>
+                                </span>
+                            </td>
+                            <td><?= $u['is_active'] ? '<span class="text-success small">Active</span>' : '<span class="text-danger small">Disabled</span>' ?></td>
+                            <td class="text-muted small"><?= htmlspecialchars($u['created_at']) ?></td>
+                        </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <?php endif; ?>
+
+        <!-- System Info -->
+        <div class="card-admin p-3">
+            <h2 class="h6 mb-3"><i class="bi bi-info-circle me-2"></i>System Info</h2>
+            <table class="table table-sm table-borderless mb-0 small">
+                <tr><td class="text-muted" style="width:40%">PHP Version</td><td><?= phpversion() ?></td></tr>
+                <tr><td class="text-muted">Database Driver</td><td><?= ucfirst(DB_CONFIG['driver']) ?></td></tr>
+                <?php if (DB_CONFIG['driver'] === 'sqlite'): ?>
+                <tr><td class="text-muted">Database File</td><td><code class="small"><?= htmlspecialchars(basename(DB_CONFIG['sqlite']['path'])) ?></code></td></tr>
+                <?php endif; ?>
+                <tr><td class="text-muted">Your Role</td><td><?= htmlspecialchars(roleLabel($currentUser['role'])) ?></td></tr>
+                <tr><td class="text-muted">Your Username</td><td><code><?= htmlspecialchars($currentUser['username']) ?></code></td></tr>
+            </table>
+        </div>
+
+    </div>
+</body>
+</html>

--- a/appWeb/public_html/manage/users.php
+++ b/appWeb/public_html/manage/users.php
@@ -3,62 +3,169 @@
 declare(strict_types=1);
 
 /**
- * iHymns — Admin User Management (#229)
+ * iHymns — Admin User Management (#229, #260)
  *
  * Copyright (c) 2026 iHymns. All rights reserved.
  *
  * PURPOSE:
- * Allows admins to create new user accounts. Only accessible to
- * authenticated users with the 'admin' role. The public setup page
- * is disabled after the first admin is created — all subsequent
- * user creation goes through this page.
+ * Full user management for admins: create, edit roles, activate/deactivate,
+ * reset passwords, and delete user accounts. Enforces role hierarchy so
+ * admins can only manage users below their own privilege level.
  */
 
 require_once __DIR__ . '/includes/auth.php';
 requireAdmin();
 
 $currentUser = getCurrentUser();
+$activePage  = 'users';
 
-/* Handle form submission */
+/* =========================================================================
+ * HANDLE POST ACTIONS
+ * ========================================================================= */
+
 $error   = '';
 $success = '';
+
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $token       = $_POST['csrf_token'] ?? '';
-    $username    = $_POST['username'] ?? '';
-    $displayName = $_POST['display_name'] ?? '';
-    $password    = $_POST['password'] ?? '';
-    $confirm     = $_POST['password_confirm'] ?? '';
-    $role        = $_POST['role'] ?? 'editor';
+    $token  = $_POST['csrf_token'] ?? '';
+    $action = $_POST['action'] ?? 'create';
 
     if (!validateCsrf($token)) {
         $error = 'Invalid form submission. Please try again.';
-    } elseif (strlen(trim($username)) < 3) {
-        $error = 'Username must be at least 3 characters.';
-    } elseif (strlen($password) < 8) {
-        $error = 'Password must be at least 8 characters.';
-    } elseif ($password !== $confirm) {
-        $error = 'Passwords do not match.';
-    } elseif (!in_array($role, allRoles(), true)) {
-        $error = 'Invalid role.';
-    } elseif ($role === 'global_admin' && $currentUser['role'] !== 'global_admin') {
-        $error = 'Only Global Admin can assign the Global Admin role.';
-    } elseif (roleLevel($role) > roleLevel($currentUser['role'])) {
-        $error = 'Cannot assign a role higher than your own.';
     } else {
-        try {
-            createUser($username, $password, $displayName ?: $username, $role);
-            $success = 'User "' . htmlspecialchars($username) . '" created successfully.';
-        } catch (\RuntimeException $e) {
-            $error = $e->getMessage();
+        switch ($action) {
+
+            /* ----- Create new user ----- */
+            case 'create':
+                $username    = $_POST['username'] ?? '';
+                $displayName = $_POST['display_name'] ?? '';
+                $password    = $_POST['password'] ?? '';
+                $confirm     = $_POST['password_confirm'] ?? '';
+                $role        = $_POST['role'] ?? 'editor';
+
+                if (strlen(trim($username)) < 3) {
+                    $error = 'Username must be at least 3 characters.';
+                } elseif (strlen($password) < 8) {
+                    $error = 'Password must be at least 8 characters.';
+                } elseif ($password !== $confirm) {
+                    $error = 'Passwords do not match.';
+                } elseif (!in_array($role, allRoles(), true)) {
+                    $error = 'Invalid role.';
+                } elseif ($role === 'global_admin' && $currentUser['role'] !== 'global_admin') {
+                    $error = 'Only Global Admin can assign the Global Admin role.';
+                } elseif (roleLevel($role) > roleLevel($currentUser['role'])) {
+                    $error = 'Cannot assign a role higher than your own.';
+                } else {
+                    try {
+                        createUser($username, $password, $displayName ?: $username, $role);
+                        $success = 'User "' . htmlspecialchars($username) . '" created successfully.';
+                    } catch (\RuntimeException $e) {
+                        $error = $e->getMessage();
+                    }
+                }
+                break;
+
+            /* ----- Change role ----- */
+            case 'change_role':
+                $targetId = (int)($_POST['user_id'] ?? 0);
+                $newRole  = $_POST['new_role'] ?? '';
+                try {
+                    updateUserRole($targetId, $newRole, $currentUser);
+                    $success = 'Role updated successfully.';
+                } catch (\RuntimeException $e) {
+                    $error = $e->getMessage();
+                }
+                break;
+
+            /* ----- Toggle active status ----- */
+            case 'toggle_active':
+                $targetId  = (int)($_POST['user_id'] ?? 0);
+                $target    = getUserById($targetId);
+                if (!$target) {
+                    $error = 'User not found.';
+                } elseif ($targetId === $currentUser['id']) {
+                    $error = 'Cannot deactivate your own account.';
+                } elseif (roleLevel($target['role']) >= roleLevel($currentUser['role']) && $currentUser['role'] !== 'global_admin') {
+                    $error = 'Cannot modify a user at or above your role level.';
+                } else {
+                    $newState = !$target['is_active'];
+                    setUserActive($targetId, $newState);
+                    $success = 'User ' . ($newState ? 'activated' : 'deactivated') . ' successfully.';
+                }
+                break;
+
+            /* ----- Reset password ----- */
+            case 'reset_password':
+                $targetId    = (int)($_POST['user_id'] ?? 0);
+                $newPassword = $_POST['new_password'] ?? '';
+                $target      = getUserById($targetId);
+                if (!$target) {
+                    $error = 'User not found.';
+                } elseif (strlen($newPassword) < 8) {
+                    $error = 'Password must be at least 8 characters.';
+                } elseif (roleLevel($target['role']) >= roleLevel($currentUser['role']) && $currentUser['role'] !== 'global_admin' && $targetId !== $currentUser['id']) {
+                    $error = 'Cannot reset password for a user at or above your role level.';
+                } else {
+                    changeUserPassword($targetId, $newPassword);
+                    $success = 'Password reset successfully for "' . htmlspecialchars($target['username']) . '".';
+                }
+                break;
+
+            /* ----- Update profile ----- */
+            case 'update_profile':
+                $targetId    = (int)($_POST['user_id'] ?? 0);
+                $displayName = trim($_POST['display_name'] ?? '');
+                $email       = trim($_POST['email'] ?? '');
+                $target      = getUserById($targetId);
+                if (!$target) {
+                    $error = 'User not found.';
+                } elseif (roleLevel($target['role']) >= roleLevel($currentUser['role']) && $currentUser['role'] !== 'global_admin' && $targetId !== $currentUser['id']) {
+                    $error = 'Cannot edit a user at or above your role level.';
+                } elseif ($displayName === '') {
+                    $error = 'Display name cannot be empty.';
+                } else {
+                    updateUserProfile($targetId, $displayName, $email);
+                    $success = 'Profile updated for "' . htmlspecialchars($target['username']) . '".';
+                }
+                break;
+
+            /* ----- Delete user ----- */
+            case 'delete':
+                $targetId = (int)($_POST['user_id'] ?? 0);
+                $target   = getUserById($targetId);
+                if (!$target) {
+                    $error = 'User not found.';
+                } elseif ($targetId === $currentUser['id']) {
+                    $error = 'Cannot delete your own account.';
+                } elseif (roleLevel($target['role']) >= roleLevel($currentUser['role']) && $currentUser['role'] !== 'global_admin') {
+                    $error = 'Cannot delete a user at or above your role level.';
+                } else {
+                    deleteUser($targetId);
+                    $success = 'User "' . htmlspecialchars($target['username']) . '" deleted permanently.';
+                }
+                break;
         }
     }
+
+    /* Refresh current user in case they edited themselves */
+    $currentUser = getCurrentUser();
 }
 
-/* Fetch existing users for the list */
+/* =========================================================================
+ * FETCH DATA
+ * ========================================================================= */
+
 $db = getDb();
-$users = $db->query('SELECT id, username, display_name, role, is_active, created_at FROM users ORDER BY created_at ASC')->fetchAll(PDO::FETCH_ASSOC);
+$users = $db->query('SELECT id, username, display_name, email, role, is_active, created_at FROM users ORDER BY created_at ASC')->fetchAll(PDO::FETCH_ASSOC);
 
 $csrf = csrfToken();
+
+/* Helper: can the current user manage this target user? */
+function canManage(array $target, array $actor): bool {
+    if ((int)$target['id'] === (int)$actor['id']) return true; /* can edit self (limited) */
+    if ($actor['role'] === 'global_admin') return true;
+    return roleLevel($target['role']) < roleLevel($actor['role']);
+}
 ?>
 <!DOCTYPE html>
 <html lang="en" data-bs-theme="dark">
@@ -85,99 +192,149 @@ $csrf = csrfToken();
             --ih-border: #334155;
         }
         body { background: var(--ih-bg); color: var(--ih-text); }
+        .navbar-admin { background: var(--ih-surface); border-bottom: 1px solid var(--ih-border); padding: 0.75rem 1rem; }
+        .navbar-admin .nav-link { color: var(--ih-text-muted); }
+        .navbar-admin .nav-link:hover, .navbar-admin .nav-link.active { color: var(--ih-amber); }
         .card-admin { background: var(--ih-surface); border: 1px solid var(--ih-border); border-radius: 12px; }
         .btn-amber { background: var(--ih-amber); border-color: var(--ih-amber); color: #1a1a2e; font-weight: 600; }
         .btn-amber:hover { background: var(--ih-amber-hover); border-color: var(--ih-amber-hover); color: #1a1a2e; }
         .form-control:focus, .form-select:focus { border-color: var(--ih-amber); box-shadow: 0 0 0 0.2rem rgba(245, 158, 11, 0.25); }
-        .navbar-admin { background: var(--ih-surface); border-bottom: 1px solid var(--ih-border); padding: 0.75rem 1rem; }
-        .navbar-admin .nav-link { color: var(--ih-text-muted); }
-        .navbar-admin .nav-link:hover { color: var(--ih-amber); }
         .table { color: var(--ih-text); }
-        .badge-global-admin { background: #dc2626; }
-        .badge-admin { background: var(--ih-amber); color: #1a1a2e; }
-        .badge-editor { background: #3b82f6; }
-        .badge-user { background: #6b7280; }
+        .user-row:hover { background: rgba(255,255,255,0.02); }
+        .user-actions .btn { padding: 0.15rem 0.4rem; font-size: 0.75rem; }
     </style>
 </head>
 <body>
-    <!-- Navigation -->
-    <nav class="navbar-admin d-flex align-items-center">
-        <a href="/manage/editor/" class="text-decoration-none me-auto d-flex align-items-center gap-2" style="color: var(--ih-amber);">
-            <i class="bi bi-music-note-beamed"></i>
-            <strong>iHymns Admin</strong>
-        </a>
-        <a href="/manage/editor/" class="nav-link d-inline"><i class="bi bi-pencil-square me-1"></i>Editor</a>
-        <span class="text-muted mx-2">|</span>
-        <span class="text-muted small"><?= htmlspecialchars($currentUser['display_name'] ?? $currentUser['username']) ?></span>
-        <a href="/manage/logout" class="btn btn-sm btn-outline-secondary ms-2">
-            <i class="bi bi-box-arrow-right me-1"></i>Logout
-        </a>
-    </nav>
+    <?php require __DIR__ . '/includes/admin-nav.php'; ?>
 
-    <div class="container py-4" style="max-width: 800px;">
+    <div class="container py-4" style="max-width: 960px;">
 
         <h1 class="h4 mb-4"><i class="bi bi-people me-2"></i>User Management</h1>
 
+        <?php if ($success): ?>
+            <div class="alert alert-success py-2 alert-dismissible fade show">
+                <i class="bi bi-check-circle me-1"></i><?= $success ?>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="alert"></button>
+            </div>
+        <?php endif; ?>
+        <?php if ($error): ?>
+            <div class="alert alert-danger py-2 alert-dismissible fade show">
+                <i class="bi bi-exclamation-triangle me-1"></i><?= htmlspecialchars($error) ?>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="alert"></button>
+            </div>
+        <?php endif; ?>
+
         <!-- Existing users -->
         <div class="card-admin p-3 mb-4">
-            <h2 class="h6 mb-3">Existing Users</h2>
-            <table class="table table-sm table-borderless mb-0">
-                <thead>
-                    <tr class="text-muted small">
-                        <th>Username</th>
-                        <th>Display Name</th>
-                        <th>Role</th>
-                        <th>Status</th>
-                        <th>Created</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <?php foreach ($users as $u): ?>
-                    <tr>
-                        <td><code><?= htmlspecialchars($u['username']) ?></code></td>
-                        <td><?= htmlspecialchars($u['display_name']) ?></td>
-                        <td>
-                            <span class="badge <?= match($u['role']) {
-                                'global_admin' => 'badge-global-admin',
-                                'admin'        => 'badge-admin',
-                                'editor'       => 'badge-editor',
-                                default        => 'badge-user',
-                            } ?>">
-                                <?= htmlspecialchars(roleLabel($u['role'])) ?>
-                            </span>
-                        </td>
-                        <td><?= $u['is_active'] ? '<span class="text-success">Active</span>' : '<span class="text-danger">Disabled</span>' ?></td>
-                        <td class="text-muted small"><?= htmlspecialchars($u['created_at']) ?></td>
-                    </tr>
-                    <?php endforeach; ?>
-                </tbody>
-            </table>
+            <h2 class="h6 mb-3">All Users <span class="badge bg-secondary ms-1"><?= count($users) ?></span></h2>
+            <div class="table-responsive">
+                <table class="table table-sm table-borderless mb-0">
+                    <thead>
+                        <tr class="text-muted small">
+                            <th>Username</th>
+                            <th>Display Name</th>
+                            <th>Email</th>
+                            <th>Role</th>
+                            <th>Status</th>
+                            <th class="text-end">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($users as $u): ?>
+                        <?php $manageable = canManage($u, $currentUser); $isSelf = ((int)$u['id'] === $currentUser['id']); ?>
+                        <tr class="user-row">
+                            <td>
+                                <code><?= htmlspecialchars($u['username']) ?></code>
+                                <?php if ($isSelf): ?><span class="badge bg-info text-dark" style="font-size:0.6rem">You</span><?php endif; ?>
+                            </td>
+                            <td><?= htmlspecialchars($u['display_name']) ?></td>
+                            <td class="text-muted small"><?= htmlspecialchars($u['email'] ?? '') ?></td>
+                            <td>
+                                <span class="badge <?= match($u['role']) {
+                                    'global_admin' => 'bg-danger',
+                                    'admin'        => 'bg-warning text-dark',
+                                    'editor'       => 'bg-primary',
+                                    default        => 'bg-secondary',
+                                } ?>" style="font-size: 0.7rem;">
+                                    <?= htmlspecialchars(roleLabel($u['role'])) ?>
+                                </span>
+                            </td>
+                            <td>
+                                <?php if ($u['is_active']): ?>
+                                    <span class="text-success small"><i class="bi bi-circle-fill" style="font-size:0.5rem"></i> Active</span>
+                                <?php else: ?>
+                                    <span class="text-danger small"><i class="bi bi-circle-fill" style="font-size:0.5rem"></i> Disabled</span>
+                                <?php endif; ?>
+                            </td>
+                            <td class="text-end user-actions">
+                                <?php if ($manageable): ?>
+                                    <!-- Edit Profile -->
+                                    <button class="btn btn-outline-info" title="Edit profile"
+                                            onclick="openEditModal(<?= (int)$u['id'] ?>, '<?= htmlspecialchars($u['display_name'], ENT_QUOTES) ?>', '<?= htmlspecialchars($u['email'] ?? '', ENT_QUOTES) ?>')">
+                                        <i class="bi bi-pencil"></i>
+                                    </button>
+                                    <!-- Change Role (not for self) -->
+                                    <?php if (!$isSelf): ?>
+                                    <button class="btn btn-outline-warning" title="Change role"
+                                            onclick="openRoleModal(<?= (int)$u['id'] ?>, '<?= htmlspecialchars($u['username'], ENT_QUOTES) ?>', '<?= $u['role'] ?>')">
+                                        <i class="bi bi-shield"></i>
+                                    </button>
+                                    <?php endif; ?>
+                                    <!-- Reset Password -->
+                                    <button class="btn btn-outline-secondary" title="Reset password"
+                                            onclick="openPasswordModal(<?= (int)$u['id'] ?>, '<?= htmlspecialchars($u['username'], ENT_QUOTES) ?>')">
+                                        <i class="bi bi-key"></i>
+                                    </button>
+                                    <!-- Toggle Active (not for self) -->
+                                    <?php if (!$isSelf): ?>
+                                    <form method="POST" class="d-inline" onsubmit="return confirm('<?= $u['is_active'] ? 'Deactivate' : 'Activate' ?> user <?= htmlspecialchars($u['username'], ENT_QUOTES) ?>?')">
+                                        <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                                        <input type="hidden" name="action" value="toggle_active">
+                                        <input type="hidden" name="user_id" value="<?= (int)$u['id'] ?>">
+                                        <button class="btn <?= $u['is_active'] ? 'btn-outline-warning' : 'btn-outline-success' ?>"
+                                                title="<?= $u['is_active'] ? 'Deactivate' : 'Activate' ?>">
+                                            <i class="bi <?= $u['is_active'] ? 'bi-pause-circle' : 'bi-play-circle' ?>"></i>
+                                        </button>
+                                    </form>
+                                    <!-- Delete -->
+                                    <form method="POST" class="d-inline" onsubmit="return confirm('PERMANENTLY delete user <?= htmlspecialchars($u['username'], ENT_QUOTES) ?>? This cannot be undone.')">
+                                        <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                                        <input type="hidden" name="action" value="delete">
+                                        <input type="hidden" name="user_id" value="<?= (int)$u['id'] ?>">
+                                        <button class="btn btn-outline-danger" title="Delete user">
+                                            <i class="bi bi-trash"></i>
+                                        </button>
+                                    </form>
+                                    <?php endif; ?>
+                                <?php else: ?>
+                                    <span class="text-muted small">—</span>
+                                <?php endif; ?>
+                            </td>
+                        </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
         </div>
 
         <!-- Create new user form -->
         <div class="card-admin p-3">
-            <h2 class="h6 mb-3">Create New User</h2>
-
-            <?php if ($success): ?>
-                <div class="alert alert-success py-2"><?= $success ?></div>
-            <?php endif; ?>
-            <?php if ($error): ?>
-                <div class="alert alert-danger py-2"><i class="bi bi-exclamation-triangle me-1"></i><?= htmlspecialchars($error) ?></div>
-            <?php endif; ?>
+            <h2 class="h6 mb-3"><i class="bi bi-person-plus me-2"></i>Create New User</h2>
 
             <form method="POST">
                 <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                <input type="hidden" name="action" value="create">
 
                 <div class="row mb-3">
                     <div class="col-md-6">
                         <label for="username" class="form-label">Username <span class="text-danger">*</span></label>
                         <input type="text" class="form-control" id="username" name="username"
-                               value="<?= htmlspecialchars($_POST['username'] ?? '') ?>" minlength="3" required>
+                               value="<?= htmlspecialchars($_POST['action'] ?? '') === 'create' ? htmlspecialchars($_POST['username'] ?? '') : '' ?>" minlength="3" required>
                     </div>
                     <div class="col-md-6">
                         <label for="display_name" class="form-label">Display Name</label>
                         <input type="text" class="form-control" id="display_name" name="display_name"
-                               value="<?= htmlspecialchars($_POST['display_name'] ?? '') ?>" placeholder="Defaults to username">
+                               value="<?= htmlspecialchars($_POST['action'] ?? '') === 'create' ? htmlspecialchars($_POST['display_name'] ?? '') : '' ?>" placeholder="Defaults to username">
                     </div>
                 </div>
 
@@ -210,5 +367,134 @@ $csrf = csrfToken();
             </form>
         </div>
     </div>
+
+    <!-- ================================================================
+         MODALS
+         ================================================================ -->
+
+    <!-- Edit Profile Modal -->
+    <div class="modal fade" id="editModal" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content" style="background: var(--ih-surface); color: var(--ih-text); border-color: var(--ih-border);">
+                <form method="POST">
+                    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                    <input type="hidden" name="action" value="update_profile">
+                    <input type="hidden" name="user_id" id="edit-user-id">
+                    <div class="modal-header" style="border-color: var(--ih-border);">
+                        <h5 class="modal-title"><i class="bi bi-pencil me-2"></i>Edit Profile</h5>
+                        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+                    </div>
+                    <div class="modal-body">
+                        <div class="mb-3">
+                            <label class="form-label">Display Name</label>
+                            <input type="text" class="form-control" name="display_name" id="edit-display-name" required>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Email</label>
+                            <input type="email" class="form-control" name="email" id="edit-email" placeholder="Optional">
+                        </div>
+                    </div>
+                    <div class="modal-footer" style="border-color: var(--ih-border);">
+                        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                        <button type="submit" class="btn btn-amber">Save Changes</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <!-- Change Role Modal -->
+    <div class="modal fade" id="roleModal" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content" style="background: var(--ih-surface); color: var(--ih-text); border-color: var(--ih-border);">
+                <form method="POST">
+                    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                    <input type="hidden" name="action" value="change_role">
+                    <input type="hidden" name="user_id" id="role-user-id">
+                    <div class="modal-header" style="border-color: var(--ih-border);">
+                        <h5 class="modal-title"><i class="bi bi-shield me-2"></i>Change Role — <span id="role-username"></span></h5>
+                        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+                    </div>
+                    <div class="modal-body">
+                        <select class="form-select" name="new_role" id="role-select">
+                            <option value="user">User — can save setlists centrally</option>
+                            <option value="editor">Curator / Editor — can edit songs</option>
+                            <option value="admin">Admin — full access including user management</option>
+                            <?php if ($currentUser['role'] === 'global_admin'): ?>
+                            <option value="global_admin">Global Admin — unrestricted access</option>
+                            <?php endif; ?>
+                        </select>
+                        <div class="form-text" style="color: var(--ih-text-muted);">
+                            You cannot assign a role higher than your own.
+                        </div>
+                    </div>
+                    <div class="modal-footer" style="border-color: var(--ih-border);">
+                        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                        <button type="submit" class="btn btn-amber">Update Role</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <!-- Reset Password Modal -->
+    <div class="modal fade" id="passwordModal" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content" style="background: var(--ih-surface); color: var(--ih-text); border-color: var(--ih-border);">
+                <form method="POST">
+                    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                    <input type="hidden" name="action" value="reset_password">
+                    <input type="hidden" name="user_id" id="pw-user-id">
+                    <div class="modal-header" style="border-color: var(--ih-border);">
+                        <h5 class="modal-title"><i class="bi bi-key me-2"></i>Reset Password — <span id="pw-username"></span></h5>
+                        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+                    </div>
+                    <div class="modal-body">
+                        <div class="mb-3">
+                            <label class="form-label">New Password</label>
+                            <input type="password" class="form-control" name="new_password" minlength="8" required
+                                   placeholder="Minimum 8 characters">
+                        </div>
+                        <div class="alert alert-warning py-2 small mb-0">
+                            <i class="bi bi-exclamation-triangle me-1"></i>
+                            This will invalidate all active sessions and API tokens for this user.
+                        </div>
+                    </div>
+                    <div class="modal-footer" style="border-color: var(--ih-border);">
+                        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                        <button type="submit" class="btn btn-danger">Reset Password</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+            integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
+            crossorigin="anonymous"></script>
+    <script>
+        /* Open Edit Profile modal */
+        function openEditModal(userId, displayName, email) {
+            document.getElementById('edit-user-id').value = userId;
+            document.getElementById('edit-display-name').value = displayName;
+            document.getElementById('edit-email').value = email;
+            new bootstrap.Modal(document.getElementById('editModal')).show();
+        }
+
+        /* Open Change Role modal */
+        function openRoleModal(userId, username, currentRole) {
+            document.getElementById('role-user-id').value = userId;
+            document.getElementById('role-username').textContent = username;
+            document.getElementById('role-select').value = currentRole;
+            new bootstrap.Modal(document.getElementById('roleModal')).show();
+        }
+
+        /* Open Reset Password modal */
+        function openPasswordModal(userId, username) {
+            document.getElementById('pw-user-id').value = userId;
+            document.getElementById('pw-username').textContent = username;
+            new bootstrap.Modal(document.getElementById('passwordModal')).show();
+        }
+    </script>
 </body>
 </html>


### PR DESCRIPTION
Add central admin dashboard with stats, role breakdown, quick links, and recent users. Rewrite user management with full CRUD (create, edit profile, change role, reset password, toggle active, delete) with Bootstrap modals and role hierarchy enforcement. Extract shared admin navbar component. Update .htaccess to serve dashboard at /manage/.

https://claude.ai/code/session_019iLcFctpajfVnyEsGqZCvj