### PR TITLE
fix: auto-scroll iOS support and floating stop button (#267)

### DIFF
--- a/appWeb/public_html/css/app.css
+++ b/appWeb/public_html/css/app.css
@@ -1504,6 +1504,38 @@ body.reduce-motion .scroll-to-top-btn {
     font-size: 0.85rem;
 }
 
+/* Auto-scroll floating stop button — stays visible when toolbar scrolls away */
+.btn-autoscroll-fab {
+    position: fixed;
+    bottom: calc(var(--footer-total-height, 88px) + 16px);
+    right: 16px;
+    z-index: 1025;
+    border-radius: var(--radius-pill, 50px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    font-size: 0.85rem;
+    padding: 8px 16px;
+    animation: fabSlideIn 0.25s ease;
+}
+
+@keyframes fabSlideIn {
+    from { opacity: 0; transform: translateY(12px); }
+    to   { opacity: 1; transform: translateY(0); }
+}
+
+@media (display-mode: standalone) {
+    .btn-autoscroll-fab {
+        bottom: calc(var(--footer-total-height, 88px) + env(safe-area-inset-bottom, 0px) + 16px);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .btn-autoscroll-fab { animation: none; }
+}
+
+body.reduce-motion .btn-autoscroll-fab {
+    animation: none;
+}
+
 /* Line spacing variants */
 .song-lyrics.spacing-compact .lyric-line {
     margin-bottom: 0 !important;

--- a/appWeb/public_html/js/modules/display.js
+++ b/appWeb/public_html/js/modules/display.js
@@ -21,8 +21,8 @@ export class Display {
         /** @type {string} localStorage key */
         this.storageKey = STORAGE_DISPLAY;
 
-        /** @type {number|null} Auto-scroll interval ID */
-        this.autoScrollInterval = null;
+        /** @type {number|null} requestAnimationFrame ID for auto-scroll */
+        this.autoScrollRAF = null;
 
         /** @type {boolean} Whether auto-scroll is active */
         this.autoScrollActive = false;
@@ -345,37 +345,89 @@ export class Display {
         }
     }
 
-    /** Start auto-scrolling */
+    /**
+     * Start auto-scrolling using requestAnimationFrame.
+     * Uses rAF instead of setInterval for reliable scrolling on all
+     * platforms including iOS Safari, which throttles setInterval.
+     * Delta-time based so scroll speed is consistent regardless of
+     * frame rate (e.g. 60fps, 120fps ProMotion, or throttled).
+     */
     startAutoScroll() {
         this.autoScrollActive = true;
         const speed = this.get('autoScrollSpeed');
-        const pxPerFrame = speed / 60; /* 60fps */
 
         const btn = document.getElementById('display-autoscroll-btn');
         if (btn) btn.classList.add('active', 'btn-primary');
         btn?.classList.remove('btn-outline-secondary');
 
-        this.autoScrollInterval = setInterval(() => {
-            window.scrollBy({ top: pxPerFrame, behavior: 'auto' });
+        this._showFloatingStop();
 
-            /* Stop at bottom */
-            if ((window.innerHeight + window.scrollY) >= document.body.scrollHeight) {
-                this.stopAutoScroll();
+        let lastTime = null;
+
+        const tick = (timestamp) => {
+            if (!this.autoScrollActive) return;
+
+            if (lastTime !== null) {
+                const delta = (timestamp - lastTime) / 1000; /* seconds */
+                const px = speed * delta;
+                /* Use simple (x, y) signature — the options-object form
+                   is unreliable on iOS Safari */
+                window.scrollBy(0, px);
             }
-        }, 1000 / 60);
+            lastTime = timestamp;
+
+            /* Stop at bottom of page */
+            if ((window.innerHeight + window.scrollY) >= document.body.scrollHeight - 1) {
+                this.stopAutoScroll();
+                return;
+            }
+
+            this.autoScrollRAF = requestAnimationFrame(tick);
+        };
+
+        this.autoScrollRAF = requestAnimationFrame(tick);
     }
 
     /** Stop auto-scrolling */
     stopAutoScroll() {
         this.autoScrollActive = false;
-        if (this.autoScrollInterval) {
-            clearInterval(this.autoScrollInterval);
-            this.autoScrollInterval = null;
+        if (this.autoScrollRAF) {
+            cancelAnimationFrame(this.autoScrollRAF);
+            this.autoScrollRAF = null;
         }
 
         const btn = document.getElementById('display-autoscroll-btn');
         if (btn) btn.classList.remove('active', 'btn-primary');
         btn?.classList.add('btn-outline-secondary');
+
+        this._hideFloatingStop();
+    }
+
+    /**
+     * Show a floating "Stop" button so auto-scroll can be stopped
+     * even after the toolbar has scrolled off-screen.
+     * @private
+     */
+    _showFloatingStop() {
+        if (document.getElementById('autoscroll-fab')) return;
+
+        const fab = document.createElement('button');
+        fab.id = 'autoscroll-fab';
+        fab.type = 'button';
+        fab.className = 'btn btn-primary btn-autoscroll-fab';
+        fab.setAttribute('aria-label', 'Stop auto-scroll');
+        fab.title = 'Stop auto-scroll';
+        fab.innerHTML = '<i class="fa-solid fa-stop me-1" aria-hidden="true"></i> Stop';
+        fab.addEventListener('click', () => this.stopAutoScroll());
+        document.body.appendChild(fab);
+    }
+
+    /**
+     * Remove the floating stop button.
+     * @private
+     */
+    _hideFloatingStop() {
+        document.getElementById('autoscroll-fab')?.remove();
     }
 
     /* =====================================================================


### PR DESCRIPTION
Two issues fixed:

1. Auto-scroll didn't work on iOS — replaced setInterval + scrollBy options-object with requestAnimationFrame + scrollBy(x,y) simple signature. Uses delta time for consistent speed across frame rates (60fps, 120fps ProMotion, or throttled).

2. Auto-scroll button scrolled out of view — added a floating "Stop" FAB that appears when auto-scroll is active, positioned above the footer with safe area support for standalone PWA mode.

https://claude.ai/code/session_019iLcFctpajfVnyEsGqZCvj