### PR TITLE
fix: JSON fallback, hide .php from URLs, importers

### DIFF
--- a/.importers/scrapers/MissionPraise.com.applescript
+++ b/.importers/scrapers/MissionPraise.com.applescript
@@ -1,0 +1,2675 @@
+(*
+	MissionPraise.com.applescript
+	importers/scrapers/MissionPraise.com.applescript
+
+	Mission Praise Scraper for macOS — scrapes lyrics and downloads files from missionpraise.com.
+	Copyright 2025-2026 MWBM Partners Ltd.
+
+	Overview:
+		This AppleScript authenticates with missionpraise.com (a WordPress-based site
+		that requires a paid subscription), then crawls the paginated song index
+		to discover all songs across three hymnbooks:
+			- Mission Praise (MP)  — ~1000+ songs, 4-digit numbering
+			- Carol Praise (CP)    — ~300 songs, 3-digit numbering
+			- Junior Praise (JP)   — ~300 songs, 3-digit numbering
+
+		For each song, it:
+		1. Scrapes the lyrics from the song detail page
+		2. Optionally downloads associated files (words RTF/DOC, music PDF, audio MP3)
+		3. Saves everything with a consistent filename convention
+
+		The scraper is designed to be resumable: it checks the output directory for
+		existing files on startup and skips songs that already have saved lyrics/downloads.
+
+	Authentication:
+		The site uses WordPress standard login (wp-login.php) with CSRF nonces
+		and may be behind a Sucuri WAF (Web Application Firewall). The login
+		flow handles:
+		- Extracting hidden form fields (nonces) from the login page via shell regex
+		- Setting proper Referer/Origin headers to pass WAF checks
+		- Detecting WAF blocks, login failures, and ambiguous states
+		- Cookie-based session management via a temp cookie jar file
+
+	How to use:
+		1. Open this file in Script Editor (double-click it)
+		2. Click the "Run" (play) button
+		3. Follow the interactive dialogs to configure and start
+		-OR-
+		1. In Script Editor, choose File > Export... > File Format: Application
+		2. Save as "Mission Praise Scraper.app"
+		3. Double-click the .app from Finder to run
+
+	File output format:
+		Lyrics are saved as plain-text files:
+			{padded_number} ({LABEL}) - {Title Case Title}.txt
+		Download files use the same base name with type suffixes:
+			{base}.rtf          (words — primary download, no suffix)
+			{base}_music.pdf    (music score)
+			{base}_audio.mp3    (audio recording)
+
+		Files are organised into book-specific subdirectories:
+			hymns/Mission Praise [MP]/
+			hymns/Carol Praise [CP]/
+			hymns/Junior Praise [JP]/
+
+	Dependencies:
+		None — uses only macOS built-in tools (curl, grep, sed, awk, file, xxd).
+		Requires macOS 10.12+ for full compatibility.
+
+	Notes:
+		- All HTTP requests are made via `do shell script` calling curl
+		- HTML parsing is performed via grep/sed/awk shell pipelines
+		- Progress is shown via `display notification` and Script Editor's log
+		- Passwords are entered with `with hidden answer` to mask input
+		- All temp files (cookie jar, helper scripts) are cleaned up on exit
+		- Use `quoted form of` for all shell arguments to prevent injection
+*)
+
+
+-- ==========================================================================
+-- PROPERTIES — Script-level constants and configuration
+-- ==========================================================================
+
+-- Script metadata (displayed in welcome dialog)
+property scriptName : "Mission Praise Scraper"
+property scriptVersion : "1.0.0"
+property scriptCopyright : "Copyright 2025-2026 MWBM Partners Ltd."
+
+-- Base URL for the Mission Praise website
+property baseURL : "https://missionpraise.com"
+
+-- WordPress standard login endpoint
+property loginURL : "https://missionpraise.com/wp-login.php"
+
+-- Paginated song index URL base — append page number and trailing slash
+property indexURL : "https://missionpraise.com/songs/page/"
+
+-- Default delay between HTTP requests (seconds). 1.2s is chosen to be
+-- respectful to the server while keeping scraping at a reasonable speed.
+property defaultDelay : 1.2
+
+-- Force re-download: when true, skips the file cache check and re-downloads
+-- all songs even if they already exist on disk. Useful for refreshing lyrics
+-- after upstream corrections or re-downloading files that may be corrupt.
+property defaultForceRedownload : false
+
+-- User-Agent string mimicking Chrome on macOS (avoids WAF blocks)
+property userAgent : "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36 Edg/145.0.0.0"
+
+
+-- ==========================================================================
+-- MAIN ENTRY POINT — Show welcome dialog and branch to user's choice
+-- ==========================================================================
+
+-- Wrap the entire script in a try block so we can clean up temp files on error
+-- The cookieJar variable is declared here so it is accessible in the on error block
+set cookieJar to ""
+
+try
+	-- ======================================================================
+	-- WELCOME DIALOG — Introduction, with Help and Start options
+	-- ======================================================================
+	-- The welcome dialog gives the user three choices:
+	--   "Help / ?" — show detailed usage information
+	--   "Configure & Start" — show all configuration dialogs
+	--   "Quick Start" — use defaults, only prompt for credentials
+	set welcomeMsg to scriptName & " v" & scriptVersion & return & return & ¬
+		"Scrapes lyrics and downloads files from missionpraise.com." & return & ¬
+		"Supports Mission Praise (MP), Carol Praise (CP), and Junior Praise (JP)." & return & return & ¬
+		scriptCopyright
+
+	set welcomeResult to display dialog welcomeMsg with title scriptName buttons {"Help / ?", "Configure & Start", "Quick Start"} default button "Quick Start" with icon note
+	set welcomeChoice to button returned of welcomeResult
+
+	-- ======================================================================
+	-- HELP DIALOG — Detailed usage information (shown if user clicks Help)
+	-- ======================================================================
+	if welcomeChoice is "Help / ?" then
+		set helpMsg to "MISSION PRAISE SCRAPER — HELP" & return & return & ¬
+			"This script scrapes lyrics and optionally downloads files (words, music, audio) " & ¬
+			"from missionpraise.com. A valid paid subscription is required." & return & return & ¬
+			"AUTHENTICATION:" & return & ¬
+			"  - Enter your missionpraise.com email and password when prompted" & return & ¬
+			"  - The script authenticates via WordPress login (wp-login.php)" & return & ¬
+			"  - Cookies are stored in a temporary file and deleted on exit" & return & ¬
+			"  - The site may use a Sucuri WAF — if blocked, log in via browser first" & return & return & ¬
+			"BOOKS:" & return & ¬
+			"  - Mission Praise (MP): ~1000+ songs, 4-digit numbering" & return & ¬
+			"  - Carol Praise (CP): ~300 songs, 3-digit numbering" & return & ¬
+			"  - Junior Praise (JP): ~300 songs, 3-digit numbering" & return & return & ¬
+			"OUTPUT FORMAT:" & return & ¬
+			"  Lyrics: {number} ({BOOK}) - {Title}.txt" & return & ¬
+			"  Words:  {number} ({BOOK}) - {Title}.rtf" & return & ¬
+			"  Music:  {number} ({BOOK}) - {Title}_music.pdf" & return & ¬
+			"  Audio:  {number} ({BOOK}) - {Title}_audio.mp3" & return & return & ¬
+			"FILES ARE SAVED INTO SUBDIRECTORIES:" & return & ¬
+			"  hymns/Mission Praise [MP]/" & return & ¬
+			"  hymns/Carol Praise [CP]/" & return & ¬
+			"  hymns/Junior Praise [JP]/" & return & return & ¬
+			"RESUMABILITY:" & return & ¬
+			"  The scraper checks for existing files and skips them." & return & ¬
+			"  Use 'Start Page' to resume from a specific index page." & return & ¬
+			"  Use 'Force Re-download' to overwrite all existing files." & return & return & ¬
+			"DEPENDENCIES: None — uses only macOS built-in tools."
+
+		display dialog helpMsg with title scriptName & " — Help" buttons {"OK"} default button "OK" with icon note
+
+		-- After showing help, return to welcome dialog by re-running
+		-- (AppleScript doesn't have goto, so we show the config dialog)
+		set welcomeChoice to "Configure & Start"
+	end if
+
+	-- ======================================================================
+	-- CONFIGURATION DIALOGS — Gather all settings from the user
+	-- ======================================================================
+
+	-- Variables for all configuration values (set defaults first)
+	set mpUsername to ""
+	set mpPassword to ""
+	set selectedBooks to {"mp", "cp", "jp"}
+	set outputDir to ""
+	set startPage to 1
+	set singleSongNumber to 0
+	set requestDelay to defaultDelay
+	set downloadFiles to true
+	set forceRedownload to defaultForceRedownload
+	set debugMode to false
+
+	if welcomeChoice is "Configure & Start" then
+		-- ================================================================
+		-- USERNAME — Prompt for missionpraise.com email address
+		-- ================================================================
+		set usernameResult to display dialog "Mission Praise email:" with title scriptName default answer "" buttons {"Cancel", "OK"} default button "OK" with icon note
+		set mpUsername to text returned of usernameResult
+
+		-- Validate that username is not empty
+		if mpUsername is "" then
+			display dialog "Error: Username cannot be empty." with title scriptName buttons {"OK"} default button "OK" with icon stop
+			return
+		end if
+
+		-- ================================================================
+		-- PASSWORD — Prompt with hidden input (masks characters)
+		-- The `with hidden answer` option hides the password as it is typed
+		-- ================================================================
+		set passwordResult to display dialog "Password:" with title scriptName default answer "" buttons {"Cancel", "OK"} default button "OK" with icon note with hidden answer
+		set mpPassword to text returned of passwordResult
+
+		-- Validate that password is not empty
+		if mpPassword is "" then
+			display dialog "Error: Password cannot be empty." with title scriptName buttons {"OK"} default button "OK" with icon stop
+			return
+		end if
+
+		-- ================================================================
+		-- BOOK SELECTION — Choose which hymnbooks to scrape
+		-- ================================================================
+		set bookChoices to {"Mission Praise (MP)", "Carol Praise (CP)", "Junior Praise (JP)", "All"}
+		set bookResult to choose from list bookChoices with title scriptName with prompt "Select books to scrape:" default items {"All"} with multiple selections allowed
+
+		-- Handle user cancellation
+		if bookResult is false then
+			return
+		end if
+
+		-- Convert the human-readable book names to internal keys
+		set selectedBooks to {}
+		repeat with bookItem in bookResult
+			set bookItem to bookItem as text
+			if bookItem is "Mission Praise (MP)" then
+				set end of selectedBooks to "mp"
+			else if bookItem is "Carol Praise (CP)" then
+				set end of selectedBooks to "cp"
+			else if bookItem is "Junior Praise (JP)" then
+				set end of selectedBooks to "jp"
+			else if bookItem is "All" then
+				set selectedBooks to {"mp", "cp", "jp"}
+				exit repeat
+			end if
+		end repeat
+
+		-- ================================================================
+		-- OUTPUT DIRECTORY — Let the user pick a folder with Finder dialog
+		-- ================================================================
+		try
+			set outputFolder to choose folder with prompt "Select output directory for scraped files:" default location (path to desktop)
+			set outputDir to POSIX path of outputFolder
+			-- Remove trailing slash if present (we add it ourselves later)
+			if outputDir ends with "/" and (count of outputDir) > 1 then
+				set outputDir to text 1 thru -2 of outputDir
+			end if
+		on error
+			-- User cancelled the folder picker
+			return
+		end try
+
+		-- ================================================================
+		-- START PAGE — For resuming from a specific index page
+		-- ================================================================
+		set startPageResult to display dialog "Start page (for resuming):" with title scriptName default answer "1" buttons {"Cancel", "OK"} default button "OK" with icon note
+		try
+			set startPage to (text returned of startPageResult) as integer
+			if startPage < 1 then set startPage to 1
+		on error
+			set startPage to 1
+		end try
+
+		-- ================================================================
+		-- SONG NUMBER — Scrape a single song by number (optional)
+		-- When set, only this song number will be scraped. Force mode
+		-- is automatically enabled and scraping stops after the song
+		-- is found. Leave blank (0) to scrape all songs.
+		-- ================================================================
+		set songNumResult to display dialog "Single song number (0 = all songs):" & return & "(auto-enables force mode when set)" with title scriptName default answer "0" buttons {"Cancel", "OK"} default button "OK" with icon note
+		try
+			set singleSongNumber to (text returned of songNumResult) as integer
+			if singleSongNumber < 0 then set singleSongNumber to 0
+		on error
+			set singleSongNumber to 0
+		end try
+
+		-- Auto-enable force mode when targeting a single song
+		if singleSongNumber > 0 then
+			set forceRedownload to true
+		end if
+
+		-- ================================================================
+		-- REQUEST DELAY — Seconds between HTTP requests
+		-- ================================================================
+		set delayResult to display dialog "Delay between requests (seconds):" with title scriptName default answer "1.2" buttons {"Cancel", "OK"} default button "OK" with icon note
+		try
+			set requestDelay to (text returned of delayResult) as real
+			if requestDelay < 0.3 then set requestDelay to 0.3
+		on error
+			set requestDelay to defaultDelay
+		end try
+
+		-- ================================================================
+		-- DOWNLOAD FILES — Whether to download words/music/audio files
+		-- ================================================================
+		set dlResult to display dialog "Download associated files (words, music, audio)?" with title scriptName buttons {"No", "Yes"} default button "Yes" with icon note
+		if button returned of dlResult is "No" then
+			set downloadFiles to false
+		else
+			set downloadFiles to true
+		end if
+
+		-- ================================================================
+		-- FORCE RE-DOWNLOAD — Whether to overwrite existing files
+		-- When enabled, the file cache is bypassed and all songs are
+		-- re-scraped and re-downloaded regardless of what already exists.
+		-- ================================================================
+		set forceResult to display dialog "Force re-download existing files?" with title scriptName buttons {"No", "Yes"} default button "No" with icon note
+		if button returned of forceResult is "Yes" then
+			set forceRedownload to true
+		else
+			set forceRedownload to false
+		end if
+
+		-- ================================================================
+		-- DEBUG MODE — Whether to dump HTML responses for troubleshooting
+		-- ================================================================
+		set debugResult to display dialog "Enable debug mode? (Dumps HTML to Script Editor log)" with title scriptName buttons {"No", "Yes"} default button "No" with icon note
+		if button returned of debugResult is "Yes" then
+			set debugMode to true
+		else
+			set debugMode to false
+		end if
+
+	else if welcomeChoice is "Quick Start" then
+		-- ================================================================
+		-- QUICK START — Only prompt for credentials, use all defaults
+		-- ================================================================
+
+		-- Username
+		set usernameResult to display dialog "Mission Praise email:" with title scriptName default answer "" buttons {"Cancel", "OK"} default button "OK" with icon note
+		set mpUsername to text returned of usernameResult
+		if mpUsername is "" then
+			display dialog "Error: Username cannot be empty." with title scriptName buttons {"OK"} default button "OK" with icon stop
+			return
+		end if
+
+		-- Password (hidden input)
+		set passwordResult to display dialog "Password:" with title scriptName default answer "" buttons {"Cancel", "OK"} default button "OK" with icon note with hidden answer
+		set mpPassword to text returned of passwordResult
+		if mpPassword is "" then
+			display dialog "Error: Password cannot be empty." with title scriptName buttons {"OK"} default button "OK" with icon stop
+			return
+		end if
+
+		-- Default output directory: ~/Desktop/hymns
+		set outputDir to (POSIX path of (path to desktop)) & "hymns"
+
+		-- All other settings use defaults defined above
+	end if
+
+	-- ======================================================================
+	-- CONFIRMATION DIALOG — Show all settings before starting
+	-- ======================================================================
+
+	-- Build a human-readable books string for display
+	set booksDisplay to ""
+	repeat with i from 1 to count of selectedBooks
+		set bk to item i of selectedBooks
+		if bk is "mp" then
+			set booksDisplay to booksDisplay & "Mission Praise (MP)"
+		else if bk is "cp" then
+			set booksDisplay to booksDisplay & "Carol Praise (CP)"
+		else if bk is "jp" then
+			set booksDisplay to booksDisplay & "Junior Praise (JP)"
+		end if
+		if i < (count of selectedBooks) then
+			set booksDisplay to booksDisplay & ", "
+		end if
+	end repeat
+
+	-- Format the download option for display
+	if downloadFiles then
+		set dlDisplay to "Yes (words, music, audio)"
+	else
+		set dlDisplay to "No (lyrics only)"
+	end if
+
+	-- Format the force re-download option for display
+	if forceRedownload then
+		set forceDisplay to "Yes (overwrite existing)"
+	else
+		set forceDisplay to "No (skip existing)"
+	end if
+
+	-- Format the debug option for display
+	if debugMode then
+		set debugDisplay to "Yes"
+	else
+		set debugDisplay to "No"
+	end if
+
+	-- Format the song number option for display
+	if singleSongNumber > 0 then
+		set songDisplay to (singleSongNumber as text) & " (force mode auto-enabled)"
+	else
+		set songDisplay to "All"
+	end if
+
+	set confirmMsg to "Please confirm your settings:" & return & return & ¬
+		"Username:     " & mpUsername & return & ¬
+		"Password:     " & "********" & return & ¬
+		"Books:        " & booksDisplay & return & ¬
+		"Output:       " & outputDir & return & ¬
+		"Start Page:   " & (startPage as text) & return & ¬
+		"Song:         " & songDisplay & return & ¬
+		"Delay:        " & (requestDelay as text) & "s" & return & ¬
+		"Downloads:    " & dlDisplay & return & ¬
+		"Force:        " & forceDisplay & return & ¬
+		"Debug:        " & debugDisplay
+
+	set confirmResult to display dialog confirmMsg with title scriptName & " — Confirm" buttons {"Cancel", "Start Scraping"} default button "Start Scraping" with icon note
+
+	if button returned of confirmResult is "Cancel" then
+		return
+	end if
+
+	-- ======================================================================
+	-- SETUP — Create temp files and output directories
+	-- ======================================================================
+
+	-- Create a temporary cookie jar file for curl session management.
+	-- mktemp creates a unique temp file that we delete when done.
+	set cookieJar to do shell script "mktemp /tmp/mp_cookies.XXXXXX"
+	log "Cookie jar: " & cookieJar
+
+	-- Create the base output directory if it doesn't exist
+	do shell script "mkdir -p " & quoted form of outputDir
+
+	-- Create book-specific subdirectories for each selected book
+	repeat with bk in selectedBooks
+		set subdir to getBookSubdir(bk)
+		set bookPath to outputDir & "/" & subdir
+		do shell script "mkdir -p " & quoted form of bookPath
+	end repeat
+
+	-- ======================================================================
+	-- AUTHENTICATION — Log in to missionpraise.com via WordPress login
+	-- ======================================================================
+
+	log "Logging in as " & mpUsername & "..."
+	display notification "Logging in to missionpraise.com..." with title scriptName
+
+	-- Step 1: GET the login page to extract CSRF nonces (hidden form fields).
+	-- WordPress login forms contain hidden fields (nonces) that must be
+	-- submitted with the POST request to prevent CSRF attacks.
+	-- We use curl with cookie jar to store any initial cookies.
+	set loginPageHTML to do shell script "curl -s -L " & ¬
+		"-c " & quoted form of cookieJar & " " & ¬
+		"-b " & quoted form of cookieJar & " " & ¬
+		"-A " & quoted form of userAgent & " " & ¬
+		"-H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8' " & ¬
+		"-H 'Accept-Language: en-GB,en;q=0.9' " & ¬
+		"-H 'Accept-Encoding: identity' " & ¬
+		"-H 'Connection: keep-alive' " & ¬
+		"-H 'Upgrade-Insecure-Requests: 1' " & ¬
+		"-H 'Sec-Fetch-Dest: document' " & ¬
+		"-H 'Sec-Fetch-Mode: navigate' " & ¬
+		"-H 'Sec-Fetch-Site: none' " & ¬
+		"-H 'Sec-Fetch-User: ?1' " & ¬
+		"-H 'Cache-Control: max-age=0' " & ¬
+		quoted form of loginURL
+
+	if debugMode then
+		log "DEBUG: Login page HTML (first 3000 chars):"
+		log text 1 thru (min(3000, count of loginPageHTML)) of loginPageHTML
+	end if
+
+	-- Step 2: Extract hidden form fields from the login page.
+	-- These typically include testcookie, _wpnonce, and various plugin-specific nonces.
+	-- We use grep/sed to find all <input type="hidden"> fields and extract name=value pairs.
+	set hiddenFields to extractHiddenFields(loginPageHTML)
+
+	if debugMode then
+		log "DEBUG: Hidden fields found: " & hiddenFields
+	end if
+
+	-- Step 3: Brief pause to appear more human-like.
+	-- Some WAFs flag requests that POST to the login form within milliseconds
+	-- of loading the page, as this is a strong indicator of automated access.
+	delay 2
+
+	-- Step 4: POST the login credentials with proper headers.
+	-- Build the form data string including WordPress standard fields and all nonces.
+	-- We URL-encode the username and password to handle special characters.
+	set encodedUsername to urlEncode(mpUsername)
+	set encodedPassword to urlEncode(mpPassword)
+
+	-- Construct the POST payload: WordPress standard fields + hidden nonces
+	set postData to "log=" & encodedUsername & "&pwd=" & encodedPassword & "&wp-submit=Log+In&redirect_to=" & urlEncode(baseURL & "/songs/") & "&rememberme=forever"
+
+	-- Append hidden form fields to the POST data
+	if hiddenFields is not "" then
+		set postData to postData & "&" & hiddenFields
+	end if
+
+	-- Execute the login POST request with curl.
+	-- -L follows redirects (WordPress redirects after successful login).
+	-- -D - dumps response headers so we can check the redirect URL.
+	-- We write the full response (headers + body) for analysis.
+	set loginResult to do shell script "curl -s -L -w '\\n__HTTP_CODE__:%{http_code}\\n__FINAL_URL__:%{url_effective}' " & ¬
+		"-c " & quoted form of cookieJar & " " & ¬
+		"-b " & quoted form of cookieJar & " " & ¬
+		"-A " & quoted form of userAgent & " " & ¬
+		"-H 'Referer: " & loginURL & "' " & ¬
+		"-H 'Origin: " & baseURL & "' " & ¬
+		"-H 'Content-Type: application/x-www-form-urlencoded' " & ¬
+		"-H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8' " & ¬
+		"-H 'Accept-Language: en-GB,en;q=0.9' " & ¬
+		"-H 'Accept-Encoding: identity' " & ¬
+		"-H 'Sec-Fetch-Dest: document' " & ¬
+		"-H 'Sec-Fetch-Mode: navigate' " & ¬
+		"-H 'Sec-Fetch-Site: same-origin' " & ¬
+		"-H 'Sec-Fetch-User: ?1' " & ¬
+		"-d " & quoted form of postData & " " & ¬
+		quoted form of loginURL
+
+	if debugMode then
+		log "DEBUG: Login POST result (first 3000 chars):"
+		log text 1 thru (min(3000, count of loginResult)) of loginResult
+	end if
+
+	-- Step 5: Extract the final URL and HTTP status code from curl output
+	set finalURL to extractCurlMetadata(loginResult, "__FINAL_URL__:")
+	set httpCode to extractCurlMetadata(loginResult, "__HTTP_CODE__:")
+
+	if debugMode then
+		log "DEBUG: Post-login final URL: " & finalURL
+		log "DEBUG: Post-login HTTP code: " & httpCode
+	end if
+
+	-- Step 6: Check for various failure modes
+	set loginBody to loginResult
+	set loginBodyLower to toLower(loginBody)
+
+	-- Check for WAF / firewall blocks (e.g. Sucuri CDN/WAF)
+	if loginBodyLower contains "sucuri" or loginBodyLower contains "access denied" then
+		display dialog "BLOCKED by website firewall." & return & return & ¬
+			"Your request was blocked by the site's security system (Sucuri WAF)." & return & ¬
+			"Try logging in via a web browser first to whitelist your IP." with title scriptName buttons {"OK"} default button "OK" with icon stop
+		cleanupCookieJar(cookieJar)
+		return
+	end if
+
+	-- Check for incorrect credentials (WordPress stays on wp-login.php with error)
+	if finalURL contains "wp-login.php" and loginBodyLower contains "incorrect" then
+		display dialog "Login failed — check username/password." with title scriptName buttons {"OK"} default button "OK" with icon stop
+		cleanupCookieJar(cookieJar)
+		return
+	end if
+
+	-- Check for other WordPress login errors (still on login page after POST)
+	if finalURL contains "wp-login.php" then
+		-- Try to extract the WordPress login error message
+		set wpError to extractWPLoginError(loginBody)
+		if wpError is not "" then
+			display dialog "Login error: " & wpError with title scriptName buttons {"OK"} default button "OK" with icon stop
+			cleanupCookieJar(cookieJar)
+			return
+		end if
+	end if
+
+	-- Step 7: Verify login by fetching the songs page and checking for logged-in indicators
+	set songsCheckHTML to do shell script "curl -s -L " & ¬
+		"-c " & quoted form of cookieJar & " " & ¬
+		"-b " & quoted form of cookieJar & " " & ¬
+		"-A " & quoted form of userAgent & " " & ¬
+		"-H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8' " & ¬
+		"-H 'Accept-Encoding: identity' " & ¬
+		"-H 'Sec-Fetch-Dest: document' " & ¬
+		"-H 'Sec-Fetch-Mode: navigate' " & ¬
+		"-H 'Sec-Fetch-Site: same-origin' " & ¬
+		"-w '\\n__FINAL_URL__:%{url_effective}' " & ¬
+		quoted form of (baseURL & "/songs/")
+
+	set songsCheckURL to extractCurlMetadata(songsCheckHTML, "__FINAL_URL__:")
+	set songsCheckLower to toLower(songsCheckHTML)
+
+	if debugMode then
+		log "DEBUG: Songs page URL: " & songsCheckURL
+		log "DEBUG: Songs page HTML (first 2000 chars):"
+		log text 1 thru (min(2000, count of songsCheckHTML)) of songsCheckHTML
+	end if
+
+	-- Look for multiple indicators of being logged in
+	set loggedIn to false
+	if songsCheckLower contains "logout" or ¬
+		songsCheckLower contains "log out" or ¬
+		songsCheckLower contains "log-out" or ¬
+		songsCheckHTML contains "Welcome" or ¬
+		songsCheckLower contains "my-account" or ¬
+		songsCheckLower contains "wp-admin" or ¬
+		songsCheckLower contains "logged-in" then
+		set loggedIn to true
+	end if
+
+	if loggedIn then
+		log "Logged in successfully."
+		display notification "Logged in successfully." with title scriptName
+	else if songsCheckURL contains "wp-login" or songsCheckURL contains "login" then
+		-- Redirected back to login page means session was not established
+		display dialog "Login failed — redirected back to login page." & return & ¬
+			"Check your credentials and try again." with title scriptName buttons {"OK"} default button "OK" with icon stop
+		cleanupCookieJar(cookieJar)
+		return
+	else
+		-- Login status is ambiguous — proceed anyway
+		log "Login status unclear — proceeding anyway."
+		log "(Re-run with Debug mode enabled to see full HTML responses)"
+	end if
+
+	-- ======================================================================
+	-- BUILD FILE CACHE — Scan existing files for resumability
+	-- ======================================================================
+
+	-- Build a list of existing filenames across all book subdirectories.
+	-- This allows O(1) lookup to skip songs that have already been saved.
+	-- When force re-download is enabled, we skip building the cache entirely
+	-- so that every song is re-scraped and overwritten on disk.
+	set fileCache to {}
+
+	if forceRedownload then
+		-- Force mode: use empty cache so nothing is considered "existing"
+		log "Force mode: will re-download and overwrite existing files."
+	else
+		repeat with bk in selectedBooks
+			set subdir to getBookSubdir(bk)
+			set bookPath to outputDir & "/" & subdir
+			try
+				set existingFiles to do shell script "ls -1 " & quoted form of bookPath & " 2>/dev/null || true"
+				if existingFiles is not "" then
+					set existingFiles to splitString(existingFiles, linefeed)
+					repeat with ef in existingFiles
+						set end of fileCache to ef as text
+					end repeat
+				end if
+			end try
+		end repeat
+
+		set fileCacheCount to count of fileCache
+		if fileCacheCount > 0 then
+			log "Found " & (fileCacheCount as text) & " existing files across output folders — will skip duplicates."
+		end if
+	end if
+
+	-- ======================================================================
+	-- MAIN CRAWL AND SCRAPE — Paginated index crawling
+	-- ======================================================================
+
+	-- Print configuration summary to log
+	log ""
+	log "Books    : " & booksDisplay
+	log "Output   : " & outputDir
+	if downloadFiles then
+		log "Downloads: enabled (words, music, audio)"
+	else
+		log "Downloads: disabled (lyrics only)"
+	end if
+	log ""
+
+	-- Counters for the final summary
+	set savedCount to 0
+	set skippedCount to 0
+	set existedCount to 0
+
+	-- Current page number (starts at user-specified start page)
+	set currentPage to startPage
+
+	-- Track the last page's first song URL to detect loops
+	set lastFirstSongURL to ""
+
+	-- Main pagination loop — fetch each index page and process songs
+	repeat
+		-- Construct the URL for the current index page
+		set pageURL to indexURL & (currentPage as text) & "/"
+
+		log "Fetching index page " & (currentPage as text) & "..."
+
+		-- Fetch the index page HTML
+		set indexHTML to ""
+		try
+			set indexHTML to do shell script "curl -s -L " & ¬
+				"-c " & quoted form of cookieJar & " " & ¬
+				"-b " & quoted form of cookieJar & " " & ¬
+				"-A " & quoted form of userAgent & " " & ¬
+				"-H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8' " & ¬
+				"-H 'Accept-Encoding: identity' " & ¬
+				"-H 'Sec-Fetch-Dest: document' " & ¬
+				"-H 'Sec-Fetch-Mode: navigate' " & ¬
+				"-H 'Sec-Fetch-Site: same-origin' " & ¬
+				quoted form of pageURL
+		on error errMsg
+			log "Error fetching page " & (currentPage as text) & ": " & errMsg
+			exit repeat
+		end try
+
+		-- Check for empty response or "Page not found"
+		if indexHTML is "" or indexHTML contains "Page not found" then
+			if debugMode then
+				if indexHTML is "" then
+					log "DEBUG: Page " & (currentPage as text) & " — empty response"
+				else
+					log "DEBUG: Page " & (currentPage as text) & " — Page not found detected"
+				end if
+			end if
+			exit repeat
+		end if
+
+		-- Debug dump of the first page
+		if currentPage is startPage and debugMode then
+			log "DEBUG: Index page " & (currentPage as text) & " HTML (first 3000 chars):"
+			log text 1 thru (min(3000, count of indexHTML)) of indexHTML
+		end if
+
+		-- Loop detection: Check the X-Y of Z counter.
+		-- WordPress has a quirk where out-of-range page numbers silently serve
+		-- page 1 content instead of returning a 404.
+		set counterInfo to extractPageCounter(indexHTML)
+		set counterLo to item 1 of counterInfo
+		set counterHi to item 2 of counterInfo
+		set counterTotal to item 3 of counterInfo
+
+		if counterTotal > 0 then
+			-- Print total count on the first page
+			if currentPage is startPage then
+				set totalPages to (counterTotal + 9) div 10
+				log counterTotal & " total songs across ~" & (totalPages as text) & " pages"
+				log ""
+			end if
+
+			-- Detect loops: impossible counter or WordPress served page 1 again
+			if counterLo > counterHi or (currentPage > 1 and counterLo is 1) then
+				log "Loop detected at page " & (currentPage as text) & " — stopping."
+				exit repeat
+			end if
+		else
+			-- If we can't find the counter and we're past page 1,
+			-- assume we've gone beyond the last page
+			if currentPage > 1 then
+				exit repeat
+			end if
+		end if
+
+		-- Parse the index page for song links using grep/sed.
+		-- Songs appear as <a> tags inside <h2> or <h3> elements with /songs/ URLs.
+		set songLinks to extractSongLinks(indexHTML)
+
+		if (count of songLinks) is 0 then
+			-- No song links found — we've reached the end of the index
+			if debugMode then
+				log "DEBUG: No song links found on page " & (currentPage as text)
+			end if
+			exit repeat
+		end if
+
+		-- Loop detection via first song URL: if the first song on this page
+		-- is the same as the first song on the previous page, we're looping
+		if (count of songLinks) > 0 then
+			set firstSongURL to item 2 of item 1 of songLinks
+			if firstSongURL is lastFirstSongURL and currentPage > startPage then
+				log "Loop detected (same first song as previous page) — stopping."
+				exit repeat
+			end if
+			set lastFirstSongURL to firstSongURL
+		end if
+
+		-- Filter songs to only the requested books
+		set pageSongs to {}
+		repeat with songItem in songLinks
+			set songTitle to item 1 of songItem
+			set songURL to item 2 of songItem
+
+			-- Check which book this song belongs to
+			repeat with bk in selectedBooks
+				set bkText to bk as text
+				set bookPattern to getBookPattern(bkText)
+				try
+					-- Use grep to test if the title matches the book pattern
+					do shell script "echo " & quoted form of songTitle & " | grep -iE " & quoted form of bookPattern & " > /dev/null 2>&1"
+					-- If grep succeeds (no error), the song matches this book
+					set end of pageSongs to {songTitle, songURL, bkText}
+					exit repeat
+				on error
+					-- grep returned non-zero = no match, try next book
+				end try
+			end repeat
+		end repeat
+
+		-- If targeting a single song number, filter pageSongs to only that number
+		if singleSongNumber > 0 then
+			set filteredSongs to {}
+			repeat with songItem in pageSongs
+				set sTitle to item 1 of songItem
+				set sBook to item 3 of songItem
+				set sNum to extractSongNumber(sTitle, sBook)
+				if sNum is singleSongNumber then
+					set end of filteredSongs to (songItem as list)
+				end if
+			end repeat
+			set pageSongs to filteredSongs
+		end if
+
+		-- Print page summary with running totals
+		set pageMatchCount to count of pageSongs
+		log "  Page " & rightPad(currentPage as text, 4) & "  —  " & (pageMatchCount as text) & " matching songs  (saved: " & (savedCount as text) & ", existed: " & (existedCount as text) & ", skipped: " & (skippedCount as text) & ")"
+
+		-- Show notification every 10 pages for progress feedback
+		if currentPage mod 10 is 0 then
+			display notification "Processing page " & (currentPage as text) & "... (saved: " & (savedCount as text) & ")" with title scriptName
+		end if
+
+		-- Process each song on this page
+		set pageExisted to 0
+		repeat with songItem in pageSongs
+			set songTitle to item 1 of songItem
+			set songURL to item 2 of songItem
+			set songBook to item 3 of songItem
+
+			-- Process the individual song (scrape lyrics, download files)
+			set result to processSong(songTitle, songURL, songBook, outputDir, downloadFiles, requestDelay, debugMode, cookieJar, fileCache)
+
+			if result is "saved" then
+				set savedCount to savedCount + 1
+				-- Show notification every 10 saved songs
+				if savedCount mod 10 is 0 then
+					display notification (savedCount as text) & " songs saved so far..." with title scriptName
+				end if
+			else if result is "skipped" then
+				set skippedCount to skippedCount + 1
+			else if result is "exists" then
+				set existedCount to existedCount + 1
+				set pageExisted to pageExisted + 1
+			end if
+		end repeat
+
+		-- If every song on this page already existed, print a compact summary
+		if pageExisted is pageMatchCount and pageMatchCount > 0 then
+			log "           >>  all " & (pageExisted as text) & " songs on this page already exist"
+		end if
+
+		-- If targeting a single song and we found it, stop immediately
+		if singleSongNumber > 0 and savedCount > 0 then
+			log "Single song " & (singleSongNumber as text) & " found and saved — stopping."
+			exit repeat
+		end if
+
+		-- Move to the next page
+		set currentPage to currentPage + 1
+
+		-- Rate limit between index pages
+		delay requestDelay
+	end repeat
+
+	-- ======================================================================
+	-- FINAL SUMMARY — Show results and clean up
+	-- ======================================================================
+
+	log ""
+	log "Done!  " & (savedCount as text) & " saved, " & (existedCount as text) & " already existed, " & (skippedCount as text) & " skipped."
+	log "Output: " & outputDir
+
+	-- Show a final dialog with the results
+	set summaryMsg to "Scraping complete!" & return & return & ¬
+		"Saved:          " & (savedCount as text) & return & ¬
+		"Already existed: " & (existedCount as text) & return & ¬
+		"Skipped:        " & (skippedCount as text) & return & return & ¬
+		"Output: " & outputDir
+
+	if skippedCount > 0 then
+		set summaryMsg to summaryMsg & return & return & "Skipped songs have been logged to skipped.log in each book's output folder."
+	end if
+
+	display dialog summaryMsg with title scriptName & " — Complete" buttons {"Open Output Folder", "OK"} default button "OK" with icon note
+
+	if button returned of result is "Open Output Folder" then
+		-- Open the output folder in Finder
+		do shell script "open " & quoted form of outputDir
+	end if
+
+	-- Clean up the temporary cookie jar file
+	cleanupCookieJar(cookieJar)
+
+on error errMsg number errNum
+	-- Global error handler: display the error and clean up temp files
+	if errNum is -128 then
+		-- User cancelled — not an error, just clean up silently
+		log "User cancelled."
+	else
+		log "ERROR: " & errMsg & " (error " & (errNum as text) & ")"
+		try
+			display dialog "An error occurred:" & return & return & errMsg & return & return & "(Error " & (errNum as text) & ")" with title scriptName & " — Error" buttons {"OK"} default button "OK" with icon stop
+		end try
+	end if
+
+	-- Clean up the cookie jar file even on error
+	cleanupCookieJar(cookieJar)
+end try
+
+
+-- ==========================================================================
+-- HANDLER: processSong — Scrape lyrics and download files for a single song
+-- ==========================================================================
+-- Orchestrates the full scraping pipeline for one song:
+-- 1. Extract the song number from the index title
+-- 2. Check if lyrics/downloads already exist (skip if so)
+-- 3. Fetch the song detail page
+-- 4. Parse the HTML to extract lyrics, copyright, and download links
+-- 5. Save the lyrics as a .txt file
+-- 6. Download and save words/music/audio files (if enabled)
+--
+-- Parameters:
+--   songTitle     — Song title from the index page (includes book code)
+--   songURL       — URL of the song detail page
+--   songBook      — Book identifier key ("mp", "cp", or "jp")
+--   outputDir     — Base output directory path
+--   downloadFiles — Boolean: whether to download words/music/audio files
+--   requestDelay  — Seconds to wait between requests
+--   debugMode     — Boolean: whether to dump HTML for debugging
+--   cookieJar     — Path to the temp cookie jar file
+--   fileCache     — List of existing filenames for skip-detection
+--
+-- Returns:
+--   "saved"   — Lyrics were newly saved
+--   "skipped" — Song couldn't be scraped (logged to skipped.log)
+--   "exists"  — Song was already saved from a previous run
+
+on processSong(songTitle, songURL, songBook, outputDir, downloadFiles, requestDelay, debugMode, cookieJar, fileCache)
+	-- Get book configuration values
+	set bookLabel to getBookLabel(songBook)
+	set bookPad to getBookPad(songBook)
+	set bookSubdir to getBookSubdir(songBook)
+	set bookDir to outputDir & "/" & bookSubdir
+
+	-- Extract the hymn number from the title (e.g. "Amazing Grace (MP0023)" -> 23)
+	set songNumber to extractSongNumber(songTitle, songBook)
+
+	if songNumber is 0 then
+		-- Title doesn't contain a recognisable book code — can't save this song
+		logSkip(bookDir, "??", "????", songTitle, songURL, "no book number found in title")
+		return "skipped"
+	end if
+
+	-- Zero-pad the number according to the book's configuration
+	set paddedNumber to zeroPad(songNumber, bookPad)
+
+	-- Check if lyrics already exist in the file cache
+	set lyricsPrefix to paddedNumber & " (" & bookLabel & ") -"
+	set lyricsExist to false
+	repeat with cachedFile in fileCache
+		set cf to cachedFile as text
+		if cf starts with lyricsPrefix and cf ends with ".txt" then
+			set lyricsExist to true
+			exit repeat
+		end if
+	end repeat
+
+	-- If lyrics exist and we don't need files, skip entirely (no network request)
+	if lyricsExist and not downloadFiles then
+		return "exists"
+	end if
+
+	-- If lyrics exist, check whether downloads also exist
+	if lyricsExist then
+		-- Derive the base filename for download comparison
+		set cleanedTitle to cleanSongTitle(songTitle, songBook)
+		set baseFile to buildBaseFilename(songNumber, songBook, cleanedTitle)
+
+		-- Look for any non-txt file with the same base name
+		set hasAnyDownload to false
+		repeat with cachedFile in fileCache
+			set cf to cachedFile as text
+			if (cf starts with (baseFile & ".") or cf starts with (baseFile & "_")) and cf does not end with ".txt" then
+				set hasAnyDownload to true
+				exit repeat
+			end if
+		end repeat
+
+		if not downloadFiles or hasAnyDownload then
+			return "exists"
+		end if
+
+		-- Lyrics exist but no downloads — need to fetch page for download links
+		log "    " & bookLabel & paddedNumber & "  " & (text 1 thru (min(55, count of songTitle)) of songTitle) & "  >> fetching missing downloads..."
+	else
+		-- Neither lyrics nor files exist — full scrape needed
+		log "    " & bookLabel & paddedNumber & "  " & (text 1 thru (min(55, count of songTitle)) of songTitle)
+	end if
+
+	-- Make the song URL absolute if it starts with /
+	set fullSongURL to songURL
+	if songURL starts with "/" then
+		set fullSongURL to baseURL & songURL
+	else if songURL does not start with "http" then
+		set fullSongURL to baseURL & "/" & songURL
+	end if
+
+	-- Fetch the song detail page
+	set songHTML to ""
+	try
+		set songHTML to do shell script "curl -s -L " & ¬
+			"-c " & quoted form of cookieJar & " " & ¬
+			"-b " & quoted form of cookieJar & " " & ¬
+			"-A " & quoted form of userAgent & " " & ¬
+			"-H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8' " & ¬
+			"-H 'Accept-Encoding: identity' " & ¬
+			"-H 'Sec-Fetch-Dest: document' " & ¬
+			"-H 'Sec-Fetch-Mode: navigate' " & ¬
+			"-H 'Sec-Fetch-Site: same-origin' " & ¬
+			"--max-time 20 " & ¬
+			quoted form of fullSongURL
+	on error errMsg
+		log "    Error fetching song: " & errMsg
+		logSkip(bookDir, bookLabel, paddedNumber, songTitle, fullSongURL, "fetch error: " & errMsg)
+		delay requestDelay
+		return "skipped"
+	end try
+
+	-- Check for login wall (session may have expired during the scrape)
+	if songHTML is "" or songHTML contains "Please login to continue" or songHTML contains "loginform" then
+		set reason to "empty response"
+		if songHTML contains "Please login to continue" or songHTML contains "loginform" then
+			set reason to "login wall"
+		end if
+		log "    FAILED (" & reason & ")"
+		logSkip(bookDir, bookLabel, paddedNumber, songTitle, fullSongURL, reason)
+		if debugMode and songHTML is not "" then
+			writeDebugHTML(bookDir, bookLabel, paddedNumber, songHTML, reason)
+		end if
+		delay requestDelay
+		return "skipped"
+	end if
+
+	-- Check for subscription paywall (song is behind a higher-tier subscription)
+	-- This happens when the user is logged in but the song is not included
+	-- in their subscription plan. The page shows a "not part of your subscription"
+	-- message instead of the lyrics.
+	set songHTMLLower to toLower(songHTML)
+	if songHTMLLower contains "not part of your subscription" then
+		log "    FAILED (subscription paywall)"
+		logSkip(bookDir, bookLabel, paddedNumber, songTitle, fullSongURL, "subscription paywall")
+		if debugMode then
+			writeDebugHTML(bookDir, bookLabel, paddedNumber, songHTML, "paywall")
+		end if
+		delay requestDelay
+		return "skipped"
+	end if
+
+	-- Check for WAF block on the song page
+	if songHTMLLower contains "sucuri" or songHTMLLower contains "access denied" then
+		log "    FAILED (blocked by firewall)"
+		logSkip(bookDir, bookLabel, paddedNumber, songTitle, fullSongURL, "blocked by WAF/firewall")
+		if debugMode then
+			writeDebugHTML(bookDir, bookLabel, paddedNumber, songHTML, "waf")
+		end if
+		delay requestDelay
+		return "skipped"
+	end if
+
+	if debugMode then
+		log "DEBUG: Song page HTML (first 2000 chars):"
+		log text 1 thru (min(2000, count of songHTML)) of songHTML
+	end if
+
+	-- Parse the song page to extract title, lyrics, copyright, and download links.
+	-- We write the HTML to a temp file and process it with a shell script
+	-- to handle the complex parsing that AppleScript's string handling can't do well.
+	set parsedSong to parseSongPage(songHTML, debugMode)
+
+	set parsedTitle to item 1 of parsedSong
+	set parsedLyrics to item 2 of parsedSong
+	set parsedCopyright to item 3 of parsedSong
+	set parsedDownloads to item 4 of parsedSong
+
+	-- If the parser couldn't find a title, retry once
+	if parsedTitle is "" then
+		delay (requestDelay * 2)
+		try
+			set songHTML to do shell script "curl -s -L " & ¬
+				"-c " & quoted form of cookieJar & " " & ¬
+				"-b " & quoted form of cookieJar & " " & ¬
+				"-A " & quoted form of userAgent & " " & ¬
+				"-H 'Accept-Encoding: identity' " & ¬
+				"--max-time 20 " & ¬
+				quoted form of fullSongURL
+
+			if songHTML is not "" and songHTML does not contain "loginform" then
+				set parsedSong to parseSongPage(songHTML, debugMode)
+				set parsedTitle to item 1 of parsedSong
+				set parsedLyrics to item 2 of parsedSong
+				set parsedCopyright to item 3 of parsedSong
+				set parsedDownloads to item 4 of parsedSong
+			end if
+		end try
+	end if
+
+	-- If still no title after retry, try fallback strategies before giving up
+	if parsedTitle is "" then
+		-- Fallback 1: Extract from HTML <title> tag and strip site name suffix
+		try
+			set parsedTitle to do shell script "echo " & quoted form of songHTML & " | sed -n 's/.*<title>\\([^<]*\\)<\\/title>.*/\\1/p' | sed 's/ – Mission Praise$//' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | head -1"
+		end try
+
+		-- Fallback 2: Use the song title from the index page, strip book code like "(MP1270)"
+		if parsedTitle is "" then
+			try
+				set parsedTitle to do shell script "echo " & quoted form of songTitle & " | sed 's/[[:space:]]*([A-Z]*[0-9]*)[[:space:]]*$//' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'"
+			end try
+		end if
+
+		-- Only skip if STILL no title after all fallbacks
+		if parsedTitle is "" then
+			log "    FAILED (no title parsed)"
+			logSkip(bookDir, bookLabel, paddedNumber, songTitle, fullSongURL, "parser found no title in page HTML")
+			if debugMode then
+				writeDebugHTML(bookDir, bookLabel, paddedNumber, songHTML, "notitle")
+			end if
+			delay requestDelay
+			return "skipped"
+		end if
+	end if
+
+	-- Verse count validation — count actual text lines (not paragraph entries)
+	-- to detect incomplete parses without false positives from multi-line <p> blocks
+	set totalLines to 0
+	repeat with verseEntry in parsedLyrics
+		set vText to item 1 of verseEntry
+		if vText is not "" then
+			-- Count lines by counting linefeeds + 1
+			set lfCount to 0
+			repeat with c in (characters of vText)
+				if c is (ASCII character 10) then set lfCount to lfCount + 1
+			end repeat
+			set totalLines to totalLines + lfCount + 1
+		end if
+	end repeat
+	if totalLines is 0 then
+		log "    WARNING (no lyrics found)"
+		logSkip(bookDir, bookLabel, paddedNumber, songTitle, fullSongURL, "parser found title but 0 lyric lines")
+		if debugMode then
+			writeDebugHTML(bookDir, bookLabel, paddedNumber, songHTML, "nolyrics")
+		end if
+	else if totalLines < 4 then
+		log "    WARNING (" & totalLines & " lines - may be incomplete)"
+	end if
+
+	-- Save lyrics to a .txt file
+	if not lyricsExist then
+		set cleanedTitle to cleanSongTitle(parsedTitle, songBook)
+		set baseFile to buildBaseFilename(songNumber, songBook, cleanedTitle)
+
+		-- Format the lyrics using the same format as the Python scraper
+		set formattedLyrics to formatLyrics(cleanedTitle, parsedLyrics, parsedCopyright, songBook)
+
+		-- Write the lyrics file
+		set lyricsPath to bookDir & "/" & baseFile & ".txt"
+		writeTextFile(lyricsPath, formattedLyrics)
+
+		-- Add to file cache
+		set end of fileCache to baseFile & ".txt"
+
+		log "    OK - saved " & baseFile & ".txt"
+	else
+		-- Re-derive base filename from the parsed title for downloads
+		set cleanedTitle to cleanSongTitle(parsedTitle, songBook)
+		set baseFile to buildBaseFilename(songNumber, songBook, cleanedTitle)
+	end if
+
+	-- Download files (words, music, audio) if enabled
+	set fileResults to {}
+	if downloadFiles and (count of parsedDownloads) > 0 then
+		repeat with dlItem in parsedDownloads
+			set dlType to item 1 of dlItem
+			set dlURL to item 2 of dlItem
+
+			-- Make download URL absolute if needed
+			if dlURL starts with "/" then
+				set dlURL to baseURL & dlURL
+			end if
+
+			-- Check if this download type already exists in cache
+			set dlPrefix to baseFile & "."
+			if dlType is not "words" then
+				set dlPrefix to baseFile & "_" & dlType & "."
+			end if
+
+			set dlExists to false
+			repeat with cachedFile in fileCache
+				set cf to cachedFile as text
+				if cf starts with dlPrefix then
+					set dlExists to true
+					exit repeat
+				end if
+			end repeat
+
+			if dlExists then
+				-- Already exists — record lowercase indicator
+				set end of fileResults to (text 1 of dlType)
+			else
+				-- Download the file
+				set dlResult to downloadFile(dlURL, baseFile, dlType, bookDir, cookieJar, debugMode)
+				if dlResult is not "" then
+					set end of fileResults to toUpper(text 1 of dlType)
+					set end of fileCache to dlResult
+				end if
+
+				-- Brief delay between downloads (30% of normal delay)
+				delay (requestDelay * 0.3)
+			end if
+		end repeat
+	end if
+
+	-- Print status line with download indicators
+	if (count of fileResults) > 0 then
+		set fileStr to " [" & joinList(fileResults, ",") & "]"
+	else
+		set fileStr to ""
+	end if
+
+	if not lyricsExist then
+		log "    OK" & fileStr
+	else
+		log "    OK (downloads)" & fileStr
+	end if
+
+	-- Rate limit between songs
+	delay requestDelay
+	return "saved"
+end processSong
+
+
+-- ==========================================================================
+-- HANDLER: parseSongPage — Parse a song detail page's HTML
+-- ==========================================================================
+-- Extracts the title, lyrics, copyright, and download links from a song page.
+-- Uses a shell script with sed/grep/awk for the heavy HTML parsing because
+-- AppleScript's native string handling is too limited for complex HTML.
+--
+-- Parameters:
+--   htmlContent — The full HTML of the song detail page
+--   debugMode   — Boolean: whether to log debug info
+--
+-- Returns:
+--   A list: {title, lyrics, copyright, downloads}
+--   Where downloads is a list of {type, url} pairs
+
+on parseSongPage(htmlContent, debugMode)
+	-- Write HTML to a temp file for shell processing
+	set tmpHTML to do shell script "mktemp /tmp/mp_song.XXXXXX"
+
+	try
+		-- Write the HTML content to the temp file using a shell heredoc approach
+		-- We pipe the content via stdin to avoid shell escaping issues with the HTML
+		do shell script "cat > " & quoted form of tmpHTML & " << 'EOFHTMLINPUT'\n" & htmlContent & "\nEOFHHTMLINPUT" without altering line endings
+	on error
+		-- If heredoc fails (e.g., HTML contains the delimiter), try write via Python
+		try
+			-- Use base64 encoding to safely pass the HTML to the file
+			-- First encode to base64, then decode to file
+			set b64Content to do shell script "echo " & quoted form of htmlContent & " | base64"
+			do shell script "echo " & quoted form of b64Content & " | base64 -d > " & quoted form of tmpHTML
+		on error
+			-- Last resort: write chunks
+			writeTextFile(tmpHTML, htmlContent)
+		end try
+	end try
+
+	-- Extract title from .entry-title element
+	set songTitle to ""
+	try
+		set songTitle to do shell script "sed -n 's/.*class=\"[^\"]*entry-title[^\"]*\"[^>]*>\\([^<]*\\)<.*/\\1/p' " & quoted form of tmpHTML & " | head -1 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'"
+	end try
+	-- Fallback: try with single quotes in class attribute
+	if songTitle is "" then
+		try
+			set songTitle to do shell script "grep -oP '(?<=class=\"[^\"]*entry-title[^\"]*\">)[^<]+' " & quoted form of tmpHTML & " 2>/dev/null | head -1 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'"
+		end try
+	end if
+	-- Fallback: try broader pattern with <h1> or <h2> containing entry-title
+	if songTitle is "" then
+		try
+			set songTitle to do shell script "grep -i 'entry-title' " & quoted form of tmpHTML & " | sed 's/<[^>]*>//g' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | head -1"
+		end try
+	end if
+
+	-- Decode HTML entities in the title
+	if songTitle is not "" then
+		set songTitle to decodeHTMLEntities(songTitle)
+	end if
+
+	-- Extract lyrics from .song-details section.
+	-- The lyrics are in <p> elements inside a div with class "song-details".
+	-- We extract the content between the song-details opening tag and its closing tag,
+	-- then process each <p> element to extract text and detect chorus (italic) lines.
+	--
+	-- IMPORTANT: Chorus detection must handle TWO patterns of italic markup:
+	--   Pattern A (inner): <p><em>chorus text</em></p>  — <em>/<i> is INSIDE the <p>
+	--   Pattern B (outer): <em><p>chorus text</p></em>   — <p> is INSIDE an outer <em>/<i>
+	-- The awk pre-processor below detects Pattern B by tracking whether there is an
+	-- unclosed <em>/<i> tag before each <p>. If so, it injects __EM_START__ / __EM_END__
+	-- markers around the <p> content so the downstream processing treats it identically
+	-- to Pattern A.
+	set songLyrics to ""
+	try
+		-- Use a comprehensive awk script to extract and format lyrics.
+		-- The awk script does two things:
+		--   1. Extracts content between song-details div tags
+		--   2. Detects outer <em>/<i> wrapping <p> elements (Pattern B) by counting
+		--      opens vs closes of <em>/<i> tags. When a <p> appears while an <em>/<i>
+		--      is open, it injects __EM_START__ after the <p> tag and __EM_END__ before
+		--      the </p> tag so downstream sed/grep treats it as italic.
+		set songLyrics to do shell script "awk '
+		BEGIN { inside=0; buf=\"\" }
+		/class=\"[^\"]*song-details/ { inside=1; next }
+		inside && (/<\\/div>/ || /<\\/section>/) {
+			# Check if this is the closing div/section for song-details
+			# by tracking depth (simplified: first </div> or </section> after entry)
+			inside=0
+			print buf
+			next
+		}
+		inside {
+			# Accumulate lines
+			buf = buf $0 \"\\n\"
+		}
+		' " & quoted form of tmpHTML & " | \
+		awk '
+		# Pre-processor: detect outer <em>/<i> wrapping <p> elements.
+		# Track the nesting depth of <em> and <i> tags. When a <p> tag
+		# appears while em_depth > 0, inject italic markers so the
+		# downstream pipeline recognises it as chorus/italic text.
+		BEGIN { em_depth = 0 }
+		{
+			line = $0
+			# Count opening <em> and <i> tags (case-insensitive via tolower)
+			tmp = tolower(line)
+			# Count <em> opens (but not </em>)
+			n = gsub(/<em[> ]/, \"&\", tmp)
+			c = gsub(/<\\/em>/, \"&\", tmp)
+			# Re-scan for <i> opens (but not </i>, and not <img, <input, etc.)
+			tmp2 = tolower(line)
+			n2 = gsub(/<i[> ]/, \"&\", tmp2)
+			c2 = gsub(/<\\/i>/, \"&\", tmp2)
+			em_depth = em_depth + n - c + n2 - c2
+			if (em_depth < 0) em_depth = 0
+
+			# If we are inside an outer <em>/<i> and this line contains <p>,
+			# inject __EM_START__ after each <p...> and __EM_END__ before </p>
+			if (em_depth > 0) {
+				gsub(/<p[^>]*>/, \"&\\n__EM_START__\\n\", line)
+				gsub(/<\\/p>/, \"\\n__EM_END__\\n&\", line)
+			}
+			print line
+		}
+		' | \
+		sed -E 's/(<br[[:space:]]*\\/?>[[:space:]]*)+/\\n/gi' | \
+		sed 's/<p[^>]*>/\\n<\\/p>\\n&\\n/gi' | \
+		sed 's/<\\/p>/\\n__PARA_BREAK__\\n/gi' | \
+		sed 's/<p[^>]*>/\\n__PARA_START__\\n/gi' | \
+		sed 's/<em>/\\n__EM_START__\\n/gi; s/<\\/em>/\\n__EM_END__\\n/gi' | \
+		sed 's/<i>/\\n__EM_START__\\n/gi; s/<\\/i>/\\n__EM_END__\\n/gi' | \
+		sed 's/<[^>]*>//g' | \
+		sed \"s/&#145;/$(printf '\\xe2\\x80\\x98')/g; s/&#146;/$(printf '\\xe2\\x80\\x99')/g; s/&#147;/$(printf '\\xe2\\x80\\x9c')/g; s/&#148;/$(printf '\\xe2\\x80\\x9d')/g; s/&#150;/$(printf '\\xe2\\x80\\x93')/g; s/&#151;/$(printf '\\xe2\\x80\\x94')/g\" | \
+		sed 's/&amp;/\\&/g; s/&lt;/</g; s/&gt;/>/g; s/&quot;/\"/g; s/&#8217;/'\"'\"'/g; s/&#8216;/'\"'\"'/g; s/&#8220;/\"/g; s/&#8221;/\"/g; s/&rsquo;/'\"'\"'/g; s/&lsquo;/'\"'\"'/g; s/&rdquo;/\"/g; s/&ldquo;/\"/g; s/&mdash;/—/g; s/&ndash;/–/g; s/&nbsp;/ /g; s/&#160;/ /g' | \
+		sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | \
+		grep -v '^$'"
+	end try
+
+	-- If the awk approach didn't work, try a simpler grep-based extraction
+	if songLyrics is "" then
+		try
+			-- Simpler approach: find all text within song-details class.
+			-- Also includes the outer <em>/<i> detection pre-processor (Pattern B)
+			-- to ensure chorus detection works regardless of which extraction path runs.
+			set songLyrics to do shell script "sed -n '/song-details/,/<\\/div>\\|<\\/section>/p' " & quoted form of tmpHTML & " | \
+			awk '
+			BEGIN { em_depth = 0 }
+			{
+				line = $0
+				tmp = tolower(line)
+				n = gsub(/<em[> ]/, \"&\", tmp)
+				c = gsub(/<\\/em>/, \"&\", tmp)
+				tmp2 = tolower(line)
+				n2 = gsub(/<i[> ]/, \"&\", tmp2)
+				c2 = gsub(/<\\/i>/, \"&\", tmp2)
+				em_depth = em_depth + n - c + n2 - c2
+				if (em_depth < 0) em_depth = 0
+				if (em_depth > 0) {
+					gsub(/<p[^>]*>/, \"&\\n__EM_START__\\n\", line)
+					gsub(/<\\/p>/, \"\\n__EM_END__\\n&\", line)
+				}
+				print line
+			}
+			' | \
+			sed -E 's/(<br[[:space:]]*\\/?>[[:space:]]*)+/\\n/gi' | \
+			sed 's/<p[^>]*>/\\n<\\/p>\\n&\\n/gi' | \
+			sed 's/<\\/p>/\\n__PARA_BREAK__\\n/gi' | \
+			sed 's/<p[^>]*>/__PARA_START__/gi' | \
+			sed 's/<em>/__EM_START__/gi; s/<\\/em>/__EM_END__/gi' | \
+			sed 's/<i>/__EM_START__/gi; s/<\\/i>/__EM_END__/gi' | \
+			sed 's/<[^>]*>//g' | \
+			sed \"s/&#145;/$(printf '\\xe2\\x80\\x98')/g; s/&#146;/$(printf '\\xe2\\x80\\x99')/g; s/&#147;/$(printf '\\xe2\\x80\\x9c')/g; s/&#148;/$(printf '\\xe2\\x80\\x9d')/g; s/&#150;/$(printf '\\xe2\\x80\\x93')/g; s/&#151;/$(printf '\\xe2\\x80\\x94')/g\" | \
+			sed 's/&amp;/\\&/g; s/&lt;/</g; s/&gt;/>/g; s/&quot;/\"/g; s/&#8217;/'\"'\"'/g; s/&rsquo;/'\"'\"'/g; s/&mdash;/—/g; s/&ndash;/–/g; s/&nbsp;/ /g' | \
+			sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | \
+			grep -v '^$'"
+		end try
+	end if
+
+	-- Extract copyright from .copyright-info element
+	set songCopyright to ""
+	try
+		set songCopyright to do shell script "sed -n '/copyright-info/,/<\\/div>/p' " & quoted form of tmpHTML & " | sed 's/<[^>]*>//g' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$' | tr '\\n' ' ' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'"
+	end try
+	if songCopyright is "" then
+		try
+			set songCopyright to do shell script "grep -i 'copyright-info' " & quoted form of tmpHTML & " | sed 's/<[^>]*>//g' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | head -1"
+		end try
+	end if
+	-- Decode HTML entities in copyright
+	if songCopyright is not "" then
+		set songCopyright to decodeHTMLEntities(songCopyright)
+	end if
+
+	-- Extract download links from .col-sm-4 sidebar or .files section.
+	-- Links in this section with text containing "words", "music", or "audio"
+	-- are captured as download URLs.
+	set downloadLinks to {}
+	try
+		-- Extract all <a> tags from the col-sm-4 or files section
+		set dlSection to do shell script "sed -n '/col-sm-4\\|class=\"[^\"]*files/,/<\\/div>/p' " & quoted form of tmpHTML
+
+		-- Find all href values and their link text
+		set dlAnchors to do shell script "echo " & quoted form of dlSection & " | grep -ioE '<a[^>]+href=\"[^\"]+\"[^>]*>[^<]*</a>' | while read -r line; do
+			href=$(echo \"$line\" | sed 's/.*href=\"\\([^\"]*\\)\".*/\\1/')
+			text=$(echo \"$line\" | sed 's/<[^>]*>//g' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+			echo \"$href|$text\"
+		done"
+
+		if dlAnchors is not "" then
+			set dlLines to splitString(dlAnchors, linefeed)
+			repeat with dlLine in dlLines
+				set dlText to dlLine as text
+				if dlText contains "|" then
+					set dlParts to splitString(dlText, "|")
+					if (count of dlParts) >= 2 then
+						set dlHref to item 1 of dlParts
+						set dlLabel to toLower(item 2 of dlParts)
+
+						-- Skip placeholder links
+						if dlHref is not "#" and dlHref is not "" then
+							if dlLabel contains "words" then
+								set end of downloadLinks to {"words", dlHref}
+							else if dlLabel contains "music" then
+								set end of downloadLinks to {"music", dlHref}
+							else if dlLabel contains "audio" then
+								set end of downloadLinks to {"audio", dlHref}
+							end if
+						end if
+					end if
+				end if
+			end repeat
+		end if
+	end try
+
+	-- Clean up temp file
+	try
+		do shell script "rm -f " & quoted form of tmpHTML
+	end try
+
+	if debugMode then
+		log "DEBUG: Parsed title: " & songTitle
+		log "DEBUG: Parsed lyrics length: " & ((count of songLyrics) as text)
+		log "DEBUG: Parsed copyright: " & songCopyright
+		log "DEBUG: Download links found: " & ((count of downloadLinks) as text)
+	end if
+
+	return {songTitle, songLyrics, songCopyright, downloadLinks}
+end parseSongPage
+
+
+-- ==========================================================================
+-- HANDLER: formatLyrics — Format parsed lyrics into clean plain text
+-- ==========================================================================
+-- Converts the raw parsed lyrics (with __PARA_BREAK__, __EM_START__, etc.
+-- markers) into a clean plain-text format matching the Python scraper output.
+--
+-- Output format:
+--   "Song Title"
+--   (blank line)
+--   First verse line
+--   Second verse line
+--   (blank line)
+--   Chorus:
+--   Chorus line one
+--   Chorus line two
+--   (blank line)
+--   ...
+--   (double blank line)
+--   Words: Author Name
+--   (blank line)
+--   Copyright notice
+--
+-- Parameters:
+--   cleanTitle     — The cleaned song title (book code removed)
+--   rawLyrics      — Raw lyrics string with paragraph/italic markers
+--   copyrightText  — Copyright notice string
+--   songBook       — Book identifier key
+--
+-- Returns:
+--   Formatted plain-text string ready to save
+
+on formatLyrics(cleanTitle, rawLyrics, copyrightText, songBook)
+	-- Start with quoted title and blank line
+	set outputLines to {"\"" & cleanTitle & "\"", ""}
+
+	-- Split the raw lyrics into lines for processing
+	set lyricLines to splitString(rawLyrics, linefeed)
+
+	-- State tracking for stanza grouping and chorus detection
+	set stanzaBuf to {}
+	set stanzaIsChorus to false
+	set authorLines to {}
+	set foundAttribution to false
+	set inItalic to false
+
+	-- Smart stanza break detection: track consecutive empty paragraphs.
+	--
+	-- BACKGROUND — WHY SINGLE EMPTIES ARE NOT STANZA BREAKS:
+	-- On missionpraise.com, every lyric line is wrapped in its own <p> tag,
+	-- and the site uses CSS margin/padding on <p> elements for visual spacing.
+	-- This means there is a single empty <p> between EVERY line — these are
+	-- purely cosmetic spacers inserted by WordPress for CSS styling purposes,
+	-- NOT structural stanza boundaries.
+	--
+	-- BUG (pre-fix): The old code flushed the stanza buffer on every
+	-- __PARA_BREAK__ marker, which treated every single empty <p> as a
+	-- stanza break. This produced double-spaced output — a blank line after
+	-- every single lyric line — which is incorrect.
+	--
+	-- FIX: We count consecutive empties and only treat them as a real stanza
+	-- break when structural signals are present:
+	--   1. Two or more consecutive empties (a true structural gap in the HTML)
+	--   2. An italic state change (verse -> chorus or chorus -> verse transition)
+	--   3. A verse number at the start of the next non-empty line (e.g. "2 Amazing...")
+	-- A single empty between lines of the same stanza type is just CSS spacing
+	-- and is silently absorbed.
+	set consecutiveEmpties to 0
+
+	-- Process each line from the parsed lyrics
+	repeat with lyricLine in lyricLines
+		set lineText to lyricLine as text
+
+		-- Handle paragraph markers (potential stanza breaks).
+		-- IMPORTANT: We do NOT flush the stanza buffer here. Instead we
+		-- increment the consecutiveEmpties counter. The actual decision to
+		-- flush is deferred to when we encounter the next non-empty content
+		-- line, at which point we can inspect structural signals to determine
+		-- whether a genuine stanza boundary exists (see smart detection below).
+		if lineText is "__PARA_BREAK__" then
+			set consecutiveEmpties to consecutiveEmpties + 1
+
+		else if lineText is "__PARA_START__" then
+			-- Start of a new paragraph — handled implicitly
+
+		else if lineText is "__EM_START__" then
+			-- Entering italic (chorus) text
+			set inItalic to true
+			set stanzaIsChorus to true
+
+		else if lineText is "__EM_END__" then
+			-- Exiting italic text
+			set inItalic to false
+
+		else
+			-- Regular text line — strip whitespace
+			set strippedLine to trimString(lineText)
+
+			if strippedLine is not "" then
+				-- ============================================================
+				-- SMART STANZA BREAK DETECTION
+				-- ============================================================
+				-- We have a non-empty line and there are pending empties from
+				-- __PARA_BREAK__ markers. Decide whether the gap represents a
+				-- real stanza boundary or just CSS inter-line spacing.
+				--
+				-- A single empty <p> is just CSS spacing between lines within
+				-- the same stanza — we skip it silently (no flush).
+				--
+				-- We flush (start a new stanza) when ANY of these are true:
+				--   (a) consecutiveEmpties >= 2 — a structural HTML gap that
+				--       goes beyond normal inter-line CSS spacing
+				--   (b) Italic state changed — the current line's italic state
+				--       differs from the stanza's chorus flag, indicating a
+				--       verse-to-chorus or chorus-to-verse transition
+				--   (c) Line starts with a digit followed by a space — this
+				--       is a numbered verse marker (e.g. "2 O worship the King")
+				--       indicating the start of a new numbered verse
+				-- ============================================================
+				if consecutiveEmpties > 0 and (count of stanzaBuf) > 0 then
+					set shouldFlush to false
+
+					-- (a) Multiple consecutive empties = structural break
+					-- Two or more empty <p> elements in a row is a deliberate
+					-- gap in the HTML, not just inter-line CSS spacing.
+					if consecutiveEmpties >= 2 then
+						set shouldFlush to true
+					end if
+
+					-- (b) Italic state change = verse/chorus transition
+					-- If the current line is italic but stanza is not chorus,
+					-- or the current line is non-italic but stanza is chorus,
+					-- we have a transition that warrants a new stanza.
+					if not shouldFlush then
+						if inItalic is not equal to stanzaIsChorus then
+							set shouldFlush to true
+						end if
+					end if
+
+					-- (c) Line starts with a digit followed by a space = numbered verse
+					-- This detects patterns like "2 Amazing grace" or "10 Praise the Lord"
+					-- indicating the beginning of a new numbered verse/stanza.
+					if not shouldFlush then
+						set startsWithVerseNumber to false
+						if (count of strippedLine) >= 2 then
+							set firstChar to character 1 of strippedLine
+							if firstChar is in {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"} then
+								-- Use grep to confirm the pattern is "digits followed by space"
+								-- (not just a line that happens to start with a number)
+								try
+									set digitCheck to do shell script "echo " & quoted form of strippedLine & " | grep -c '^[[:digit:]][[:digit:]]* '"
+									if digitCheck is not "0" then set startsWithVerseNumber to true
+								end try
+							end if
+						end if
+						if startsWithVerseNumber then
+							set shouldFlush to true
+						end if
+					end if
+
+					-- Flush the current stanza if a break signal was detected
+					if shouldFlush then
+						if stanzaIsChorus then
+							-- Guard: Do NOT add "Chorus:" if the stanza's first line starts
+							-- with a verse number (digit followed by space). Some websites
+							-- wrap verse-numbered stanzas in <em> for styling, which would
+							-- cause a false-positive chorus detection.
+							set firstLine to first item of stanzaBuf
+							set startsWithDigit to 0
+							try
+								set startsWithDigit to (do shell script "echo " & quoted form of firstLine & " | grep -c '^[[:digit:]][[:digit:]]* '") as integer
+							end try
+							if startsWithDigit is 0 then
+								set end of outputLines to "Chorus:"
+							end if
+						end if
+						set end of outputLines to joinList(stanzaBuf, linefeed)
+						set end of outputLines to ""
+						set stanzaBuf to {}
+						set stanzaIsChorus to false
+					end if
+				end if
+
+				-- Reset the consecutive empties counter now that we have content
+				set consecutiveEmpties to 0
+				-- Check for attribution lines (Words:, Music:, etc.)
+				-- Require a colon, separator, or "by" after the keyword to prevent
+				-- false positives (e.g. sidebar text "Music file" or lyrics like "Words of...").
+				set isAttribution to false
+				set isExplicitAttribution to 0
+				try
+					set isExplicitAttribution to (do shell script "echo " & quoted form of strippedLine & " | grep -c -i '^\\(Words\\|Music\\|Arranged\\|Words and music\\|Based on\\|Translated\\|Paraphrase\\)[[:space:]]*[:&\\-/by]'") as integer
+				end try
+				if isExplicitAttribution is 0 then
+					try
+						set isExplicitAttribution to (do shell script "echo " & quoted form of strippedLine & " | grep -c -i '^\\(Words and music\\|Words & music\\)'") as integer
+					end try
+				end if
+				if isExplicitAttribution > 0 then
+					set isAttribution to true
+				else if foundAttribution and strippedLine does not contain (linefeed) then
+					-- Only cascade if line doesn't look like a numbered verse and is short
+					set startsWithVerseNum to 0
+					try
+						set startsWithVerseNum to (do shell script "echo " & quoted form of strippedLine & " | grep -c '^[[:digit:]][[:digit:]]* '") as integer
+					end try
+					if startsWithVerseNum is 0 and (count of strippedLine) < 120 then
+						set isAttribution to true
+					end if
+				end if
+
+				if isAttribution then
+					-- Flush any pending stanza
+					if (count of stanzaBuf) > 0 then
+						if stanzaIsChorus then
+							-- Guard: skip Chorus label if first line starts with a verse number
+							set firstLine to first item of stanzaBuf
+							set startsWithDigit to 0
+							try
+								set startsWithDigit to (do shell script "echo " & quoted form of firstLine & " | grep -c '^[[:digit:]][[:digit:]]* '") as integer
+							end try
+							if startsWithDigit is 0 then
+								set end of outputLines to "Chorus:"
+							end if
+						end if
+						set end of outputLines to joinList(stanzaBuf, linefeed)
+						set end of outputLines to ""
+						set stanzaBuf to {}
+						set stanzaIsChorus to false
+					end if
+					set foundAttribution to true
+					set end of authorLines to strippedLine
+
+				else
+					-- If we see a numbered verse after attribution, reset the cascade
+					-- to prevent a single false positive from consuming remaining lyrics.
+					if foundAttribution then
+						set startsWithVerseNum2 to 0
+						try
+							set startsWithVerseNum2 to (do shell script "echo " & quoted form of strippedLine & " | grep -c '^[[:digit:]][[:digit:]]* '") as integer
+						end try
+						if startsWithVerseNum2 > 0 then
+							set foundAttribution to false
+						end if
+					end if
+
+					if strippedLine does not start with (ASCII character 10) and ¬
+						(strippedLine contains "/" or strippedLine contains "&") and ¬
+						(count of strippedLine) < 120 then
+						-- Standalone author line (e.g. "Stuart Townend / Keith Getty")
+						-- Check it doesn't start with a digit and doesn't contain common lyric words
+						set firstChar to text 1 of strippedLine
+						set hasLyricWords to 0
+						try
+							set hasLyricWords to (do shell script "echo " & quoted form of strippedLine & " | grep -c -i '\\b\\(the\\|and\\|you\\|your\\|my\\|our\\|lord\\|god\\|love\\|sing\\|praise\\)\\b'") as integer
+						end try
+						if firstChar is not in {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"} and hasLyricWords is 0 then
+							-- Flush stanza
+							if (count of stanzaBuf) > 0 then
+								if stanzaIsChorus then
+									-- Guard: skip Chorus label if first line starts with a verse number
+									set firstLine to first item of stanzaBuf
+									set startsWithDigit to 0
+									try
+										set startsWithDigit to (do shell script "echo " & quoted form of firstLine & " | grep -c '^[[:digit:]][[:digit:]]* '") as integer
+									end try
+									if startsWithDigit is 0 then
+										set end of outputLines to "Chorus:"
+									end if
+								end if
+								set end of outputLines to joinList(stanzaBuf, linefeed)
+								set end of outputLines to ""
+								set stanzaBuf to {}
+								set stanzaIsChorus to false
+							end if
+							set end of authorLines to strippedLine
+						else
+							-- Starts with digit or contains lyric words — treat as lyric
+							if inItalic then set stanzaIsChorus to true
+							set end of stanzaBuf to strippedLine
+						end if
+					else
+						-- Regular lyric line — add to current stanza buffer
+						if inItalic then set stanzaIsChorus to true
+						set end of stanzaBuf to strippedLine
+					end if
+				end if
+			end if
+		end if
+	end repeat
+
+	-- Flush any remaining stanza
+	if (count of stanzaBuf) > 0 then
+		if stanzaIsChorus then
+			-- Guard: skip Chorus label if first line starts with a verse number.
+			-- Prevents false positives from verse-numbered stanzas wrapped in <em>
+			-- for styling on the website (e.g. "2 Lord, I come to You...").
+			set firstLine to first item of stanzaBuf
+			set startsWithDigit to 0
+			try
+				set startsWithDigit to (do shell script "echo " & quoted form of firstLine & " | grep -c '^[[:digit:]][[:digit:]]* '") as integer
+			end try
+			if startsWithDigit is 0 then
+				set end of outputLines to "Chorus:"
+			end if
+		end if
+		set end of outputLines to joinList(stanzaBuf, linefeed)
+		set end of outputLines to ""
+	end if
+
+	-- Remove trailing blank lines from the lyrics section
+	repeat while (count of outputLines) > 0 and item -1 of outputLines is ""
+		set outputLines to items 1 thru -2 of outputLines
+	end repeat
+
+	-- Append author attribution lines (separated from lyrics by double blank line)
+	if (count of authorLines) > 0 then
+		set end of outputLines to ""
+		set end of outputLines to ""
+		repeat with al in authorLines
+			set end of outputLines to al as text
+		end repeat
+	end if
+
+	-- Append copyright notice if available
+	if copyrightText is not "" then
+		set end of outputLines to ""
+		set end of outputLines to copyrightText
+	end if
+
+	-- Join all output lines with newlines
+	set formattedResult to joinList(outputLines, linefeed)
+
+	-- Post-processing: normalise spaced ellipses
+	-- WordPress sometimes renders "..." as ". . ." with spaces between dots
+	try
+		set formattedResult to do shell script "echo " & quoted form of formattedResult & " | sed 's/ *\\(\\. \\)\\{2,\\}\\./\\.\\.\\./'g"
+	end try
+
+	-- Strip legacy formatting codes f*I (italic start) and f*R (format reset)
+	-- that appear as data-entry artefacts in some song texts
+	try
+		set formattedResult to do shell script "echo " & quoted form of formattedResult & " | sed 's/f\\*I//g; s/f\\*R//g'"
+	end try
+
+	-- Collapse 3+ consecutive newlines down to 2 (one blank line maximum)
+	try
+		set formattedResult to do shell script "echo " & quoted form of formattedResult & " | perl -0pe 's/\\n{3,}/\\n\\n/g'"
+	end try
+
+	return formattedResult
+end formatLyrics
+
+
+-- ==========================================================================
+-- HANDLER: downloadFile — Download a binary file (words/music/audio)
+-- ==========================================================================
+-- Downloads a file via curl with the authenticated session, detects the
+-- file type from Content-Type header, URL extension, or magic bytes,
+-- and saves it with the correct extension and naming convention.
+--
+-- Parameters:
+--   dlURL      — Download URL
+--   baseFile   — Base filename (from buildBaseFilename)
+--   dlType     — Download type ("words", "music", or "audio")
+--   bookDir    — Directory to save the file in
+--   cookieJar  — Path to the temp cookie jar file
+--   debugMode  — Boolean: whether to log debug info
+--
+-- Returns:
+--   The saved filename (for adding to file cache), or "" on failure
+
+on downloadFile(dlURL, baseFile, dlType, bookDir, cookieJar, debugMode)
+	-- Create a temp file for the download
+	set tmpFile to do shell script "mktemp /tmp/mp_dl.XXXXXX"
+
+	try
+		-- Download with curl, capturing Content-Type and HTTP code
+		-- -w outputs metadata after the file data
+		-- -o writes the file to our temp path
+		set dlMeta to do shell script "curl -s -L " & ¬
+			"-o " & quoted form of tmpFile & " " & ¬
+			"-w '%{content_type}\\n%{http_code}\\n%{url_effective}' " & ¬
+			"-c " & quoted form of cookieJar & " " & ¬
+			"-b " & quoted form of cookieJar & " " & ¬
+			"-A " & quoted form of userAgent & " " & ¬
+			"-H 'Accept: */*' " & ¬
+			"-H 'Sec-Fetch-Dest: document' " & ¬
+			"-H 'Sec-Fetch-Mode: navigate' " & ¬
+			"--max-time 30 " & ¬
+			quoted form of dlURL
+
+		-- Parse the metadata output (content_type, http_code, url_effective)
+		set metaLines to splitString(dlMeta, linefeed)
+		set contentType to ""
+		set dlHttpCode to ""
+		set effectiveURL to ""
+
+		if (count of metaLines) >= 1 then set contentType to item 1 of metaLines
+		if (count of metaLines) >= 2 then set dlHttpCode to item 2 of metaLines
+		if (count of metaLines) >= 3 then set effectiveURL to item 3 of metaLines
+
+		-- Extract just the MIME type (strip charset and other parameters)
+		if contentType contains ";" then
+			set contentType to text 1 thru ((offset of ";" in contentType) - 1) of contentType
+		end if
+		set contentType to trimString(toLower(contentType))
+
+		if debugMode then
+			log "DEBUG: Download content-type: " & contentType
+			log "DEBUG: Download HTTP code: " & dlHttpCode
+		end if
+
+		-- Check for HTTP errors
+		if dlHttpCode is not "200" then
+			log "    Download failed (HTTP " & dlHttpCode & ")"
+			do shell script "rm -f " & quoted form of tmpFile
+			return ""
+		end if
+
+		-- Check file size and detect error pages masquerading as downloads
+		set fileSize to do shell script "stat -f '%z' " & quoted form of tmpFile
+		set fileSizeNum to fileSize as integer
+
+		if fileSizeNum is 0 then
+			log "    Download failed (empty file)"
+			do shell script "rm -f " & quoted form of tmpFile
+			return ""
+		end if
+
+		-- Error page detection: check if content looks like HTML error page.
+		-- Threshold raised to 500KB to catch larger error pages (e.g. styled
+		-- server error pages with embedded CSS/JS can exceed 50KB).
+		if fileSizeNum < 500000 then
+			try
+				set firstBytes to do shell script "head -c 100 " & quoted form of tmpFile
+				set firstBytesLower to toLower(firstBytes)
+				if firstBytes starts with "<" or firstBytes starts with "s" or firstBytes starts with "e" or firstBytes starts with "{" then
+					if firstBytesLower contains "exception" or firstBytesLower contains "<html" or firstBytesLower contains "<!doctype" or firstBytesLower contains "error" or firstBytesLower contains "not found" or firstBytesLower contains "string(" or firstBytesLower contains "nosuchkey" or firstBytesLower contains "stacktrace" then
+						log "    Download failed (server error page)"
+						if debugMode then
+							log "DEBUG: Error page content: " & firstBytes
+						end if
+						do shell script "rm -f " & quoted form of tmpFile
+						return ""
+					end if
+				end if
+			end try
+		end if
+
+		-- Determine the file extension using a cascade strategy:
+		-- 1. MIME type from Content-Type header
+		-- 2. File extension from the URL
+		-- 3. Magic bytes detection from the file content
+		set fileExt to extFromMIME(contentType)
+
+		if fileExt is "" then
+			set fileExt to extFromURL(effectiveURL)
+		end if
+
+		if fileExt is "" then
+			-- Use magic bytes detection via the `file` command
+			set fileExt to extFromMagic(tmpFile)
+		end if
+
+		-- Fallback to .bin if no extension could be determined
+		if fileExt is "" then set fileExt to ".bin"
+
+		-- Build the final filename using the naming convention:
+		-- Words: base.ext (no suffix)
+		-- Music: base_music.ext
+		-- Audio: base_audio.ext
+		if dlType is "words" then
+			set finalFilename to baseFile & fileExt
+		else
+			set finalFilename to baseFile & "_" & dlType & fileExt
+		end if
+
+		-- Move the temp file to the final destination
+		set finalPath to bookDir & "/" & finalFilename
+		do shell script "mv " & quoted form of tmpFile & " " & quoted form of finalPath
+
+		return finalFilename
+
+	on error errMsg
+		log "    Download error: " & errMsg
+		-- Clean up temp file on error
+		try
+			do shell script "rm -f " & quoted form of tmpFile
+		end try
+		return ""
+	end try
+end downloadFile
+
+
+-- ==========================================================================
+-- HANDLER: extractHiddenFields — Extract hidden form fields from HTML
+-- ==========================================================================
+-- Parses the login page HTML to find all <input type="hidden"> fields
+-- and returns them as a URL-encoded query string (name=value&name=value).
+-- These are CSRF nonces needed for the login POST request.
+--
+-- Parameters:
+--   htmlText — The HTML content of the login page
+--
+-- Returns:
+--   URL-encoded string of hidden field name=value pairs
+
+on extractHiddenFields(htmlText)
+	try
+		-- Write HTML to a temp file for grep processing
+		set tmpFile to do shell script "mktemp /tmp/mp_hidden.XXXXXX"
+		-- Use printf to write the HTML to avoid echo interpretation issues
+		do shell script "cat > " & quoted form of tmpFile & " << 'EOFHIDDENINPUT'\n" & htmlText & "\nEOFHIDDENINPUT" without altering line endings
+
+		-- Extract hidden field name/value pairs using grep and sed.
+		-- Pattern: <input type="hidden" name="..." value="...">
+		-- The name and value attributes can appear in any order.
+		set fieldsStr to do shell script "grep -ioE '<input[^>]+type=[\"'\"'\"']hidden[\"'\"'\"'][^>]*>' " & quoted form of tmpFile & " | while read -r line; do
+			name=$(echo \"$line\" | grep -oE 'name=[\"'\"'\"'][^\"'\"'\"']+[\"'\"'\"']' | sed 's/name=[\"'\"'\"']//;s/[\"'\"'\"']$//')
+			value=$(echo \"$line\" | grep -oE 'value=[\"'\"'\"'][^\"'\"'\"']*[\"'\"'\"']' | sed 's/value=[\"'\"'\"']//;s/[\"'\"'\"']$//')
+			if [ -n \"$name\" ]; then
+				# URL-encode the value for safe inclusion in POST data
+				encoded_value=$(python3 -c \"import urllib.parse; print(urllib.parse.quote('$value', safe=''))\" 2>/dev/null || echo \"$value\")
+				echo \"${name}=${encoded_value}\"
+			fi
+		done | tr '\\n' '&' | sed 's/&$//'"
+
+		-- Clean up temp file
+		do shell script "rm -f " & quoted form of tmpFile
+
+		return fieldsStr
+	on error errMsg
+		log "Warning: Failed to extract hidden fields: " & errMsg
+		return ""
+	end try
+end extractHiddenFields
+
+
+-- ==========================================================================
+-- HANDLER: extractCurlMetadata — Extract a metadata line from curl output
+-- ==========================================================================
+-- curl's -w option appends metadata to the output. This handler finds
+-- a line starting with the given prefix and returns its value.
+--
+-- Parameters:
+--   curlOutput — The full output from curl (including -w metadata)
+--   prefix     — The metadata prefix to search for (e.g. "__FINAL_URL__:")
+--
+-- Returns:
+--   The metadata value, or "" if not found
+
+on extractCurlMetadata(curlOutput, prefix)
+	set outputLines to splitString(curlOutput, linefeed)
+	repeat with outputLine in outputLines
+		set lineText to outputLine as text
+		if lineText starts with prefix then
+			return text ((count of prefix) + 1) thru -1 of lineText
+		end if
+	end repeat
+	return ""
+end extractCurlMetadata
+
+
+-- ==========================================================================
+-- HANDLER: extractWPLoginError — Extract WordPress login error message
+-- ==========================================================================
+-- Looks for the WordPress login error div in the HTML and extracts
+-- the error text, stripping HTML tags.
+--
+-- Parameters:
+--   htmlText — The login page HTML
+--
+-- Returns:
+--   The error message text, or "" if none found
+
+on extractWPLoginError(htmlText)
+	try
+		set errorText to do shell script "echo " & quoted form of htmlText & " | grep -oiE '<div[^>]*id=[\"'\"'\"']login_error[\"'\"'\"'][^>]*>.*?</div>' | sed 's/<[^>]*>//g' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | head -1"
+		return errorText
+	on error
+		return ""
+	end try
+end extractWPLoginError
+
+
+-- ==========================================================================
+-- HANDLER: extractPageCounter — Extract X-Y of Z counter from index page
+-- ==========================================================================
+-- The index page contains a counter like "1-10 of 1523" that tells us
+-- how many songs exist and enables loop detection.
+--
+-- Parameters:
+--   htmlText — The index page HTML
+--
+-- Returns:
+--   A list: {lo, hi, total} where lo and hi are the current range
+--   and total is the overall count. Returns {0, 0, 0} if not found.
+
+on extractPageCounter(htmlText)
+	try
+		set counterLine to do shell script "echo " & quoted form of htmlText & " | grep -oE '[0-9]+-[0-9]+[[:space:]]+of[[:space:]]+[0-9]+' | head -1"
+		if counterLine is not "" then
+			set counterParts to do shell script "echo " & quoted form of counterLine & " | sed 's/^\\([0-9]*\\)-\\([0-9]*\\)[[:space:]]*of[[:space:]]*\\([0-9]*\\)/\\1 \\2 \\3/'"
+			set counterNums to splitString(counterParts, " ")
+			if (count of counterNums) >= 3 then
+				set lo to (item 1 of counterNums) as integer
+				set hi to (item 2 of counterNums) as integer
+				set total to (item 3 of counterNums) as integer
+				return {lo, hi, total}
+			end if
+		end if
+	end try
+	return {0, 0, 0}
+end extractPageCounter
+
+
+-- ==========================================================================
+-- HANDLER: extractSongLinks — Parse song links from an index page
+-- ==========================================================================
+-- Extracts all song links from the index page HTML. Songs appear as
+-- <a> tags inside <h2> or <h3> elements with /songs/ URLs.
+--
+-- Parameters:
+--   htmlText — The index page HTML
+--
+-- Returns:
+--   A list of {title, url} pairs
+
+on extractSongLinks(htmlText)
+	set songLinks to {}
+
+	try
+		-- Write HTML to temp file for processing
+		set tmpFile to do shell script "mktemp /tmp/mp_index.XXXXXX"
+		try
+			do shell script "cat > " & quoted form of tmpFile & " << 'EOFINDEXINPUT'\n" & htmlText & "\nEOFINDEXINPUT" without altering line endings
+		on error
+			writeTextFile(tmpFile, htmlText)
+		end try
+
+		-- Extract song links: find <a> tags with /songs/ in href that are inside headings.
+		-- We use a multi-step approach:
+		-- 1. Flatten the HTML to single lines per link
+		-- 2. Find <a> tags with /songs/ in href
+		-- 3. Extract the href and link text
+		set linksOutput to do shell script "cat " & quoted form of tmpFile & " | \
+		tr '\\n' ' ' | \
+		sed 's/<h[23]/\\n<h/g' | \
+		grep -i '<h[23]' | \
+		grep -ioE '<a[[:space:]]+[^>]*href=[\"'\"'\"'][^\"'\"'\"']*\\/songs\\/[^\"'\"'\"']*[\"'\"'\"'][^>]*>[^<]*<\\/a>' | \
+		while read -r line; do
+			href=$(echo \"$line\" | sed 's/.*href=[\"'\"'\"']\\([^\"'\"'\"']*\\)[\"'\"'\"'].*/\\1/')
+			text=$(echo \"$line\" | sed 's/<[^>]*>//g' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+			if [ -n \"$href\" ] && [ -n \"$text\" ]; then
+				echo \"$text||$href\"
+			fi
+		done"
+
+		-- Clean up temp file
+		do shell script "rm -f " & quoted form of tmpFile
+
+		-- Parse the output into a list of {title, url} pairs
+		if linksOutput is not "" then
+			set linkLines to splitString(linksOutput, linefeed)
+			repeat with linkLine in linkLines
+				set linkText to linkLine as text
+				if linkText contains "||" then
+					set delimPos to offset of "||" in linkText
+					set linkTitle to text 1 thru (delimPos - 1) of linkText
+					set linkURL to text (delimPos + 2) thru -1 of linkText
+					-- Decode HTML entities in the title
+					set linkTitle to decodeHTMLEntities(linkTitle)
+					-- Only include actual song links (not navigation, etc.)
+					if linkURL contains "/songs/" and linkURL is not "/songs/" and linkURL is not "/songs" then
+						set end of songLinks to {linkTitle, linkURL}
+					end if
+				end if
+			end repeat
+		end if
+	on error errMsg
+		log "Warning: Error extracting song links: " & errMsg
+	end try
+
+	return songLinks
+end extractSongLinks
+
+
+-- ==========================================================================
+-- HANDLER: extractSongNumber — Extract hymn number from title for a book
+-- ==========================================================================
+-- Song titles include the book code and number in parentheses:
+--   "Amazing Grace (MP0023)" -> 23
+--
+-- Parameters:
+--   songTitle — Full song title from the index page
+--   songBook  — Book identifier key ("mp", "cp", or "jp")
+--
+-- Returns:
+--   The hymn number as an integer, or 0 if not found
+
+on extractSongNumber(songTitle, songBook)
+	set bookPattern to getBookPattern(songBook)
+	try
+		-- Use grep to extract the number from the book pattern
+		set numStr to do shell script "echo " & quoted form of songTitle & " | grep -ioE " & quoted form of bookPattern & " | grep -oE '[0-9]+' | head -1"
+		if numStr is not "" then
+			return numStr as integer
+		end if
+	end try
+	return 0
+end extractSongNumber
+
+
+-- ==========================================================================
+-- HANDLER: cleanSongTitle — Remove the book code suffix from a title
+-- ==========================================================================
+-- Strips the "(MP0023)" or similar suffix from the end of the title,
+-- leaving just the human-readable song name for use in filenames.
+--
+-- Parameters:
+--   songTitle — Full song title (e.g. "Amazing Grace (MP0023)")
+--   songBook  — Book identifier key
+--
+-- Returns:
+--   Cleaned title (e.g. "Amazing Grace")
+
+on cleanSongTitle(songTitle, songBook)
+	set bookLabel to getBookLabel(songBook)
+	-- Remove the book code suffix: strip "(MP0023)" or similar from end
+	try
+		set cleanedTitle to do shell script "echo " & quoted form of songTitle & " | sed 's/[[:space:]]*(" & bookLabel & "[0-9]*)[[:space:]]*$//' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'"
+		if cleanedTitle is not "" then
+			return cleanedTitle
+		end if
+	end try
+	return songTitle
+end cleanSongTitle
+
+
+-- ==========================================================================
+-- HANDLER: buildBaseFilename — Construct the base filename for a song
+-- ==========================================================================
+-- Generates a consistent filename from the song's book, number, and title.
+-- The title is sanitized and converted to Title Case.
+--
+-- Format: "{paddedNumber} ({LABEL}) - {Title Case Title}"
+--
+-- Parameters:
+--   songNumber — The song number (integer)
+--   songBook   — Book identifier key
+--   cleanTitle — The cleaned song title (book code already removed)
+--
+-- Returns:
+--   The base filename string (without extension)
+
+on buildBaseFilename(songNumber, songBook, cleanTitle)
+	set bookLabel to getBookLabel(songBook)
+	set bookPad to getBookPad(songBook)
+	set paddedNumber to zeroPad(songNumber, bookPad)
+	set sanitizedTitle to sanitizeFilename(toTitleCase(cleanTitle))
+	return paddedNumber & " (" & bookLabel & ") - " & sanitizedTitle
+end buildBaseFilename
+
+
+-- ==========================================================================
+-- HANDLER: logSkip — Record a skipped song in the skipped.log file
+-- ==========================================================================
+-- Creates a persistent log of songs that couldn't be scraped, with
+-- timestamps, identifiers, and reasons.
+--
+-- Log format:
+--   [2026-03-13 14:30:00]  MP0023  Amazing Grace  --  login wall  --  https://...
+--
+-- Parameters:
+--   bookDir   — Directory to write the log file in
+--   label     — Book label (e.g. "MP")
+--   padded    — Zero-padded song number string
+--   songTitle — The song title
+--   songURL   — The song URL that was attempted
+--   reason    — Human-readable explanation of why it was skipped
+
+on logSkip(bookDir, label, padded, songTitle, songURL, reason)
+	try
+		-- Ensure the directory exists
+		do shell script "mkdir -p " & quoted form of bookDir
+
+		-- Get the current timestamp
+		set timestamp to do shell script "date '+%Y-%m-%d %H:%M:%S'"
+
+		-- Append to skipped.log
+		set logPath to bookDir & "/skipped.log"
+		set logLine to "[" & timestamp & "]  " & label & padded & "  " & songTitle & "  --  " & reason & "  --  " & songURL
+		do shell script "echo " & quoted form of logLine & " >> " & quoted form of logPath
+	on error errMsg
+		log "Warning: Failed to write skip log: " & errMsg
+	end try
+end logSkip
+
+
+-- ==========================================================================
+-- BOOK CONFIGURATION HANDLERS
+-- ==========================================================================
+-- These handlers return book-specific configuration values.
+-- Equivalent to the Python BOOK_CONFIG dictionary.
+
+-- Get the display label for a book (e.g. "mp" -> "MP")
+on getBookLabel(bookKey)
+	if bookKey is "mp" then
+		return "MP"
+	else if bookKey is "cp" then
+		return "CP"
+	else if bookKey is "jp" then
+		return "JP"
+	end if
+	return "??"
+end getBookLabel
+
+-- Get the zero-padding width for a book's numbers (MP=4, CP/JP=3)
+on getBookPad(bookKey)
+	if bookKey is "mp" then
+		return 4
+	else if bookKey is "cp" then
+		return 3
+	else if bookKey is "jp" then
+		return 3
+	end if
+	return 4
+end getBookPad
+
+-- Get the regex pattern to match a book code in a title
+-- These are POSIX extended regex patterns for use with grep -E
+on getBookPattern(bookKey)
+	if bookKey is "mp" then
+		return "\\(MP[0-9]+\\)"
+	else if bookKey is "cp" then
+		return "\\(CP[0-9]+\\)"
+	else if bookKey is "jp" then
+		return "\\(JP[0-9]+\\)"
+	end if
+	return ""
+end getBookPattern
+
+-- Get the human-readable subdirectory name for a book
+on getBookSubdir(bookKey)
+	if bookKey is "mp" then
+		return "Mission Praise [MP]"
+	else if bookKey is "cp" then
+		return "Carol Praise [CP]"
+	else if bookKey is "jp" then
+		return "Junior Praise [JP]"
+	end if
+	return "Unknown"
+end getBookSubdir
+
+
+-- ==========================================================================
+-- MIME TYPE HANDLERS
+-- ==========================================================================
+
+-- Map a MIME type to a file extension
+-- Equivalent to the Python MIME_TO_EXT dictionary
+on extFromMIME(mimeType)
+	if mimeType is "application/rtf" or mimeType is "text/rtf" then
+		return ".rtf"
+	else if mimeType is "application/msword" then
+		return ".doc"
+	else if mimeType is "application/vnd.openxmlformats-officedocument.wordprocessingml.document" then
+		return ".docx"
+	else if mimeType is "application/pdf" then
+		return ".pdf"
+	else if mimeType is "audio/midi" or mimeType is "audio/x-midi" then
+		return ".mid"
+	else if mimeType is "audio/mpeg" or mimeType is "audio/mp3" then
+		return ".mp3"
+	else if mimeType is "audio/wav" or mimeType is "audio/x-wav" then
+		return ".wav"
+	else if mimeType is "audio/ogg" then
+		return ".ogg"
+	else if mimeType is "application/octet-stream" then
+		-- Generic binary — fall back to other methods
+		return ""
+	end if
+	return ""
+end extFromMIME
+
+
+-- ==========================================================================
+-- HANDLER: extFromURL — Guess file extension from a URL's path
+-- ==========================================================================
+-- Parses the URL to extract the path, then gets the extension from the
+-- last path segment. Server-side script extensions are ignored.
+--
+-- Parameters:
+--   fileURL — The download URL
+--
+-- Returns:
+--   The lowercase file extension (e.g. ".rtf") or "" if none found
+
+on extFromURL(fileURL)
+	try
+		-- Extract the path from the URL and get the extension
+		set fileExt to do shell script "echo " & quoted form of fileURL & " | sed 's/[?#].*//' | grep -oE '\\.[a-zA-Z0-9]+$' | tr 'A-Z' 'a-z'"
+		-- Ignore server-side script extensions
+		if fileExt is in {".php", ".asp", ".aspx", ".jsp", ".cgi", ".py"} then
+			return ""
+		end if
+		return fileExt
+	on error
+		return ""
+	end try
+end extFromURL
+
+
+-- ==========================================================================
+-- HANDLER: extFromMagic — Detect file type from magic bytes
+-- ==========================================================================
+-- Uses the macOS `file` command to detect the file type from its
+-- content (magic bytes), then maps the result to a file extension.
+--
+-- Parameters:
+--   filePath — Path to the file to check
+--
+-- Returns:
+--   The detected file extension or "" if not recognised
+
+on extFromMagic(filePath)
+	try
+		-- Use the `file` command for magic byte detection
+		set fileType to do shell script "file -b --mime-type " & quoted form of filePath
+		set fileType to trimString(toLower(fileType))
+
+		-- Map the detected MIME type to an extension
+		set ext to extFromMIME(fileType)
+		if ext is not "" then return ext
+
+		-- Additional detection via raw magic bytes for common formats
+		set magicHex to do shell script "xxd -p -l 4 " & quoted form of filePath
+
+		-- %PDF -> PDF
+		if magicHex starts with "25504446" then return ".pdf"
+		-- PK (ZIP-based, e.g. docx) -> .docx
+		if magicHex starts with "504b0304" then return ".docx"
+		-- OLE2 (doc, xls) -> .doc
+		if magicHex starts with "d0cf11e0" then return ".doc"
+		-- {\\rtf -> RTF
+		if magicHex starts with "7b5c7274" then return ".rtf"
+		-- MThd -> MIDI
+		if magicHex starts with "4d546864" then return ".mid"
+		-- ID3 -> MP3
+		if magicHex starts with "49443303" or magicHex starts with "49443302" then return ".mp3"
+		-- MP3 frame sync
+		if magicHex starts with "fffb" or magicHex starts with "fff3" then return ".mp3"
+		-- OggS -> Ogg
+		if magicHex starts with "4f676753" then return ".ogg"
+		-- RIFF -> WAV
+		if magicHex starts with "52494646" then return ".wav"
+		-- fLaC -> FLAC
+		if magicHex starts with "664c6143" then return ".flac"
+
+	on error
+		-- file command failed — return empty
+	end try
+	return ""
+end extFromMagic
+
+
+-- ==========================================================================
+-- STRING UTILITY HANDLERS
+-- ==========================================================================
+
+-- Split a string into a list using a delimiter
+-- Equivalent to Python's str.split()
+on splitString(theString, theDelimiter)
+	set oldDelimiters to AppleScript's text item delimiters
+	set AppleScript's text item delimiters to theDelimiter
+	set theItems to text items of theString
+	set AppleScript's text item delimiters to oldDelimiters
+	return theItems
+end splitString
+
+-- Join a list into a string using a delimiter
+-- Equivalent to Python's str.join()
+on joinList(theList, theDelimiter)
+	set oldDelimiters to AppleScript's text item delimiters
+	set AppleScript's text item delimiters to theDelimiter
+	set theString to theList as text
+	set AppleScript's text item delimiters to oldDelimiters
+	return theString
+end joinList
+
+-- Trim whitespace from both ends of a string
+on trimString(theString)
+	try
+		set trimmed to do shell script "echo " & quoted form of theString & " | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'"
+		return trimmed
+	on error
+		return theString
+	end try
+end trimString
+
+-- Convert a string to lowercase
+-- Uses a shell command for reliable Unicode-aware lowercasing
+on toLower(theString)
+	try
+		return do shell script "echo " & quoted form of theString & " | tr 'A-Z' 'a-z'"
+	on error
+		return theString
+	end try
+end toLower
+
+-- Convert a string to uppercase
+on toUpper(theString)
+	try
+		return do shell script "echo " & quoted form of theString & " | tr 'a-z' 'A-Z'"
+	on error
+		return theString
+	end try
+end toUpper
+
+-- Convert a string to Title Case.
+-- Handles apostrophes correctly (e.g. "don't" -> "Don't", not "Don'T")
+-- Includes Unicode curly/smart apostrophes (\u2019 RIGHT SINGLE QUOTATION
+-- MARK and \u2018 LEFT SINGLE QUOTATION MARK) because HTML entities like
+-- &rsquo; decode to \u2019. Without this, "Eagle\u2019s" would produce "Eagle'S".
+-- Equivalent to the Python title_case() function.
+on toTitleCase(theString)
+	try
+		-- Use awk for reliable Title Case with apostrophe handling.
+		-- awk splits on whitespace, so words containing any kind of apostrophe
+		-- (ASCII ' or Unicode curly \u2019/\u2018) are naturally treated as
+		-- single tokens — no special character class needed.
+		return do shell script "echo " & quoted form of theString & " | awk '{for(i=1;i<=NF;i++){w=tolower($i);$i=toupper(substr(w,1,1)) substr(w,2)}}1'"
+	on error
+		-- Fallback: use simple sed-based title case
+		try
+			return do shell script "echo " & quoted form of theString & " | sed 's/.*/\\L&/' | sed 's/\\b./\\u&/g'"
+		on error
+			return theString
+		end try
+	end try
+end toTitleCase
+
+-- Remove characters that are invalid in filenames
+-- Strips: \ / * ? : " < > |
+on sanitizeFilename(theString)
+	try
+		return do shell script "echo " & quoted form of theString & " | sed 's/[\\\\/\\*\\?:\"<>|]//g' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'"
+	on error
+		return theString
+	end try
+end sanitizeFilename
+
+-- Zero-pad a number to a specified width
+-- e.g. zeroPad(23, 4) -> "0023"
+on zeroPad(theNumber, theWidth)
+	set numStr to theNumber as text
+	repeat while (count of numStr) < theWidth
+		set numStr to "0" & numStr
+	end repeat
+	return numStr
+end zeroPad
+
+-- Right-pad a string to a minimum width with spaces
+-- Used for aligned log output
+on rightPad(theString, minWidth)
+	set padded to theString
+	repeat while (count of padded) < minWidth
+		set padded to padded & " "
+	end repeat
+	return padded
+end rightPad
+
+-- URL-encode a string for use in HTTP POST data
+-- Encodes special characters to their percent-encoded equivalents
+on urlEncode(theString)
+	try
+		return do shell script "python3 -c \"import urllib.parse; print(urllib.parse.quote('" & theString & "', safe=''))\" 2>/dev/null || echo " & quoted form of theString
+	on error
+		-- Fallback: use a basic encoding for common special characters
+		try
+			return do shell script "echo " & quoted form of theString & " | sed 's/%/%25/g;s/ /%20/g;s/!/%21/g;s/#/%23/g;s/\\$/%24/g;s/&/%26/g;s/(/%28/g;s/)/%29/g;s/+/%2B/g;s/=/%3D/g;s/@/%40/g'"
+		on error
+			return theString
+		end try
+	end try
+end urlEncode
+
+-- Decode common HTML entities in a string
+-- Handles both named entities (&amp;) and numeric references (&#8217;)
+on decodeHTMLEntities(theString)
+	try
+		-- Windows-1252 entity mapping: the site uses &#145;-&#151; which are
+		-- Windows-1252 code points, NOT Unicode. chr(146) etc. produce control
+		-- characters, not the intended typographic glyphs. Map them explicitly
+		-- BEFORE the generic entity handling.
+		-- Reference: https://en.wikipedia.org/wiki/Windows-1252#Character_set
+		return do shell script "echo " & quoted form of theString & " | \
+		sed \"s/&#145;/$(printf '\\xe2\\x80\\x98')/g\" | \
+		sed \"s/&#146;/$(printf '\\xe2\\x80\\x99')/g\" | \
+		sed \"s/&#147;/$(printf '\\xe2\\x80\\x9c')/g\" | \
+		sed \"s/&#148;/$(printf '\\xe2\\x80\\x9d')/g\" | \
+		sed \"s/&#150;/$(printf '\\xe2\\x80\\x93')/g\" | \
+		sed \"s/&#151;/$(printf '\\xe2\\x80\\x94')/g\" | \
+		sed 's/&amp;/\\&/g' | \
+		sed 's/&lt;/</g' | \
+		sed 's/&gt;/>/g' | \
+		sed \"s/&quot;/\\\"/g\" | \
+		sed \"s/&#8217;/'/g\" | \
+		sed \"s/&#8216;/'/g\" | \
+		sed 's/&#8220;/\"/g' | \
+		sed 's/&#8221;/\"/g' | \
+		sed \"s/&rsquo;/'/g\" | \
+		sed \"s/&lsquo;/'/g\" | \
+		sed 's/&rdquo;/\"/g' | \
+		sed 's/&ldquo;/\"/g' | \
+		sed 's/&mdash;/—/g' | \
+		sed 's/&ndash;/–/g' | \
+		sed 's/&nbsp;/ /g' | \
+		sed 's/&#160;/ /g'"
+	on error
+		return theString
+	end try
+end decodeHTMLEntities
+
+-- Write text content to a file (UTF-8)
+-- Creates the file if it doesn't exist, overwrites if it does
+on writeTextFile(filePath, textContent)
+	try
+		-- Use printf for safer writing (handles special characters better than echo)
+		do shell script "printf '%s' " & quoted form of textContent & " > " & quoted form of filePath
+	on error
+		-- Fallback: use a temp file approach
+		try
+			set tmpWrite to do shell script "mktemp /tmp/mp_write.XXXXXX"
+			do shell script "cat > " & quoted form of tmpWrite & " << 'EOFWRITECONTENT'\n" & textContent & "\nEOFWRITECONTENT" without altering line endings
+			do shell script "mv " & quoted form of tmpWrite & " " & quoted form of filePath
+		on error errMsg
+			log "Warning: Failed to write file " & filePath & ": " & errMsg
+		end try
+	end try
+end writeTextFile
+
+
+-- ==========================================================================
+-- HANDLER: writeDebugHTML — Dump raw HTML to a debug file for skip diagnosis
+-- ==========================================================================
+-- When a song is skipped, this handler writes the raw HTML response to a
+-- diagnostic file so the developer can inspect exactly what the server
+-- returned. The file is saved alongside the lyrics in the book directory.
+--
+-- Filename format: _debug_{LABEL}{NUM}_skipped.html
+--   e.g. _debug_MP0023_skipped.html
+--
+-- Parameters:
+--   bookDir  — Directory to save the debug file in
+--   label    — Book label (e.g. "MP")
+--   padded   — Zero-padded song number string
+--   htmlContent — The raw HTML response from the server
+--   reason   — Short label for the skip reason (used in log only)
+
+on writeDebugHTML(bookDir, label, padded, htmlContent, reason)
+	try
+		set debugPath to bookDir & "/_debug_" & label & padded & "_skipped.html"
+		writeTextFile(debugPath, htmlContent)
+		log "    DEBUG: raw HTML saved to _debug_" & label & padded & "_skipped.html (" & reason & ")"
+	on error errMsg
+		log "    Warning: failed to write debug HTML: " & errMsg
+	end try
+end writeDebugHTML
+
+
+-- ==========================================================================
+-- HANDLER: cleanupCookieJar — Delete the temp cookie jar file
+-- ==========================================================================
+-- Called on normal exit and in the error handler to ensure temp files
+-- are always cleaned up, even when the script encounters an error.
+--
+-- Parameters:
+--   jarPath — Path to the cookie jar temp file
+
+on cleanupCookieJar(jarPath)
+	if jarPath is not "" then
+		try
+			do shell script "rm -f " & quoted form of jarPath
+			log "Cleaned up cookie jar: " & jarPath
+		on error
+			-- Silently ignore cleanup errors
+		end try
+	end if
+end cleanupCookieJar
+
+
+-- ==========================================================================
+-- HANDLER: min — Return the smaller of two numbers
+-- ==========================================================================
+on min(a, b)
+	if a < b then
+		return a
+	else
+		return b
+	end if
+end min

--- a/.importers/scrapers/MissionPraise.com.bat
+++ b/.importers/scrapers/MissionPraise.com.bat
@@ -1,0 +1,2866 @@
+@if (@CodeSection == @Batch) @then
+@echo off
+REM ============================================================================
+REM MissionPraise.com.bat
+REM importers/scrapers/MissionPraise.com.bat
+REM
+REM Mission Praise Scraper (Windows Batch/JScript Hybrid)
+REM Scrapes lyrics and downloads files from missionpraise.com.
+REM Copyright 2025-2026 MWBM Partners Ltd.
+REM
+REM ============================================================================
+REM HYBRID TECHNIQUE EXPLANATION
+REM ============================================================================
+REM
+REM This file is simultaneously a valid Windows Batch script and a valid JScript
+REM file. The trick works because:
+REM
+REM   1. The first line "@if (@CodeSection == @Batch) @then" is:
+REM      - In Batch: "@if" runs the "if" command. Since @CodeSection and @Batch
+REM        are undefined environment variables, they evaluate to empty strings,
+REM        making the condition false. The @then part is ignored. The "@" prefix
+REM        suppresses echo. Batch then falls through to the next line.
+REM      - In JScript: This is a conditional compilation directive. @CodeSection
+REM        is undefined (evaluates to NaN), @Batch is also undefined, so the
+REM        condition NaN == NaN is false. Everything between @if and @end is
+REM        skipped by the JScript engine.
+REM
+REM   2. The Batch section runs between "@then" and "@end". It handles the
+REM      interactive menu, collects user input, validates settings, and then
+REM      launches the JScript section by calling:
+REM        cscript //nologo //e:jscript "%~f0" [arguments...]
+REM      This tells Windows Script Host (cscript.exe) to interpret THIS SAME
+REM      FILE as JScript code. The JScript engine ignores the Batch section
+REM      (wrapped in @if/@end) and executes only the JScript code below @end.
+REM
+REM   3. The JScript section (after @end) contains the actual scraping engine
+REM      using native Windows COM objects:
+REM        - WinHttp.WinHttpRequest.5.1  for HTTP requests (with cookie support)
+REM        - ADODB.Stream                for binary file I/O
+REM        - Scripting.FileSystemObject  for filesystem operations
+REM        - WScript.Shell               for environment access
+REM
+REM AUTHENTICATION FLOW:
+REM   1. GET wp-login.php to extract CSRF nonces (hidden form fields)
+REM   2. 2-second pause to appear human-like
+REM   3. POST credentials + nonces with browser-like headers
+REM   4. Detect: WAF blocks (Sucuri), incorrect credentials, login errors
+REM   5. Verify login by fetching /songs/ and checking for logged-in indicators
+REM
+REM DEPENDENCIES: None. Uses only native Windows components:
+REM   - cscript.exe (Windows Script Host) -- present on all Windows versions
+REM   - WinHttp.WinHttpRequest.5.1 -- native HTTP client since Windows XP SP3
+REM   - ADODB.Stream -- native since Windows 2000 (part of MDAC/ADO)
+REM   - Scripting.FileSystemObject -- native since Windows 98
+REM
+REM OUTPUT FORMAT:
+REM   Lyrics saved as plain text:
+REM     {padded_number} ({LABEL}) - {Title Case Title}.txt
+REM   Downloads use the same base name with type suffixes:
+REM     {base}.rtf            (words document)
+REM     {base}_music.pdf      (sheet music)
+REM     {base}_audio.mp3      (audio recording)
+REM   Files organised into book-specific subdirectories:
+REM     hymns\Mission Praise [MP]\
+REM     hymns\Carol Praise [CP]\
+REM     hymns\Junior Praise [JP]\
+REM
+REM ============================================================================
+
+REM === INITIALIZE DEFAULT SETTINGS ===
+REM These variables hold the current configuration. They are modified by the
+REM interactive menu and passed as arguments to the JScript scraping engine.
+
+setlocal enabledelayedexpansion
+
+REM Credentials (initially empty -- must be set by the user before scraping)
+set "MP_USERNAME="
+set "MP_PASSWORD="
+
+REM Books to scrape: mp, cp, jp, or all (comma-separated)
+set "MP_BOOKS=all"
+
+REM Output directory (default: "hymns" subfolder in the current directory)
+set "MP_OUTPUT=.\hymns"
+
+REM Start page for the paginated song index (1 = beginning)
+set "MP_STARTPAGE=1"
+
+REM Whether to download files (words/music/audio): yes or no
+set "MP_DOWNLOAD=yes"
+
+REM Delay between HTTP requests in milliseconds (1200ms = 1.2 seconds)
+set "MP_DELAY=1200"
+
+REM Debug mode: dumps full HTML responses for troubleshooting
+set "MP_DEBUG=no"
+
+REM Force mode: re-download and overwrite all files, ignoring existing file cache.
+REM When enabled, the scraper skips building the file existence cache and treats
+REM every song as new, downloading lyrics and files even if they already exist.
+set "MP_FORCE=no"
+
+REM ============================================================================
+REM CHECK FOR HELP FLAG
+REM ============================================================================
+REM If the user passes /? or no arguments, display usage information.
+
+if "%~1"=="/?" goto :showhelp
+if "%~1"=="-?" goto :showhelp
+if "%~1"=="--help" goto :showhelp
+if "%~1"=="-h" goto :showhelp
+
+REM Check for /force and /song:NNN command-line flags.
+REM These allow force mode and single-song mode to be activated directly
+REM from the command line, bypassing the interactive menu. Checks all
+REM positional arguments so flags can appear anywhere on the command line.
+set "MP_SONG="
+for %%A in (%*) do (
+    if /i "%%~A"=="/force" set "MP_FORCE=yes"
+    for /f "tokens=1,2 delims=:" %%B in ("%%~A") do (
+        if /i "%%B"=="/song" set "MP_SONG=%%C"
+    )
+)
+REM If /song is specified, auto-enable force mode so the song is re-downloaded
+if defined MP_SONG set "MP_FORCE=yes"
+
+REM ============================================================================
+REM ASCII BANNER
+REM ============================================================================
+:banner
+cls
+echo.
+echo  ============================================================================
+echo  #     # ###  #####   #####  ###  #####  #   #    ####  ####   ###  ###  ##### #####
+echo  ##   ##  #  #       #        #  #     # ##  #    #   # #   # #   #  #  #     #
+echo  # # # #  #   ####    ####    #  #     # # # #    ####  ####  #####  #   ####  ####
+echo  #  #  #  #       #       #   #  #     # #  ##    #     #  #  #   #  #       # #
+echo  #     # ### #####   #####   ###  #####  #   #    #     #   # #   # ### #####  #####
+echo.
+echo   Mission Praise Scraper - Windows Batch/JScript Hybrid
+echo   Copyright 2025-2026 MWBM Partners Ltd.
+echo  ============================================================================
+echo.
+
+REM ============================================================================
+REM MAIN MENU LOOP
+REM ============================================================================
+REM Display the interactive numbered menu and process user choices.
+REM The menu loops until the user selects option S (START) or 0 (Exit).
+
+:menu
+echo   Current Settings:
+echo   -----------------
+
+REM Display username (show as "not set" if empty)
+if defined MP_USERNAME (
+    echo   Username    : !MP_USERNAME!
+) else (
+    echo   Username    : [not set]
+)
+
+REM Display password (masked for security -- show asterisks if set)
+if defined MP_PASSWORD (
+    echo   Password    : ********
+) else (
+    echo   Password    : [not set]
+)
+
+REM Display books selection
+if "!MP_BOOKS!"=="all" (
+    echo   Books       : ALL ^(MP, CP, JP^)
+) else (
+    echo   Books       : !MP_BOOKS!
+)
+
+echo   Output Dir  : !MP_OUTPUT!
+echo   Start Page  : !MP_STARTPAGE!
+echo   Downloads   : !MP_DOWNLOAD!
+
+REM Convert delay from milliseconds to seconds for display (integer division)
+set /a "MP_DELAY_SEC=!MP_DELAY! / 1000"
+echo   Delay       : !MP_DELAY_SEC!s ^(!MP_DELAY!ms^)
+echo   Debug Mode  : !MP_DEBUG!
+echo   Force Mode  : !MP_FORCE!
+echo.
+echo   -----------------
+echo   Menu:
+echo     1. Enter credentials (username + password)
+echo     2. Choose books (mp/cp/jp/all)
+echo     3. Set output directory
+echo     4. Set start page
+echo     5. Toggle file downloads (currently: !MP_DOWNLOAD!)
+echo     6. Set delay between requests
+echo     7. Toggle debug mode (currently: !MP_DEBUG!)
+echo     8. Toggle force mode (currently: !MP_FORCE!)
+echo     9. Show current settings (refresh)
+echo     S. START scraping
+echo     0. Exit
+echo.
+set "CHOICE="
+set /p "CHOICE=  Enter choice [0-9/S]: "
+
+REM --- Process menu choice ---
+
+if "!CHOICE!"=="1" goto :set_credentials
+if "!CHOICE!"=="2" goto :set_books
+if "!CHOICE!"=="3" goto :set_output
+if "!CHOICE!"=="4" goto :set_startpage
+if "!CHOICE!"=="5" goto :toggle_downloads
+if "!CHOICE!"=="6" goto :set_delay
+if "!CHOICE!"=="7" goto :toggle_debug
+if "!CHOICE!"=="8" goto :toggle_force
+if "!CHOICE!"=="9" goto :banner
+if /i "!CHOICE!"=="S" goto :start_scrape
+if "!CHOICE!"=="0" goto :exit_script
+
+REM Invalid input -- redisplay menu
+echo.
+echo   [!] Invalid choice. Please enter a number from 0-9 or S.
+echo.
+goto :menu
+
+REM ============================================================================
+REM MENU OPTION HANDLERS
+REM ============================================================================
+
+REM --- Option 1: Enter Credentials ---
+:set_credentials
+echo.
+set /p "MP_USERNAME=  Enter username/email: "
+
+REM NOTE ON PASSWORD INPUT:
+REM Windows Batch (cmd.exe) does not support hiding input natively.
+REM The "set /p" command will display the password as the user types it.
+REM This is a known limitation of the Batch environment. For truly hidden
+REM input, use the Python version of this scraper instead.
+REM
+REM Alternative approaches that were considered but rejected:
+REM   - PowerShell's Read-Host -AsSecureString: Requires PowerShell, adds
+REM     complexity, and the secure string can't easily be passed back to Batch.
+REM   - VBScript InputBox with password masking: Opens a GUI dialog which
+REM     breaks the console-only workflow.
+REM   - Reading from a file: Less secure than typing (file persists on disk).
+echo.
+echo   NOTE: Password will be visible as you type (Batch limitation).
+echo   For hidden input, use the Python version of this scraper.
+set /p "MP_PASSWORD=  Enter password: "
+echo.
+goto :banner
+
+REM --- Option 2: Choose Books ---
+:set_books
+echo.
+echo   Available books:
+echo     mp  - Mission Praise (~1000+ songs, 4-digit numbering)
+echo     cp  - Carol Praise (~300 songs, 3-digit numbering)
+echo     jp  - Junior Praise (~300 songs, 3-digit numbering)
+echo     all - All three books (mp,cp,jp)
+echo.
+echo   Enter one or more, comma-separated (e.g. mp,cp):
+set /p "MP_BOOKS=  Books: "
+REM Convert to lowercase for consistency
+REM (Batch doesn't have a built-in lowercase function, but the JScript
+REM section handles case-insensitive comparison, so mixed case is fine)
+echo.
+goto :banner
+
+REM --- Option 3: Set Output Directory ---
+:set_output
+echo.
+echo   Current output directory: !MP_OUTPUT!
+set /p "MP_OUTPUT=  Enter new output directory: "
+echo.
+goto :banner
+
+REM --- Option 4: Set Start Page ---
+:set_startpage
+echo.
+echo   Current start page: !MP_STARTPAGE!
+echo   (Use this to resume scraping from a specific index page)
+set /p "MP_STARTPAGE=  Enter start page number: "
+
+REM Validate that the input is a positive integer
+REM The "set /a" trick: if the input isn't numeric, it evaluates to 0
+set /a "VALIDATE=!MP_STARTPAGE!" 2>nul
+if !VALIDATE! LEQ 0 (
+    echo   [!] Invalid page number. Reset to 1.
+    set "MP_STARTPAGE=1"
+)
+echo.
+goto :banner
+
+REM --- Option 5: Toggle File Downloads ---
+:toggle_downloads
+if "!MP_DOWNLOAD!"=="yes" (
+    set "MP_DOWNLOAD=no"
+    echo.
+    echo   File downloads DISABLED (lyrics only).
+) else (
+    set "MP_DOWNLOAD=yes"
+    echo.
+    echo   File downloads ENABLED (words, music, audio).
+)
+echo.
+goto :banner
+
+REM --- Option 6: Set Delay ---
+:set_delay
+echo.
+echo   Current delay: !MP_DELAY!ms
+echo   Recommended: 1200ms (1.2 seconds) -- be respectful to the server.
+echo   Enter delay in milliseconds (e.g. 1200 for 1.2s):
+set /p "MP_DELAY=  Delay (ms): "
+
+REM Validate that the input is a positive integer
+set /a "VALIDATE=!MP_DELAY!" 2>nul
+if !VALIDATE! LEQ 0 (
+    echo   [!] Invalid delay. Reset to 1200ms.
+    set "MP_DELAY=1200"
+)
+echo.
+goto :banner
+
+REM --- Option 7: Toggle Debug Mode ---
+:toggle_debug
+if "!MP_DEBUG!"=="yes" (
+    set "MP_DEBUG=no"
+    echo.
+    echo   Debug mode DISABLED.
+) else (
+    set "MP_DEBUG=yes"
+    echo.
+    echo   Debug mode ENABLED -- HTML responses will be dumped to console.
+)
+echo.
+goto :banner
+
+REM --- Option 8: Toggle Force Mode ---
+REM Force mode skips the file existence cache and re-downloads everything,
+REM overwriting any existing files. Useful when lyrics or files have been
+REM updated on the server and you want to refresh your local copies.
+:toggle_force
+if "!MP_FORCE!"=="yes" (
+    set "MP_FORCE=no"
+    echo.
+    echo   Force mode DISABLED -- existing files will be skipped.
+) else (
+    set "MP_FORCE=yes"
+    echo.
+    echo   Force mode ENABLED -- will re-download and overwrite existing files.
+)
+echo.
+goto :banner
+
+REM ============================================================================
+REM START SCRAPING -- Validate settings and launch JScript engine
+REM ============================================================================
+:start_scrape
+echo.
+
+REM Validate that credentials have been entered
+if not defined MP_USERNAME (
+    echo   [!] ERROR: Username is required. Use option 1 to enter credentials.
+    echo.
+    goto :menu
+)
+if not defined MP_PASSWORD (
+    echo   [!] ERROR: Password is required. Use option 1 to enter credentials.
+    echo.
+    goto :menu
+)
+
+REM Validate books selection
+if "!MP_BOOKS!"=="" (
+    echo   [!] ERROR: No books selected. Use option 2 to choose books.
+    echo.
+    goto :menu
+)
+
+REM Display final configuration before starting
+echo   ============================================================================
+echo   STARTING SCRAPE
+echo   ============================================================================
+echo   Username   : !MP_USERNAME!
+echo   Books      : !MP_BOOKS!
+echo   Output     : !MP_OUTPUT!
+echo   Start Page : !MP_STARTPAGE!
+echo   Downloads  : !MP_DOWNLOAD!
+echo   Delay      : !MP_DELAY!ms
+echo   Debug      : !MP_DEBUG!
+echo   Force      : !MP_FORCE!
+echo   ============================================================================
+echo.
+
+REM Launch the JScript section of THIS SAME FILE using cscript.exe.
+REM cscript.exe is the console-mode Windows Script Host, present on all
+REM Windows versions since Windows 98. The //nologo flag suppresses the
+REM WSH version banner. The //e:jscript flag forces JScript interpretation.
+REM "%~f0" expands to the full path of this batch file.
+REM
+REM Arguments are passed positionally:
+REM   arg0 = username
+REM   arg1 = password
+REM   arg2 = books (comma-separated or "all")
+REM   arg3 = output directory path
+REM   arg4 = start page number
+REM   arg5 = download files flag ("yes" or "no")
+REM   arg6 = delay in milliseconds
+REM   arg7 = debug flag ("yes" or "no")
+REM   arg8 = force flag ("yes" or "no") -- skip file cache, re-download everything
+REM   arg9 = song number (optional) -- scrape only this song number
+
+cscript //nologo //e:jscript "%~f0" "!MP_USERNAME!" "!MP_PASSWORD!" "!MP_BOOKS!" "!MP_OUTPUT!" "!MP_STARTPAGE!" "!MP_DOWNLOAD!" "!MP_DELAY!" "!MP_DEBUG!" "!MP_FORCE!" "!MP_SONG!"
+
+echo.
+echo   ============================================================================
+echo   Scraping complete. Press any key to return to the menu.
+echo   ============================================================================
+pause >nul
+goto :banner
+
+REM ============================================================================
+REM HELP / USAGE
+REM ============================================================================
+:showhelp
+echo.
+echo  MissionPraise.com.bat -- Mission Praise Scraper (Windows Batch/JScript Hybrid)
+echo  Copyright 2025-2026 MWBM Partners Ltd.
+echo.
+echo  DESCRIPTION:
+echo    Scrapes lyrics and downloads files from missionpraise.com.
+echo    Authenticates with WordPress login, crawls the paginated song index,
+echo    and saves lyrics as plain text with optional file downloads.
+echo.
+echo  USAGE:
+echo    MissionPraise.com.bat           Launch interactive menu
+echo    MissionPraise.com.bat /force    Launch with force mode (re-download all)
+echo    MissionPraise.com.bat /song:123 Scrape only song number 123
+echo    MissionPraise.com.bat /?        Show this help
+echo.
+echo  FLAGS:
+echo    /force      Skip the file existence cache and re-download everything,
+echo                overwriting existing files. Useful when server content has
+echo                been updated. Can also be toggled from the interactive menu.
+echo    /song:NNN   Scrape only the specified song number. Automatically enables
+echo                force mode. Stops after finding and processing the song.
+echo.
+echo  SUPPORTED BOOKS:
+echo    MP  - Mission Praise   (~1000+ songs, 4-digit numbering)
+echo    CP  - Carol Praise     (~300 songs, 3-digit numbering)
+echo    JP  - Junior Praise    (~300 songs, 3-digit numbering)
+echo.
+echo  OUTPUT FORMAT:
+echo    Lyrics:   0001 (MP) - Abba Father.txt
+echo    Words:    0001 (MP) - Abba Father.rtf
+echo    Music:    0001 (MP) - Abba Father_music.pdf
+echo    Audio:    0001 (MP) - Abba Father_audio.mp3
+echo.
+echo  EXAMPLES (using interactive menu):
+echo    1. Run MissionPraise.com.bat
+echo    2. Enter credentials (option 1)
+echo    3. Choose books (option 2) -- default is ALL
+echo    4. Start scraping (option S)
+echo.
+echo  REQUIREMENTS:
+echo    - Windows XP SP3 or later (uses WinHttp + ADODB)
+echo    - Valid missionpraise.com subscription credentials
+echo    - No Python or other dependencies required
+echo.
+echo  NOTES:
+echo    - This is a Batch/JScript hybrid -- no external tools needed
+echo    - The scraper is resumable: existing files are detected and skipped
+echo    - Use /force to override resume behaviour and re-download everything
+echo    - Password input is visible (Batch limitation)
+echo    - For hidden password input, use the Python version instead
+echo.
+goto :exit_script
+
+REM ============================================================================
+REM EXIT
+REM ============================================================================
+:exit_script
+endlocal
+exit /b 0
+
+@end
+// =============================================================================
+// JSCRIPT SECTION -- Mission Praise Scraping Engine
+// =============================================================================
+//
+// This section contains the full scraping engine implemented in JScript (the
+// Microsoft implementation of ECMAScript 3, native to all Windows versions).
+//
+// It is invoked by the Batch section above via:
+//   cscript //nologo //e:jscript "%~f0" [arguments...]
+//
+// The JScript engine skips the Batch section (wrapped in @if/@end conditional
+// compilation directives) and executes only this code.
+//
+// COM Objects Used:
+//   - WinHttp.WinHttpRequest.5.1: HTTP client with automatic cookie handling,
+//     SSL/TLS support, and redirect following. Native since Windows XP SP3.
+//   - ADODB.Stream: Binary and text stream I/O. Used for saving downloaded
+//     binary files (RTF, PDF, MP3) and reading/writing text with encoding
+//     control. Native since Windows 2000.
+//   - Scripting.FileSystemObject: File system operations (create directories,
+//     check file existence, enumerate directory contents). Native since Win98.
+//   - WScript.Shell: Access to environment variables and process execution.
+//
+// Copyright 2025-2026 MWBM Partners Ltd.
+// =============================================================================
+
+
+// ---------------------------------------------------------------------------
+// Argument parsing -- extract settings passed from the Batch section
+// ---------------------------------------------------------------------------
+// Arguments are passed positionally from the Batch section's cscript call.
+// WScript.Arguments provides access to command-line arguments.
+
+var args = WScript.Arguments;
+
+// Validate that all required arguments were provided
+if (args.length < 8) {
+    WScript.Echo("ERROR: Insufficient arguments. This script should be launched from the Batch menu.");
+    WScript.Echo("Usage: cscript //e:jscript MissionPraise.com.bat username password books output startpage download delay debug [force]");
+    WScript.Quit(1);
+}
+
+// Extract arguments into named variables for clarity
+var USERNAME   = args(0);            // missionpraise.com login email
+var PASSWORD   = args(1);            // missionpraise.com password
+var BOOKS_ARG  = args(2);            // Books to scrape: "all" or comma-separated "mp,cp,jp"
+var OUTPUT_DIR = args(3);            // Base output directory path
+var START_PAGE = parseInt(args(4), 10) || 1;  // Index page to start from
+var DO_DOWNLOAD = (args(5).toLowerCase() === "yes");  // Whether to download files
+var DELAY_MS   = parseInt(args(6), 10) || 1200;       // Delay between requests in ms
+var DEBUG      = (args(7).toLowerCase() === "yes");    // Debug mode flag
+
+// Force mode flag (arg8, optional for backward compatibility).
+// When true, the file existence cache is skipped entirely -- every song is
+// treated as new, and lyrics/downloads are re-downloaded and overwritten.
+// This is useful when content on the server has been corrected or updated.
+var FORCE      = (args.length > 8 && args(8).toLowerCase() === "yes");
+
+// Single-song mode (arg9, optional). When set to a song number, only that
+// song will be scraped. Force mode is auto-enabled and the scraper stops
+// after finding the song.
+var SONG_FILTER = 0;  // 0 = disabled (scrape all songs)
+if (args.length > 9 && args(9) !== "") {
+    SONG_FILTER = parseInt(args(9), 10) || 0;
+}
+
+
+// ---------------------------------------------------------------------------
+// Constants -- URLs, patterns, and configuration
+// ---------------------------------------------------------------------------
+
+/** Base URL for the Mission Praise website */
+var BASE_URL = "https://missionpraise.com";
+
+/** WordPress standard login endpoint */
+var LOGIN_URL = BASE_URL + "/wp-login.php";
+
+/** Paginated song index URL -- append page number (e.g. /songs/page/1/) */
+var INDEX_URL = BASE_URL + "/songs/page/";
+
+/**
+ * Browser-like User-Agent string (Chrome on Windows).
+ * Modern WAFs (Sucuri, Cloudflare, etc.) check this header to distinguish
+ * real browsers from automated scripts. An empty or generic UA will be blocked.
+ */
+var USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " +
+    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36 Edg/145.0.0.0";
+
+
+// ---------------------------------------------------------------------------
+// Book configuration -- defines the three hymnbooks scraped from the site
+// ---------------------------------------------------------------------------
+// Each book has:
+//   label:   Short identifier used in filenames (e.g. "MP", "CP", "JP")
+//   pad:     Number of digits to zero-pad the hymn number to (MP=4, others=3)
+//   pattern: Regex to extract the book number from the index page title
+//            e.g. "Amazing Grace (MP0023)" -> match group(1) = "0023"
+//   subdir:  Human-readable subdirectory name for organised file output
+
+var BOOK_CONFIG = {
+    "mp": { label: "MP", pad: 4, pattern: /\(MP(\d+)\)/i, subdir: "Mission Praise [MP]" },
+    "cp": { label: "CP", pad: 3, pattern: /\(CP(\d+)\)/i, subdir: "Carol Praise [CP]" },
+    "jp": { label: "JP", pad: 3, pattern: /\(JP(\d+)\)/i, subdir: "Junior Praise [JP]" }
+};
+
+
+// ---------------------------------------------------------------------------
+// MIME type -> file extension mapping for downloaded files
+// ---------------------------------------------------------------------------
+// When downloading files (words, music, audio), the server's Content-Type
+// header tells us what format the file is in. This mapping converts common
+// MIME types to their standard file extensions.
+
+var MIME_TO_EXT = {
+    "application/rtf":          ".rtf",
+    "text/rtf":                 ".rtf",
+    "application/msword":       ".doc",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx",
+    "application/pdf":          ".pdf",
+    "audio/midi":               ".mid",
+    "audio/x-midi":             ".mid",
+    "audio/mpeg":               ".mp3",
+    "audio/mp3":                ".mp3",
+    "audio/wav":                ".wav",
+    "audio/x-wav":              ".wav",
+    "audio/ogg":                ".ogg",
+    "application/octet-stream": ""    // Generic binary -- fall back to URL/magic bytes
+};
+
+
+// ---------------------------------------------------------------------------
+// Magic bytes -- file type detection from binary content
+// ---------------------------------------------------------------------------
+// When Content-Type header is unhelpful (e.g. "application/octet-stream")
+// and the URL doesn't reveal the file type, we identify the format by
+// examining the first few bytes. Most file formats begin with a distinctive
+// signature ("magic number").
+//
+// Note: In JScript, we compare byte values from ADODB.Stream reads because
+// direct binary string comparison is unreliable with extended characters.
+// We store signatures as arrays of decimal byte values for clarity.
+
+var MAGIC_BYTES = [
+    { sig: [0x25, 0x50, 0x44, 0x46],             ext: ".pdf"  },  // %PDF
+    { sig: [0x50, 0x4B, 0x03, 0x04],             ext: ".docx" },  // PK.. (ZIP/docx)
+    { sig: [0xD0, 0xCF, 0x11, 0xE0],             ext: ".doc"  },  // OLE2 compound
+    { sig: [0x7B, 0x5C, 0x72, 0x74, 0x66],       ext: ".rtf"  },  // {\rtf
+    { sig: [0x4D, 0x54, 0x68, 0x64],             ext: ".mid"  },  // MThd (MIDI)
+    { sig: [0x49, 0x44, 0x33],                   ext: ".mp3"  },  // ID3 (MP3)
+    { sig: [0xFF, 0xFB],                         ext: ".mp3"  },  // MPEG1 Layer3
+    { sig: [0xFF, 0xF3],                         ext: ".mp3"  },  // MPEG2 Layer3
+    { sig: [0x4F, 0x67, 0x67, 0x53],             ext: ".ogg"  },  // OggS
+    { sig: [0x52, 0x49, 0x46, 0x46],             ext: ".wav"  },  // RIFF (WAV)
+    { sig: [0x66, 0x4C, 0x61, 0x43],             ext: ".flac" }   // fLaC
+];
+
+
+// ---------------------------------------------------------------------------
+// Parse books argument -- determine which books to scrape
+// ---------------------------------------------------------------------------
+// The BOOKS_ARG comes from the Batch menu: "all" means mp,cp,jp; otherwise
+// it's a comma-separated list like "mp,cp" or just "mp".
+
+var booksToScrape = [];
+
+if (BOOKS_ARG.toLowerCase() === "all") {
+    // Scrape all three books
+    booksToScrape = ["mp", "cp", "jp"];
+} else {
+    // Parse the comma-separated list and validate each entry
+    var parts = BOOKS_ARG.toLowerCase().split(",");
+    for (var i = 0; i < parts.length; i++) {
+        var b = parts[i].replace(/^\s+|\s+$/g, "");  // Trim whitespace
+        if (BOOK_CONFIG[b]) {
+            booksToScrape.push(b);
+        }
+    }
+}
+
+// Abort if no valid books were selected
+if (booksToScrape.length === 0) {
+    WScript.Echo("ERROR: No valid books specified. Use mp, cp, jp, or all.");
+    WScript.Quit(1);
+}
+
+
+// ---------------------------------------------------------------------------
+// Global COM objects -- created once and reused throughout the script
+// ---------------------------------------------------------------------------
+
+/** Scripting.FileSystemObject for all file/directory operations */
+var fso = new ActiveXObject("Scripting.FileSystemObject");
+
+
+// ---------------------------------------------------------------------------
+// Cookie management -- manual cookie jar for WinHttpRequest
+// ---------------------------------------------------------------------------
+// WinHttp.WinHttpRequest.5.1 does NOT automatically manage cookies across
+// requests (unlike browser or Python's cookiejar). We must manually:
+//   1. Extract Set-Cookie headers from responses
+//   2. Store them in our cookie jar
+//   3. Send them as Cookie headers on subsequent requests
+//
+// This is essential for WordPress login session management.
+
+/** Global cookie storage: maps cookie names to their full "name=value" strings */
+var cookieJar = {};
+
+/**
+ * Extract cookies from a Set-Cookie response header and store them in the jar.
+ *
+ * Set-Cookie headers have the format:
+ *   name=value; path=/; expires=...; HttpOnly; Secure
+ * We only need the "name=value" part for sending back.
+ * Multiple Set-Cookie headers may be present (separated by commas or newlines
+ * depending on the server/proxy configuration).
+ *
+ * @param {string} setCookieHeader - The raw Set-Cookie header value
+ */
+function extractCookies(setCookieHeader) {
+    if (!setCookieHeader) return;
+
+    // Split on newlines (WinHttp may concatenate multiple Set-Cookie headers
+    // with newlines). Also handle comma-separated cookies, but be careful
+    // not to split on commas within cookie values (e.g. expires=Thu, 01 Jan...).
+    var lines = setCookieHeader.split(/\n/);
+    for (var i = 0; i < lines.length; i++) {
+        var line = lines[i].replace(/^\s+|\s+$/g, "");
+        if (!line) continue;
+
+        // Sometimes multiple cookies are concatenated with comma + space.
+        // However, "expires=Thu, 01 Jan 2030" also contains commas.
+        // Strategy: split on ", " only if followed by a token containing "="
+        // For safety, we just take the first cookie from each line.
+
+        // Extract just the name=value portion (before the first semicolon)
+        var nameValue = line.split(";")[0].replace(/^\s+|\s+$/g, "");
+        if (nameValue.indexOf("=") > 0) {
+            var eqPos = nameValue.indexOf("=");
+            var name = nameValue.substring(0, eqPos);
+            cookieJar[name] = nameValue;
+        }
+    }
+}
+
+/**
+ * Build the Cookie header string from all stored cookies.
+ *
+ * Concatenates all "name=value" pairs with "; " separators, which is the
+ * standard format for the Cookie request header.
+ *
+ * @returns {string} The Cookie header value, or empty string if no cookies
+ */
+function getCookieHeader() {
+    var parts = [];
+    for (var name in cookieJar) {
+        if (cookieJar.hasOwnProperty(name)) {
+            parts.push(cookieJar[name]);
+        }
+    }
+    return parts.join("; ");
+}
+
+
+// ---------------------------------------------------------------------------
+// HTTP helper functions -- request/response utilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Perform an HTTP GET request and return the response body as text.
+ *
+ * Uses WinHttp.WinHttpRequest.5.1 which handles SSL/TLS, redirects, and
+ * response decompression natively. We add browser-like headers to avoid
+ * WAF blocks and manually manage cookies.
+ *
+ * @param {string} url - The URL to fetch
+ * @returns {Object|null} Object with { text, finalUrl, status } or null on error
+ */
+function httpGet(url) {
+    try {
+        var http = new ActiveXObject("WinHttp.WinHttpRequest.5.1");
+
+        // Open a GET request. The third parameter (true/false) controls async;
+        // we use synchronous (false) for simplicity.
+        http.Open("GET", url, false);
+
+        // Set browser-like headers to pass WAF checks
+        http.SetRequestHeader("User-Agent", USER_AGENT);
+        http.SetRequestHeader("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8");
+        http.SetRequestHeader("Accept-Language", "en-GB,en;q=0.9");
+        http.SetRequestHeader("Connection", "keep-alive");
+        http.SetRequestHeader("Upgrade-Insecure-Requests", "1");
+        // Sec-Fetch-* headers: modern security headers checked by WAFs
+        http.SetRequestHeader("Sec-Fetch-Dest", "document");
+        http.SetRequestHeader("Sec-Fetch-Mode", "navigate");
+        http.SetRequestHeader("Sec-Fetch-Site", "same-origin");
+        http.SetRequestHeader("Sec-Fetch-User", "?1");
+        http.SetRequestHeader("Cache-Control", "max-age=0");
+
+        // Send stored cookies with the request
+        var cookies = getCookieHeader();
+        if (cookies) {
+            http.SetRequestHeader("Cookie", cookies);
+        }
+
+        // Configure timeouts: resolve=5s, connect=10s, send=15s, receive=30s
+        // These prevent the script from hanging on unresponsive servers
+        http.SetTimeouts(5000, 10000, 15000, 30000);
+
+        // Allow automatic redirect following (up to 10 redirects)
+        http.Option(6, false);  // WinHttpRequestOption_EnableRedirects = 6
+
+        http.Send();
+
+        // Extract and store any cookies from the response
+        try {
+            var setCookie = http.GetResponseHeader("Set-Cookie");
+            extractCookies(setCookie);
+        } catch (e) {
+            // No Set-Cookie header -- that's fine, not all responses set cookies
+        }
+
+        // Return the response text, final URL, and status code
+        return {
+            text: http.ResponseText,
+            // WinHttpRequest follows redirects automatically; the final URL
+            // can be read from the response URL option
+            finalUrl: url,  // WinHttp doesn't expose final URL directly
+            status: http.Status
+        };
+    } catch (e) {
+        WScript.Echo("  [!] HTTP GET error for " + url + ": " + e.message);
+        return null;
+    }
+}
+
+/**
+ * Perform an HTTP POST request (used for WordPress login).
+ *
+ * Sends URL-encoded form data with proper Content-Type and headers.
+ * The Referer and Origin headers are critical for passing Sucuri WAF checks.
+ *
+ * @param {string} url - The URL to POST to
+ * @param {string} postData - URL-encoded form data string
+ * @param {string} referer - The Referer header value (usually the login page URL)
+ * @returns {Object|null} Object with { text, status } or null on error
+ */
+function httpPost(url, postData, referer) {
+    try {
+        var http = new ActiveXObject("WinHttp.WinHttpRequest.5.1");
+
+        http.Open("POST", url, false);
+
+        // Set browser-like headers
+        http.SetRequestHeader("User-Agent", USER_AGENT);
+        http.SetRequestHeader("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
+        http.SetRequestHeader("Accept-Language", "en-GB,en;q=0.9");
+        http.SetRequestHeader("Connection", "keep-alive");
+        // Content-Type for URL-encoded form submission
+        http.SetRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+        // Referer and Origin are checked by Sucuri WAF to prevent CSRF
+        http.SetRequestHeader("Referer", referer);
+        http.SetRequestHeader("Origin", BASE_URL);
+        http.SetRequestHeader("Upgrade-Insecure-Requests", "1");
+        // Sec-Fetch headers for form submission context
+        http.SetRequestHeader("Sec-Fetch-Dest", "document");
+        http.SetRequestHeader("Sec-Fetch-Mode", "navigate");
+        http.SetRequestHeader("Sec-Fetch-Site", "same-origin");
+        http.SetRequestHeader("Sec-Fetch-User", "?1");
+
+        // Send stored cookies with the request
+        var cookies = getCookieHeader();
+        if (cookies) {
+            http.SetRequestHeader("Cookie", cookies);
+        }
+
+        // Configure timeouts
+        http.SetTimeouts(5000, 10000, 15000, 30000);
+
+        http.Send(postData);
+
+        // Extract and store cookies from the response
+        try {
+            var setCookie = http.GetResponseHeader("Set-Cookie");
+            extractCookies(setCookie);
+        } catch (e) {
+            // No Set-Cookie header
+        }
+
+        return {
+            text: http.ResponseText,
+            status: http.Status
+        };
+    } catch (e) {
+        WScript.Echo("  [!] HTTP POST error for " + url + ": " + e.message);
+        return null;
+    }
+}
+
+/**
+ * Download a binary file from a URL using WinHttpRequest + ADODB.Stream.
+ *
+ * WinHttpRequest.ResponseBody returns a VBArray of bytes, which can be
+ * written directly to an ADODB.Stream in binary mode. This handles all
+ * binary formats (PDF, RTF, MP3, etc.) without corruption.
+ *
+ * Includes safety checks for:
+ *   - Gzip-compressed responses (uncommon for file downloads but possible)
+ *   - Server error pages masquerading as file downloads (HTML with 200 status)
+ *
+ * @param {string} url - The download URL
+ * @returns {Object|null} { body (VBArray), contentType (string), status } or null
+ */
+function httpGetBinary(url) {
+    try {
+        var http = new ActiveXObject("WinHttp.WinHttpRequest.5.1");
+
+        http.Open("GET", url, false);
+
+        http.SetRequestHeader("User-Agent", USER_AGENT);
+        http.SetRequestHeader("Accept", "*/*");
+        http.SetRequestHeader("Accept-Language", "en-GB,en;q=0.9");
+        http.SetRequestHeader("Connection", "keep-alive");
+
+        var cookies = getCookieHeader();
+        if (cookies) {
+            http.SetRequestHeader("Cookie", cookies);
+        }
+
+        http.SetTimeouts(5000, 10000, 15000, 60000);  // Longer receive timeout for large files
+
+        http.Send();
+
+        // Extract cookies from download responses too (session maintenance)
+        try {
+            var setCookie = http.GetResponseHeader("Set-Cookie");
+            extractCookies(setCookie);
+        } catch (e) {}
+
+        // Get the Content-Type header, stripping any charset parameter
+        var ct = "";
+        try {
+            ct = http.GetResponseHeader("Content-Type");
+            ct = ct.split(";")[0].replace(/^\s+|\s+$/g, "").toLowerCase();
+        } catch (e) {}
+
+        // Check for server error pages in the response.
+        // Some servers return HTML error pages (PHP exceptions, 404 pages) with
+        // a 200 status code instead of the actual file.
+        var respText = "";
+        try {
+            respText = http.ResponseText;
+        } catch (e) {}
+
+        // Heuristic: if the response starts with HTML-like characters and is
+        // small enough to be an error page, check for error keywords
+        if (respText.length > 0 && respText.length < 500000) {
+            var firstChar = respText.charAt(0);
+            if (firstChar === "<" || firstChar === "s" || firstChar === "e" || firstChar === "{") {
+                var lower = respText.toLowerCase();
+                if (lower.indexOf("exception") >= 0 || lower.indexOf("<html") >= 0 ||
+                    lower.indexOf("<!doctype") >= 0 || lower.indexOf("error") >= 0 ||
+                    lower.indexOf("not found") >= 0 || lower.indexOf("string(") >= 0 ||
+                    lower.indexOf("nosuchkey") >= 0 || lower.indexOf("stacktrace") >= 0) {
+                    WScript.StdOut.Write("server error ");
+                    if (DEBUG) {
+                        debugDump("Server error in download", respText.substring(0, 500));
+                    }
+                    return null;
+                }
+            }
+        }
+
+        return {
+            body: http.ResponseBody,   // VBArray of bytes for binary saving
+            contentType: ct,
+            status: http.Status,
+            responseText: respText
+        };
+    } catch (e) {
+        WScript.Echo("  [!] Download error " + url + ": " + e.message);
+        return null;
+    }
+}
+
+
+// ---------------------------------------------------------------------------
+// Debug helper -- dump HTML content for troubleshooting
+// ---------------------------------------------------------------------------
+
+/**
+ * Print a labelled debug dump of HTML/text content (only when DEBUG is true).
+ *
+ * Used during development and troubleshooting to inspect raw HTML responses.
+ * Truncates output to maxChars to avoid flooding the console.
+ *
+ * @param {string} label - A descriptive label for what's being dumped
+ * @param {string} text - The text content to dump
+ * @param {number} [maxChars=3000] - Maximum characters to display
+ */
+function debugDump(label, text, maxChars) {
+    if (!DEBUG) return;
+    if (typeof maxChars === "undefined") maxChars = 3000;
+
+    var sep = "============================================================";
+    WScript.Echo("\n" + sep);
+    WScript.Echo("DEBUG: " + label);
+    WScript.Echo(sep);
+    WScript.Echo(text.substring(0, maxChars));
+    if (text.length > maxChars) {
+        WScript.Echo("... (" + (text.length - maxChars) + " more chars)");
+    }
+    WScript.Echo(sep + "\n");
+}
+
+
+// ---------------------------------------------------------------------------
+// URL encoding -- encode form data for POST requests
+// ---------------------------------------------------------------------------
+
+/**
+ * URL-encode a string for use in POST form data.
+ *
+ * Encodes special characters as %XX hex sequences. This is equivalent to
+ * Python's urllib.parse.quote() or JavaScript's encodeURIComponent().
+ *
+ * JScript's built-in encodeURIComponent() handles most cases, but we also
+ * need to encode some characters it misses (!, ', (, ), *) per RFC 3986.
+ *
+ * @param {string} str - The string to encode
+ * @returns {string} The URL-encoded string
+ */
+function urlEncode(str) {
+    // encodeURIComponent handles most special characters correctly
+    var encoded = encodeURIComponent(str);
+    // Encode additional characters that encodeURIComponent misses
+    // but that are required for form data encoding
+    encoded = encoded.replace(/!/g, "%21");
+    encoded = encoded.replace(/'/g, "%27");
+    encoded = encoded.replace(/\(/g, "%28");
+    encoded = encoded.replace(/\)/g, "%29");
+    encoded = encoded.replace(/\*/g, "%2A");
+    return encoded;
+}
+
+/**
+ * Build a URL-encoded form data string from a key-value object.
+ *
+ * Produces the standard "key1=value1&key2=value2" format used by HTML forms
+ * and expected by WordPress login.
+ *
+ * @param {Object} params - Key-value pairs to encode
+ * @returns {string} The URL-encoded form data string
+ */
+function buildFormData(params) {
+    var parts = [];
+    for (var key in params) {
+        if (params.hasOwnProperty(key)) {
+            parts.push(urlEncode(key) + "=" + urlEncode(params[key]));
+        }
+    }
+    return parts.join("&");
+}
+
+
+// ---------------------------------------------------------------------------
+// HTML entity decoding -- convert HTML entities to plain text
+// ---------------------------------------------------------------------------
+
+/**
+ * Decode HTML entities in a string to their Unicode character equivalents.
+ *
+ * Handles three types of entities:
+ *   1. Named entities: &amp; &lt; &gt; &quot; &apos; &nbsp; &rsquo; etc.
+ *   2. Decimal numeric: &#8217; &#169; etc.
+ *   3. Hexadecimal numeric: &#x2019; &#xA9; etc.
+ *
+ * Common typographic entities found in song lyrics include smart quotes
+ * (rsquo, lsquo, rdquo, ldquo) and dashes (mdash, ndash).
+ *
+ * @param {string} str - The HTML string containing entities
+ * @returns {string} The decoded plain text string
+ */
+function decodeEntities(str) {
+    if (!str) return "";
+
+    // Map of common named HTML entities to their character equivalents
+    var entities = {
+        "amp": "&", "lt": "<", "gt": ">", "quot": '"', "apos": "'",
+        "nbsp": " ",
+        "rsquo": "\u2019", "lsquo": "\u2018",   // Right/left single quotes
+        "rdquo": "\u201D", "ldquo": "\u201C",   // Right/left double quotes
+        "mdash": "\u2014", "ndash": "\u2013",   // Em dash, en dash
+        "hellip": "\u2026",                       // Horizontal ellipsis
+        "copy": "\u00A9",                         // Copyright symbol
+        "reg": "\u00AE",                          // Registered trademark
+        "trade": "\u2122"                         // Trademark
+    };
+
+    // Replace named entities: &name; -> character
+    str = str.replace(/&([a-zA-Z]+);/g, function(match, name) {
+        var lower = name.toLowerCase();
+        if (entities[lower]) {
+            return entities[lower];
+        }
+        return match;  // Unknown entity -- leave as-is
+    });
+
+    // Windows-1252 entity mapping -- the site uses &#145;-&#151; which are
+    // Windows-1252 code points, NOT Unicode. String.fromCharCode(146) etc.
+    // produce control characters, not the intended typographic glyphs.
+    // We map them explicitly BEFORE the generic decimal decoder runs.
+    // Reference: https://en.wikipedia.org/wiki/Windows-1252#Character_set
+    var win1252Map = {
+        145: "\u2018",  // Left single quote
+        146: "\u2019",  // Right single quote / apostrophe
+        147: "\u201C",  // Left double quote
+        148: "\u201D",  // Right double quote
+        150: "\u2013",  // En dash
+        151: "\u2014"   // Em dash
+    };
+
+    // Replace decimal numeric entities: &#NNN; -> character
+    str = str.replace(/&#(\d+);/g, function(match, num) {
+        var code = parseInt(num, 10);
+        // Check Windows-1252 mapping first
+        if (win1252Map[code]) { return win1252Map[code]; }
+        try { return String.fromCharCode(code); }
+        catch (e) { return ""; }
+    });
+
+    // Replace hexadecimal numeric entities: &#xHHH; -> character
+    str = str.replace(/&#x([0-9a-fA-F]+);/g, function(match, hex) {
+        var code = parseInt(hex, 16);
+        try { return String.fromCharCode(code); }
+        catch (e) { return ""; }
+    });
+
+    return str;
+}
+
+
+// ---------------------------------------------------------------------------
+// HTML parsing -- regex-based parsing for index and song pages
+// ---------------------------------------------------------------------------
+// Note: JScript (ECMAScript 3) does not have a built-in DOM parser. We use
+// regex-based parsing which is adequate for the structured HTML on
+// missionpraise.com. The patterns are designed to handle the specific HTML
+// structure of the site's index and song pages.
+
+/**
+ * Parse the song index page to extract song links.
+ *
+ * The index page lists songs as links within heading elements (h2/h3).
+ * Each song appears as:
+ *   <h2><a href="/songs/amazing-grace-mp0023/">Amazing Grace (MP0023)</a></h2>
+ *
+ * We use a two-pass approach:
+ *   1. Find all <h2> and <h3> blocks
+ *   2. Extract <a> tags with /songs/ in the href from within those blocks
+ *
+ * @param {string} html - The raw HTML of an index page
+ * @returns {Array} Array of { title, url } objects for each song found
+ */
+function parseIndexPage(html) {
+    var songs = [];
+
+    // Strategy: find all <a> tags inside <h2> or <h3> elements that link to /songs/
+    // We use a simplified approach: find all <a> tags with /songs/ in href,
+    // then check if they appear within heading context by looking at surrounding HTML.
+    //
+    // Regex breakdown:
+    //   <h[23][^>]*>   -- opening h2 or h3 tag (with optional attributes)
+    //   ([\s\S]*?)     -- minimal match of any content between the tags
+    //   <\/h[23]>      -- closing h2 or h3 tag
+    var headingPattern = /<h[23][^>]*>([\s\S]*?)<\/h[23]>/gi;
+    var match;
+
+    while ((match = headingPattern.exec(html)) !== null) {
+        var headingContent = match[1];
+
+        // Within the heading, find <a> tags that link to song pages
+        // Regex breakdown:
+        //   <a[^>]+        -- opening <a> tag with attributes
+        //   href="([^"]*)" -- capture the href value (in double quotes)
+        //   [^>]*>         -- any remaining attributes, then close the tag
+        //   ([\s\S]*?)     -- capture the link text (may contain child elements)
+        //   <\/a>          -- closing </a> tag
+        var linkPattern = /<a[^>]+href=["']([^"']*\/songs\/[^"']*)["'][^>]*>([\s\S]*?)<\/a>/i;
+        var linkMatch = linkPattern.exec(headingContent);
+
+        if (linkMatch) {
+            var href = linkMatch[1];
+            // Strip HTML tags from the link text to get the plain title
+            var title = linkMatch[2].replace(/<[^>]+>/g, "").replace(/^\s+|\s+$/g, "");
+            title = decodeEntities(title);
+
+            // Convert relative URLs to absolute
+            if (href.charAt(0) === "/") {
+                href = BASE_URL + href;
+            }
+
+            songs.push({ title: title, url: href });
+        }
+    }
+
+    return songs;
+}
+
+/**
+ * Parse a song detail page to extract lyrics, copyright, and download links.
+ *
+ * The song page structure on missionpraise.com:
+ *   - Title: element with class "entry-title"
+ *   - Lyrics: <p> elements inside a div with class "song-details"
+ *     - Each <p> is a lyric line or stanza break (empty <p>)
+ *     - <em>/<i> tags indicate chorus lines (italic)
+ *     - <br> tags represent line breaks within a verse
+ *   - Copyright: element with class "copyright-info"
+ *   - Downloads: <a> tags in a sidebar with class "col-sm-4"
+ *
+ * @param {string} html - The raw HTML of a song detail page
+ * @returns {Object} { title, verses[], copyright, downloads{} }
+ *   where verses is an array of { text, isItalic } objects
+ *   and downloads is a map of type ("words"/"music"/"audio") -> URL
+ */
+function parseSongPage(html) {
+    var result = {
+        title: "",
+        verses: [],
+        copyright: "",
+        downloads: {}
+    };
+
+    // --- TITLE ---
+    // Extract the song title from the element with class "entry-title".
+    // Pattern matches: <ANY_TAG class="...entry-title...">CONTENT</ANY_TAG>
+    // Uses [\s\S]*? for minimal match across newlines.
+    var titleMatch = html.match(/<[^>]+class=["'][^"']*entry-title[^"']*["'][^>]*>([\s\S]*?)<\/[^>]+>/i);
+    if (titleMatch) {
+        result.title = titleMatch[1].replace(/<[^>]+>/g, "").replace(/^\s+|\s+$/g, "");
+        result.title = decodeEntities(result.title);
+    }
+
+    // --- LYRICS ---
+    // Extract the lyrics section from the div with class "song-details".
+    // First, find the entire song-details block.
+    var songMatch = html.match(/<(?:div|section)[^>]+class=["'][^"']*song-details[^"']*["'][^>]*>([\s\S]*?)<\/(?:div|section)>/i);
+    if (songMatch) {
+        var songHtml = songMatch[1];
+
+        // Split on <p> boundaries to handle unclosed <p> tags.
+        // The site uses bare <P> tags as verse separators without closing
+        // the previous <p>, so matching <p>...</p> pairs misses earlier verses.
+        var pBlocks = songHtml.split(/<p[^>]*>/i);
+        for (var pi = 0; pi < pBlocks.length; pi++) {
+            var pContent = pBlocks[pi].replace(/<\/p>\s*$/i, "");
+
+            // Check if this paragraph contains italic text (chorus indicator).
+            // Italic is marked by <em> or <i> tags on the site.
+            var hasItalic = (/<(em|i)[\s>]/i).test(pContent);
+
+            // Also check if this <p> is wrapped inside an outer <em>/<i> element.
+            // Some pages wrap entire stanzas in <em>...</em> around multiple <p> tags,
+            // so the italic tag is not inside the <p> content but in the surrounding HTML.
+            // We detect this by counting unclosed <em>/<i> opens vs closes before this block.
+            if (!hasItalic) {
+                var preceding = pBlocks.slice(0, pi).join("");
+                var emOpens = (preceding.match(/<(em|i)[\s>]/gi) || []).length;
+                var emCloses = (preceding.match(/<\/(em|i)>/gi) || []).length;
+                if (emOpens > emCloses) { hasItalic = true; }
+            }
+
+            // Convert <br> tags to newline characters (line breaks within a verse)
+            // The site emits <BR><br /> (both uppercase and lowercase) on every
+            // line, which produces double line breaks. We match one or more
+            // consecutive <br> tags (with optional whitespace between) as a
+            // single newline to avoid double-spacing.
+            pContent = pContent.replace(/(?:<br\s*\/?>[\s]*)+/gi, "\n");
+
+            // Strip all remaining HTML tags to get plain text
+            var text = pContent.replace(/<[^>]+>/g, "");
+
+            // Decode HTML entities in the text
+            text = decodeEntities(text);
+
+            // Trim each line individually (handles multi-line verses from <br> tags)
+            var lines = text.split("\n");
+            var trimmedLines = [];
+            for (var i = 0; i < lines.length; i++) {
+                trimmedLines.push(lines[i].replace(/^\s+|\s+$/g, ""));
+            }
+            text = trimmedLines.join("\n").replace(/^\s+|\s+$/g, "");
+
+            // Add the verse to the result (preserving empty strings as stanza break markers)
+            result.verses.push({ text: text, isItalic: hasItalic });
+        }
+    }
+
+    // --- COPYRIGHT ---
+    // Extract copyright notice from the element with class "copyright-info"
+    var copyrightMatch = html.match(/<[^>]+class=["'][^"']*copyright-info[^"']*["'][^>]*>([\s\S]*?)<\/[^>]+>/i);
+    if (copyrightMatch) {
+        result.copyright = copyrightMatch[1].replace(/<[^>]+>/g, "").replace(/^\s+|\s+$/g, "");
+        result.copyright = decodeEntities(result.copyright);
+    }
+
+    // --- DOWNLOAD LINKS ---
+    // Download links are in a sidebar div with class "col-sm-4" or "files".
+    // Each download type (words, music, audio) is an <a> tag with descriptive text.
+    var sidebarMatch = html.match(/<div[^>]+class=["'][^"']*(?:col-sm-4|files)[^"']*["'][^>]*>([\s\S]*?)<\/div>/i);
+    if (sidebarMatch) {
+        var sidebarHtml = sidebarMatch[1];
+
+        // Find all <a> tags within the sidebar
+        var aPattern = /<a[^>]+href=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi;
+        var aMatch;
+
+        while ((aMatch = aPattern.exec(sidebarHtml)) !== null) {
+            var aHref = aMatch[1];
+            var aText = aMatch[2].replace(/<[^>]+>/g, "").toLowerCase().replace(/^\s+|\s+$/g, "");
+
+            // Skip placeholder links
+            if (aHref === "#") continue;
+
+            // Determine the download type from the link text
+            if (aText.indexOf("words") >= 0) {
+                result.downloads["words"] = aHref;
+            } else if (aText.indexOf("music") >= 0) {
+                result.downloads["music"] = aHref;
+            } else if (aText.indexOf("audio") >= 0) {
+                result.downloads["audio"] = aHref;
+            }
+        }
+    }
+
+    return result;
+}
+
+
+// ---------------------------------------------------------------------------
+// Book helpers -- extract and clean book-specific data from song titles
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the hymn number from a song title for a specific book.
+ *
+ * Song titles on the index page include the book code and number in
+ * parentheses, e.g. "Amazing Grace (MP0023)". This function uses the
+ * book-specific regex pattern to extract just the numeric part.
+ *
+ * @param {string} title - The full song title from the index page
+ * @param {string} book - Book identifier key ("mp", "cp", or "jp")
+ * @returns {number|null} The hymn number (e.g. 23) or null if not found
+ */
+function extractNumber(title, book) {
+    var cfg = BOOK_CONFIG[book];
+    var m = cfg.pattern.exec(title);
+    // Reset lastIndex since we reuse the regex (it may have the global flag in future)
+    cfg.pattern.lastIndex = 0;
+    if (m) {
+        return parseInt(m[1], 10);
+    }
+    return null;
+}
+
+/**
+ * Determine which book a song belongs to based on its title.
+ *
+ * Checks the title against each book's regex pattern (MP, CP, JP)
+ * and returns the first match.
+ *
+ * @param {string} title - The full song title from the index page
+ * @returns {string|null} Book key ("mp", "cp", or "jp") or null
+ */
+function detectBook(title) {
+    for (var book in BOOK_CONFIG) {
+        if (BOOK_CONFIG.hasOwnProperty(book)) {
+            if (extractNumber(title, book) !== null) {
+                return book;
+            }
+        }
+    }
+    return null;
+}
+
+/**
+ * Remove the book code suffix from a song title.
+ *
+ * Strips the "(MP0023)" or similar suffix from the end of the title,
+ * leaving just the human-readable song name for use in filenames.
+ *
+ * @param {string} title - The full song title (e.g. "Amazing Grace (MP0023)")
+ * @param {string} book - Book identifier key ("mp", "cp", or "jp")
+ * @returns {string} The cleaned title (e.g. "Amazing Grace")
+ */
+function cleanTitle(title, book) {
+    var cfg = BOOK_CONFIG[book];
+    // Build a pattern that matches the entire book code suffix.
+    // We construct it from the book label (MP, CP, JP) to avoid
+    // having to maintain separate non-capturing patterns.
+    var label = cfg.label;
+    // Match optional whitespace + opening paren + label + digits + closing paren
+    // at the end of the string
+    var suffixPattern = new RegExp("\\s*\\(" + label + "\\d+\\)\\s*$", "i");
+    return title.replace(suffixPattern, "").replace(/^\s+|\s+$/g, "");
+}
+
+
+// ---------------------------------------------------------------------------
+// Text formatting helpers -- title case, sanitization, filename generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a string to Title Case, with correct handling of apostrophes.
+ *
+ * Standard title casing treats apostrophes as word boundaries, producing
+ * incorrect results like "Don'T" instead of "Don't". This function treats
+ * contractions as single words.
+ *
+ * @param {string} s - The input string
+ * @returns {string} The Title Cased string
+ *
+ * @example titleCase("AMAZING GRACE")     -> "Amazing Grace"
+ * @example titleCase("don't let me down") -> "Don't Let Me Down"
+ * @example titleCase("EAGLE\u2019S WINGS") -> "Eagle\u2019s Wings"
+ *
+ * We include Unicode curly/smart apostrophes (\u2019 RIGHT SINGLE QUOTATION
+ * MARK and \u2018 LEFT SINGLE QUOTATION MARK) because the HTML entity decoder
+ * converts &rsquo; to \u2019. Without this, "Eagle\u2019s" would produce "Eagle'S".
+ */
+function titleCase(s) {
+    // Match whole words including contractions (e.g. "don't", "it's", "o'er").
+    // The character class ['\u2019\u2018] matches ASCII apostrophe and Unicode
+    // curly quotes — covering all apostrophe variants after HTML entity decoding.
+    return s.replace(/[a-zA-Z]+(['\u2019\u2018][a-zA-Z]+)?/g, function(word) {
+        // Capitalize first character, lowercase the rest
+        return word.charAt(0).toUpperCase() + word.substring(1).toLowerCase();
+    });
+}
+
+/**
+ * Remove characters that are invalid in filenames across operating systems.
+ *
+ * Strips characters forbidden in Windows filenames: \ / * ? : " < > |
+ * Also trims leading/trailing whitespace.
+ *
+ * @param {string} name - The raw string to sanitize (typically a song title)
+ * @returns {string} The sanitized string
+ */
+function sanitize(name) {
+    return name.replace(/[\\\/\*\?:"<>|]/g, "").replace(/^\s+|\s+$/g, "");
+}
+
+/**
+ * Zero-pad a number to a specified width.
+ *
+ * Prepends leading zeros to ensure the string representation has at least
+ * 'width' characters. Used for consistent hymn numbering (MP=4 digits, CP/JP=3).
+ *
+ * @param {number} num - The number to pad
+ * @param {number} width - The desired minimum width
+ * @returns {string} The zero-padded number string
+ *
+ * @example zeroPad(23, 4) -> "0023"
+ * @example zeroPad(7, 3)  -> "007"
+ */
+function zeroPad(num, width) {
+    var s = String(num);
+    while (s.length < width) {
+        s = "0" + s;
+    }
+    return s;
+}
+
+/**
+ * Construct the base filename for a song (without file extension).
+ *
+ * Generates a consistent filename from the song's book, number, and title.
+ * Format: "{padded_number} ({LABEL}) - {Title Case Title}"
+ *
+ * @param {number} number - The song number (e.g. 23)
+ * @param {string} book - Book identifier key ("mp", "cp", or "jp")
+ * @param {string} title - The cleaned song title (book code already removed)
+ * @returns {string} The base filename, e.g. "0023 (MP) - Amazing Grace"
+ */
+function baseFilename(number, book, title) {
+    var cfg = BOOK_CONFIG[book];
+    var padded = zeroPad(number, cfg.pad);
+    return padded + " (" + cfg.label + ") - " + titleCase(sanitize(title));
+}
+
+
+// ---------------------------------------------------------------------------
+// Lyrics formatting -- convert parsed song data to clean plain text
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a parsed song into a clean plain-text string for saving.
+ *
+ * This is the most complex formatting function because the source HTML has
+ * several structural quirks:
+ *
+ *   1. STANZA GROUPING: Each lyric line is its own <p>, stanza breaks are
+ *      empty <p> tags. We group lines into stanzas.
+ *
+ *   2. CHORUS DETECTION: Chorus lines are in italic (<em>/<i>). We prepend
+ *      "Chorus:" before chorus stanzas.
+ *
+ *   3. ATTRIBUTION DETECTION: Lines starting with "Words:", "Music:", etc.
+ *      are author credits, separated from lyrics with extra blank lines.
+ *
+ *   4. STANDALONE AUTHOR LINES: Short lines with "/" or "&" (name separators)
+ *      that don't start with "Words:" etc. are treated as attribution.
+ *
+ *   5. MULTI-LINE VERSES: Verses with \n (from <br> tags) are treated as
+ *      complete stanzas on their own.
+ *
+ * Output format:
+ *   "Song Title"
+ *   (blank line)
+ *   First verse line
+ *   Second verse line
+ *   (blank line between stanzas)
+ *   Chorus:
+ *   Chorus line one
+ *   (blank line)
+ *   (double blank line before attribution)
+ *   Words: Author Name
+ *   (blank line)
+ *   Copyright notice
+ *
+ * @param {Object} song - Parsed song data with title, verses, copyright
+ * @param {string} book - Book identifier key
+ * @returns {string} The formatted plain-text song content
+ */
+function formatLyrics(song, book) {
+    var title = cleanTitle(song.title, book);
+    // Start with quoted title and blank line (matching Python output format)
+    var lines = ['"' + title + '"', ""];
+
+    var authorLines = [];           // Accumulated attribution lines
+    var foundAttribution = false;   // Flag: have we started seeing attribution?
+    var stanzaBuf = [];             // Lines of the current stanza being built
+    var stanzaIsChorus = false;     // Does current stanza contain chorus (italic)?
+    var consecutiveEmpties = 0;     // Count of consecutive empty <p> elements seen
+
+    /**
+     * Write the accumulated stanza to the output lines array.
+     * If the stanza contains italic lines, prepends "Chorus:" label.
+     * Adds a blank line after the stanza for separation.
+     */
+    function flushStanza() {
+        if (stanzaBuf.length === 0) return;
+        if (stanzaIsChorus) {
+            // Guard: Do not add "Chorus:" if the first line starts with a digit
+            // followed by whitespace (e.g., "2 Lord, I come..."). This prevents
+            // false positives from verse numbers wrapped in <em> tags for styling.
+            var firstLine = stanzaBuf[0] ? stanzaBuf[0].replace(/^\s+|\s+$/g, '') : '';
+            if (!/^\d+\s/.test(firstLine)) {
+                lines.push("Chorus:");
+            }
+        }
+        lines.push(stanzaBuf.join("\n"));
+        lines.push("");  // Blank line between stanzas
+        stanzaBuf = [];
+        stanzaIsChorus = false;
+    }
+
+    // Pattern for detecting attribution lines (Words:, Music:, etc.)
+    // Require a colon, separator, or "by" after the keyword to prevent
+    // false positives (e.g. sidebar text "Music file" or lyrics like "Words of...").
+    var attributionPattern = /^(Words|Music|Arranged|Words and music|Based on|Translated|Paraphrase)\s*[:&\-\/by]/i;
+    // Also match bare "Words and music" / "Words & music" phrases
+    var attributionPatternBare = /^(Words and music|Words & music)\b/i;
+
+    // Process each verse (paragraph) from the parsed HTML
+    for (var i = 0; i < song.verses.length; i++) {
+        var verse = song.verses[i];
+        var stripped = verse.text.replace(/^\s+|\s+$/g, "");
+
+        // --- Empty verse: count but don't flush yet ---
+        // On missionpraise.com, single empty <p> elements appear between EVERY
+        // lyric line as CSS spacing.  They are NOT stanza boundaries.  If we
+        // flushed on every empty we would double-space the entire output.
+        // Instead we count consecutive empties and decide at the NEXT non-empty
+        // line whether the gap constitutes a real stanza break.
+        if (!stripped) {
+            consecutiveEmpties++;
+            continue;
+        }
+
+        // --- Stanza break decision (smart detection) ---
+        // We only treat a gap as a real stanza boundary when there is strong
+        // structural evidence, not merely a single CSS-spacer empty <p>.
+        //
+        // Evidence of a real break:
+        //   1. consecutiveEmpties >= 2  -- Multiple empty <p> elements in a
+        //      row indicate a genuine structural gap in the source HTML, not
+        //      the single-<p> CSS spacing that appears between every line.
+        //   2. Italic state change      -- The site uses <em>/<i> to mark
+        //      chorus lines.  A transition from italic to non-italic (or vice
+        //      versa) signals a verse/chorus boundary.
+        //   3. Leading verse number     -- A line starting with a digit
+        //      followed by whitespace (e.g. "2 Lord, I come…") marks the
+        //      beginning of a new numbered verse.
+        //
+        // When none of these conditions are met, the empty was just a
+        // single CSS spacer between consecutive lines of the SAME stanza,
+        // so we continue accumulating into the current stanza buffer.
+        if (stanzaBuf.length > 0 && consecutiveEmpties > 0) {
+            var isItalic = verse.isItalic;
+            var shouldBreak = (
+                consecutiveEmpties >= 2 ||           // structural break (multiple empties)
+                isItalic !== stanzaIsChorus ||        // verse ↔ chorus transition
+                /^\d+\s/.test(stripped)               // new numbered verse
+            );
+            if (shouldBreak) {
+                flushStanza();
+            }
+        }
+        consecutiveEmpties = 0;
+
+        // --- Attribution line detection ---
+        // Lines starting with "Words:", "Music:", "Arranged:", etc. are
+        // author/composer credits, not lyrics. We require a colon/separator
+        // after the keyword to prevent false positives.
+        var isAttribution = attributionPattern.test(stripped) || attributionPatternBare.test(stripped);
+        if (!isAttribution && foundAttribution && stripped.indexOf("\n") < 0 &&
+            !(/^\d+\s/).test(stripped) && stripped.length < 120) {
+            // Once we've found the first attribution line, subsequent short
+            // single-line entries are also treated as attribution — but NOT
+            // if they look like numbered verses.
+            isAttribution = true;
+        }
+
+        if (isAttribution) {
+            flushStanza();
+            foundAttribution = true;
+            authorLines.push(stripped);
+            continue;
+        }
+
+        // If we see a normal lyric line after attribution, reset the cascade.
+        // This prevents a single false-positive from consuming remaining lyrics.
+        if (foundAttribution && (/^\d+\s/).test(stripped)) {
+            foundAttribution = false;
+        }
+
+        // --- Standalone author lines ---
+        // Some attribution lines don't follow the "Words:" pattern but are
+        // recognisable as author names by containing "/" or "&" separators.
+        // Heuristics: single line, doesn't start with digit, contains / or &,
+        // short, and not a typical lyric pattern.
+        if (stripped.indexOf("\n") < 0 &&
+            !(/^\d/).test(stripped) &&
+            (stripped.indexOf("/") >= 0 || stripped.indexOf("&") >= 0) &&
+            stripped.length < 120 &&
+            !(/\b(the|and|you|your|my|our|lord|god|love|sing|praise)\b/i).test(stripped)) {
+            flushStanza();
+            authorLines.push(stripped);
+            continue;
+        }
+
+        // --- Multi-line verse ---
+        // If the verse text contains "\n" (from <br> tags), it's a multi-line
+        // verse that should be treated as its own stanza.
+        if (stripped.indexOf("\n") >= 0) {
+            flushStanza();
+            // Clean up each line within the verse
+            var multiLines = stripped.split("\n");
+            var cleaned = [];
+            for (var j = 0; j < multiLines.length; j++) {
+                cleaned.push(multiLines[j].replace(/^\s+|\s+$/g, ""));
+            }
+            if (verse.isItalic) {
+                // Guard: Do not add "Chorus:" if the first line starts with a digit
+                // followed by whitespace (e.g., "2 Lord, I come..."). This prevents
+                // false positives from verse numbers wrapped in <em> tags for styling.
+                var firstLine = cleaned[0] ? cleaned[0].replace(/^\s+|\s+$/g, '') : '';
+                if (!/^\d+\s/.test(firstLine)) {
+                    lines.push("Chorus:");
+                }
+            }
+            lines.push(cleaned.join("\n"));
+            lines.push("");  // Blank line after the stanza
+        } else {
+            // --- Single-line verse ---
+            // Accumulate into the current stanza buffer.
+            if (verse.isItalic) {
+                stanzaIsChorus = true;
+            }
+            stanzaBuf.push(stripped);
+        }
+    }
+
+    // Flush any remaining stanza that wasn't terminated by an empty verse
+    flushStanza();
+
+    // Remove trailing blank lines from the lyrics section
+    while (lines.length > 0 && lines[lines.length - 1] === "") {
+        lines.pop();
+    }
+
+    // Append author attribution lines (separated from lyrics by double blank line)
+    if (authorLines.length > 0) {
+        lines.push("");   // First blank line
+        lines.push("");   // Second blank line (visual separation)
+        for (var k = 0; k < authorLines.length; k++) {
+            lines.push(authorLines[k]);
+        }
+    }
+
+    // Append copyright notice if available
+    if (song.copyright) {
+        lines.push("");
+        lines.push(song.copyright);
+    }
+
+    // Post-processing: normalise spaced ellipses
+    // WordPress sometimes converts "..." to ". . ." with spaces.
+    // We normalise these back to standard "..."
+    var result = lines.join("\n");
+    result = result.replace(/ ?(?:\. ){2,}\./g, "...");
+
+    // Strip legacy formatting codes f*I (italic start) and f*R (format reset)
+    // that appear as data-entry artefacts in some song texts
+    result = result.replace(/f\*I/g, "");
+    result = result.replace(/f\*R/g, "");
+
+    // Collapse 3+ consecutive newlines down to 2 (one blank line maximum)
+    result = result.replace(/\n{3,}/g, "\n\n");
+
+    return result;
+}
+
+
+// ---------------------------------------------------------------------------
+// File extension detection -- cascade strategy for download file types
+// ---------------------------------------------------------------------------
+
+/**
+ * Guess the file extension from a URL's path component.
+ *
+ * Parses the URL to extract the path, then gets the extension from the
+ * last path segment. Server-side script extensions (.php, .asp, etc.)
+ * are ignored because they indicate dynamic download endpoints.
+ *
+ * @param {string} url - The download URL
+ * @returns {string} The lowercase file extension (e.g. ".rtf") or ""
+ */
+function extFromUrl(url) {
+    // Parse the URL path (strip query string and fragment)
+    var path = url.split("?")[0].split("#")[0];
+    // Get the filename from the last path segment
+    var lastSlash = path.lastIndexOf("/");
+    var filename = (lastSlash >= 0) ? path.substring(lastSlash + 1) : path;
+    // Get the extension
+    var lastDot = filename.lastIndexOf(".");
+    if (lastDot < 0) return "";
+    var ext = filename.substring(lastDot).toLowerCase();
+    // Ignore server-side script extensions
+    var scriptExts = { ".php": 1, ".asp": 1, ".aspx": 1, ".jsp": 1, ".cgi": 1, ".py": 1 };
+    if (scriptExts[ext]) return "";
+    return ext;
+}
+
+/**
+ * Detect file type from the first few bytes of binary data (magic bytes).
+ *
+ * Reads the beginning of the file using ADODB.Stream and compares against
+ * known file format signatures. This is the last-resort detection method.
+ *
+ * Note: In JScript, we can't directly access individual bytes of a VBArray.
+ * Instead, we write the data to a temporary ADODB.Stream, reposition to the
+ * start, switch to text mode, and read the first few characters for comparison.
+ * For reliable byte-level comparison, we use a binary-to-byte helper.
+ *
+ * @param {string} firstBytes - The first few characters of the file as a string
+ * @returns {string} The detected file extension (e.g. ".pdf") or ""
+ */
+function extFromMagic(firstBytes) {
+    if (!firstBytes || firstBytes.length < 4) return "";
+
+    // Check each known magic byte signature
+    for (var i = 0; i < MAGIC_BYTES.length; i++) {
+        var sig = MAGIC_BYTES[i].sig;
+        var match = true;
+
+        for (var j = 0; j < sig.length; j++) {
+            if (j >= firstBytes.length) { match = false; break; }
+            // Compare the character code of each byte
+            if (firstBytes.charCodeAt(j) !== sig[j]) {
+                match = false;
+                break;
+            }
+        }
+
+        if (match) {
+            return MAGIC_BYTES[i].ext;
+        }
+    }
+    return "";
+}
+
+/**
+ * Determine the correct file extension for a download using a cascade strategy.
+ *
+ * Tries three methods in order of reliability:
+ *   1. MIME type from Content-Type header (most reliable)
+ *   2. File extension from the URL path (fallback)
+ *   3. Magic bytes from the file content (last resort)
+ *
+ * @param {string} contentType - The Content-Type header value
+ * @param {string} url - The download URL
+ * @param {string} [firstBytes] - First few bytes of file content (for magic detection)
+ * @returns {string} The file extension including dot (e.g. ".pdf", ".rtf", ".bin")
+ */
+function extForDownload(contentType, url, firstBytes) {
+    // Strategy 1: MIME type lookup
+    var ext = MIME_TO_EXT[contentType] || "";
+    if (!ext) {
+        // Strategy 2: URL extension
+        ext = extFromUrl(url);
+    }
+    if (!ext && firstBytes) {
+        // Strategy 3: Magic bytes detection
+        ext = extFromMagic(firstBytes);
+    }
+    // Fallback: .bin so the file is still saved for manual inspection
+    return ext || ".bin";
+}
+
+
+// ---------------------------------------------------------------------------
+// File system operations -- directory creation, file existence checks
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a directory path, including all intermediate directories.
+ *
+ * Equivalent to Python's os.makedirs(path, exist_ok=True).
+ * Splits the path into segments and creates each level that doesn't exist.
+ *
+ * @param {string} path - The full directory path to create
+ */
+function makedirs(path) {
+    // Normalise path separators to backslash (Windows convention)
+    path = path.replace(/\//g, "\\");
+
+    // Remove trailing backslash if present
+    if (path.charAt(path.length - 1) === "\\") {
+        path = path.substring(0, path.length - 1);
+    }
+
+    // If the directory already exists, nothing to do
+    if (fso.FolderExists(path)) return;
+
+    // Split into segments and build path progressively
+    var parts = path.split("\\");
+    var current = "";
+    for (var i = 0; i < parts.length; i++) {
+        if (i === 0) {
+            current = parts[0];
+            // Handle drive letter (e.g. "C:")
+            if (current.match(/^[A-Za-z]:$/)) {
+                continue;  // Don't try to create the drive root
+            }
+        } else {
+            current += "\\" + parts[i];
+        }
+
+        if (current && !fso.FolderExists(current)) {
+            try {
+                fso.CreateFolder(current);
+            } catch (e) {
+                // Folder may have been created by another process (race condition)
+                if (!fso.FolderExists(current)) {
+                    throw e;  // Re-throw if it genuinely failed
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Build a set (object) of existing filenames in a directory for quick lookup.
+ *
+ * Called once at startup per book to avoid repeated directory scans.
+ * Returns an object where keys are filenames for O(1) membership testing.
+ *
+ * @param {string} dirPath - Path to the directory to scan
+ * @returns {Object} Object with filename keys (values are true), or empty object
+ */
+function buildFileCache(dirPath) {
+    var cache = {};
+    dirPath = dirPath.replace(/\//g, "\\");
+
+    if (!fso.FolderExists(dirPath)) return cache;
+
+    var folder = fso.GetFolder(dirPath);
+    var files = new Enumerator(folder.Files);
+
+    for (; !files.atEnd(); files.moveNext()) {
+        var f = files.item();
+        cache[f.Name] = true;
+    }
+
+    return cache;
+}
+
+/**
+ * Merge one file cache object into another (union operation).
+ *
+ * Copies all keys from source into target. Since filenames include the book
+ * label (MP, CP, JP), they're unique across books, making merging safe.
+ *
+ * @param {Object} target - The target cache to merge into
+ * @param {Object} source - The source cache to merge from
+ */
+function mergeCache(target, source) {
+    for (var key in source) {
+        if (source.hasOwnProperty(key)) {
+            target[key] = true;
+        }
+    }
+}
+
+/**
+ * Check if lyrics for a specific song have already been saved.
+ *
+ * Matches files by their prefix pattern (number + label) and .txt extension.
+ *
+ * @param {number} number - The song number
+ * @param {string} book - Book identifier key
+ * @param {Object} fileCache - File cache object from buildFileCache()
+ * @returns {boolean} True if a matching .txt file exists
+ */
+function alreadySavedLyrics(number, book, fileCache) {
+    var cfg = BOOK_CONFIG[book];
+    var padded = zeroPad(number, cfg.pad);
+    var prefix = padded + " (" + cfg.label + ") -";
+
+    for (var f in fileCache) {
+        if (fileCache.hasOwnProperty(f)) {
+            if (f.indexOf(prefix) === 0 && f.indexOf(".txt", f.length - 4) >= 0) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+/**
+ * Check if a specific download file (words/music/audio) already exists.
+ *
+ * Words files use the base name directly (base.ext), while music and
+ * audio files add a type suffix (base_music.ext, base_audio.ext).
+ *
+ * @param {string} base - The base filename
+ * @param {string} dlType - Download type ("words", "music", or "audio")
+ * @param {Object} fileCache - File cache object
+ * @returns {boolean} True if a matching file exists
+ */
+function alreadySavedDownload(base, dlType, fileCache) {
+    // Words files: "base.ext", other types: "base_type.ext"
+    var prefix = (dlType === "words") ? (base + ".") : (base + "_" + dlType + ".");
+
+    for (var f in fileCache) {
+        if (fileCache.hasOwnProperty(f)) {
+            if (f.indexOf(prefix) === 0) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+
+// ---------------------------------------------------------------------------
+// File saving operations -- write lyrics and binary downloads to disk
+// ---------------------------------------------------------------------------
+
+/**
+ * Save formatted lyrics text to a UTF-8 encoded plain-text file.
+ *
+ * Uses ADODB.Stream in text mode with UTF-8 charset. This ensures proper
+ * handling of Unicode characters (smart quotes, em dashes, etc.) that
+ * commonly appear in song lyrics.
+ *
+ * @param {string} text - The formatted lyrics text
+ * @param {string} filePath - The full path to save the file
+ */
+function saveTextFile(text, filePath) {
+    try {
+        var stream = new ActiveXObject("ADODB.Stream");
+        stream.Type = 2;           // adTypeText = 2 (text mode)
+        stream.Charset = "UTF-8";  // Use UTF-8 encoding for Unicode support
+        stream.Open();
+        stream.WriteText(text);
+
+        // ADODB.Stream with UTF-8 charset writes a BOM (Byte Order Mark) at
+        // the start of the file. While this doesn't cause problems for most
+        // programs, the Python version doesn't write a BOM, so we strip it
+        // for consistency.
+        // To strip BOM: reposition to byte 3 (skip the 3-byte UTF-8 BOM),
+        // copy the rest to a new stream, and save that instead.
+        stream.Position = 0;
+        stream.Type = 1;  // Switch to binary mode to strip BOM
+        stream.Position = 3;  // Skip 3-byte UTF-8 BOM (EF BB BF)
+        var bomless = new ActiveXObject("ADODB.Stream");
+        bomless.Type = 1;  // Binary
+        bomless.Open();
+        bomless.Write(stream.Read());  // Copy everything after BOM
+        bomless.SaveToFile(filePath, 2);  // 2 = adSaveCreateOverWrite
+        bomless.Close();
+        stream.Close();
+    } catch (e) {
+        WScript.Echo("  [!] Error saving text file " + filePath + ": " + e.message);
+    }
+}
+
+/**
+ * Save binary data (downloaded file) to disk using ADODB.Stream.
+ *
+ * ADODB.Stream in binary mode (Type=1) can write VBArray byte data
+ * directly to a file without corruption. This handles all binary formats
+ * (RTF, PDF, MP3, MIDI, etc.).
+ *
+ * @param {Object} binaryData - VBArray of bytes from WinHttpRequest.ResponseBody
+ * @param {string} filePath - The full path to save the file
+ * @returns {boolean} True on success, false on error
+ */
+function saveBinaryFile(binaryData, filePath) {
+    try {
+        var stream = new ActiveXObject("ADODB.Stream");
+        stream.Type = 1;  // adTypeBinary = 1 (binary mode)
+        stream.Open();
+        stream.Write(binaryData);               // Write the binary data
+        stream.SaveToFile(filePath, 2);          // 2 = adSaveCreateOverWrite
+        stream.Close();
+        return true;
+    } catch (e) {
+        WScript.Echo("  [!] Error saving binary file " + filePath + ": " + e.message);
+        return false;
+    }
+}
+
+/**
+ * Get the first few bytes of binary data as a string for magic byte detection.
+ *
+ * Writes the binary data to a temporary ADODB.Stream, repositions to the start,
+ * and reads the first N bytes as a binary string. The character codes of the
+ * string correspond to the byte values, enabling magic number comparison.
+ *
+ * @param {Object} binaryData - VBArray of bytes from WinHttpRequest.ResponseBody
+ * @param {number} [numBytes=16] - Number of bytes to read
+ * @returns {string} The first bytes as a string (charCode = byte value)
+ */
+function getFirstBytes(binaryData, numBytes) {
+    if (typeof numBytes === "undefined") numBytes = 16;
+    try {
+        // Write to a temporary stream in binary mode
+        var tempStream = new ActiveXObject("ADODB.Stream");
+        tempStream.Type = 1;  // Binary
+        tempStream.Open();
+        tempStream.Write(binaryData);
+
+        // Reposition to start and read as text in binary-compatible encoding
+        tempStream.Position = 0;
+        tempStream.Type = 2;  // Switch to text
+        tempStream.Charset = "iso-8859-1";  // Single-byte encoding: charCode = byte value
+        var text = tempStream.ReadText(numBytes);
+        tempStream.Close();
+        return text;
+    } catch (e) {
+        return "";
+    }
+}
+
+
+// ---------------------------------------------------------------------------
+// Skip logging -- record skipped songs for later review
+// ---------------------------------------------------------------------------
+
+/**
+ * Record a skipped song in the skipped.log file.
+ *
+ * Creates a persistent log of songs that couldn't be scraped, with
+ * timestamps, identifiers, and reasons.
+ *
+ * Log format:
+ *   [2026-03-13 14:30:00]  MP0023  Amazing Grace  --  login wall  --  https://...
+ *
+ * @param {string} outputDir - Directory to write the log file in
+ * @param {string} label - Book label (e.g. "MP")
+ * @param {string} padded - Zero-padded song number string
+ * @param {string} title - The song title
+ * @param {string} url - The song page URL
+ * @param {string} reason - Why the song was skipped
+ */
+function logSkip(outputDir, label, padded, title, url, reason) {
+    makedirs(outputDir);
+    var logPath = outputDir.replace(/\//g, "\\") + "\\skipped.log";
+
+    // Build timestamp in ISO-ish format: YYYY-MM-DD HH:MM:SS
+    var now = new Date();
+    var timestamp = now.getFullYear() + "-" +
+        zeroPad(now.getMonth() + 1, 2) + "-" +
+        zeroPad(now.getDate(), 2) + " " +
+        zeroPad(now.getHours(), 2) + ":" +
+        zeroPad(now.getMinutes(), 2) + ":" +
+        zeroPad(now.getSeconds(), 2);
+
+    var line = "[" + timestamp + "]  " + label + padded + "  " + title +
+               "  --  " + reason + "  --  " + url + "\n";
+
+    try {
+        // Open file for appending (8 = ForAppending, true = create if missing)
+        var file = fso.OpenTextFile(logPath, 8, true);
+        file.Write(line);
+        file.Close();
+    } catch (e) {
+        // Non-fatal: log failure shouldn't stop the scrape
+        WScript.Echo("  [!] Warning: could not write to skipped.log: " + e.message);
+    }
+}
+
+
+// ---------------------------------------------------------------------------
+// Skip diagnostic HTML dump -- save raw HTML for debugging skipped songs
+// ---------------------------------------------------------------------------
+
+/**
+ * Write raw HTML to a diagnostic file when a song is skipped.
+ *
+ * Creates a debug file containing the raw HTML response that caused the skip,
+ * enabling post-mortem analysis of why a song was skipped. Files are saved
+ * alongside the song files in the book output directory.
+ *
+ * Output filename format:
+ *   _debug_{LABEL}{NUM}_skipped.html
+ *   e.g. _debug_MP0023_skipped.html
+ *
+ * @param {string} bookDir - Book output directory path
+ * @param {string} label - Book label (e.g. "MP")
+ * @param {string} padded - Zero-padded song number string
+ * @param {string} title - The song title
+ * @param {string} url - The song page URL
+ * @param {string} reason - Why the song was skipped (used in header comment)
+ * @param {string} htmlText - The raw HTML response to dump
+ */
+function dumpSkipHtml(bookDir, label, padded, title, url, reason, htmlText) {
+    if (!htmlText) return;
+    try {
+        makedirs(bookDir);
+        var debugPath = bookDir.replace(/\//g, "\\") + "\\_debug_" + label + padded + "_skipped.html";
+        var header = "<!-- Skip diagnostic dump -->\n" +
+                     "<!-- Song: " + label + padded + " - " + title + " -->\n" +
+                     "<!-- URL: " + url + " -->\n" +
+                     "<!-- Reason: " + reason + " -->\n" +
+                     "<!-- Date: " + (new Date()).toISOString() + " -->\n\n";
+        var file = fso.CreateTextFile(debugPath, true);  // true = overwrite
+        file.Write(header + htmlText);
+        file.Close();
+    } catch (e) {
+        // Non-fatal: diagnostic dump failure shouldn't stop the scrape
+        if (DEBUG) {
+            WScript.Echo("  [!] Warning: could not write skip diagnostic HTML: " + e.message);
+        }
+    }
+}
+
+
+// ---------------------------------------------------------------------------
+// Authentication -- WordPress login with CSRF nonce extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Authenticate with missionpraise.com using WordPress standard login.
+ *
+ * The login flow:
+ *   1. GET the login page to obtain CSRF nonces (hidden form fields)
+ *   2. Brief pause (2s) to appear more human-like
+ *   3. POST credentials + nonces with proper Referer/Origin headers
+ *   4. Handle failure modes: WAF blocks, wrong password, login errors
+ *   5. Verify login by fetching /songs/ and checking for logged-in indicators
+ *
+ * @returns {boolean} True if login appears successful, false if failed
+ */
+function doLogin() {
+    WScript.Echo("Logging in as " + USERNAME + "...");
+
+    // --- Step 1: GET the login page to extract CSRF nonces ---
+    var loginPage = httpGet(LOGIN_URL);
+    if (!loginPage) {
+        WScript.Echo("  [!] Could not reach login page.");
+        return false;
+    }
+
+    debugDump("Login page HTML", loginPage.text);
+
+    // Extract all <input type="hidden"> fields from the login form.
+    // These typically include testcookie, _wpnonce, and plugin-specific nonces.
+    var hiddenFields = {};
+    var hiddenPattern = /<input[^>]+type=["']hidden["'][^>]*>/gi;
+    var hiddenMatch;
+
+    while ((hiddenMatch = hiddenPattern.exec(loginPage.text)) !== null) {
+        var tag = hiddenMatch[0];
+        // Extract the name attribute
+        var nameMatch = tag.match(/name=["']([^"']+)["']/);
+        // Extract the value attribute
+        var valueMatch = tag.match(/value=["']([^"']*)["']/);
+
+        if (nameMatch) {
+            hiddenFields[nameMatch[1]] = valueMatch ? valueMatch[1] : "";
+        }
+    }
+
+    if (DEBUG) {
+        var fieldNames = [];
+        for (var fn in hiddenFields) {
+            if (hiddenFields.hasOwnProperty(fn)) fieldNames.push(fn);
+        }
+        WScript.Echo("  DEBUG: Hidden fields: " + fieldNames.join(", "));
+        var cookieNames = [];
+        for (var cn in cookieJar) {
+            if (cookieJar.hasOwnProperty(cn)) cookieNames.push(cn);
+        }
+        WScript.Echo("  DEBUG: Cookies after GET login page: " + cookieNames.join(", "));
+    }
+
+    // --- Step 2: Brief pause to appear more human-like ---
+    // Some WAFs flag requests that POST to the login form within milliseconds
+    // of loading the page, as this indicates automated access.
+    WScript.Sleep(2000);
+
+    // --- Step 3: POST the login credentials ---
+    // Build the login form data with WordPress standard field names
+    var payload = {
+        "log":         USERNAME,           // WordPress username field
+        "pwd":         PASSWORD,           // WordPress password field
+        "wp-submit":   "Log In",           // Submit button value
+        "redirect_to": BASE_URL + "/songs/",  // Redirect target after login
+        "rememberme":  "forever"           // Keep the session alive
+    };
+
+    // Merge in all hidden fields (CSRF nonces)
+    for (var field in hiddenFields) {
+        if (hiddenFields.hasOwnProperty(field)) {
+            payload[field] = hiddenFields[field];
+        }
+    }
+
+    var postData = buildFormData(payload);
+    var loginResp = httpPost(LOGIN_URL, postData, LOGIN_URL);
+
+    if (!loginResp) {
+        WScript.Echo("  [!] Login POST request failed.");
+        return false;
+    }
+
+    if (DEBUG) {
+        WScript.Echo("  DEBUG: Post-login status: " + loginResp.status);
+        var postCookies = [];
+        for (var pcn in cookieJar) {
+            if (cookieJar.hasOwnProperty(pcn)) postCookies.push(pcn);
+        }
+        WScript.Echo("  DEBUG: Cookies after POST login: " + postCookies.join(", "));
+        debugDump("Post-login body", loginResp.text);
+    }
+
+    var body = loginResp.text;
+
+    // --- Step 4: Check for various failure modes ---
+
+    // Check for WAF / firewall blocks (e.g. Sucuri CDN/WAF)
+    var bodyLower = body.toLowerCase();
+    if (bodyLower.indexOf("sucuri") >= 0 || bodyLower.indexOf("access denied") >= 0) {
+        // Extract block reason and IP if available
+        var reasonMatch = body.match(/Block reason:<\/td>\s*<td><span>(.*?)<\/span>/);
+        var ipMatch = body.match(/Your IP:<\/td>\s*<td><span>(.*?)<\/span>/);
+        var reason = reasonMatch ? reasonMatch[1].replace(/^\s+|\s+$/g, "") : "unknown";
+        var ip = ipMatch ? ipMatch[1].replace(/^\s+|\s+$/g, "") : "unknown";
+        WScript.Echo("  [!] BLOCKED by website firewall: " + reason);
+        WScript.Echo("       Your IP: " + ip);
+        WScript.Echo("       Try again later or log in via browser first to whitelist your IP.");
+        return false;
+    }
+
+    // Check for incorrect credentials -- WordPress stays on wp-login.php
+    if (bodyLower.indexOf("wp-login.php") >= 0 && bodyLower.indexOf("incorrect") >= 0) {
+        WScript.Echo("  [!] Login failed -- check username/password.");
+        return false;
+    }
+
+    // Check for other WordPress login errors (still on login page after POST)
+    if (bodyLower.indexOf("wp-login.php") >= 0) {
+        // Look for the WordPress login error div
+        var errorMatch = body.match(/<div[^>]*id=["']login_error["'][^>]*>([\s\S]*?)<\/div>/i);
+        if (errorMatch) {
+            var errorText = errorMatch[1].replace(/<[^>]+>/g, "").replace(/^\s+|\s+$/g, "");
+            WScript.Echo("  [!] Login error: " + errorText);
+            return false;
+        }
+        if (DEBUG) {
+            WScript.Echo("  DEBUG: Still on login page after POST -- login likely failed");
+        }
+    }
+
+    // --- Step 5: Verify login by fetching the songs page ---
+    var songsResp = httpGet(BASE_URL + "/songs/");
+    if (!songsResp) {
+        WScript.Echo("  [?] Could not verify login (songs page unreachable).");
+        return true;  // Proceed anyway -- the login POST may have worked
+    }
+
+    if (DEBUG) {
+        debugDump("Songs page HTML", songsResp.text);
+    }
+
+    var checkLower = songsResp.text.toLowerCase();
+
+    // Look for multiple indicators of being logged in
+    var loggedIn = (
+        checkLower.indexOf("logout") >= 0 ||
+        checkLower.indexOf("log out") >= 0 ||
+        checkLower.indexOf("log-out") >= 0 ||
+        songsResp.text.indexOf("Welcome") >= 0 ||
+        checkLower.indexOf("my-account") >= 0 ||
+        checkLower.indexOf("wp-admin") >= 0 ||
+        checkLower.indexOf("logged-in") >= 0
+    );
+
+    if (loggedIn) {
+        WScript.Echo("  [OK] Logged in.");
+        return true;
+    }
+
+    // Check if redirected back to login page
+    if (checkLower.indexOf("wp-login") >= 0 || checkLower.indexOf("loginform") >= 0) {
+        WScript.Echo("  [!] Login failed -- redirected back to login page.");
+        return false;
+    }
+
+    // Login status is ambiguous -- proceed anyway
+    WScript.Echo("  [?] Login status unclear -- proceeding anyway.");
+    WScript.Echo("       (Re-run with debug mode enabled to see full HTML responses)");
+    return true;
+}
+
+
+// ---------------------------------------------------------------------------
+// Song processing -- scrape lyrics and downloads for a single song
+// ---------------------------------------------------------------------------
+
+/**
+ * Scrape lyrics and download files for a single song.
+ *
+ * This is the core function that handles one song from start to finish:
+ *   1. Extract the song number from the index title
+ *   2. Check if lyrics/downloads already exist (skip if so)
+ *   3. Fetch the song detail page
+ *   4. Parse HTML to extract lyrics, copyright, and download links
+ *   5. Save lyrics as a .txt file
+ *   6. Download and save words/music/audio files (if enabled)
+ *
+ * Handles edge cases:
+ *   - Songs with no extractable number
+ *   - Login walls (session expired mid-scrape)
+ *   - WAF blocks on individual song pages
+ *   - Failed title parsing (retried once for transient errors)
+ *   - Missing downloads (re-fetches page if lyrics exist but files don't)
+ *
+ * @param {string} indexTitle - Song title from the index page (includes book code)
+ * @param {string} url - URL of the song detail page
+ * @param {string} book - Book identifier key ("mp", "cp", or "jp")
+ * @param {string} outputDir - Base output directory
+ * @param {Object} fileCache - Mutable file cache object (updated on save)
+ * @returns {string} "saved", "skipped", or "exists"
+ */
+function processSong(indexTitle, url, book, outputDir, fileCache) {
+    var number = extractNumber(indexTitle, book);
+    var cfg = BOOK_CONFIG[book];
+
+    // Route output into a book-specific subdirectory
+    var bookDir = outputDir.replace(/\//g, "\\") + "\\" + cfg.subdir;
+
+    if (number === null) {
+        // Title doesn't contain a recognisable book code
+        logSkip(bookDir, "??", "????", indexTitle, url, "no book number found in title");
+        return "skipped";
+    }
+
+    var padded = zeroPad(number, cfg.pad);
+    var label = cfg.label;
+
+    // --- Check if lyrics already exist ---
+    var lyricsExist = alreadySavedLyrics(number, book, fileCache);
+
+    // If lyrics exist and we don't need files, skip entirely (no network request)
+    if (lyricsExist && !DO_DOWNLOAD) {
+        return "exists";
+    }
+
+    // If lyrics exist, check whether downloads also exist
+    if (lyricsExist) {
+        var cleanT = cleanTitle(indexTitle, book);
+        var base = baseFilename(number, book, cleanT);
+        var hasAnyDownload = false;
+
+        for (var f in fileCache) {
+            if (fileCache.hasOwnProperty(f) && !f.match(/\.txt$/i)) {
+                if (f.indexOf(base + ".") === 0 || f.indexOf(base + "_") === 0) {
+                    hasAnyDownload = true;
+                    break;
+                }
+            }
+        }
+
+        if (!DO_DOWNLOAD || hasAnyDownload) {
+            return "exists";
+        }
+
+        // Lyrics exist but no downloads -- need to fetch page for download links
+        WScript.StdOut.Write("    " + label + padded + "  " +
+            padRight(indexTitle.substring(0, 55), 55) + " ");
+        WScript.StdOut.Write("[refetch for downloads] ");
+    } else {
+        // Neither lyrics nor files exist -- full scrape needed
+        WScript.StdOut.Write("    " + label + padded + "  " +
+            padRight(indexTitle.substring(0, 55), 55) + " ");
+    }
+
+    // --- Fetch the song detail page ---
+    var pageResp = httpGet(url);
+
+    if (!pageResp || !pageResp.text) {
+        WScript.Echo("X (empty response)");
+        dumpSkipHtml(bookDir, label, padded, indexTitle, url, "empty_response", pageResp ? pageResp.text : "");
+        logSkip(bookDir, label, padded, indexTitle, url, "empty response");
+        WScript.Sleep(DELAY_MS);
+        return "skipped";
+    }
+
+    var htmlText = pageResp.text;
+
+    // Check for login wall (session may have expired during the scrape)
+    if (htmlText.indexOf("Please login to continue") >= 0 ||
+        htmlText.indexOf("loginform") >= 0) {
+        WScript.Echo("X (login wall)");
+        dumpSkipHtml(bookDir, label, padded, indexTitle, url, "login_wall", htmlText);
+        logSkip(bookDir, label, padded, indexTitle, url, "login wall");
+        WScript.Sleep(DELAY_MS);
+        return "skipped";
+    }
+
+    // Check for subscription paywall
+    if (htmlText && htmlText.indexOf("not part of your subscription") >= 0) {
+        WScript.Echo("X (not in subscription)");
+        dumpSkipHtml(bookDir, label, padded, indexTitle, url, "subscription_paywall", htmlText);
+        logSkip(bookDir, label, padded, indexTitle, url, "song not part of subscription");
+        WScript.Sleep(DELAY_MS);
+        return "skipped";
+    }
+
+    // Check for WAF block on the song page
+    var htmlLower = htmlText.toLowerCase();
+    if (htmlLower.indexOf("sucuri") >= 0 || htmlLower.indexOf("access denied") >= 0) {
+        WScript.Echo("X (blocked by firewall)");
+        dumpSkipHtml(bookDir, label, padded, indexTitle, url, "waf_block", htmlText);
+        logSkip(bookDir, label, padded, indexTitle, url, "blocked by WAF/firewall");
+        WScript.Sleep(DELAY_MS);
+        return "skipped";
+    }
+
+    // --- Parse the song page HTML ---
+    var song = parseSongPage(htmlText);
+
+    // If the parser couldn't find a title, retry once
+    if (!song.title) {
+        WScript.Sleep(DELAY_MS * 2);  // Longer delay before retry
+        pageResp = httpGet(url);
+        if (pageResp && pageResp.text && pageResp.text.indexOf("loginform") < 0) {
+            song = parseSongPage(pageResp.text);
+        }
+    }
+
+    // If still no title after retry, try fallbacks before skipping
+    if (!song.title) {
+        // Fallback 1: Extract from HTML <title> tag, strip " – Mission Praise" suffix
+        // The site uses &#8211; (en dash) or a literal – character before "Mission Praise"
+        var htmlTitleMatch = (pageResp && pageResp.text) ?
+            pageResp.text.match(/<title[^>]*>([\s\S]*?)<\/title>/i) : null;
+        if (htmlTitleMatch) {
+            var htmlTitle = htmlTitleMatch[1].replace(/<[^>]+>/g, "").replace(/^\s+|\s+$/g, "");
+            htmlTitle = decodeEntities(htmlTitle);
+            // Strip " – Mission Praise" or " - Mission Praise" suffix (&#8211; decodes to \u2013)
+            htmlTitle = htmlTitle.replace(/\s*[\u2013\u2014\-]\s*Mission Praise\s*$/i, "").replace(/^\s+|\s+$/g, "");
+            if (htmlTitle) {
+                song.title = htmlTitle;
+            }
+        }
+    }
+
+    if (!song.title) {
+        // Fallback 2: Use the index page title, stripping the book code like "(MP1270)"
+        var fallbackTitle = indexTitle.replace(/\s*\([A-Z]{2}\d+\)\s*$/i, "").replace(/^\s+|\s+$/g, "");
+        if (fallbackTitle) {
+            song.title = fallbackTitle;
+        }
+    }
+
+    // If STILL no title after all fallbacks, skip this song
+    if (!song.title) {
+        WScript.Echo("X (no title parsed)");
+        dumpSkipHtml(bookDir, label, padded, indexTitle, url, "no_title", htmlText);
+        logSkip(bookDir, label, padded, indexTitle, url, "parser found no title in page HTML");
+        WScript.Sleep(DELAY_MS);
+        return "skipped";
+    }
+
+    // --- Verse count validation ---
+    // Count actual text lines (not <p> entries) to detect incomplete parses.
+    // Many songs use a few large <p> blocks with <br> line breaks inside,
+    // so counting entries would produce false "incomplete" warnings.
+    var totalLines = 0;
+    for (var vi = 0; vi < song.verses.length; vi++) {
+        var vText = song.verses[vi].text;
+        if (vText && vText.replace(/^\s+|\s+$/g, "")) {
+            totalLines += vText.replace(/^\s+|\s+$/g, "").split("\n").length;
+        }
+    }
+    if (totalLines === 0) {
+        WScript.Echo(" WARNING (no lyrics found)");
+        dumpSkipHtml(bookDir, label, padded, indexTitle, url, "no_lyrics", htmlText);
+        logSkip(bookDir, label, padded, indexTitle, url, "parser found title but 0 lyric lines");
+    } else if (totalLines < 4) {
+        WScript.Echo(" WARNING (" + totalLines + " lines - may be incomplete)");
+    }
+
+    // --- Save lyrics ---
+    var base;
+    if (lyricsExist) {
+        // Lyrics already saved -- just derive the base name for downloads
+        base = baseFilename(number, book, cleanTitle(song.title, book));
+    } else {
+        // Save lyrics to .txt file
+        makedirs(bookDir);
+        var cleanedTitle = cleanTitle(song.title, book);
+        base = baseFilename(number, book, cleanedTitle);
+        var lyricsPath = bookDir + "\\" + base + ".txt";
+        var formattedLyrics = formatLyrics(song, book);
+        saveTextFile(formattedLyrics, lyricsPath);
+        fileCache[base + ".txt"] = true;  // Add to cache
+    }
+
+    // --- Download files (words, music, audio) ---
+    var fileResults = [];  // Track download results for the status line
+
+    if (DO_DOWNLOAD) {
+        var dlTypes = ["words", "music", "audio"];
+        for (var d = 0; d < dlTypes.length; d++) {
+            var dlType = dlTypes[d];
+            var dlUrl = song.downloads[dlType];
+
+            if (!dlUrl) continue;  // Download type not available for this song
+
+            // Skip if already downloaded
+            if (alreadySavedDownload(base, dlType, fileCache)) {
+                fileResults.push(dlType.charAt(0).toLowerCase());  // lowercase = existed
+                continue;
+            }
+
+            // Convert relative URLs to absolute
+            if (dlUrl.charAt(0) === "/") {
+                dlUrl = BASE_URL + dlUrl;
+            }
+
+            // Download the file
+            var dlResp = httpGetBinary(dlUrl);
+            if (dlResp && dlResp.body) {
+                // Determine the file extension using the cascade strategy
+                var firstBytes = getFirstBytes(dlResp.body);
+                var ext = extForDownload(dlResp.contentType, dlUrl, firstBytes);
+
+                // Build the filename with type suffix for music/audio
+                var fname;
+                if (dlType === "words") {
+                    fname = base + ext;
+                } else {
+                    fname = base + "_" + dlType + ext;
+                }
+
+                var dlPath = bookDir + "\\" + fname;
+                if (saveBinaryFile(dlResp.body, dlPath)) {
+                    fileResults.push(dlType.charAt(0).toUpperCase());  // UPPERCASE = new
+                    fileCache[fname] = true;  // Add to cache
+                }
+            }
+
+            // Brief delay between downloads (30% of normal delay)
+            WScript.Sleep(Math.floor(DELAY_MS * 0.3));
+        }
+    }
+
+    // Print the status line with download indicators
+    var fileStr = (fileResults.length > 0) ? " [" + fileResults.join(",") + "]" : "";
+    WScript.Echo("OK" + fileStr);
+
+    WScript.Sleep(DELAY_MS);  // Rate limit between songs
+    return "saved";
+}
+
+
+// ---------------------------------------------------------------------------
+// Utility -- string padding
+// ---------------------------------------------------------------------------
+
+/**
+ * Pad a string to a minimum width by appending spaces.
+ *
+ * Used for aligning console output in columnar format.
+ *
+ * @param {string} s - The string to pad
+ * @param {number} width - The desired minimum width
+ * @returns {string} The padded string
+ */
+function padRight(s, width) {
+    while (s.length < width) {
+        s += " ";
+    }
+    return s;
+}
+
+
+// ---------------------------------------------------------------------------
+// Main crawl-and-scrape loop -- paginated index crawling
+// ---------------------------------------------------------------------------
+
+/**
+ * Crawl the paginated song index and scrape each discovered song.
+ *
+ * The missionpraise.com song index is paginated (10 songs per page).
+ * This function:
+ *   1. Fetches each index page sequentially
+ *   2. Parses the page to discover song links
+ *   3. Filters songs to only the requested books
+ *   4. Scrapes each song on the current page before moving to the next
+ *
+ * End-of-index detection:
+ *   - "Page not found" in the response
+ *   - WordPress serving page 1 content for out-of-range pages (loop detection)
+ *   - No song links found on the page
+ *   - Empty response
+ *
+ * @returns {Object} { saved, skipped, existed } counters
+ */
+function crawlAndScrape() {
+    var page = START_PAGE;
+
+    // Build a combined file cache from all book subdirectories.
+    // In force mode, we skip cache building entirely and use an empty object,
+    // so every song is treated as new and all files are re-downloaded/overwritten.
+    var fileCache = {};
+
+    if (FORCE) {
+        WScript.Echo("  Force mode: will re-download and overwrite existing files.\n");
+    } else {
+        for (var bi = 0; bi < booksToScrape.length; bi++) {
+            var bk = booksToScrape[bi];
+            var subdir = OUTPUT_DIR.replace(/\//g, "\\") + "\\" + BOOK_CONFIG[bk].subdir;
+            mergeCache(fileCache, buildFileCache(subdir));
+        }
+
+        // Count existing files for the startup message
+        var cacheCount = 0;
+        for (var ck in fileCache) {
+            if (fileCache.hasOwnProperty(ck)) cacheCount++;
+        }
+
+        if (cacheCount > 0) {
+            WScript.Echo("  Found " + cacheCount + " existing files across output folders -- will skip duplicates.\n");
+        }
+    }
+
+    // Counters for the final summary
+    var saved = 0;
+    var skipped = 0;
+    var existed = 0;
+
+    // Build lookup set for books to scrape (for efficient membership testing)
+    var bookSet = {};
+    for (var bs = 0; bs < booksToScrape.length; bs++) {
+        bookSet[booksToScrape[bs]] = true;
+    }
+
+    // --- Main pagination loop ---
+    while (true) {
+        // Construct the URL for the current index page
+        var indexUrl = INDEX_URL + page + "/";
+        var indexResp = httpGet(indexUrl);
+
+        // Detect end of pagination: empty response or "Page not found"
+        if (!indexResp || !indexResp.text) {
+            if (DEBUG) {
+                WScript.Echo("  DEBUG: Page " + page + " -- empty response");
+            }
+            break;
+        }
+
+        if (indexResp.text.indexOf("Page not found") >= 0) {
+            if (DEBUG) {
+                WScript.Echo("  DEBUG: Page " + page + " -- Page not found detected");
+            }
+            break;
+        }
+
+        // Dump the first page's HTML for debugging
+        if (page === START_PAGE) {
+            debugDump("Index page " + page + " HTML", indexResp.text);
+        }
+
+        // --- Loop detection ---
+        // WordPress silently serves page 1 content for out-of-range pages.
+        // We detect this by parsing the "Showing X-Y of Z" counter.
+        var countMatch = indexResp.text.match(/(\d+)-(\d+)\s+of\s+(\d+)/);
+        if (countMatch) {
+            var lo = parseInt(countMatch[1], 10);
+            var hi = parseInt(countMatch[2], 10);
+            var total = parseInt(countMatch[3], 10);
+            var totalPages = Math.ceil(total / 10);
+
+            // Print total count on the first page
+            if (page === START_PAGE) {
+                WScript.Echo("  " + total + " total songs across ~" + totalPages + " pages\n");
+            }
+
+            // Detect loops: lo > hi (impossible) or past page 1 but seeing results from 1
+            if (lo > hi || (page > 1 && lo === 1)) {
+                break;
+            }
+        } else {
+            // If no counter found and past page 1, assume end of index
+            if (page > 1) {
+                break;
+            }
+        }
+
+        // --- Parse the index page for song links ---
+        var allSongs = parseIndexPage(indexResp.text);
+
+        if (allSongs.length === 0) {
+            if (DEBUG) {
+                WScript.Echo("  DEBUG: IndexParser found 0 song links on page " + page);
+            }
+            break;
+        }
+
+        // --- Filter songs to requested books ---
+        var pageSongs = [];
+        for (var si = 0; si < allSongs.length; si++) {
+            var songEntry = allSongs[si];
+            for (var bk2 in bookSet) {
+                if (bookSet.hasOwnProperty(bk2)) {
+                    if (extractNumber(songEntry.title, bk2) !== null) {
+                        pageSongs.push({
+                            title: songEntry.title,
+                            url: songEntry.url,
+                            book: bk2
+                        });
+                        break;  // A song belongs to exactly one book
+                    }
+                }
+            }
+        }
+
+        // Print page summary with running totals
+        WScript.Echo("  Page " + padRight(String(page), 4) + "  --  " +
+            pageSongs.length + " matching songs  " +
+            "(saved: " + saved + ", existed: " + existed + ", skipped: " + skipped + ")");
+
+        // --- Scrape each song on this page ---
+        var pageExisted = 0;
+        var songFilterFound = false;
+        for (var pi = 0; pi < pageSongs.length; pi++) {
+            var ps = pageSongs[pi];
+
+            // If /song:NNN was specified, skip songs that don't match
+            if (SONG_FILTER > 0) {
+                var songNum = extractNumber(ps.title, ps.book);
+                if (songNum !== SONG_FILTER) {
+                    continue;
+                }
+                songFilterFound = true;
+            }
+
+            var result = processSong(ps.title, ps.url, ps.book, OUTPUT_DIR, fileCache);
+
+            if (result === "saved") {
+                saved++;
+            } else if (result === "skipped") {
+                skipped++;
+            } else if (result === "exists") {
+                existed++;
+                pageExisted++;
+            }
+
+            // If /song:NNN was specified and we found it, stop after processing
+            if (SONG_FILTER > 0 && songFilterFound) {
+                WScript.Echo("\n  Single-song mode: song " + SONG_FILTER + " processed. Stopping.");
+                return { saved: saved, skipped: skipped, existed: existed };
+            }
+        }
+
+        // If every song on this page already existed, print a compact summary
+        if (pageExisted === pageSongs.length && pageSongs.length > 0) {
+            WScript.Echo("           >>  all " + pageExisted + " songs on this page already exist");
+        }
+
+        page++;
+        WScript.Sleep(DELAY_MS);  // Rate limit between index pages
+    }
+
+    return { saved: saved, skipped: skipped, existed: existed };
+}
+
+
+// ---------------------------------------------------------------------------
+// MAIN -- Entry point for the JScript scraping engine
+// ---------------------------------------------------------------------------
+
+// Print startup banner
+WScript.Echo("============================================================");
+WScript.Echo("  Mission Praise Scraper (Windows Batch/JScript Hybrid)");
+WScript.Echo("  Copyright 2025-2026 MWBM Partners Ltd.");
+WScript.Echo("============================================================");
+WScript.Echo("");
+
+// --- Authenticate with the site ---
+if (!doLogin()) {
+    WScript.Echo("\n[!] Authentication failed. Exiting.");
+    WScript.Quit(1);
+}
+
+// --- Print configuration summary ---
+var bookLabels = [];
+for (var li = 0; li < booksToScrape.length; li++) {
+    bookLabels.push(booksToScrape[li].toUpperCase());
+}
+
+// Resolve the output directory to an absolute path for display
+var absOutput = OUTPUT_DIR;
+try {
+    absOutput = fso.GetAbsolutePathName(OUTPUT_DIR);
+} catch (e) {}
+
+WScript.Echo("");
+WScript.Echo("Books    : " + bookLabels.join(", "));
+WScript.Echo("Output   : " + absOutput);
+WScript.Echo("Downloads: " + (DO_DOWNLOAD ? "enabled (words, music, audio)" : "disabled"));
+if (SONG_FILTER > 0) {
+    WScript.Echo("Song     : " + SONG_FILTER + " (single-song mode, force enabled)");
+}
+WScript.Echo("");
+
+// --- Run the main crawl-and-scrape process ---
+var results = crawlAndScrape();
+
+// --- Print final summary ---
+WScript.Echo("");
+WScript.Echo("Done!  " + results.saved + " saved, " +
+    results.existed + " already existed, " +
+    results.skipped + " skipped.");
+WScript.Echo("Output: " + absOutput);
+
+if (results.skipped > 0) {
+    WScript.Echo("Skipped songs logged to: skipped.log in each book's output folder.");
+}

--- a/.importers/scrapers/MissionPraise.com.php
+++ b/.importers/scrapers/MissionPraise.com.php
@@ -1,0 +1,2297 @@
+<?php
+/**
+ * MissionPraise.com.php
+ * importers/scrapers/MissionPraise.com.php
+ *
+ * Mission Praise Scraper — scrapes lyrics and downloads files from missionpraise.com.
+ * Copyright 2025-2026 MWBM Partners Ltd.
+ *
+ * Overview:
+ *     This scraper authenticates with missionpraise.com (a WordPress-based site
+ *     that requires a paid subscription), then crawls the paginated song index
+ *     to discover all songs across three hymnbooks:
+ *         - Mission Praise (MP)  — ~1000+ songs, 4-digit numbering
+ *         - Carol Praise (CP)    — ~300 songs, 3-digit numbering
+ *         - Junior Praise (JP)   — ~300 songs, 3-digit numbering
+ *
+ *     For each song, it:
+ *     1. Scrapes the lyrics from the song detail page
+ *     2. Optionally downloads associated files (words RTF/DOC, music PDF, audio MP3)
+ *     3. Saves everything with a consistent filename convention
+ *
+ *     The scraper is designed to be resumable: it caches the list of existing
+ *     files on startup and skips songs that already have saved lyrics/downloads.
+ *
+ * Authentication:
+ *     The site uses WordPress standard login (wp-login.php) with CSRF nonces
+ *     and may be behind a Sucuri WAF (Web Application Firewall). The login
+ *     flow handles:
+ *     - Extracting hidden form fields (nonces) from the login page
+ *     - Setting proper Referer/Origin headers to pass WAF checks
+ *     - Detecting WAF blocks, login failures, and ambiguous states
+ *     - Cookie-based session management via cURL cookie jar (temp file)
+ *
+ * File output format:
+ *     Lyrics are saved as plain-text files:
+ *         {padded_number} ({LABEL}) - {Title Case Title}.txt
+ *     Download files use the same base name with type suffixes:
+ *         {base}.rtf          (words — primary download, no suffix)
+ *         {base}_music.pdf    (music score)
+ *         {base}_audio.mp3    (audio recording)
+ *
+ *     Files are organised into book-specific subdirectories:
+ *         hymns/Mission Praise [MP]/
+ *         hymns/Carol Praise [CP]/
+ *         hymns/Junior Praise [JP]/
+ *
+ * Dependencies:
+ *     PHP 8.4+ with cURL extension (no Composer dependencies).
+ *     This is intentional so the script can run on any system with PHP CLI.
+ *
+ * Usage:
+ *     php MissionPraise.com.php --username YOUR_EMAIL --password YOUR_PASSWORD
+ *     php MissionPraise.com.php --username YOUR_EMAIL --password YOUR_PASSWORD --output ~/Desktop/hymns
+ *     php MissionPraise.com.php --username YOUR_EMAIL --password YOUR_PASSWORD --books mp,cp,jp
+ *     php MissionPraise.com.php --username YOUR_EMAIL --password YOUR_PASSWORD --start-page 5
+ *     php MissionPraise.com.php --username YOUR_EMAIL --password YOUR_PASSWORD --no-files
+ *     php MissionPraise.com.php --username YOUR_EMAIL --password YOUR_PASSWORD --song 584 --books jp
+ *     php MissionPraise.com.php --username YOUR_EMAIL --password YOUR_PASSWORD --debug
+ *     php MissionPraise.com.php --username YOUR_EMAIL --password YOUR_PASSWORD --force
+ *
+ * @package iLyricsDB
+ * @author  MWBM Partners Ltd
+ * @license Proprietary
+ */
+
+// Ensure this script is run from the command line only
+if (php_sapi_name() !== 'cli') {
+    echo "This script must be run from the command line.\n";
+    exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Constants — URLs, timing, and global configuration
+// ---------------------------------------------------------------------------
+
+/** Base URL for the Mission Praise website */
+define('BASE', 'https://missionpraise.com');
+
+/** WordPress standard login endpoint */
+define('LOGIN_URL', BASE . '/wp-login.php');
+
+/** Paginated song index URL — append page number (e.g. /songs/page/1/) */
+define('INDEX_URL', BASE . '/songs/page/');
+
+/**
+ * Default delay between HTTP requests (seconds). 1.2s is chosen to be
+ * respectful to the server while keeping scraping at a reasonable speed.
+ */
+define('DEFAULT_DELAY', 1.2);
+
+/** Default output directory (relative to where the script is run) */
+define('DEFAULT_OUT', './hymns');
+
+/**
+ * Global debug flag — set to true via --debug CLI argument to dump HTML
+ * responses for troubleshooting login/parsing issues.
+ * We use a global variable rather than a constant because it's set at runtime.
+ */
+$DEBUG = false;
+
+// ---------------------------------------------------------------------------
+// Book configuration — defines the three hymnbooks scraped from the site
+// ---------------------------------------------------------------------------
+// Each book has:
+//   label:   Short identifier used in filenames (e.g. "MP", "CP", "JP")
+//   pad:     Number of digits to zero-pad the hymn number to (MP=4, others=3)
+//   pattern: Regex to extract the book number from the index page title
+//            e.g. "Amazing Grace (MP0023)" → matches "(MP0023)" → group(1) = "0023"
+//   subdir:  Human-readable subdirectory name for organised file output
+$BOOK_CONFIG = [
+    'mp' => ['label' => 'MP', 'pad' => 4, 'pattern' => '/\\(MP(\\d+)\\)/i', 'subdir' => 'Mission Praise [MP]'],
+    'cp' => ['label' => 'CP', 'pad' => 3, 'pattern' => '/\\(CP(\\d+)\\)/i', 'subdir' => 'Carol Praise [CP]'],
+    'jp' => ['label' => 'JP', 'pad' => 3, 'pattern' => '/\\(JP(\\d+)\\)/i', 'subdir' => 'Junior Praise [JP]'],
+];
+
+// ---------------------------------------------------------------------------
+// MIME type → file extension mapping for downloaded files
+// ---------------------------------------------------------------------------
+// When downloading files (words, music, audio), the server's Content-Type
+// header tells us what format the file is in. This mapping converts common
+// MIME types to their standard file extensions.
+// "application/octet-stream" is a generic binary type — we fall back to
+// guessing the extension from the URL or magic bytes in that case.
+$MIME_TO_EXT = [
+    'application/rtf'          => '.rtf',     // Rich Text Format (words)
+    'text/rtf'                 => '.rtf',     // Alternate RTF MIME type
+    'application/msword'       => '.doc',     // Microsoft Word (legacy)
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document' => '.docx',
+    'application/pdf'          => '.pdf',     // PDF (music scores)
+    'audio/midi'               => '.mid',     // MIDI audio
+    'audio/x-midi'             => '.mid',     // Alternate MIDI MIME type
+    'audio/mpeg'               => '.mp3',     // MP3 audio
+    'audio/mp3'                => '.mp3',     // Alternate MP3 MIME type
+    'audio/wav'                => '.wav',     // WAV audio
+    'audio/x-wav'              => '.wav',     // Alternate WAV MIME type
+    'audio/ogg'                => '.ogg',     // Ogg Vorbis audio
+    'application/octet-stream' => '',         // Generic binary — fall back to URL/magic
+];
+
+// ---------------------------------------------------------------------------
+// Magic bytes — file type detection from binary content
+// ---------------------------------------------------------------------------
+// When the Content-Type header is unhelpful (e.g. "application/octet-stream")
+// and the URL doesn't reveal the file type, we can identify the format by
+// examining the first few bytes of the file content. Most file formats begin
+// with a distinctive "magic number" or signature.
+$MAGIC_BYTES = [
+    ['%PDF',                       '.pdf'],    // PDF files start with %PDF
+    ["PK\x03\x04",                '.docx'],   // ZIP-based formats (docx, xlsx, pptx)
+    ["\xd0\xcf\x11\xe0",          '.doc'],    // OLE2 compound files (doc, xls, ppt)
+    ["{\\rtf",                     '.rtf'],    // Rich Text Format
+    ['MThd',                       '.mid'],    // MIDI music files
+    ['ID3',                        '.mp3'],    // MP3 with ID3v2 metadata header
+    ["\xff\xfb",                   '.mp3'],    // MP3 frame sync (MPEG1 Layer 3)
+    ["\xff\xf3",                   '.mp3'],    // MP3 frame sync (MPEG2 Layer 3)
+    ['OggS',                       '.ogg'],    // Ogg Vorbis audio container
+    ['RIFF',                       '.wav'],    // WAV audio (RIFF container format)
+    ['fLaC',                       '.flac'],   // FLAC lossless audio
+];
+
+// ---------------------------------------------------------------------------
+// Windows-1252 entity mapping — for numeric character references
+// ---------------------------------------------------------------------------
+// Some HTML from the site uses Windows-1252 code page numeric entities
+// (&#145;, &#146;, &#150; etc.) which are NOT valid Unicode code points.
+// These map to the 0x80-0x9F range in Windows-1252 and need special handling.
+// Reference: https://en.wikipedia.org/wiki/Windows-1252
+$WIN1252_MAP = [
+    145 => "\u{2018}", // LEFT SINGLE QUOTATION MARK (')
+    146 => "\u{2019}", // RIGHT SINGLE QUOTATION MARK (')
+    147 => "\u{201C}", // LEFT DOUBLE QUOTATION MARK (")
+    148 => "\u{201D}", // RIGHT DOUBLE QUOTATION MARK (")
+    149 => "\u{2022}", // BULLET (•)
+    150 => "\u{2013}", // EN DASH (–)
+    151 => "\u{2014}", // EM DASH (—)
+    152 => "\u{02DC}", // SMALL TILDE (~)
+    153 => "\u{2122}", // TRADE MARK SIGN (™)
+];
+
+
+// =========================================================================
+// Session / cURL — HTTP session management with cookie support
+// =========================================================================
+
+/**
+ * Print a labelled debug dump of HTML/text content (only when DEBUG is true).
+ *
+ * Used during development and troubleshooting to inspect raw HTML responses
+ * from the server. Truncates output to $maxChars to avoid flooding the terminal.
+ *
+ * @param string $label    A descriptive label for what's being dumped
+ * @param string $text     The text content to dump
+ * @param int    $maxChars Maximum characters to display (default: 3000)
+ *
+ * @return void
+ */
+function debugDump(string $label, string $text, int $maxChars = 3000): void
+{
+    global $DEBUG;
+    if (!$DEBUG) {
+        return;
+    }
+    echo "\n" . str_repeat('=', 60) . "\n";
+    echo "DEBUG: {$label}\n";
+    echo str_repeat('=', 60) . "\n";
+    echo mb_substr($text, 0, $maxChars);
+    if (mb_strlen($text) > $maxChars) {
+        echo "\n... (" . (mb_strlen($text) - $maxChars) . " more chars)";
+    }
+    echo "\n" . str_repeat('=', 60) . "\n\n";
+}
+
+
+/**
+ * Create a cURL handle configured with cookie support and browser-like headers.
+ *
+ * Returns a cURL handle configured to:
+ * 1. Automatically store and send cookies (for session management after login)
+ * 2. Send headers that mimic a real browser (to avoid being blocked by WAFs
+ *    or bot detection systems)
+ *
+ * The headers are modelled after a real Chrome/Edge browser on macOS,
+ * including Sec-Fetch-* headers that modern WAFs check to distinguish
+ * legitimate browser requests from automated scripts.
+ *
+ * @return array{0: \CurlHandle, 1: string} Tuple of (cURL handle, cookie jar file path)
+ */
+function makeSession(): array
+{
+    // Create a temporary file for cookie storage. cURL's CURLOPT_COOKIEJAR
+    // and CURLOPT_COOKIEFILE manage cookies automatically across requests.
+    $cookieFile = tempnam(sys_get_temp_dir(), 'mp_cookies_');
+
+    $ch = curl_init();
+
+    // Cookie management: store received cookies and send them with subsequent requests
+    curl_setopt($ch, CURLOPT_COOKIEJAR, $cookieFile);
+    curl_setopt($ch, CURLOPT_COOKIEFILE, $cookieFile);
+
+    // Return the response body as a string instead of outputting it
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+
+    // Follow HTTP redirects automatically (up to 10 hops)
+    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+    curl_setopt($ch, CURLOPT_MAXREDIRS, 10);
+
+    // Accept compressed responses (gzip, deflate) — cURL handles decompression
+    curl_setopt($ch, CURLOPT_ENCODING, '');
+
+    // Connection timeout (10s) and transfer timeout (30s)
+    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 30);
+
+    // Include the response headers in the output (we'll parse them separately)
+    curl_setopt($ch, CURLOPT_HEADER, false);
+
+    // Set browser-like headers to avoid WAF blocks.
+    // These headers are sent with every request made through this handle.
+    curl_setopt($ch, CURLOPT_HTTPHEADER, [
+        // User-Agent string mimicking Chrome on macOS
+        'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) '
+            . 'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36 Edg/145.0.0.0',
+        // Accept header indicating we prefer HTML but accept anything
+        'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,'
+            . 'image/webp,image/apng,*/*;q=0.8',
+        'Accept-Language: en-GB,en;q=0.9',
+        'Connection: keep-alive',
+        'Upgrade-Insecure-Requests: 1',
+        // Sec-Fetch-* headers: modern security headers that WAFs use to verify
+        // requests come from a real browser navigation context
+        'Sec-Fetch-Dest: document',
+        'Sec-Fetch-Mode: navigate',
+        'Sec-Fetch-Site: same-origin',
+        'Sec-Fetch-User: ?1',
+        'Cache-Control: max-age=0',
+    ]);
+
+    // SSL verification (use system CA bundle)
+    curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+    curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
+
+    return [$ch, $cookieFile];
+}
+
+
+/**
+ * Perform a GET request using the cURL session.
+ *
+ * @param \CurlHandle $ch  cURL handle with cookie support
+ * @param string      $url The URL to fetch
+ *
+ * @return array{0: string|null, 1: string|null} Tuple of (response body, final URL)
+ *         Returns (null, null) on any error.
+ */
+function fetchText(\CurlHandle $ch, string $url): array
+{
+    curl_setopt($ch, CURLOPT_URL, $url);
+    curl_setopt($ch, CURLOPT_HTTPGET, true);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 20);
+
+    $body = curl_exec($ch);
+    if ($body === false) {
+        echo "\n  [!] Error fetching {$url}: " . curl_error($ch) . "\n";
+        return [null, null];
+    }
+
+    $finalUrl = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
+    return [$body, $finalUrl];
+}
+
+
+/**
+ * Download a binary file (words/music/audio) from a URL.
+ *
+ * Includes several safety checks:
+ * 1. Detects server error pages masquerading as file downloads — some
+ *    servers return HTML error pages with a 200 status code when the
+ *    actual file is missing or access is denied
+ *
+ * The error detection heuristic checks if the response:
+ * - Starts with common text/HTML bytes ('<', 's', 'e', '{')
+ * - Is small enough to be an error page (< 500KB)
+ * - Contains error-related keywords when decoded as UTF-8
+ *
+ * @param \CurlHandle $ch  cURL handle with cookie support
+ * @param string      $url The download URL
+ *
+ * @return array{0: string|null, 1: string|null, 2: string|null}
+ *         Tuple of (binary data, content type, final URL) on success,
+ *         or (null, null, null) on error.
+ */
+function fetchBinary(\CurlHandle $ch, string $url): array
+{
+    global $DEBUG;
+
+    curl_setopt($ch, CURLOPT_URL, $url);
+    curl_setopt($ch, CURLOPT_HTTPGET, true);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 30);
+
+    $data = curl_exec($ch);
+    if ($data === false) {
+        echo "\n  [!] Download error {$url}: " . curl_error($ch) . "\n";
+        return [null, null, null];
+    }
+
+    // Extract the MIME type from Content-Type (strip charset parameter)
+    $ct = curl_getinfo($ch, CURLINFO_CONTENT_TYPE);
+    if ($ct !== null) {
+        $ct = strtolower(trim(explode(';', $ct)[0]));
+    } else {
+        $ct = '';
+    }
+
+    $finalUrl = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
+
+    // --- Error page detection ---
+    // Some servers return HTML error pages (PHP exceptions, 404 pages, etc.)
+    // with a 200 status code instead of the actual file. We detect these by
+    // checking if the content looks like text/HTML rather than binary data.
+    // The size threshold is 500KB — PHP error dumps with full AWS S3 stack
+    // traces can be 200KB+, so the previous 50KB limit missed them.
+    $firstByte = substr($data, 0, 1);
+    if (in_array($firstByte, ['<', 's', 'e', '{'], true) && strlen($data) < 500000) {
+        // Check if it's valid UTF-8 text containing error keywords
+        if (mb_check_encoding($data, 'UTF-8')) {
+            $textLower = strtolower($data);
+            $errorKeywords = ['exception', '<html', '<!doctype', 'error', 'not found', 'string(', 'nosuchkey', 'stacktrace'];
+            foreach ($errorKeywords as $kw) {
+                if (str_contains($textLower, $kw)) {
+                    echo "server error ";
+                    if ($DEBUG) {
+                        debugDump('Server error in download', substr($data, 0, 500), 500);
+                    }
+                    return [null, null, null];
+                }
+            }
+        }
+    }
+
+    return [$data, $ct, $finalUrl];
+}
+
+
+/**
+ * Authenticate with missionpraise.com using WordPress standard login.
+ *
+ * The login flow is:
+ * 1. GET the login page to obtain CSRF nonces (hidden form fields)
+ * 2. Brief pause (2s) to appear more human-like
+ * 3. POST credentials + nonces with proper Referer/Origin headers
+ * 4. Handle various failure modes (WAF blocks, wrong password, etc.)
+ * 5. Verify login succeeded by fetching the songs page and checking
+ *    for logged-in indicators
+ *
+ * @param \CurlHandle $ch       cURL handle with cookie support
+ * @param string      $username The user's missionpraise.com email address
+ * @param string      $password The user's missionpraise.com password
+ *
+ * @return bool True if login appears successful, false if definitely failed
+ */
+function login(\CurlHandle $ch, string $username, string $password): bool
+{
+    global $DEBUG;
+
+    echo "Logging in as {$username}...\n";
+
+    // --- Step 1: GET the login page to extract CSRF nonces ---
+    // WordPress login forms contain hidden fields (nonces) that must be
+    // submitted with the POST request to prevent CSRF attacks.
+    [$htmlText, ] = fetchText($ch, LOGIN_URL);
+    if ($htmlText === null) {
+        echo "  [!] Could not load login page.\n";
+        return false;
+    }
+
+    debugDump('Login page HTML', $htmlText);
+
+    // Extract all <input type="hidden"> fields from the login form.
+    // These typically include:
+    //   - testcookie: WordPress test cookie check
+    //   - _wpnonce: WordPress CSRF nonce
+    //   - Various plugin-specific nonces
+    $hidden = [];
+    if (preg_match_all('/<input[^>]+type=["\']hidden["\'][^>]*>/i', $htmlText, $inputMatches)) {
+        foreach ($inputMatches[0] as $inputTag) {
+            $nm = null;
+            $vm = null;
+            if (preg_match('/name=["\']([^"\']+)["\']/', $inputTag, $nameMatch)) {
+                $nm = $nameMatch[1];
+            }
+            if (preg_match('/value=["\']([^"\']*)["\']/', $inputTag, $valMatch)) {
+                $vm = $valMatch[1];
+            }
+            if ($nm !== null) {
+                $hidden[$nm] = $vm ?? '';
+            }
+        }
+    }
+
+    if ($DEBUG) {
+        echo "  DEBUG: Hidden fields: " . json_encode($hidden) . "\n";
+    }
+
+    // --- Step 2: Brief pause to appear more human-like ---
+    // Some WAFs flag requests that POST to the login form within milliseconds
+    // of loading the page, as this is a strong indicator of automated access.
+    sleep(2);
+
+    // --- Step 3: POST the login credentials ---
+    // Build the login form data with WordPress standard field names
+    $payload = array_merge([
+        'log'         => $username,              // WordPress username field
+        'pwd'         => $password,              // WordPress password field
+        'wp-submit'   => 'Log In',               // Submit button value
+        'redirect_to' => BASE . '/songs/',        // Where to redirect after login
+        'rememberme'  => 'forever',              // Keep the session alive
+    ], $hidden);                                  // Include all CSRF nonces
+
+    $postData = http_build_query($payload);
+
+    // Configure cURL for the POST request with proper Referer and Origin headers.
+    // The Sucuri WAF checks these headers — missing or incorrect values
+    // will result in a 403 block.
+    curl_setopt($ch, CURLOPT_URL, LOGIN_URL);
+    curl_setopt($ch, CURLOPT_POST, true);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, $postData);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, [
+        'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) '
+            . 'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36 Edg/145.0.0.0',
+        'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Accept-Language: en-GB,en;q=0.9',
+        'Content-Type: application/x-www-form-urlencoded',
+        'Referer: ' . LOGIN_URL,
+        'Origin: ' . BASE,
+        'Sec-Fetch-Dest: document',
+        'Sec-Fetch-Mode: navigate',
+        'Sec-Fetch-Site: same-origin',
+        'Sec-Fetch-User: ?1',
+        'Cache-Control: max-age=0',
+    ]);
+
+    $body = curl_exec($ch);
+    $finalUrl = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
+
+    // Handle cURL errors (network failures, timeouts, etc.)
+    if ($body === false) {
+        echo "  [!] Login request failed: " . curl_error($ch) . "\n";
+        return false;
+    }
+
+    // Reset to GET mode for subsequent requests
+    curl_setopt($ch, CURLOPT_HTTPGET, true);
+    // Restore the default headers (POST overrode them with Content-Type)
+    curl_setopt($ch, CURLOPT_HTTPHEADER, [
+        'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) '
+            . 'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36 Edg/145.0.0.0',
+        'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,'
+            . 'image/webp,image/apng,*/*;q=0.8',
+        'Accept-Language: en-GB,en;q=0.9',
+        'Connection: keep-alive',
+        'Upgrade-Insecure-Requests: 1',
+        'Sec-Fetch-Dest: document',
+        'Sec-Fetch-Mode: navigate',
+        'Sec-Fetch-Site: same-origin',
+        'Sec-Fetch-User: ?1',
+        'Cache-Control: max-age=0',
+    ]);
+
+    if ($DEBUG) {
+        echo "  DEBUG: Post-login redirect URL: {$finalUrl}\n";
+        debugDump('Post-login body', $body);
+    }
+
+    // --- Step 4: Check for various failure modes ---
+
+    // Check for WAF / firewall blocks (e.g. Sucuri CDN/WAF)
+    $bodyLower = strtolower($body);
+    if (str_contains($bodyLower, 'sucuri') || str_contains($bodyLower, 'access denied')) {
+        $reason = 'unknown';
+        $ip     = 'unknown';
+        if (preg_match('/Block reason:<\/td>\s*<td><span>(.*?)<\/span>/s', $body, $brMatch)) {
+            $reason = trim($brMatch[1]);
+        }
+        if (preg_match('/Your IP:<\/td>\s*<td><span>(.*?)<\/span>/s', $body, $ipMatch)) {
+            $ip = trim($ipMatch[1]);
+        }
+        echo "  [!] BLOCKED by website firewall: {$reason}\n";
+        echo "       Your IP: {$ip}\n";
+        echo "       Try again later or log in via browser first to whitelist your IP.\n";
+        return false;
+    }
+
+    // Check for incorrect credentials — WordPress stays on wp-login.php
+    // and includes an error message in the response body
+    if (str_contains($finalUrl, 'wp-login.php') && str_contains($bodyLower, 'incorrect')) {
+        echo "  [!] Login failed — check username/password.\n";
+        return false;
+    }
+
+    // Check for other WordPress login errors (still on login page after POST)
+    if (str_contains($finalUrl, 'wp-login.php')) {
+        if ($DEBUG) {
+            echo "  DEBUG: Still on login page after POST — login likely failed\n";
+        }
+        // Look for the WordPress login error div which contains specific messages
+        if (preg_match('/<div[^>]*id=["\']login_error["\'][^>]*>(.*?)<\/div>/s', $body, $errMatch)) {
+            $errorText = trim(strip_tags($errMatch[1]));
+            echo "  [!] Login error: {$errorText}\n";
+            return false;
+        }
+    }
+
+    // --- Step 5: Verify login by fetching the songs page ---
+    // Even if the POST didn't show an error, we verify by checking if the
+    // songs page shows logged-in indicators.
+    [$check, $checkUrl] = fetchText($ch, BASE . '/songs/');
+
+    if ($DEBUG && $check !== null) {
+        echo "  DEBUG: Songs page URL: {$checkUrl}\n";
+        debugDump('Songs page HTML', $check);
+    }
+
+    if ($check !== null) {
+        // Look for multiple indicators of being logged in — different WordPress
+        // themes show different indicators, so we check several possibilities
+        $checkLower = strtolower($check);
+        $loggedIn = (
+            str_contains($checkLower, 'logout')
+            || str_contains($checkLower, 'log out')
+            || str_contains($checkLower, 'log-out')
+            || str_contains($check, 'Welcome')
+            || str_contains($checkLower, 'my-account')
+            || str_contains($checkLower, 'wp-admin')
+            || str_contains($checkLower, 'logged-in')
+        );
+
+        if ($loggedIn) {
+            echo "  [OK] Logged in.\n";
+            return true;
+        }
+
+        // Check if we were redirected back to the login page
+        if (str_contains($checkUrl ?? '', 'wp-login') || str_contains($checkUrl ?? '', 'login')) {
+            echo "  [!] Login failed — redirected back to login page.\n";
+            return false;
+        }
+    }
+
+    // Login status is ambiguous — proceed anyway
+    echo "  [?] Login status unclear — proceeding anyway.\n";
+    echo "       (Re-run with --debug to see full HTML responses)\n";
+    return true;
+}
+
+
+// =========================================================================
+// HTML Parsing — regex-based parsing for index and song pages
+// =========================================================================
+
+/**
+ * Parse the paginated song index page to discover song links.
+ *
+ * The index page lists songs as links within heading elements. Each song
+ * appears as an <a> tag inside an <h2> or <h3>, with the title text
+ * including the book code (e.g. "Amazing Grace (MP0023)").
+ *
+ * HTML structure being parsed:
+ *     <h2>
+ *         <a href="/songs/amazing-grace-mp0023/">Amazing Grace (MP0023)</a>
+ *     </h2>
+ *
+ * @param string $html The raw HTML of the index page
+ *
+ * @return array<int, array{0: string, 1: string}> List of [title, url] pairs
+ */
+function parseIndex(string $html): array
+{
+    $songs = [];
+
+    // Match <h2> or <h3> elements containing <a> tags with /songs/ URLs.
+    // The regex captures both the href and the link text in one pass.
+    // We use a non-greedy match across the heading content to handle
+    // nested tags and whitespace variations.
+    if (preg_match_all(
+        '/<h[23][^>]*>\s*<a\s+[^>]*href=["\']([^"\']*\/songs\/[^"\']*)["\'][^>]*>(.*?)<\/a>/si',
+        $html,
+        $matches,
+        PREG_SET_ORDER
+    )) {
+        foreach ($matches as $m) {
+            $url   = $m[1];
+            // Strip any HTML tags from the title text (e.g. <span> wrappers)
+            $title = trim(strip_tags($m[2]));
+            if ($title !== '' && $url !== '') {
+                $songs[] = [$title, $url];
+            }
+        }
+    }
+
+    return $songs;
+}
+
+
+/**
+ * Parse a song detail page to extract lyrics, copyright, title, and download links.
+ *
+ * Uses regex-based HTML parsing with preg_match/preg_match_all instead of
+ * HTMLParser. Matches both <div> and <section> tags for song-details,
+ * copyright-info, and files/col-sm-4 containers.
+ *
+ * The parsing handles several quirks of the missionpraise.com HTML:
+ * - Unclosed <P> tags acting as verse separators (split on <p> boundaries)
+ * - Double <BR><br /> collapse to single line breaks
+ * - Windows-1252 entity mapping (&#145;, &#146;, &#150; etc.)
+ * - f*I/f*R formatting code stripping (proprietary formatting marks)
+ * - <em>/<i> tags indicating chorus lines (italic in the original)
+ *
+ * @param string $html The raw HTML of the song detail page
+ *
+ * @return array{title: string, verses: array, copyright: string, downloads: array}
+ *         Parsed song data with:
+ *         - title: The song title
+ *         - verses: List of [text, is_italic] pairs
+ *         - copyright: Copyright notice text
+ *         - downloads: Map of type (words/music/audio) => URL
+ */
+function parseSong(string $html): array
+{
+    global $WIN1252_MAP;
+
+    $title     = '';
+    $verses    = [];
+    $copyright = '';
+    $downloads = [];
+
+    // --- TITLE EXTRACTION ---
+    // Look for the entry-title class on any element (div, h1, h2, span, etc.)
+    if (preg_match('/<[^>]+class=["\'][^"\']*entry-title[^"\']*["\'][^>]*>(.*?)<\/[^>]+>/si', $html, $titleMatch)) {
+        $title = trim(strip_tags($titleMatch[1]));
+    }
+
+    // --- DOWNLOAD LINKS ---
+    // Download links are in a sidebar container with class "col-sm-4" or "files".
+    // Match both <div> and <section> tags for maximum compatibility.
+    $filesPattern = '/<(?:div|section)[^>]+class=["\'][^"\']*(?:col-sm-4|files)[^"\']*["\'][^>]*>([\s\S]*?)(?=<\/(?:div|section)>)/i';
+    if (preg_match($filesPattern, $html, $filesMatch)) {
+        $filesHtml = $filesMatch[1];
+        // Extract all <a> tags within the files section
+        if (preg_match_all('/<a\s+[^>]*href=["\']([^"\']+)["\'][^>]*>(.*?)<\/a>/si', $filesHtml, $linkMatches, PREG_SET_ORDER)) {
+            foreach ($linkMatches as $lm) {
+                $href  = $lm[1];
+                $label = strtolower(trim(strip_tags($lm[2])));
+                if ($href !== '' && $href !== '#') {
+                    // Match the link to a download type based on its label text
+                    foreach (['words', 'music', 'audio'] as $key) {
+                        if (str_contains($label, $key)) {
+                            $downloads[$key] = $href;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // --- COPYRIGHT EXTRACTION ---
+    // Match both <div> and <section> tags with class "copyright-info"
+    if (preg_match('/<(?:div|section)[^>]+class=["\'][^"\']*copyright-info[^"\']*["\'][^>]*>([\s\S]*?)<\/(?:div|section)>/i', $html, $crMatch)) {
+        $copyright = trim(strip_tags($crMatch[1]));
+    }
+
+    // --- LYRICS EXTRACTION ---
+    // The song-details container holds the lyrics in <p> blocks.
+    // Match both <div> and <section> tags.
+    $songDetailsPattern = '/<(?:div|section)[^>]+class=["\'][^"\']*song-details[^"\']*["\'][^>]*>([\s\S]*?)<\/(?:div|section)>/i';
+    if (preg_match($songDetailsPattern, $html, $sdMatch)) {
+        $songHtml = $sdMatch[1];
+
+        // Remove the files/col-sm-4 sidebar from within song-details to prevent
+        // download link text from being captured as lyrics
+        $songHtml = preg_replace(
+            '/<(?:div|section)[^>]+class=["\'][^"\']*(?:col-sm-4|files)[^"\']*["\'][^>]*>[\s\S]*?<\/(?:div|section)>/i',
+            '',
+            $songHtml
+        );
+
+        // --- Strip f*I / f*R formatting codes ---
+        // Some songs contain proprietary formatting marks like f*I (start italic)
+        // and f*R (reset formatting) that are not HTML. Remove them.
+        $songHtml = preg_replace('/f\*[IR]/i', '', $songHtml);
+
+        // --- Windows-1252 entity mapping ---
+        // Replace numeric character references for Windows-1252 code points
+        // (0x80-0x9F range) with their Unicode equivalents.
+        $songHtml = preg_replace_callback(
+            '/&#(\d+);/',
+            function (array $m) use ($WIN1252_MAP): string {
+                $num = (int) $m[1];
+                if (isset($WIN1252_MAP[$num])) {
+                    return $WIN1252_MAP[$num];
+                }
+                // For valid Unicode code points, convert to UTF-8 character
+                if ($num > 0 && $num < 0x110000) {
+                    $char = mb_chr($num, 'UTF-8');
+                    return ($char !== false) ? $char : $m[0];
+                }
+                return $m[0];
+            },
+            $songHtml
+        );
+
+        // Decode standard named HTML entities (&amp;, &rsquo;, etc.)
+        $songHtml = html_entity_decode($songHtml, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
+        // --- Double <BR> collapse ---
+        // The site often emits <BR><br /> (double break) on each line.
+        // Collapse consecutive <br> tags into a single line break marker
+        // before splitting on <p> boundaries.
+        $songHtml = preg_replace('/(<br\s*\/?>\s*){2,}/i', '<br>', $songHtml);
+
+        // --- Split on <p> boundaries ---
+        // On missionpraise.com, each verse/line is a <p> element. Some pages
+        // use unclosed <P> tags that don't have matching </p> closers.
+        // Splitting on <p> tag boundaries handles both closed and unclosed styles.
+        // First, normalize: split on any <p> or </p> tag boundary
+        $parts = preg_split('/<\/?p[^>]*>/i', $songHtml);
+
+        foreach ($parts as $part) {
+            $part = trim($part);
+            if ($part === '') {
+                // Empty part = stanza break (from empty <p> or </p><p> gap)
+                $verses[] = ['', false];
+                continue;
+            }
+
+            // --- Detect italic/chorus ---
+            // Check if this paragraph contains <em> or <i> tags (chorus indicator)
+            $isItalic = (bool) preg_match('/<(?:em|i)\b/i', $part);
+
+            // Strip remaining HTML tags but preserve line breaks
+            // Convert <br> to newline before stripping tags
+            $text = preg_replace('/<br\s*\/?>/i', "\n", $part);
+            $text = strip_tags($text);
+            $text = trim($text);
+
+            if ($text !== '') {
+                $verses[] = [$text, $isItalic];
+            }
+        }
+    }
+
+    return [
+        'title'     => $title,
+        'verses'    => $verses,
+        'copyright' => $copyright,
+        'downloads' => $downloads,
+    ];
+}
+
+
+// =========================================================================
+// File extension detection — cascade strategy for download files
+// =========================================================================
+
+/**
+ * Guess the file extension from a URL's path component.
+ *
+ * Parses the URL to extract the path, then gets the extension from the
+ * last path segment. Server-side script extensions (.php, .asp, etc.)
+ * are ignored because they indicate dynamic download endpoints rather
+ * than actual file types.
+ *
+ * @param string $url The download URL to extract the extension from
+ *
+ * @return string The lowercase file extension (e.g. ".rtf") or "" if none found
+ */
+function extFromUrl(string $url): string
+{
+    $parsed = parse_url($url);
+    $path   = $parsed['path'] ?? '';
+    $ext    = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+
+    if ($ext === '') {
+        return '';
+    }
+
+    // Ignore server-side script extensions — these are dynamic endpoints
+    // that serve files, not the actual file extension
+    $scriptExts = ['php', 'asp', 'aspx', 'jsp', 'cgi', 'py'];
+    if (in_array($ext, $scriptExts, true)) {
+        return '';
+    }
+
+    return '.' . $ext;
+}
+
+
+/**
+ * Detect file type from the first few bytes of binary data (magic bytes).
+ *
+ * Compares the file's opening bytes against known signatures for common
+ * document and audio formats. This is the last-resort detection method
+ * when Content-Type and URL are both unhelpful.
+ *
+ * @param string $data The raw bytes of the downloaded file (at least 4 bytes needed)
+ *
+ * @return string The detected file extension (e.g. ".pdf") or "" if not recognised
+ */
+function extFromMagic(string $data): string
+{
+    global $MAGIC_BYTES;
+
+    if (strlen($data) < 4) {
+        return '';
+    }
+
+    foreach ($MAGIC_BYTES as [$magic, $ext]) {
+        if (str_starts_with($data, $magic)) {
+            return $ext;
+        }
+    }
+
+    return '';
+}
+
+
+/**
+ * Determine the correct file extension for a download using a cascade strategy.
+ *
+ * Tries three methods in order of reliability:
+ * 1. MIME type from the Content-Type header (most reliable)
+ * 2. File extension from the URL path (fallback)
+ * 3. Magic bytes from the file content (last resort)
+ *
+ * If none of the methods identify the file type, defaults to ".bin" to
+ * ensure the file is still saved (can be manually identified later).
+ *
+ * @param string      $contentType The Content-Type header value (e.g. "application/pdf")
+ * @param string      $url         The download URL
+ * @param string|null $data        The raw file bytes (optional, for magic byte detection)
+ *
+ * @return string The file extension including the dot (e.g. ".pdf", ".rtf", ".bin")
+ */
+function extForDownload(string $contentType, string $url, ?string $data = null): string
+{
+    global $MIME_TO_EXT;
+
+    // Strategy 1: Check the MIME type lookup table
+    $ext = $MIME_TO_EXT[$contentType] ?? '';
+    if ($ext === '') {
+        // Strategy 2: Extract extension from the URL path
+        $ext = extFromUrl($url);
+    }
+    if ($ext === '' && $data !== null) {
+        // Strategy 3: Detect from magic bytes in the file content
+        $ext = extFromMagic($data);
+    }
+
+    // Fallback: use .bin so the file is still saved for manual inspection
+    return ($ext !== '') ? $ext : '.bin';
+}
+
+
+// =========================================================================
+// Book helpers — extract and clean book-specific data from song titles
+// =========================================================================
+
+/**
+ * Extract the hymn number from a song title string for a specific book.
+ *
+ * Song titles on the index page include the book code and number in
+ * parentheses, e.g. "Amazing Grace (MP0023)". This function uses the
+ * book-specific regex pattern to extract just the numeric part.
+ *
+ * @param string $title The full song title from the index page
+ * @param string $book  Book identifier key ("mp", "cp", or "jp")
+ *
+ * @return int|null The hymn number (e.g. 23 from "MP0023") or null if not found
+ */
+function extractNumber(string $title, string $book): ?int
+{
+    global $BOOK_CONFIG;
+    $cfg = $BOOK_CONFIG[$book];
+    if (preg_match($cfg['pattern'], $title, $m)) {
+        return (int) $m[1];
+    }
+    return null;
+}
+
+
+/**
+ * Determine which book a song belongs to based on its title.
+ *
+ * Checks the title against each book's regex pattern (MP, CP, JP)
+ * and returns the first match.
+ *
+ * @param string $title The full song title from the index page
+ *
+ * @return string|null Book key ("mp", "cp", or "jp") or null if no match
+ */
+function detectBook(string $title): ?string
+{
+    global $BOOK_CONFIG;
+    foreach (array_keys($BOOK_CONFIG) as $book) {
+        if (extractNumber($title, $book) !== null) {
+            return $book;
+        }
+    }
+    return null;
+}
+
+
+/**
+ * Remove the book code suffix from a song title.
+ *
+ * Strips the "(MP0023)" or similar suffix from the end of the title,
+ * leaving just the human-readable song name for use in filenames
+ * and formatted output.
+ *
+ * @param string $title The full song title (e.g. "Amazing Grace (MP0023)")
+ * @param string $book  Book identifier key ("mp", "cp", or "jp")
+ *
+ * @return string The cleaned title (e.g. "Amazing Grace")
+ */
+function cleanTitle(string $title, string $book): string
+{
+    global $BOOK_CONFIG;
+    $cfg = $BOOK_CONFIG[$book];
+    // The book pattern uses a capturing group for the number: \(MP(\d+)\)
+    // We replace (\d+) with \d+ to make it non-capturing for the full-match removal
+    $pat = str_replace('(\\d+)', '\\d+', $cfg['pattern']);
+    // Remove the leading/trailing delimiters and flags from the pattern for use in preg_replace
+    // The pattern is like /\(MP\d+\)/i — we need just the inner regex
+    $innerPat = preg_replace('/^\/|\/[a-z]*$/i', '', $pat);
+    $result = preg_replace('/\s*' . $innerPat . '\s*$/i', '', $title);
+    return trim($result);
+}
+
+
+/**
+ * Remove characters that are invalid in filenames across operating systems.
+ *
+ * Strips characters that are forbidden in Windows filenames and/or could
+ * cause issues on other platforms: \ / * ? : " < > |
+ *
+ * @param string $name The raw string to sanitize (typically a song title)
+ *
+ * @return string The sanitized string with invalid characters removed
+ */
+function sanitizeFilename(string $name): string
+{
+    return trim(preg_replace('/[\\\\\/\*\?:"<>\|]/', '', $name));
+}
+
+
+/**
+ * Convert a string to Title Case, with correct handling of apostrophes.
+ *
+ * PHP's ucwords() and mb_convert_case() don't handle apostrophes correctly
+ * in contractions (e.g. "Don't" becomes "Don'T"). This function uses a
+ * regex to match whole words (including contractions like "don't", "it's",
+ * "o'er") and capitalises each correctly.
+ *
+ * The regex pattern includes Unicode curly/smart apostrophes (\u{2019} and
+ * \u{2018}) because the HTML entity decoder converts &rsquo; to \u{2019}.
+ *
+ * @param string $s The input string
+ *
+ * @return string The Title Cased string
+ */
+function titleCase(string $s): string
+{
+    // Match words including those with apostrophes (straight and curly)
+    // mb_strtolower first, then capitalize each match
+    return preg_replace_callback(
+        "/[a-zA-Z]+(['\x{2019}\x{2018}][a-zA-Z]+)?/u",
+        function (array $m): string {
+            // ucfirst + strtolower handles ASCII; for Unicode we use mb_ functions
+            $word = mb_strtolower($m[0], 'UTF-8');
+            return mb_strtoupper(mb_substr($word, 0, 1, 'UTF-8'), 'UTF-8')
+                 . mb_substr($word, 1, null, 'UTF-8');
+        },
+        $s
+    );
+}
+
+
+/**
+ * Construct the base filename for a song (without file extension).
+ *
+ * Generates a consistent filename from the song's book, number, and title.
+ * The title is sanitized and converted to Title Case. The number is
+ * zero-padded according to the book's configuration (MP=4 digits, CP/JP=3).
+ *
+ * @param int    $number The song number (e.g. 23)
+ * @param string $book   Book identifier key ("mp", "cp", or "jp")
+ * @param string $title  The cleaned song title (book code already removed)
+ *
+ * @return string The base filename, e.g. "0023 (MP) - Amazing Grace"
+ */
+function baseFilename(int $number, string $book, string $title): string
+{
+    global $BOOK_CONFIG;
+    $cfg    = $BOOK_CONFIG[$book];
+    $padded = str_pad((string) $number, $cfg['pad'], '0', STR_PAD_LEFT);
+    $label  = $cfg['label'];
+    return "{$padded} ({$label}) - " . titleCase(sanitizeFilename($title));
+}
+
+
+// =========================================================================
+// File cache and existence checks — for resumable scraping
+// =========================================================================
+
+/**
+ * Build a set of existing filenames in a directory for quick lookup.
+ *
+ * Called once at startup to avoid repeated scandir() calls during
+ * the scrape. Returns an array for O(1) membership testing.
+ *
+ * @param string $outputDir Path to the directory to scan
+ *
+ * @return array<string, true> Associative array of filename => true, or empty array
+ */
+function buildFileCache(string $outputDir): array
+{
+    $cache = [];
+    if (is_dir($outputDir)) {
+        $files = scandir($outputDir);
+        if ($files !== false) {
+            foreach ($files as $f) {
+                if ($f !== '.' && $f !== '..') {
+                    $cache[$f] = true;
+                }
+            }
+        }
+    }
+    return $cache;
+}
+
+
+/**
+ * Check if lyrics for a specific song have already been saved.
+ *
+ * Uses the cached file listing for O(1) lookup instead of checking
+ * the filesystem directly. Matches files by their prefix pattern
+ * (number + label) and .txt extension.
+ *
+ * @param int                  $number    The song number
+ * @param string               $book      Book identifier key
+ * @param array<string, true>  $fileCache Existing filenames from buildFileCache()
+ *
+ * @return bool True if a matching .txt file exists in the cache
+ */
+function alreadySavedLyrics(int $number, string $book, array $fileCache): bool
+{
+    global $BOOK_CONFIG;
+    $cfg    = $BOOK_CONFIG[$book];
+    $padded = str_pad((string) $number, $cfg['pad'], '0', STR_PAD_LEFT);
+    $label  = $cfg['label'];
+    $prefix = "{$padded} ({$label}) -";
+
+    foreach (array_keys($fileCache) as $f) {
+        if (str_starts_with($f, $prefix) && str_ends_with($f, '.txt')) {
+            return true;
+        }
+    }
+    return false;
+}
+
+
+/**
+ * Check if a specific download file (words/music/audio) already exists.
+ *
+ * Words files use the base name directly (base.rtf), while music and
+ * audio files add a type suffix (base_music.pdf, base_audio.mp3).
+ *
+ * @param string               $base      The base filename (from baseFilename())
+ * @param string               $dlType    Download type ("words", "music", or "audio")
+ * @param array<string, true>  $fileCache Existing filenames
+ *
+ * @return bool True if a matching file exists in the cache
+ */
+function alreadySavedDownload(string $base, string $dlType, array $fileCache): bool
+{
+    // Words files: "base.ext", other types: "base_type.ext"
+    $prefix = ($dlType === 'words') ? "{$base}." : "{$base}_{$dlType}.";
+
+    foreach (array_keys($fileCache) as $f) {
+        if (str_starts_with($f, $prefix)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+
+// =========================================================================
+// Format lyrics — the most complex formatting function in the scraper
+// =========================================================================
+
+/**
+ * Format a parsed song into a clean plain-text string for saving.
+ *
+ * This is the most complex formatting function in the scraper because
+ * the source HTML has several structural quirks that need handling:
+ *
+ * 1. STANZA GROUPING: On missionpraise.com, each lyric line is its own <p>
+ *    element, and stanza breaks are represented by empty <p> tags. The
+ *    parser preserves this as empty strings in the verses list, which
+ *    this function uses to group lines into stanzas.
+ *
+ * 2. CHORUS DETECTION: Chorus lines are rendered in italic (<em>/<i>) on
+ *    the site. The parser flags each verse with is_italic=true if it
+ *    contains any italic text. This function prepends "Chorus:" before
+ *    chorus stanzas.
+ *
+ * 3. ATTRIBUTION DETECTION: After the lyrics, songs may have author/composer
+ *    credits like "Words: Stuart Townend" or "Music: Keith Getty". These
+ *    are detected by pattern matching and separated from the lyrics with
+ *    extra blank lines. Requires a colon, "by", or separator after the keyword
+ *    to prevent false positives.
+ *
+ * 4. STANDALONE AUTHOR LINES: Some songs have short attribution lines like
+ *    "Stuart Townend / Keith Getty" that don't follow the "Words:" pattern.
+ *    Detected by heuristics (contains "/" or "&", short, no lyric words).
+ *
+ * 5. MULTI-LINE VERSES: Some verses contain <br> tags (represented as \n
+ *    in the parser output), meaning multiple lines in a single <p>.
+ *    These are treated as complete stanzas on their own.
+ *
+ * @param array  $song Parsed song data with title, verses, copyright, downloads
+ * @param string $book Book identifier key ("mp", "cp", or "jp")
+ *
+ * @return string The formatted plain-text song content
+ */
+function formatLyrics(array $song, string $book): string
+{
+    $title = cleanTitle($song['title'], $book);
+    $lines = ['"' . $title . '"', ''];  // Start with quoted title and blank line
+
+    // --- Stanza/attribution tracking ---
+    $authorLines       = [];     // Accumulated attribution lines
+    $foundAttribution  = false;  // Flag: have we started seeing attribution lines?
+    $stanzaBuf         = [];     // Lines of the current stanza being built
+    $stanzaIsChorus    = false;  // Does the current stanza contain chorus (italic) lines?
+
+    /**
+     * Flush the accumulated stanza to the output lines list.
+     *
+     * If the stanza contains italic lines, prepends "Chorus:" label —
+     * UNLESS the first line starts with a verse number.
+     */
+    $flushStanza = function () use (&$lines, &$stanzaBuf, &$stanzaIsChorus): void {
+        if (empty($stanzaBuf)) {
+            return;
+        }
+        if ($stanzaIsChorus) {
+            $firstLine = trim($stanzaBuf[0]);
+            if (!preg_match('/^\d+\s/', $firstLine)) {
+                $lines[] = 'Chorus:';
+            }
+        }
+        $lines[] = implode("\n", $stanzaBuf);
+        $lines[] = '';  // Blank line between stanzas
+        $stanzaBuf      = [];
+        $stanzaIsChorus = false;
+    };
+
+    // --- Consecutive empty tracking ---
+    // On missionpraise.com, single empty <p> elements appear between EVERY
+    // lyric line for CSS spacing, not just at actual stanza boundaries.
+    $consecutiveEmpties = 0;
+
+    // Process each verse (paragraph) from the parsed HTML
+    foreach ($song['verses'] as [$verseText, $isItalic]) {
+        $stripped = trim($verseText);
+
+        // --- Empty verse: count but don't flush yet ---
+        if ($stripped === '') {
+            $consecutiveEmpties++;
+            continue;
+        }
+
+        // --- Stanza break decision ---
+        if (!empty($stanzaBuf) && $consecutiveEmpties > 0) {
+            $shouldBreak = (
+                $consecutiveEmpties >= 2                             // structural break
+                || ($isItalic !== $stanzaIsChorus)                   // verse<->chorus
+                || (bool) preg_match('/^\d+\s/', $stripped)          // verse number
+            );
+            if ($shouldBreak) {
+                $flushStanza();
+            }
+        }
+        $consecutiveEmpties = 0;
+
+        // --- Attribution line detection ---
+        // Lines starting with "Words:", "Music:", "Arranged:", etc. are
+        // author/composer credits, not lyrics. We require a colon, "by",
+        // or "and" after the keyword to prevent false positives.
+        $isExplicitAttribution = (bool) preg_match(
+            '/^(Words|Music|Arranged|Words and music|Based on|Translated|Paraphrase)\s*[:&\-\/by]/i',
+            $stripped
+        );
+        // Also match bare keywords followed by author names
+        if (!$isExplicitAttribution) {
+            $isExplicitAttribution = (bool) preg_match(
+                '/^(Words and music|Words & music)\b/i',
+                $stripped
+            );
+        }
+        $isAttribution = (
+            $isExplicitAttribution
+            || ($foundAttribution
+                && !str_contains($stripped, "\n")
+                && !preg_match('/^\d+\s/', $stripped)   // Don't swallow numbered verses
+                && mb_strlen($stripped) < 120)           // Don't swallow long lyric lines
+        );
+        if ($isAttribution) {
+            $flushStanza();
+            $foundAttribution = true;
+            $authorLines[] = $stripped;
+            continue;
+        }
+
+        // If we see a normal lyric line after attribution, reset the cascade.
+        if ($foundAttribution && preg_match('/^\d+\s/', $stripped)) {
+            $foundAttribution = false;
+        }
+
+        // --- Standalone author lines ---
+        // Some attribution lines don't follow the "Words:" pattern but are
+        // recognisable as author names by containing "/" or "&" separators.
+        if (!str_contains($stripped, "\n")
+            && !preg_match('/^\d/', $stripped)
+            && (str_contains($stripped, '/') || str_contains($stripped, '&'))
+            && mb_strlen($stripped) < 120
+            && !preg_match('/\b(the|and|you|your|my|our|lord|god|love|sing|praise)\b/i', $stripped)
+        ) {
+            $flushStanza();
+            $authorLines[] = $stripped;
+            continue;
+        }
+
+        // --- Multi-line verse ---
+        // If the verse text contains "\n" (from <br> tags in the HTML),
+        // it's a multi-line verse that should be treated as its own stanza.
+        if (str_contains($stripped, "\n")) {
+            $flushStanza();
+            // Clean up each line within the verse (strip whitespace)
+            $cleanedLines = array_map('trim', explode("\n", $stripped));
+            $cleaned = implode("\n", $cleanedLines);
+            if ($isItalic) {
+                $firstLine = trim($cleanedLines[0]);
+                if (!preg_match('/^\d+\s/', $firstLine)) {
+                    $lines[] = 'Chorus:';
+                }
+            }
+            $lines[] = $cleaned;
+            $lines[] = '';  // Blank line after the stanza
+        } else {
+            // --- Single-line verse ---
+            if ($isItalic) {
+                $stanzaIsChorus = true;
+            }
+            $stanzaBuf[] = $stripped;
+        }
+    }
+
+    // Flush any remaining stanza
+    $flushStanza();
+
+    // Remove trailing blank lines from the lyrics section
+    while (!empty($lines) && $lines[count($lines) - 1] === '') {
+        array_pop($lines);
+    }
+
+    // Append author attribution lines (separated from lyrics by double blank line)
+    if (!empty($authorLines)) {
+        $lines[] = '';   // First blank line
+        $lines[] = '';   // Second blank line (visual separation)
+        foreach ($authorLines as $al) {
+            $lines[] = $al;
+        }
+    }
+
+    // Append copyright notice if available
+    if (!empty($song['copyright'])) {
+        $lines[] = '';
+        $lines[] = $song['copyright'];
+    }
+
+    // --- Post-processing: normalise spaced ellipses ---
+    // WordPress's text rendering sometimes converts "..." to ". . ." with
+    // spaces between the dots. We normalise these back to standard "..."
+    $result = implode("\n", $lines);
+    $result = preg_replace('/ ?(?:\. ){2,}\./', '...', $result);
+
+    return $result;
+}
+
+
+// =========================================================================
+// Save lyrics & download files
+// =========================================================================
+
+/**
+ * Format and save a song's lyrics to a plain-text file.
+ *
+ * Creates the output directory if needed, generates the filename,
+ * formats the lyrics, and writes the file.
+ *
+ * @param array  $song      Parsed song data with title, verses, copyright
+ * @param int    $number    The song number (e.g. 23)
+ * @param string $book      Book identifier key ("mp", "cp", or "jp")
+ * @param string $outputDir Directory to save the file in
+ *
+ * @return string The base filename (without extension) — for download reuse
+ */
+function saveLyrics(array $song, int $number, string $book, string $outputDir): string
+{
+    if (!is_dir($outputDir)) {
+        mkdir($outputDir, 0755, true);
+    }
+    $title    = cleanTitle($song['title'], $book);
+    $base     = baseFilename($number, $book, $title);
+    $filepath = $outputDir . DIRECTORY_SEPARATOR . $base . '.txt';
+    file_put_contents($filepath, formatLyrics($song, $book), LOCK_EX);
+    return $base;
+}
+
+
+/**
+ * Save a downloaded binary file (words, music, or audio) to disk.
+ *
+ * Naming convention:
+ * - Words (primary):  {base}.rtf       (same name as lyrics, different ext)
+ * - Music:            {base}_music.pdf  (suffix distinguishes from words)
+ * - Audio:            {base}_audio.mp3  (suffix distinguishes from words)
+ *
+ * @param string $data        Raw bytes of the downloaded file
+ * @param string $base        Base filename (from baseFilename())
+ * @param string $dlType      Download type ("words", "music", or "audio")
+ * @param string $contentType MIME type from the Content-Type header
+ * @param string $dlUrl       The download URL (for extension guessing fallback)
+ * @param string $outputDir   Directory to save the file in
+ *
+ * @return string The complete filename (with extension) that was saved
+ */
+function saveDownload(string $data, string $base, string $dlType, string $contentType, string $dlUrl, string $outputDir): string
+{
+    $ext = extForDownload($contentType, $dlUrl, $data);
+
+    // Words files share the same base name as lyrics (just different extension):
+    //   "0023 (MP) - Amazing Grace.rtf"
+    // Music and audio files add a type suffix:
+    //   "0023 (MP) - Amazing Grace_music.pdf"
+    //   "0023 (MP) - Amazing Grace_audio.mp3"
+    if ($dlType === 'words') {
+        $filename = $base . $ext;
+    } else {
+        $filename = $base . "_{$dlType}" . $ext;
+    }
+
+    $filepath = $outputDir . DIRECTORY_SEPARATOR . $filename;
+    file_put_contents($filepath, $data, LOCK_EX);
+    return $filename;
+}
+
+
+// =========================================================================
+// Skip logging and diagnostic HTML dumps
+// =========================================================================
+
+/**
+ * Record a skipped song in the skipped.log file for later review.
+ *
+ * Creates a persistent log of songs that couldn't be scraped, with
+ * timestamps, identifiers, and reasons. Useful for identifying gaps
+ * and diagnosing systematic issues.
+ *
+ * @param string $outputDir Directory to write the log file in
+ * @param string $label     Book label (e.g. "MP")
+ * @param string $padded    Zero-padded song number string (e.g. "0023")
+ * @param string $title     The song title from the index page
+ * @param string $url       The song page URL that was attempted
+ * @param string $reason    Human-readable explanation of why it was skipped
+ *
+ * @return void
+ */
+function logSkip(string $outputDir, string $label, string $padded, string $title, string $url, string $reason): void
+{
+    if (!is_dir($outputDir)) {
+        mkdir($outputDir, 0755, true);
+    }
+    $logPath   = $outputDir . DIRECTORY_SEPARATOR . 'skipped.log';
+    $timestamp = date('Y-m-d H:i:s');
+    $entry     = "[{$timestamp}]  {$label}{$padded}  {$title}  —  {$reason}  —  {$url}\n";
+    file_put_contents($logPath, $entry, FILE_APPEND | LOCK_EX);
+}
+
+
+/**
+ * Write a diagnostic HTML dump for a skipped song so the raw server
+ * response can be inspected to determine why the scrape failed.
+ *
+ * @param string      $bookDir  Output directory for the book
+ * @param string      $label    Book label (e.g. "JP")
+ * @param string      $padded   Zero-padded song number
+ * @param string      $title    Song title from the index page
+ * @param string      $url      The song page URL
+ * @param string      $reason   Why the song was skipped
+ * @param string|null $htmlText Raw HTML response (may be null for empty responses)
+ *
+ * @return void
+ */
+function dumpSkipHtml(string $bookDir, string $label, string $padded, string $title, string $url, string $reason, ?string $htmlText): void
+{
+    global $DEBUG;
+
+    try {
+        if (!is_dir($bookDir)) {
+            mkdir($bookDir, 0755, true);
+        }
+        $diagPath = $bookDir . DIRECTORY_SEPARATOR . "_debug_{$label}{$padded}_skipped.html";
+        $htmlLen  = ($htmlText !== null) ? strlen($htmlText) : 0;
+
+        $content  = "<!-- SKIPPED: {$label}{$padded} -->\n";
+        $content .= "<!-- Song: {$title} -->\n";
+        $content .= "<!-- URL: {$url} -->\n";
+        $content .= "<!-- Reason: {$reason} -->\n";
+        $content .= "<!-- HTML length: {$htmlLen} -->\n\n";
+        if ($htmlText !== null) {
+            $content .= $htmlText;
+        } else {
+            $content .= "<!-- (no HTML received — empty/null response) -->\n";
+        }
+
+        file_put_contents($diagPath, $content, LOCK_EX);
+        echo " [diag: {$diagPath}]";
+    } catch (\Throwable $e) {
+        if ($DEBUG) {
+            echo " [skip diag failed: " . $e->getMessage() . "]";
+        }
+    }
+}
+
+
+// =========================================================================
+// Process a single song — orchestrates scraping + downloading for one song
+// =========================================================================
+
+/**
+ * Scrape lyrics and download files for a single song.
+ *
+ * This is the core function that handles one song from start to finish:
+ * 1. Extract the song number from the index title
+ * 2. Check if lyrics/downloads already exist (skip if so)
+ * 3. Fetch the song detail page
+ * 4. Parse the HTML to extract lyrics, copyright, and download links
+ * 5. Save the lyrics as a .txt file
+ * 6. Download and save words/music/audio files (if enabled)
+ *
+ * The function handles several edge cases:
+ * - Songs with no extractable number (logged and skipped)
+ * - Login walls (the session expired mid-scrape)
+ * - WAF blocks on individual song pages
+ * - Failed title parsing (retried once in case of transient errors)
+ * - Missing downloads (re-fetches the page if lyrics exist but files don't)
+ *
+ * @param \CurlHandle         $ch        cURL handle with active login session
+ * @param string               $title     Song title from the index page (includes book code)
+ * @param string               $url       URL of the song detail page
+ * @param string               $book      Book identifier key ("mp", "cp", or "jp")
+ * @param string               $outputDir Base output directory
+ * @param bool                 $noFiles   If true, skip downloading words/music/audio files
+ * @param float                $delay     Seconds to wait between requests
+ * @param array<string, true>  &$fileCache Mutable array of existing filenames (updated when new files saved)
+ * @param array                $argv      Command-line arguments (for --song detection)
+ *
+ * @return string "saved" if lyrics were newly saved,
+ *                "skipped" if the song couldn't be scraped,
+ *                "exists" if the song was already saved from a previous run
+ */
+function processSong(\CurlHandle $ch, string $title, string $url, string $book, string $outputDir, bool $noFiles, float $delay, array &$fileCache, array $argv): string
+{
+    global $BOOK_CONFIG, $DEBUG;
+
+    // Extract the hymn number from the title (e.g. "Amazing Grace (MP0023)" -> 23)
+    $number = extractNumber($title, $book);
+    $cfg    = $BOOK_CONFIG[$book];
+
+    // Route output into a book-specific subdirectory
+    $bookDir = $outputDir . DIRECTORY_SEPARATOR . $cfg['subdir'];
+
+    if ($number === null) {
+        logSkip($bookDir, '??', '????', $title, $url, 'no book number found in title');
+        return 'skipped';
+    }
+
+    $padded = str_pad((string) $number, $cfg['pad'], '0', STR_PAD_LEFT);
+    $label  = $cfg['label'];
+
+    // --- Check if lyrics already exist ---
+    $lyricsExist = alreadySavedLyrics($number, $book, $fileCache);
+
+    // If lyrics exist and we don't need files, skip entirely (no network request)
+    if ($lyricsExist && $noFiles) {
+        return 'exists';
+    }
+
+    // If lyrics exist, check whether downloads also exist
+    if ($lyricsExist) {
+        $clean = cleanTitle($title, $book);
+        $base  = baseFilename($number, $book, $clean);
+        // Look for any non-txt file with the same base name
+        $hasAnyDownload = false;
+        foreach (array_keys($fileCache) as $f) {
+            if (!str_ends_with($f, '.txt') && (str_starts_with($f, "{$base}.") || str_starts_with($f, "{$base}_"))) {
+                $hasAnyDownload = true;
+                break;
+            }
+        }
+        if ($noFiles || $hasAnyDownload) {
+            return 'exists';
+        }
+        // Lyrics exist but no downloads — need to fetch page for download links
+        $titleTrunc = mb_substr($title, 0, 55);
+        echo "    {$label}{$padded}  " . str_pad($titleTrunc, 55) . " ";
+        echo "[re-fetch] fetching missing downloads... ";
+    } else {
+        // Neither lyrics nor files exist — full scrape needed
+        $titleTrunc = mb_substr($title, 0, 55);
+        echo "    {$label}{$padded}  " . str_pad($titleTrunc, 55) . " ";
+    }
+
+    // --- Fetch the song detail page ---
+    [$htmlText, ] = fetchText($ch, $url);
+
+    // Check for login wall (session may have expired during the scrape)
+    if ($htmlText === null || str_contains($htmlText, 'Please login to continue') || str_contains($htmlText ?? '', 'loginform')) {
+        $reason = ($htmlText === null) ? 'empty response' : 'login wall';
+        echo "FAIL ({$reason})\n";
+        logSkip($bookDir, $label, $padded, $title, $url, $reason);
+        dumpSkipHtml($bookDir, $label, $padded, $title, $url, $reason, $htmlText);
+        usleep((int) ($delay * 1000000));
+        return 'skipped';
+    }
+
+    // Check for subscription paywall (song not included in user's plan)
+    if (str_contains($htmlText, 'not part of your subscription')) {
+        echo "FAIL (not in subscription)\n";
+        logSkip($bookDir, $label, $padded, $title, $url, 'song not part of subscription');
+        dumpSkipHtml($bookDir, $label, $padded, $title, $url, 'not in subscription', $htmlText);
+        usleep((int) ($delay * 1000000));
+        return 'skipped';
+    }
+
+    // Check for WAF block on the song page
+    $htmlLower = strtolower($htmlText);
+    if (str_contains($htmlLower, 'sucuri') || str_contains($htmlLower, 'access denied')) {
+        echo "FAIL (blocked by firewall)\n";
+        logSkip($bookDir, $label, $padded, $title, $url, 'blocked by WAF/firewall');
+        dumpSkipHtml($bookDir, $label, $padded, $title, $url, 'blocked by WAF/firewall', $htmlText);
+        usleep((int) ($delay * 1000000));
+        return 'skipped';
+    }
+
+    // --- Parse the song page HTML ---
+    $sp = parseSong($htmlText);
+
+    // If the parser couldn't find a title, retry once — transient issue
+    if ($sp['title'] === '') {
+        usleep((int) ($delay * 2 * 1000000));
+        [$htmlText2, ] = fetchText($ch, $url);
+        if ($htmlText2 !== null && !str_contains($htmlText2, 'loginform')) {
+            $sp = parseSong($htmlText2);
+            $htmlText = $htmlText2;
+        }
+    }
+
+    // If still no title from entry-title class, try fallbacks:
+    // 1. Extract from the HTML <title> tag (strip " – Mission Praise" suffix)
+    if ($sp['title'] === '' && $htmlText !== null) {
+        if (preg_match('/<title>([^<]+)<\/title>/i', $htmlText, $titleTagMatch)) {
+            $rawTitle = html_entity_decode($titleTagMatch[1], ENT_QUOTES | ENT_HTML5, 'UTF-8');
+            // Strip the site name suffix (e.g. " – Mission Praise" or " - Mission Praise")
+            $rawTitle = preg_replace('/\s*[\x{2013}\x{2014}\-]\s*Mission Praise\s*$/u', '', $rawTitle);
+            $rawTitle = trim($rawTitle);
+            if ($rawTitle !== '') {
+                $sp['title'] = $rawTitle;
+                echo "(title from <title> tag) ";
+            }
+        }
+    }
+
+    // 2. Final fallback: use the title from the index page
+    if ($sp['title'] === '') {
+        $fallbackTitle = preg_replace('/\s*\([A-Z]+\d+\)\s*$/', '', $title);
+        $fallbackTitle = trim($fallbackTitle);
+        if ($fallbackTitle !== '') {
+            $sp['title'] = $fallbackTitle;
+            echo "(title from index) ";
+        }
+    }
+
+    // If still no title after all fallbacks, skip this song
+    if ($sp['title'] === '') {
+        echo "FAIL (no title parsed)\n";
+        logSkip($bookDir, $label, $padded, $title, $url, 'parser found no title in page HTML');
+        dumpSkipHtml($bookDir, $label, $padded, $title, $url, 'no title parsed', $htmlText);
+        usleep((int) ($delay * 1000000));
+        return 'skipped';
+    }
+
+    // Build the structured song data array
+    $song = [
+        'title'     => $sp['title'],
+        'verses'    => $sp['verses'],
+        'copyright' => trim($sp['copyright']),
+        'downloads' => $sp['downloads'],
+    ];
+
+    // --- Verse count validation ---
+    // Count actual text lines (not <p> entries) to detect incomplete parses.
+    $totalLines = 0;
+    foreach ($sp['verses'] as [$v, ]) {
+        $v = trim($v);
+        if ($v !== '') {
+            $totalLines += substr_count($v, "\n") + 1;
+        }
+    }
+
+    if ($totalLines === 0) {
+        echo "WARN (no lyrics found) ";
+        logSkip($bookDir, $label, $padded, $title, $url,
+            'parser found title but 0 lyric lines — possible HTML structure change');
+    } elseif ($totalLines < 4) {
+        echo "WARN ({$totalLines} lines — may be incomplete) ";
+    }
+
+    if ($DEBUG && !empty($sp['verses'])) {
+        $nonEmptyEntries = 0;
+        foreach ($sp['verses'] as [$v, ]) {
+            if (trim($v) !== '') {
+                $nonEmptyEntries++;
+            }
+        }
+        echo "\n  DEBUG: " . count($sp['verses']) . " raw verse entries, "
+            . "{$nonEmptyEntries} non-empty, {$totalLines} text lines\n";
+    }
+
+    // --- HTML diagnostic dump for incomplete songs ---
+    $isSingleSong = in_array('--song', $argv, true);
+    if (($totalLines < 8 || $isSingleSong) && $htmlText !== null) {
+        $diagPath = $bookDir . DIRECTORY_SEPARATOR . "_debug_{$label}{$padded}_raw.html";
+        try {
+            if (!is_dir($bookDir)) {
+                mkdir($bookDir, 0755, true);
+            }
+            // Extract the song-details section via regex as a diagnostic cross-check.
+            // Match both <div> and <section> tags.
+            $sdMatch = null;
+            if (preg_match(
+                '/<(?:div|section)[^>]+class=["\'][^"\']*song-details[^"\']*["\'][^>]*>'
+                . '([\s\S]*?)'
+                . '(?=<[^>]+class=["\'][^"\']*(?:copyright-info|col-sm-4|files))/i',
+                $htmlText, $sdRegex
+            )) {
+                $sdMatch = $sdRegex[0];
+            } else {
+                // Fallback: simpler regex
+                if (preg_match(
+                    '/<(?:div|section)[^>]+class=["\'][^"\']*song-details[^"\']*["\'][^>]*>'
+                    . '([\s\S]*?)<\/(?:div|section)>/i',
+                    $htmlText, $sdRegex
+                )) {
+                    $sdMatch = $sdRegex[0];
+                }
+            }
+
+            $diagContent  = "<!-- Song: {$title} -->\n";
+            $diagContent .= "<!-- URL: {$url} -->\n";
+            $diagContent .= "<!-- Parser found {$totalLines} text lines, "
+                          . count($sp['verses']) . " verse entries -->\n\n";
+            if ($sdMatch !== null) {
+                $diagContent .= "<!-- === song-details content (regex extract) === -->\n";
+                $diagContent .= $sdMatch . "\n\n";
+                $pCount = preg_match_all('/<p[^>]*>/i', $sdMatch);
+                $diagContent .= "<!-- Regex found {$pCount} <p> tags in song-details -->\n\n";
+            } else {
+                $diagContent .= "<!-- WARNING: regex could NOT find song-details div! -->\n\n";
+            }
+            $diagContent .= "<!-- === Raw verse entries from parser === -->\n";
+            foreach ($sp['verses'] as $idx => [$v, $it]) {
+                $vRepr = addslashes(mb_substr($v, 0, 200));
+                $itStr = $it ? 'true' : 'false';
+                $diagContent .= "<!-- Verse[{$idx}] italic={$itStr}: \"{$vRepr}\" -->\n";
+            }
+            $diagContent .= "\n<!-- === Full page HTML (" . strlen($htmlText) . " chars) === -->\n";
+            $diagContent .= $htmlText;
+
+            file_put_contents($diagPath, $diagContent, LOCK_EX);
+            echo "[diag: {$diagPath}] ";
+        } catch (\Throwable $e) {
+            echo "[diag write failed: " . $e->getMessage() . "] ";
+        }
+    }
+
+    // --- Save lyrics ---
+    if ($lyricsExist) {
+        // Lyrics already saved — just re-derive the base name for download files
+        $base = baseFilename($number, $book, cleanTitle($sp['title'], $book));
+    } elseif ($totalLines === 0) {
+        // No actual lyrics content — don't save an empty lyrics file
+        echo "WARN (empty — lyrics file not saved) ";
+        $base = baseFilename($number, $book, cleanTitle($sp['title'], $book));
+        logSkip($bookDir, $label, $padded, $title, $url,
+            'no lyrics content on page — only title/attribution');
+    } else {
+        // Save lyrics to .txt file and add to the file cache
+        $base = saveLyrics($song, $number, $book, $bookDir);
+        $fileCache[$base . '.txt'] = true;
+    }
+
+    // --- Download files (words, music, audio) ---
+    $fileResults = [];  // Track download results for the status line
+    if (!$noFiles && !empty($song['downloads'])) {
+        foreach (['words', 'music', 'audio'] as $dlType) {
+            $dlUrl = $song['downloads'][$dlType] ?? null;
+            if ($dlUrl === null) {
+                continue;  // This download type isn't available for this song
+            }
+
+            // Skip if already downloaded
+            if (alreadySavedDownload($base, $dlType, $fileCache)) {
+                $fileResults[] = strtolower($dlType[0]);  // Lowercase = already existed
+                continue;
+            }
+
+            // Convert relative URLs to absolute
+            if (str_starts_with($dlUrl, '/')) {
+                $dlUrl = BASE . $dlUrl;
+            }
+
+            // Download the file
+            [$data, $ct, $finalUrl] = fetchBinary($ch, $dlUrl);
+            if ($data !== null) {
+                $fname = saveDownload($data, $base, $dlType, $ct, $finalUrl ?? $dlUrl, $bookDir);
+                $fileResults[] = strtoupper($dlType[0]);  // Uppercase = newly downloaded
+                $fileCache[$fname] = true;  // Add to cache
+            }
+
+            // Brief delay between downloads (30% of normal delay)
+            usleep((int) ($delay * 0.3 * 1000000));
+        }
+    }
+
+    // Print the status line with download indicators:
+    // [W,M,A] = newly downloaded words/music/audio (uppercase)
+    // [w,m,a] = already existed (lowercase)
+    $fileStr = !empty($fileResults) ? ' [' . implode(',', $fileResults) . ']' : '';
+    echo "OK{$fileStr}\n";
+    usleep((int) ($delay * 1000000));  // Rate limit between songs
+    return 'saved';
+}
+
+
+// =========================================================================
+// Crawl & scrape — paginated index crawling with per-page song processing
+// =========================================================================
+
+/**
+ * Crawl the paginated song index and scrape each discovered song.
+ *
+ * The missionpraise.com song index is paginated (10 songs per page).
+ * This function:
+ * 1. Fetches each index page sequentially
+ * 2. Parses the page to discover song links
+ * 3. Filters songs to only the requested books (MP, CP, JP)
+ * 4. Scrapes each song on the current page before moving to the next
+ *
+ * End-of-index detection:
+ * - "Page not found" in the response
+ * - WordPress serving page 1 content for out-of-range page numbers
+ * - No song links found on the page
+ * - Empty response
+ *
+ * @param \CurlHandle $ch         cURL handle with active login session
+ * @param array       $books      List of book keys to scrape (e.g. ["mp", "cp", "jp"])
+ * @param string      $outputDir  Base output directory
+ * @param bool        $noFiles    If true, skip file downloads
+ * @param int         $startPage  Index page number to start from (default: 1)
+ * @param float       $delay      Seconds between requests
+ * @param bool        $force      If true, re-download and overwrite existing files
+ * @param int|null    $songNumber If set, only scrape this specific song number
+ * @param array       $argv       Command-line arguments (for --song detection)
+ *
+ * @return array{0: int, 1: int, 2: int} Tuple of (saved, skipped, existed)
+ */
+function crawlAndScrape(\CurlHandle $ch, array $books, string $outputDir, bool $noFiles, int $startPage, float $delay, bool $force, ?int $songNumber, array $argv): array
+{
+    global $BOOK_CONFIG, $DEBUG;
+
+    $page = $startPage;
+
+    // Build a combined file cache from all book subdirectories.
+    // When --force is set, skip the cache entirely so everything is re-downloaded.
+    $fileCache = [];
+    if (!$force) {
+        foreach ($books as $b) {
+            $subdir = $outputDir . DIRECTORY_SEPARATOR . $BOOK_CONFIG[$b]['subdir'];
+            $fileCache = array_merge($fileCache, buildFileCache($subdir));
+        }
+    }
+
+    // Counters for the final summary
+    $saved   = 0;
+    $skipped = 0;
+    $existed = 0;
+
+    if ($songNumber !== null) {
+        echo "  Single-song mode: looking for song #{$songNumber}\n\n";
+        $force = true;  // Always re-download in single-song mode
+    }
+    if ($force) {
+        echo "  Force mode: will re-download and overwrite existing files.\n\n";
+    } elseif (!empty($fileCache)) {
+        echo "  Found " . count($fileCache) . " existing files across output folders — will skip duplicates.\n\n";
+    }
+
+    // --- Main pagination loop ---
+    while (true) {
+        // Construct the URL for the current index page
+        $url = INDEX_URL . $page . '/';
+        [$htmlText, ] = fetchText($ch, $url);
+
+        // Detect end of pagination
+        if ($htmlText === null || str_contains($htmlText, 'Page not found')) {
+            if ($DEBUG) {
+                $reason = ($htmlText === null) ? 'empty response' : 'Page not found detected';
+                echo "  DEBUG: Page {$page} — {$reason}\n";
+            }
+            break;
+        }
+
+        // Dump the first page's HTML for debugging (only on startPage)
+        if ($page === $startPage) {
+            debugDump("Index page {$page} HTML", $htmlText);
+        }
+
+        // --- Loop detection ---
+        // WordPress has a quirk where out-of-range page numbers silently serve
+        // page 1 content. We detect this by parsing the "Showing X-Y of Z" counter.
+        $countMatch = null;
+        if (preg_match('/(\d+)-(\d+)\s+of\s+(\d+)/', $htmlText, $countMatch)) {
+            $lo    = (int) $countMatch[1];
+            $hi    = (int) $countMatch[2];
+            $total = (int) $countMatch[3];
+            $totalPages = (int) ceil($total / 10);
+
+            if ($page === $startPage) {
+                echo "  {$total} total songs across ~{$totalPages} pages\n\n";
+            }
+
+            // Detect loops: lo > hi (impossible) or past page 1 seeing results from 1
+            if ($lo > $hi || ($page > 1 && $lo === 1)) {
+                break;
+            }
+        } else {
+            // No counter found — if past page 1, assume end of pagination
+            if ($page > 1) {
+                break;
+            }
+        }
+
+        // --- Parse the index page for song links ---
+        $pageSongsRaw = parseIndex($htmlText);
+
+        if (empty($pageSongsRaw)) {
+            if ($DEBUG) {
+                echo "  DEBUG: parseIndex found 0 song links on page {$page}\n";
+                // Debug: count <a> links with /songs/ for diagnostics
+                preg_match_all('/<a[^>]+href=["\']([^"\']*)["\'][^>]*>/i', $htmlText, $allLinks);
+                $songLinks = array_filter($allLinks[1] ?? [], function (string $l): bool {
+                    return str_contains($l, '/songs/');
+                });
+                echo "  DEBUG: Total <a> links: " . count($allLinks[1] ?? []) . ", with /songs/: " . count($songLinks) . "\n";
+            }
+            break;
+        }
+
+        // --- Filter songs to requested books ---
+        $pageSongs = [];
+        foreach ($pageSongsRaw as [$songTitle, $songUrl]) {
+            foreach ($books as $bookKey) {
+                if (preg_match($BOOK_CONFIG[$bookKey]['pattern'], $songTitle)) {
+                    // If --song was specified, filter to only that song number
+                    if ($songNumber !== null) {
+                        $num = extractNumber($songTitle, $bookKey);
+                        if ($num !== $songNumber) {
+                            break;  // Skip — wrong number
+                        }
+                    }
+                    $pageSongs[] = [$songTitle, $songUrl, $bookKey];
+                    break;  // A song belongs to exactly one book
+                }
+            }
+        }
+
+        // Print page summary with running totals
+        if ($songNumber === null) {
+            echo "  Page " . str_pad((string) $page, 4, ' ', STR_PAD_LEFT) . "  —  "
+                . count($pageSongs) . " matching songs  "
+                . "(saved: {$saved}, existed: {$existed}, skipped: {$skipped})\n";
+        }
+
+        // --- Scrape each song on this page ---
+        $pageExisted = 0;
+        foreach ($pageSongs as [$songTitle, $songUrl, $bookKey]) {
+            // Convert relative URLs to absolute
+            if (str_starts_with($songUrl, '/')) {
+                $songUrl = BASE . $songUrl;
+            }
+
+            $result = processSong($ch, $songTitle, $songUrl, $bookKey, $outputDir, $noFiles, $delay, $fileCache, $argv);
+            if ($result === 'saved') {
+                $saved++;
+            } elseif ($result === 'skipped') {
+                $skipped++;
+            } elseif ($result === 'exists') {
+                $existed++;
+                $pageExisted++;
+            }
+        }
+
+        // If --song was specified and we found it, stop immediately
+        if ($songNumber !== null && ($saved + $skipped) > 0) {
+            break;
+        }
+
+        // If every song on this page already existed, print a compact summary
+        if ($pageExisted === count($pageSongs) && !empty($pageSongs) && $songNumber === null) {
+            echo "           >>  all {$pageExisted} songs on this page already exist\n";
+        }
+
+        $page++;
+        usleep((int) ($delay * 1000000));  // Rate limit between index pages
+    }
+
+    // If --song was specified but never found, warn the user
+    if ($songNumber !== null && $saved === 0 && $skipped === 0) {
+        echo "\n  WARN: Song #{$songNumber} was not found in the index for books: " . implode(', ', $books) . "\n";
+    }
+
+    return [$saved, $skipped, $existed];
+}
+
+
+// =========================================================================
+// CLI argument parsing — mimics Python's argparse for PHP CLI scripts
+// =========================================================================
+
+/**
+ * Parse command-line arguments into an associative array.
+ *
+ * Supports the same argument style as the Python version:
+ *   --username VALUE    Named argument with value
+ *   --no-files          Boolean flag (no value)
+ *   --debug             Boolean flag
+ *   -?                  Alias for --help
+ *
+ * @param array $argv The raw $argv array from PHP
+ *
+ * @return array Parsed arguments as key => value pairs
+ */
+function parseArgs(array $argv): array
+{
+    // Default values matching the Python version
+    $args = [
+        'username'   => null,
+        'password'   => null,
+        'output'     => DEFAULT_OUT,
+        'books'      => 'mp,cp,jp',
+        'start-page' => 1,
+        'delay'      => DEFAULT_DELAY,
+        'song'       => null,
+        'no-files'   => false,
+        'debug'      => false,
+        'force'      => false,
+    ];
+
+    // Support -? as an alias for --help
+    if (in_array('-?', $argv, true) || in_array('--help', $argv, true) || in_array('-h', $argv, true)) {
+        printUsage();
+        exit(0);
+    }
+
+    $i = 1;  // Skip argv[0] (the script name)
+    $count = count($argv);
+    while ($i < $count) {
+        $arg = $argv[$i];
+
+        switch ($arg) {
+            case '--username':
+                $args['username'] = $argv[++$i] ?? null;
+                break;
+            case '--password':
+                $args['password'] = $argv[++$i] ?? null;
+                break;
+            case '--output':
+                $args['output'] = $argv[++$i] ?? DEFAULT_OUT;
+                break;
+            case '--books':
+                $args['books'] = $argv[++$i] ?? 'mp,cp,jp';
+                break;
+            case '--start-page':
+                $args['start-page'] = (int) ($argv[++$i] ?? 1);
+                break;
+            case '--delay':
+                $args['delay'] = (float) ($argv[++$i] ?? DEFAULT_DELAY);
+                break;
+            case '--song':
+                $args['song'] = (int) ($argv[++$i] ?? 0);
+                break;
+            case '--no-files':
+                $args['no-files'] = true;
+                break;
+            case '--debug':
+                $args['debug'] = true;
+                break;
+            case '--force':
+                $args['force'] = true;
+                break;
+            default:
+                echo "Unknown argument: {$arg}\n";
+                echo "Use --help or -? for usage information.\n";
+                exit(1);
+        }
+
+        $i++;
+    }
+
+    return $args;
+}
+
+
+/**
+ * Print usage information and examples.
+ *
+ * Mimics the Python argparse --help output with description, arguments,
+ * examples, and notes sections.
+ *
+ * @return void
+ */
+function printUsage(): void
+{
+    $script = basename(__FILE__);
+
+    echo <<<USAGE
+Mission Praise scraper — MP, CP, JP + file downloads
+
+Usage:
+  php {$script} --username EMAIL --password PASS [options]
+
+Options:
+  --username EMAIL    missionpraise.com login email (prompted interactively if omitted)
+  --password PASS     missionpraise.com password (prompted with hidden input if omitted)
+  --output DIR        output folder path (default: ./hymns)
+  --books BOOKS       comma-separated books to scrape: mp, cp, jp (default: mp,cp,jp)
+  --start-page N      index page number to start from, for resuming (default: 1)
+  --delay SECS        seconds to wait between HTTP requests (default: 1.2)
+  --song NUM          scrape only this song number (e.g. --song 584 --books jp)
+  --no-files          skip downloading words/music/audio files (lyrics only)
+  --debug             dump full HTML responses to terminal for troubleshooting
+  --force             force re-download of all songs, even if files already exist
+  --help, -?, -h      show this help message
+
+Examples:
+  php {$script} --username you@email.com --password secret
+                                           Scrape all books (MP, CP, JP)
+  php {$script} --username you@email.com --password secret --books mp
+                                           Scrape only Mission Praise
+  php {$script} --username you@email.com --password secret --books mp,cp
+                                           Scrape Mission Praise + Carol Praise
+  php {$script} --username you@email.com --password secret --no-files
+                                           Scrape lyrics only (skip downloads)
+  php {$script} --username you@email.com --password secret --start-page 5
+                                           Resume from index page 5
+  php {$script} --username you@email.com --password secret --output ~/hymns
+                                           Save to a custom output folder
+  php {$script} --username you@email.com --password secret --song 584
+                                           Scrape only song number 584
+  php {$script} --username you@email.com --password secret --debug
+                                           Dump HTML responses for debugging
+
+Output:
+  Lyrics are saved as plain text in book-specific subdirectories:
+    hymns/Mission Praise [MP]/0001 (MP) - Abba Father.txt
+    hymns/Carol Praise [CP]/001 (CP) - A Great And Mighty Wonder.txt
+    hymns/Junior Praise [JP]/001 (JP) - A Boy Gave To Jesus.txt
+
+  Download files use the same base name with type suffixes:
+    0001 (MP) - Abba Father.rtf            (words document)
+    0001 (MP) - Abba Father_music.pdf      (sheet music)
+    0001 (MP) - Abba Father_audio.mp3      (audio recording)
+
+  The scraper is resumable — existing files are detected and skipped.
+  Skipped songs are logged to skipped.log in each book's output folder.
+
+Authentication:
+  A valid missionpraise.com subscription is required. Credentials can be
+  provided via --username/--password flags, or entered interactively at
+  the prompt (password input is hidden). The site may be protected by a
+  Sucuri WAF — if blocked, try logging in via a browser first.
+
+Notes:
+  - No Composer dependencies — uses only PHP built-in extensions (cURL).
+  - The scraper crawls the paginated song index (10 songs per page).
+  - Downloads include words (RTF/DOC), music (PDF), and audio (MP3/MIDI).
+  - Use --no-files to skip downloads and only scrape lyrics text.
+
+USAGE;
+}
+
+
+/**
+ * Prompt for hidden password input on CLI (hides characters while typing).
+ *
+ * Uses stty on Unix/macOS to disable echo, or falls back to visible input
+ * if stty is not available (e.g. Windows without specific extensions).
+ *
+ * @param string $prompt The prompt text to display
+ *
+ * @return string The entered password
+ */
+function promptPassword(string $prompt = 'Password: '): string
+{
+    // Check if we're on a system that supports stty (Unix/macOS)
+    if (str_contains(PHP_OS, 'WIN')) {
+        // Windows: no easy way to hide input without extensions
+        echo $prompt;
+        return trim(fgets(STDIN));
+    }
+
+    // Unix/macOS: use stty to disable terminal echo
+    echo $prompt;
+    system('stty -echo');
+    $password = trim(fgets(STDIN));
+    system('stty echo');
+    echo "\n";  // Print newline since the user's Enter wasn't echoed
+
+    return $password;
+}
+
+
+// =========================================================================
+// Main — CLI entry point
+// =========================================================================
+
+/**
+ * Parse command-line arguments, authenticate, and start the scrape.
+ *
+ * Handles the full lifecycle:
+ * 1. Parse CLI arguments (or prompt for missing credentials)
+ * 2. Validate the requested books
+ * 3. Create an HTTP session and authenticate with the site
+ * 4. Print configuration summary
+ * 5. Run the crawl-and-scrape process
+ * 6. Print final results
+ * 7. Clean up resources (cURL handle, cookie file)
+ *
+ * @return void
+ */
+function main(): void
+{
+    global $argv, $DEBUG, $BOOK_CONFIG;
+
+    // Parse CLI arguments
+    $args = parseArgs($argv);
+
+    // Set the global debug flag
+    $DEBUG = $args['debug'];
+
+    // Prompt for credentials if not provided via CLI arguments
+    if ($args['username'] === null) {
+        echo "Mission Praise username/email: ";
+        $args['username'] = trim(fgets(STDIN));
+    }
+    if ($args['password'] === null) {
+        $args['password'] = promptPassword('Mission Praise password: ');
+    }
+
+    // Parse and validate the books argument (filter out invalid entries)
+    $books = [];
+    foreach (explode(',', $args['books']) as $b) {
+        $b = strtolower(trim($b));
+        if ($b !== '' && isset($BOOK_CONFIG[$b])) {
+            $books[] = $b;
+        }
+    }
+    if (empty($books)) {
+        echo "No valid books specified. Use --books mp,cp,jp\n";
+        return;
+    }
+
+    // Create the HTTP session (cURL handle + cookie jar)
+    [$ch, $cookieFile] = makeSession();
+
+    // Authenticate with the site
+    if (!login($ch, $args['username'], $args['password'])) {
+        // Login failed — error already printed by login()
+        curl_close($ch);
+        if (file_exists($cookieFile)) {
+            unlink($cookieFile);
+        }
+        return;
+    }
+
+    // Print configuration summary
+    echo "\nBooks    : " . implode(', ', array_map('strtoupper', $books)) . "\n";
+    echo "Output   : " . realpath($args['output']) ?: $args['output'];
+    echo "\n";
+    echo "Downloads: " . ($args['no-files'] ? 'disabled' : 'enabled (words, music, audio)') . "\n";
+    echo "\n";
+
+    // Run the main crawl-and-scrape process
+    [$saved, $skipped, $existed] = crawlAndScrape(
+        $ch,
+        $books,
+        $args['output'],
+        $args['no-files'],
+        $args['start-page'],
+        $args['delay'],
+        $args['force'],
+        $args['song'],
+        $argv
+    );
+
+    // Print final summary
+    echo "\nDone!  {$saved} saved, {$existed} already existed, {$skipped} skipped.\n";
+    echo "Output: " . (realpath($args['output']) ?: $args['output']) . "\n";
+    if ($skipped > 0) {
+        $logPath = $args['output'] . DIRECTORY_SEPARATOR . 'skipped.log';
+        echo "Skipped songs logged to: {$logPath}\n";
+    }
+
+    // Clean up resources
+    curl_close($ch);
+    if (file_exists($cookieFile)) {
+        unlink($cookieFile);
+    }
+}
+
+// Run the main function
+main();

--- a/.importers/scrapers/MissionPraise.com.ps1
+++ b/.importers/scrapers/MissionPraise.com.ps1
@@ -1,0 +1,2839 @@
+<#
+.SYNOPSIS
+    MissionPraise.com.ps1
+    importers/scrapers/MissionPraise.com.ps1
+
+    Mission Praise Scraper — scrapes lyrics and downloads files from missionpraise.com.
+    Copyright 2025-2026 MWBM Partners Ltd.
+
+.DESCRIPTION
+    This scraper authenticates with missionpraise.com (a WordPress-based site
+    that requires a paid subscription), then crawls the paginated song index
+    to discover all songs across three hymnbooks:
+        - Mission Praise (MP)  — ~1000+ songs, 4-digit numbering
+        - Carol Praise (CP)    — ~300 songs, 3-digit numbering
+        - Junior Praise (JP)   — ~300 songs, 3-digit numbering
+
+    For each song, it:
+    1. Scrapes the lyrics from the song detail page
+    2. Optionally downloads associated files (words RTF/DOC, music PDF, audio MP3)
+    3. Saves everything with a consistent filename convention
+
+    The scraper is designed to be resumable: it caches the list of existing
+    files on startup and skips songs that already have saved lyrics/downloads.
+
+    When double-clicked or run with no arguments, the script presents an
+    interactive GUI menu using Write-Host with colours. It prompts for
+    credentials (password masked via Read-Host -AsSecureString), offers
+    sensible defaults for all other options, and lets the user accept
+    defaults or customise each setting before starting.
+
+.PARAMETER Username
+    missionpraise.com login email. Prompted interactively if omitted.
+
+.PARAMETER Password
+    missionpraise.com password. Prompted securely (masked) if omitted.
+
+.PARAMETER Output
+    Output folder path. Default: ./hymns
+
+.PARAMETER Books
+    Comma-separated books to scrape: mp, cp, jp. Default: mp,cp,jp
+
+.PARAMETER StartPage
+    Index page number to start from, for resuming. Default: 1
+
+.PARAMETER Delay
+    Seconds to wait between HTTP requests. Default: 1.2
+
+.PARAMETER NoFiles
+    Skip downloading words/music/audio files (lyrics only).
+
+.PARAMETER Debug
+    Dump full HTML responses to terminal for troubleshooting.
+
+.PARAMETER Force
+    Bypass the file cache and re-download/overwrite all files, even if they
+    already exist on disk. Useful when lyrics have been corrected upstream or
+    when a previous run saved corrupt/incomplete files. When set, the scraper
+    treats every song as new and will overwrite any existing .txt, .rtf, .pdf,
+    .mp3, etc. without prompting.
+
+.PARAMETER Song
+    Scrape a single song by its number (e.g. "1270" for MP1270). When specified,
+    Force mode is automatically enabled and the scraper stops after finding the
+    target song. Useful for re-scraping or debugging a specific song.
+
+.PARAMETER Help
+    Show help information and exit.
+
+.NOTES
+    Authentication:
+        The site uses WordPress standard login (wp-login.php) with CSRF nonces
+        and may be behind a Sucuri WAF (Web Application Firewall). The login
+        flow handles:
+        - Extracting hidden form fields (nonces) from the login page
+        - Setting proper Referer/Origin headers to pass WAF checks
+        - Detecting WAF blocks, login failures, and ambiguous states
+        - Cookie-based session management via Invoke-WebRequest -SessionVariable
+
+    Dependencies:
+        None — uses only built-in PowerShell cmdlets (no external modules).
+        Requires PowerShell 5.1+ (Windows) or PowerShell 7+ (cross-platform).
+
+    File output format:
+        Lyrics are saved as plain-text files:
+            {padded_number} ({LABEL}) - {Title Case Title}.txt
+        Download files use the same base name with type suffixes:
+            {base}.rtf          (words — primary download, no suffix)
+            {base}_music.pdf    (music score)
+            {base}_audio.mp3    (audio recording)
+
+        Files are organised into book-specific subdirectories:
+            hymns/Mission Praise [MP]/
+            hymns/Carol Praise [CP]/
+            hymns/Junior Praise [JP]/
+
+.EXAMPLE
+    .\MissionPraise.com.ps1 -Username you@email.com -Password secret
+    Scrape all books (MP, CP, JP) with defaults.
+
+.EXAMPLE
+    .\MissionPraise.com.ps1 -Username you@email.com -Password secret -Books mp
+    Scrape only Mission Praise.
+
+.EXAMPLE
+    .\MissionPraise.com.ps1 -Username you@email.com -Password secret -Books mp,cp
+    Scrape Mission Praise + Carol Praise.
+
+.EXAMPLE
+    .\MissionPraise.com.ps1 -Username you@email.com -Password secret -NoFiles
+    Scrape lyrics only (skip downloads).
+
+.EXAMPLE
+    .\MissionPraise.com.ps1 -Username you@email.com -Password secret -StartPage 5
+    Resume from index page 5.
+
+.EXAMPLE
+    .\MissionPraise.com.ps1 -Username you@email.com -Password secret -Output ~/hymns
+    Save to a custom output folder.
+
+.EXAMPLE
+    .\MissionPraise.com.ps1 -Username you@email.com -Password secret -Debug
+    Dump HTML responses for debugging.
+
+.EXAMPLE
+    .\MissionPraise.com.ps1 -Username you@email.com -Password secret -Force
+    Re-download and overwrite ALL files, ignoring the existing-file cache.
+
+.EXAMPLE
+    .\MissionPraise.com.ps1 -Username you@email.com -Password secret -Force -Books mp
+    Force re-scrape Mission Praise only.
+
+.EXAMPLE
+    .\MissionPraise.com.ps1 -Username you@email.com -Password secret -Song 1270 -Books mp
+    Scrape only song MP1270 (auto-enables Force mode, stops after finding it).
+#>
+
+# ---------------------------------------------------------------------------
+# Parameter block — PowerShell named parameters with defaults
+# ---------------------------------------------------------------------------
+# CmdletBinding enables -Verbose, -ErrorAction, etc. automatically.
+# The "Help" parameter is handled manually to provide a custom menu.
+[CmdletBinding()]
+param(
+    [string]$Username,          # missionpraise.com login email (prompted if omitted)
+    [string]$Password,          # missionpraise.com password (prompted securely if omitted)
+    [string]$Output = "./hymns",# Output folder path (default: ./hymns)
+    [string]$Books = "mp,cp,jp",# Comma-separated books to scrape
+    [int]$StartPage = 1,        # Index page to start from (for resuming)
+    [double]$Delay = 1.2,       # Seconds between HTTP requests
+    [switch]$NoFiles,           # Skip downloading words/music/audio files
+    [switch]$Debug,             # Dump HTML responses for troubleshooting
+    [switch]$Force,             # Bypass file cache — re-download and overwrite all existing files
+    [string]$Song,              # Scrape a single song by number (e.g. "1270") — auto-enables Force mode
+    [Alias("?")]
+    [switch]$Help               # Show help and exit
+)
+
+# ---------------------------------------------------------------------------
+# Force TLS 1.2 — required for HTTPS connections on older PowerShell versions
+# ---------------------------------------------------------------------------
+# PowerShell 5.1 on Windows may default to TLS 1.0/1.1 which most modern
+# servers reject. Force TLS 1.2 to ensure secure connections work.
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
+
+# ---------------------------------------------------------------------------
+# Constants — URLs, timing, and global configuration
+# ---------------------------------------------------------------------------
+
+# Base URL for the Mission Praise website
+$script:BASE = "https://missionpraise.com"
+
+# WordPress standard login endpoint
+$script:LOGIN_URL = "$($script:BASE)/wp-login.php"
+
+# Paginated song index URL — append page number (e.g. /songs/page/1/)
+$script:INDEX_URL = "$($script:BASE)/songs/page/"
+
+# Default delay between HTTP requests (seconds). 1.2s is chosen to be
+# respectful to the server while keeping scraping at a reasonable speed.
+$script:DEFAULT_DELAY = 1.2
+
+# Default output directory (relative to where the script is run)
+$script:DEFAULT_OUT = "./hymns"
+
+# Global debug flag — set to $true via -Debug parameter to dump HTML
+# responses for troubleshooting login/parsing issues
+$script:DEBUG_MODE = $false
+
+# Global web session variable — holds cookies for authenticated requests.
+# Initialised during login via Invoke-WebRequest -SessionVariable.
+$script:WebSession = $null
+
+# ---------------------------------------------------------------------------
+# Book configuration — defines the three hymnbooks scraped from the site
+# ---------------------------------------------------------------------------
+# Each book has:
+#   Label:   Short identifier used in filenames (e.g. "MP", "CP", "JP")
+#   Pad:     Number of digits to zero-pad the hymn number to (MP=4, others=3)
+#   Pattern: Regex to extract the book number from the index page title
+#            e.g. "Amazing Grace (MP0023)" -> matches "(MP0023)" -> group(1) = "0023"
+#   Subdir:  Human-readable subdirectory name for organised file output
+$script:BOOK_CONFIG = @{
+    "mp" = @{ Label = "MP"; Pad = 4; Pattern = '\(MP(\d+)\)'; Subdir = "Mission Praise [MP]" }
+    "cp" = @{ Label = "CP"; Pad = 3; Pattern = '\(CP(\d+)\)'; Subdir = "Carol Praise [CP]" }
+    "jp" = @{ Label = "JP"; Pad = 3; Pattern = '\(JP(\d+)\)'; Subdir = "Junior Praise [JP]" }
+}
+
+# ---------------------------------------------------------------------------
+# MIME type -> file extension mapping for downloaded files
+# ---------------------------------------------------------------------------
+# When downloading files (words, music, audio), the server's Content-Type
+# header tells us what format the file is in. This mapping converts common
+# MIME types to their standard file extensions.
+# "application/octet-stream" is a generic binary type — we fall back to
+# guessing the extension from the URL or magic bytes in that case.
+$script:MIME_TO_EXT = @{
+    "application/rtf"          = ".rtf"     # Rich Text Format (words)
+    "text/rtf"                 = ".rtf"     # Alternate RTF MIME type
+    "application/msword"       = ".doc"     # Microsoft Word (legacy)
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document" = ".docx"
+    "application/pdf"          = ".pdf"     # PDF (music scores)
+    "audio/midi"               = ".mid"     # MIDI audio
+    "audio/x-midi"             = ".mid"     # Alternate MIDI MIME type
+    "audio/mpeg"               = ".mp3"     # MP3 audio
+    "audio/mp3"                = ".mp3"     # Alternate MP3 MIME type
+    "audio/wav"                = ".wav"     # WAV audio
+    "audio/x-wav"              = ".wav"     # Alternate WAV MIME type
+    "audio/ogg"                = ".ogg"     # Ogg Vorbis audio
+    "application/octet-stream" = ""         # Generic binary — fall back to URL/magic
+}
+
+# ---------------------------------------------------------------------------
+# Magic bytes — file type detection from binary content
+# ---------------------------------------------------------------------------
+# When the Content-Type header is unhelpful (e.g. "application/octet-stream")
+# and the URL doesn't reveal the file type, we can identify the format by
+# examining the first few bytes of the file content. Most file formats begin
+# with a distinctive "magic number" or signature.
+$script:MAGIC_BYTES = @(
+    @{ Bytes = [byte[]]@(0x25, 0x50, 0x44, 0x46);                     Ext = ".pdf"  }  # %PDF
+    @{ Bytes = [byte[]]@(0x50, 0x4B, 0x03, 0x04);                     Ext = ".docx" }  # PK (ZIP-based: docx, xlsx, pptx)
+    @{ Bytes = [byte[]]@(0xD0, 0xCF, 0x11, 0xE0);                     Ext = ".doc"  }  # OLE2 compound (doc, xls, ppt)
+    @{ Bytes = [byte[]]@(0x7B, 0x5C, 0x72, 0x74, 0x66);               Ext = ".rtf"  }  # {\rtf — Rich Text Format
+    @{ Bytes = [byte[]]@(0x4D, 0x54, 0x68, 0x64);                     Ext = ".mid"  }  # MThd — MIDI
+    @{ Bytes = [byte[]]@(0x49, 0x44, 0x33);                           Ext = ".mp3"  }  # ID3 — MP3 with ID3v2 tag
+    @{ Bytes = [byte[]]@(0xFF, 0xFB);                                 Ext = ".mp3"  }  # MP3 frame sync (MPEG1 Layer 3)
+    @{ Bytes = [byte[]]@(0xFF, 0xF3);                                 Ext = ".mp3"  }  # MP3 frame sync (MPEG2 Layer 3)
+    @{ Bytes = [byte[]]@(0x4F, 0x67, 0x67, 0x53);                     Ext = ".ogg"  }  # OggS — Ogg Vorbis
+    @{ Bytes = [byte[]]@(0x52, 0x49, 0x46, 0x46);                     Ext = ".wav"  }  # RIFF — WAV audio
+    @{ Bytes = [byte[]]@(0x66, 0x4C, 0x61, 0x43);                     Ext = ".flac" }  # fLaC — FLAC lossless audio
+)
+
+# ---------------------------------------------------------------------------
+# Browser-like headers — sent with every request to avoid WAF blocks
+# ---------------------------------------------------------------------------
+# The headers are modelled after a real Chrome/Edge browser on macOS,
+# including Sec-Fetch-* headers that modern WAFs check to distinguish
+# legitimate browser requests from automated scripts.
+$script:BrowserHeaders = @{
+    "User-Agent"               = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36 Edg/145.0.0.0"
+    "Accept"                   = "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8"
+    "Accept-Language"          = "en-GB,en;q=0.9"
+    "Accept-Encoding"          = "gzip, deflate, br"
+    "Connection"               = "keep-alive"
+    "Upgrade-Insecure-Requests"= "1"
+    "Sec-Fetch-Dest"           = "document"
+    "Sec-Fetch-Mode"           = "navigate"
+    "Sec-Fetch-Site"           = "same-origin"
+    "Sec-Fetch-User"           = "?1"
+    "Cache-Control"            = "max-age=0"
+}
+
+
+# ===========================================================================
+# INTERACTIVE GUI MENU — shown when script is double-clicked or run with
+# no CLI arguments (no Username/Password provided and not piped)
+# ===========================================================================
+
+function Show-InteractiveMenu {
+    <#
+    .SYNOPSIS
+        Display a colourful interactive menu when the script is launched with
+        no arguments (e.g. by double-clicking in Windows Explorer).
+
+    .DESCRIPTION
+        Presents the script name, description, copyright, and usage info,
+        then prompts the user for each configurable parameter. Uses
+        Write-Host with -ForegroundColor for visual appeal. Passwords are
+        collected securely via Read-Host -AsSecureString.
+
+    .OUTPUTS
+        Hashtable with keys: Username, Password, Output, Books, StartPage,
+        Delay, NoFiles, Debug — ready to pass to the main scraping logic.
+    #>
+
+    Clear-Host
+
+    # --- Header banner ---
+    Write-Host ""
+    Write-Host "  ============================================================" -ForegroundColor Cyan
+    Write-Host "   Mission Praise Scraper" -ForegroundColor Yellow
+    Write-Host "   missionpraise.com — MP, CP, JP lyrics and file downloads" -ForegroundColor White
+    Write-Host "  ============================================================" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "  Copyright 2025-2026 MWBM Partners Ltd." -ForegroundColor DarkGray
+    Write-Host "  Part of iLyricsDB — International Lyrics Database" -ForegroundColor DarkGray
+    Write-Host ""
+
+    # --- Description ---
+    Write-Host "  ABOUT:" -ForegroundColor Green
+    Write-Host "    This scraper authenticates with missionpraise.com and crawls" -ForegroundColor White
+    Write-Host "    the paginated song index to scrape lyrics and download files" -ForegroundColor White
+    Write-Host "    (words RTF/DOC, sheet music PDF, audio MP3) for:" -ForegroundColor White
+    Write-Host ""
+    Write-Host "      - Mission Praise (MP)  ~1000+ songs, 4-digit numbering" -ForegroundColor White
+    Write-Host "      - Carol Praise   (CP)  ~300 songs,   3-digit numbering" -ForegroundColor White
+    Write-Host "      - Junior Praise  (JP)  ~300 songs,   3-digit numbering" -ForegroundColor White
+    Write-Host ""
+
+    # --- Usage help ---
+    Write-Host "  USAGE (command-line):" -ForegroundColor Green
+    Write-Host "    .\MissionPraise.com.ps1 -Username you@email.com -Password secret" -ForegroundColor Gray
+    Write-Host "    .\MissionPraise.com.ps1 -Username you@email.com -Password secret -Books mp" -ForegroundColor Gray
+    Write-Host "    .\MissionPraise.com.ps1 -Username you@email.com -Password secret -NoFiles" -ForegroundColor Gray
+    Write-Host "    .\MissionPraise.com.ps1 -Username you@email.com -Password secret -StartPage 5" -ForegroundColor Gray
+    Write-Host "    .\MissionPraise.com.ps1 -Username you@email.com -Password secret -Force" -ForegroundColor Gray
+    Write-Host ""
+
+    # --- Credentials prompt (required) ---
+    Write-Host "  ============================================================" -ForegroundColor Cyan
+    Write-Host "   Configuration" -ForegroundColor Yellow
+    Write-Host "  ============================================================" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "  A valid missionpraise.com subscription is required." -ForegroundColor White
+    Write-Host ""
+
+    # Username — plain text input
+    Write-Host "  Username/email: " -ForegroundColor Yellow -NoNewline
+    $menuUsername = Read-Host
+    if ([string]::IsNullOrWhiteSpace($menuUsername)) {
+        Write-Host "  [!] Username is required. Exiting." -ForegroundColor Red
+        Write-Host ""
+        Write-Host "  Press any key to exit..." -ForegroundColor DarkGray
+        $null = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
+        exit 1
+    }
+
+    # Password — masked input via Read-Host -AsSecureString
+    Write-Host "  Password: " -ForegroundColor Yellow -NoNewline
+    $securePass = Read-Host -AsSecureString
+    # Convert SecureString back to plain text for use with Invoke-WebRequest
+    # (PowerShell's web cmdlets need plain text for form POST bodies)
+    $bstr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($securePass)
+    $menuPassword = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
+    [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+
+    if ([string]::IsNullOrWhiteSpace($menuPassword)) {
+        Write-Host "  [!] Password is required. Exiting." -ForegroundColor Red
+        Write-Host ""
+        Write-Host "  Press any key to exit..." -ForegroundColor DarkGray
+        $null = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
+        exit 1
+    }
+
+    Write-Host ""
+
+    # --- Optional settings with defaults ---
+    Write-Host "  Accept defaults for remaining settings? (Y/n): " -ForegroundColor Yellow -NoNewline
+    $acceptDefaults = Read-Host
+
+    # Initialise with defaults
+    $menuOutput    = $script:DEFAULT_OUT
+    $menuBooks     = "mp,cp,jp"
+    $menuStartPage = 1
+    $menuDelay     = $script:DEFAULT_DELAY
+    $menuNoFiles   = $false
+    $menuDebug     = $false
+    $menuForce     = $false
+
+    if ($acceptDefaults -match "^[Nn]") {
+        # User wants to customise settings — prompt for each one
+        Write-Host ""
+
+        # Books selection
+        Write-Host "  Books to scrape [mp,cp,jp]: " -ForegroundColor Yellow -NoNewline
+        $input_books = Read-Host
+        if (-not [string]::IsNullOrWhiteSpace($input_books)) {
+            $menuBooks = $input_books
+        }
+
+        # Output directory
+        Write-Host "  Output directory [./hymns]: " -ForegroundColor Yellow -NoNewline
+        $input_output = Read-Host
+        if (-not [string]::IsNullOrWhiteSpace($input_output)) {
+            $menuOutput = $input_output
+        }
+
+        # Start page
+        Write-Host "  Start page [1]: " -ForegroundColor Yellow -NoNewline
+        $input_start = Read-Host
+        if (-not [string]::IsNullOrWhiteSpace($input_start)) {
+            $menuStartPage = [int]$input_start
+        }
+
+        # Delay
+        Write-Host "  Delay between requests (seconds) [1.2]: " -ForegroundColor Yellow -NoNewline
+        $input_delay = Read-Host
+        if (-not [string]::IsNullOrWhiteSpace($input_delay)) {
+            $menuDelay = [double]$input_delay
+        }
+
+        # No-files toggle
+        Write-Host "  Skip file downloads (lyrics only)? (y/N): " -ForegroundColor Yellow -NoNewline
+        $input_nofiles = Read-Host
+        if ($input_nofiles -match "^[Yy]") {
+            $menuNoFiles = $true
+        }
+
+        # Debug toggle
+        Write-Host "  Enable debug output? (y/N): " -ForegroundColor Yellow -NoNewline
+        $input_debug = Read-Host
+        if ($input_debug -match "^[Yy]") {
+            $menuDebug = $true
+        }
+
+        # Force toggle — re-download everything, ignoring existing files
+        Write-Host "  Force re-download (overwrite existing)? (y/N): " -ForegroundColor Yellow -NoNewline
+        $input_force = Read-Host
+        if ($input_force -match "^[Yy]") {
+            $menuForce = $true
+        }
+    }
+
+    # --- Confirm and start ---
+    Write-Host ""
+    Write-Host "  ============================================================" -ForegroundColor Cyan
+    Write-Host "   Configuration Summary" -ForegroundColor Yellow
+    Write-Host "  ============================================================" -ForegroundColor Cyan
+    Write-Host "    Username  : $menuUsername" -ForegroundColor White
+    Write-Host "    Password  : ********" -ForegroundColor White
+    Write-Host "    Books     : $($menuBooks.ToUpper())" -ForegroundColor White
+    Write-Host "    Output    : $menuOutput" -ForegroundColor White
+    Write-Host "    Start page: $menuStartPage" -ForegroundColor White
+    Write-Host "    Delay     : $menuDelay seconds" -ForegroundColor White
+    Write-Host "    Downloads : $(if ($menuNoFiles) { 'disabled' } else { 'enabled (words, music, audio)' })" -ForegroundColor White
+    Write-Host "    Force     : $(if ($menuForce) { 'ON -- will overwrite existing files' } else { 'off' })" -ForegroundColor $(if ($menuForce) { 'Red' } else { 'White' })
+    Write-Host "    Debug     : $(if ($menuDebug) { 'enabled' } else { 'disabled' })" -ForegroundColor White
+    Write-Host ""
+    Write-Host "  Press ENTER to start scraping, or Ctrl+C to cancel..." -ForegroundColor Green -NoNewline
+    Read-Host
+    Write-Host ""
+
+    # Return the configuration as a hashtable
+    return @{
+        Username  = $menuUsername
+        Password  = $menuPassword
+        Output    = $menuOutput
+        Books     = $menuBooks
+        StartPage = $menuStartPage
+        Delay     = $menuDelay
+        NoFiles   = $menuNoFiles
+        Debug     = $menuDebug
+        Force     = $menuForce
+    }
+}
+
+
+# ===========================================================================
+# DEBUG HELPER — conditional HTML dump for troubleshooting
+# ===========================================================================
+
+function Write-DebugDump {
+    <#
+    .SYNOPSIS
+        Print a labelled debug dump of HTML/text content (only when DEBUG_MODE is $true).
+
+    .DESCRIPTION
+        Used during development and troubleshooting to inspect raw HTML responses
+        from the server. Truncates output to MaxChars to avoid flooding the terminal.
+
+    .PARAMETER Label
+        A descriptive label for what's being dumped.
+
+    .PARAMETER Text
+        The text content to dump.
+
+    .PARAMETER MaxChars
+        Maximum characters to display. Default: 3000.
+    #>
+    param(
+        [string]$Label,
+        [string]$Text,
+        [int]$MaxChars = 3000
+    )
+
+    # Only output when debug mode is active
+    if (-not $script:DEBUG_MODE) { return }
+
+    Write-Host ""
+    Write-Host ("=" * 60)
+    Write-Host "DEBUG: $Label"
+    Write-Host ("=" * 60)
+
+    if ($Text.Length -le $MaxChars) {
+        Write-Host $Text
+    }
+    else {
+        Write-Host $Text.Substring(0, $MaxChars)
+        Write-Host "... ($($Text.Length - $MaxChars) more chars)"
+    }
+
+    Write-Host ("=" * 60)
+    Write-Host ""
+}
+
+
+# ===========================================================================
+# HTML ENTITY DECODING — convert &amp; &rsquo; &#8217; etc. to characters
+# ===========================================================================
+
+function ConvertFrom-HtmlEntities {
+    <#
+    .SYNOPSIS
+        Decode HTML entities in a string to their Unicode character equivalents.
+
+    .DESCRIPTION
+        Handles both named entities (e.g. &amp;, &rsquo;, &nbsp;) and numeric
+        character references (e.g. &#8217;, &#x2019;). Common typographic
+        entities found in song lyrics include smart quotes and dashes.
+
+        Uses .NET's System.Net.WebUtility for standard entities and adds
+        manual handling for entities that .NET may miss.
+
+    .PARAMETER Text
+        The HTML text containing entities to decode.
+
+    .OUTPUTS
+        String with HTML entities replaced by their Unicode characters.
+    #>
+    param([string]$Text)
+
+    if ([string]::IsNullOrEmpty($Text)) { return $Text }
+
+    # Windows-1252 entity mapping — the site uses &#145;–&#151; which are
+    # Windows-1252 code points, NOT Unicode. chr(146) etc. produce control
+    # characters, not the intended typographic glyphs. We must map them
+    # explicitly BEFORE the generic .NET decoder runs.
+    # Reference: https://en.wikipedia.org/wiki/Windows-1252#Character_set
+    $Text = $Text -replace '&#145;', [char]0x2018   # Left single quote  (')
+    $Text = $Text -replace '&#146;', [char]0x2019   # Right single quote (') / apostrophe
+    $Text = $Text -replace '&#147;', [char]0x201C   # Left double quote  (")
+    $Text = $Text -replace '&#148;', [char]0x201D   # Right double quote (")
+    $Text = $Text -replace '&#150;', [char]0x2013   # En dash (–)
+    $Text = $Text -replace '&#151;', [char]0x2014   # Em dash (—)
+
+    # Use .NET's built-in HTML decoder for standard entities
+    # This handles &amp; &lt; &gt; &quot; &#8217; &#x2019; etc.
+    $decoded = [System.Net.WebUtility]::HtmlDecode($Text)
+
+    # Manual fallback for entities that .NET's decoder may not handle
+    # (some WordPress-specific or less common entities)
+    $decoded = $decoded -replace '&rsquo;', [char]0x2019   # Right single quote
+    $decoded = $decoded -replace '&lsquo;', [char]0x2018   # Left single quote
+    $decoded = $decoded -replace '&rdquo;', [char]0x201D   # Right double quote
+    $decoded = $decoded -replace '&ldquo;', [char]0x201C   # Left double quote
+    $decoded = $decoded -replace '&mdash;', [char]0x2014   # Em dash
+    $decoded = $decoded -replace '&ndash;', [char]0x2013   # En dash
+    $decoded = $decoded -replace '&nbsp;',  ' '             # Non-breaking space
+
+    return $decoded
+}
+
+
+# ===========================================================================
+# LOGIN — WordPress authentication with CSRF nonce extraction
+# ===========================================================================
+
+function Invoke-Login {
+    <#
+    .SYNOPSIS
+        Authenticate with missionpraise.com using WordPress standard login.
+
+    .DESCRIPTION
+        The login flow is:
+        1. GET the login page to obtain CSRF nonces (hidden form fields)
+        2. Brief pause (2s) to appear more human-like
+        3. POST credentials + nonces with proper Referer/Origin headers
+        4. Handle various failure modes (WAF blocks, wrong password, etc.)
+        5. Verify login succeeded by fetching the songs page and checking
+           for logged-in indicators
+
+        The function is defensive about error detection because:
+        - The Sucuri WAF can block requests that look automated
+        - WordPress login failures manifest in different ways (redirect
+          back to login, error div, etc.)
+        - The login page structure may vary between WordPress versions
+
+    .PARAMETER Username
+        The user's missionpraise.com email address.
+
+    .PARAMETER Password
+        The user's missionpraise.com password.
+
+    .OUTPUTS
+        Boolean: $true if login appears successful, $false if definitely failed.
+    #>
+    param(
+        [string]$Username,
+        [string]$Password
+    )
+
+    Write-Host "Logging in as $Username..."
+
+    # --- Step 1: GET the login page to extract CSRF nonces ---
+    # WordPress login forms contain hidden fields (nonces) that must be
+    # submitted with the POST request to prevent CSRF attacks.
+    try {
+        $loginPageResponse = Invoke-WebRequest -Uri $script:LOGIN_URL `
+            -Headers $script:BrowserHeaders `
+            -SessionVariable "loginSession" `
+            -UseBasicParsing `
+            -MaximumRedirection 5 `
+            -ErrorAction Stop
+    }
+    catch {
+        Write-Host "  [!] Failed to load login page: $_" -ForegroundColor Red
+        return $false
+    }
+
+    # Store the session for subsequent requests (holds all cookies)
+    $script:WebSession = $loginSession
+    $loginHtml = $loginPageResponse.Content
+
+    Write-DebugDump -Label "Login page HTML" -Text $loginHtml
+
+    # Extract all <input type="hidden"> fields from the login form.
+    # These typically include:
+    #   - testcookie: WordPress test cookie check
+    #   - _wpnonce: WordPress CSRF nonce
+    #   - Various plugin-specific nonces
+    $hiddenFields = @{}
+    $hiddenMatches = [regex]::Matches($loginHtml, '<input[^>]+type=["\x27]hidden["\x27][^>]*>', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+    foreach ($match in $hiddenMatches) {
+        $tag = $match.Value
+        # Extract the name attribute
+        $nameMatch = [regex]::Match($tag, 'name=["\x27]([^"\x27]+)["\x27]')
+        # Extract the value attribute
+        $valueMatch = [regex]::Match($tag, 'value=["\x27]([^"\x27]*)["\x27]')
+        if ($nameMatch.Success) {
+            $fieldName  = $nameMatch.Groups[1].Value
+            $fieldValue = if ($valueMatch.Success) { $valueMatch.Groups[1].Value } else { "" }
+            $hiddenFields[$fieldName] = $fieldValue
+        }
+    }
+
+    if ($script:DEBUG_MODE) {
+        Write-Host "  DEBUG: Hidden fields: $($hiddenFields | ConvertTo-Json -Compress)"
+    }
+
+    # --- Step 2: Brief pause to appear more human-like ---
+    # Some WAFs flag requests that POST to the login form within milliseconds
+    # of loading the page, as this is a strong indicator of automated access.
+    Start-Sleep -Seconds 2
+
+    # --- Step 3: POST the login credentials ---
+    # Build the login form data with WordPress standard field names
+    $formData = @{
+        "log"         = $Username                  # WordPress username field
+        "pwd"         = $Password                  # WordPress password field
+        "wp-submit"   = "Log In"                   # Submit button value
+        "redirect_to" = "$($script:BASE)/songs/"   # Where to redirect after login
+        "rememberme"  = "forever"                  # Keep the session alive
+    }
+
+    # Merge hidden fields (CSRF nonces) into the form data
+    foreach ($key in $hiddenFields.Keys) {
+        $formData[$key] = $hiddenFields[$key]
+    }
+
+    # Build additional POST headers — Referer and Origin are critical for
+    # passing the Sucuri WAF check
+    $postHeaders = $script:BrowserHeaders.Clone()
+    $postHeaders["Referer"]      = $script:LOGIN_URL
+    $postHeaders["Origin"]       = $script:BASE
+    $postHeaders["Content-Type"] = "application/x-www-form-urlencoded"
+
+    # Perform the POST request
+    $body = $null
+    $finalUrl = ""
+    try {
+        $postResponse = Invoke-WebRequest -Uri $script:LOGIN_URL `
+            -Method POST `
+            -Body $formData `
+            -Headers $postHeaders `
+            -WebSession $script:WebSession `
+            -UseBasicParsing `
+            -MaximumRedirection 10 `
+            -ErrorAction Stop
+
+        $finalUrl = $postResponse.BaseResponse.ResponseUri.ToString()
+        $body = $postResponse.Content
+    }
+    catch {
+        # Some servers return HTTP errors (403, etc.) for blocked login attempts.
+        # We still need to read the response body to check for WAF messages.
+        $finalUrl = ""
+        if ($_.Exception.Response) {
+            try {
+                $stream = $_.Exception.Response.GetResponseStream()
+                $reader = New-Object System.IO.StreamReader($stream)
+                $body = $reader.ReadToEnd()
+                $reader.Close()
+                $stream.Close()
+            }
+            catch {
+                $body = ""
+            }
+        }
+        else {
+            $body = ""
+        }
+    }
+
+    if ($script:DEBUG_MODE) {
+        Write-Host "  DEBUG: Post-login redirect URL: $finalUrl"
+        Write-DebugDump -Label "Post-login body" -Text $body
+    }
+
+    # --- Step 4: Check for various failure modes ---
+
+    # Check for WAF / firewall blocks (e.g. Sucuri CDN/WAF)
+    # Sucuri blocks show a distinctive page with "Access Denied" and details
+    # about the block reason and the client's IP address.
+    $bodyLower = $body.ToLower()
+    if ($bodyLower.Contains("sucuri") -or $bodyLower.Contains("access denied")) {
+        $blockReason = [regex]::Match($body, 'Block reason:</td>\s*<td><span>(.*?)</span>', [System.Text.RegularExpressions.RegexOptions]::Singleline)
+        $blockIp     = [regex]::Match($body, 'Your IP:</td>\s*<td><span>(.*?)</span>', [System.Text.RegularExpressions.RegexOptions]::Singleline)
+        $reason = if ($blockReason.Success) { $blockReason.Groups[1].Value.Trim() } else { "unknown" }
+        $ip     = if ($blockIp.Success)     { $blockIp.Groups[1].Value.Trim() }     else { "unknown" }
+        Write-Host "  [!] BLOCKED by website firewall: $reason" -ForegroundColor Red
+        Write-Host "       Your IP: $ip" -ForegroundColor Red
+        Write-Host "       Try again later or log in via browser first to whitelist your IP." -ForegroundColor Yellow
+        return $false
+    }
+
+    # Check for incorrect credentials — WordPress stays on wp-login.php
+    # and includes an error message in the response body
+    if ($finalUrl.Contains("wp-login.php") -and $bodyLower.Contains("incorrect")) {
+        Write-Host "  [!] Login failed -- check username/password." -ForegroundColor Red
+        return $false
+    }
+
+    # Check for other WordPress login errors (still on login page after POST)
+    if ($finalUrl.Contains("wp-login.php")) {
+        if ($script:DEBUG_MODE) {
+            Write-Host "  DEBUG: Still on login page after POST -- login likely failed"
+        }
+        # Look for the WordPress login error div which contains specific messages
+        # like "Unknown username", "Incorrect password", etc.
+        $errorMatch = [regex]::Match($body, '<div[^>]*id=["\x27]login_error["\x27][^>]*>(.*?)</div>', [System.Text.RegularExpressions.RegexOptions]::Singleline)
+        if ($errorMatch.Success) {
+            # Strip HTML tags from the error message for clean display
+            $errorText = [regex]::Replace($errorMatch.Groups[1].Value, '<[^>]+>', '').Trim()
+            Write-Host "  [!] Login error: $errorText" -ForegroundColor Red
+            return $false
+        }
+    }
+
+    # --- Step 5: Verify login by fetching the songs page ---
+    # Even if the POST didn't show an error, we verify by checking if the
+    # songs page shows logged-in indicators (some sites silently fail login).
+    try {
+        $checkResponse = Invoke-WebRequest -Uri "$($script:BASE)/songs/" `
+            -Headers $script:BrowserHeaders `
+            -WebSession $script:WebSession `
+            -UseBasicParsing `
+            -MaximumRedirection 5 `
+            -ErrorAction Stop
+
+        $checkHtml = $checkResponse.Content
+        $checkUrl  = $checkResponse.BaseResponse.ResponseUri.ToString()
+    }
+    catch {
+        Write-Host "  [!] Failed to verify login -- could not load songs page." -ForegroundColor Red
+        return $false
+    }
+
+    if ($script:DEBUG_MODE) {
+        Write-Host "  DEBUG: Songs page URL: $checkUrl"
+        Write-DebugDump -Label "Songs page HTML" -Text $checkHtml
+    }
+
+    # Look for multiple indicators of being logged in — different WordPress
+    # themes show different indicators, so we check several possibilities
+    $checkLower = $checkHtml.ToLower()
+    $loggedIn = (
+        $checkLower.Contains("logout") -or
+        $checkLower.Contains("log out") -or
+        $checkLower.Contains("log-out") -or
+        $checkHtml.Contains("Welcome") -or
+        $checkLower.Contains("my-account") -or
+        $checkLower.Contains("wp-admin") -or
+        $checkLower.Contains("logged-in")
+    )
+
+    if ($loggedIn) {
+        Write-Host "  [+] Logged in." -ForegroundColor Green
+        return $true
+    }
+
+    # Check if we were redirected back to the login page (session not established)
+    if ($checkUrl.Contains("wp-login") -or $checkUrl.Contains("login")) {
+        Write-Host "  [!] Login failed -- redirected back to login page." -ForegroundColor Red
+        return $false
+    }
+
+    # Login status is ambiguous — proceed anyway (some themes don't show
+    # obvious logged-in indicators). The user can re-run with -Debug to investigate.
+    Write-Host "  [?] Login status unclear -- proceeding anyway." -ForegroundColor Yellow
+    Write-Host "       (Re-run with -Debug to see full HTML responses)" -ForegroundColor Yellow
+    return $true
+}
+
+
+# ===========================================================================
+# FETCH HELPERS — HTTP request and response handling utilities
+# ===========================================================================
+
+function Invoke-FetchText {
+    <#
+    .SYNOPSIS
+        Fetch a URL and return its text content, handling errors gracefully.
+
+    .PARAMETER Url
+        The URL to fetch.
+
+    .OUTPUTS
+        Array of two elements: [string]$Content, [string]$FinalUrl
+        Returns $null, $null on any error.
+    #>
+    param([string]$Url)
+
+    try {
+        $response = Invoke-WebRequest -Uri $Url `
+            -Headers $script:BrowserHeaders `
+            -WebSession $script:WebSession `
+            -UseBasicParsing `
+            -TimeoutSec 20 `
+            -MaximumRedirection 5 `
+            -ErrorAction Stop
+
+        $content  = $response.Content
+        $finalUrl = $response.BaseResponse.ResponseUri.ToString()
+
+        return @($content, $finalUrl)
+    }
+    catch {
+        Write-Host "`n  [!] Error fetching ${Url}: $_" -ForegroundColor Red
+        return @($null, $null)
+    }
+}
+
+
+function Invoke-FetchBinary {
+    <#
+    .SYNOPSIS
+        Download a binary file (words/music/audio) from a URL.
+
+    .DESCRIPTION
+        Includes several safety checks:
+        1. Detects server error pages masquerading as file downloads — some
+           servers return HTML error pages with a 200 status code when the
+           actual file is missing or access is denied.
+
+        The error detection heuristic checks if the response:
+        - Starts with common text/HTML bytes ('<', 's', 'e', '{')
+        - Is small enough to be an error page (< 500KB)
+        - Contains error-related keywords when decoded as UTF-8
+
+    .PARAMETER Url
+        The download URL.
+
+    .OUTPUTS
+        Array of three elements: [byte[]]$Data, [string]$ContentType, [string]$FinalUrl
+        Returns $null, $null, $null on any error.
+    #>
+    param([string]$Url)
+
+    try {
+        # Use Invoke-WebRequest to download raw bytes
+        $response = Invoke-WebRequest -Uri $Url `
+            -Headers $script:BrowserHeaders `
+            -WebSession $script:WebSession `
+            -UseBasicParsing `
+            -TimeoutSec 30 `
+            -MaximumRedirection 5 `
+            -ErrorAction Stop
+
+        # Extract the MIME type from Content-Type (strip charset parameter)
+        $ct = ""
+        $contentTypeHeader = $response.Headers["Content-Type"]
+        if ($contentTypeHeader) {
+            # Handle both string and string[] (PowerShell version differences)
+            $ctRaw = if ($contentTypeHeader -is [array]) { $contentTypeHeader[0] } else { $contentTypeHeader }
+            $ct = $ctRaw.Split(";")[0].Trim().ToLower()
+        }
+
+        # Get the raw bytes of the response
+        $raw = $response.Content
+        # Invoke-WebRequest may return string for text content types; convert if needed
+        if ($raw -is [string]) {
+            $raw = [System.Text.Encoding]::UTF8.GetBytes($raw)
+        }
+
+        $finalUrl = $response.BaseResponse.ResponseUri.ToString()
+
+        # --- Error page detection ---
+        # Some servers return HTML error pages (PHP exceptions, 404 pages, etc.)
+        # with a 200 status code instead of the actual file. We detect these by
+        # checking if the content looks like text/HTML rather than binary data.
+        if ($raw.Length -gt 0 -and $raw.Length -lt 500000) {
+            $firstByte = $raw[0]
+            # Check if first byte looks like text: '<' (0x3C), 's' (0x73), 'e' (0x65), '{' (0x7B)
+            if ($firstByte -eq 0x3C -or $firstByte -eq 0x73 -or $firstByte -eq 0x65 -or $firstByte -eq 0x7B) {
+                try {
+                    $textContent = [System.Text.Encoding]::UTF8.GetString($raw)
+                    $textLower = $textContent.ToLower()
+                    if ($textLower.Contains("exception") -or $textLower.Contains("<html") -or
+                        $textLower.Contains("<!doctype") -or $textLower.Contains("error") -or
+                        $textLower.Contains("not found") -or $textLower.Contains("string(") -or
+                        $textLower.Contains("nosuchkey") -or $textLower.Contains("stacktrace")) {
+                        Write-Host "server error " -NoNewline
+                        if ($script:DEBUG_MODE) {
+                            Write-DebugDump -Label "Server error in download" -Text $textContent -MaxChars 500
+                        }
+                        return @($null, $null, $null)
+                    }
+                }
+                catch {
+                    # Not valid UTF-8 -> genuinely binary data, carry on
+                }
+            }
+        }
+
+        return @($raw, $ct, $finalUrl)
+    }
+    catch {
+        Write-Host "`n  [!] Download error ${Url}: $_" -ForegroundColor Red
+        return @($null, $null, $null)
+    }
+}
+
+
+# ===========================================================================
+# FILE EXTENSION DETECTION — cascade of Content-Type, URL, magic bytes
+# ===========================================================================
+
+function Get-ExtFromUrl {
+    <#
+    .SYNOPSIS
+        Guess the file extension from a URL's path component.
+
+    .DESCRIPTION
+        Parses the URL to extract the path, then gets the extension from the
+        last path segment. Server-side script extensions (.php, .asp, etc.)
+        are ignored because they indicate dynamic download endpoints rather
+        than actual file types.
+
+    .PARAMETER Url
+        The download URL to extract the extension from.
+
+    .OUTPUTS
+        String: The lowercase file extension (e.g. ".rtf") or "" if none found.
+    #>
+    param([string]$Url)
+
+    try {
+        $uri  = [System.Uri]::new($Url)
+        $path = $uri.AbsolutePath
+        $ext  = [System.IO.Path]::GetExtension($path).ToLower()
+
+        # Ignore server-side script extensions — these are dynamic endpoints
+        # that serve files, not the actual file extension
+        if ($ext -in @(".php", ".asp", ".aspx", ".jsp", ".cgi", ".py")) {
+            return ""
+        }
+        return $ext
+    }
+    catch {
+        return ""
+    }
+}
+
+
+function Get-ExtFromMagic {
+    <#
+    .SYNOPSIS
+        Detect file type from the first few bytes of binary data (magic bytes).
+
+    .DESCRIPTION
+        Compares the file's opening bytes against known signatures for common
+        document and audio formats. This is the last-resort detection method
+        when Content-Type and URL are both unhelpful.
+
+    .PARAMETER Data
+        The raw bytes of the downloaded file (at least 4 bytes needed).
+
+    .OUTPUTS
+        String: The detected file extension (e.g. ".pdf") or "" if not recognised.
+    #>
+    param([byte[]]$Data)
+
+    # Need at least 4 bytes for reliable magic number matching
+    if (-not $Data -or $Data.Length -lt 4) {
+        return ""
+    }
+
+    # Compare file header bytes against known magic byte signatures
+    foreach ($magic in $script:MAGIC_BYTES) {
+        $magicBytes = $magic.Bytes
+        $matchLen = $magicBytes.Length
+
+        # Ensure we have enough bytes to compare
+        if ($Data.Length -lt $matchLen) { continue }
+
+        # Compare each byte in the signature
+        $isMatch = $true
+        for ($i = 0; $i -lt $matchLen; $i++) {
+            if ($Data[$i] -ne $magicBytes[$i]) {
+                $isMatch = $false
+                break
+            }
+        }
+
+        if ($isMatch) {
+            return $magic.Ext
+        }
+    }
+
+    return ""
+}
+
+
+function Get-ExtForDownload {
+    <#
+    .SYNOPSIS
+        Determine the correct file extension for a download using a cascade strategy.
+
+    .DESCRIPTION
+        Tries three methods in order of reliability:
+        1. MIME type from the Content-Type header (most reliable)
+        2. File extension from the URL path (fallback)
+        3. Magic bytes from the file content (last resort)
+
+        If none of the methods identify the file type, defaults to ".bin" to
+        ensure the file is still saved (can be manually identified later).
+
+    .PARAMETER ContentType
+        The Content-Type header value (e.g. "application/pdf").
+
+    .PARAMETER Url
+        The download URL.
+
+    .PARAMETER Data
+        The raw file bytes (optional, for magic byte detection).
+
+    .OUTPUTS
+        String: The file extension including the dot (e.g. ".pdf", ".rtf", ".bin").
+    #>
+    param(
+        [string]$ContentType,
+        [string]$Url,
+        [byte[]]$Data = $null
+    )
+
+    # Strategy 1: Check the MIME type lookup table
+    $ext = ""
+    if ($script:MIME_TO_EXT.ContainsKey($ContentType)) {
+        $ext = $script:MIME_TO_EXT[$ContentType]
+    }
+
+    # Strategy 2: Extract extension from the URL path
+    if (-not $ext) {
+        $ext = Get-ExtFromUrl -Url $Url
+    }
+
+    # Strategy 3: Detect from magic bytes in the file content
+    if (-not $ext -and $Data) {
+        $ext = Get-ExtFromMagic -Data $Data
+    }
+
+    # Fallback: use .bin so the file is still saved for manual inspection
+    if (-not $ext) { $ext = ".bin" }
+
+    return $ext
+}
+
+
+# ===========================================================================
+# INDEX PAGE PARSER — extract song links from paginated index pages
+# ===========================================================================
+
+function Parse-IndexPage {
+    <#
+    .SYNOPSIS
+        Parse a paginated song index page for song links.
+
+    .DESCRIPTION
+        The index page lists songs as links within heading elements. Each song
+        appears as an <a> tag inside an <h2> or <h3>, with the title text
+        including the book code (e.g. "Amazing Grace (MP0023)").
+
+        Uses regex to match the HTML structure:
+            <h2><a href="/songs/amazing-grace-mp0023/">Amazing Grace (MP0023)</a></h2>
+
+        This is equivalent to the Python IndexParser class but implemented
+        with regex instead of an HTML parser state machine.
+
+    .PARAMETER Html
+        The raw HTML content of the index page.
+
+    .OUTPUTS
+        Array of PSCustomObjects with Title and Url properties.
+    #>
+    param([string]$Html)
+
+    $songs = @()
+
+    # Match <h2> or <h3> elements containing <a> tags with /songs/ in the href.
+    # The regex captures:
+    #   Group 1: The href URL
+    #   Group 2: The link text (song title)
+    # The [\s\S]*? allows for attributes between the h tag and the a tag.
+    $pattern = '<h[23][^>]*>[\s\S]*?<a[^>]+href=["\x27]([^"\x27]*?/songs/[^"\x27]*?)["\x27][^>]*>([\s\S]*?)</a>[\s\S]*?</h[23]>'
+    $matches = [regex]::Matches($Html, $pattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+
+    foreach ($m in $matches) {
+        $href  = $m.Groups[1].Value.Trim()
+        # Strip any nested HTML tags from the title text (e.g. <span> wrappers)
+        $title = [regex]::Replace($m.Groups[2].Value, '<[^>]+>', '').Trim()
+        # Decode HTML entities in the title (e.g. &amp; -> &)
+        $title = ConvertFrom-HtmlEntities -Text $title
+
+        if ($href -and $title) {
+            $songs += [PSCustomObject]@{
+                Title = $title
+                Url   = $href
+            }
+        }
+    }
+
+    return $songs
+}
+
+
+# ===========================================================================
+# SONG PAGE PARSER — extract title, lyrics, copyright, download links
+# ===========================================================================
+
+function Parse-SongPage {
+    <#
+    .SYNOPSIS
+        Parse an individual song detail page for lyrics, copyright, and downloads.
+
+    .DESCRIPTION
+        Each song page contains:
+        - A title in an element with class "entry-title"
+        - Lyrics in <p> blocks inside a div with class "song-details"
+        - Copyright info in an element with class "copyright-info"
+        - Download links in a sidebar with class "col-sm-4"
+
+        Lyrics detection:
+        - Each <p> inside .song-details represents a line or stanza break
+        - <em>/<i> tags indicate chorus lines (italic in the original)
+        - Empty <p> tags represent stanza breaks between verses
+        - <br> tags represent line breaks within a verse
+
+        Download link detection:
+        - Links in the .col-sm-4 sidebar with text containing "words", "music",
+          or "audio" are captured as download URLs
+
+        This is equivalent to the Python SongParser class but uses regex.
+
+    .PARAMETER Html
+        The raw HTML content of the song page.
+
+    .OUTPUTS
+        PSCustomObject with Title, Verses (array of [text, is_italic] pairs),
+        Copyright, and Downloads (hashtable) properties.
+    #>
+    param([string]$Html)
+
+    # --- Extract title from .entry-title ---
+    $title = ""
+    $titleMatch = [regex]::Match($Html, '<[^>]+class=["\x27][^"\x27]*entry-title[^"\x27]*["\x27][^>]*>([\s\S]*?)</[^>]+>', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+    if ($titleMatch.Success) {
+        # Strip HTML tags from the title content
+        $title = [regex]::Replace($titleMatch.Groups[1].Value, '<[^>]+>', '').Trim()
+        $title = ConvertFrom-HtmlEntities -Text $title
+    }
+
+    # --- Extract lyrics from .song-details ---
+    # First, extract the entire song-details container.
+    # We use a greedy [\s\S]* with a last-resort </div> to capture the full
+    # container contents even if it contains nested <div> elements.
+    # The approach: find the opening tag, then capture everything up to the
+    # matching closing </div>. We use a balanced-group approach by finding
+    # the section boundary via the next major section (copyright-info or col-sm-4).
+    # Fallback: greedy match up to the last </div> before copyright-info.
+    $verses = @()
+    # Try to extract from song-details to the next known section boundary
+    $songDetailsMatch = [regex]::Match($Html, '<(?:div|section)[^>]+class=["\x27][^"\x27]*song-details[^"\x27]*["\x27][^>]*>([\s\S]*?)(?=<[^>]+class=["\x27][^"\x27]*(?:copyright-info|col-sm-4|files))', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+    # Fallback: simpler regex if no section boundary found
+    if (-not $songDetailsMatch.Success) {
+        $songDetailsMatch = [regex]::Match($Html, '<(?:div|section)[^>]+class=["\x27][^"\x27]*song-details[^"\x27]*["\x27][^>]*>([\s\S]*?)</(?:div|section)>', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+    }
+    if ($songDetailsMatch.Success) {
+        $songDetailsHtml = $songDetailsMatch.Groups[1].Value
+
+        # Split on <p> boundaries to handle unclosed <p> tags.
+        # The site inconsistently uses bare <P> tags as verse separators
+        # without closing the previous <p>, so matching <p>...</p> pairs
+        # only captures the last verse. Splitting on <p> handles both cases.
+        $pBlocks = [regex]::Split($songDetailsHtml, '<p[^>]*>', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+        # Also find the positions of each <p> tag so we can reconstruct
+        # the "preceding HTML" for outer <em>/<i> wrapper detection.
+        $pTagMatches = [regex]::Matches($songDetailsHtml, '<p[^>]*>', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+        $blockIndex = 0
+        foreach ($pBlock in $pBlocks) {
+            # Strip any trailing </p> tag and trim
+            $pContent = [regex]::Replace($pBlock, '</p>\s*$', '', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+
+            # Detect italic text (chorus indicator) — check for <em> or <i> tags
+            # INSIDE this <p> element's content
+            $hasItalic = [regex]::IsMatch($pContent, '<(em|i)[\s>]', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+
+            # Also check if this <p> is INSIDE an outer <em>/<i> wrapper.
+            # On some songs, the chorus is wrapped as <em><p>line</p><p>line</p></em>
+            # rather than <p><em>line</em></p>. In that case, <em> opens before the
+            # <p> and closes after it. We detect this by counting unclosed <em>/<i>
+            # tags in the HTML preceding this <p> match.
+            if (-not $hasItalic -and $blockIndex -gt 0 -and $blockIndex -le $pTagMatches.Count) {
+                # Use the position of the <p> tag that started this block
+                $preceding = $songDetailsHtml.Substring(0, $pTagMatches[$blockIndex - 1].Index)
+                $emOpens  = [regex]::Matches($preceding, '<(em|i)[\s>]', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase).Count
+                $emCloses = [regex]::Matches($preceding, '</(em|i)>', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase).Count
+                if ($emOpens -gt $emCloses) {
+                    $hasItalic = $true
+                }
+            }
+
+            # Replace <br> and <br/> tags with newline characters
+            # (represents line breaks within a verse/stanza)
+            # The site emits <BR><br /> (both uppercase and lowercase) on every
+            # line, which produces double line breaks. We match one or more
+            # consecutive <br> tags (with optional whitespace between) as a
+            # single newline to avoid double-spacing.
+            $text = [regex]::Replace($pContent, '(?:<br\s*/?>[\s]*)+', "`n", [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+
+            # Strip all remaining HTML tags
+            $text = [regex]::Replace($text, '<[^>]+>', '')
+
+            # Decode HTML entities
+            $text = ConvertFrom-HtmlEntities -Text $text
+
+            # Trim the text (but keep empty strings as stanza-break markers)
+            $text = $text.Trim()
+
+            # Store as [text, is_italic] pair — matching Python's tuple format
+            $verses += ,@($text, $hasItalic)
+            $blockIndex++
+        }
+    }
+
+    # --- Extract copyright from .copyright-info ---
+    $copyright = ""
+    $copyrightMatch = [regex]::Match($Html, '<[^>]+class=["\x27][^"\x27]*copyright-info[^"\x27]*["\x27][^>]*>([\s\S]*?)</[^>]+>', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+    if ($copyrightMatch.Success) {
+        $copyright = [regex]::Replace($copyrightMatch.Groups[1].Value, '<[^>]+>', '').Trim()
+        $copyright = ConvertFrom-HtmlEntities -Text $copyright
+    }
+
+    # --- Extract download links from .col-sm-4 sidebar ---
+    $downloads = @{}
+    $sidebarMatch = [regex]::Match($Html, '<div[^>]+class=["\x27][^"\x27]*(?:col-sm-4|files)[^"\x27]*["\x27][^>]*>([\s\S]*?)</div>', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+    if ($sidebarMatch.Success) {
+        $sidebarHtml = $sidebarMatch.Groups[1].Value
+
+        # Find all <a> tags within the sidebar
+        $linkMatches = [regex]::Matches($sidebarHtml, '<a[^>]+href=["\x27]([^"\x27]+)["\x27][^>]*>([\s\S]*?)</a>', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+
+        foreach ($lm in $linkMatches) {
+            $href  = $lm.Groups[1].Value.Trim()
+            $label = [regex]::Replace($lm.Groups[2].Value, '<[^>]+>', '').Trim().ToLower()
+
+            # Skip empty or placeholder links
+            if (-not $href -or $href -eq "#") { continue }
+
+            # Match the link to a download type based on its label text
+            foreach ($key in @("words", "music", "audio")) {
+                if ($label.Contains($key)) {
+                    $downloads[$key] = $href
+                    break
+                }
+            }
+        }
+    }
+
+    return [PSCustomObject]@{
+        Title     = $title
+        Verses    = $verses
+        Copyright = $copyright
+        Downloads = $downloads
+    }
+}
+
+
+# ===========================================================================
+# BOOK HELPERS — extract and clean book-specific data from song titles
+# ===========================================================================
+
+function Get-HymnNumber {
+    <#
+    .SYNOPSIS
+        Extract the hymn number from a song title string for a specific book.
+
+    .DESCRIPTION
+        Song titles on the index page include the book code and number in
+        parentheses, e.g. "Amazing Grace (MP0023)". This function uses the
+        book-specific regex pattern to extract just the numeric part.
+
+    .PARAMETER Title
+        The full song title from the index page.
+
+    .PARAMETER Book
+        Book identifier key ("mp", "cp", or "jp").
+
+    .OUTPUTS
+        Int: The hymn number (e.g. 23 from "MP0023"), or -1 if not found.
+    #>
+    param(
+        [string]$Title,
+        [string]$Book
+    )
+
+    $cfg = $script:BOOK_CONFIG[$Book]
+    $m = [regex]::Match($Title, $cfg.Pattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+
+    if ($m.Success) {
+        return [int]$m.Groups[1].Value
+    }
+    return -1
+}
+
+
+function Get-DetectedBook {
+    <#
+    .SYNOPSIS
+        Determine which book a song belongs to based on its title.
+
+    .DESCRIPTION
+        Checks the title against each book's regex pattern (MP, CP, JP)
+        and returns the first match.
+
+    .PARAMETER Title
+        The full song title from the index page.
+
+    .OUTPUTS
+        String: Book key ("mp", "cp", or "jp") if found, or $null if no match.
+    #>
+    param([string]$Title)
+
+    foreach ($book in $script:BOOK_CONFIG.Keys) {
+        $num = Get-HymnNumber -Title $Title -Book $book
+        if ($num -ge 0) {
+            return $book
+        }
+    }
+    return $null
+}
+
+
+function Get-CleanTitle {
+    <#
+    .SYNOPSIS
+        Remove the book code suffix from a song title.
+
+    .DESCRIPTION
+        Strips the "(MP0023)" or similar suffix from the end of the title,
+        leaving just the human-readable song name for use in filenames
+        and formatted output.
+
+    .PARAMETER Title
+        The full song title (e.g. "Amazing Grace (MP0023)").
+
+    .PARAMETER Book
+        Book identifier key ("mp", "cp", or "jp").
+
+    .OUTPUTS
+        String: The cleaned title (e.g. "Amazing Grace").
+    #>
+    param(
+        [string]$Title,
+        [string]$Book
+    )
+
+    $cfg = $script:BOOK_CONFIG[$Book]
+    # Convert the capturing group pattern to a simple match pattern
+    # e.g. '\(MP(\d+)\)' -> '\(MP\d+\)' (no longer captures, just matches)
+    $pat = $cfg.Pattern -replace '\(\\d\+\)', '\d+'
+    # Remove the book code suffix from the end of the title
+    $cleaned = [regex]::Replace($Title, "\s*$pat\s*$", '', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase).Trim()
+    return $cleaned
+}
+
+
+# ===========================================================================
+# TITLE CASE & SANITIZE — filename-safe title formatting
+# ===========================================================================
+
+function ConvertTo-TitleCase {
+    <#
+    .SYNOPSIS
+        Convert a string to Title Case, with correct handling of apostrophes.
+
+    .DESCRIPTION
+        PowerShell's (Get-Culture).TextInfo.ToTitleCase() and Python's str.title()
+        both treat apostrophes as word boundaries, producing incorrect results like
+        "Don'T" instead of "Don't". This function uses a regex to match whole words
+        (including contractions like "don't", "it's", "o'er") and capitalises each correctly.
+
+        The regex pattern [a-zA-Z]+(['\u2019\u2018][a-zA-Z]+)? matches:
+        - One or more letters (the main word)
+        - Optionally an apostrophe (ASCII or Unicode curly) followed by more letters
+
+        We include Unicode curly/smart apostrophes (\u2019 RIGHT SINGLE QUOTATION
+        MARK and \u2018 LEFT SINGLE QUOTATION MARK) because HTML entities like
+        &rsquo; decode to \u2019. Without this, "Eagle\u2019s" would produce "Eagle'S".
+
+        The capitalize equivalent: uppercase first char, lowercase the rest of the match.
+
+    .PARAMETER Text
+        The input string.
+
+    .OUTPUTS
+        String: The Title Cased string.
+    #>
+    param([string]$Text)
+
+    # Use regex with a script block evaluator to capitalise each word correctly.
+    # [a-zA-Z]+(['\u2019\u2018][a-zA-Z]+)? matches words and contractions, including
+    # Unicode curly apostrophes (\u2019/\u2018) from decoded HTML entities like &rsquo;.
+    $result = [regex]::Replace($Text, "[a-zA-Z]+(['\u2019\u2018][a-zA-Z]+)?", {
+        param($m)
+        $word = $m.Value
+        # Capitalize: uppercase first char, lowercase the rest
+        if ($word.Length -eq 1) {
+            return $word.ToUpper()
+        }
+        return $word.Substring(0,1).ToUpper() + $word.Substring(1).ToLower()
+    })
+
+    return $result
+}
+
+
+function Invoke-Sanitize {
+    <#
+    .SYNOPSIS
+        Remove characters that are invalid in filenames across operating systems.
+
+    .DESCRIPTION
+        Strips characters that are forbidden in Windows filenames and/or could
+        cause issues on other platforms: \ / * ? : " < > |
+
+    .PARAMETER Name
+        The raw string to sanitize (typically a song title).
+
+    .OUTPUTS
+        String: The sanitized string with invalid characters removed.
+    #>
+    param([string]$Name)
+
+    return ([regex]::Replace($Name, '[\\/*?:"<>|]', '')).Trim()
+}
+
+
+function Get-BaseFilename {
+    <#
+    .SYNOPSIS
+        Construct the base filename for a song (without file extension).
+
+    .DESCRIPTION
+        Generates a consistent filename from the song's book, number, and title.
+        The title is sanitized and converted to Title Case. The number is
+        zero-padded according to the book's configuration (MP=4 digits, CP/JP=3).
+
+    .PARAMETER Number
+        The song number (e.g. 23).
+
+    .PARAMETER Book
+        Book identifier key ("mp", "cp", or "jp").
+
+    .PARAMETER Title
+        The cleaned song title (book code already removed).
+
+    .OUTPUTS
+        String: The base filename, e.g. "0023 (MP) - Amazing Grace".
+    #>
+    param(
+        [int]$Number,
+        [string]$Book,
+        [string]$Title
+    )
+
+    $cfg    = $script:BOOK_CONFIG[$Book]
+    $padded = $Number.ToString().PadLeft($cfg.Pad, '0')   # Zero-pad: 23 -> "0023" (for MP)
+    $label  = $cfg.Label                                    # Book label: "MP", "CP", or "JP"
+    $safeTitle = ConvertTo-TitleCase -Text (Invoke-Sanitize -Name $Title)
+    return "$padded ($label) - $safeTitle"
+}
+
+
+# ===========================================================================
+# LYRICS FORMATTING — convert parsed song data to plain text
+# ===========================================================================
+
+function Format-Lyrics {
+    <#
+    .SYNOPSIS
+        Format a parsed song into a clean plain-text string for saving.
+
+    .DESCRIPTION
+        This is the most complex formatting function in the scraper because
+        the source HTML has several structural quirks that need handling:
+
+        1. STANZA GROUPING: On missionpraise.com, each lyric line is its own <p>
+           element, and stanza breaks are represented by empty <p> tags. The
+           parser preserves this as empty strings in the verses list, which
+           this function uses to group lines into stanzas.
+
+        2. CHORUS DETECTION: Chorus lines are rendered in italic (<em>/<i>) on
+           the site. The parser flags each verse with is_italic=$true if it
+           contains any italic text. This function prepends "Chorus:" before
+           chorus stanzas.
+
+        3. ATTRIBUTION DETECTION: After the lyrics, songs may have author/composer
+           credits like "Words: Stuart Townend" or "Music: Keith Getty". These
+           are detected by pattern matching and separated from the lyrics with
+           extra blank lines.
+
+        4. STANDALONE AUTHOR LINES: Some songs have short attribution lines like
+           "Stuart Townend / Keith Getty" that don't start with "Words:" or
+           "Music:". These are detected by heuristics (contains "/" or "&",
+           short length, doesn't start with a digit).
+
+        5. MULTI-LINE VERSES: Some verses contain <br> tags (represented as \n
+           in the parser output), meaning multiple lines in a single <p>.
+           These are treated as complete stanzas on their own.
+
+    .PARAMETER Song
+        PSCustomObject with Title, Verses, Copyright, and Downloads properties.
+
+    .PARAMETER Book
+        Book identifier key ("mp", "cp", or "jp").
+
+    .OUTPUTS
+        String: The formatted plain-text song content.
+    #>
+    param(
+        [PSCustomObject]$Song,
+        [string]$Book
+    )
+
+    $cleanedTitle = Get-CleanTitle -Title $Song.Title -Book $Book
+    # Start with quoted title and blank line
+    $lines = [System.Collections.ArrayList]::new()
+    [void]$lines.Add("`"$cleanedTitle`"")
+    [void]$lines.Add("")
+
+    # --- Stanza/attribution tracking ---
+    # We need to separate actual lyrics from author/attribution lines that
+    # appear after the last verse. We also need to group single-line verses
+    # into stanzas (separated by empty <p> elements in the source).
+    $authorLines     = [System.Collections.ArrayList]::new()
+    $foundAttribution = $false
+    $stanzaBuf       = [System.Collections.ArrayList]::new()
+    $stanzaIsChorus  = $false
+
+    # --- Helper: flush the accumulated stanza to the output lines list ---
+    # (Implemented inline since PowerShell closures over ArrayList need care)
+
+    # --- Consecutive empty tracking ---
+    # On missionpraise.com, single empty <p> elements appear between EVERY
+    # lyric line for CSS spacing, not just at actual stanza boundaries. If we
+    # flushed on every empty <p>, each line would become its own "stanza" with
+    # a blank line after it (double-spaced output). Instead, we count
+    # consecutive empties and only flush when there's strong evidence of a
+    # real stanza boundary:
+    #   - 2+ consecutive empties (structural break in the HTML)
+    #   - Italic state change (verse <-> chorus transition)
+    #   - Verse number at start of the next line (new numbered verse)
+    $consecutiveEmpties = 0
+
+    # Process each verse (paragraph) from the parsed HTML
+    foreach ($versePair in $Song.Verses) {
+        $verseText = $versePair[0]
+        $isItalic  = $versePair[1]
+        $stripped   = $verseText.Trim()
+
+        # --- Empty verse: count but don't flush yet ---
+        # We defer the stanza-break decision until we see the next content
+        # line, so we can use content-based heuristics to decide.
+        if ([string]::IsNullOrEmpty($stripped)) {
+            $consecutiveEmpties++
+            continue
+        }
+
+        # --- Stanza break decision ---
+        # Now that we have a non-empty verse, decide whether the preceding
+        # empty <p> element(s) represent a real stanza break.
+        if ($stanzaBuf.Count -gt 0 -and $consecutiveEmpties -gt 0) {
+            $shouldBreak = (
+                $consecutiveEmpties -ge 2 -or                             # structural break
+                $isItalic -ne $stanzaIsChorus -or                         # verse<->chorus
+                [regex]::IsMatch($stripped, '^\d+\s')                     # verse number
+            )
+            if ($shouldBreak) {
+                # Flush stanza
+                if ($stanzaBuf.Count -gt 0) {
+                    if ($stanzaIsChorus) {
+                        $firstBufLine = if ($stanzaBuf.Count -gt 0) { $stanzaBuf[0].Trim() } else { "" }
+                        if (-not [regex]::IsMatch($firstBufLine, '^\d+\s')) {
+                            [void]$lines.Add("Chorus:")
+                        }
+                    }
+                    [void]$lines.Add(($stanzaBuf -join "`n"))
+                    [void]$lines.Add("")
+                    $stanzaBuf.Clear()
+                    $stanzaIsChorus = $false
+                }
+            }
+        }
+        $consecutiveEmpties = 0
+
+        # --- Attribution line detection ---
+        # Lines starting with "Words:", "Music:", "Arranged:", etc. are
+        # author/composer credits, not lyrics. We require a colon, "by",
+        # or separator after the keyword to prevent false positives (e.g.
+        # sidebar text "Music file" or lyrics starting with "Words of...").
+        # Once we find a genuine attribution line, subsequent short lines
+        # are also treated as attribution — but ONLY if they don't look
+        # like lyrics (i.e. they don't start with a digit/verse number).
+        $isAttribution = $false
+        if ([regex]::IsMatch($stripped, '^(Words|Music|Arranged|Words and music|Based on|Translated|Paraphrase)\s*[:&\-/by]', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)) {
+            $isAttribution = $true
+        }
+        elseif ([regex]::IsMatch($stripped, '^(Words and music|Words & music)\b', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)) {
+            $isAttribution = $true
+        }
+        elseif ($foundAttribution -and (-not $stripped.Contains("`n")) -and (-not [regex]::IsMatch($stripped, '^\d+\s')) -and ($stripped.Length -lt 120)) {
+            $isAttribution = $true
+        }
+
+        if ($isAttribution) {
+            # Flush stanza before adding attribution
+            if ($stanzaBuf.Count -gt 0) {
+                if ($stanzaIsChorus) {
+                    # Guard: don't label as Chorus if stanza starts with verse number
+                    $firstBufLine = if ($stanzaBuf.Count -gt 0) { $stanzaBuf[0].Trim() } else { "" }
+                    if (-not [regex]::IsMatch($firstBufLine, '^\d+\s')) {
+                        [void]$lines.Add("Chorus:")
+                    }
+                }
+                [void]$lines.Add(($stanzaBuf -join "`n"))
+                [void]$lines.Add("")
+                $stanzaBuf.Clear()
+                $stanzaIsChorus = $false
+            }
+            $foundAttribution = $true
+            [void]$authorLines.Add($stripped)
+            continue
+        }
+
+        # If we see a normal lyric line after attribution, reset the cascade.
+        # This prevents a single false-positive attribution from consuming
+        # all remaining lyrics in the song.
+        if ($foundAttribution -and [regex]::IsMatch($stripped, '^\d+\s')) {
+            $foundAttribution = $false
+        }
+
+        # --- Standalone author lines ---
+        # Some attribution lines don't follow the "Words:" pattern but are
+        # recognisable as author names by containing "/" or "&" separators
+        # (e.g. "Stuart Townend / Keith Getty"). We use several heuristics:
+        # - Single line (no internal line breaks)
+        # - Doesn't start with a digit (not a verse number)
+        # - Contains "/" or "&" (name separators)
+        # - Short enough to be a name, not lyrics (< 120 chars)
+        # - Not a typical lyric pattern (doesn't contain common verse words)
+        if ((-not $stripped.Contains("`n")) -and
+            (-not [regex]::IsMatch($stripped, '^\d')) -and
+            ($stripped.Contains("/") -or $stripped.Contains("&")) -and
+            ($stripped.Length -lt 120) -and
+            (-not [regex]::IsMatch($stripped, '\b(the|and|you|your|my|our|lord|god|love|sing|praise)\b', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase))) {
+            # Flush stanza
+            if ($stanzaBuf.Count -gt 0) {
+                if ($stanzaIsChorus) {
+                    # Guard: don't label as Chorus if stanza starts with verse number
+                    $firstBufLine = if ($stanzaBuf.Count -gt 0) { $stanzaBuf[0].Trim() } else { "" }
+                    if (-not [regex]::IsMatch($firstBufLine, '^\d+\s')) {
+                        [void]$lines.Add("Chorus:")
+                    }
+                }
+                [void]$lines.Add(($stanzaBuf -join "`n"))
+                [void]$lines.Add("")
+                $stanzaBuf.Clear()
+                $stanzaIsChorus = $false
+            }
+            [void]$authorLines.Add($stripped)
+            continue
+        }
+
+        # --- Multi-line verse ---
+        # If the verse text contains "\n" (from <br> tags in the HTML),
+        # it's a multi-line verse that should be treated as its own stanza.
+        if ($stripped.Contains("`n")) {
+            # Flush any single-line stanza we were building
+            if ($stanzaBuf.Count -gt 0) {
+                if ($stanzaIsChorus) {
+                    # Guard: don't label as Chorus if stanza starts with verse number
+                    $firstBufLine = if ($stanzaBuf.Count -gt 0) { $stanzaBuf[0].Trim() } else { "" }
+                    if (-not [regex]::IsMatch($firstBufLine, '^\d+\s')) {
+                        [void]$lines.Add("Chorus:")
+                    }
+                }
+                [void]$lines.Add(($stanzaBuf -join "`n"))
+                [void]$lines.Add("")
+                $stanzaBuf.Clear()
+                $stanzaIsChorus = $false
+            }
+            # Clean up each line within the verse (strip whitespace)
+            $cleaned = ($stripped.Split("`n") | ForEach-Object { $_.Trim() }) -join "`n"
+            if ($isItalic) {
+                # Guard: don't label as Chorus if first line starts with verse number
+                $firstCleanedLine = ($cleaned -split "`n")[0].Trim()
+                if (-not [regex]::IsMatch($firstCleanedLine, '^\d+\s')) {
+                    [void]$lines.Add("Chorus:")
+                }
+            }
+            [void]$lines.Add($cleaned)
+            [void]$lines.Add("")   # Blank line after the stanza
+        }
+        else {
+            # --- Single-line verse ---
+            # Accumulate into the current stanza buffer. The stanza will be
+            # flushed when we encounter an empty verse (stanza break) or a
+            # different type of content.
+            if ($isItalic) {
+                $stanzaIsChorus = $true
+            }
+            [void]$stanzaBuf.Add($stripped)
+        }
+    }
+
+    # Flush any remaining stanza that wasn't terminated by an empty verse
+    if ($stanzaBuf.Count -gt 0) {
+        if ($stanzaIsChorus) {
+            # Guard: don't label as Chorus if stanza starts with verse number
+            $firstBufLine = if ($stanzaBuf.Count -gt 0) { $stanzaBuf[0].Trim() } else { "" }
+            if (-not [regex]::IsMatch($firstBufLine, '^\d+\s')) {
+                [void]$lines.Add("Chorus:")
+            }
+        }
+        [void]$lines.Add(($stanzaBuf -join "`n"))
+        [void]$lines.Add("")
+        $stanzaBuf.Clear()
+        $stanzaIsChorus = $false
+    }
+
+    # Remove trailing blank lines from the lyrics section
+    while ($lines.Count -gt 0 -and $lines[$lines.Count - 1] -eq "") {
+        $lines.RemoveAt($lines.Count - 1)
+    }
+
+    # Append author attribution lines (separated from lyrics by double blank line)
+    if ($authorLines.Count -gt 0) {
+        [void]$lines.Add("")   # First blank line
+        [void]$lines.Add("")   # Second blank line (visual separation)
+        foreach ($al in $authorLines) {
+            [void]$lines.Add($al)
+        }
+    }
+
+    # Append copyright notice if available
+    if (-not [string]::IsNullOrWhiteSpace($Song.Copyright)) {
+        [void]$lines.Add("")
+        [void]$lines.Add($Song.Copyright)
+    }
+
+    # --- Post-processing: normalise spaced ellipses ---
+    # WordPress's text rendering sometimes converts "..." to ". . ." with
+    # spaces between the dots. We normalise these back to standard "..."
+    # The regex matches patterns like ". . ." or " . . ." with 2+ dots.
+    $result = $lines -join "`n"
+    $result = [regex]::Replace($result, ' ?(?:\. ){2,}\.', '...')
+
+    # Strip legacy formatting codes f*I (italic start) and f*R (format reset)
+    # that appear as data-entry artefacts in some song texts
+    $result = $result -replace 'f\*I', ''
+    $result = $result -replace 'f\*R', ''
+
+    # Collapse 3+ consecutive newlines down to 2 (one blank line maximum)
+    $result = [regex]::Replace($result, '(\r?\n){3,}', "`n`n")
+
+    return $result
+}
+
+
+# ===========================================================================
+# FILE CACHE — resumability support via cached directory listings
+# ===========================================================================
+
+function Build-FileCache {
+    <#
+    .SYNOPSIS
+        Build a set of existing filenames in a directory for quick lookup.
+
+    .DESCRIPTION
+        Called once at startup to avoid repeated directory scans during
+        the scrape. Returns a HashSet for O(1) membership testing.
+
+    .PARAMETER OutputDir
+        Path to the directory to scan.
+
+    .OUTPUTS
+        HashSet[string]: Set of filename strings (not full paths), or empty set
+        if the directory doesn't exist.
+    #>
+    param([string]$OutputDir)
+
+    $cache = [System.Collections.Generic.HashSet[string]]::new()
+    if (Test-Path $OutputDir -PathType Container) {
+        Get-ChildItem -Path $OutputDir -File | ForEach-Object {
+            [void]$cache.Add($_.Name)
+        }
+    }
+    return $cache
+}
+
+
+function Test-LyricsExist {
+    <#
+    .SYNOPSIS
+        Check if lyrics for a specific song have already been saved.
+
+    .DESCRIPTION
+        Uses the cached file listing for O(1) lookup instead of checking
+        the filesystem directly. Matches files by their prefix pattern
+        (number + label) and .txt extension.
+
+    .PARAMETER Number
+        The song number.
+
+    .PARAMETER Book
+        Book identifier key.
+
+    .PARAMETER FileCache
+        HashSet of existing filenames (from Build-FileCache).
+
+    .OUTPUTS
+        Boolean: $true if a matching .txt file exists in the cache.
+    #>
+    param(
+        [int]$Number,
+        [string]$Book,
+        [System.Collections.Generic.HashSet[string]]$FileCache
+    )
+
+    $cfg    = $script:BOOK_CONFIG[$Book]
+    $padded = $Number.ToString().PadLeft($cfg.Pad, '0')
+    $label  = $cfg.Label
+    # Build the prefix that all files for this song start with
+    $prefix = "$padded ($label) -"
+
+    foreach ($f in $FileCache) {
+        if ($f.StartsWith($prefix) -and $f.EndsWith(".txt")) {
+            return $true
+        }
+    }
+    return $false
+}
+
+
+function Test-DownloadExists {
+    <#
+    .SYNOPSIS
+        Check if a specific download file (words/music/audio) already exists.
+
+    .DESCRIPTION
+        Words files use the base name directly (base.rtf), while music and
+        audio files add a type suffix (base_music.pdf, base_audio.mp3).
+
+    .PARAMETER Base
+        The base filename (from Get-BaseFilename).
+
+    .PARAMETER DlType
+        Download type ("words", "music", or "audio").
+
+    .PARAMETER FileCache
+        HashSet of existing filenames.
+
+    .OUTPUTS
+        Boolean: $true if a matching file exists in the cache.
+    #>
+    param(
+        [string]$Base,
+        [string]$DlType,
+        [System.Collections.Generic.HashSet[string]]$FileCache
+    )
+
+    # Words files: "base.ext", other types: "base_type.ext"
+    $prefix = if ($DlType -eq "words") { "$Base." } else { "${Base}_${DlType}." }
+
+    foreach ($f in $FileCache) {
+        if ($f.StartsWith($prefix)) {
+            return $true
+        }
+    }
+    return $false
+}
+
+
+# ===========================================================================
+# SAVE FUNCTIONS — write lyrics and downloads to disk
+# ===========================================================================
+
+function Save-Lyrics {
+    <#
+    .SYNOPSIS
+        Format and save a song's lyrics to a plain-text file.
+
+    .DESCRIPTION
+        Creates the output directory if needed, generates the filename,
+        formats the lyrics, and writes the file with UTF-8 encoding.
+
+    .PARAMETER Song
+        Parsed song PSCustomObject with Title, Verses, Copyright.
+
+    .PARAMETER Number
+        The song number (e.g. 23).
+
+    .PARAMETER Book
+        Book identifier key ("mp", "cp", or "jp").
+
+    .PARAMETER OutputDir
+        Directory to save the file in.
+
+    .OUTPUTS
+        String: The base filename (without extension) — returned so that
+        download files can reuse the same base name.
+    #>
+    param(
+        [PSCustomObject]$Song,
+        [int]$Number,
+        [string]$Book,
+        [string]$OutputDir
+    )
+
+    # Create the output directory if it doesn't exist
+    if (-not (Test-Path $OutputDir)) {
+        New-Item -Path $OutputDir -ItemType Directory -Force | Out-Null
+    }
+
+    $cleanedTitle = Get-CleanTitle -Title $Song.Title -Book $Book
+    $base     = Get-BaseFilename -Number $Number -Book $Book -Title $cleanedTitle
+    $filepath = Join-Path $OutputDir "$base.txt"
+
+    # Format the lyrics and write to file (UTF-8 without BOM for cross-platform compatibility)
+    $content = Format-Lyrics -Song $Song -Book $Book
+    [System.IO.File]::WriteAllText($filepath, $content, [System.Text.UTF8Encoding]::new($false))
+
+    return $base
+}
+
+
+function Save-Download {
+    <#
+    .SYNOPSIS
+        Save a downloaded binary file (words, music, or audio) to disk.
+
+    .DESCRIPTION
+        Naming convention:
+        - Words (primary):  {base}.rtf       (same name as lyrics, different ext)
+        - Music:            {base}_music.pdf  (suffix distinguishes from words)
+        - Audio:            {base}_audio.mp3  (suffix distinguishes from words)
+
+        The extension is determined by Get-ExtForDownload using a cascade of
+        Content-Type -> URL extension -> magic bytes detection.
+
+    .PARAMETER Data
+        Raw bytes of the downloaded file.
+
+    .PARAMETER Base
+        Base filename (from Get-BaseFilename).
+
+    .PARAMETER DlType
+        Download type ("words", "music", or "audio").
+
+    .PARAMETER ContentType
+        MIME type from the Content-Type header.
+
+    .PARAMETER DlUrl
+        The download URL (for extension guessing fallback).
+
+    .PARAMETER OutputDir
+        Directory to save the file in.
+
+    .OUTPUTS
+        String: The complete filename (with extension) that was saved.
+    #>
+    param(
+        [byte[]]$Data,
+        [string]$Base,
+        [string]$DlType,
+        [string]$ContentType,
+        [string]$DlUrl,
+        [string]$OutputDir
+    )
+
+    $ext = Get-ExtForDownload -ContentType $ContentType -Url $DlUrl -Data $Data
+
+    # Words files share the same base name as lyrics (just different extension):
+    #   "0023 (MP) - Amazing Grace.rtf"
+    # Music and audio files add a type suffix to avoid extension conflicts:
+    #   "0023 (MP) - Amazing Grace_music.pdf"
+    #   "0023 (MP) - Amazing Grace_audio.mp3"
+    if ($DlType -eq "words") {
+        $filename = "$Base$ext"
+    }
+    else {
+        $filename = "${Base}_${DlType}$ext"
+    }
+
+    $filepath = Join-Path $OutputDir $filename
+    [System.IO.File]::WriteAllBytes($filepath, $Data)
+
+    return $filename
+}
+
+
+# ===========================================================================
+# SKIP DIAGNOSTIC HTML DUMP — write raw HTML for skipped songs to aid debugging
+# ===========================================================================
+
+function Write-SkipHtmlDump {
+    <#
+    .SYNOPSIS
+        Write the raw HTML of a skipped song page to a debug file for inspection.
+
+    .DESCRIPTION
+        When a song is skipped (login wall, WAF block, subscription paywall,
+        no title parsed), the raw HTML is dumped to a file named
+        _debug_{LABEL}{NUM}_skipped.html in the output directory.
+        This allows post-run diagnosis of why songs were skipped without
+        needing to re-run the scraper in debug mode.
+
+    .PARAMETER OutputDir
+        Directory to write the debug file in.
+
+    .PARAMETER Label
+        Book label (e.g. "MP").
+
+    .PARAMETER Padded
+        Zero-padded song number string (e.g. "0023").
+
+    .PARAMETER Html
+        The raw HTML content of the page that triggered the skip.
+    #>
+    param(
+        [string]$OutputDir,
+        [string]$Label,
+        [string]$Padded,
+        [string]$Html
+    )
+
+    if (-not $Html) {
+        return   # Nothing to dump if the response was empty
+    }
+
+    # Create the output directory if it doesn't exist
+    if (-not (Test-Path $OutputDir)) {
+        New-Item -Path $OutputDir -ItemType Directory -Force | Out-Null
+    }
+
+    $filename = "_debug_${Label}${Padded}_skipped.html"
+    $filepath = Join-Path $OutputDir $filename
+    [System.IO.File]::WriteAllText($filepath, $Html, [System.Text.Encoding]::UTF8)
+}
+
+
+# ===========================================================================
+# SKIP LOGGING — record skipped songs for later review
+# ===========================================================================
+
+function Write-SkipLog {
+    <#
+    .SYNOPSIS
+        Record a skipped song in the skipped.log file for later review.
+
+    .DESCRIPTION
+        Creates a persistent log of songs that couldn't be scraped, with
+        timestamps, identifiers, and reasons. Useful for identifying gaps
+        and diagnosing systematic issues.
+
+    .PARAMETER OutputDir
+        Directory to write the log file in.
+
+    .PARAMETER Label
+        Book label (e.g. "MP").
+
+    .PARAMETER Padded
+        Zero-padded song number string (e.g. "0023").
+
+    .PARAMETER Title
+        The song title from the index page.
+
+    .PARAMETER Url
+        The song page URL that was attempted.
+
+    .PARAMETER Reason
+        Human-readable explanation of why it was skipped.
+    #>
+    param(
+        [string]$OutputDir,
+        [string]$Label,
+        [string]$Padded,
+        [string]$Title,
+        [string]$Url,
+        [string]$Reason
+    )
+
+    # Create the output directory if it doesn't exist
+    if (-not (Test-Path $OutputDir)) {
+        New-Item -Path $OutputDir -ItemType Directory -Force | Out-Null
+    }
+
+    $logPath   = Join-Path $OutputDir "skipped.log"
+    $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+    $logEntry  = "[$timestamp]  ${Label}${Padded}  $Title  --  $Reason  --  $Url"
+
+    # Append to the log file (create if it doesn't exist)
+    Add-Content -Path $logPath -Value $logEntry -Encoding UTF8
+}
+
+
+# ===========================================================================
+# PROCESS SONG — orchestrate scraping + downloading for a single song
+# ===========================================================================
+
+function Invoke-ProcessSong {
+    <#
+    .SYNOPSIS
+        Scrape lyrics and download files for a single song.
+
+    .DESCRIPTION
+        This is the core function that handles one song from start to finish:
+        1. Extract the song number from the index title
+        2. Check if lyrics/downloads already exist (skip if so)
+        3. Fetch the song detail page
+        4. Parse the HTML to extract lyrics, copyright, and download links
+        5. Save the lyrics as a .txt file
+        6. Download and save words/music/audio files (if enabled)
+
+        The function handles several edge cases:
+        - Songs with no extractable number (logged and skipped)
+        - Login walls (the session expired mid-scrape)
+        - WAF blocks on individual song pages
+        - Failed title parsing (retried once in case of transient errors)
+        - Missing downloads (re-fetches the page if lyrics exist but files don't)
+
+    .PARAMETER Title
+        Song title from the index page (includes book code).
+
+    .PARAMETER Url
+        URL of the song detail page.
+
+    .PARAMETER Book
+        Book identifier key ("mp", "cp", or "jp").
+
+    .PARAMETER OutputDir
+        Base output directory.
+
+    .PARAMETER NoFiles
+        If $true, skip downloading words/music/audio files.
+
+    .PARAMETER Delay
+        Seconds to wait between requests.
+
+    .PARAMETER FileCache
+        Mutable HashSet of existing filenames (updated when new files saved).
+
+    .OUTPUTS
+        String: "saved" if lyrics were newly saved,
+                "skipped" if the song couldn't be scraped,
+                "exists" if the song was already saved from a previous run.
+    #>
+    param(
+        [string]$Title,
+        [string]$Url,
+        [string]$Book,
+        [string]$OutputDir,
+        [bool]$NoFiles,
+        [double]$Delay,
+        [System.Collections.Generic.HashSet[string]]$FileCache
+    )
+
+    # Extract the hymn number from the title (e.g. "Amazing Grace (MP0023)" -> 23)
+    $number = Get-HymnNumber -Title $Title -Book $Book
+    $cfg    = $script:BOOK_CONFIG[$Book]
+
+    # Route output into a book-specific subdirectory
+    $bookDir = Join-Path $OutputDir $cfg.Subdir
+
+    if ($number -lt 0) {
+        # Title doesn't contain a recognisable book code — can't save this song
+        Write-SkipLog -OutputDir $bookDir -Label "??" -Padded "????" -Title $Title -Url $Url -Reason "no book number found in title"
+        return "skipped"
+    }
+
+    $padded = $number.ToString().PadLeft($cfg.Pad, '0')
+    $label  = $cfg.Label
+
+    # --- Check if lyrics already exist ---
+    $lyricsExist = Test-LyricsExist -Number $number -Book $Book -FileCache $FileCache
+
+    # If lyrics exist and we don't need files, skip entirely (no network request)
+    if ($lyricsExist -and $NoFiles) {
+        return "exists"
+    }
+
+    # If lyrics exist, check whether downloads also exist
+    if ($lyricsExist) {
+        $clean = Get-CleanTitle -Title $Title -Book $Book
+        $base  = Get-BaseFilename -Number $number -Book $Book -Title $clean
+        # Look for any non-txt file with the same base name
+        $hasAnyDownload = $false
+        foreach ($f in $FileCache) {
+            if (-not $f.EndsWith(".txt") -and ($f.StartsWith("$base.") -or $f.StartsWith("${base}_"))) {
+                $hasAnyDownload = $true
+                break
+            }
+        }
+        if ($NoFiles -or $hasAnyDownload) {
+            return "exists"
+        }
+        # Lyrics exist but no downloads — need to fetch page for download links
+        $displayTitle = $Title.Substring(0, [Math]::Min(55, $Title.Length)).PadRight(55)
+        Write-Host "    $label$padded  $displayTitle " -NoNewline
+        Write-Host ">> fetching missing downloads... " -NoNewline
+    }
+    else {
+        # Neither lyrics nor files exist — full scrape needed
+        $displayTitle = $Title.Substring(0, [Math]::Min(55, $Title.Length)).PadRight(55)
+        Write-Host "    $label$padded  $displayTitle " -NoNewline
+    }
+
+    # --- Fetch the song detail page ---
+    $result = Invoke-FetchText -Url $Url
+    $htmlText = $result[0]
+
+    # Check for login wall (session may have expired during the scrape)
+    if (-not $htmlText -or $htmlText.Contains("Please login to continue") -or $htmlText.Contains("loginform")) {
+        $reason = if ($htmlText) { "login wall" } else { "empty response" }
+        Write-Host "X ($reason)" -ForegroundColor Red
+        Write-SkipHtmlDump -OutputDir $bookDir -Label $label -Padded $padded -Html $htmlText
+        Write-SkipLog -OutputDir $bookDir -Label $label -Padded $padded -Title $Title -Url $Url -Reason $reason
+        Start-Sleep -Seconds $Delay
+        return "skipped"
+    }
+
+    # Check for subscription paywall (song exists but isn't included in the
+    # user's subscription tier — the page loads but content is gated)
+    if ($htmlText -and $htmlText.Contains("not part of your subscription")) {
+        Write-Host "X (not in subscription)" -ForegroundColor Red
+        Write-SkipHtmlDump -OutputDir $bookDir -Label $label -Padded $padded -Html $htmlText
+        Write-SkipLog -OutputDir $bookDir -Label $label -Padded $padded -Title $Title -Url $Url -Reason "song not part of subscription"
+        Start-Sleep -Seconds $Delay
+        return "skipped"
+    }
+
+    # Check for WAF block on the song page (can happen on individual pages)
+    $htmlLower = $htmlText.ToLower()
+    if ($htmlLower.Contains("sucuri") -or $htmlLower.Contains("access denied")) {
+        Write-Host "X (blocked by firewall)" -ForegroundColor Red
+        Write-SkipHtmlDump -OutputDir $bookDir -Label $label -Padded $padded -Html $htmlText
+        Write-SkipLog -OutputDir $bookDir -Label $label -Padded $padded -Title $Title -Url $Url -Reason "blocked by WAF/firewall"
+        Start-Sleep -Seconds $Delay
+        return "skipped"
+    }
+
+    # --- Parse the song page HTML ---
+    $sp = Parse-SongPage -Html $htmlText
+
+    # If the parser couldn't find a title, retry once — this may be a transient
+    # issue like a session hiccup or a partially-loaded page
+    if ([string]::IsNullOrWhiteSpace($sp.Title)) {
+        Start-Sleep -Seconds ($Delay * 2)   # Longer delay before retry
+        $result = Invoke-FetchText -Url $Url
+        $htmlText = $result[0]
+        if ($htmlText -and (-not $htmlText.Contains("loginform"))) {
+            $sp = Parse-SongPage -Html $htmlText
+        }
+    }
+
+    # --- Title fallback: try extracting from HTML <title> tag ---
+    # If Parse-SongPage couldn't find the title via its normal selectors,
+    # try the HTML <title> element as a fallback (usually "Song Name - Mission Praise")
+    if ([string]::IsNullOrWhiteSpace($sp.Title) -and $htmlText) {
+        $titleTagMatch = [regex]::Match($htmlText, '<title>([^<]+)</title>', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+        if ($titleTagMatch.Success) {
+            $fallbackTitle = $titleTagMatch.Groups[1].Value.Trim()
+            # Strip the site name suffix (e.g. " - Mission Praise" or " – Mission Praise")
+            $fallbackTitle = [regex]::Replace($fallbackTitle, '\s*[\-\x{2013}\x{2014}]\s*Mission\s+Praise.*$', '', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase).Trim()
+            if ($fallbackTitle -and $fallbackTitle.Length -gt 0) {
+                $sp.Title = $fallbackTitle
+            }
+        }
+    }
+
+    # --- Title fallback: use the index page title (strip book code) ---
+    # Last resort: use the title from the song index, stripping the book code
+    # suffix like "(MP1270)" from the end
+    if ([string]::IsNullOrWhiteSpace($sp.Title) -and -not [string]::IsNullOrWhiteSpace($Title)) {
+        $indexFallback = [regex]::Replace($Title, '\s*\([A-Z]{2}\d+\)\s*$', '').Trim()
+        if ($indexFallback -and $indexFallback.Length -gt 0) {
+            $sp.Title = $indexFallback
+        }
+    }
+
+    # If still no title after retry and fallbacks, skip this song
+    if ([string]::IsNullOrWhiteSpace($sp.Title)) {
+        Write-Host "X (no title parsed)" -ForegroundColor Red
+        Write-SkipHtmlDump -OutputDir $bookDir -Label $label -Padded $padded -Html $htmlText
+        Write-SkipLog -OutputDir $bookDir -Label $label -Padded $padded -Title $Title -Url $Url -Reason "parser found no title in page HTML"
+        Start-Sleep -Seconds $Delay
+        return "skipped"
+    }
+
+    # Build the structured song data (already a PSCustomObject from Parse-SongPage)
+    $song = $sp
+
+    # --- Verse count validation ---
+    # Count actual text lines (not <p> entries) to detect incomplete parses.
+    # Many songs use a few large <p> blocks with <br> line breaks inside,
+    # so counting entries would produce false "incomplete" warnings.
+    $totalLines = 0
+    foreach ($v in $sp.Verses) {
+        $vText = $v[0]
+        if ($vText -and $vText.Trim()) {
+            $totalLines += ($vText.Trim().Split("`n")).Count
+        }
+    }
+    if ($totalLines -eq 0) {
+        Write-Host " WARNING (no lyrics found)" -NoNewline -ForegroundColor Yellow
+        Log-Skip -OutputDir $bookDir -Label $label -Padded $padded -Title $title -Url $url -Reason "parser found title but 0 lyric lines"
+    }
+    elseif ($totalLines -lt 4) {
+        Write-Host " WARNING ($totalLines lines - may be incomplete)" -NoNewline -ForegroundColor Yellow
+    }
+
+    # --- Save lyrics ---
+    if ($lyricsExist) {
+        # Lyrics already saved — just re-derive the base name for download files
+        $base = Get-BaseFilename -Number $number -Book $Book -Title (Get-CleanTitle -Title $sp.Title -Book $Book)
+    }
+    else {
+        # Save lyrics to .txt file and add to the file cache
+        $base = Save-Lyrics -Song $song -Number $number -Book $Book -OutputDir $bookDir
+        [void]$FileCache.Add("$base.txt")
+    }
+
+    # --- Download files (words, music, audio) ---
+    $fileResults = @()   # Track download results for the status line
+    if (-not $NoFiles -and $song.Downloads.Count -gt 0) {
+        foreach ($dlType in @("words", "music", "audio")) {
+            $dlUrl = $song.Downloads[$dlType]
+            if (-not $dlUrl) {
+                continue   # This download type isn't available for this song
+            }
+
+            # Skip if already downloaded
+            if (Test-DownloadExists -Base $base -DlType $dlType -FileCache $FileCache) {
+                $fileResults += $dlType.Substring(0,1).ToLower()   # Lowercase = already existed
+                continue
+            }
+
+            # Convert relative URLs to absolute
+            if ($dlUrl.StartsWith("/")) {
+                $dlUrl = "$($script:BASE)$dlUrl"
+            }
+
+            # Download the file
+            $dlResult = Invoke-FetchBinary -Url $dlUrl
+            $data     = $dlResult[0]
+            $ct       = $dlResult[1]
+            $dlFinalUrl = $dlResult[2]
+
+            if ($data) {
+                $effectiveUrl = if ($dlFinalUrl) { $dlFinalUrl } else { $dlUrl }
+                $fname = Save-Download -Data $data -Base $base -DlType $dlType `
+                    -ContentType $ct -DlUrl $effectiveUrl -OutputDir $bookDir
+                $fileResults += $dlType.Substring(0,1).ToUpper()   # Uppercase = newly downloaded
+                [void]$FileCache.Add($fname)   # Add to cache so we don't re-download
+            }
+
+            # Brief delay between downloads (30% of normal delay)
+            Start-Sleep -Seconds ($Delay * 0.3)
+        }
+    }
+
+    # Print the status line with download indicators:
+    # [W,M,A] = newly downloaded words/music/audio (uppercase)
+    # [w,m,a] = already existed (lowercase)
+    $fileStr = if ($fileResults.Count -gt 0) { " [$($fileResults -join ',')]" } else { "" }
+    Write-Host "[+]$fileStr" -ForegroundColor Green
+    Start-Sleep -Seconds $Delay   # Rate limit between songs
+    return "saved"
+}
+
+
+# ===========================================================================
+# CRAWL & SCRAPE — paginated index crawling with per-page song processing
+# ===========================================================================
+
+function Invoke-CrawlAndScrape {
+    <#
+    .SYNOPSIS
+        Crawl the paginated song index and scrape each discovered song.
+
+    .DESCRIPTION
+        The missionpraise.com song index is paginated (10 songs per page).
+        This function:
+        1. Fetches each index page sequentially
+        2. Parses the page to discover song links
+        3. Filters songs to only the requested books (MP, CP, JP)
+        4. Scrapes each song on the current page before moving to the next
+
+        End-of-index detection:
+        - "Page not found" in the response -> no more pages
+        - WordPress serving page 1 content for out-of-range page numbers
+          (detected by checking the "X-Y of Z" counter in the HTML)
+        - No song links found on the page
+        - Empty response
+
+        The function is designed for resumability:
+        - Builds a file cache of existing files on startup
+        - Supports -StartPage for resuming from a specific index page
+        - Each song is individually checked for existing files
+
+    .PARAMETER Books
+        Array of book keys to scrape (e.g. @("mp", "cp", "jp")).
+
+    .PARAMETER OutputDir
+        Base output directory.
+
+    .PARAMETER NoFiles
+        If $true, skip file downloads.
+
+    .PARAMETER StartPage
+        Index page number to start from. Default: 1.
+
+    .PARAMETER Delay
+        Seconds between requests.
+
+    .PARAMETER Force
+        When $true, skip building the file cache so every song is treated as
+        new. Existing files on disk will be overwritten without checking.
+
+    .PARAMETER Song
+        When specified, scrape only the song with this number. Auto-enables
+        Force mode and stops after the song is found.
+
+    .OUTPUTS
+        Array of three integers: [saved, skipped, existed].
+    #>
+    param(
+        [string[]]$Books,
+        [string]$OutputDir,
+        [bool]$NoFiles,
+        [int]$StartPage = 1,
+        [double]$Delay = 1.2,
+        [bool]$Force = $false,
+        [string]$Song = ""
+    )
+
+    # When -Song is specified, auto-enable Force mode so the file cache
+    # doesn't cause the target song to be skipped as "already exists"
+    if ($Song) {
+        $Force = $true
+    }
+
+    $page = $StartPage
+
+    # Pre-compile book pattern regexes for efficient matching
+    $bookPats = @{}
+    foreach ($b in $Books) {
+        $bookPats[$b] = [regex]::new($script:BOOK_CONFIG[$b].Pattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+    }
+
+    # Build a combined file cache from all book subdirectories.
+    # Filenames are unique across books because they include the book label,
+    # so merging into one set is safe and simplifies lookup logic.
+    # When -Force is active, we deliberately use an empty cache so that every
+    # song is treated as new, causing lyrics and downloads to be re-fetched
+    # and any existing files on disk to be overwritten.
+    $fileCache = [System.Collections.Generic.HashSet[string]]::new()
+    if ($Force) {
+        Write-Host "  Force mode: will re-download and overwrite existing files.`n" -ForegroundColor Yellow
+    }
+    else {
+        foreach ($b in $Books) {
+            $subdir = Join-Path $OutputDir $script:BOOK_CONFIG[$b].Subdir
+            $bookCache = Build-FileCache -OutputDir $subdir
+            foreach ($f in $bookCache) {
+                [void]$fileCache.Add($f)
+            }
+        }
+    }
+
+    # Counters for the final summary
+    $saved   = 0   # Songs newly saved in this run
+    $skipped = 0   # Songs that couldn't be scraped
+    $existed = 0   # Songs that already existed from previous runs
+
+    if (-not $Force -and $fileCache.Count -gt 0) {
+        Write-Host "  Found $($fileCache.Count) existing files across output folders -- will skip duplicates.`n"
+    }
+
+    # --- Main pagination loop ---
+    while ($true) {
+        # Construct the URL for the current index page
+        $url = "$($script:INDEX_URL)$page/"
+        $result = Invoke-FetchText -Url $url
+        $htmlText = $result[0]
+
+        # Detect end of pagination
+        if (-not $htmlText -or $htmlText.Contains("Page not found")) {
+            if ($script:DEBUG_MODE) {
+                $reason = if (-not $htmlText) { "empty response" } else { "Page not found detected" }
+                Write-Host "  DEBUG: Page $page -- $reason"
+            }
+            break
+        }
+
+        # Dump the first page's HTML for debugging (only on StartPage)
+        if ($page -eq $StartPage) {
+            Write-DebugDump -Label "Index page $page HTML" -Text $htmlText
+        }
+
+        # --- Loop detection ---
+        # WordPress has a quirk where out-of-range page numbers silently serve
+        # page 1 content (instead of returning a 404). We detect this by parsing
+        # the "Showing X-Y of Z" counter in the HTML.
+        $countMatch = [regex]::Match($htmlText, '(\d+)-(\d+)\s+of\s+(\d+)')
+        if ($countMatch.Success) {
+            $lo    = [int]$countMatch.Groups[1].Value
+            $hi    = [int]$countMatch.Groups[2].Value
+            $total = [int]$countMatch.Groups[3].Value
+            # Ceiling division: songs / 10 per page
+            $totalPages = [math]::Ceiling($total / 10)
+
+            # Print total count on the first page
+            if ($page -eq $StartPage) {
+                Write-Host "  $total total songs across ~$totalPages pages`n"
+            }
+
+            # Detect loops: if lo > hi (impossible) or we're past page 1 but
+            # seeing results starting from 1 (WordPress served page 1 again)
+            if ($lo -gt $hi -or ($page -gt 1 -and $lo -eq 1)) {
+                break
+            }
+        }
+        else {
+            # If we can't find the counter and we're past page 1, assume we've
+            # gone beyond the last page (page 1 might legitimately lack the counter)
+            if ($page -gt 1) {
+                break
+            }
+        }
+
+        # --- Parse the index page for song links ---
+        $indexSongs = Parse-IndexPage -Html $htmlText
+
+        if (-not $indexSongs -or $indexSongs.Count -eq 0) {
+            # No song links found — we've reached the end of the index
+            if ($script:DEBUG_MODE) {
+                Write-Host "  DEBUG: IndexParser found 0 song links on page $page"
+                # Debug: dump all <a> links to help diagnose parser issues
+                $allLinks = [regex]::Matches($htmlText, '<a[^>]+href=["\x27]([^"\x27]*)["\x27][^>]*>')
+                $songLinks = $allLinks | Where-Object { $_.Groups[1].Value -match '/songs/' }
+                Write-Host "  DEBUG: Total <a> links: $($allLinks.Count), with /songs/: $($songLinks.Count)"
+                $songLinks | Select-Object -First 10 | ForEach-Object {
+                    Write-Host "         $($_.Groups[1].Value)"
+                }
+            }
+            break
+        }
+
+        # --- Filter songs to requested books ---
+        # Each song title includes a book code like "(MP0023)" — we match
+        # against the patterns for the books the user wants to scrape
+        $pageSongs = @()
+        foreach ($songEntry in $indexSongs) {
+            foreach ($bookKey in $bookPats.Keys) {
+                if ($bookPats[$bookKey].IsMatch($songEntry.Title)) {
+                    $pageSongs += [PSCustomObject]@{
+                        Title = $songEntry.Title
+                        Url   = $songEntry.Url
+                        Book  = $bookKey
+                    }
+                    break   # A song belongs to exactly one book
+                }
+            }
+        }
+
+        # --- Filter to a specific song number when -Song is specified ---
+        # Match by extracting the numeric part from each song's book code
+        $targetFound = $false
+        if ($Song) {
+            $filteredSongs = @()
+            foreach ($ps in $pageSongs) {
+                $cfg = $script:BOOK_CONFIG[$ps.Book]
+                $m = [regex]::Match($ps.Title, $cfg.Pattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+                if ($m.Success) {
+                    $songNum = [int]$m.Groups[1].Value
+                    if ($songNum -eq [int]$Song) {
+                        $filteredSongs += $ps
+                        $targetFound = $true
+                    }
+                }
+            }
+            $pageSongs = $filteredSongs
+        }
+
+        # Print page summary with running totals
+        $pageStr = $page.ToString().PadLeft(4)
+        Write-Host "  Page $pageStr  --  $($pageSongs.Count) matching songs  (saved: $saved, existed: $existed, skipped: $skipped)"
+
+        # --- Scrape each song on this page ---
+        $pageExisted = 0
+        foreach ($ps in $pageSongs) {
+            # Build absolute URL if the link is relative
+            $songUrl = $ps.Url
+            if ($songUrl.StartsWith("/")) {
+                $songUrl = "$($script:BASE)$songUrl"
+            }
+            elseif (-not $songUrl.StartsWith("http")) {
+                $songUrl = "$($script:BASE)/$songUrl"
+            }
+
+            $songResult = Invoke-ProcessSong -Title $ps.Title -Url $songUrl -Book $ps.Book `
+                -OutputDir $OutputDir -NoFiles $NoFiles -Delay $Delay -FileCache $fileCache
+
+            switch ($songResult) {
+                "saved"   { $saved++;   break }
+                "skipped" { $skipped++; break }
+                "exists"  { $existed++; $pageExisted++; break }
+            }
+        }
+
+        # If every song on this page already existed, print a compact summary
+        # instead of per-song output (reduces noise during resumed scrapes)
+        if ($pageExisted -eq $pageSongs.Count -and $pageSongs.Count -gt 0) {
+            Write-Host "           >>  all $pageExisted songs on this page already exist" -ForegroundColor DarkGray
+        }
+
+        # When targeting a specific song and it was found, stop crawling
+        if ($Song -and $targetFound) {
+            Write-Host "`n  Target song $Song found -- stopping." -ForegroundColor Cyan
+            break
+        }
+
+        $page++
+        Start-Sleep -Seconds $Delay   # Rate limit between index pages
+    }
+
+    return @($saved, $skipped, $existed)
+}
+
+
+# ===========================================================================
+# MAIN — entry point: interactive menu or CLI parameter processing
+# ===========================================================================
+
+function Invoke-Main {
+    <#
+    .SYNOPSIS
+        Parse parameters, authenticate, and start the scrape.
+
+    .DESCRIPTION
+        Handles the full lifecycle:
+        1. Detect whether to show interactive menu (no args) or use CLI params
+        2. Validate the requested books
+        3. Create an HTTP session and authenticate with the site
+        4. Print configuration summary
+        5. Run the crawl-and-scrape process
+        6. Print final results
+    #>
+
+    # --- Handle -Help / -? ---
+    if ($Help) {
+        Get-Help $PSCommandPath -Detailed
+        return
+    }
+
+    # --- Detect interactive mode ---
+    # If neither Username nor Password was provided via CLI params, show
+    # the interactive GUI menu (typical when script is double-clicked).
+    $isInteractive = [string]::IsNullOrWhiteSpace($Username) -and [string]::IsNullOrWhiteSpace($Password)
+
+    if ($isInteractive) {
+        $config = Show-InteractiveMenu
+
+        # Unpack the menu configuration into local variables
+        $effectiveUsername  = $config.Username
+        $effectivePassword  = $config.Password
+        $effectiveOutput    = $config.Output
+        $effectiveBooks     = $config.Books
+        $effectiveStartPage = $config.StartPage
+        $effectiveDelay     = $config.Delay
+        $effectiveNoFiles   = $config.NoFiles
+        $effectiveDebug     = $config.Debug
+        $effectiveForce     = $config.Force
+        $effectiveSong      = ""   # Interactive mode doesn't support -Song
+    }
+    else {
+        # CLI mode — use the parameters as provided
+        $effectiveUsername  = $Username
+        $effectivePassword  = $Password
+        $effectiveOutput    = $Output
+        $effectiveBooks     = $Books
+        $effectiveStartPage = $StartPage
+        $effectiveDelay     = $Delay
+        $effectiveNoFiles   = [bool]$NoFiles
+        $effectiveDebug     = [bool]$Debug
+        $effectiveForce     = [bool]$Force
+        $effectiveSong      = $Song
+
+        # Prompt for credentials if not provided via CLI arguments
+        if ([string]::IsNullOrWhiteSpace($effectiveUsername)) {
+            $effectiveUsername = Read-Host "Mission Praise username/email"
+        }
+        if ([string]::IsNullOrWhiteSpace($effectivePassword)) {
+            $securePass = Read-Host "Mission Praise password" -AsSecureString
+            $bstr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($securePass)
+            $effectivePassword = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
+            [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+        }
+    }
+
+    # Set the global debug flag
+    $script:DEBUG_MODE = $effectiveDebug
+
+    # Parse and validate the books argument (filter out invalid entries)
+    $bookList = @()
+    foreach ($b in $effectiveBooks.Split(",")) {
+        $trimmed = $b.Trim().ToLower()
+        if ($script:BOOK_CONFIG.ContainsKey($trimmed)) {
+            $bookList += $trimmed
+        }
+    }
+
+    if ($bookList.Count -eq 0) {
+        Write-Host "No valid books specified. Use -Books mp,cp,jp" -ForegroundColor Red
+        return
+    }
+
+    # Authenticate with the site
+    $loginSuccess = Invoke-Login -Username $effectiveUsername -Password $effectivePassword
+    if (-not $loginSuccess) {
+        # Login failed — error already printed by Invoke-Login
+        if ($isInteractive) {
+            Write-Host ""
+            Write-Host "  Press any key to exit..." -ForegroundColor DarkGray
+            $null = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
+        }
+        return
+    }
+
+    # Print configuration summary
+    $absOutput = (Resolve-Path -Path $effectiveOutput -ErrorAction SilentlyContinue)
+    if (-not $absOutput) {
+        $absOutput = [System.IO.Path]::GetFullPath($effectiveOutput)
+    }
+    Write-Host ""
+    Write-Host "Books    : $(($bookList | ForEach-Object { $_.ToUpper() }) -join ', ')"
+    Write-Host "Output   : $absOutput"
+    Write-Host "Downloads: $(if ($effectiveNoFiles) { 'disabled' } else { 'enabled (words, music, audio)' })"
+    if ($effectiveSong) {
+        Write-Host "Song     : $effectiveSong (single-song mode, force enabled)" -ForegroundColor Cyan
+    }
+    elseif ($effectiveForce) {
+        Write-Host "Force    : ON -- overwriting existing files" -ForegroundColor Yellow
+    }
+    Write-Host ""
+
+    # Run the main crawl-and-scrape process
+    $results = Invoke-CrawlAndScrape -Books $bookList -OutputDir $effectiveOutput `
+        -NoFiles $effectiveNoFiles -StartPage $effectiveStartPage -Delay $effectiveDelay `
+        -Force $effectiveForce -Song $effectiveSong
+
+    $savedCount   = $results[0]
+    $skippedCount = $results[1]
+    $existedCount = $results[2]
+
+    # Print final summary
+    Write-Host ""
+    Write-Host "Done!  $savedCount saved, $existedCount already existed, $skippedCount skipped." -ForegroundColor Green
+    Write-Host "Output: $absOutput"
+    if ($skippedCount -gt 0) {
+        $logPath = Join-Path $effectiveOutput "skipped.log"
+        Write-Host "Skipped songs logged to: $logPath"
+    }
+
+    # Keep the window open if running interactively (double-clicked)
+    if ($isInteractive) {
+        Write-Host ""
+        Write-Host "  Press any key to exit..." -ForegroundColor DarkGray
+        $null = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
+    }
+}
+
+
+# ---------------------------------------------------------------------------
+# Script entry point — call the main function
+# ---------------------------------------------------------------------------
+Invoke-Main

--- a/.importers/scrapers/MissionPraise.com.py
+++ b/.importers/scrapers/MissionPraise.com.py
@@ -1,0 +1,2160 @@
+#!/usr/bin/env python3
+"""
+MissionPraise.com.py
+importers/scrapers/MissionPraise.com.py
+
+Mission Praise Scraper — scrapes lyrics and downloads files from missionpraise.com.
+Copyright 2025-2026 MWBM Partners Ltd.
+
+Overview:
+    This scraper authenticates with missionpraise.com (a WordPress-based site
+    that requires a paid subscription), then crawls the paginated song index
+    to discover all songs across three hymnbooks:
+        - Mission Praise (MP)  — ~1000+ songs, 4-digit numbering
+        - Carol Praise (CP)    — ~300 songs, 3-digit numbering
+        - Junior Praise (JP)   — ~300 songs, 3-digit numbering
+
+    For each song, it:
+    1. Scrapes the lyrics from the song detail page
+    2. Optionally downloads associated files (words RTF/DOC, music PDF, audio MP3)
+    3. Saves everything with a consistent filename convention
+
+    The scraper is designed to be resumable: it caches the list of existing
+    files on startup and skips songs that already have saved lyrics/downloads.
+
+Authentication:
+    The site uses WordPress standard login (wp-login.php) with CSRF nonces
+    and may be behind a Sucuri WAF (Web Application Firewall). The login
+    flow handles:
+    - Extracting hidden form fields (nonces) from the login page
+    - Setting proper Referer/Origin headers to pass WAF checks
+    - Detecting WAF blocks, login failures, and ambiguous states
+    - Cookie-based session management via http.cookiejar
+
+File output format:
+    Lyrics are saved as plain-text files:
+        {padded_number} ({LABEL}) - {Title Case Title}.txt
+    Download files use the same base name with type suffixes:
+        {base}.rtf          (words — primary download, no suffix)
+        {base}_music.pdf    (music score)
+        {base}_audio.mp3    (audio recording)
+
+    Files are organised into book-specific subdirectories:
+        hymns/Mission Praise [MP]/
+        hymns/Carol Praise [CP]/
+        hymns/Junior Praise [JP]/
+
+Dependencies:
+    None — uses only Python standard library modules (no pip install needed).
+    This is intentional so the script can run on any system with Python 3.6+.
+
+Usage:
+    python3 mp_scraper.py --username YOUR_EMAIL --password YOUR_PASSWORD
+    python3 mp_scraper.py --username YOUR_EMAIL --password YOUR_PASSWORD --output ~/Desktop/hymns
+    python3 mp_scraper.py --username YOUR_EMAIL --password YOUR_PASSWORD --books mp,cp,jp
+    python3 mp_scraper.py --username YOUR_EMAIL --password YOUR_PASSWORD --start-page 5
+    python3 mp_scraper.py --username YOUR_EMAIL --password YOUR_PASSWORD --no-files
+"""
+
+# ---------------------------------------------------------------------------
+# Standard library imports (no third-party dependencies required)
+# ---------------------------------------------------------------------------
+import urllib.request    # For making HTTP requests (GET and POST)
+import urllib.parse      # For URL encoding of form data and URL parsing
+import urllib.error      # For handling HTTP error responses
+import sys
+
+# Force line-buffered stdout so progress messages appear immediately in the
+# terminal, even when output is piped or redirected. Without this, Python
+# uses block buffering when stdout is not a TTY, which delays progress output.
+sys.stdout.reconfigure(line_buffering=True)
+
+import http.cookiejar   # Cookie management for maintaining login session
+import html.parser       # Base class for custom HTML parsers (no BeautifulSoup)
+import gzip              # For decompressing gzip-encoded HTTP responses
+import os                # File system operations (makedirs, path joining, etc.)
+import re                # Regular expressions for HTML parsing and text processing
+import time              # For rate-limiting delays between requests
+import argparse          # Command-line argument parsing
+import getpass           # Secure password input (hides characters while typing)
+
+
+# ---------------------------------------------------------------------------
+# Constants — URLs, timing, and global configuration
+# ---------------------------------------------------------------------------
+
+# Base URL for the Mission Praise website
+BASE        = "https://missionpraise.com"
+
+# WordPress standard login endpoint
+LOGIN_URL   = f"{BASE}/wp-login.php"
+
+# Paginated song index URL — append page number (e.g. /songs/page/1/)
+INDEX_URL   = f"{BASE}/songs/page/"
+
+# Default delay between HTTP requests (seconds). 1.2s is chosen to be
+# respectful to the server while keeping scraping at a reasonable speed.
+DELAY       = 1.2
+
+# Default output directory (relative to where the script is run)
+DEFAULT_OUT = "./hymns"
+
+# Global debug flag — set to True via --debug CLI argument to dump HTML
+# responses for troubleshooting login/parsing issues
+DEBUG       = False
+
+# HTML5 void elements — these tags have no closing tag, so they must NOT
+# affect depth tracking. Without this exclusion, each <br> (etc.) inflates
+# the depth counter by +1 with no matching -1, preventing proper detection
+# of when the parser has exited a container element like <div class="song-details">.
+# Reference: https://html.spec.whatwg.org/multipage/syntax.html#void-elements
+VOID_ELEMENTS = frozenset([
+    "area", "base", "br", "col", "embed", "hr", "img", "input",
+    "link", "meta", "param", "source", "track", "wbr",
+])
+
+# ---------------------------------------------------------------------------
+# Book configuration — defines the three hymnbooks scraped from the site
+# ---------------------------------------------------------------------------
+# Each book has:
+#   label:   Short identifier used in filenames (e.g. "MP", "CP", "JP")
+#   pad:     Number of digits to zero-pad the hymn number to (MP=4, others=3)
+#   pattern: Regex to extract the book number from the index page title
+#            e.g. "Amazing Grace (MP0023)" → matches "(MP0023)" → group(1) = "0023"
+#   subdir:  Human-readable subdirectory name for organised file output
+BOOK_CONFIG = {
+    "mp": {"label": "MP", "pad": 4, "pattern": r'\(MP(\d+)\)', "subdir": "Mission Praise [MP]"},
+    "cp": {"label": "CP", "pad": 3, "pattern": r'\(CP(\d+)\)', "subdir": "Carol Praise [CP]"},
+    "jp": {"label": "JP", "pad": 3, "pattern": r'\(JP(\d+)\)', "subdir": "Junior Praise [JP]"},
+}
+
+# ---------------------------------------------------------------------------
+# MIME type → file extension mapping for downloaded files
+# ---------------------------------------------------------------------------
+# When downloading files (words, music, audio), the server's Content-Type
+# header tells us what format the file is in. This mapping converts common
+# MIME types to their standard file extensions.
+# "application/octet-stream" is a generic binary type — we fall back to
+# guessing the extension from the URL or magic bytes in that case.
+MIME_TO_EXT = {
+    "application/rtf":          ".rtf",     # Rich Text Format (words)
+    "text/rtf":                 ".rtf",     # Alternate RTF MIME type
+    "application/msword":       ".doc",     # Microsoft Word (legacy)
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx",
+    "application/pdf":          ".pdf",     # PDF (music scores)
+    "audio/midi":               ".mid",     # MIDI audio
+    "audio/x-midi":             ".mid",     # Alternate MIDI MIME type
+    "audio/mpeg":               ".mp3",     # MP3 audio
+    "audio/mp3":                ".mp3",     # Alternate MP3 MIME type
+    "audio/wav":                ".wav",     # WAV audio
+    "audio/x-wav":              ".wav",     # Alternate WAV MIME type
+    "audio/ogg":                ".ogg",     # Ogg Vorbis audio
+    "application/octet-stream": "",         # Generic binary — fall back to URL/magic
+}
+
+# Mapping of download type keys to human-readable labels (used in logging)
+TYPE_LABEL = {
+    "words": "words",
+    "music": "music",
+    "audio": "audio",
+}
+
+
+# ---------------------------------------------------------------------------
+# Session / opener — HTTP session management with cookie support
+# ---------------------------------------------------------------------------
+
+def debug_dump(label, text, max_chars=3000):
+    """
+    Print a labelled debug dump of HTML/text content (only when DEBUG is True).
+
+    Used during development and troubleshooting to inspect raw HTML responses
+    from the server. Truncates output to max_chars to avoid flooding the terminal.
+
+    Args:
+        label:     A descriptive label for what's being dumped
+        text:      The text content to dump
+        max_chars: Maximum characters to display (default: 3000)
+    """
+    if not DEBUG:
+        return
+    print(f"\n{'='*60}")
+    print(f"DEBUG: {label}")
+    print(f"{'='*60}")
+    print(text[:max_chars])
+    if len(text) > max_chars:
+        print(f"... ({len(text) - max_chars} more chars)")
+    print(f"{'='*60}\n")
+
+
+def make_opener():
+    """
+    Create an HTTP opener with cookie support and browser-like headers.
+
+    Returns a urllib opener configured to:
+    1. Automatically store and send cookies (for session management after login)
+    2. Send headers that mimic a real browser (to avoid being blocked by WAFs
+       or bot detection systems)
+
+    The headers are modelled after a real Chrome/Edge browser on macOS,
+    including Sec-Fetch-* headers that modern WAFs check to distinguish
+    legitimate browser requests from automated scripts.
+
+    Returns:
+        tuple: (opener, jar) where:
+            opener: urllib.request.OpenerDirector configured with cookies
+            jar:    http.cookiejar.CookieJar instance for inspecting cookies
+    """
+    # CookieJar stores all cookies received from the server and automatically
+    # sends them back on subsequent requests (essential for login sessions)
+    jar    = http.cookiejar.CookieJar()
+    opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(jar))
+
+    # Set default headers that mimic a real browser to avoid WAF blocks.
+    # These headers are sent with every request made through this opener.
+    opener.addheaders = [
+        # User-Agent string mimicking Chrome on macOS
+        ("User-Agent",
+         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+         "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36 Edg/145.0.0.0"),
+        # Accept header indicating we prefer HTML but accept anything
+        ("Accept",
+         "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,"
+         "image/webp,image/apng,*/*;q=0.8"),
+        ("Accept-Language", "en-GB,en;q=0.9"),
+        ("Accept-Encoding", "gzip, deflate, br"),      # We handle gzip decompression
+        ("Connection", "keep-alive"),                    # Reuse TCP connections
+        ("Upgrade-Insecure-Requests", "1"),              # Standard browser header
+        # Sec-Fetch-* headers: modern security headers that WAFs use to verify
+        # requests come from a real browser navigation context
+        ("Sec-Fetch-Dest", "document"),     # We're requesting a document
+        ("Sec-Fetch-Mode", "navigate"),     # This is a navigation request
+        ("Sec-Fetch-Site", "same-origin"),  # Request is to the same site
+        ("Sec-Fetch-User", "?1"),           # User-initiated request
+        ("Cache-Control", "max-age=0"),     # Don't serve cached responses
+    ]
+    return opener, jar
+
+
+def login(opener, jar, username, password):
+    """
+    Authenticate with missionpraise.com using WordPress standard login.
+
+    The login flow is:
+    1. GET the login page to obtain CSRF nonces (hidden form fields)
+    2. Brief pause (2s) to appear more human-like
+    3. POST credentials + nonces with proper Referer/Origin headers
+    4. Handle various failure modes (WAF blocks, wrong password, etc.)
+    5. Verify login succeeded by fetching the songs page and checking
+       for logged-in indicators
+
+    The function is defensive about error detection because:
+    - The Sucuri WAF can block requests that look automated
+    - WordPress login failures manifest in different ways (redirect
+      back to login, error div, etc.)
+    - The login page structure may vary between WordPress versions
+
+    Args:
+        opener:   urllib opener with cookie support (from make_opener)
+        jar:      CookieJar instance for cookie inspection during debugging
+        username: The user's missionpraise.com email address
+        password: The user's missionpraise.com password
+
+    Returns:
+        bool: True if login appears successful, False if definitely failed
+    """
+    print(f"Logging in as {username}...")
+
+    # --- Step 1: GET the login page to extract CSRF nonces ---
+    # WordPress login forms contain hidden fields (nonces) that must be
+    # submitted with the POST request to prevent CSRF attacks.
+    with opener.open(LOGIN_URL) as resp:
+        html_text = _decode_response(resp)
+
+    debug_dump("Login page HTML", html_text)
+
+    # Extract all <input type="hidden"> fields from the login form.
+    # These typically include:
+    #   - testcookie: WordPress test cookie check
+    #   - _wpnonce: WordPress CSRF nonce
+    #   - Various plugin-specific nonces
+    hidden = {}
+    for m in re.finditer(r'<input[^>]+type=["\']hidden["\'][^>]*>', html_text, re.I):
+        nm = re.search(r'name=["\']([^"\']+)["\']',  m.group())
+        vm = re.search(r'value=["\']([^"\']*)["\']', m.group())
+        if nm:
+            hidden[nm.group(1)] = vm.group(1) if vm else ""
+
+    if DEBUG:
+        print(f"  DEBUG: Hidden fields: {hidden}")
+        print(f"  DEBUG: Cookies after GET login page: {[c.name for c in jar]}")
+
+    # --- Step 2: Brief pause to appear more human-like ---
+    # Some WAFs flag requests that POST to the login form within milliseconds
+    # of loading the page, as this is a strong indicator of automated access.
+    time.sleep(2)
+
+    # --- Step 3: POST the login credentials ---
+    # Build the login form data with WordPress standard field names
+    payload = {
+        "log":         username,              # WordPress username field
+        "pwd":         password,              # WordPress password field
+        "wp-submit":   "Log In",              # Submit button value
+        "redirect_to": f"{BASE}/songs/",      # Where to redirect after login
+        "rememberme":  "forever",             # Keep the session alive
+        **hidden,                             # Include all CSRF nonces
+    }
+    data = urllib.parse.urlencode(payload).encode()
+
+    # Build a POST request with proper Referer and Origin headers.
+    # The Sucuri WAF checks these headers — missing or incorrect values
+    # will result in a 403 block.
+    login_req = urllib.request.Request(LOGIN_URL, data=data)
+    login_req.add_header("Referer", LOGIN_URL)      # Must match the login page URL
+    login_req.add_header("Origin", BASE)             # Must match the site origin
+    login_req.add_header("Content-Type", "application/x-www-form-urlencoded")
+
+    try:
+        with opener.open(login_req) as resp:
+            final_url = resp.url       # Where did the server redirect us?
+            body      = _decode_response(resp)
+    except urllib.error.HTTPError as e:
+        # Some servers return HTTP errors (403, etc.) for blocked login attempts.
+        # We still need to read the response body to check for WAF messages.
+        final_url = getattr(e, "url", "") or ""
+        raw = e.read()
+        # Decompress gzip if needed (error responses can be compressed too)
+        if raw[:2] == b'\x1f\x8b':
+            raw = gzip.decompress(raw)
+        body = raw.decode("utf-8", errors="replace")
+
+    if DEBUG:
+        print(f"  DEBUG: Post-login redirect URL: {final_url}")
+        print(f"  DEBUG: Cookies after POST login: {[c.name for c in jar]}")
+        debug_dump("Post-login body", body)
+
+    # --- Step 4: Check for various failure modes ---
+
+    # Check for WAF / firewall blocks (e.g. Sucuri CDN/WAF)
+    # Sucuri blocks show a distinctive page with "Access Denied" and details
+    # about the block reason and the client's IP address.
+    if "sucuri" in body.lower() or "access denied" in body.lower():
+        block_reason = re.search(r'Block reason:</td>\s*<td><span>(.*?)</span>', body, re.S)
+        block_ip     = re.search(r'Your IP:</td>\s*<td><span>(.*?)</span>', body, re.S)
+        reason = block_reason.group(1).strip() if block_reason else "unknown"
+        ip     = block_ip.group(1).strip() if block_ip else "unknown"
+        print(f"  [!] BLOCKED by website firewall: {reason}")
+        print(f"       Your IP: {ip}")
+        print("       Try again later or log in via browser first to whitelist your IP.")
+        return False
+
+    # Check for incorrect credentials — WordPress stays on wp-login.php
+    # and includes an error message in the response body
+    if "wp-login.php" in final_url and "incorrect" in body.lower():
+        print("  [!] Login failed — check username/password.")
+        return False
+
+    # Check for other WordPress login errors (still on login page after POST)
+    if "wp-login.php" in final_url:
+        if DEBUG:
+            print(f"  DEBUG: Still on login page after POST — login likely failed")
+        # Look for the WordPress login error div which contains specific messages
+        # like "Unknown username", "Incorrect password", etc.
+        error_m = re.search(r'<div[^>]*id=["\']login_error["\'][^>]*>(.*?)</div>', body, re.S)
+        if error_m:
+            # Strip HTML tags from the error message for clean display
+            error_text = re.sub(r'<[^>]+>', '', error_m.group(1)).strip()
+            print(f"  [!] Login error: {error_text}")
+            return False
+
+    # --- Step 5: Verify login by fetching the songs page ---
+    # Even if the POST didn't show an error, we verify by checking if the
+    # songs page shows logged-in indicators (some sites silently fail login).
+    with opener.open(f"{BASE}/songs/") as resp:
+        check     = _decode_response(resp)
+        check_url = resp.url
+
+    if DEBUG:
+        print(f"  DEBUG: Songs page URL: {check_url}")
+        print(f"  DEBUG: Cookies when checking songs: {[c.name for c in jar]}")
+        debug_dump("Songs page HTML", check)
+
+    # Look for multiple indicators of being logged in — different WordPress
+    # themes show different indicators, so we check several possibilities
+    check_lower = check.lower()
+    logged_in = any([
+        "logout" in check_lower,           # "Log out" link in header/nav
+        "log out" in check_lower,           # Alternate spelling
+        "log-out" in check_lower,           # Hyphenated version
+        "Welcome" in check,                 # "Welcome, Username" greeting
+        "my-account" in check_lower,        # Account menu link
+        "wp-admin" in check_lower,          # Admin bar (for admin users)
+        'logged-in' in check_lower,         # CSS class on <body> tag
+    ])
+
+    if logged_in:
+        print("  ✓ Logged in.")
+        return True
+
+    # Check if we were redirected back to the login page (session not established)
+    if "wp-login" in check_url or "login" in check_url:
+        print("  [!] Login failed — redirected back to login page.")
+        return False
+
+    # Login status is ambiguous — proceed anyway (some themes don't show
+    # obvious logged-in indicators). The user can re-run with --debug to
+    # investigate if songs fail to load.
+    print("  [?] Login status unclear — proceeding anyway.")
+    print("       (Re-run with --debug to see full HTML responses)")
+    return True
+
+
+# ---------------------------------------------------------------------------
+# HTML parsers — custom parsers for the site's index and song pages
+# ---------------------------------------------------------------------------
+
+class IndexParser(html.parser.HTMLParser):
+    """
+    Parser for the paginated song index page at missionpraise.com/songs/page/N/.
+
+    The index page lists songs as links within heading elements. Each song
+    appears as an <a> tag inside an <h2> or <h3>, with the title text
+    including the book code (e.g. "Amazing Grace (MP0023)").
+
+    HTML structure being parsed:
+        <h2>
+            <a href="/songs/amazing-grace-mp0023/">Amazing Grace (MP0023)</a>
+        </h2>
+
+    Attributes:
+        songs: List of (title_text, url) tuples discovered on the page
+    """
+    def __init__(self):
+        super().__init__()
+        self.songs   = []      # Output: list of (title, url) tuples
+        self._in_h   = False   # True when inside an <h2> or <h3> element
+        self._a_href = None    # The href of the current <a> tag (if inside heading)
+        self._buf    = []      # Text buffer for accumulating link text
+
+    def handle_starttag(self, tag, attrs):
+        """Track entry into heading elements and capture song links within them."""
+        # Enter heading context (songs are listed inside <h2> or <h3> tags)
+        if tag in ("h2", "h3"):
+            self._in_h = True
+
+        # When we find an <a> tag inside a heading with a /songs/ URL,
+        # start capturing its text content
+        if self._in_h and tag == "a":
+            href = dict(attrs).get("href", "")
+            if "/songs/" in href:
+                self._a_href = href
+                self._buf    = []
+
+    def handle_endtag(self, tag):
+        """Capture the completed song entry when the link tag closes."""
+        if tag == "a" and self._a_href:
+            # We've reached the end of a song link — save the title and URL
+            self.songs.append(("".join(self._buf).strip(), self._a_href))
+            self._a_href = None
+            self._buf    = []
+        if tag in ("h2", "h3"):
+            # Exit heading context
+            self._in_h = False
+
+    def handle_data(self, data):
+        """Accumulate text content when inside a song link."""
+        if self._a_href:
+            self._buf.append(data)
+
+
+class SongParser(html.parser.HTMLParser):
+    """
+    Parser for individual song detail pages on missionpraise.com.
+
+    Each song page contains:
+    - A title in an element with class "entry-title"
+    - Lyrics in <p> blocks inside a div with class "song-details"
+    - Copyright info in an element with class "copyright-info"
+    - Download links in a sidebar with class "col-sm-4"
+
+    The parser uses depth tracking to know when it has fully exited each
+    section's container element.
+
+    Lyrics detection:
+    - Each <p> inside .song-details represents a line or stanza break
+    - <em>/<i> tags indicate chorus lines (italic in the original)
+    - Empty <p> tags represent stanza breaks between verses
+    - <br> tags represent line breaks within a verse
+
+    Download link detection:
+    - Links in the .col-sm-4 sidebar with text containing "words", "music",
+      or "audio" are captured as download URLs
+
+    Attributes:
+        title (str):      The song title
+        verses (list):    List of (text, is_italic) tuples
+        copyright (str):  Copyright notice text
+        downloads (dict): Map of type ("words"/"music"/"audio") → URL
+    """
+    def __init__(self):
+        super().__init__()
+        # --- Public output attributes ---
+        self.title     = ""            # Song title from .entry-title
+        self.verses    = []            # List of (text, is_italic) tuples
+        self.copyright = ""            # Copyright notice text
+        self.downloads = {}            # Download links: type → URL
+
+        # --- Section tracking state ---
+        # The parser tracks which content section we're currently inside:
+        # "title", "song", or "copyright" (or None when outside all sections).
+        # Depth tracking tells us when we've exited the section's container.
+        self._section    = None        # Current section: "title"/"song"/"copyright"/None
+        self._depth      = 0           # Depth counter within current section
+        self._in_p       = False       # True when inside a <p> tag in the song section
+        self._buf        = []          # Text buffer for title and copyright sections
+        self._verse_buf  = []          # Text buffer for lyrics within a <p> tag
+
+        # --- Italic (chorus) tracking ---
+        # On missionpraise.com, chorus lines are rendered in italic (<em>/<i>).
+        # We track whether any italic text appears in the current <p> to mark
+        # entire verses as chorus lines in the output.
+        self._in_em        = False     # True when inside an <em> or <i> tag
+        self._verse_has_em = False     # True if current verse contains any italic text
+
+        # --- Download link tracking ---
+        # Download links are in a sidebar div with class "col-sm-4".
+        # We track entry into this container and capture <a> tags within it.
+        self._in_files   = False       # True when inside the download sidebar
+        self._files_depth = 0          # Depth counter within the sidebar
+        self._in_a       = False       # True when inside an <a> tag in the sidebar
+        self._a_href     = None        # The href of the current download link
+        self._a_buf      = []          # Text buffer for the link label
+
+    def _classes(self, attrs):
+        """Extract CSS class names from an HTML tag's attribute list."""
+        return dict(attrs).get("class", "").split()
+
+    def _flush(self):
+        """Drain the text buffer and return its contents as a stripped string."""
+        t = "".join(self._buf).strip()
+        self._buf = []
+        return t
+
+    def handle_starttag(self, tag, attrs):
+        """
+        Called for each opening HTML tag. Routes processing based on the
+        current parsing state (download sidebar, title, song, or copyright).
+
+        Args:
+            tag:   HTML tag name
+            attrs: List of (name, value) attribute tuples
+        """
+        cls  = self._classes(attrs)
+        attr = dict(attrs)
+
+        # --- DOWNLOAD SIDEBAR ---
+        # The download links (words/music/audio) are in a Bootstrap column
+        # with class "col-sm-4" in the page sidebar. On some pages the
+        # sidebar uses class "files" instead (inside a <section> tag).
+        if "col-sm-4" in cls or "files" in cls:
+            self._in_files    = True
+            self._files_depth = 1
+        elif self._in_files:
+            # Track depth inside the sidebar to know when we exit.
+            # Skip void elements — same rationale as section depth tracking.
+            if tag not in VOID_ELEMENTS:
+                self._files_depth += 1
+            # Capture <a> tags within the sidebar that have href attributes
+            if tag == "a" and attr.get("href"):
+                self._in_a   = True
+                self._a_href = attr["href"]
+                self._a_buf  = []
+
+        # --- CONTENT SECTIONS ---
+        # Detect entry into the three content sections by their CSS classes.
+        # Each section uses depth tracking (self._depth) to know when we've
+        # fully exited the container element.
+        if "entry-title" in cls:
+            self._section = "title";  self._depth = 1;  return
+        if "song-details" in cls:
+            self._section = "song";   self._depth = 1;  return
+        if "copyright-info" in cls:
+            self._section = "copyright"; self._depth = 1; return
+
+        # If we're inside a section, track nested tag depth.
+        # IMPORTANT: void elements (<br>, <img>, <hr>, etc.) must NOT
+        # increment depth because they have no closing tag — without
+        # this guard, each <br> inflates the counter by +1 with no
+        # matching -1 in handle_endtag, preventing the parser from
+        # detecting when it has exited the section container.
+        if self._section:
+            if tag not in VOID_ELEMENTS:
+                self._depth += 1
+
+            if self._section == "song" and not self._in_files:
+                # --- Song lyrics section (outside download sidebar) ---
+                # Guard: skip verse capture when inside the col-sm-4
+                # download sidebar to prevent sidebar link text (e.g.
+                # "Music file") from being captured as lyrics, which
+                # can trigger false attribution detection downstream.
+                if tag == "p":
+                    # IMPLICIT CLOSE: if a <p> opens while another is already
+                    # open (common in missionpraise.com HTML where bare <P> tags
+                    # separate verses without closing the previous one), flush
+                    # the current verse buffer before starting the new paragraph.
+                    # Without this, only the last paragraph's content is captured
+                    # because earlier buffers are silently overwritten.
+                    if self._in_p and self._verse_buf:
+                        verse = "".join(self._verse_buf).strip()
+                        self.verses.append((verse, self._verse_has_em))
+
+                    # Starting a new paragraph — each <p> is either a lyric line,
+                    # a stanza break (empty <p>), or an attribution line
+                    self._in_p        = True
+                    self._verse_buf   = []
+                    # Inherit the outer <em> state. On some songs, the chorus
+                    # is wrapped as <em><p>line</p><p>line</p></em> rather than
+                    # <p><em>line</em></p>. In that case, _in_em is already True
+                    # when the <p> starts, so we propagate it here. If instead
+                    # the <em> appears inside this <p>, handle_starttag("em")
+                    # below will set _verse_has_em = True as before.
+                    self._verse_has_em = self._in_em
+
+                if tag in ("em", "i") and self._in_p:
+                    # Italic text within a verse indicates a chorus line
+                    self._in_em        = True
+                    self._verse_has_em = True
+
+                if tag == "br" and self._in_p:
+                    # <br> within a <p> represents a line break within a verse.
+                    # Guard: the site often emits <BR><br /> (double break) on
+                    # each line — collapse consecutive newlines to avoid blanks.
+                    if not self._verse_buf or self._verse_buf[-1] != "\n":
+                        self._verse_buf.append("\n")
+
+            # Handle <br> in title and copyright sections
+            if tag == "br" and self._section in ("title", "copyright"):
+                self._buf.append("\n")
+
+    def handle_endtag(self, tag):
+        """
+        Called for each closing HTML tag. Handles extraction of completed
+        content when sections and subsections close.
+
+        Args:
+            tag: HTML tag name being closed
+        """
+        # --- DOWNLOAD SIDEBAR ---
+        if self._in_files:
+            if tag == "a" and self._in_a:
+                # The download link has closed — determine its type from the
+                # link text (which contains "words", "music", or "audio")
+                label = "".join(self._a_buf).strip().lower()
+                href  = self._a_href
+                if href and href != "#":
+                    # Match the link to a download type based on its label text
+                    for key in ("words", "music", "audio"):
+                        if key in label:
+                            self.downloads[key] = href
+                            break
+                self._in_a   = False
+                self._a_href = None
+                self._a_buf  = []
+
+            # Track depth to detect when we've exited the sidebar container.
+            # Ignore void element close tags (shouldn't appear, but be safe).
+            if tag not in VOID_ELEMENTS:
+                self._files_depth -= 1
+                if self._files_depth <= 0:
+                    self._in_files = False
+
+        # --- CONTENT SECTIONS ---
+        if not self._section:
+            return
+
+        # Ignore void element close tags for section depth tracking.
+        # Void elements should never appear as </br> etc., but malformed
+        # HTML can include them — ignoring prevents depth counter underflow.
+        if tag in VOID_ELEMENTS:
+            return
+
+        # Track italic tag closure within song lyrics
+        if self._section == "song" and tag in ("em", "i"):
+            self._in_em = False
+
+        # Handle verse completion when a <p> tag closes inside the song section
+        if self._section == "song" and tag == "p" and self._in_p:
+            verse = "".join(self._verse_buf).strip()
+            # We keep empty strings as stanza-break markers so that format_lyrics()
+            # can distinguish between "lines within a stanza" (which should be joined)
+            # and "stanza gaps" (which should be separated by blank lines).
+            # Each verse is stored as a (text, is_italic) tuple where italic = chorus.
+            self.verses.append((verse, self._verse_has_em))
+            self._in_p     = False
+            self._verse_buf = []
+
+        # Track section depth — when we reach 0, we've exited the section container
+        self._depth -= 1
+        if self._depth == 0:
+            text = self._flush()
+            if self._section == "title" and not self.title:
+                self.title = text
+            elif self._section == "copyright" and not self.copyright:
+                self.copyright = text
+            self._section = None
+
+    def handle_startendtag(self, tag, attrs):
+        """
+        Called for self-closing tags like <br/> or <img ... />.
+
+        The default HTMLParser implementation calls handle_starttag() then
+        handle_endtag(), which would double-count depth for void elements.
+        Since we now skip void elements in both handlers, we only need to
+        call handle_starttag() to process the tag's content effects (e.g.
+        appending "\\n" for <br/> in lyrics) without any depth side effects.
+        """
+        self.handle_starttag(tag, attrs)
+
+    def handle_data(self, data):
+        """
+        Called for plain text content between HTML tags. Routes text to
+        the appropriate buffer based on current parsing state.
+
+        Args:
+            data: Text content string
+        """
+        # Download link text (to determine the type: words/music/audio)
+        if self._in_a:
+            self._a_buf.append(data)
+        # Lyrics text within a <p> in the song section.
+        # Guard: exclude text inside the download sidebar (col-sm-4) to prevent
+        # sidebar link labels (e.g. "Music file") from being captured as verse
+        # content, which would trigger false attribution detection in format_lyrics().
+        if self._section == "song" and self._in_p and not self._in_files:
+            self._verse_buf.append(data)
+        # Title or copyright text
+        elif self._section in ("title", "copyright"):
+            self._buf.append(data)
+
+    def _entity(self, name=None, num=None):
+        """
+        Convert an HTML entity to its Unicode character.
+
+        Handles both named entities (e.g. &amp;, &rsquo;) and numeric
+        character references (e.g. &#8217;). Common typographic entities
+        found in song lyrics include smart quotes and dashes.
+
+        Args:
+            name: Named entity (e.g. "rsquo") — mutually exclusive with num
+            num:  Numeric character code (e.g. 8217)
+
+        Returns:
+            str: The Unicode character, or "" if not recognised
+        """
+        if num is not None:
+            try: return chr(num)
+            except: return ""
+        return {"amp":"&","lt":"<","gt":">","quot":'"',"apos":"'","nbsp":" ",
+                "rsquo":"\u2019","lsquo":"\u2018","rdquo":"\u201d","ldquo":"\u201c",
+                "mdash":"\u2014","ndash":"\u2013"}.get(name,"")
+
+    def handle_entityref(self, name):
+        """Handle named HTML entities like &amp; or &rsquo;."""
+        ch = self._entity(name=name)
+        self._push(ch)
+
+    def handle_charref(self, name):
+        """Handle numeric character references like &#8217; or &#x2019;."""
+        try: num = int(name[1:],16) if name.startswith("x") else int(name)
+        except: return
+        self._push(self._entity(num=num))
+
+    def _push(self, ch):
+        """
+        Route a character to the appropriate buffer(s) based on parsing state.
+
+        Note: download link text and section text can overlap (a download link
+        could technically appear inside a section), so we check multiple
+        conditions independently rather than using elif.
+
+        Args:
+            ch: The character to append to the buffer(s)
+        """
+        if not ch: return
+        if self._in_a:                                                self._a_buf.append(ch)
+        if self._section == "song" and self._in_p and not self._in_files:  self._verse_buf.append(ch)
+        elif self._section in ("title","copyright"):                  self._buf.append(ch)
+
+
+# ---------------------------------------------------------------------------
+# Fetch helpers — HTTP request and response handling utilities
+# ---------------------------------------------------------------------------
+
+def _decode_response(resp):
+    """
+    Read an HTTP response, decompress it if gzip-encoded, and decode to text.
+
+    Many web servers (including WordPress/Sucuri) compress responses with gzip.
+    This function handles both cases:
+    1. Server sets Content-Encoding: gzip header
+    2. Response body starts with gzip magic bytes (0x1f 0x8b) regardless of header
+
+    The second check is a defensive fallback — some servers/proxies don't set
+    the header correctly even when the content is compressed.
+
+    Args:
+        resp: An HTTP response object (from urllib.request.urlopen)
+
+    Returns:
+        str: The decoded text content of the response
+    """
+    raw = resp.read()
+    encoding = resp.headers.get("Content-Encoding", "").lower()
+    # Check both the header and the magic bytes — defensive against
+    # misconfigured servers that compress without setting the header
+    if encoding == "gzip" or raw[:2] == b'\x1f\x8b':
+        raw = gzip.decompress(raw)
+    return raw.decode("utf-8", errors="replace")
+
+
+def fetch_text(opener, url):
+    """
+    Fetch a URL and return its text content, handling errors gracefully.
+
+    Args:
+        opener: urllib opener with cookie/session support
+        url:    The URL to fetch
+
+    Returns:
+        tuple: (text_content, final_url) on success
+               (None, None) on any error
+    """
+    try:
+        with opener.open(url, timeout=20) as resp:
+            return _decode_response(resp), resp.url
+    except Exception as e:
+        print(f"\n  [!] Error fetching {url}: {e}")
+        return None, None
+
+
+def fetch_binary(opener, url):
+    """
+    Download a binary file (words/music/audio) from a URL.
+
+    Includes several safety checks:
+    1. Decompresses gzip responses (some servers compress file downloads)
+    2. Detects server error pages masquerading as file downloads — some
+       servers return HTML error pages with a 200 status code when the
+       actual file is missing or access is denied
+
+    The error detection heuristic checks if the response:
+    - Starts with common text/HTML bytes ('<', 's', 'e', '{')
+    - Is small enough to be an error page (< 50KB)
+    - Contains error-related keywords when decoded as UTF-8
+
+    Args:
+        opener: urllib opener with cookie/session support
+        url:    The download URL
+
+    Returns:
+        tuple: (bytes_data, content_type, final_url) on success
+               (None, None, None) on any error
+    """
+    try:
+        with opener.open(url, timeout=30) as resp:
+            # Extract the MIME type from Content-Type (strip charset parameter)
+            ct  = resp.headers.get("Content-Type", "").split(";")[0].strip().lower()
+            raw = resp.read()
+
+            # Decompress gzip if the server compressed the download
+            encoding = resp.headers.get("Content-Encoding", "").lower()
+            if encoding == "gzip" or raw[:2] == b'\x1f\x8b':
+                raw = gzip.decompress(raw)
+
+            # --- Error page detection ---
+            # Some servers return HTML error pages (PHP exceptions, 404 pages, etc.)
+            # with a 200 status code instead of the actual file. We detect these by
+            # checking if the content looks like text/HTML rather than binary data.
+            # The size threshold is 500KB — PHP error dumps with full AWS S3 stack
+            # traces can be 200KB+, so the previous 50KB limit missed them.
+            if raw[:1] in (b'<', b's', b'e', b'{') and len(raw) < 500000:
+                try:
+                    text = raw.decode("utf-8", errors="strict")
+                    if any(kw in text.lower() for kw in ("exception", "<html", "<!doctype", "error", "not found", "string(", "nosuchkey", "stacktrace")):
+                        print(f"server error", end=" ")
+                        if DEBUG:
+                            debug_dump("Server error in download", text, max_chars=500)
+                        return None, None, None
+                except UnicodeDecodeError:
+                    pass  # Not valid UTF-8 → genuinely binary data, carry on
+
+            return raw, ct, resp.url
+    except Exception as e:
+        print(f"\n  [!] Download error {url}: {e}")
+        return None, None, None
+
+
+def ext_from_url(url):
+    """
+    Guess the file extension from a URL's path component.
+
+    Parses the URL to extract the path, then gets the extension from the
+    last path segment. Server-side script extensions (.php, .asp, etc.)
+    are ignored because they indicate dynamic download endpoints rather
+    than actual file types.
+
+    Args:
+        url: The download URL to extract the extension from
+
+    Returns:
+        str: The lowercase file extension (e.g. ".rtf") or "" if none found
+
+    Example:
+        "https://example.com/download.php?id=123"  → "" (php is ignored)
+        "https://example.com/files/song.rtf"        → ".rtf"
+    """
+    path = urllib.parse.urlparse(url).path
+    _, ext = os.path.splitext(path)
+    ext = ext.lower()
+    # Ignore server-side script extensions — these are dynamic endpoints
+    # that serve files, not the actual file extension
+    if ext in (".php", ".asp", ".aspx", ".jsp", ".cgi", ".py"):
+        return ""
+    return ext if ext else ""
+
+
+# ---------------------------------------------------------------------------
+# Magic bytes — file type detection from binary content
+# ---------------------------------------------------------------------------
+# When the Content-Type header is unhelpful (e.g. "application/octet-stream")
+# and the URL doesn't reveal the file type, we can identify the format by
+# examining the first few bytes of the file content. Most file formats begin
+# with a distinctive "magic number" or signature.
+MAGIC_BYTES = [
+    (b"%PDF",                       ".pdf"),    # PDF files start with %PDF
+    (b"PK\x03\x04",                ".docx"),   # ZIP-based formats (docx, xlsx, pptx)
+    (b"\xd0\xcf\x11\xe0",          ".doc"),    # OLE2 compound files (doc, xls, ppt)
+    (b"{\\rtf",                     ".rtf"),    # Rich Text Format
+    (b"MThd",                       ".mid"),    # MIDI music files
+    (b"ID3",                        ".mp3"),    # MP3 with ID3v2 metadata header
+    (b"\xff\xfb",                   ".mp3"),    # MP3 frame sync (MPEG1 Layer 3)
+    (b"\xff\xf3",                   ".mp3"),    # MP3 frame sync (MPEG2 Layer 3)
+    (b"OggS",                       ".ogg"),    # Ogg Vorbis audio container
+    (b"RIFF",                       ".wav"),    # WAV audio (RIFF container format)
+    (b"fLaC",                       ".flac"),   # FLAC lossless audio
+]
+
+
+def ext_from_magic(data):
+    """
+    Detect file type from the first few bytes of binary data (magic bytes).
+
+    Compares the file's opening bytes against known signatures for common
+    document and audio formats. This is the last-resort detection method
+    when Content-Type and URL are both unhelpful.
+
+    Args:
+        data: The raw bytes of the downloaded file (at least 4 bytes needed)
+
+    Returns:
+        str: The detected file extension (e.g. ".pdf") or "" if not recognised
+    """
+    if not data or len(data) < 4:
+        return ""
+    for magic, ext in MAGIC_BYTES:
+        if data[:len(magic)] == magic:
+            return ext
+    return ""
+
+
+def ext_for_download(content_type, url, data=None):
+    """
+    Determine the correct file extension for a download using a cascade strategy.
+
+    Tries three methods in order of reliability:
+    1. MIME type from the Content-Type header (most reliable)
+    2. File extension from the URL path (fallback)
+    3. Magic bytes from the file content (last resort)
+
+    If none of the methods identify the file type, defaults to ".bin" to
+    ensure the file is still saved (can be manually identified later).
+
+    Args:
+        content_type: The Content-Type header value (e.g. "application/pdf")
+        url:          The download URL
+        data:         The raw file bytes (optional, for magic byte detection)
+
+    Returns:
+        str: The file extension including the dot (e.g. ".pdf", ".rtf", ".bin")
+    """
+    # Strategy 1: Check the MIME type lookup table
+    ext = MIME_TO_EXT.get(content_type, "")
+    if not ext:
+        # Strategy 2: Extract extension from the URL path
+        ext = ext_from_url(url)
+    if not ext and data:
+        # Strategy 3: Detect from magic bytes in the file content
+        ext = ext_from_magic(data)
+    # Fallback: use .bin so the file is still saved for manual inspection
+    return ext if ext else ".bin"
+
+
+# ---------------------------------------------------------------------------
+# Book helpers — extract and clean book-specific data from song titles
+# ---------------------------------------------------------------------------
+
+def extract_number(title, book):
+    """
+    Extract the hymn number from a song title string for a specific book.
+
+    Song titles on the index page include the book code and number in
+    parentheses, e.g. "Amazing Grace (MP0023)". This function uses the
+    book-specific regex pattern to extract just the numeric part.
+
+    Args:
+        title: The full song title from the index page
+        book:  Book identifier key ("mp", "cp", or "jp")
+
+    Returns:
+        int:  The hymn number (e.g. 23 from "MP0023")
+        None: If no matching book code was found in the title
+    """
+    cfg = BOOK_CONFIG[book]
+    m   = re.search(cfg["pattern"], title, re.I)
+    return int(m.group(1)) if m else None
+
+
+def detect_book(title):
+    """
+    Determine which book a song belongs to based on its title.
+
+    Checks the title against each book's regex pattern (MP, CP, JP)
+    and returns the first match.
+
+    Args:
+        title: The full song title from the index page
+
+    Returns:
+        str:  Book key ("mp", "cp", or "jp") if a match is found
+        None: If the title doesn't match any known book pattern
+    """
+    for book in BOOK_CONFIG:
+        if extract_number(title, book) is not None:
+            return book
+    return None
+
+
+def clean_title(title, book):
+    """
+    Remove the book code suffix from a song title.
+
+    Strips the "(MP0023)" or similar suffix from the end of the title,
+    leaving just the human-readable song name for use in filenames
+    and formatted output.
+
+    Args:
+        title: The full song title (e.g. "Amazing Grace (MP0023)")
+        book:  Book identifier key ("mp", "cp", or "jp")
+
+    Returns:
+        str: The cleaned title (e.g. "Amazing Grace")
+
+    How it works:
+        The book's regex pattern captures the number with a group: (MP(\\d+))
+        We replace the capture group with a non-capturing \\d+ so the regex
+        matches the entire suffix "(MP0023)" without needing the exact number.
+        Then we strip that match (plus any surrounding whitespace) from the
+        end of the title string.
+    """
+    cfg = BOOK_CONFIG[book]
+    # Convert the capturing group pattern to a simple match pattern
+    # e.g. r'\(MP(\d+)\)' → r'\(MP\d+\)' (no longer captures, just matches)
+    pat = cfg["pattern"].replace(r'(\d+)', r'\d+')
+    # Remove the book code suffix from the end of the title
+    t = re.sub(r'\s*' + pat + r'\s*$', '', title, flags=re.I).strip()
+    return t
+
+
+# ---------------------------------------------------------------------------
+# Format, save lyrics & download files
+# ---------------------------------------------------------------------------
+
+def format_lyrics(song, book):
+    """
+    Format a parsed song into a clean plain-text string for saving.
+
+    This is the most complex formatting function in the scraper because
+    the source HTML has several structural quirks that need handling:
+
+    1. STANZA GROUPING: On missionpraise.com, each lyric line is its own <p>
+       element, and stanza breaks are represented by empty <p> tags. The
+       parser preserves this as empty strings in the verses list, which
+       this function uses to group lines into stanzas.
+
+    2. CHORUS DETECTION: Chorus lines are rendered in italic (<em>/<i>) on
+       the site. The parser flags each verse with is_italic=True if it
+       contains any italic text. This function prepends "Chorus:" before
+       chorus stanzas.
+
+    3. ATTRIBUTION DETECTION: After the lyrics, songs may have author/composer
+       credits like "Words: Stuart Townend" or "Music: Keith Getty". These
+       are detected by pattern matching and separated from the lyrics with
+       extra blank lines.
+
+    4. STANDALONE AUTHOR LINES: Some songs have short attribution lines like
+       "Stuart Townend / Keith Getty" that don't start with "Words:" or
+       "Music:". These are detected by heuristics (contains "/" or "&",
+       short length, doesn't start with a digit).
+
+    5. MULTI-LINE VERSES: Some verses contain <br> tags (represented as \\n
+       in the parser output), meaning multiple lines in a single <p>.
+       These are treated as complete stanzas on their own.
+
+    Output format:
+        "Song Title"
+                                ← blank line
+        First verse line        ← single-line verses grouped into stanzas
+        Second verse line
+                                ← blank line between stanzas
+        Chorus:                 ← prefix for italic stanzas
+        Chorus line one
+        Chorus line two
+                                ← blank line
+        ...
+                                ← double blank line before attribution
+        Words: Author Name
+        Music: Composer Name
+                                ← blank line
+        Copyright notice
+
+    Args:
+        song: Dict with "title", "verses" (list of (text, is_italic) tuples),
+              "copyright" (str), and "downloads" (dict)
+        book: Book identifier key ("mp", "cp", or "jp")
+
+    Returns:
+        str: The formatted plain-text song content
+    """
+    title = clean_title(song["title"], book)
+    lines = [f'"{title}"', ""]  # Start with quoted title and blank line
+
+    # --- Stanza/attribution tracking ---
+    # We need to separate actual lyrics from author/attribution lines that
+    # appear after the last verse. We also need to group single-line verses
+    # into stanzas (separated by empty <p> elements in the source).
+    author_lines = []              # Accumulated attribution lines
+    found_attribution = False      # Flag: have we started seeing attribution lines?
+    stanza_buf = []                # Lines of the current stanza being built
+    stanza_is_chorus = False       # Does the current stanza contain chorus (italic) lines?
+
+    def flush_stanza():
+        """
+        Write the accumulated stanza to the output lines list.
+
+        If the stanza contains italic lines, prepends "Chorus:" label —
+        UNLESS the first line starts with a verse number (e.g. "2 Lord, I
+        come..."), which indicates a numbered verse that happens to contain
+        a small italic element (like the verse number itself in <em>).
+
+        Adds a blank line after the stanza for separation.
+        Uses nonlocal to modify the enclosing function's stanza_buf
+        and stanza_is_chorus variables.
+        """
+        nonlocal stanza_buf, stanza_is_chorus
+        if not stanza_buf:
+            return
+        if stanza_is_chorus:
+            # Guard against false positives: if the stanza's first line starts
+            # with a digit (verse number), it's a numbered verse, not a chorus.
+            # Some songs wrap verse numbers in <em> for styling, which triggers
+            # the italic flag incorrectly (e.g. "<em>2</em> Lord, I come...").
+            first_line = stanza_buf[0].strip()
+            if not re.match(r'^\d+\s', first_line):
+                lines.append("Chorus:")
+        lines.append("\n".join(stanza_buf))
+        lines.append("")                        # Blank line between stanzas
+        stanza_buf = []
+        stanza_is_chorus = False
+
+    # --- Consecutive empty tracking ---
+    # On missionpraise.com, single empty <p> elements appear between EVERY
+    # lyric line for CSS spacing, not just at actual stanza boundaries. If we
+    # flushed on every empty <p>, each line would become its own "stanza" with
+    # a blank line after it (double-spaced output). Instead, we count
+    # consecutive empties and only flush when there's strong evidence of a
+    # real stanza boundary:
+    #   - 2+ consecutive empties (structural break in the HTML)
+    #   - Italic state change (verse ↔ chorus transition)
+    #   - Verse number at start of the next line (new numbered verse)
+    consecutive_empties = 0
+
+    # Process each verse (paragraph) from the parsed HTML
+    for verse_text, is_italic in song["verses"]:
+        stripped = verse_text.strip()
+
+        # --- Empty verse: count but don't flush yet ---
+        # We defer the stanza-break decision until we see the next content
+        # line, so we can use content-based heuristics to decide whether
+        # the empty <p> was a true stanza break or just a line spacer.
+        if not stripped:
+            consecutive_empties += 1
+            continue
+
+        # --- Stanza break decision ---
+        # Now that we have a non-empty verse, decide whether the preceding
+        # empty <p> element(s) represent a real stanza break.
+        if stanza_buf and consecutive_empties > 0:
+            should_break = (
+                consecutive_empties >= 2                              # structural break
+                or is_italic != stanza_is_chorus                     # verse↔chorus
+                or bool(re.match(r'^\d+\s', stripped))               # verse number
+            )
+            if should_break:
+                flush_stanza()
+        consecutive_empties = 0
+
+        # --- Attribution line detection ---
+        # Lines starting with "Words:", "Music:", "Arranged:", etc. are
+        # author/composer credits, not lyrics. We require a colon, "by",
+        # or "and" after the keyword to prevent false positives (e.g.
+        # sidebar text "Music file" or lyrics starting with "Words of...").
+        # Once we find a genuine attribution line, subsequent short lines
+        # are also treated as attribution — but ONLY if they don't look
+        # like lyrics (i.e. they don't start with a digit/verse number).
+        is_explicit_attribution = bool(re.match(
+            r'^(Words|Music|Arranged|Words and music|Based on|Translated|Paraphrase)\s*[:&\-/by]',
+            stripped, re.I
+        ))
+        # Also match bare keywords followed by author names (e.g. "Words and Music Stuart Townend")
+        if not is_explicit_attribution:
+            is_explicit_attribution = bool(re.match(
+                r'^(Words and music|Words & music)\b', stripped, re.I
+            ))
+        is_attribution = (
+            is_explicit_attribution
+            or (found_attribution
+                and "\n" not in stripped
+                and not re.match(r'^\d+\s', stripped)   # Don't swallow numbered verses
+                and len(stripped) < 120)                 # Don't swallow long lyric lines
+        )
+        if is_attribution:
+            flush_stanza()              # Ensure any pending stanza is written
+            found_attribution = True
+            author_lines.append(stripped)
+            continue
+
+        # If we see a normal lyric line after attribution, reset the cascade.
+        # This prevents a single false-positive attribution from consuming
+        # all remaining lyrics in the song.
+        if found_attribution and re.match(r'^\d+\s', stripped):
+            found_attribution = False
+
+        # --- Standalone author lines ---
+        # Some attribution lines don't follow the "Words:" pattern but are
+        # recognisable as author names by containing "/" or "&" separators
+        # (e.g. "Stuart Townend / Keith Getty"). We use several heuristics:
+        # - Single line (no internal line breaks)
+        # - Doesn't start with a digit (not a verse number)
+        # - Contains "/" or "&" (name separators)
+        # - Short enough to be a name, not lyrics (< 120 chars)
+        # - Not a typical lyric pattern (doesn't contain common verse words)
+        if ("\n" not in stripped
+                and not re.match(r'^\d', stripped)
+                and ("/" in stripped or "&" in stripped)
+                and len(stripped) < 120
+                and not re.search(r'\b(the|and|you|your|my|our|lord|god|love|sing|praise)\b', stripped, re.I)):
+            flush_stanza()
+            author_lines.append(stripped)
+            continue
+
+        # --- Multi-line verse ---
+        # If the verse text contains "\n" (from <br> tags in the HTML),
+        # it's a multi-line verse that should be treated as its own stanza.
+        if "\n" in stripped:
+            flush_stanza()  # Flush any single-line stanza we were building
+            # Clean up each line within the verse (strip whitespace)
+            cleaned = "\n".join(l.strip() for l in stripped.split("\n"))
+            if is_italic:
+                # Guard against false positives: skip "Chorus:" if the first
+                # line starts with a digit (numbered verse, not chorus)
+                first_line = cleaned.split("\n")[0].strip()
+                if not re.match(r'^\d+\s', first_line):
+                    lines.append("Chorus:")
+            lines.append(cleaned)
+            lines.append("")  # Blank line after the stanza
+        else:
+            # --- Single-line verse ---
+            # Accumulate into the current stanza buffer. The stanza will be
+            # flushed when we encounter an empty verse (stanza break) or a
+            # different type of content.
+            if is_italic:
+                stanza_is_chorus = True
+            stanza_buf.append(stripped)
+
+    # Flush any remaining stanza that wasn't terminated by an empty verse
+    flush_stanza()
+
+    # Remove trailing blank lines from the lyrics section
+    while lines and lines[-1] == "":
+        lines.pop()
+
+    # Append author attribution lines (separated from lyrics by double blank line)
+    if author_lines:
+        lines.append("")   # First blank line
+        lines.append("")   # Second blank line (visual separation)
+        for al in author_lines:
+            lines.append(al)
+
+    # Append copyright notice if available
+    if song.get("copyright"):
+        lines.append("")
+        lines.append(song["copyright"])
+
+    # --- Post-processing: normalise spaced ellipses ---
+    # WordPress's text rendering sometimes converts "..." to ". . ." with
+    # spaces between the dots. We normalise these back to standard "..."
+    # The regex matches patterns like ". . ." or " . . ." with 2+ dots.
+    result = "\n".join(lines)
+    result = re.sub(r' ?(?:\. ){2,}\.', '...', result)
+
+    return result
+
+
+def sanitize(name):
+    """
+    Remove characters that are invalid in filenames across operating systems.
+
+    Strips characters that are forbidden in Windows filenames and/or could
+    cause issues on other platforms: \\ / * ? : " < > |
+
+    Args:
+        name: The raw string to sanitize (typically a song title)
+
+    Returns:
+        str: The sanitized string with invalid characters removed
+    """
+    return re.sub(r'[\\/*?:"<>|]', "", name).strip()
+
+
+def title_case(s):
+    """
+    Convert a string to Title Case, with correct handling of apostrophes.
+
+    Python's built-in str.title() treats apostrophes as word boundaries,
+    producing incorrect results like "Don'T" instead of "Don't". This
+    function uses a regex to match whole words (including contractions
+    like "don't", "it's", "o'er") and capitalises each correctly.
+
+    The regex pattern [a-zA-Z]+(['\u2019\u2018][a-zA-Z]+)? matches:
+    - One or more letters (the main word)
+    - Optionally an apostrophe followed by more letters (contraction)
+
+    We include Unicode curly/smart apostrophes (\u2019 RIGHT SINGLE QUOTATION
+    MARK and \u2018 LEFT SINGLE QUOTATION MARK) because the HTML entity decoder
+    converts &rsquo; to \u2019. Without this, "Eagle\u2019s" would be split into
+    separate words, producing "Eagle'S" instead of "Eagle's".
+
+    str.capitalize() uppercases the first character and lowercases the rest.
+
+    Args:
+        s: The input string
+
+    Returns:
+        str: The Title Cased string
+
+    Examples:
+        "AMAZING GRACE"      → "Amazing Grace"
+        "don't let me down"  → "Don't Let Me Down"
+        "EAGLE\u2019S WINGS" → "Eagle\u2019s Wings"
+    """
+    return re.sub(r"[a-zA-Z]+(['\u2019\u2018][a-zA-Z]+)?", lambda m: m.group(0).capitalize(), s)
+
+
+def base_filename(number, book, title):
+    """
+    Construct the base filename for a song (without file extension).
+
+    Generates a consistent filename from the song's book, number, and title.
+    The title is sanitized and converted to Title Case. The number is
+    zero-padded according to the book's configuration (MP=4 digits, CP/JP=3).
+
+    Args:
+        number: The song number (e.g. 23)
+        book:   Book identifier key ("mp", "cp", or "jp")
+        title:  The cleaned song title (book code already removed)
+
+    Returns:
+        str: The base filename, e.g. "0023 (MP) - Amazing Grace"
+    """
+    cfg    = BOOK_CONFIG[book]
+    padded = str(number).zfill(cfg["pad"])   # Zero-pad: 23 → "0023" (for MP)
+    label  = cfg["label"]                     # Book label: "MP", "CP", or "JP"
+    return f"{padded} ({label}) - {title_case(sanitize(title))}"
+
+
+def build_file_cache(output_dir):
+    """
+    Build a set of existing filenames in a directory for quick lookup.
+
+    Called once at startup to avoid repeated os.listdir() calls during
+    the scrape. Returns a set for O(1) membership testing.
+
+    Args:
+        output_dir: Path to the directory to scan
+
+    Returns:
+        set: Set of filename strings (not full paths), or empty set if
+             the directory doesn't exist
+    """
+    if os.path.isdir(output_dir):
+        return set(os.listdir(output_dir))
+    return set()
+
+
+def already_saved_lyrics(number, book, file_cache):
+    """
+    Check if lyrics for a specific song have already been saved.
+
+    Uses the cached file listing for O(1) lookup instead of checking
+    the filesystem directly. Matches files by their prefix pattern
+    (number + label) and .txt extension.
+
+    Args:
+        number:     The song number
+        book:       Book identifier key
+        file_cache: Set of existing filenames (from build_file_cache)
+
+    Returns:
+        bool: True if a matching .txt file exists in the cache
+    """
+    cfg    = BOOK_CONFIG[book]
+    padded = str(number).zfill(cfg["pad"])
+    label  = cfg["label"]
+    # Build the prefix that all files for this song start with
+    prefix = f"{padded} ({label}) -"
+    return any(f.startswith(prefix) and f.endswith(".txt") for f in file_cache)
+
+
+def already_saved_download(base, dl_type, file_cache):
+    """
+    Check if a specific download file (words/music/audio) already exists.
+
+    Words files use the base name directly (base.rtf), while music and
+    audio files add a type suffix (base_music.pdf, base_audio.mp3).
+
+    Args:
+        base:       The base filename (from base_filename())
+        dl_type:    Download type ("words", "music", or "audio")
+        file_cache: Set of existing filenames
+
+    Returns:
+        bool: True if a matching file exists in the cache
+    """
+    # Words files: "base.ext", other types: "base_type.ext"
+    prefix = f"{base}." if dl_type == "words" else f"{base}_{dl_type}."
+    return any(f.startswith(prefix) for f in file_cache)
+
+
+def save_lyrics(song, number, book, output_dir):
+    """
+    Format and save a song's lyrics to a plain-text file.
+
+    Creates the output directory if needed, generates the filename,
+    formats the lyrics, and writes the file.
+
+    Args:
+        song:       Parsed song dict with "title", "verses", "copyright"
+        number:     The song number (e.g. 23)
+        book:       Book identifier key ("mp", "cp", or "jp")
+        output_dir: Directory to save the file in
+
+    Returns:
+        str: The base filename (without extension) — returned so that
+             download files can reuse the same base name
+    """
+    os.makedirs(output_dir, exist_ok=True)
+    title    = clean_title(song["title"], book)
+    base     = base_filename(number, book, title)
+    filepath = os.path.join(output_dir, base + ".txt")
+    with open(filepath, "w", encoding="utf-8") as f:
+        f.write(format_lyrics(song, book))
+    return base   # Return base so file downloads can reuse the same name
+
+
+def save_download(data, base, dl_type, content_type, dl_url, output_dir):
+    """
+    Save a downloaded binary file (words, music, or audio) to disk.
+
+    Naming convention:
+    - Words (primary):  {base}.rtf       (same name as lyrics, different ext)
+    - Music:            {base}_music.pdf  (suffix distinguishes from words)
+    - Audio:            {base}_audio.mp3  (suffix distinguishes from words)
+
+    The extension is determined by ext_for_download() using a cascade of
+    Content-Type → URL extension → magic bytes detection.
+
+    Args:
+        data:         Raw bytes of the downloaded file
+        base:         Base filename (from base_filename())
+        dl_type:      Download type ("words", "music", or "audio")
+        content_type: MIME type from the Content-Type header
+        dl_url:       The download URL (for extension guessing fallback)
+        output_dir:   Directory to save the file in
+
+    Returns:
+        str: The complete filename (with extension) that was saved
+    """
+    ext      = ext_for_download(content_type, dl_url, data)
+    # Map type to a suffix — but words files use no suffix (they're the primary)
+    suffix   = {"words": "_words", "music": "_music", "audio": "_audio"}.get(dl_type, f"_{dl_type}")
+    # Words files share the same base name as lyrics (just different extension):
+    #   "0023 (MP) - Amazing Grace.rtf"
+    # Music and audio files add a type suffix to avoid extension conflicts:
+    #   "0023 (MP) - Amazing Grace_music.pdf"
+    #   "0023 (MP) - Amazing Grace_audio.mp3"
+    if dl_type == "words":
+        filename = base + ext
+    else:
+        filename = base + f"_{dl_type}" + ext
+    filepath = os.path.join(output_dir, filename)
+    with open(filepath, "wb") as f:
+        f.write(data)
+    return filename
+
+
+# ---------------------------------------------------------------------------
+# Process a single song — orchestrates scraping + downloading for one song
+# ---------------------------------------------------------------------------
+
+def log_skip(output_dir, label, padded, title, url, reason):
+    """
+    Record a skipped song in the skipped.log file for later review.
+
+    Creates a persistent log of songs that couldn't be scraped, with
+    timestamps, identifiers, and reasons. Useful for identifying gaps
+    and diagnosing systematic issues.
+
+    Args:
+        output_dir: Directory to write the log file in
+        label:      Book label (e.g. "MP")
+        padded:     Zero-padded song number string (e.g. "0023")
+        title:      The song title from the index page
+        url:        The song page URL that was attempted
+        reason:     Human-readable explanation of why it was skipped
+
+    Log format:
+        [2026-03-13 14:30:00]  MP0023  Amazing Grace  —  login wall  —  https://...
+    """
+    os.makedirs(output_dir, exist_ok=True)
+    log_path = os.path.join(output_dir, "skipped.log")
+    timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
+    with open(log_path, "a", encoding="utf-8") as f:
+        f.write(f"[{timestamp}]  {label}{padded}  {title}  —  {reason}  —  {url}\n")
+
+
+def _dump_skip_html(book_dir, label, padded, title, url, reason, html_text):
+    """
+    Write a diagnostic HTML dump for a skipped song so the raw server
+    response can be inspected to determine why the scrape failed.
+
+    Args:
+        book_dir:  Output directory for the book
+        label:     Book label (e.g. "JP")
+        padded:    Zero-padded song number
+        title:     Song title from the index page
+        url:       The song page URL
+        reason:    Why the song was skipped
+        html_text: Raw HTML response (may be None for empty responses)
+    """
+    try:
+        os.makedirs(book_dir, exist_ok=True)
+        diag_path = os.path.join(book_dir, f"_debug_{label}{padded}_skipped.html")
+        with open(diag_path, "w", encoding="utf-8") as f:
+            f.write(f"<!-- SKIPPED: {label}{padded} -->\n")
+            f.write(f"<!-- Song: {title} -->\n")
+            f.write(f"<!-- URL: {url} -->\n")
+            f.write(f"<!-- Reason: {reason} -->\n")
+            f.write(f"<!-- HTML length: {len(html_text) if html_text else 0} -->\n\n")
+            if html_text:
+                f.write(html_text)
+            else:
+                f.write("<!-- (no HTML received — empty/null response) -->\n")
+        print(f" [diag: {diag_path}]", end="", flush=True)
+    except Exception as e:
+        if DEBUG:
+            print(f" [skip diag failed: {e}]", end="", flush=True)
+
+
+def process_song(opener, title, url, book, output_dir, no_files, delay, file_cache):
+    """
+    Scrape lyrics and download files for a single song.
+
+    This is the core function that handles one song from start to finish:
+    1. Extract the song number from the index title
+    2. Check if lyrics/downloads already exist (skip if so)
+    3. Fetch the song detail page
+    4. Parse the HTML to extract lyrics, copyright, and download links
+    5. Save the lyrics as a .txt file
+    6. Download and save words/music/audio files (if enabled)
+
+    The function handles several edge cases:
+    - Songs with no extractable number (logged and skipped)
+    - Login walls (the session expired mid-scrape)
+    - WAF blocks on individual song pages
+    - Failed title parsing (retried once in case of transient errors)
+    - Missing downloads (re-fetches the page if lyrics exist but files don't)
+
+    Args:
+        opener:     urllib opener with active login session
+        title:      Song title from the index page (includes book code)
+        url:        URL of the song detail page
+        book:       Book identifier key ("mp", "cp", or "jp")
+        output_dir: Base output directory
+        no_files:   If True, skip downloading words/music/audio files
+        delay:      Seconds to wait between requests
+        file_cache: Mutable set of existing filenames (updated when new files saved)
+
+    Returns:
+        str: "saved" if lyrics were newly saved
+             "skipped" if the song couldn't be scraped
+             "exists" if the song was already saved from a previous run
+    """
+    # Extract the hymn number from the title (e.g. "Amazing Grace (MP0023)" → 23)
+    number = extract_number(title, book)
+    cfg    = BOOK_CONFIG[book]
+
+    # Route output into a book-specific subdirectory
+    book_dir = os.path.join(output_dir, cfg["subdir"])
+
+    if number is None:
+        # Title doesn't contain a recognisable book code — can't save this song
+        log_skip(book_dir, "??", "????", title, url, "no book number found in title")
+        return "skipped"
+
+    padded = str(number).zfill(cfg["pad"])
+    label  = cfg["label"]
+
+    # --- Check if lyrics already exist ---
+    lyrics_exist = already_saved_lyrics(number, book, file_cache)
+
+    # If lyrics exist and we don't need files, skip entirely (no network request)
+    if lyrics_exist and no_files:
+        return "exists"
+
+    # If lyrics exist, check whether downloads also exist
+    if lyrics_exist:
+        clean = clean_title(title, book)
+        base  = base_filename(number, book, clean)
+        # Look for any non-txt file with the same base name
+        has_any_download = any(
+            f.startswith(f"{base}.") or f.startswith(f"{base}_")
+            for f in file_cache if not f.endswith(".txt")
+        )
+        if no_files or has_any_download:
+            return "exists"
+        # Lyrics exist but no downloads — need to fetch page for download links
+        print(f"    {label}{padded}  {title[:55]:<55}", end=" ", flush=True)
+        print("↻ fetching missing downloads...", end=" ", flush=True)
+    else:
+        # Neither lyrics nor files exist — full scrape needed
+        print(f"    {label}{padded}  {title[:55]:<55}", end=" ", flush=True)
+
+    # --- Fetch the song detail page ---
+    html_text, _ = fetch_text(opener, url)
+
+    # Check for login wall (session may have expired during the scrape)
+    if not html_text or "Please login to continue" in html_text or "loginform" in (html_text or ""):
+        reason = "login wall" if html_text else "empty response"
+        print(f"✗ ({reason})")
+        log_skip(book_dir, label, padded, title, url, reason)
+        _dump_skip_html(book_dir, label, padded, title, url, reason, html_text)
+        time.sleep(delay)
+        return "skipped"
+
+    # Check for subscription paywall (song not included in user's plan)
+    if "not part of your subscription" in html_text:
+        print("✗ (not in subscription)")
+        log_skip(book_dir, label, padded, title, url, "song not part of subscription")
+        _dump_skip_html(book_dir, label, padded, title, url, "not in subscription", html_text)
+        time.sleep(delay)
+        return "skipped"
+
+    # Check for WAF block on the song page (can happen on individual pages)
+    if "sucuri" in html_text.lower() or "access denied" in html_text.lower():
+        print("✗ (blocked by firewall)")
+        log_skip(book_dir, label, padded, title, url, "blocked by WAF/firewall")
+        _dump_skip_html(book_dir, label, padded, title, url, "blocked by WAF/firewall", html_text)
+        time.sleep(delay)
+        return "skipped"
+
+    # --- Parse the song page HTML ---
+    sp = SongParser()
+    sp.feed(html_text)
+
+    # If the parser couldn't find a title, retry once — this may be a transient
+    # issue like a session hiccup or a partially-loaded page
+    if not sp.title:
+        time.sleep(delay * 2)  # Longer delay before retry
+        html_text, _ = fetch_text(opener, url)
+        if html_text and "loginform" not in html_text:
+            sp = SongParser()
+            sp.feed(html_text)
+
+    # If still no title from entry-title class, try fallbacks:
+    # 1. Extract from the HTML <title> tag (strip " – Mission Praise" suffix)
+    # 2. Use the index page title (already available as the 'title' parameter)
+    if not sp.title and html_text:
+        title_match = re.search(r'<title>([^<]+)</title>', html_text, re.I)
+        if title_match:
+            import html as html_mod
+            raw_title = html_mod.unescape(title_match.group(1))
+            # Strip the site name suffix (e.g. " – Mission Praise" or " - Mission Praise")
+            raw_title = re.sub(r'\s*[\u2013\u2014\-]\s*Mission Praise\s*$', '', raw_title).strip()
+            if raw_title:
+                sp.title = raw_title
+                print("(title from <title> tag)", end=" ", flush=True)
+
+    # Final fallback: use the title from the index page
+    if not sp.title:
+        # Extract just the song name from the index title (strip book code like "(MP1270)")
+        fallback_title = re.sub(r'\s*\([A-Z]+\d+\)\s*$', '', title).strip()
+        if fallback_title:
+            sp.title = fallback_title
+            print("(title from index)", end=" ", flush=True)
+
+    # If still no title after all fallbacks, skip this song
+    if not sp.title:
+        print("✗ (no title parsed)")
+        log_skip(book_dir, label, padded, title, url, "parser found no title in page HTML")
+        _dump_skip_html(book_dir, label, padded, title, url, "no title parsed", html_text)
+        time.sleep(delay)
+        return "skipped"
+
+    # Build the structured song data dict
+    song = {"title": sp.title, "verses": sp.verses,
+            "copyright": sp.copyright.strip(), "downloads": sp.downloads}
+
+    # --- Verse count validation ---
+    # Count actual text lines (not <p> entries) to detect incomplete parses.
+    # Many songs use a few large <p> blocks with <br> line breaks inside,
+    # so counting entries would produce false "incomplete" warnings. Instead,
+    # we count the total lines of text across all verse entries.
+    total_lines = sum(v.strip().count("\n") + 1 for v, _ in sp.verses if v.strip())
+    if total_lines == 0:
+        print("⚠ (no lyrics found)", end=" ", flush=True)
+        log_skip(book_dir, label, padded, title, url,
+                 f"parser found title but 0 lyric lines — possible HTML structure change")
+    elif total_lines < 4:
+        print(f"⚠ ({total_lines} lines — may be incomplete)", end=" ", flush=True)
+    if DEBUG and sp.verses:
+        non_empty_entries = sum(1 for v, _ in sp.verses if v.strip())
+        print(f"\n  DEBUG: {len(sp.verses)} raw verse entries, "
+              f"{non_empty_entries} non-empty, {total_lines} text lines", flush=True)
+
+    # --- HTML diagnostic dump for incomplete songs ---
+    # When the parser captures suspiciously few lines, or when running in
+    # single-song mode (--song), dump the raw HTML surrounding the song-details
+    # section to a diagnostic file. This helps identify HTML structure changes.
+    # Single-song mode always dumps because it's inherently a debugging operation.
+    is_single_song = (len(sys.argv) > 1 and "--song" in " ".join(sys.argv))
+    if (total_lines < 8 or is_single_song) and html_text:
+        diag_path = os.path.join(book_dir, f"_debug_{label}{padded}_raw.html")
+        try:
+            os.makedirs(book_dir, exist_ok=True)
+            # Extract the song-details section via regex as a diagnostic cross-check.
+            # Match both <div> and <section> tags — the site uses both inconsistently.
+            sd_match = re.search(
+                r'<(?:div|section)[^>]+class=["\x27][^"\x27]*song-details[^"\x27]*["\x27][^>]*>'
+                r'([\s\S]*?)'
+                r'(?=<[^>]+class=["\x27][^"\x27]*(?:copyright-info|col-sm-4|files))',
+                html_text, re.I)
+            if not sd_match:
+                # Fallback: simpler regex
+                sd_match = re.search(
+                    r'<(?:div|section)[^>]+class=["\x27][^"\x27]*song-details[^"\x27]*["\x27][^>]*>'
+                    r'([\s\S]*?)</(?:div|section)>',
+                    html_text, re.I)
+            with open(diag_path, "w", encoding="utf-8") as f:
+                f.write(f"<!-- Song: {title} -->\n")
+                f.write(f"<!-- URL: {url} -->\n")
+                f.write(f"<!-- Parser found {total_lines} text lines, "
+                        f"{len(sp.verses)} verse entries -->\n\n")
+                if sd_match:
+                    f.write("<!-- === song-details content (regex extract) === -->\n")
+                    f.write(sd_match.group(0) + "\n\n")
+                    # Also count <p> tags in the regex extract as cross-check
+                    p_count = len(re.findall(r'<p[^>]*>', sd_match.group(0), re.I))
+                    f.write(f"<!-- Regex found {p_count} <p> tags in song-details -->\n\n")
+                else:
+                    f.write("<!-- WARNING: regex could NOT find song-details div! -->\n\n")
+                f.write("<!-- === Raw verse entries from HTMLParser === -->\n")
+                for idx, (v, it) in enumerate(sp.verses):
+                    f.write(f"<!-- Verse[{idx}] italic={it}: {repr(v[:200])} -->\n")
+                f.write(f"\n<!-- === Full page HTML ({len(html_text)} chars) === -->\n")
+                f.write(html_text)
+            print(f"[diag: {diag_path}]", end=" ", flush=True)
+        except Exception as e:
+            print(f"[diag write failed: {e}]", end=" ", flush=True)
+
+    # --- Save lyrics ---
+    if lyrics_exist:
+        # Lyrics already saved — just re-derive the base name for download files
+        base = base_filename(number, book, clean_title(sp.title, book))
+    elif total_lines == 0:
+        # No actual lyrics content — don't save an empty lyrics file.
+        # The debug raw HTML file (if generated above) is kept for reference.
+        print("⚠ (empty — lyrics file not saved)", end=" ", flush=True)
+        base = base_filename(number, book, clean_title(sp.title, book))
+        log_skip(book_dir, label, padded, title, url,
+                 "no lyrics content on page — only title/attribution")
+    else:
+        # Save lyrics to .txt file and add to the file cache
+        base = save_lyrics(song, number, book, book_dir)
+        file_cache.add(base + ".txt")
+
+    # --- Download files (words, music, audio) ---
+    file_results = []  # Track download results for the status line
+    if not no_files and song["downloads"]:
+        for dl_type in ("words", "music", "audio"):
+            dl_url = song["downloads"].get(dl_type)
+            if not dl_url:
+                continue  # This download type isn't available for this song
+
+            # Skip if already downloaded
+            if already_saved_download(base, dl_type, file_cache):
+                file_results.append(dl_type[0].lower())  # Lowercase = already existed
+                continue
+
+            # Convert relative URLs to absolute
+            if dl_url.startswith("/"):
+                dl_url = BASE + dl_url
+
+            # Download the file
+            data, ct, final_url = fetch_binary(opener, dl_url)
+            if data:
+                fname = save_download(data, base, dl_type, ct, final_url or dl_url, book_dir)
+                file_results.append(dl_type[0].upper())  # Uppercase = newly downloaded
+                file_cache.add(fname)  # Add to cache so we don't re-download
+
+            # Brief delay between downloads (30% of normal delay)
+            time.sleep(delay * 0.3)
+
+    # Print the status line with download indicators:
+    # [W,M,A] = newly downloaded words/music/audio (uppercase)
+    # [w,m,a] = already existed (lowercase)
+    file_str = f" [{','.join(file_results)}]" if file_results else ""
+    print(f"✓{file_str}")
+    time.sleep(delay)  # Rate limit between songs
+    return "saved"
+
+
+# ---------------------------------------------------------------------------
+# Crawl & scrape — paginated index crawling with per-page song processing
+# ---------------------------------------------------------------------------
+
+def crawl_and_scrape(opener, books, output_dir, no_files, start_page=1, delay=DELAY, force=False, song_number=None):
+    """
+    Crawl the paginated song index and scrape each discovered song.
+
+    The missionpraise.com song index is paginated (10 songs per page).
+    This function:
+    1. Fetches each index page sequentially
+    2. Parses the page to discover song links
+    3. Filters songs to only the requested books (MP, CP, JP)
+    4. Scrapes each song on the current page before moving to the next
+
+    End-of-index detection:
+    - "Page not found" in the response → no more pages
+    - WordPress serving page 1 content for out-of-range page numbers
+      (detected by checking the "X-Y of Z" counter in the HTML)
+    - No song links found on the page
+    - Empty response
+
+    The function is designed for resumability:
+    - Builds a file cache of existing files on startup
+    - Supports --start-page for resuming from a specific index page
+    - Each song is individually checked for existing files
+
+    Args:
+        opener:      urllib opener with active login session
+        books:       List of book keys to scrape (e.g. ["mp", "cp", "jp"])
+        output_dir:  Base output directory
+        no_files:    If True, skip file downloads
+        start_page:  Index page number to start from (default: 1)
+        delay:       Seconds between requests
+        force:       If True, re-download and overwrite existing files
+        song_number: If set, only scrape this specific song number (e.g. 584)
+
+    Returns:
+        tuple: (saved_count, skipped_count, existed_count)
+    """
+    page       = start_page
+
+    # Pre-compile book pattern regexes for efficient matching
+    book_pats  = {b: re.compile(BOOK_CONFIG[b]["pattern"], re.I) for b in books}
+
+    # Build a combined file cache from all book subdirectories.
+    # Filenames are unique across books because they include the book label,
+    # so merging into one set is safe and simplifies lookup logic.
+    # When --force is set, skip the cache entirely so everything is re-downloaded.
+    file_cache = set()
+    if not force:
+        for b in books:
+            subdir = os.path.join(output_dir, BOOK_CONFIG[b]["subdir"])
+            file_cache |= build_file_cache(subdir)  # Union with existing cache
+
+    # Counters for the final summary
+    saved      = 0   # Songs newly saved in this run
+    skipped    = 0   # Songs that couldn't be scraped
+    existed    = 0   # Songs that already existed from previous runs
+
+    if song_number:
+        print(f"  Single-song mode: looking for song #{song_number}\n")
+        force = True  # Always re-download in single-song mode
+    if force:
+        print(f"  Force mode: will re-download and overwrite existing files.\n")
+    elif file_cache:
+        print(f"  Found {len(file_cache)} existing files across output folders — will skip duplicates.\n")
+
+    # --- Main pagination loop ---
+    while True:
+        # Construct the URL for the current index page
+        url  = f"{INDEX_URL}{page}/"
+        html_text, _ = fetch_text(opener, url)
+
+        # Detect end of pagination
+        if not html_text or "Page not found" in html_text:
+            if DEBUG:
+                print(f"  DEBUG: Page {page} — {'empty response' if not html_text else 'Page not found detected'}")
+            break
+
+        # Dump the first page's HTML for debugging (only on start_page)
+        if page == start_page:
+            debug_dump(f"Index page {page} HTML", html_text)
+
+        # --- Loop detection ---
+        # WordPress has a quirk where out-of-range page numbers silently serve
+        # page 1 content (instead of returning a 404). We detect this by parsing
+        # the "Showing X-Y of Z" counter in the HTML.
+        count_m = re.search(r'(\d+)-(\d+)\s+of\s+(\d+)', html_text)
+        if count_m:
+            lo, hi, total = int(count_m.group(1)), int(count_m.group(2)), int(count_m.group(3))
+            total_pages   = (total + 9) // 10  # Ceiling division: songs ÷ 10 per page
+
+            # Print total count on the first page
+            if page == start_page:
+                print(f"  {total} total songs across ~{total_pages} pages\n")
+
+            # Detect loops: if lo > hi (impossible) or we're past page 1 but
+            # seeing results starting from 1 (WordPress served page 1 again)
+            if lo > hi or (page > 1 and lo == 1):
+                break
+        else:
+            # If we can't find the counter and we're past page 1, assume we've
+            # gone beyond the last page (page 1 might legitimately lack the counter)
+            if page > 1:
+                break
+
+        # --- Parse the index page for song links ---
+        p = IndexParser()
+        p.feed(html_text)
+
+        if not p.songs:
+            # No song links found — we've reached the end of the index
+            if DEBUG:
+                print(f"  DEBUG: IndexParser found 0 song links on page {page}")
+                # Debug: dump all <a> links to help diagnose parser issues
+                links = re.findall(r'<a[^>]+href=["\']([^"\']*)["\'][^>]*>', html_text)
+                song_links = [l for l in links if "/songs/" in l]
+                print(f"  DEBUG: Total <a> links: {len(links)}, with /songs/: {len(song_links)}")
+                for sl in song_links[:10]:
+                    print(f"         {sl}")
+            break
+
+        # --- Filter songs to requested books ---
+        # Each song title includes a book code like "(MP0023)" — we match
+        # against the patterns for the books the user wants to scrape
+        page_songs = []
+        for title, song_url in p.songs:
+            for book, pat in book_pats.items():
+                if pat.search(title):
+                    # If --song was specified, filter to only that song number
+                    if song_number is not None:
+                        num = extract_number(title, book)
+                        if num != song_number:
+                            break  # Skip — wrong number
+                    page_songs.append((title, song_url, book))
+                    break  # A song belongs to exactly one book
+
+        # Print page summary with running totals
+        if not song_number:
+            print(f"  Page {page:4d}  —  {len(page_songs)} matching songs  "
+                  f"(saved: {saved}, existed: {existed}, skipped: {skipped})")
+
+        # --- Scrape each song on this page ---
+        page_existed = 0
+        for title, song_url, book in page_songs:
+            result = process_song(opener, title, song_url, book, output_dir, no_files, delay, file_cache)
+            if result == "saved":
+                saved += 1
+            elif result == "skipped":
+                skipped += 1
+            elif result == "exists":
+                existed += 1
+                page_existed += 1
+
+        # If --song was specified and we found it, stop immediately
+        if song_number is not None and (saved + skipped) > 0:
+            break
+
+        # If every song on this page already existed, print a compact summary
+        # instead of per-song output (reduces noise during resumed scrapes)
+        if page_existed == len(page_songs) and page_songs and not song_number:
+            print(f"           ⏭  all {page_existed} songs on this page already exist")
+
+        page += 1
+        time.sleep(delay)   # Rate limit between index pages
+
+    # If --song was specified but never found, warn the user
+    if song_number is not None and saved == 0 and skipped == 0:
+        print(f"\n  ⚠ Song #{song_number} was not found in the index for books: {', '.join(books)}")
+
+    return saved, skipped, existed
+
+
+# ---------------------------------------------------------------------------
+# Main — CLI entry point and argument parsing
+# ---------------------------------------------------------------------------
+
+def main():
+    """
+    Parse command-line arguments, authenticate, and start the scrape.
+
+    Handles the full lifecycle:
+    1. Parse CLI arguments (or prompt for missing credentials)
+    2. Validate the requested books
+    3. Create an HTTP session and authenticate with the site
+    4. Print configuration summary
+    5. Run the crawl-and-scrape process
+    6. Print final results
+    """
+    # Support -? as an alias for --help (common on Windows and DOS-style CLIs).
+    # We intercept it here because argparse doesn't natively support '?' in
+    # option strings. Note: users may need to quote or escape -? in their shell
+    # (e.g. '-?' or -\?) since ? is a glob wildcard character in most shells.
+    if "-?" in sys.argv:
+        sys.argv[sys.argv.index("-?")] = "--help"
+
+    ap = argparse.ArgumentParser(
+        description="Mission Praise scraper — MP, CP, JP + file downloads",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""examples:
+  python3 %(prog)s --username you@email.com --password secret
+                                           Scrape all books (MP, CP, JP)
+  python3 %(prog)s --username you@email.com --password secret --books mp
+                                           Scrape only Mission Praise
+  python3 %(prog)s --username you@email.com --password secret --books mp,cp
+                                           Scrape Mission Praise + Carol Praise
+  python3 %(prog)s --username you@email.com --password secret --no-files
+                                           Scrape lyrics only (skip downloads)
+  python3 %(prog)s --username you@email.com --password secret --start-page 5
+                                           Resume from index page 5
+  python3 %(prog)s --username you@email.com --password secret --output ~/hymns
+                                           Save to a custom output folder
+  python3 %(prog)s --username you@email.com --password secret --song 584
+                                           Scrape only song number 584
+  python3 %(prog)s --username you@email.com --password secret --debug
+                                           Dump HTML responses for debugging
+
+output:
+  Lyrics are saved as plain text in book-specific subdirectories:
+    hymns/Mission Praise [MP]/0001 (MP) - Abba Father.txt
+    hymns/Carol Praise [CP]/001 (CP) - A Great And Mighty Wonder.txt
+    hymns/Junior Praise [JP]/001 (JP) - A Boy Gave To Jesus.txt
+
+  Download files use the same base name with type suffixes:
+    0001 (MP) - Abba Father.rtf            (words document)
+    0001 (MP) - Abba Father_music.pdf      (sheet music)
+    0001 (MP) - Abba Father_audio.mp3      (audio recording)
+
+  The scraper is resumable — existing files are detected and skipped.
+  Skipped songs are logged to skipped.log in each book's output folder.
+
+authentication:
+  A valid missionpraise.com subscription is required. Credentials can be
+  provided via --username/--password flags, or entered interactively at
+  the prompt (password input is hidden). The site may be protected by a
+  Sucuri WAF — if blocked, try logging in via a browser first.
+
+notes:
+  - No dependencies required — uses only Python standard library modules.
+  - The scraper crawls the paginated song index (10 songs per page).
+  - Downloads include words (RTF/DOC), music (PDF), and audio (MP3/MIDI).
+  - Use --no-files to skip downloads and only scrape lyrics text.""")
+    ap.add_argument("--username",   default=None,
+                    help="missionpraise.com login email (prompted interactively if omitted)")
+    ap.add_argument("--password",   default=None,
+                    help="missionpraise.com password (prompted with hidden input if omitted)")
+    ap.add_argument("--output",     default=DEFAULT_OUT,
+                    help="output folder path (default: ./hymns)")
+    ap.add_argument("--books",      default="mp,cp,jp",
+                    help="comma-separated books to scrape: mp, cp, jp (default: mp,cp,jp)")
+    ap.add_argument("--start-page", type=int, default=1,
+                    help="index page number to start from, for resuming (default: 1)")
+    ap.add_argument("--delay",      type=float, default=DELAY,
+                    help="seconds to wait between HTTP requests (default: 1.2)")
+    ap.add_argument("--song",       type=int, default=None,
+                    help="scrape only this song number (e.g. --song 584 --books jp)")
+    ap.add_argument("--no-files",   action="store_true",
+                    help="skip downloading words/music/audio files (lyrics only)")
+    ap.add_argument("--debug",      action="store_true",
+                    help="dump full HTML responses to terminal for troubleshooting")
+    ap.add_argument("--force",      action="store_true",
+                    help="force re-download of all songs, even if files already exist")
+    args = ap.parse_args()
+
+    # Set the global debug flag (used by debug_dump and various functions)
+    global DEBUG
+    DEBUG = args.debug
+
+    # Prompt for credentials if not provided via CLI arguments.
+    # getpass.getpass() hides the password as the user types it.
+    if not args.username:
+        args.username = input("Mission Praise username/email: ").strip()
+    if not args.password:
+        args.password = getpass.getpass("Mission Praise password: ")
+
+    # Parse and validate the books argument (filter out invalid entries)
+    books = [b.strip().lower() for b in args.books.split(",") if b.strip().lower() in BOOK_CONFIG]
+    if not books:
+        print("No valid books specified. Use --books mp,cp,jp")
+        return
+
+    # Create the HTTP session (cookie jar + browser-like headers)
+    opener, jar = make_opener()
+
+    # Authenticate with the site
+    if not login(opener, jar, args.username, args.password):
+        return  # Login failed — error already printed by login()
+
+    # Print configuration summary
+    print(f"\nBooks    : {', '.join(b.upper() for b in books)}")
+    print(f"Output   : {os.path.abspath(args.output)}")
+    print(f"Downloads: {'disabled' if args.no_files else 'enabled (words, music, audio)'}")
+    print()
+
+    # Run the main crawl-and-scrape process
+    saved, skipped, existed = crawl_and_scrape(
+        opener, books, args.output, args.no_files, args.start_page, args.delay, args.force,
+        song_number=args.song)
+
+    # Print final summary
+    print(f"\nDone!  {saved} saved, {existed} already existed, {skipped} skipped.")
+    print(f"Output: {os.path.abspath(args.output)}")
+    if skipped:
+        log_path = os.path.join(args.output, "skipped.log")
+        print(f"Skipped songs logged to: {log_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.importers/scrapers/SDAHymnals_SDAHymnal.org.applescript
+++ b/.importers/scrapers/SDAHymnals_SDAHymnal.org.applescript
@@ -1,0 +1,1490 @@
+(*
+================================================================================
+SDAHymnals_SDAHymnal.org.applescript
+importers/scrapers/SDAHymnals_SDAHymnal.org.applescript
+
+Hymnal Scraper (AppleScript) -- scrapes both sdahymnal.org (SDAH) and hymnal.xyz (CH).
+Copyright 2025-2026 MWBM Partners Ltd.
+
+Overview:
+    This AppleScript is the macOS-native equivalent of the Python scraper
+    SDAHymnals_SDAHymnal.org.py. It fetches hymn lyrics from two Seventh-day
+    Adventist hymnal websites that share the same underlying codebase (identical
+    HTML structure and CSS class names). It iterates through hymn numbers
+    sequentially, parses the HTML via shell commands (curl, sed, grep, awk) to
+    extract the title, section indicators (e.g. "Verse 1", "Chorus"), and
+    lyrics text, then saves each hymn as a plain-text file.
+
+    The scraper is designed to be resumable: it scans the output directory for
+    existing files on startup and skips hymns that have already been saved.
+    A "Force Re-download" option overrides this behaviour, re-downloading and
+    overwriting all files in the range (useful when source data has changed).
+    It also handles rate limiting, server errors, and auto-detects the end of
+    the hymnal when the site redirects to the homepage.
+
+Dependencies:
+    None -- uses only native macOS tools:
+    - curl (HTTP requests)
+    - sed, grep, awk (HTML parsing / text extraction)
+    - AppleScript file I/O and shell integration via "do shell script"
+
+    No Python, pip, Homebrew, or third-party software is required.
+
+How to Run:
+    Option A (Script Editor):
+        1. Open this file in Script Editor.app (in /Applications/Utilities/)
+        2. Click the Run (play) button
+        3. Follow the interactive dialogs
+
+    Option B (Save as Application):
+        1. Open in Script Editor
+        2. File > Export... > File Format: Application
+        3. Save to Desktop (or anywhere)
+        4. Double-click the .app to run from Finder
+
+Output Format:
+    Each hymn is saved as a plain-text file with the naming convention:
+        {number zero-padded to 3 digits} ({LABEL}) - {Title Case Title}.txt
+    e.g.: "001 (SDAH) - Praise To The Lord.txt"
+
+    Files are organised into book-specific subdirectories:
+        hymns/Seventh-day Adventist Hymnal [SDAH]/
+        hymns/The Church Hymnal [CH]/
+
+    The file content format is:
+        "Hymn Title"
+
+        Verse 1
+        lyrics line 1
+        lyrics line 2
+
+        Chorus
+        chorus line 1
+        chorus line 2
+
+Site Configuration:
+    SDAH: base_url = https://www.sdahymnal.org/Hymn
+          home_url = https://www.sdahymnal.org
+          label    = SDAH
+          subdir   = Seventh-day Adventist Hymnal [SDAH]
+          lang     = en  (ISO 639-1: English)
+
+    CH:   base_url = https://www.hymnal.xyz/Hymn
+          home_url = https://www.hymnal.xyz
+          label    = CH
+          subdir   = The Church Hymnal [CH]
+          lang     = en  (ISO 639-1: English)
+================================================================================
+*)
+
+-- =============================================================================
+-- GLOBAL PROPERTIES
+-- =============================================================================
+-- These properties define the default configuration values and site metadata.
+-- They are set at the top level so all handlers can access them.
+-- =============================================================================
+
+-- Script metadata displayed in the welcome dialog
+property scriptName : "SDA Hymnal Scraper"
+property scriptVersion : "2.0"
+property scriptCopyright : "Copyright 2025-2026 MWBM Partners Ltd."
+
+-- SDAH site configuration
+-- sdahymnal.org hosts the Seventh-day Adventist Hymnal (695 hymns)
+property sdahBaseURL : "https://www.sdahymnal.org/Hymn"
+property sdahHomeURL : "https://www.sdahymnal.org"
+property sdahLabel : "SDAH"
+property sdahSubdir : "Seventh-day Adventist Hymnal [SDAH]"
+property sdahLang : "en" -- ISO 639-1 language code: English
+
+-- CH site configuration
+-- hymnal.xyz hosts The Church Hymnal (same HTML structure as SDAH)
+property chBaseURL : "https://www.hymnal.xyz/Hymn"
+property chHomeURL : "https://www.hymnal.xyz"
+property chLabel : "CH"
+property chSubdir : "The Church Hymnal [CH]"
+property chLang : "en" -- ISO 639-1 language code: English
+
+-- Default scraping parameters
+-- These are used when the user clicks "Start with Defaults"
+property defaultStartHymn : 1
+property defaultEndHymn : 0 -- 0 means auto-detect (no fixed end)
+property defaultDelay : 1.0 -- seconds between HTTP requests
+property defaultOutputDir : "" -- will be set to ~/Desktop/hymns at runtime
+
+-- Force re-download flag: when true, the scraper will re-download and
+-- overwrite existing hymn files instead of skipping them. This is useful
+-- when the source data has been updated or a previous download was corrupted.
+-- Default is false (preserve existing files for resumability).
+property pForceRedownload : false
+
+-- Maximum consecutive failures before assuming end of hymnal.
+-- If 10 hymns in a row fail to scrape, we stop rather than continuing
+-- to hammer the server with requests for non-existent hymns.
+property maxConsecutiveSkips : 10
+
+-- Maximum retry attempts for HTTP 500 server errors.
+-- Transient server errors are common; retrying usually succeeds.
+property maxRetries : 3
+
+-- HTTP request timeout in seconds
+property httpTimeout : 15
+
+-- User-Agent string for HTTP requests (identifies the scraper politely)
+property userAgent : "Mozilla/5.0 (compatible; HymnScraper/2.0)"
+
+-- Progress notification interval: show a macOS notification every N hymns
+-- to give the user visual feedback without blocking the script with dialogs
+property notifyInterval : 10
+
+
+-- =============================================================================
+-- MAIN ENTRY POINT
+-- =============================================================================
+-- This is the top-level script block that runs when the script is executed.
+-- It displays the welcome dialog, handles user choices (Help, Configure, or
+-- Start with Defaults), and then launches the scraping process.
+-- =============================================================================
+
+-- Set the default output directory to ~/Desktop/hymns using the shell to
+-- reliably resolve the home directory path (AppleScript's "path to desktop"
+-- returns an alias, but we need a POSIX path for shell commands)
+set defaultOutputDir to (do shell script "echo $HOME") & "/Desktop/hymns"
+
+-- -------------------------------------------------------------------------
+-- Welcome Dialog Loop
+-- -------------------------------------------------------------------------
+-- This loop shows the welcome screen and handles the Help button by
+-- returning to the welcome screen after displaying help text.
+-- The loop exits when the user clicks "Configure & Start" or
+-- "Start with Defaults" (or cancels).
+-- -------------------------------------------------------------------------
+set userChoice to ""
+repeat
+	-- Display the welcome dialog with three options:
+	-- "Help / ?" shows detailed usage information
+	-- "Configure & Start" lets the user customise all settings
+	-- "Start with Defaults" uses sensible defaults and begins immediately
+	set welcomeResult to display dialog scriptName & " v" & scriptVersion & return & return & scriptCopyright & return & return & "This script scrapes hymn lyrics from sdahymnal.org (SDAH) and hymnal.xyz (CH), saving each hymn as a plain-text file." & return & return & "Choose an option:" buttons {"Help / ?", "Configure & Start", "Start with Defaults"} default button "Start with Defaults" with title scriptName with icon note
+
+	set userChoice to button returned of welcomeResult
+
+	if userChoice is "Help / ?" then
+		-- Show detailed help information in a scrollable dialog.
+		-- This explains what the script does, output format, available options,
+		-- and tips for running the script.
+		display dialog "HELP - " & scriptName & " v" & scriptVersion & return & return & "WHAT THIS SCRIPT DOES:" & return & "Scrapes hymn lyrics from two SDA hymnal websites:" & return & "  - sdahymnal.org (Seventh-day Adventist Hymnal)" & return & "  - hymnal.xyz (The Church Hymnal)" & return & "Both sites share the same HTML structure." & return & return & "OUTPUT FORMAT:" & return & "Each hymn is saved as a plain-text (.txt) file:" & return & "  001 (SDAH) - Praise To The Lord.txt" & return & return & "Files are organised in subdirectories:" & return & "  <output>/Seventh-day Adventist Hymnal [SDAH]/" & return & "  <output>/The Church Hymnal [CH]/" & return & return & "File contents:" & return & "  \"Hymn Title\"" & return & "  " & return & "  Verse 1" & return & "  First line of lyrics" & return & "  Second line..." & return & "  " & return & "  Chorus" & return & "  Chorus lyrics..." & return & return & "AVAILABLE OPTIONS:" & return & "  - Site: SDAH only, CH only, or Both" & return & "  - Start hymn number (default: 1)" & return & "  - End hymn number (blank = auto-detect)" & return & "  - Output folder (default: ~/Desktop/hymns)" & return & "  - Delay between requests (default: 1.0s)" & return & "  - Force re-download: overwrite existing files" & return & "    (default: No -- existing hymns are skipped)" & return & return & "FEATURES:" & return & "  - Resumable: skips already-saved hymns" & return & "  - Auto-detects end of hymnal" & return & "  - Handles rate limiting (pauses 60s)" & return & "  - Retries on server errors (3 attempts)" & return & "  - Logs skipped hymns to skipped.log" & return & return & "TIPS:" & return & "  - Save as .app (File > Export > Application)" & return & "    to run by double-clicking from Finder" & return & "  - Progress is shown via macOS notifications" & return & "  - Check Script Editor's log for detailed output" buttons {"OK"} default button "OK" with title scriptName & " - Help" with icon note
+		-- After dismissing help, the repeat loop brings us back to the welcome dialog
+	else
+		-- User chose "Configure & Start" or "Start with Defaults" -- exit the loop
+		exit repeat
+	end if
+end repeat
+
+-- -------------------------------------------------------------------------
+-- Configuration
+-- -------------------------------------------------------------------------
+-- Based on the user's choice, either show configuration dialogs or use
+-- defaults. All settings are stored in local variables.
+-- -------------------------------------------------------------------------
+
+-- These variables hold the final configuration for the scrape run
+set selectedSites to {"sdah", "ch"} -- which sites to scrape (list of site keys)
+set startHymn to defaultStartHymn -- first hymn number to scrape
+set endHymn to defaultEndHymn -- last hymn number (0 = auto-detect)
+set outputDir to defaultOutputDir -- base output directory (POSIX path)
+set requestDelay to defaultDelay -- seconds between HTTP requests
+
+if userChoice is "Configure & Start" then
+	-- =====================================================================
+	-- CONFIGURATION DIALOGS
+	-- =====================================================================
+	-- Each setting is configured via its own dialog, presented sequentially.
+	-- The user can cancel at any point, which stops the script.
+	-- =====================================================================
+
+	-- -----------------------------------------------------------------
+	-- Dialog 1: Site Selection
+	-- -----------------------------------------------------------------
+	-- Let the user choose which site(s) to scrape. "Both" is the default
+	-- because most users will want the complete collection.
+	-- -----------------------------------------------------------------
+	set siteChoices to {"SDAH (sdahymnal.org)", "CH (hymnal.xyz)", "Both"}
+	set siteSelection to choose from list siteChoices with prompt "Select which site(s) to scrape:" with title scriptName & " - Site Selection" default items {"Both"}
+
+	-- choose from list returns false if the user cancels
+	if siteSelection is false then
+		-- User cancelled -- exit the script gracefully
+		return
+	end if
+
+	-- Convert the user's selection to our internal site key format
+	set siteChoice to item 1 of siteSelection
+	if siteChoice is "SDAH (sdahymnal.org)" then
+		set selectedSites to {"sdah"}
+	else if siteChoice is "CH (hymnal.xyz)" then
+		set selectedSites to {"ch"}
+	else
+		-- "Both" selected
+		set selectedSites to {"sdah", "ch"}
+	end if
+
+	-- -----------------------------------------------------------------
+	-- Dialog 2: Start Hymn Number
+	-- -----------------------------------------------------------------
+	-- The user can specify a starting hymn number for resuming or testing.
+	-- Default is 1 (start from the beginning).
+	-- -----------------------------------------------------------------
+	set startResult to display dialog "Start hymn number:" default answer "1" buttons {"Cancel", "OK"} default button "OK" with title scriptName & " - Start Hymn"
+
+	-- Parse the start hymn number, defaulting to 1 if the input is invalid
+	try
+		set startHymn to (text returned of startResult) as integer
+		if startHymn < 1 then set startHymn to 1
+	on error
+		set startHymn to 1
+	end try
+
+	-- -----------------------------------------------------------------
+	-- Dialog 3: End Hymn Number
+	-- -----------------------------------------------------------------
+	-- The user can specify an end hymn number, or leave blank to let the
+	-- scraper auto-detect the end (by detecting homepage redirects).
+	-- -----------------------------------------------------------------
+	set endResult to display dialog "End hymn number:" & return & "(Leave blank to auto-detect the end of the hymnal)" default answer "" buttons {"Cancel", "OK"} default button "OK" with title scriptName & " - End Hymn"
+
+	-- Parse the end hymn number; blank/invalid = 0 = auto-detect
+	set endText to text returned of endResult
+	if endText is "" then
+		set endHymn to 0
+	else
+		try
+			set endHymn to endText as integer
+			if endHymn < startHymn then set endHymn to 0
+		on error
+			set endHymn to 0
+		end try
+	end if
+
+	-- -----------------------------------------------------------------
+	-- Dialog 4: Output Directory
+	-- -----------------------------------------------------------------
+	-- Let the user choose a folder for output files. The default prompt
+	-- points to the Desktop. The user can navigate to any folder.
+	-- -----------------------------------------------------------------
+	try
+		set outputFolder to choose folder with prompt "Select the output folder for hymn files:" default location (path to desktop)
+		-- Convert the AppleScript alias to a POSIX path for use in shell commands
+		set outputDir to POSIX path of outputFolder
+		-- Remove trailing slash if present (for consistency)
+		if outputDir ends with "/" then
+			set outputDir to text 1 thru -2 of outputDir
+		end if
+	on error
+		-- User cancelled the folder picker -- exit gracefully
+		return
+	end try
+
+	-- -----------------------------------------------------------------
+	-- Dialog 5: Request Delay
+	-- -----------------------------------------------------------------
+	-- The delay between HTTP requests, in seconds. 1.0 is polite;
+	-- lower values risk rate limiting; higher values are slower but safer.
+	-- -----------------------------------------------------------------
+	set delayResult to display dialog "Delay between requests (seconds):" & return & "(Recommended: 1.0 or higher to avoid rate limiting)" default answer "1.0" buttons {"Cancel", "OK"} default button "OK" with title scriptName & " - Request Delay"
+
+	-- Parse the delay value, defaulting to 1.0 if invalid
+	try
+		set requestDelay to (text returned of delayResult) as real
+		if requestDelay < 0.0 then set requestDelay to 1.0
+	on error
+		set requestDelay to 1.0
+	end try
+
+	-- -----------------------------------------------------------------
+	-- Dialog 6: Force Re-download
+	-- -----------------------------------------------------------------
+	-- Ask whether to force re-download existing files. Normally the
+	-- scraper skips hymns that already exist on disk (resumability).
+	-- Force mode overrides this, re-downloading and overwriting every
+	-- hymn in the range. Useful when source data has changed or files
+	-- are suspected to be corrupted/incomplete.
+	-- -----------------------------------------------------------------
+	set forceResult to display dialog "Force re-download existing files?" buttons {"No", "Yes"} default button "No" with title scriptName & " - Force Re-download"
+
+	if button returned of forceResult is "Yes" then
+		set pForceRedownload to true
+	else
+		set pForceRedownload to false
+	end if
+end if
+
+-- -------------------------------------------------------------------------
+-- Confirmation Dialog
+-- -------------------------------------------------------------------------
+-- Show a summary of all settings before starting, so the user can verify
+-- everything is correct. This prevents wasted time from misconfiguration.
+-- -------------------------------------------------------------------------
+
+-- Build a human-readable string for the site selection
+set siteDisplay to ""
+if selectedSites is {"sdah"} then
+	set siteDisplay to "SDAH (sdahymnal.org)"
+else if selectedSites is {"ch"} then
+	set siteDisplay to "CH (hymnal.xyz)"
+else
+	set siteDisplay to "Both (SDAH + CH)"
+end if
+
+-- Build a human-readable string for the end hymn setting
+set endDisplay to ""
+if endHymn is 0 then
+	set endDisplay to "Auto-detect"
+else
+	set endDisplay to endHymn as text
+end if
+
+-- Build a human-readable string for the force re-download setting
+set forceDisplay to "No"
+if pForceRedownload then
+	set forceDisplay to "Yes (overwrite existing)"
+end if
+
+-- Display the confirmation dialog with all settings
+set confirmResult to display dialog "Ready to start scraping with these settings:" & return & return & "  Site(s):    " & siteDisplay & return & "  Start:      Hymn " & (startHymn as text) & return & "  End:        " & endDisplay & return & "  Output:     " & outputDir & return & "  Delay:      " & (requestDelay as text) & "s" & return & "  Force:      " & forceDisplay & return & return & "Proceed?" buttons {"Cancel", "Start Scraping"} default button "Start Scraping" with title scriptName & " - Confirm" with icon note
+
+if button returned of confirmResult is not "Start Scraping" then
+	return
+end if
+
+
+-- =============================================================================
+-- SCRAPING ORCHESTRATION
+-- =============================================================================
+-- Iterate through the selected sites and scrape each one sequentially.
+-- This mirrors the Python version's main() function behavior.
+-- =============================================================================
+
+-- Track the total number of hymns saved across all sites
+set totalSaved to 0
+
+-- Log the start time for the final summary
+set startTime to current date
+
+-- Iterate through each selected site and run the scraping loop
+repeat with siteKey in selectedSites
+	-- Call the main scraping handler for this site.
+	-- It returns the number of hymns successfully saved.
+	set siteSaved to my scrapeSite(siteKey as text, startHymn, endHymn, outputDir, requestDelay, pForceRedownload)
+	set totalSaved to totalSaved + siteSaved
+end repeat
+
+-- Calculate elapsed time for the summary
+set elapsedSeconds to (current date) - startTime
+set elapsedMinutes to (elapsedSeconds div 60)
+set elapsedRemaining to (elapsedSeconds mod 60)
+
+-- -------------------------------------------------------------------------
+-- Completion Dialog
+-- -------------------------------------------------------------------------
+-- Show the final summary to the user with totals and elapsed time.
+-- -------------------------------------------------------------------------
+display dialog "Scraping complete!" & return & return & "Total hymns saved: " & (totalSaved as text) & return & "Output folder: " & outputDir & return & "Elapsed time: " & (elapsedMinutes as text) & "m " & (elapsedRemaining as text) & "s" buttons {"OK"} default button "OK" with title scriptName & " - Complete" with icon note
+
+-- Also log the summary to Script Editor's log pane
+log "===== SCRAPING COMPLETE ====="
+log "Total hymns saved: " & (totalSaved as text)
+log "Output: " & outputDir
+log "Elapsed: " & (elapsedMinutes as text) & "m " & (elapsedRemaining as text) & "s"
+
+
+-- =============================================================================
+-- HANDLERS (FUNCTIONS)
+-- =============================================================================
+-- AppleScript uses "on ... end" blocks for reusable handlers (functions).
+-- These are defined below the main script body but are callable from anywhere
+-- in the script via "my handlerName()" syntax.
+-- =============================================================================
+
+
+-- =============================================================================
+-- Handler: scrapeSite
+-- =============================================================================
+-- Main scraping loop for a single site (SDAH or CH).
+-- Iterates through hymn numbers, fetches each one, parses the HTML, and
+-- saves the result as a plain-text file. Includes resumability (skips
+-- existing files), retry logic, rate limit handling, and consecutive
+-- failure detection.
+--
+-- Parameters:
+--   siteKey       - Site identifier: "sdah" or "ch"
+--   pStartHymn    - First hymn number to scrape (inclusive)
+--   pEndHymn      - Last hymn number to scrape (inclusive), or 0 for auto-detect
+--   pOutputDir    - Base output directory (POSIX path)
+--   pDelay        - Seconds to wait between HTTP requests
+--   pForceMode    - Boolean: when true, skip the existing-file check and
+--                   re-download/overwrite every hymn in the range
+--
+-- Returns:
+--   Integer - number of hymns successfully saved in this run
+-- =============================================================================
+on scrapeSite(siteKey, pStartHymn, pEndHymn, pOutputDir, pDelay, pForceMode)
+	-- Look up the site configuration based on the site key
+	-- Each site has a base URL, home URL, label, subdirectory name, and ISO 639-1 language code
+	set baseURL to ""
+	set homeURL to ""
+	set siteLabel to ""
+	set siteSubdir to ""
+	set siteLang to "" -- ISO 639-1 language code for this songbook
+
+	if siteKey is "sdah" then
+		set baseURL to sdahBaseURL
+		set homeURL to sdahHomeURL
+		set siteLabel to sdahLabel
+		set siteSubdir to sdahSubdir
+		set siteLang to sdahLang
+	else if siteKey is "ch" then
+		set baseURL to chBaseURL
+		set homeURL to chHomeURL
+		set siteLabel to chLabel
+		set siteSubdir to chSubdir
+		set siteLang to chLang
+	end if
+
+	-- Build the full path to the book-specific output subdirectory
+	-- e.g. "/Users/name/Desktop/hymns/Seventh-day Adventist Hymnal [SDAH]"
+	set bookDir to pOutputDir & "/" & siteSubdir
+
+	-- Ensure the output directory exists (mkdir -p creates parent dirs too)
+	try
+		do shell script "mkdir -p " & quoted form of bookDir
+	on error errMsg
+		log "ERROR: Could not create output directory: " & errMsg
+		display dialog "Error: Could not create output directory:" & return & bookDir & return & return & errMsg buttons {"OK"} default button "OK" with title scriptName & " - Error" with icon stop
+		return 0
+	end try
+
+	-- Log the scraping banner to Script Editor's log pane
+	log "=================================================="
+	log "  Scraping: " & baseURL & "  [" & siteLabel & "]"
+	log "  Output  : " & bookDir
+	if pEndHymn > 0 then
+		log "  Range   : " & (pStartHymn as text) & " to " & (pEndHymn as text)
+	else
+		log "  Range   : " & (pStartHymn as text) & " to auto-detect"
+	end if
+	log "=================================================="
+
+	-- Build the set of hymn numbers that are already saved in the output
+	-- directory. This enables resumability -- we skip these hymns.
+	-- When force mode is active, we use an empty list instead so that
+	-- every hymn is re-downloaded and overwritten regardless of whether
+	-- a file already exists on disk.
+	if pForceMode then
+		set existingHymns to {}
+		log "  Force mode: will re-download and overwrite existing files."
+	else
+		set existingHymns to my buildExistingSet(siteLabel, bookDir)
+	end if
+	set existingCount to count of existingHymns
+
+	if existingCount > 0 then
+		log "  Found " & (existingCount as text) & " existing " & siteLabel & " hymns -- will skip."
+	end if
+
+	-- Show a macOS notification that scraping has started for this site
+	try
+		display notification "Starting " & siteLabel & " scrape from hymn " & (pStartHymn as text) & "..." with title scriptName subtitle "Scraping " & siteLabel
+	end try
+
+	-- Initialize counters for the scrape run
+	set savedCount to 0 -- number of hymns successfully saved
+	set skippedCount to 0 -- number of hymns skipped due to errors
+	set consecutiveSkips to 0 -- consecutive failures counter
+	set currentHymn to pStartHymn -- current hymn number being processed
+
+	-- =====================================================================
+	-- MAIN SCRAPING LOOP
+	-- =====================================================================
+	-- Iterate through hymn numbers sequentially, fetching and saving each.
+	-- The loop exits when:
+	--   1. We reach the user-specified end hymn
+	--   2. The site redirects to the homepage (end of hymnal detected)
+	--   3. We hit maxConsecutiveSkips failures in a row
+	--   4. Rate limiting persists after retry
+	-- =====================================================================
+	repeat
+		-- Check if we've reached the user-specified end hymn
+		if pEndHymn > 0 and currentHymn > pEndHymn then
+			log "  Reached end hymn (" & (pEndHymn as text) & "). Done."
+			exit repeat
+		end if
+
+		-- Check if this hymn already exists in the output directory.
+		-- If so, skip it without making any network request.
+		if existingHymns contains currentHymn then
+			log "  Hymn " & my padNumber(currentHymn, 4) & ": already exists, skipping."
+			set currentHymn to currentHymn + 1
+			-- No delay needed -- no network request was made
+		else
+			-- Fetch the hymn page from the website
+			log "  Hymn " & my padNumber(currentHymn, 4) & ": fetching..."
+
+			-- fetchHymn returns a record with keys:
+			--   status: "OK", "SKIP", or "STOP"
+			--   title: hymn title (only if status is "OK")
+			--   sections: list of {indicator, lyrics} records (only if status is "OK")
+			set fetchResult to my fetchHymn(currentHymn, baseURL, homeURL)
+
+			set fetchStatus to status of fetchResult
+
+			if fetchStatus is "STOP" then
+				-- The site redirected to the homepage or rate limiting persists.
+				-- This means we've reached the end of the hymnal.
+				log "  Reached end of hymnal or persistent rate limit. Stopping."
+				exit repeat
+
+			else if fetchStatus is "SKIP" then
+				-- This hymn could not be scraped -- log it and continue
+				log "  Hymn " & my padNumber(currentHymn, 4) & ": SKIPPED."
+				my logSkip(currentHymn, siteLabel, "fetch failed or no title found", bookDir)
+				set skippedCount to skippedCount + 1
+				set consecutiveSkips to consecutiveSkips + 1
+
+				-- Safety net: too many consecutive failures suggests we're past
+				-- the end rather than hitting intermittent errors
+				if consecutiveSkips >= maxConsecutiveSkips then
+					log "  " & (maxConsecutiveSkips as text) & " consecutive errors -- assuming end of hymnal."
+					exit repeat
+				end if
+
+				set currentHymn to currentHymn + 1
+				-- Rate limit even on failures (be polite to the server)
+				delay pDelay
+
+			else
+				-- SUCCESS: hymn was fetched and parsed
+				-- Reset the consecutive skip counter
+				set consecutiveSkips to 0
+
+				-- Extract the hymn data from the fetch result
+				set hymnTitle to hymnTitleText of fetchResult
+				set hymnSections to hymnSections of fetchResult
+
+				-- Format the hymn into plain text and save to a file
+				set savedPath to my saveHymn(currentHymn, hymnTitle, hymnSections, siteLabel, bookDir)
+				set savedCount to savedCount + 1
+
+				-- Log the saved file (just the filename, not the full path)
+				set savedFilename to my getFilename(savedPath)
+				log "  Hymn " & my padNumber(currentHymn, 4) & ": SAVED - " & savedFilename
+
+				-- Show periodic progress notifications via macOS Notification Center
+				-- This gives the user feedback without blocking the script
+				if savedCount mod notifyInterval is 0 then
+					try
+						display notification siteLabel & ": " & (savedCount as text) & " hymns saved so far (hymn " & (currentHymn as text) & ")" with title scriptName subtitle "Progress Update"
+					end try
+				end if
+
+				set currentHymn to currentHymn + 1
+				-- Rate limit between requests (be polite to the server)
+				delay pDelay
+			end if
+		end if
+	end repeat
+
+	-- Log the per-site summary
+	log ""
+	log siteLabel & ": " & (savedCount as text) & " hymns saved, " & (skippedCount as text) & " skipped."
+	log ""
+
+	-- Show a notification that this site is complete
+	try
+		display notification siteLabel & " complete: " & (savedCount as text) & " saved, " & (skippedCount as text) & " skipped." with title scriptName subtitle siteLabel & " Finished"
+	end try
+
+	return savedCount
+end scrapeSite
+
+
+-- =============================================================================
+-- Handler: fetchHymn
+-- =============================================================================
+-- Fetch a single hymn page from the website and parse it into structured data.
+-- Uses curl for HTTP requests and sed/grep/awk for HTML parsing.
+--
+-- Includes resilience features:
+--   - Retries up to 3 times on HTTP 500 errors (with 3-second delays)
+--   - Detects rate-limiting pages and pauses 60 seconds before retrying
+--   - Detects end-of-hymnal by checking if the site redirects to homepage
+--   - Falls back gracefully on parse errors
+--
+-- Parameters:
+--   hymnNumber - The hymn number to fetch (integer, e.g. 1, 42, 695)
+--   baseURL    - The site's hymn page base URL (e.g. "https://www.sdahymnal.org/Hymn")
+--   homeURL    - The site's homepage URL (used to detect end-of-hymnal redirects)
+--
+-- Returns:
+--   Record with keys:
+--     status: "OK" (success), "SKIP" (skip this hymn), or "STOP" (stop entirely)
+--     hymnTitleText: string (only when status is "OK")
+--     hymnSections: list of records (only when status is "OK")
+-- =============================================================================
+on fetchHymn(hymnNumber, baseURL, homeURL)
+	-- Construct the hymn page URL using the query parameter format
+	-- Both sites use ?no=N to specify the hymn number
+	set hymnURL to baseURL & "?no=" & (hymnNumber as text)
+
+	-- =====================================================================
+	-- HTTP REQUEST WITH RETRY LOGIC
+	-- =====================================================================
+	-- Attempt to fetch the page up to maxRetries times on server errors.
+	-- We use curl with:
+	--   -s        : silent mode (no progress meter)
+	--   -L        : follow redirects (important for end-of-hymnal detection)
+	--   --max-time: timeout after httpTimeout seconds
+	--   -A        : set the User-Agent header
+	--   -w        : write out the effective URL after redirects (for detection)
+	--   -D        : dump response headers to a temp file (for HTTP status code)
+	-- =====================================================================
+
+	set htmlContent to ""
+	set effectiveURL to ""
+	set httpCode to ""
+	set fetchSuccess to false
+
+	repeat with attemptNum from 1 to maxRetries
+		try
+			-- Execute curl via do shell script.
+			-- We use a compound command that:
+			-- 1. Fetches the page with curl, writing HTTP code and effective URL
+			--    to separate temp files
+			-- 2. Outputs the HTML body to stdout (captured by do shell script)
+			--
+			-- The -w flag appends metadata after the body, separated by a
+			-- unique delimiter so we can split them apart.
+			--
+			-- Using printf for the delimiter avoids issues with newlines in the URL.
+			set curlCommand to "curl -s -L --max-time " & (httpTimeout as text) & " -A " & quoted form of userAgent & " -o /tmp/hymn_body.tmp -w '%{http_code}\\n%{url_effective}' " & quoted form of hymnURL
+
+			-- Run curl and capture the status code + effective URL from -w output
+			set curlMeta to do shell script curlCommand
+
+			-- Parse the curl -w output: first line is HTTP code, second is effective URL
+			-- Split on newline to get both values
+			set oldDelims to AppleScript's text item delimiters
+			set AppleScript's text item delimiters to {return, linefeed, character id 10}
+			set metaParts to text items of curlMeta
+			set AppleScript's text item delimiters to oldDelims
+
+			-- Extract HTTP status code (first line of -w output)
+			if (count of metaParts) >= 1 then
+				set httpCode to item 1 of metaParts
+			end if
+
+			-- Extract effective URL (second line of -w output)
+			if (count of metaParts) >= 2 then
+				set effectiveURL to item 2 of metaParts
+			end if
+
+			-- Read the response body from the temp file
+			-- Using a temp file avoids issues with binary characters in do shell script
+			set htmlContent to do shell script "cat /tmp/hymn_body.tmp 2>/dev/null || echo ''"
+
+			-- Check the HTTP status code for errors
+			if httpCode starts with "5" then
+				-- Server error (5xx) -- retry with backoff
+				if attemptNum < maxRetries then
+					log "  Hymn " & (hymnNumber as text) & ": server error (" & httpCode & "), retrying (" & (attemptNum as text) & "/" & (maxRetries as text) & ")..."
+					delay 3 -- wait 3 seconds before retrying
+				else
+					-- All attempts exhausted
+					log "  Hymn " & (hymnNumber as text) & ": server error (" & httpCode & ") after " & (maxRetries as text) & " attempts."
+					return {status:"SKIP", hymnTitleText:"", hymnSections:{}}
+				end if
+			else if httpCode starts with "4" then
+				-- Client error (4xx, e.g. 404 Not Found) -- don't retry
+				log "  Hymn " & (hymnNumber as text) & ": HTTP " & httpCode & "."
+				return {status:"SKIP", hymnTitleText:"", hymnSections:{}}
+			else
+				-- Success (2xx or 3xx handled by -L) -- exit retry loop
+				set fetchSuccess to true
+				exit repeat
+			end if
+
+		on error errMsg
+			-- Network error, timeout, or other curl failure
+			if attemptNum < maxRetries then
+				log "  Hymn " & (hymnNumber as text) & ": error (" & errMsg & "), retrying (" & (attemptNum as text) & "/" & (maxRetries as text) & ")..."
+				delay 3
+			else
+				log "  Hymn " & (hymnNumber as text) & ": error after " & (maxRetries as text) & " attempts: " & errMsg
+				return {status:"SKIP", hymnTitleText:"", hymnSections:{}}
+			end if
+		end try
+	end repeat
+
+	-- If we never got a successful response, skip this hymn
+	if not fetchSuccess then
+		return {status:"SKIP", hymnTitleText:"", hymnSections:{}}
+	end if
+
+	-- =====================================================================
+	-- REDIRECT DETECTION (End of Hymnal)
+	-- =====================================================================
+	-- When you request a hymn number that doesn't exist, the site redirects
+	-- to the homepage. We detect this by checking if the effective URL
+	-- (after following redirects) still contains "Hymn" in the path.
+	-- We only check for hymn numbers > 1 because hymn 1 should always exist.
+	-- =====================================================================
+	if hymnNumber > 1 and effectiveURL does not contain "Hymn" then
+		log "  Hymn " & (hymnNumber as text) & ": redirected to home -- reached end."
+		return {status:"STOP", hymnTitleText:"", hymnSections:{}}
+	end if
+
+	-- =====================================================================
+	-- RATE LIMIT DETECTION
+	-- =====================================================================
+	-- Both sites show a "reached limit for today" or "we are sorry" message
+	-- when too many requests have been made. If detected, pause 60 seconds
+	-- and retry once.
+	-- =====================================================================
+	set lowerHTML to my toLower(htmlContent)
+	if lowerHTML contains "reached limit for today" or lowerHTML contains "we are sorry" then
+		log "  Rate limit hit -- pausing 60 seconds..."
+		delay 60
+
+		-- Retry the request after the cooldown
+		try
+			set retryCommand to "curl -s -L --max-time " & (httpTimeout as text) & " -A " & quoted form of userAgent & " " & quoted form of hymnURL
+			set htmlContent to do shell script retryCommand
+
+			-- Check if still rate limited after waiting
+			set lowerHTML2 to my toLower(htmlContent)
+			if lowerHTML2 contains "reached limit for today" then
+				log "  Still rate limited -- stopping. Try again tomorrow."
+				return {status:"STOP", hymnTitleText:"", hymnSections:{}}
+			end if
+		on error
+			-- Network error during retry -- stop scraping
+			return {status:"STOP", hymnTitleText:"", hymnSections:{}}
+		end try
+	end if
+
+	-- =====================================================================
+	-- HTML PARSING
+	-- =====================================================================
+	-- Parse the HTML to extract the hymn title and lyrics sections.
+	-- Since AppleScript doesn't have a built-in HTML parser, we use shell
+	-- commands (sed, grep, awk) to extract the relevant content.
+	--
+	-- The HTML structure on both sites is:
+	--   <div class="block-heading-four">
+	--       <h3 class="wedding-heading">
+	--           <strong>Hymn Title Here</strong>
+	--       </h3>
+	--   </div>
+	--   <div class="block-heading-three">Verse 1</div>
+	--   <div class="block-heading-five">lyrics<br>lyrics<br></div>
+	--   ...
+	-- =====================================================================
+
+	-- Write the HTML to a temp file so we can process it with shell tools.
+	-- Using a file avoids issues with shell escaping of the HTML content.
+	try
+		do shell script "cat /tmp/hymn_body.tmp > /tmp/hymn_parse.tmp 2>/dev/null"
+	on error
+		-- If the temp file doesn't exist, write htmlContent directly
+		-- We use a heredoc-style approach to safely write arbitrary content
+		try
+			set tempFileRef to open for access POSIX file "/tmp/hymn_parse.tmp" with write permission
+			set eof of tempFileRef to 0
+			write htmlContent to tempFileRef as «class utf8»
+			close access tempFileRef
+		on error
+			try
+				close access POSIX file "/tmp/hymn_parse.tmp"
+			end try
+			return {status:"SKIP", hymnTitleText:"", hymnSections:{}}
+		end try
+	end try
+
+	-- -----------------------------------------------------------------
+	-- Extract the hymn title
+	-- -----------------------------------------------------------------
+	-- The title is inside: <strong>...</strong> within a wedding-heading
+	-- class element. We use a multi-step pipeline:
+	-- 1. Collapse all HTML to a single line (tr removes newlines)
+	-- 2. Find the wedding-heading section
+	-- 3. Extract content between <strong> and </strong>
+	-- 4. Strip any remaining HTML tags
+	-- 5. Decode HTML entities
+	-- 6. Trim whitespace
+	-- -----------------------------------------------------------------
+	set hymnTitle to ""
+	try
+		-- This sed/grep pipeline extracts the title from the HTML:
+		-- Step 1: tr -d '\n' collapses multi-line HTML to a single line
+		-- Step 2: sed isolates the wedding-heading block
+		-- Step 3: sed extracts content between <strong> and </strong>
+		-- Step 4: sed strips remaining HTML tags
+		-- Step 5: sed decodes common HTML entities
+		-- Step 6: sed trims leading/trailing whitespace
+		set titleCommand to "cat /tmp/hymn_parse.tmp | tr -d '\\n\\r' | sed -n 's/.*wedding-heading[^>]*>[[:space:]]*<strong>\\([^<]*\\)<\\/strong>.*/\\1/p' | head -1 | sed 's/<[^>]*>//g' | " & my entityDecodeCommand() & " | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'"
+		set hymnTitle to do shell script titleCommand
+	on error errMsg
+		log "  Title extraction error: " & errMsg
+	end try
+
+	-- If the primary extraction failed, try an alternative approach
+	-- that handles more complex nesting or whitespace in the HTML
+	if hymnTitle is "" then
+		try
+			set altTitleCommand to "cat /tmp/hymn_parse.tmp | tr -d '\\n\\r' | grep -o 'wedding-heading[^\"]*\"[^>]*>[^<]*<strong>[^<]*</strong>' | head -1 | sed 's/.*<strong>//;s/<\\/strong>.*//' | sed 's/<[^>]*>//g' | " & my entityDecodeCommand() & " | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'"
+			set hymnTitle to do shell script altTitleCommand
+		on error
+			-- Still no title found
+			set hymnTitle to ""
+		end try
+	end if
+
+	-- If we still have no title, try the broadest possible extraction:
+	-- look for any <strong> inside a block-heading-four container
+	if hymnTitle is "" then
+		try
+			set broadTitleCommand to "cat /tmp/hymn_parse.tmp | tr -d '\\n\\r' | sed -n 's/.*block-heading-four[^>]*>.*<strong>\\([^<]*\\)<\\/strong>.*/\\1/p' | head -1 | sed 's/<[^>]*>//g' | " & my entityDecodeCommand() & " | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'"
+			set hymnTitle to do shell script broadTitleCommand
+		on error
+			set hymnTitle to ""
+		end try
+	end if
+
+	-- If no title was found, the page probably isn't a valid hymn page
+	if hymnTitle is "" then
+		log "  Hymn " & (hymnNumber as text) & ": no title found."
+		return {status:"SKIP", hymnTitleText:"", hymnSections:{}}
+	end if
+
+	-- -----------------------------------------------------------------
+	-- Extract section indicators and lyrics
+	-- -----------------------------------------------------------------
+	-- We extract indicators (e.g. "Verse 1", "Chorus") and lyrics blocks
+	-- separately, then pair them together in order.
+	--
+	-- Strategy:
+	-- 1. Use sed to mark the start of each indicator and lyrics block
+	--    with unique delimiters
+	-- 2. Process the marked text to extract paired sections
+	-- -----------------------------------------------------------------
+	set hymnSections to {}
+
+	try
+		-- This complex shell pipeline extracts sections from the HTML:
+		--
+		-- 1. Collapse HTML to a single line
+		-- 2. Replace block-heading-three (indicators) with a unique marker: %%INDICATOR%%
+		-- 3. Replace block-heading-five (lyrics) with a unique marker: %%LYRICS%%
+		-- 4. Insert newlines before each marker so they become separate lines
+		-- 5. Process each marker+content line to extract the text
+		--
+		-- The output format is one line per section:
+		--   INDICATOR:Verse 1
+		--   LYRICS:First line|Second line|Third line
+		--   INDICATOR:Chorus
+		--   LYRICS:Chorus line 1|Chorus line 2
+		--
+		-- where | represents a line break within the lyrics.
+		set extractCommand to "cat /tmp/hymn_parse.tmp | tr -d '\\n\\r' " & ¬
+			"| sed 's/<div[^>]*class=\"[^\"]*block-heading-three[^\"]*\"[^>]*>/\\n%%INDICATOR%%/g' " & ¬
+			"| sed 's/<div[^>]*class=\"[^\"]*block-heading-five[^\"]*\"[^>]*>/\\n%%LYRICS%%/g' " & ¬
+			"| sed 's/<\\/div>/\\n%%ENDDIV%%\\n/g' " & ¬
+			"| awk '" & ¬
+			"BEGIN { mode=\"\"; buf=\"\" } " & ¬
+			"/^%%INDICATOR%%/ { mode=\"indicator\"; buf=\"\"; next } " & ¬
+			"/^%%LYRICS%%/ { mode=\"lyrics\"; buf=\"\"; next } " & ¬
+			"/^%%ENDDIV%%/ { " & ¬
+			"  if (mode==\"indicator\") { gsub(/<[^>]*>/,\"\",buf); gsub(/^[ \\t]+|[ \\t]+$/,\"\",buf); print \"INDICATOR:\" buf; } " & ¬
+			"  if (mode==\"lyrics\") { gsub(/<br[ \\/]*>/,\"|NEWLINE|\",buf); gsub(/<[^>]*>/,\"\",buf); gsub(/^[ \\t]+|[ \\t]+$/,\"\",buf); print \"LYRICS:\" buf; } " & ¬
+			"  mode=\"\"; buf=\"\"; next " & ¬
+			"} " & ¬
+			"{ if (mode!=\"\") buf = buf $0 }'"
+		set extractOutput to do shell script extractCommand
+
+		-- Parse the extracted sections into a list of records.
+		-- Each INDICATOR line is followed by a LYRICS line; together they
+		-- form one section of the hymn.
+		set currentIndicator to ""
+		set oldDelims to AppleScript's text item delimiters
+		set AppleScript's text item delimiters to {return, linefeed, character id 10}
+		set extractLines to text items of extractOutput
+		set AppleScript's text item delimiters to oldDelims
+
+		repeat with extractLine in extractLines
+			set lineText to extractLine as text
+
+			if lineText starts with "INDICATOR:" then
+				-- Extract the indicator text after the "INDICATOR:" prefix
+				set currentIndicator to text 11 thru -1 of lineText
+				-- Decode HTML entities in the indicator
+				try
+					set currentIndicator to do shell script "echo " & quoted form of currentIndicator & " | " & my entityDecodeCommand()
+				end try
+
+			else if lineText starts with "LYRICS:" then
+				-- Extract the lyrics text after the "LYRICS:" prefix
+				set lyricsRaw to text 8 thru -1 of lineText
+
+				-- Decode HTML entities in the lyrics
+				try
+					set lyricsRaw to do shell script "echo " & quoted form of lyricsRaw & " | " & my entityDecodeCommand()
+				end try
+
+				-- Convert our |NEWLINE| markers back to actual newlines
+				set lyricsText to my replaceText(lyricsRaw, "|NEWLINE|", linefeed)
+
+				-- Collapse runs of 3+ newlines down to 2 (clean up excessive
+				-- whitespace from empty <br> tags in the source HTML).
+				-- This matches the Python version's re.sub(r'\n{3,}', '\n\n', text)
+				try
+					set lyricsText to do shell script "echo " & quoted form of lyricsText & " | sed '/^$/{ N; /^\\n$/{ N; s/^\\n\\n$/\\n/; }; }' | sed 's/^[[:space:]]*$//'"
+				end try
+
+				-- Trim leading/trailing whitespace from the lyrics
+				set lyricsText to my trimText(lyricsText)
+
+				-- Add this section to the hymn sections list
+				-- Each section is a record with indicator and lyrics keys
+				set end of hymnSections to {sectionIndicator:currentIndicator, sectionLyrics:lyricsText}
+
+				-- Reset the indicator for the next section
+				-- (some lyrics blocks may not have a preceding indicator)
+				set currentIndicator to ""
+			end if
+		end repeat
+	on error errMsg
+		log "  Section extraction error: " & errMsg
+		-- If section extraction fails but we have a title, we'll save
+		-- what we have (title only, no lyrics). This is better than
+		-- losing the title entirely.
+	end try
+
+	-- Return the successfully parsed hymn data
+	return {status:"OK", hymnTitleText:hymnTitle, hymnSections:hymnSections}
+end fetchHymn
+
+
+-- =============================================================================
+-- Handler: entityDecodeCommand
+-- =============================================================================
+-- Returns a shell command string (sed pipeline) that decodes common HTML
+-- entities into their character equivalents. This is used by multiple
+-- parsing steps to clean up extracted text.
+--
+-- Handles:
+--   &amp;   -> &
+--   &lt;    -> <
+--   &gt;    -> >
+--   &quot;  -> "
+--   &apos;  -> '
+--   &nbsp;  -> (space)
+--   &rsquo; -> ' (right single quote, but we normalize to ASCII apostrophe)
+--   &lsquo; -> ' (left single quote, normalized to ASCII)
+--   &rdquo; -> " (right double quote, normalized to ASCII)
+--   &ldquo; -> " (left double quote, normalized to ASCII)
+--   &mdash; -> -- (em dash, approximated with double hyphen)
+--   &ndash; -> - (en dash, approximated with hyphen)
+--   &#NNN;  -> decimal numeric character references (common ones)
+--   &#145;  -> ' (Windows-1252 left single quote, normalized to ASCII)
+--   &#146;  -> ' (Windows-1252 right single quote, normalized to ASCII)
+--   &#147;  -> " (Windows-1252 left double quote, normalized to ASCII)
+--   &#148;  -> " (Windows-1252 right double quote, normalized to ASCII)
+--   &#150;  -> - (Windows-1252 en dash, approximated with hyphen)
+--   &#151;  -> -- (Windows-1252 em dash, approximated with double hyphen)
+--
+-- Returns:
+--   String - a sed command pipeline for entity decoding
+-- =============================================================================
+on entityDecodeCommand()
+	-- Build a sed command chain that replaces HTML entities with their
+	-- character equivalents. We normalize smart quotes to ASCII equivalents
+	-- for maximum compatibility across text editors and operating systems.
+	return "sed " & ¬
+		"'s/&amp;/\\&/g; " & ¬
+		"s/&lt;/</g; " & ¬
+		"s/&gt;/>/g; " & ¬
+		"s/&quot;/\"/g; " & ¬
+		"s/&apos;/'\\''/g; " & ¬
+		"s/&nbsp;/ /g; " & ¬
+		"s/&rsquo;/'\\''/g; " & ¬
+		"s/&lsquo;/'\\''/g; " & ¬
+		"s/&rdquo;/\"/g; " & ¬
+		"s/&ldquo;/\"/g; " & ¬
+		"s/&mdash;/--/g; " & ¬
+		"s/&ndash;/-/g; " & ¬
+		"s/&#39;/'\\''/g; " & ¬
+		"s/&#34;/\"/g; " & ¬
+		"s/&#160;/ /g; " & ¬
+		"s/&#8217;/'\\''/g; " & ¬
+		"s/&#8216;/'\\''/g; " & ¬
+		"s/&#8220;/\"/g; " & ¬
+		"s/&#8221;/\"/g; " & ¬
+		"s/&#8212;/--/g; " & ¬
+		"s/&#8213;/--/g; " & ¬
+		"s/&#8211;/-/g; " & ¬
+		"s/&#145;/'\\''/g; " & ¬
+		"s/&#146;/'\\''/g; " & ¬
+		"s/&#147;/\"/g; " & ¬
+		"s/&#148;/\"/g; " & ¬
+		"s/&#150;/-/g; " & ¬
+		"s/&#151;/--/g'"
+end entityDecodeCommand
+
+
+-- =============================================================================
+-- Handler: saveHymn
+-- =============================================================================
+-- Format a parsed hymn into plain text and save it to a file in the output
+-- directory. Creates the file with UTF-8 encoding.
+--
+-- Output format matches the Python version:
+--   "Hymn Title"
+--
+--   Verse 1
+--   lyrics line 1
+--   lyrics line 2
+--
+--   Chorus
+--   chorus line 1
+--
+-- Parameters:
+--   hymnNumber   - The hymn number (integer)
+--   hymnTitle    - The hymn title (string)
+--   hymnSections - List of records with sectionIndicator and sectionLyrics keys
+--   siteLabel    - Book label for the filename (e.g. "SDAH", "CH")
+--   bookDir      - Directory path where the file should be saved (POSIX path)
+--
+-- Returns:
+--   String - the full POSIX path to the saved file
+-- =============================================================================
+on saveHymn(hymnNumber, hymnTitle, hymnSections, siteLabel, bookDir)
+	-- Format the hymn content as plain text
+	set formattedText to my formatHymn(hymnTitle, hymnSections)
+
+	-- Zero-pad the hymn number to 3 digits for consistent sorting
+	-- e.g. 1 -> "001", 42 -> "042", 695 -> "695"
+	set paddedNumber to my padNumber(hymnNumber, 3)
+
+	-- Sanitize the title to remove characters invalid in filenames,
+	-- then convert to Title Case for consistent, readable filenames
+	set cleanTitle to my titleCase(my sanitizeFilename(hymnTitle))
+
+	-- Build the full filename in the standard format:
+	-- "{padded} ({LABEL}) - {Title Case Title}.txt"
+	set fileName to paddedNumber & " (" & siteLabel & ") - " & cleanTitle & ".txt"
+
+	-- Build the full file path
+	set filePath to bookDir & "/" & fileName
+
+	-- Write the formatted text to the file using AppleScript file I/O.
+	-- We use the "open for access" approach for reliable UTF-8 writing.
+	try
+		-- Open the file for writing (create if it doesn't exist)
+		set fileRef to open for access POSIX file filePath with write permission
+		-- Truncate the file (in case it already exists with different content)
+		set eof of fileRef to 0
+		-- Write the content as UTF-8 encoded text
+		write formattedText to fileRef as «class utf8»
+		-- Close the file handle
+		close access fileRef
+	on error errMsg
+		-- Ensure the file handle is closed even on error
+		try
+			close access POSIX file filePath
+		end try
+		log "  ERROR saving file: " & errMsg
+	end try
+
+	return filePath
+end saveHymn
+
+
+-- =============================================================================
+-- Handler: formatHymn
+-- =============================================================================
+-- Format a hymn title and sections list into a clean plain-text string.
+-- The output format matches the Python version exactly.
+--
+-- Parameters:
+--   hymnTitle    - The hymn title string
+--   hymnSections - List of records with sectionIndicator and sectionLyrics keys
+--
+-- Returns:
+--   String - the formatted plain-text hymn content
+-- =============================================================================
+on formatHymn(hymnTitle, hymnSections)
+	-- Start with the quoted title and a blank line (matches Python output)
+	set outputLines to {"\"" & hymnTitle & "\"", ""}
+
+	-- Append each section (indicator + lyrics) with blank line separators
+	repeat with aSection in hymnSections
+		set indicator to sectionIndicator of aSection
+		set lyrics to sectionLyrics of aSection
+
+		-- Add the indicator line if present (e.g. "Verse 1", "Chorus")
+		if indicator is not "" then
+			set end of outputLines to indicator
+		end if
+
+		-- Add the lyrics text if present
+		if lyrics is not "" then
+			set end of outputLines to lyrics
+		end if
+
+		-- Blank line between sections
+		set end of outputLines to ""
+	end repeat
+
+	-- Remove trailing blank lines for a cleaner file ending.
+	-- This matches the Python version's behavior of stripping trailing empties.
+	repeat while (count of outputLines) > 0 and (item -1 of outputLines) is ""
+		if (count of outputLines) > 1 then
+			set outputLines to items 1 thru -2 of outputLines
+		else
+			set outputLines to {}
+		end if
+	end repeat
+
+	-- Join all lines with newline characters to form the final text
+	set oldDelims to AppleScript's text item delimiters
+	set AppleScript's text item delimiters to linefeed
+	set outputText to outputLines as text
+	set AppleScript's text item delimiters to oldDelims
+
+	return outputText
+end formatHymn
+
+
+-- =============================================================================
+-- Handler: buildExistingSet
+-- =============================================================================
+-- Scan the output directory to find hymn numbers that have already been saved.
+-- This enables the scraper to resume from where it left off without
+-- re-downloading hymns.
+--
+-- Looks for files matching the naming pattern:
+--   {number} ({label}) - {title}.txt
+-- and extracts the hymn number from each matching filename.
+--
+-- Parameters:
+--   siteLabel - The book label to filter by (e.g. "SDAH", "CH")
+--   bookDir   - Path to the directory to scan (POSIX path)
+--
+-- Returns:
+--   List of integers - hymn numbers already saved (empty list if none)
+-- =============================================================================
+on buildExistingSet(siteLabel, bookDir)
+	set existingNumbers to {}
+
+	try
+		-- Use ls and grep to find files matching our naming pattern.
+		-- The grep pattern matches files containing "({label}) -" and ending in .txt.
+		-- We extract just the leading number from each filename.
+		--
+		-- Pipeline breakdown:
+		-- 1. ls: list files in the book directory
+		-- 2. grep: filter for files with the correct label and .txt extension
+		-- 3. sed: extract the leading digits (hymn number) from each filename
+		-- 4. sort -n: sort numerically for consistent ordering
+		set prefixTag to "(" & siteLabel & ") -"
+		set listCommand to "ls " & quoted form of bookDir & " 2>/dev/null | grep " & quoted form of prefixTag & " | grep '\\.txt$' | sed 's/^[[:space:]]*\\([0-9]*\\).*/\\1/' | sort -n"
+		set fileList to do shell script listCommand
+
+		-- Parse the output (one number per line) into a list of integers
+		if fileList is not "" then
+			set oldDelims to AppleScript's text item delimiters
+			set AppleScript's text item delimiters to {return, linefeed, character id 10}
+			set numberStrings to text items of fileList
+			set AppleScript's text item delimiters to oldDelims
+
+			repeat with numStr in numberStrings
+				set numText to numStr as text
+				if numText is not "" then
+					try
+						set end of existingNumbers to (numText as integer)
+					end try
+				end if
+			end repeat
+		end if
+	on error
+		-- Directory doesn't exist or is empty -- return empty list
+		-- This is normal for the first run
+	end try
+
+	return existingNumbers
+end buildExistingSet
+
+
+-- =============================================================================
+-- Handler: logSkip
+-- =============================================================================
+-- Record a skipped hymn entry in the skipped.log file for later review.
+-- Appends a timestamped line to the log file in the book directory.
+--
+-- Log format (one line per skipped hymn):
+--   [2026-03-13 14:30:00]  SDAH042  --  fetch failed or no title found
+--
+-- Parameters:
+--   hymnNumber - The hymn number that was skipped (integer)
+--   siteLabel  - Book label (e.g. "SDAH", "CH")
+--   reason     - Human-readable explanation of why it was skipped
+--   bookDir    - Directory path where the log file should be written (POSIX path)
+-- =============================================================================
+on logSkip(hymnNumber, siteLabel, reason, bookDir)
+	try
+		-- Ensure the directory exists
+		do shell script "mkdir -p " & quoted form of bookDir
+
+		-- Build the log entry with a timestamp
+		-- Using shell date command for consistent formatting
+		set paddedNum to my padNumber(hymnNumber, 3)
+		set logEntry to "[" & (do shell script "date '+%Y-%m-%d %H:%M:%S'") & "]  " & siteLabel & paddedNum & "  --  " & reason
+
+		-- Append the log entry to skipped.log using shell echo with >>
+		-- The >> operator appends to the file (creates it if it doesn't exist)
+		set logPath to bookDir & "/skipped.log"
+		do shell script "echo " & quoted form of logEntry & " >> " & quoted form of logPath
+	on error errMsg
+		-- Log file write failure is non-critical -- just note it in the Script Editor log
+		log "  WARNING: Could not write to skipped.log: " & errMsg
+	end try
+end logSkip
+
+
+-- =============================================================================
+-- Handler: padNumber
+-- =============================================================================
+-- Zero-pad an integer to a specified width for consistent formatting.
+-- e.g. padNumber(1, 3) -> "001", padNumber(42, 3) -> "042"
+--
+-- Parameters:
+--   num   - The integer to pad
+--   width - The desired total width (number of characters)
+--
+-- Returns:
+--   String - the zero-padded number string
+-- =============================================================================
+on padNumber(num, width)
+	-- Convert the number to a string
+	set numStr to num as text
+
+	-- Prepend zeros until we reach the desired width
+	repeat while (count of numStr) < width
+		set numStr to "0" & numStr
+	end repeat
+
+	return numStr
+end padNumber
+
+
+-- =============================================================================
+-- Handler: sanitizeFilename
+-- =============================================================================
+-- Remove characters that are invalid in filenames across operating systems.
+-- Strips: \ / * ? : " < > |
+-- These are forbidden in Windows filenames and/or could cause issues on
+-- other platforms including macOS (which forbids : and / in filenames).
+--
+-- Parameters:
+--   name - The raw string to sanitize (typically a hymn title)
+--
+-- Returns:
+--   String - the sanitized string with invalid characters removed
+-- =============================================================================
+on sanitizeFilename(name)
+	try
+		-- Use sed to remove all invalid filename characters in one pass.
+		-- The character class [\\/*?:"<>|] matches all forbidden chars.
+		-- We also trim leading/trailing whitespace.
+		set sanitized to do shell script "echo " & quoted form of name & " | sed 's/[\\\\/\\*?:\"<>|]//g; s/^[[:space:]]*//; s/[[:space:]]*$//'"
+		return sanitized
+	on error
+		-- If sed fails for any reason, do a basic AppleScript cleanup
+		return name
+	end try
+end sanitizeFilename
+
+
+-- =============================================================================
+-- Handler: titleCase
+-- =============================================================================
+-- Convert a string to Title Case with correct handling of apostrophes.
+-- This matches the Python version's behavior where contractions like
+-- "don't", "it's", "o'er" are handled correctly (the letter after the
+-- apostrophe stays lowercase).
+--
+-- Uses awk for the conversion because awk splits on whitespace, so words
+-- containing any kind of apostrophe (ASCII ' or Unicode curly \u2019/\u2018
+-- from decoded HTML entities like &rsquo;) are naturally treated as single
+-- tokens — no special character class needed.
+--
+-- Parameters:
+--   s - The input string to convert
+--
+-- Returns:
+--   String - the Title Cased string
+--
+-- Examples:
+--   "AMAZING GRACE"     -> "Amazing Grace"
+--   "don't let me down" -> "Don't Let Me Down"
+--   "o'er the hills"    -> "O'er The Hills"
+-- =============================================================================
+on titleCase(s)
+	if s is "" then return ""
+
+	try
+		-- This awk script processes each word (split by spaces) and converts
+		-- it to title case. For words containing apostrophes, it keeps the
+		-- word together and only capitalizes the first character.
+		--
+		-- The approach:
+		-- 1. Split each line into words (awk's default behavior)
+		-- 2. For each word: lowercase it, then uppercase the first character
+		-- 3. Rejoin words with spaces
+		--
+		-- The tolower() ensures consistent casing before we capitalize,
+		-- so "ALL CAPS" becomes "All Caps" rather than "ALL CAPS".
+		set titleCommand to "echo " & quoted form of s & " | awk '{for(i=1;i<=NF;i++){w=tolower($i);$i=toupper(substr(w,1,1)) substr(w,2)}}1'"
+		set result to do shell script titleCommand
+		return result
+	on error
+		-- Fallback: return the original string if awk fails
+		return s
+	end try
+end titleCase
+
+
+-- =============================================================================
+-- Handler: replaceText
+-- =============================================================================
+-- Replace all occurrences of a substring within a string.
+-- AppleScript doesn't have a built-in string replacement function, so
+-- we use text item delimiters to split and rejoin the string.
+--
+-- Parameters:
+--   sourceText  - The original string
+--   searchText  - The substring to find
+--   replaceWith - The replacement substring
+--
+-- Returns:
+--   String - the modified string with all occurrences replaced
+-- =============================================================================
+on replaceText(sourceText, searchText, replaceWith)
+	-- Save the current text item delimiters to restore them later.
+	-- AppleScript's text item delimiters are a global setting, so we must
+	-- save and restore to avoid affecting other parts of the script.
+	set oldDelims to AppleScript's text item delimiters
+
+	-- Split the string on the search text
+	set AppleScript's text item delimiters to searchText
+	set textItems to text items of sourceText
+
+	-- Rejoin with the replacement text
+	set AppleScript's text item delimiters to replaceWith
+	set resultText to textItems as text
+
+	-- Restore original delimiters
+	set AppleScript's text item delimiters to oldDelims
+
+	return resultText
+end replaceText
+
+
+-- =============================================================================
+-- Handler: trimText
+-- =============================================================================
+-- Remove leading and trailing whitespace (spaces, tabs, newlines) from a string.
+--
+-- Parameters:
+--   s - The string to trim
+--
+-- Returns:
+--   String - the trimmed string
+-- =============================================================================
+on trimText(s)
+	if s is "" then return ""
+
+	try
+		-- Use sed to remove leading and trailing whitespace.
+		-- Two sed expressions:
+		-- 1. Remove leading whitespace from the first line
+		-- 2. Remove trailing whitespace from the last line
+		-- We also handle multi-line strings by removing blank leading/trailing lines.
+		set trimmed to do shell script "echo " & quoted form of s & " | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | sed -e '/./,$!d' -e :a -e '/^\\n*$/{$d;N;ba' -e '}'"
+		return trimmed
+	on error
+		return s
+	end try
+end trimText
+
+
+-- =============================================================================
+-- Handler: toLower
+-- =============================================================================
+-- Convert a string to lowercase.
+-- Used for case-insensitive string comparisons (e.g. rate limit detection).
+--
+-- Parameters:
+--   s - The string to convert
+--
+-- Returns:
+--   String - the lowercase version of the string
+-- =============================================================================
+on toLower(s)
+	if s is "" then return ""
+
+	try
+		-- Use tr to convert uppercase letters to lowercase.
+		-- We write the string to a temp file first to avoid issues
+		-- with special characters in the shell command.
+		--
+		-- For short strings we use echo; for long strings (HTML content)
+		-- we read from the temp file that was already written.
+		if (count of s) > 1000 then
+			-- For large strings (like full HTML pages), use the temp file
+			-- to avoid "argument list too long" errors in the shell
+			return do shell script "cat /tmp/hymn_parse.tmp 2>/dev/null | tr '[:upper:]' '[:lower:]'"
+		else
+			return do shell script "echo " & quoted form of s & " | tr '[:upper:]' '[:lower:]'"
+		end if
+	on error
+		return s
+	end try
+end toLower
+
+
+-- =============================================================================
+-- Handler: getFilename
+-- =============================================================================
+-- Extract just the filename from a full POSIX file path.
+-- e.g. "/path/to/folder/file.txt" -> "file.txt"
+--
+-- Parameters:
+--   filePath - A POSIX file path string
+--
+-- Returns:
+--   String - just the filename component
+-- =============================================================================
+on getFilename(filePath)
+	-- Split the path on "/" and take the last component
+	set oldDelims to AppleScript's text item delimiters
+	set AppleScript's text item delimiters to "/"
+	set pathParts to text items of filePath
+	set AppleScript's text item delimiters to oldDelims
+
+	if (count of pathParts) > 0 then
+		return item -1 of pathParts
+	else
+		return filePath
+	end if
+end getFilename

--- a/.importers/scrapers/SDAHymnals_SDAHymnal.org.bat
+++ b/.importers/scrapers/SDAHymnals_SDAHymnal.org.bat
@@ -1,0 +1,1657 @@
+@if (@CodeSection == @Batch) @then
+@REM ========================================================================
+@REM SDAHymnals_SDAHymnal.org.bat
+@REM importers/scrapers/SDAHymnals_SDAHymnal.org.bat
+@REM
+@REM Hymnal Scraper (Windows Batch/JScript Hybrid)
+@REM Copyright 2025-2026 MWBM Partners Ltd.
+@REM
+@REM HYBRID TECHNIQUE EXPLAINED:
+@REM   This file is simultaneously valid as a Windows Batch script AND as
+@REM   JScript code. The trick relies on the first line:
+@REM       @if (@CodeSection == @Batch) @then
+@REM
+@REM   In Batch: "@if" is treated as a label/command prefix (the @ suppresses
+@REM   echo), and the rest is ignored because batch doesn't evaluate JScript
+@REM   conditional compilation directives. The batch interpreter runs the
+@REM   commands between here and "goto :eof".
+@REM
+@REM   In JScript: "@if (@CodeSection == @Batch)" is a JScript conditional
+@REM   compilation directive that evaluates to false (since @CodeSection is
+@REM   undefined and @Batch is undefined, they're not equal). So the JScript
+@REM   engine skips everything between @if...@then and @end, jumping straight
+@REM   to the actual JScript code below the @end marker.
+@REM
+@REM   The batch section provides an interactive menu when the .bat file is
+@REM   double-clicked or run from a command prompt. It collects user settings
+@REM   and then invokes the JScript section via:
+@REM       cscript //nologo //e:jscript "%~f0" <args>
+@REM   This tells Windows Script Host to run THIS SAME FILE as JScript,
+@REM   which skips the batch section (via @if/@end) and executes the
+@REM   scraping engine below.
+@REM
+@REM DEPENDENCIES:
+@REM   NONE. This script uses only native Windows components:
+@REM   - cmd.exe (batch interpreter) - present on ALL Windows versions
+@REM   - cscript.exe (Windows Script Host) - present on ALL Windows versions
+@REM   - MSXML2.XMLHTTP (ActiveX) - present since Windows XP SP2
+@REM   - Scripting.FileSystemObject (ActiveX) - present since Windows 98
+@REM   No Python, no Node.js, no curl, no third-party tools required.
+@REM
+@REM OVERVIEW:
+@REM   Scrapes hymn lyrics from sdahymnal.org (Seventh-day Adventist Hymnal)
+@REM   and hymnal.xyz (The Church Hymnal). Both sites share the same HTML
+@REM   structure, so one parser handles both. Hymns are saved as plain-text
+@REM   files in book-specific subdirectories.
+@REM
+@REM USAGE:
+@REM   Double-click the .bat file for the interactive menu, or run from
+@REM   the command line:
+@REM       SDAHymnals_SDAHymnal.org.bat                  (interactive menu)
+@REM       SDAHymnals_SDAHymnal.org.bat /?                (show help)
+@REM       SDAHymnals_SDAHymnal.org.bat /site:sdah        (command-line mode)
+@REM       SDAHymnals_SDAHymnal.org.bat /force            (re-download all)
+@REM ========================================================================
+@echo off
+
+REM -- Enable delayed expansion for variable manipulation inside loops --
+setlocal enabledelayedexpansion
+
+REM -- Set console code page to UTF-8 for proper character display --
+chcp 65001 >nul 2>&1
+
+REM -- Initialise default settings --
+REM These mirror the Python version's defaults exactly.
+set "SITE=both"
+set "START_HYMN=1"
+set "END_HYMN=auto"
+set "OUTPUT_DIR=.\hymns"
+set "DELAY=1000"
+REM -- Force mode: when enabled, re-downloads and overwrites existing hymn files --
+REM By default, the scraper skips hymns that already exist in the output directory.
+REM The /force flag disables this check, causing all hymns to be re-fetched.
+set "FORCE=0"
+
+REM -- Check for command-line help request (/?  or  /help  or  -?) --
+if "%~1"=="/?" goto :ShowHelp
+if "%~1"=="-?" goto :ShowHelp
+if "%~1"=="/help" goto :ShowHelp
+if "%~1"=="--help" goto :ShowHelp
+
+REM -- Check for direct command-line arguments (non-interactive mode) --
+REM If any /site: /start: /end: /output: /delay: arguments are present,
+REM skip the interactive menu and go straight to scraping.
+REM /force is a standalone flag (no value) that enables force mode.
+set "HAS_ARGS=0"
+for %%A in (%*) do (
+    echo %%A | findstr /i /c:"/site:" /c:"/start:" /c:"/end:" /c:"/output:" /c:"/delay:" /c:"/force" >nul 2>&1
+    if not errorlevel 1 set "HAS_ARGS=1"
+)
+
+REM -- Parse command-line arguments if provided --
+if "%HAS_ARGS%"=="1" (
+    for %%A in (%*) do (
+        REM Check for standalone /force flag (no colon/value needed)
+        echo %%A | findstr /i /c:"/force" >nul 2>&1
+        if not errorlevel 1 set "FORCE=1"
+        REM Extract the parameter name and value from /name:value format
+        for /f "tokens=1,* delims=:" %%B in ("%%A") do (
+            if /i "%%B"=="/site"   set "SITE=%%C"
+            if /i "%%B"=="/start"  set "START_HYMN=%%C"
+            if /i "%%B"=="/end"    set "END_HYMN=%%C"
+            if /i "%%B"=="/output" set "OUTPUT_DIR=%%C"
+            if /i "%%B"=="/delay"  set "DELAY=%%C"
+        )
+    )
+    REM Skip the interactive menu and go straight to launching the scraper
+    goto :LaunchScraper
+)
+
+REM ======================================================================
+REM INTERACTIVE MENU — displayed when double-clicked or run with no args
+REM ======================================================================
+
+:MainMenu
+cls
+
+REM -- Display coloured ASCII banner --
+REM Using ANSI escape codes for colour (supported on Windows 10+).
+REM On older Windows, the escape codes will display as text but won't break.
+echo.
+echo  [36m========================================================[0m
+echo  [36m  ___  ____    _    _   _                         _     [0m
+echo  [36m / __^|^|  _ \  / \  ^| ^| ^| ^|                       ^| ^|    [0m
+echo  [36m \__ \^| ^| ^| ^|/ _ \ ^| ^|_^| ^|_   _ _ __ ___  _ __  ^| ^|___ [0m
+echo  [36m ___) ^| ^|_^| / ___ \^|  _  ^| ^| ^| ^| '_ ` _ \^| '_ \ ^| / __^|[0m
+echo  [36m^|____/^|____/_/   \_\_^| ^|_^|_^| ^|_^| ^| ^| ^| ^|_^| ^| ^|_^|___/[0m
+echo  [36m                            ^|__/                        [0m
+echo  [36m          SDA Hymnal Scraper (Windows)                  [0m
+echo  [36m========================================================[0m
+echo.
+echo  [33m Copyright 2025-2026 MWBM Partners Ltd.[0m
+echo.
+echo  Scrapes hymn lyrics from sdahymnal.org (SDAH) and
+echo  hymnal.xyz (The Church Hymnal). Both sites share the
+echo  same HTML structure. Hymns are saved as plain text.
+echo.
+echo  [36m--------------------------------------------------------[0m
+echo  [32m Current Settings:[0m
+echo    Site      : [33m%SITE%[0m
+echo    Start Hymn: [33m%START_HYMN%[0m
+echo    End Hymn  : [33m%END_HYMN%[0m
+echo    Output Dir: [33m%OUTPUT_DIR%[0m
+echo    Delay (ms): [33m%DELAY%[0m
+if "%FORCE%"=="1" (
+    echo    Force Mode: [31mON[0m  ^(will overwrite existing files^)
+) else (
+    echo    Force Mode: [32mOFF[0m ^(skips existing files^)
+)
+echo  [36m--------------------------------------------------------[0m
+echo.
+echo  [32m Options:[0m
+echo    [33m1[0m. Start with defaults (both sites, hymn 1, auto-detect end)
+echo    [33m2[0m. Choose site (sdah / ch / both)
+echo    [33m3[0m. Set start hymn number
+echo    [33m4[0m. Set end hymn number
+echo    [33m5[0m. Set output directory
+echo    [33m6[0m. Set delay between requests (milliseconds)
+echo    [33m7[0m. Toggle force mode (re-download and overwrite existing files)
+echo    [33m8[0m. Show current settings
+echo    [33m9[0m. START scraping with current settings
+echo    [33m0[0m. Exit
+echo.
+
+REM -- Prompt user for menu choice --
+set "CHOICE="
+set /p "CHOICE=  Enter choice [0-9]: "
+
+REM -- Validate and route the menu choice --
+if "%CHOICE%"=="1" goto :UseDefaults
+if "%CHOICE%"=="2" goto :ChooseSite
+if "%CHOICE%"=="3" goto :SetStart
+if "%CHOICE%"=="4" goto :SetEnd
+if "%CHOICE%"=="5" goto :SetOutput
+if "%CHOICE%"=="6" goto :SetDelay
+if "%CHOICE%"=="7" goto :ToggleForce
+if "%CHOICE%"=="8" goto :ShowSettings
+if "%CHOICE%"=="9" goto :LaunchScraper
+if "%CHOICE%"=="0" goto :Exit
+
+REM -- Invalid input — redisplay the menu --
+echo.
+echo  [31m  Invalid choice. Please enter a number from 0 to 9.[0m
+timeout /t 2 /nobreak >nul
+goto :MainMenu
+
+
+REM ----------------------------------------------------------------------
+REM Option 1: Reset all settings to defaults and start scraping
+REM ----------------------------------------------------------------------
+:UseDefaults
+set "SITE=both"
+set "START_HYMN=1"
+set "END_HYMN=auto"
+set "OUTPUT_DIR=.\hymns"
+set "DELAY=1000"
+set "FORCE=0"
+goto :LaunchScraper
+
+
+REM ----------------------------------------------------------------------
+REM Option 2: Choose which site to scrape
+REM ----------------------------------------------------------------------
+:ChooseSite
+echo.
+echo  [32m Available sites:[0m
+echo    [33msdah[0m  - sdahymnal.org (Seventh-day Adventist Hymnal)
+echo    [33mch[0m    - hymnal.xyz (The Church Hymnal)
+echo    [33mboth[0m  - Scrape both sites sequentially
+echo.
+set "SITE_INPUT="
+set /p "SITE_INPUT=  Enter site choice (sdah/ch/both): "
+
+REM Validate the input against allowed values
+if /i "%SITE_INPUT%"=="sdah" set "SITE=sdah" & goto :MainMenu
+if /i "%SITE_INPUT%"=="ch"   set "SITE=ch"   & goto :MainMenu
+if /i "%SITE_INPUT%"=="both" set "SITE=both"  & goto :MainMenu
+
+echo  [31m  Invalid site. Choose sdah, ch, or both.[0m
+timeout /t 2 /nobreak >nul
+goto :ChooseSite
+
+
+REM ----------------------------------------------------------------------
+REM Option 3: Set the starting hymn number
+REM ----------------------------------------------------------------------
+:SetStart
+echo.
+set "START_INPUT="
+set /p "START_INPUT=  Enter start hymn number [%START_HYMN%]: "
+
+REM If user pressed Enter without typing, keep current value
+if "%START_INPUT%"=="" goto :MainMenu
+
+REM Validate that the input is a number (must contain only digits)
+echo %START_INPUT%| findstr /r "^[0-9][0-9]*$" >nul 2>&1
+if errorlevel 1 (
+    echo  [31m  Invalid number. Please enter a positive integer.[0m
+    timeout /t 2 /nobreak >nul
+    goto :SetStart
+)
+
+set "START_HYMN=%START_INPUT%"
+goto :MainMenu
+
+
+REM ----------------------------------------------------------------------
+REM Option 4: Set the ending hymn number (or "auto" for auto-detect)
+REM ----------------------------------------------------------------------
+:SetEnd
+echo.
+echo  Enter end hymn number, or "auto" to auto-detect the end.
+set "END_INPUT="
+set /p "END_INPUT=  Enter end hymn number [%END_HYMN%]: "
+
+REM If user pressed Enter without typing, keep current value
+if "%END_INPUT%"=="" goto :MainMenu
+
+REM Allow "auto" as a special value
+if /i "%END_INPUT%"=="auto" set "END_HYMN=auto" & goto :MainMenu
+
+REM Validate that the input is a number
+echo %END_INPUT%| findstr /r "^[0-9][0-9]*$" >nul 2>&1
+if errorlevel 1 (
+    echo  [31m  Invalid input. Enter a positive integer or "auto".[0m
+    timeout /t 2 /nobreak >nul
+    goto :SetEnd
+)
+
+set "END_HYMN=%END_INPUT%"
+goto :MainMenu
+
+
+REM ----------------------------------------------------------------------
+REM Option 5: Set the output directory path
+REM ----------------------------------------------------------------------
+:SetOutput
+echo.
+set "OUTPUT_INPUT="
+set /p "OUTPUT_INPUT=  Enter output directory path [%OUTPUT_DIR%]: "
+
+REM If user pressed Enter without typing, keep current value
+if "%OUTPUT_INPUT%"=="" goto :MainMenu
+
+set "OUTPUT_DIR=%OUTPUT_INPUT%"
+goto :MainMenu
+
+
+REM ----------------------------------------------------------------------
+REM Option 6: Set the delay between HTTP requests (in milliseconds)
+REM ----------------------------------------------------------------------
+:SetDelay
+echo.
+echo  Delay is in milliseconds (e.g. 1000 = 1 second).
+set "DELAY_INPUT="
+set /p "DELAY_INPUT=  Enter delay in ms [%DELAY%]: "
+
+REM If user pressed Enter without typing, keep current value
+if "%DELAY_INPUT%"=="" goto :MainMenu
+
+REM Validate that the input is a number
+echo %DELAY_INPUT%| findstr /r "^[0-9][0-9]*$" >nul 2>&1
+if errorlevel 1 (
+    echo  [31m  Invalid number. Please enter a positive integer (milliseconds).[0m
+    timeout /t 2 /nobreak >nul
+    goto :SetDelay
+)
+
+set "DELAY=%DELAY_INPUT%"
+goto :MainMenu
+
+
+REM ----------------------------------------------------------------------
+REM Option 7: Toggle force mode on/off
+REM ----------------------------------------------------------------------
+REM Force mode causes the scraper to re-download and overwrite existing hymn
+REM files instead of skipping them. Useful when you want to refresh all files
+REM (e.g. after a site update or to fix previously corrupted downloads).
+:ToggleForce
+if "%FORCE%"=="0" (
+    set "FORCE=1"
+    echo.
+    echo  [33m  Force mode: ON[0m — existing files will be overwritten.
+) else (
+    set "FORCE=0"
+    echo.
+    echo  [32m  Force mode: OFF[0m — existing files will be skipped.
+)
+timeout /t 2 /nobreak >nul
+goto :MainMenu
+
+
+REM ----------------------------------------------------------------------
+REM Option 8: Display all current settings
+REM ----------------------------------------------------------------------
+:ShowSettings
+cls
+echo.
+echo  [36m========================================================[0m
+echo  [32m             Current Settings[0m
+echo  [36m========================================================[0m
+echo.
+echo    Site          : [33m%SITE%[0m
+echo    Start Hymn    : [33m%START_HYMN%[0m
+echo    End Hymn      : [33m%END_HYMN%[0m
+echo    Output Dir    : [33m%OUTPUT_DIR%[0m
+echo    Delay (ms)    : [33m%DELAY%[0m
+if "%FORCE%"=="1" (
+    echo    Force Mode    : [31mON[0m  ^(will overwrite existing files^)
+) else (
+    echo    Force Mode    : [32mOFF[0m ^(skips existing files^)
+)
+echo.
+echo  [36m========================================================[0m
+echo.
+pause
+goto :MainMenu
+
+
+REM ----------------------------------------------------------------------
+REM Show help text (when /? or /help is passed)
+REM ----------------------------------------------------------------------
+:ShowHelp
+echo.
+echo  SDA Hymnal Scraper (Windows Batch/JScript Hybrid)
+echo  Copyright 2025-2026 MWBM Partners Ltd.
+echo.
+echo  DESCRIPTION:
+echo    Scrapes hymn lyrics from sdahymnal.org (Seventh-day Adventist Hymnal)
+echo    and hymnal.xyz (The Church Hymnal). Both sites share the same HTML
+echo    structure. Hymns are saved as plain-text files organised into
+echo    book-specific subdirectories.
+echo.
+echo    This script requires NO external dependencies — it uses only native
+echo    Windows components (cmd.exe, cscript.exe, MSXML2.XMLHTTP, FSO).
+echo.
+echo  USAGE:
+echo    %~nx0                              Interactive menu (double-click)
+echo    %~nx0 /?                           Show this help
+echo    %~nx0 /site:sdah                   Scrape only sdahymnal.org
+echo    %~nx0 /site:ch                     Scrape only hymnal.xyz
+echo    %~nx0 /site:both                   Scrape both sites (default)
+echo    %~nx0 /start:50                    Start from hymn 50
+echo    %~nx0 /start:1 /end:100            Scrape hymns 1 to 100
+echo    %~nx0 /output:C:\hymns             Custom output directory
+echo    %~nx0 /delay:2000                  2-second delay between requests
+echo    %~nx0 /force                       Re-download and overwrite all files
+echo    %~nx0 /site:sdah /force            Combine with other flags
+echo.
+echo  OPTIONS:
+echo    /site:VALUE    Which site to scrape: sdah, ch, or both (default: both)
+echo    /start:N       First hymn number to scrape (default: 1)
+echo    /end:N         Last hymn number, or "auto" for auto-detect (default: auto)
+echo    /output:PATH   Output folder path (default: .\hymns)
+echo    /delay:MS      Milliseconds between HTTP requests (default: 1000)
+echo    /force         Re-download and overwrite existing hymn files (default: off)
+echo.
+echo  OUTPUT FORMAT:
+echo    Files are saved as:
+echo      hymns\Seventh-day Adventist Hymnal [SDAH]\001 (SDAH) - Praise To The Lord.txt
+echo      hymns\The Church Hymnal [CH]\001 (CH) - Praise To The Lord.txt
+echo.
+echo    Each file contains:
+echo      "Hymn Title"
+echo      ^<blank line^>
+echo      Verse 1
+echo      First line of lyrics...
+echo      ^<blank line^>
+echo      Chorus
+echo      Chorus text...
+echo.
+echo  FEATURES:
+echo    - Resumable: skips hymns already saved in the output directory
+echo    - Force mode (/force): override resumability, re-download everything
+echo    - Auto-detects end of hymnal (no /end needed)
+echo    - Handles rate limiting (pauses 60s, retries)
+echo    - Retries on server errors (3 attempts with 3s delay)
+echo    - Logs skipped hymns to skipped.log with timestamps
+echo    - Stops after 10 consecutive failures (assumes end of hymnal)
+echo.
+goto :eof
+
+
+REM ----------------------------------------------------------------------
+REM Launch the JScript scraping engine with collected parameters
+REM ----------------------------------------------------------------------
+:LaunchScraper
+echo.
+echo  [36m========================================================[0m
+echo  [32m  Launching scraper...[0m
+echo  [36m========================================================[0m
+echo.
+echo  Settings:
+echo    Site      : %SITE%
+echo    Start     : %START_HYMN%
+echo    End       : %END_HYMN%
+echo    Output    : %OUTPUT_DIR%
+echo    Delay (ms): %DELAY%
+if "%FORCE%"=="1" (
+    echo    Force Mode: ON  ^(will overwrite existing files^)
+) else (
+    echo    Force Mode: OFF ^(skips existing files^)
+)
+echo.
+
+REM -- Verify that cscript.exe is available (it should be on all Windows) --
+where cscript >nul 2>&1
+if errorlevel 1 (
+    echo  [31m  ERROR: cscript.exe not found. This is required for the JScript engine.[0m
+    echo  [31m  cscript.exe should be present on all Windows installations.[0m
+    echo  [31m  Check your PATH or try: C:\Windows\System32\cscript.exe[0m
+    pause
+    goto :eof
+)
+
+REM -- Invoke THIS SAME FILE as JScript via Windows Script Host --
+REM   //nologo    - Suppress the WSH banner
+REM   //e:jscript - Force JScript engine (overrides .bat extension)
+REM   "%~f0"      - Full path to this file (the hybrid .bat/.js file)
+REM   Arguments are passed positionally: site start end output delay force
+cscript //nologo //e:jscript "%~f0" "%SITE%" "%START_HYMN%" "%END_HYMN%" "%OUTPUT_DIR%" "%DELAY%" "%FORCE%"
+
+echo.
+echo  [32m  Scraping complete.[0m
+echo.
+pause
+goto :eof
+
+
+REM ----------------------------------------------------------------------
+REM Exit the script cleanly
+REM ----------------------------------------------------------------------
+:Exit
+echo.
+echo  Goodbye.
+echo.
+endlocal
+goto :eof
+
+@end
+// ========================================================================
+// JSCRIPT SECTION — Hymnal Scraping Engine
+// ========================================================================
+//
+// SDAHymnals_SDAHymnal.org.bat — JScript scraping engine
+// importers/scrapers/SDAHymnals_SDAHymnal.org.bat
+//
+// Copyright 2025-2026 MWBM Partners Ltd.
+//
+// This section contains the actual scraping logic. It is invoked by the
+// batch section above via:
+//     cscript //nologo //e:jscript "%~f0" <site> <start> <end> <output> <delay> <force>
+//
+// The @if/@end conditional compilation block at the top of the file
+// causes the JScript engine to skip the entire batch section and start
+// executing from this point.
+//
+// NATIVE WINDOWS OBJECTS USED:
+//   - MSXML2.XMLHTTP:  HTTP client (present since Windows XP SP2)
+//   - Scripting.FileSystemObject:  File system access (present since Win98)
+//   - WScript.Sleep():  Pause execution (native WSH method)
+//   - WScript.Echo():   Console output (native WSH method)
+//   - WScript.Arguments:  Read command-line arguments
+//
+// HTML PARSING STRATEGY:
+//   Since JScript in WSH doesn't have a DOM parser (no document.createElement),
+//   we use regular expressions to extract data from the HTML. The target HTML
+//   structure uses consistent CSS class names across both sites, making regex
+//   extraction reliable:
+//
+//   Title:      <div class="block-heading-four">
+//                 <h3 class="wedding-heading">
+//                   <strong>TITLE HERE</strong>
+//                 </h3>
+//               </div>
+//
+//   Indicator:  <div class="block-heading-three">Verse 1</div>
+//
+//   Lyrics:     <div class="block-heading-five">
+//                 Line one<br>Line two<br>
+//               </div>
+// ========================================================================
+
+
+// -----------------------------------------------------------------------
+// SITE CONFIGURATION
+// -----------------------------------------------------------------------
+// Both sdahymnal.org and hymnal.xyz are built on the same platform,
+// using identical CSS class names and page layouts. This allows a single
+// set of regex patterns to parse both sites.
+
+/**
+ * Site configuration object.
+ * Each site has:
+ *   baseUrl  - The hymn page URL (hymn number appended as ?no=N)
+ *   homeUrl  - The site homepage (used to detect end-of-hymnal redirects)
+ *   label    - Short identifier for filenames (e.g. "SDAH")
+ *   subdir   - Human-readable subdirectory name for organised output
+ *   lang     - ISO 639-1 language code for the songbook's language (e.g. "en")
+ */
+var SITES = {
+    "sdah": {
+        baseUrl:  "https://www.sdahymnal.org/Hymn",
+        homeUrl:  "https://www.sdahymnal.org",
+        label:    "SDAH",
+        subdir:   "Seventh-day Adventist Hymnal [SDAH]",
+        lang:     "en"    // ISO 639-1: English
+    },
+    "ch": {
+        baseUrl:  "https://www.hymnal.xyz/Hymn",
+        homeUrl:  "https://www.hymnal.xyz",
+        label:    "CH",
+        subdir:   "The Church Hymnal [CH]",
+        lang:     "en"    // ISO 639-1: English
+    }
+};
+
+// Maximum consecutive skip/failure count before assuming end of hymnal.
+// If we hit this many failures in a row, we stop rather than continuing
+// to hammer the server with requests for non-existent hymns.
+var MAX_CONSEC = 10;
+
+
+// -----------------------------------------------------------------------
+// UTILITY: FileSystemObject — shared instance for all file operations
+// -----------------------------------------------------------------------
+// Scripting.FileSystemObject is a native COM object available on all
+// Windows versions since Windows 98. It provides file/folder creation,
+// reading, writing, and path manipulation.
+var fso = new ActiveXObject("Scripting.FileSystemObject");
+
+
+// -----------------------------------------------------------------------
+// UTILITY: Pad a number with leading zeros to a specified width
+// -----------------------------------------------------------------------
+/**
+ * Pad a number with leading zeros (e.g. zeroPad(1, 3) => "001").
+ *
+ * @param {number} num   - The number to pad
+ * @param {number} width - The desired total width (default: 3)
+ * @returns {string} The zero-padded string
+ */
+function zeroPad(num, width) {
+    // Default width is 3 digits (matches the Python version)
+    if (typeof width === "undefined") { width = 3; }
+    var s = String(num);
+    // Prepend zeros until we reach the desired width
+    while (s.length < width) { s = "0" + s; }
+    return s;
+}
+
+
+// -----------------------------------------------------------------------
+// UTILITY: Sanitize a string for use as a filename
+// -----------------------------------------------------------------------
+/**
+ * Remove characters that are invalid in Windows filenames.
+ * Strips: \ / * ? : " < > |
+ * These characters are forbidden by the Windows file system (NTFS/FAT).
+ *
+ * @param {string} name - The raw string to sanitize (typically a hymn title)
+ * @returns {string} The sanitized string with invalid characters removed
+ */
+function sanitize(name) {
+    // Replace each forbidden character with an empty string
+    // Note: In JScript regex, we need to escape backslash and forward slash
+    return name.replace(/[\\\/\*\?:"<>\|]/g, "").replace(/^\s+|\s+$/g, "");
+}
+
+
+// -----------------------------------------------------------------------
+// UTILITY: Title Case conversion with proper apostrophe handling
+// -----------------------------------------------------------------------
+/**
+ * Convert a string to Title Case, handling apostrophes correctly.
+ *
+ * JavaScript's built-in methods (like CSS text-transform or manual splitting)
+ * often break on apostrophes, producing "Don'T" instead of "Don't".
+ * This function matches whole words (including contractions like don't, it's,
+ * o'er) and capitalises the first letter of each word while lowercasing
+ * the rest.
+ *
+ * Regex pattern: [a-zA-Z]+('[a-zA-Z]+)?
+ *   - [a-zA-Z]+       : One or more letters (the main word)
+ *   - ('[a-zA-Z]+)?   : Optionally an apostrophe + more letters (contraction)
+ *
+ * @param {string} s - The input string to convert
+ * @returns {string} The Title Cased string
+ *
+ * @example
+ *   titleCase("AMAZING GRACE")     => "Amazing Grace"
+ *   titleCase("don't let me down") => "Don't Let Me Down"
+ *   titleCase("o'er the hills")    => "O'er The Hills"
+ *   titleCase("EAGLE\u2019S WINGS") => "Eagle\u2019s Wings"
+ *
+ * We include Unicode curly/smart apostrophes (\u2019 RIGHT SINGLE QUOTATION
+ * MARK and \u2018 LEFT SINGLE QUOTATION MARK) because the HTML entity decoder
+ * converts &rsquo; to \u2019. Without this, "Eagle\u2019s" would be split into
+ * separate words, producing "Eagle'S" instead of "Eagle's".
+ */
+function titleCase(s) {
+    // Match each word (including apostrophe-contractions) and capitalise it.
+    // The character class ['\u2019\u2018] matches ASCII apostrophe, right single
+    // quotation mark, and left single quotation mark — covering all apostrophe
+    // variants that may appear after HTML entity decoding.
+    return s.replace(/[a-zA-Z]+(['\u2019\u2018][a-zA-Z]+)?/g, function(match) {
+        // Uppercase first character, lowercase the rest
+        return match.charAt(0).toUpperCase() + match.substring(1).toLowerCase();
+    });
+}
+
+
+// -----------------------------------------------------------------------
+// UTILITY: Decode HTML entities in a string
+// -----------------------------------------------------------------------
+/**
+ * Decode common HTML entities to their plain-text equivalents.
+ *
+ * Since we're parsing HTML with regex (no DOM available in WSH JScript),
+ * we need to manually convert HTML entities that appear in hymn titles
+ * and lyrics text. This covers the most common entities found on these
+ * hymn sites.
+ *
+ * Handles:
+ *   - Named entities: &amp; &lt; &gt; &quot; &apos; &nbsp;
+ *   - Typographic entities: &rsquo; &lsquo; &rdquo; &ldquo; &mdash; &ndash;
+ *   - Numeric decimal entities: &#8217; &#160; etc.
+ *   - Numeric hex entities: &#x2019; &#xA0; etc.
+ *
+ * @param {string} text - The HTML string containing entities
+ * @returns {string} The string with entities decoded to plain characters
+ */
+function decodeEntities(text) {
+    if (!text) { return ""; }
+
+    // --- Named entity lookup table ---
+    // Maps entity names (without & and ;) to their character equivalents
+    var namedEntities = {
+        "amp":    "&",
+        "lt":     "<",
+        "gt":     ">",
+        "quot":   '"',
+        "apos":   "'",
+        "nbsp":   " ",           // Non-breaking space -> regular space
+        "rsquo":  "\u2019",     // Right single smart quote (')
+        "lsquo":  "\u2018",     // Left single smart quote  (')
+        "rdquo":  "\u201D",     // Right double smart quote (")
+        "ldquo":  "\u201C",     // Left double smart quote  (")
+        "mdash":  "\u2014",     // Em dash (—)
+        "ndash":  "\u2013"      // En dash (–)
+    };
+
+    // Replace named entities: &name; -> character
+    text = text.replace(/&([a-zA-Z]+);/g, function(match, name) {
+        var lower = name.toLowerCase();
+        if (typeof namedEntities[lower] !== "undefined") {
+            return namedEntities[lower];
+        }
+        return match; // Unknown entity — leave as-is
+    });
+
+    // Windows-1252 remapping: code points 128-159 are C1 control characters
+    // in Unicode, but many legacy web pages use them to mean the Windows-1252
+    // characters (smart quotes, dashes, etc.). Web browsers perform this
+    // remapping automatically; we do the same here so that &#145; becomes
+    // a left single quote, etc.
+    // Reference: https://html.spec.whatwg.org/#numeric-character-reference-end-state
+    var win1252Map = {
+        145: "\u2018",  // left single quotation mark
+        146: "\u2019",  // right single quotation mark
+        147: "\u201C",  // left double quotation mark
+        148: "\u201D",  // right double quotation mark
+        150: "\u2013",  // en dash
+        151: "\u2014"   // em dash
+    };
+
+    // Replace numeric decimal entities: &#8217; -> character
+    text = text.replace(/&#(\d+);/g, function(match, digits) {
+        var code = parseInt(digits, 10);
+        // Check Windows-1252 remapping first (legacy entity codes 128-159)
+        if (typeof win1252Map[code] !== "undefined") {
+            return win1252Map[code];
+        }
+        // Safety check: valid Unicode code points range from 0 to 0x10FFFF
+        if (code > 0 && code <= 0x10FFFF) {
+            return String.fromCharCode(code);
+        }
+        return match; // Out of range — leave as-is
+    });
+
+    // Replace numeric hex entities: &#x2019; -> character
+    text = text.replace(/&#x([0-9a-fA-F]+);/g, function(match, hex) {
+        var code = parseInt(hex, 16);
+        // Check Windows-1252 remapping first
+        if (typeof win1252Map[code] !== "undefined") {
+            return win1252Map[code];
+        }
+        if (code > 0 && code <= 0x10FFFF) {
+            return String.fromCharCode(code);
+        }
+        return match; // Out of range — leave as-is
+    });
+
+    return text;
+}
+
+
+// -----------------------------------------------------------------------
+// UTILITY: Strip all HTML tags from a string
+// -----------------------------------------------------------------------
+/**
+ * Remove all HTML tags from a string, leaving only text content.
+ * Converts <br> and <br/> tags to newlines before stripping other tags.
+ *
+ * @param {string} html - The HTML string to strip
+ * @returns {string} Plain text with HTML tags removed
+ */
+function stripTags(html) {
+    if (!html) { return ""; }
+    // Convert <br>, <br/>, <br /> tags to newlines (these are line breaks in lyrics)
+    var text = html.replace(/<br\s*\/?>/gi, "\n");
+    // Remove all remaining HTML tags
+    text = text.replace(/<[^>]+>/g, "");
+    return text;
+}
+
+
+// -----------------------------------------------------------------------
+// UTILITY: Trim whitespace from both ends of a string
+// -----------------------------------------------------------------------
+/**
+ * Trim leading and trailing whitespace from a string.
+ * JScript (WSH) doesn't have String.prototype.trim(), so we implement it.
+ *
+ * @param {string} s - The string to trim
+ * @returns {string} The trimmed string
+ */
+function trim(s) {
+    if (!s) { return ""; }
+    return s.replace(/^\s+|\s+$/g, "");
+}
+
+
+// -----------------------------------------------------------------------
+// UTILITY: Ensure a directory exists (create it and all parents if needed)
+// -----------------------------------------------------------------------
+/**
+ * Recursively create a directory path, similar to Python's os.makedirs().
+ * If the directory already exists, this is a no-op.
+ *
+ * Uses Scripting.FileSystemObject to create each directory level in the
+ * path from root to leaf.
+ *
+ * @param {string} dirPath - The full directory path to create
+ */
+function ensureDir(dirPath) {
+    if (fso.FolderExists(dirPath)) { return; }
+
+    // Get the parent directory path
+    var parent = fso.GetParentFolderName(dirPath);
+
+    // Recursively ensure the parent exists first
+    if (parent && !fso.FolderExists(parent)) {
+        ensureDir(parent);
+    }
+
+    // Now create this directory (parent is guaranteed to exist)
+    try {
+        fso.CreateFolder(dirPath);
+    } catch (e) {
+        // Ignore errors if the folder was created between our check and create
+        // (race condition with concurrent scripts, unlikely but possible)
+        if (!fso.FolderExists(dirPath)) { throw e; }
+    }
+}
+
+
+// -----------------------------------------------------------------------
+// UTILITY: Get the absolute path for a given path string
+// -----------------------------------------------------------------------
+/**
+ * Convert a relative path to an absolute path using FSO.
+ * Resolves ".", "..", and relative paths against the current directory.
+ *
+ * @param {string} path - The path to resolve (may be relative or absolute)
+ * @returns {string} The fully resolved absolute path
+ */
+function getAbsolutePath(path) {
+    return fso.GetAbsolutePathName(path);
+}
+
+
+// -----------------------------------------------------------------------
+// UTILITY: Get a formatted timestamp string for log entries
+// -----------------------------------------------------------------------
+/**
+ * Return a formatted timestamp string in the format: YYYY-MM-DD HH:MM:SS
+ * Used for skipped.log entries to record when each skip occurred.
+ *
+ * @returns {string} Formatted timestamp
+ */
+function getTimestamp() {
+    var now = new Date();
+    var y   = now.getFullYear();
+    // Month and day are zero-padded to 2 digits
+    var m   = zeroPad(now.getMonth() + 1, 2);  // getMonth() is 0-based
+    var d   = zeroPad(now.getDate(), 2);
+    var hh  = zeroPad(now.getHours(), 2);
+    var mm  = zeroPad(now.getMinutes(), 2);
+    var ss  = zeroPad(now.getSeconds(), 2);
+    return y + "-" + m + "-" + d + " " + hh + ":" + mm + ":" + ss;
+}
+
+
+// -----------------------------------------------------------------------
+// HTTP: Fetch a URL with retry logic
+// -----------------------------------------------------------------------
+/**
+ * Fetch the HTML content of a URL using MSXML2.XMLHTTP (native ActiveX).
+ *
+ * Includes retry logic for HTTP 500 errors (3 attempts, 3-second delay
+ * between retries). This mirrors the Python version's resilience features.
+ *
+ * MSXML2.XMLHTTP is a native COM object available on all Windows versions
+ * since XP SP2. It supports synchronous and asynchronous HTTP requests.
+ * We use synchronous mode (third parameter = false) since WSH JScript
+ * is single-threaded and we need to wait for each response.
+ *
+ * @param {string} url - The URL to fetch
+ * @returns {object|null} Object with properties:
+ *   - status {number}: HTTP status code (200, 404, 500, etc.)
+ *   - responseText {string}: The response body as text
+ *   - responseUrl {string}: The final URL after redirects (best effort)
+ *   - error {string|null}: Error message if the request failed entirely
+ *   Returns null if all retry attempts were exhausted.
+ */
+function httpGet(url) {
+    var MAX_RETRIES = 3;     // Number of attempts on HTTP 500
+    var RETRY_DELAY = 3000;  // 3 seconds between retries (in milliseconds)
+
+    for (var attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+        try {
+            // Create a new XMLHTTP object for each attempt
+            // (reusing objects can cause issues with some error states)
+            var xhr = new ActiveXObject("MSXML2.XMLHTTP");
+
+            // Open a synchronous GET request
+            // Parameters: method, url, async (false = synchronous/blocking)
+            xhr.open("GET", url, false);
+
+            // Set a polite User-Agent header identifying this scraper
+            xhr.setRequestHeader("User-Agent",
+                "Mozilla/5.0 (compatible; HymnScraper/2.0; personal use)");
+
+            // Send the request (blocks until response is received)
+            xhr.send();
+
+            // Check for HTTP 500 (server error) — these are often transient
+            if (xhr.status === 500) {
+                if (attempt < MAX_RETRIES) {
+                    WScript.Echo("    server error (500), retrying (" +
+                                 attempt + "/" + MAX_RETRIES + ")...");
+                    WScript.Sleep(RETRY_DELAY);
+                    continue;  // Try again
+                } else {
+                    // All retries exhausted
+                    return {
+                        status: 500,
+                        responseText: "",
+                        responseUrl: url,
+                        error: "server error (500) after " + MAX_RETRIES + " attempts"
+                    };
+                }
+            }
+
+            // Return the response object with all relevant data
+            // Note: MSXML2.XMLHTTP doesn't expose the final URL after
+            // redirects, so we attempt to detect redirects by checking
+            // the response content instead (see fetchHymn function).
+            return {
+                status: xhr.status,
+                responseText: xhr.responseText,
+                responseUrl: url,  // Best we can do — XMLHTTP doesn't expose final URL
+                error: null
+            };
+
+        } catch (e) {
+            // Network errors, timeouts, DNS failures, etc.
+            if (attempt < MAX_RETRIES) {
+                WScript.Echo("    network error: " + e.message +
+                             ", retrying (" + attempt + "/" + MAX_RETRIES + ")...");
+                WScript.Sleep(RETRY_DELAY);
+                continue;
+            } else {
+                return {
+                    status: 0,
+                    responseText: "",
+                    responseUrl: url,
+                    error: "network error: " + e.message
+                };
+            }
+        }
+    }
+
+    // Should not reach here, but just in case
+    return null;
+}
+
+
+// -----------------------------------------------------------------------
+// PARSER: Extract hymn title from HTML
+// -----------------------------------------------------------------------
+/**
+ * Extract the hymn title from the page HTML using regex.
+ *
+ * The title is located in the HTML structure:
+ *   <div class="block-heading-four">
+ *     <h3 class="wedding-heading">
+ *       <strong>TITLE TEXT HERE</strong>
+ *     </h3>
+ *   </div>
+ *
+ * We use a regex that matches the <strong> tag content within any element
+ * that has the "wedding-heading" class. This is more resilient than trying
+ * to match the exact nesting structure.
+ *
+ * Regex breakdown:
+ *   block-heading-four  - Match the container div class
+ *   [\s\S]*?            - Non-greedy match of anything (including newlines)
+ *   wedding-heading     - Match the heading class
+ *   [\s\S]*?            - Non-greedy match up to the <strong> tag
+ *   <strong[^>]*>       - Match the opening <strong> tag
+ *   ([\s\S]*?)          - CAPTURE GROUP: the title text (non-greedy)
+ *   <\/strong>          - Match the closing </strong> tag
+ *
+ * @param {string} html - The full page HTML
+ * @returns {string} The extracted hymn title (empty string if not found)
+ */
+function extractTitle(html) {
+    // Regex to find the title within the block-heading-four > wedding-heading > strong path
+    var titleRegex = /block-heading-four[\s\S]*?wedding-heading[\s\S]*?<strong[^>]*>([\s\S]*?)<\/strong>/i;
+    var match = titleRegex.exec(html);
+
+    if (match && match[1]) {
+        // Strip any remaining HTML tags from the title text
+        var rawTitle = stripTags(match[1]);
+        // Decode HTML entities (e.g. &amp; -> &, &rsquo; -> ')
+        rawTitle = decodeEntities(rawTitle);
+        // Trim whitespace
+        return trim(rawTitle);
+    }
+
+    return "";  // Title not found
+}
+
+
+// -----------------------------------------------------------------------
+// PARSER: Extract lyrics sections (indicators + lyrics) from HTML
+// -----------------------------------------------------------------------
+/**
+ * Extract all hymn sections (verses, choruses, etc.) from the page HTML.
+ *
+ * The HTML structure for lyrics sections is:
+ *   <div class="block-heading-three">Verse 1</div>   <- indicator
+ *   <div class="block-heading-five">                  <- lyrics
+ *     First line<br>Second line<br>
+ *   </div>
+ *
+ * Indicators and lyrics blocks appear as sibling elements. An indicator
+ * (block-heading-three) is paired with the next lyrics block
+ * (block-heading-five) that follows it.
+ *
+ * Strategy:
+ *   1. Find all block-heading-three and block-heading-five divs using regex
+ *   2. Process them in order of appearance (by position in the HTML)
+ *   3. When we encounter an indicator, store its text
+ *   4. When we encounter a lyrics block, pair it with the stored indicator
+ *
+ * @param {string} html - The full page HTML
+ * @returns {Array} Array of {indicator, lyrics} objects, where:
+ *   - indicator: string like "Verse 1", "Chorus", or "" if no indicator
+ *   - lyrics: the verse/chorus text with \n for line breaks
+ */
+function extractSections(html) {
+    var sections = [];
+
+    // --- Step 1: Find all indicator and lyrics blocks by position ---
+    // We'll collect all matches with their position, type, and content,
+    // then sort by position to process them in document order.
+    var blocks = [];
+
+    // Find all block-heading-three divs (indicators: "Verse 1", "Chorus", etc.)
+    // Regex: match <div...class="...block-heading-three..."...>CONTENT</div>
+    // The content is captured in group 1.
+    var indicatorRegex = /<div[^>]*class="[^"]*block-heading-three[^"]*"[^>]*>([\s\S]*?)<\/div>/gi;
+    var m;
+    while ((m = indicatorRegex.exec(html)) !== null) {
+        blocks.push({
+            pos:     m.index,                     // Position in the HTML string
+            type:    "indicator",                  // Block type
+            content: trim(decodeEntities(stripTags(m[1])))  // Clean text content
+        });
+    }
+
+    // Find all block-heading-five divs (lyrics blocks)
+    // Regex: match <div...class="...block-heading-five..."...>CONTENT</div>
+    // Uses a non-greedy match but needs to handle nested divs.
+    // Since lyrics blocks typically don't contain nested divs, this is safe.
+    var lyricsRegex = /<div[^>]*class="[^"]*block-heading-five[^"]*"[^>]*>([\s\S]*?)<\/div>/gi;
+    while ((m = lyricsRegex.exec(html)) !== null) {
+        // Process the lyrics text:
+        // 1. Convert <br> tags to newlines
+        // 2. Strip remaining HTML tags
+        // 3. Decode HTML entities
+        // 4. Collapse runs of 3+ newlines to 2 (matches Python version behaviour)
+        var rawLyrics = m[1];
+        rawLyrics = rawLyrics.replace(/<br\s*\/?>/gi, "\n");  // <br> -> \n
+        rawLyrics = rawLyrics.replace(/<[^>]+>/g, "");          // Strip other tags
+        rawLyrics = decodeEntities(rawLyrics);                   // Decode entities
+        rawLyrics = rawLyrics.replace(/\n{3,}/g, "\n\n");       // Collapse excess newlines
+        rawLyrics = trim(rawLyrics);                             // Trim whitespace
+
+        blocks.push({
+            pos:     m.index,
+            type:    "lyrics",
+            content: rawLyrics
+        });
+    }
+
+    // --- Step 2: Sort all blocks by their position in the document ---
+    // This ensures we process indicators and lyrics in the correct order,
+    // regardless of which regex matched first.
+    blocks.sort(function(a, b) { return a.pos - b.pos; });
+
+    // --- Step 3: Pair indicators with their following lyrics blocks ---
+    var currentIndicator = "";
+    for (var i = 0; i < blocks.length; i++) {
+        if (blocks[i].type === "indicator") {
+            // Store the indicator text to pair with the next lyrics block
+            currentIndicator = blocks[i].content;
+        } else if (blocks[i].type === "lyrics") {
+            // Pair this lyrics block with the most recent indicator
+            sections.push({
+                indicator: currentIndicator,
+                lyrics:    blocks[i].content
+            });
+            // Reset indicator (some verses may not have one)
+            currentIndicator = "";
+        }
+    }
+
+    return sections;
+}
+
+
+// -----------------------------------------------------------------------
+// SCRAPER: Fetch and parse a single hymn
+// -----------------------------------------------------------------------
+/**
+ * Fetch a single hymn page and extract its title and lyrics sections.
+ *
+ * This is the main per-hymn function that:
+ * 1. Constructs the hymn URL
+ * 2. Makes the HTTP request (with retries via httpGet)
+ * 3. Checks for rate limiting ("reached limit for today")
+ * 4. Checks for homepage redirects (end of hymnal detection)
+ * 5. Parses the HTML to extract title and sections
+ *
+ * Return values:
+ *   - Object with {number, title, sections}: Success
+ *   - "SKIP": This hymn should be skipped (error, no title, etc.)
+ *   - null: Scraping should stop entirely (end of hymnal or persistent rate limit)
+ *
+ * @param {number} number  - The hymn number to fetch
+ * @param {string} baseUrl - The site's hymn page base URL
+ * @param {string} homeUrl - The site's homepage URL (for redirect detection)
+ * @param {number} delay   - Delay in milliseconds between requests
+ * @returns {object|string|null} Hymn data object, "SKIP", or null
+ */
+function fetchHymn(number, baseUrl, homeUrl, delay) {
+    // Construct the hymn page URL using the query parameter format
+    var url = baseUrl + "?no=" + number;
+
+    // Make the HTTP request (includes retry logic for 500 errors)
+    var resp = httpGet(url);
+
+    // Check if the request failed entirely
+    if (!resp || resp.error) {
+        var errMsg = resp ? resp.error : "unknown error";
+        WScript.Echo("  error: " + errMsg);
+        return "SKIP";
+    }
+
+    // Check for non-200 HTTP status codes
+    if (resp.status !== 200) {
+        WScript.Echo("  HTTP " + resp.status + ".");
+        return "SKIP";
+    }
+
+    var html = resp.responseText;
+
+    // --- Redirect detection ---
+    // Since MSXML2.XMLHTTP doesn't expose the final URL after redirects,
+    // we check the HTML content for signs that we've been redirected to
+    // the homepage. The homepage typically doesn't contain the hymn-specific
+    // CSS classes. If "block-heading-four" is absent AND the page contains
+    // homepage-specific content, we've reached the end of the hymnal.
+    //
+    // Additional check: if the response is suspiciously short or doesn't
+    // contain hymn content markers, treat it as a redirect.
+    if (number > 1) {
+        // Check if the page lacks hymn content entirely
+        var hasHymnContent = (html.indexOf("block-heading-four") !== -1) ||
+                             (html.indexOf("block-heading-five") !== -1);
+        if (!hasHymnContent) {
+            WScript.Echo("");
+            WScript.Echo("  Hymn " + number +
+                         ": no hymn content found (likely redirected to home) " +
+                         "-- reached end.");
+            return null;  // Signal to stop scraping
+        }
+    }
+
+    // --- Rate limit detection ---
+    // Both sites show a "reached limit for today" or "we are sorry" message
+    // when too many requests have been made. We check the HTML for these
+    // phrases (case-insensitive by converting to lowercase).
+    var htmlLower = html.toLowerCase();
+    if (htmlLower.indexOf("reached limit for today") !== -1 ||
+        htmlLower.indexOf("we are sorry") !== -1) {
+
+        WScript.Echo("  rate limit hit -- pausing 60s...");
+        WScript.Sleep(60000);  // 60-second cooldown
+
+        // Retry once after the cooldown
+        var resp2 = httpGet(url);
+        if (!resp2 || resp2.error || resp2.status !== 200) {
+            WScript.Echo("  Still failing after cooldown -- stopping.");
+            return null;  // Stop entirely
+        }
+
+        // Check if we're still rate limited after waiting
+        if (resp2.responseText.toLowerCase().indexOf("reached limit for today") !== -1) {
+            WScript.Echo("  Still rate limited -- stopping. Try again tomorrow.");
+            return null;  // Stop entirely
+        }
+
+        // Rate limit cleared — use the fresh response
+        html = resp2.responseText;
+    }
+
+    // --- Parse the HTML ---
+    var title = extractTitle(html);
+
+    // Validate that a title was found (indicates a valid hymn page)
+    if (!title) {
+        WScript.Echo("  no title found.");
+        return "SKIP";
+    }
+
+    var sections = extractSections(html);
+
+    // Return the structured hymn data
+    return {
+        number:   number,
+        title:    title,
+        sections: sections
+    };
+}
+
+
+// -----------------------------------------------------------------------
+// OUTPUT: Format a hymn object into plain text for saving
+// -----------------------------------------------------------------------
+/**
+ * Format a parsed hymn object into a clean plain-text string.
+ *
+ * Output format (matches the Python version exactly):
+ *   "Hymn Title"
+ *   <blank line>
+ *   Verse 1
+ *   First line of lyrics
+ *   Second line of lyrics
+ *   <blank line>
+ *   Chorus
+ *   Chorus lyrics here
+ *   ...
+ *
+ * @param {object} hymn - Hymn object with title and sections properties
+ * @returns {string} The formatted plain-text hymn content
+ */
+function formatHymn(hymn) {
+    // Start with the quoted title and a blank line
+    var lines = ['"' + hymn.title + '"', ""];
+
+    // Append each section (indicator + lyrics) with blank line separators
+    for (var i = 0; i < hymn.sections.length; i++) {
+        var section = hymn.sections[i];
+
+        if (section.indicator) {
+            lines.push(section.indicator);  // e.g. "Verse 1", "Chorus"
+        }
+        if (section.lyrics) {
+            lines.push(section.lyrics);     // The verse/chorus text
+        }
+        lines.push("");  // Blank line between sections
+    }
+
+    // Remove trailing blank lines (cleaner file ending)
+    while (lines.length > 0 && lines[lines.length - 1] === "") {
+        lines.pop();
+    }
+
+    return lines.join("\r\n");  // Use Windows line endings (CRLF)
+}
+
+
+// -----------------------------------------------------------------------
+// OUTPUT: Save a hymn to a text file
+// -----------------------------------------------------------------------
+/**
+ * Save a formatted hymn to a plain-text file in the output directory.
+ *
+ * Creates the output directory if it doesn't exist, formats the hymn,
+ * and writes it with the standard naming convention:
+ *   {3-digit zero-padded number} ({LABEL}) - {Title Case Title}.txt
+ *
+ * Uses Scripting.FileSystemObject for file operations, which is available
+ * on all Windows versions since Windows 98.
+ *
+ * @param {object} hymn     - Hymn object with number, title, and sections
+ * @param {string} label    - Book label for the filename (e.g. "SDAH")
+ * @param {string} outputDir - Directory path where the file should be saved
+ * @returns {string} The full file path of the saved file
+ */
+function saveHymn(hymn, label, outputDir) {
+    // Ensure the output directory exists
+    ensureDir(outputDir);
+
+    // Zero-pad the hymn number to 3 digits (e.g. 1 -> "001", 42 -> "042")
+    var padded = zeroPad(hymn.number, 3);
+
+    // Build the filename: sanitize the title, then convert to Title Case
+    var cleanTitle = titleCase(sanitize(hymn.title));
+    var filename = padded + " (" + label + ") - " + cleanTitle + ".txt";
+
+    // Construct the full file path
+    var filepath = outputDir + "\\" + filename;
+
+    // Write the formatted hymn text to the file
+    // Parameters for CreateTextFile: filename, overwrite, unicode
+    // We use unicode=true to support UTF-8/Unicode characters in hymn text
+    try {
+        var file = fso.CreateTextFile(filepath, true, true);
+        file.Write(formatHymn(hymn));
+        file.Close();
+    } catch (e) {
+        WScript.Echo("  ERROR writing file: " + e.message);
+        WScript.Echo("  Path: " + filepath);
+    }
+
+    return filepath;
+}
+
+
+// -----------------------------------------------------------------------
+// OUTPUT: Log a skipped hymn to the skip log
+// -----------------------------------------------------------------------
+/**
+ * Record a skipped hymn in skipped.log for later review.
+ *
+ * Creates a persistent log of hymns that couldn't be scraped, along with
+ * the reason and timestamp. This matches the Python version's log format:
+ *   [2026-03-13 14:30:00]  SDAH042  --  fetch failed or no title found
+ *
+ * @param {number} number  - The hymn number that was skipped
+ * @param {string} label   - Book label (e.g. "SDAH", "CH")
+ * @param {string} reason  - Human-readable explanation for the skip
+ * @param {string} bookDir - Directory where the log file should be written
+ */
+function logSkip(number, label, reason, bookDir) {
+    // Ensure the directory exists
+    ensureDir(bookDir);
+
+    var logPath   = bookDir + "\\skipped.log";
+    var timestamp = getTimestamp();
+    var padded    = zeroPad(number, 3);
+    var line      = "[" + timestamp + "]  " + label + padded +
+                    "  --  " + reason + "\r\n";
+
+    try {
+        // Open in append mode (8 = ForAppending, true = create if not exists)
+        // The second parameter of OpenTextFile is iomode:
+        //   1 = ForReading, 2 = ForWriting, 8 = ForAppending
+        // The third parameter is create (true = create if file doesn't exist)
+        var file;
+        if (fso.FileExists(logPath)) {
+            file = fso.OpenTextFile(logPath, 8, false);  // Append
+        } else {
+            file = fso.CreateTextFile(logPath, false);     // Create new
+        }
+        file.Write(line);
+        file.Close();
+    } catch (e) {
+        WScript.Echo("  WARNING: Could not write to skip log: " + e.message);
+    }
+}
+
+
+// -----------------------------------------------------------------------
+// RESUMABILITY: Build set of already-saved hymn numbers
+// -----------------------------------------------------------------------
+/**
+ * Scan the output directory for hymn files that have already been saved.
+ *
+ * This enables the scraper to resume from where it left off without
+ * re-downloading hymns. It looks for files matching the naming pattern:
+ *   {number} ({LABEL}) - {title}.txt
+ * and extracts the hymn number from each matching filename.
+ *
+ * Returns a plain object used as a set (keys are hymn numbers as strings,
+ * values are true). Check membership with: if (existing[number]) { ... }
+ *
+ * @param {string} label     - The book label to filter by (e.g. "SDAH")
+ * @param {string} outputDir - Path to the directory to scan
+ * @returns {object} Object with hymn numbers as keys (used as a set)
+ */
+function buildExistingSet(label, outputDir) {
+    var existing = {};  // Use an object as a set (keys = hymn numbers)
+    var prefixTag = "(" + label + ") -";  // Pattern to match in filenames
+
+    // Check if the directory exists
+    if (!fso.FolderExists(outputDir)) {
+        return existing;  // Empty set — directory doesn't exist yet
+    }
+
+    try {
+        var folder = fso.GetFolder(outputDir);
+        var files  = new Enumerator(folder.Files);
+
+        // Iterate through all files in the directory
+        for (; !files.atEnd(); files.moveNext()) {
+            var fname = files.item().Name;
+
+            // Check if this file matches our naming pattern
+            // (contains the label tag and ends with .txt)
+            if (fname.indexOf(prefixTag) !== -1 &&
+                fname.substring(fname.length - 4).toLowerCase() === ".txt") {
+
+                // Extract the hymn number from the start of the filename
+                // (the zero-padded number before the first space)
+                var parts = fname.split(" ");
+                if (parts.length > 0) {
+                    var numStr = parts[0];
+                    // Verify it's all digits
+                    if (/^\d+$/.test(numStr)) {
+                        existing[parseInt(numStr, 10)] = true;
+                    }
+                }
+            }
+        }
+    } catch (e) {
+        WScript.Echo("  WARNING: Could not scan directory: " + e.message);
+    }
+
+    return existing;
+}
+
+
+// -----------------------------------------------------------------------
+// MAIN LOOP: Scrape all hymns from a single site
+// -----------------------------------------------------------------------
+/**
+ * Main scraping loop for one site (SDAH or CH).
+ *
+ * Iterates through hymn numbers, fetches each one, and saves it.
+ * Features:
+ *   - RESUMABILITY: Skips hymns already saved in the output directory
+ *   - AUTO-DETECTION OF END: Stops when no hymn content is found
+ *   - CONSECUTIVE SKIP LIMIT: Stops after MAX_CONSEC (10) failures in a row
+ *   - RATE LIMITING: Pauses for the configured delay between requests
+ *
+ * @param {string} siteKey   - Site identifier ("sdah" or "ch")
+ * @param {number} start     - First hymn number to scrape
+ * @param {number|null} end  - Last hymn number, or null for auto-detect
+ * @param {string} outputDir - Base output directory
+ * @param {number} delay     - Milliseconds between requests
+ * @param {boolean} force    - When true, skip existing file check and overwrite
+ * @returns {number} Number of hymns successfully saved
+ */
+function scrapeSite(siteKey, start, end, outputDir, delay, force) {
+    // Look up the site configuration
+    var site    = SITES[siteKey];
+    var label   = site.label;
+    var baseUrl = site.baseUrl;
+    var homeUrl = site.homeUrl;
+
+    // Build the book-specific output subdirectory path
+    // e.g. ".\hymns\Seventh-day Adventist Hymnal [SDAH]\"
+    var bookDir = outputDir + "\\" + site.subdir;
+
+    // Print a banner with configuration details for this scrape run
+    WScript.Echo("");
+    WScript.Echo("==================================================");
+    WScript.Echo("  Scraping: " + baseUrl + "  [" + label + "]");
+    WScript.Echo("  Output  : " + getAbsolutePath(bookDir));
+    WScript.Echo("  Range   : " + start + " to " + (end ? end : "auto-detect"));
+    WScript.Echo("==================================================");
+    WScript.Echo("");
+
+    // Scan for already-saved hymns to enable resumability.
+    // When force mode is enabled, use an empty set so no hymns are skipped —
+    // all hymns will be re-downloaded and existing files will be overwritten.
+    var existing;
+    if (force) {
+        existing = {};  // Empty set — force mode skips the existing file check
+        WScript.Echo("  Force mode: will re-download and overwrite existing files.");
+        WScript.Echo("");
+    } else {
+        existing = buildExistingSet(label, bookDir);
+
+        // Count existing files for the summary message
+        var existingCount = 0;
+        for (var k in existing) {
+            if (existing.hasOwnProperty(k)) { existingCount++; }
+        }
+        if (existingCount > 0) {
+            WScript.Echo("  Found " + existingCount + " existing " + label +
+                         " hymns -- will skip.");
+            WScript.Echo("");
+        }
+    }
+
+    // Counters for the final summary
+    var saved       = 0;     // Successfully saved hymns
+    var skipped     = 0;     // Hymns skipped due to errors
+    var number      = start; // Current hymn number being processed
+    var consecSkip  = 0;     // Consecutive failure counter
+
+    // --- Main scraping loop ---
+    while (true) {
+        // Check if we've reached the user-specified end hymn
+        if (end && number > end) {
+            WScript.Echo("");
+            WScript.Echo("Reached end hymn (" + end + "). Done.");
+            break;
+        }
+
+        // Skip hymns that are already saved (detected during initial scan)
+        if (existing[number]) {
+            WScript.Echo("  Hymn " + padRight(String(number), 4) +
+                         ": [SKIP] already exists, skipping.");
+            number++;
+            continue;  // No delay — no network request was made
+        }
+
+        // Fetch and parse the hymn page
+        WScript.Echo("  Hymn " + padRight(String(number), 4) + ": fetching...");
+        var hymn = fetchHymn(number, baseUrl, homeUrl, delay);
+
+        if (hymn === null) {
+            // The site indicated no more hymns — stop scraping
+            WScript.Echo("");
+            break;
+        }
+
+        if (hymn === "SKIP") {
+            // This hymn couldn't be scraped — log and continue
+            WScript.Echo("    [FAIL] skipped.");
+            logSkip(number, label, "fetch failed or no title found", bookDir);
+            skipped++;
+            consecSkip++;
+
+            // Safety net: too many consecutive failures
+            if (consecSkip >= MAX_CONSEC) {
+                WScript.Echo("  " + MAX_CONSEC +
+                             " consecutive errors -- assuming end of hymnal.");
+                break;
+            }
+
+            number++;
+            WScript.Sleep(delay);  // Rate limit even on failures
+            continue;
+        }
+
+        // Success — reset consecutive skip counter and save the hymn
+        consecSkip = 0;
+        var path = saveHymn(hymn, label, bookDir);
+        saved++;
+
+        // Extract just the filename from the full path for display
+        var savedFilename = fso.GetFileName(path);
+        WScript.Echo("    [OK] " + savedFilename);
+
+        number++;
+        WScript.Sleep(delay);  // Rate limit between requests
+    }
+
+    // Print a summary for this site
+    WScript.Echo("");
+    WScript.Echo(label + ": " + saved + " hymns saved, " + skipped + " skipped.");
+    return saved;
+}
+
+
+// -----------------------------------------------------------------------
+// UTILITY: Pad a string on the right to a specified width
+// -----------------------------------------------------------------------
+/**
+ * Pad a string with trailing spaces to reach the specified width.
+ * Used for aligning console output (e.g. hymn numbers in the progress log).
+ *
+ * @param {string} s     - The string to pad
+ * @param {number} width - The desired minimum width
+ * @returns {string} The padded string
+ */
+function padRight(s, width) {
+    while (s.length < width) { s = " " + s; }
+    return s;
+}
+
+
+// -----------------------------------------------------------------------
+// MAIN — Parse arguments and orchestrate scraping
+// -----------------------------------------------------------------------
+/**
+ * Main entry point for the JScript scraping engine.
+ *
+ * Reads command-line arguments passed from the batch section:
+ *   Arg 0: site    (sdah, ch, or both)
+ *   Arg 1: start   (starting hymn number)
+ *   Arg 2: end     (ending hymn number, or "auto")
+ *   Arg 3: output  (output directory path)
+ *   Arg 4: delay   (milliseconds between requests)
+ *   Arg 5: force   ("1" to re-download and overwrite existing files)
+ *
+ * Then runs the scraping loop for the specified site(s).
+ */
+function main() {
+    var args = WScript.Arguments;
+
+    // Parse arguments from the batch section
+    // Default values match the Python version's defaults
+    var site      = (args.length > 0) ? args(0) : "both";
+    var start     = (args.length > 1) ? parseInt(args(1), 10) : 1;
+    var endArg    = (args.length > 2) ? args(2) : "auto";
+    var outputDir = (args.length > 3) ? args(3) : ".\\hymns";
+    var delay     = (args.length > 4) ? parseInt(args(4), 10) : 1000;
+
+    // Parse force flag — "1" means force mode is enabled
+    // When force is true, existing hymn files are overwritten instead of skipped
+    var forceArg  = (args.length > 5) ? args(5) : "0";
+    var force     = (forceArg === "1");
+
+    // Handle "auto" end value — null means auto-detect
+    var end = null;
+    if (endArg && endArg.toLowerCase() !== "auto") {
+        end = parseInt(endArg, 10);
+        if (isNaN(end)) { end = null; }
+    }
+
+    // Validate start number
+    if (isNaN(start) || start < 1) { start = 1; }
+
+    // Validate delay
+    if (isNaN(delay) || delay < 0) { delay = 1000; }
+
+    // Print startup banner
+    WScript.Echo("========================================================");
+    WScript.Echo("  SDA Hymnal Scraper (Windows Batch/JScript Hybrid)");
+    WScript.Echo("  Copyright 2025-2026 MWBM Partners Ltd.");
+    WScript.Echo("========================================================");
+
+    // Determine which sites to scrape
+    var sitesToRun = [];
+    site = site.toLowerCase();
+    if (site === "both") {
+        sitesToRun = ["sdah", "ch"];  // Scrape SDAH first, then CH
+    } else if (site === "sdah" || site === "ch") {
+        sitesToRun = [site];
+    } else {
+        WScript.Echo("ERROR: Invalid site '" + site +
+                     "'. Choose sdah, ch, or both.");
+        WScript.Quit(1);
+    }
+
+    // Run the scraping loop for each site, accumulating the total saved count
+    var total = 0;
+    for (var i = 0; i < sitesToRun.length; i++) {
+        total += scrapeSite(sitesToRun[i], start, end, outputDir, delay, force);
+    }
+
+    // Print the final summary
+    WScript.Echo("");
+    WScript.Echo("All done! " + total + " hymns total saved to: " +
+                 getAbsolutePath(outputDir));
+}
+
+
+// -----------------------------------------------------------------------
+// ENTRY POINT — Invoke the main function
+// -----------------------------------------------------------------------
+// Wrap in try/catch to provide a clean error message if something goes
+// wrong at the top level (e.g. missing COM objects, permission errors).
+try {
+    main();
+} catch (e) {
+    WScript.Echo("");
+    WScript.Echo("FATAL ERROR: " + e.message);
+    WScript.Echo("Error number: " + (e.number & 0xFFFF));
+    WScript.Echo("");
+    WScript.Echo("This script requires native Windows components:");
+    WScript.Echo("  - cscript.exe (Windows Script Host)");
+    WScript.Echo("  - MSXML2.XMLHTTP (ActiveX HTTP client)");
+    WScript.Echo("  - Scripting.FileSystemObject (ActiveX file system)");
+    WScript.Echo("All of these should be present on Windows XP SP2 and later.");
+    WScript.Quit(1);
+}

--- a/.importers/scrapers/SDAHymnals_SDAHymnal.org.php
+++ b/.importers/scrapers/SDAHymnals_SDAHymnal.org.php
@@ -1,0 +1,1076 @@
+#!/usr/bin/env php
+<?php
+/**
+ * SDAHymnals_SDAHymnal.org.php
+ * importers/scrapers/SDAHymnals_SDAHymnal.org.php
+ *
+ * Hymnal Scraper — scrapes both sdahymnal.org (SDAH) and hymnal.xyz (CH).
+ * Copyright 2025-2026 MWBM Partners Ltd.
+ *
+ * Overview:
+ *     This scraper fetches hymn lyrics from two Seventh-day Adventist hymnal
+ *     websites that share the same underlying codebase (identical HTML structure
+ *     and CSS class names). It iterates through hymn numbers sequentially,
+ *     parses the HTML to extract the title, section indicators (e.g. "Verse 1",
+ *     "Chorus"), and lyrics text, then saves each hymn as a plain-text file.
+ *
+ *     The scraper is designed to be resumable: it scans the output directory for
+ *     existing files on startup and skips hymns that have already been saved.
+ *     It also handles rate limiting, server errors, and auto-detects the end
+ *     of the hymnal when the site redirects to the homepage.
+ *
+ * Dependencies:
+ *     PHP 8.4+ with the cURL extension (ext-curl). No Composer packages required.
+ *     This is intentional so the script can run on any system with PHP CLI.
+ *
+ * Output format:
+ *     Each hymn is saved as a plain-text file with the naming convention:
+ *         {number zero-padded to 3 digits} ({LABEL}) - {Title Case Title}.txt
+ *     e.g.: "001 (SDAH) - Praise To The Lord.txt"
+ *
+ *     Files are organised into book-specific subdirectories:
+ *         hymns/Seventh-day Adventist Hymnal [SDAH]/
+ *         hymns/The Church Hymnal [CH]/
+ *
+ * Usage:
+ *     php SDAHymnals_SDAHymnal.org.php                         # Scrape both sites from hymn 1
+ *     php SDAHymnals_SDAHymnal.org.php --site sdah             # Only sdahymnal.org
+ *     php SDAHymnals_SDAHymnal.org.php --site ch               # Only hymnal.xyz
+ *     php SDAHymnals_SDAHymnal.org.php --start 50              # Resume from hymn 50
+ *     php SDAHymnals_SDAHymnal.org.php --start 1 --end 100     # Specific range
+ *     php SDAHymnals_SDAHymnal.org.php --output ~/Desktop/hymns
+ *     php SDAHymnals_SDAHymnal.org.php --force                 # Re-download all
+ *     php SDAHymnals_SDAHymnal.org.php --debug                 # Dump HTML for debugging
+ *
+ * @package iLyricsDB
+ * @author  MWBM Partners Ltd
+ * @license Proprietary
+ */
+
+// ===========================================================================
+// Ensure this script is run from the command line, not via a web server.
+// Running a long-lived scraper via HTTP would time out and is not intended.
+// ===========================================================================
+if (php_sapi_name() !== 'cli') {
+    echo "This script must be run from the command line.\n";
+    exit(1);
+}
+
+// Force output to be flushed immediately so progress messages appear in
+// real-time. Without this, PHP buffers CLI output and the user wouldn't
+// see progress updates until the buffer fills.
+ob_implicit_flush(true);
+
+
+// ===========================================================================
+// Site configuration — both sites share the same HTML structure
+// ===========================================================================
+// Both sdahymnal.org and hymnal.xyz are built on the same web platform,
+// so they use identical CSS class names and page layouts. This allows us
+// to use a single parsing function for both sites. Each site entry defines:
+//   - base_url:  The hymn page URL template (hymn number passed as ?no=N)
+//   - home_url:  The site homepage (used to detect end-of-hymnal redirects)
+//   - label:     Short identifier used in output filenames, e.g. "SDAH"
+//   - subdir:    Human-readable subdirectory name for organised output
+//   - lang:      ISO 639-1 language code for the songbook's language (e.g. "en")
+const SITES = [
+    'sdah' => [
+        'base_url' => 'https://www.sdahymnal.org/Hymn',
+        'home_url' => 'https://www.sdahymnal.org',
+        'label'    => 'SDAH',
+        'subdir'   => 'Seventh-day Adventist Hymnal [SDAH]',
+        'lang'     => 'en',   // ISO 639-1: English
+    ],
+    'ch' => [
+        'base_url' => 'https://www.hymnal.xyz/Hymn',
+        'home_url' => 'https://www.hymnal.xyz',
+        'label'    => 'CH',
+        'subdir'   => 'The Church Hymnal [CH]',
+        'lang'     => 'en',   // ISO 639-1: English
+    ],
+];
+
+// Default output directory (relative to where the script is run from)
+const DEFAULT_OUTPUT_DIR = './hymns';
+
+// Delay in seconds between HTTP requests to be respectful to the server
+// and avoid triggering rate limits. 1.0s is a reasonable balance between
+// speed and politeness.
+const DEFAULT_DELAY = 1.0;
+
+
+// ===========================================================================
+// Global debug flag — set to true via --debug CLI argument to dump HTML
+// ===========================================================================
+$DEBUG = false;
+
+
+// ===========================================================================
+// Helper functions
+// ===========================================================================
+
+/**
+ * Print a labelled debug dump of HTML/text content (only when $DEBUG is true).
+ *
+ * When debugging is enabled, this prints a truncated preview of the given
+ * text with a clear header and footer for easy identification in the output.
+ * Useful for inspecting raw HTML responses from the server.
+ *
+ * @param string $label     A descriptive label for this dump (e.g. "Hymn 42 HTML")
+ * @param string $text      The text content to dump
+ * @param int    $maxChars  Maximum number of characters to display (default 3000)
+ *
+ * @return void
+ */
+function debugDump(string $label, string $text, int $maxChars = 3000): void
+{
+    global $DEBUG;
+
+    if (!$DEBUG) {
+        return;
+    }
+
+    $preview = mb_substr($text, 0, $maxChars);
+    echo "\n--- DEBUG: {$label} ---\n";
+    echo $preview;
+    if (mb_strlen($text) > $maxChars) {
+        echo "\n... (truncated, " . mb_strlen($text) . " total chars)";
+    }
+    echo "\n--- END DEBUG ---\n\n";
+}
+
+
+/**
+ * Convert a string to Title Case, with correct handling of apostrophes.
+ *
+ * PHP's ucwords() and mb_convert_case(MB_CASE_TITLE) treat apostrophes as
+ * word boundaries, producing incorrect results like "Don'T" instead of
+ * "Don't". This function uses a regex to match whole words (including
+ * apostrophe contractions like "don't", "it's", "o'er") and capitalises
+ * each word correctly.
+ *
+ * The regex matches:
+ *     [a-zA-Z]+              One or more letters (the main word)
+ *     (['\x{2019}\x{2018}]   Optionally an apostrophe (ASCII ', right ' or left ')
+ *      [a-zA-Z]+)?           followed by more letters (contraction suffix)
+ *
+ * We include Unicode curly/smart apostrophes (\u2019 RIGHT SINGLE QUOTATION
+ * MARK and \u2018 LEFT SINGLE QUOTATION MARK) because HTML entities like
+ * &rsquo; decode to \u2019. Without this, "Eagle\u2019s" would be split into
+ * separate words, producing "Eagle'S" instead of "Eagle's".
+ *
+ * ucfirst(strtolower(...)) is used on each match, which uppercases the first
+ * char and lowercases the rest — perfect for Title Case.
+ *
+ * @param string $s The input string to convert
+ *
+ * @return string The Title Cased string
+ *
+ * Examples:
+ *     "AMAZING GRACE"      => "Amazing Grace"
+ *     "don't let me down"  => "Don't Let Me Down"
+ *     "o'er the hills"     => "O'er The Hills"
+ *     "EAGLE\u2019S WINGS" => "Eagle\u2019s Wings"
+ */
+function titleCase(string $s): string
+{
+    return preg_replace_callback(
+        "/[a-zA-Z]+(['\x{2019}\x{2018}][a-zA-Z]+)?/u",
+        function (array $m): string {
+            // ucfirst(strtolower()) capitalises the first letter and
+            // lowercases the rest, matching Python's str.capitalize()
+            return ucfirst(strtolower($m[0]));
+        },
+        $s
+    );
+}
+
+
+/**
+ * Remove characters that are invalid in filenames across operating systems.
+ *
+ * Strips the following characters which are forbidden in Windows filenames
+ * and/or could cause issues on other platforms:
+ *     \ / * ? : " < > |
+ *
+ * @param string $name The raw string to sanitize (typically a hymn title)
+ *
+ * @return string The sanitized string with invalid characters removed and
+ *                leading/trailing whitespace stripped
+ */
+function sanitizeFilename(string $name): string
+{
+    return trim(preg_replace('/[\\\\\\/*?:"<>|]/', '', $name));
+}
+
+
+// ===========================================================================
+// HTML Parsing — regex-based extraction of hymn data
+// ===========================================================================
+// Both sdahymnal.org and hymnal.xyz share the same underlying codebase, so
+// they use identical CSS class names for their hymn page structure. We parse
+// using regex to extract:
+//
+// 1. TITLE: Found inside a <strong> tag, nested within an <h3> with class
+//    "wedding-heading", which is itself inside a <div> with class
+//    "block-heading-four". We use a nested regex pattern to navigate
+//    this hierarchy.
+//
+// 2. SECTION INDICATORS: Found in <div class="block-heading-three">.
+//    These are labels like "Verse 1", "Chorus", "Verse 2", etc.
+//
+// 3. LYRICS TEXT: Found in <div class="block-heading-five">.
+//    Line breaks within lyrics are represented by <br> tags, which we
+//    convert to newline characters.
+//
+// The parser pairs each indicator with its following lyrics block,
+// producing a list of [indicator, lyrics] arrays.
+// ===========================================================================
+
+/**
+ * Parse hymn HTML to extract the title and lyrics sections.
+ *
+ * Uses regex patterns to navigate the specific CSS class structure used by
+ * sdahymnal.org and hymnal.xyz. The HTML structure being parsed:
+ *
+ *     <div class="block-heading-four">        <- title container
+ *         <h3 class="wedding-heading">        <- title wrapper
+ *             <strong>Hymn Title Here</strong> <- actual title text
+ *         </h3>
+ *     </div>
+ *     <div class="block-heading-three">       <- section indicator
+ *         Verse 1                              <- e.g. "Verse 1", "Chorus"
+ *     </div>
+ *     <div class="block-heading-five">        <- lyrics block
+ *         First line of lyrics<br>             <- <br> = line break
+ *         Second line of lyrics<br>
+ *     </div>
+ *
+ * @param string $html The full HTML source of the hymn page
+ *
+ * @return array{title: string, sections: list<array{0: string, 1: string}>}
+ *               An associative array with:
+ *               - 'title': The extracted hymn title (empty string if not found)
+ *               - 'sections': Array of [indicator, lyrics] pairs where:
+ *                   - indicator is a string like "Verse 1" or "" if none
+ *                   - lyrics is the verse text with \n for line breaks
+ */
+function parseHymnHtml(string $html): array
+{
+    $title    = '';
+    $sections = [];
+
+    // --- TITLE EXTRACTION ---
+    // Navigate the nested structure: div.block-heading-four > *.wedding-heading > strong
+    // Using a single regex with the 's' (DOTALL) flag to match across newlines.
+    // The regex captures the innermost <strong> content within the expected hierarchy.
+    if (preg_match(
+        '/<div[^>]*class="[^"]*\bblock-heading-four\b[^"]*"[^>]*>.*?'
+        . '<[^>]*class="[^"]*\bwedding-heading\b[^"]*"[^>]*>.*?'
+        . '<strong[^>]*>(.*?)<\/strong>/si',
+        $html,
+        $titleMatch
+    )) {
+        // Decode HTML entities (e.g. &amp; => &, &rsquo; => ', &#8217; => ')
+        // strip_tags removes any inline formatting tags within the title
+        $title = trim(strip_tags(html_entity_decode($titleMatch[1], ENT_QUOTES | ENT_HTML5, 'UTF-8')));
+    }
+
+    // --- SECTION EXTRACTION ---
+    // We need to find all block-heading-three (indicators) and block-heading-five
+    // (lyrics) divs in document order, then pair them up. We use a single regex
+    // that matches both types, with a capture group to identify which type was matched.
+    //
+    // Strategy: find all occurrences of either class in order, extract their content,
+    // then pair indicators with the lyrics blocks that follow them.
+
+    // Match all block-heading-three and block-heading-five divs.
+    // We use a regex that captures the class name and the inner content.
+    // The inner content extraction handles nested divs by using a non-greedy match
+    // up to the closing </div>, but since these content divs typically don't contain
+    // nested divs, this approach works reliably.
+    $pattern = '/<div[^>]*class="[^"]*\b(block-heading-three|block-heading-five)\b[^"]*"[^>]*>(.*?)<\/div>/si';
+
+    if (preg_match_all($pattern, $html, $matches, PREG_SET_ORDER)) {
+        $currentIndicator = '';
+
+        foreach ($matches as $match) {
+            $blockType    = $match[1];  // "block-heading-three" or "block-heading-five"
+            $innerContent = $match[2];  // The raw HTML content inside the div
+
+            if ($blockType === 'block-heading-three') {
+                // This is a section indicator (e.g. "Verse 1", "Chorus")
+                // Strip HTML tags and decode entities to get clean text
+                $currentIndicator = trim(strip_tags(html_entity_decode($innerContent, ENT_QUOTES | ENT_HTML5, 'UTF-8')));
+            } else {
+                // This is a lyrics block (block-heading-five)
+                // Convert <br> tags to newlines before stripping other HTML tags
+                $lyricsText = preg_replace('/<br\s*\/?>/i', "\n", $innerContent);
+
+                // Decode HTML entities to get proper Unicode characters
+                // (e.g. &rsquo; => right single quotation mark)
+                $lyricsText = html_entity_decode($lyricsText, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
+                // Strip any remaining HTML tags (e.g. <em>, <span>, etc.)
+                $lyricsText = strip_tags($lyricsText);
+
+                // Collapse runs of 3+ newlines down to 2 (clean up excessive whitespace
+                // that can occur from empty <br> tags in the source HTML)
+                $lyricsText = preg_replace("/\n{3,}/", "\n\n", $lyricsText);
+                $lyricsText = trim($lyricsText);
+
+                // Pair this lyrics block with its indicator and add to sections list
+                $sections[] = [$currentIndicator, $lyricsText];
+
+                // Reset indicator for the next verse (some verses may not have one)
+                $currentIndicator = '';
+            }
+        }
+    }
+
+    return ['title' => $title, 'sections' => $sections];
+}
+
+
+// ===========================================================================
+// Fetch & parse — HTTP request handling and hymn data extraction
+// ===========================================================================
+
+/**
+ * Fetch a single hymn page from the website using cURL and parse it.
+ *
+ * Makes an HTTP GET request to the hymn URL, handles various error conditions
+ * (server errors, rate limiting, redirects), and returns parsed hymn data.
+ *
+ * The function includes several resilience features:
+ * - Retries up to 3 times on HTTP 500 errors (with 3-second delays)
+ * - Detects rate-limiting pages and pauses 60 seconds before retrying
+ * - Detects end-of-hymnal by checking if the site redirects to the homepage
+ * - Falls back gracefully on encoding issues via mb_convert_encoding
+ *
+ * @param int    $number  The hymn number to fetch (e.g. 1, 42, 695)
+ * @param string $baseUrl The site's hymn page base URL (e.g. "https://www.sdahymnal.org/Hymn")
+ * @param string $homeUrl The site's homepage URL (used to detect end-of-hymnal redirects)
+ *
+ * @return array|string|null
+ *     - array:  ['number' => int, 'title' => str, 'sections' => [...]] on success
+ *     - 'SKIP': If the hymn should be skipped (server error, no title found)
+ *     - null:   If scraping should stop entirely (reached end of hymnal or
+ *               persistent rate limiting)
+ */
+function fetchHymn(int $number, string $baseUrl, string $homeUrl): array|string|null
+{
+    // Construct the hymn page URL using the query parameter format used by both sites
+    $url = $baseUrl . '?no=' . $number;
+
+    $raw = null;  // Will hold the raw response body if the request succeeds
+
+    // Retry loop: attempt up to 3 times on HTTP 500 errors
+    for ($attempt = 1; $attempt <= 3; $attempt++) {
+        // Initialise a cURL handle for this request
+        $ch = curl_init();
+
+        // Set cURL options for a standard GET request
+        curl_setopt_array($ch, [
+            CURLOPT_URL            => $url,
+            CURLOPT_RETURNTRANSFER => true,          // Return response as string instead of outputting
+            CURLOPT_FOLLOWLOCATION => true,           // Follow HTTP redirects automatically
+            CURLOPT_MAXREDIRS      => 5,              // Maximum number of redirects to follow
+            CURLOPT_TIMEOUT        => 15,             // Total request timeout in seconds
+            CURLOPT_CONNECTTIMEOUT => 10,             // Connection timeout in seconds
+            CURLOPT_USERAGENT      => 'Mozilla/5.0 (compatible; HymnScraper/2.0; personal use)',
+            CURLOPT_ENCODING       => '',             // Accept all encodings (gzip, deflate, etc.)
+            CURLOPT_SSL_VERIFYPEER => true,           // Verify SSL certificates
+        ]);
+
+        // Execute the request
+        $response = curl_exec($ch);
+        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
+        // Get the effective (final) URL after any redirects — used to detect
+        // end-of-hymnal redirects where the site sends us back to the homepage
+        $effectiveUrl = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
+
+        $curlError = curl_error($ch);
+        curl_close($ch);
+
+        // Check for cURL-level errors (network failures, DNS resolution, timeouts)
+        if ($response === false) {
+            echo "  error: {$curlError}\n";
+            return 'SKIP';
+        }
+
+        // Check if the server redirected us to the homepage — this means
+        // the requested hymn number doesn't exist (we've gone past the
+        // end of the hymnal). We only check for number > 1 because
+        // hymn 1 should always exist.
+        $cleanEffective = rtrim($effectiveUrl, '/');
+        if (strpos($cleanEffective, 'Hymn') === false && $number > 1) {
+            echo "\n  Hymn {$number}: redirected to home — reached end.\n";
+            return null;  // Signal to stop scraping entirely
+        }
+
+        // Handle HTTP status codes
+        if ($httpCode === 200) {
+            // Success — store the response and exit the retry loop
+            $raw = $response;
+            break;
+        } elseif ($httpCode === 500) {
+            // Server error — may be transient, so retry with backoff
+            if ($attempt < 3) {
+                echo "  Hymn {$number}: server error (500), retrying ({$attempt}/3)... ";
+                sleep(3);  // Wait before retrying
+            } else {
+                // All 3 attempts failed — skip this hymn
+                echo "  server error (500) after 3 attempts.\n";
+                return 'SKIP';
+            }
+        } else {
+            // Other HTTP errors (404, 403, etc.) — don't retry, just skip
+            echo "  HTTP {$httpCode}.\n";
+            return 'SKIP';
+        }
+    }
+
+    // If raw is still null, all retry attempts were exhausted without success
+    if ($raw === null) {
+        return 'SKIP';
+    }
+
+    // Ensure the response is valid UTF-8. If it contains invalid sequences
+    // (e.g. latin-1 encoded bytes), convert them. mb_detect_encoding with
+    // strict mode helps identify the actual encoding.
+    if (!mb_check_encoding($raw, 'UTF-8')) {
+        $raw = mb_convert_encoding($raw, 'UTF-8', 'ISO-8859-1');
+    }
+
+    // Dump raw HTML when debug mode is active
+    debugDump("Hymn {$number} raw HTML", $raw);
+
+    // Parse the HTML to extract hymn data
+    $parsed = parseHymnHtml($raw);
+
+    // --- Rate limit detection ---
+    // Both sites show a "reached limit for today" message when you've made
+    // too many requests. If detected, pause for 60 seconds and try once more.
+    $htmlLower = strtolower($raw);
+    if (strpos($htmlLower, 'reached limit for today') !== false || strpos($htmlLower, 'we are sorry') !== false) {
+        echo "  rate limit hit — pausing 60s...\n";
+        sleep(60);
+
+        // One retry after the cooldown period
+        $ch = curl_init();
+        curl_setopt_array($ch, [
+            CURLOPT_URL            => $url,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_FOLLOWLOCATION => true,
+            CURLOPT_MAXREDIRS      => 5,
+            CURLOPT_TIMEOUT        => 15,
+            CURLOPT_CONNECTTIMEOUT => 10,
+            CURLOPT_USERAGENT      => 'Mozilla/5.0 (compatible; HymnScraper/2.0; personal use)',
+            CURLOPT_ENCODING       => '',
+            CURLOPT_SSL_VERIFYPEER => true,
+        ]);
+
+        $response2 = curl_exec($ch);
+        curl_close($ch);
+
+        if ($response2 === false) {
+            return null;  // Network error during retry — stop scraping
+        }
+
+        // Check if we're still rate limited after waiting
+        if (strpos(strtolower($response2), 'reached limit for today') !== false) {
+            echo "  Still rate limited — stopping. Try again tomorrow.\n";
+            return null;  // Stop entirely — no point continuing today
+        }
+
+        // Rate limit cleared — re-parse with the fresh response
+        if (!mb_check_encoding($response2, 'UTF-8')) {
+            $response2 = mb_convert_encoding($response2, 'UTF-8', 'ISO-8859-1');
+        }
+        $parsed = parseHymnHtml($response2);
+    }
+
+    // Validate that the parser found a title (indicates a valid hymn page)
+    if (empty($parsed['title'])) {
+        echo "  no title found.\n";
+        return 'SKIP';
+    }
+
+    // Return the structured hymn data
+    return [
+        'number'   => $number,
+        'title'    => $parsed['title'],
+        'sections' => $parsed['sections'],
+    ];
+}
+
+
+// ===========================================================================
+// Format & save — text formatting and file output
+// ===========================================================================
+
+/**
+ * Format a parsed hymn array into a clean plain-text string for saving.
+ *
+ * The output format is:
+ *     "Hymn Title"
+ *                                 <- blank line after title
+ *     Verse 1                     <- indicator (if present)
+ *     First line of lyrics        <- lyrics text
+ *     Second line of lyrics
+ *                                 <- blank line between sections
+ *     Chorus                      <- next indicator
+ *     Chorus lyrics here
+ *     ...
+ *
+ * @param array $hymn Associative array with keys:
+ *                    - 'title'    (string): The hymn title
+ *                    - 'sections' (array):  List of [indicator, lyrics] pairs
+ *
+ * @return string The formatted plain-text hymn content
+ */
+function formatHymn(array $hymn): string
+{
+    // Start with the quoted title and a blank line
+    $lines = ['"' . $hymn['title'] . '"', ''];
+
+    // Append each section (indicator + lyrics) with blank line separators
+    foreach ($hymn['sections'] as $section) {
+        $indicator = $section[0];
+        $lyrics    = $section[1];
+
+        if (!empty($indicator)) {
+            $lines[] = $indicator;   // e.g. "Verse 1", "Chorus"
+        }
+        if (!empty($lyrics)) {
+            $lines[] = $lyrics;      // The verse/chorus text
+        }
+        $lines[] = '';               // Blank line between sections
+    }
+
+    // Remove trailing blank lines (cleaner file ending)
+    while (!empty($lines) && $lines[array_key_last($lines)] === '') {
+        array_pop($lines);
+    }
+
+    return implode("\n", $lines);
+}
+
+
+/**
+ * Scan the output directory to find hymn numbers that have already been saved.
+ *
+ * This enables the scraper to resume from where it left off without
+ * re-downloading hymns. It looks for files matching the naming pattern
+ * "{number} ({label}) - {title}.txt" and extracts the hymn number from
+ * each matching filename.
+ *
+ * @param string $label     The book label to filter by (e.g. "SDAH", "CH")
+ * @param string $outputDir Path to the directory to scan for existing files
+ *
+ * @return array<int, bool> An associative array mapping hymn numbers (int) to true.
+ *                          Empty array if the directory doesn't exist or has no matching files.
+ *
+ * Example:
+ *     If outputDir contains:
+ *         "001 (SDAH) - Praise To The Lord.txt"
+ *         "042 (SDAH) - A Mighty Fortress.txt"
+ *     Returns: [1 => true, 42 => true]
+ */
+function buildExistingSet(string $label, string $outputDir): array
+{
+    $existing = [];
+
+    if (!is_dir($outputDir)) {
+        return $existing;
+    }
+
+    // Build the prefix tag to filter files belonging to this specific book
+    $prefixTag = "({$label}) -";
+
+    // Scan the directory for matching files
+    $files = scandir($outputDir);
+    if ($files === false) {
+        return $existing;
+    }
+
+    foreach ($files as $fname) {
+        // Match files that contain the book label and have .txt extension
+        if (str_contains($fname, $prefixTag) && str_ends_with($fname, '.txt')) {
+            // Extract the hymn number from the start of the filename
+            // (the zero-padded number before the first space)
+            $parts  = explode(' ', $fname, 2);
+            $numStr = $parts[0];
+            if (ctype_digit($numStr)) {
+                $existing[(int) $numStr] = true;
+            }
+        }
+    }
+
+    return $existing;
+}
+
+
+/**
+ * Save a parsed hymn to a plain-text file in the output directory.
+ *
+ * Creates the output directory if it doesn't exist, formats the hymn
+ * content, and writes it to a file with the standard naming convention:
+ *     {number zero-padded to 3} ({label}) - {Title Case Title}.txt
+ *
+ * @param array  $hymn      Associative array with 'number', 'title', 'sections'
+ * @param string $label     Book label for the filename (e.g. "SDAH", "CH")
+ * @param string $outputDir Directory path where the file should be saved
+ *
+ * @return string The full file path of the saved file
+ */
+function saveHymn(array $hymn, string $label, string $outputDir): string
+{
+    // Ensure the output directory exists (creates parent dirs too if needed)
+    if (!is_dir($outputDir)) {
+        mkdir($outputDir, 0755, true);
+    }
+
+    // Zero-pad the hymn number to 3 digits for consistent sorting
+    // (e.g. 1 => "001", 42 => "042", 695 => "695")
+    $padded = str_pad((string) $hymn['number'], 3, '0', STR_PAD_LEFT);
+
+    // Build the filename: sanitize the title to remove invalid chars,
+    // then convert to Title Case for consistent, readable filenames
+    $safeTitle = titleCase(sanitizeFilename($hymn['title']));
+    $filename  = "{$padded} ({$label}) - {$safeTitle}.txt";
+    $filepath  = $outputDir . DIRECTORY_SEPARATOR . $filename;
+
+    // Write the formatted hymn text to the file
+    file_put_contents($filepath, formatHymn($hymn), LOCK_EX);
+
+    return $filepath;
+}
+
+
+/**
+ * Record a skipped hymn entry in the skipped.log file for later review.
+ *
+ * This creates a persistent log of hymns that couldn't be scraped,
+ * along with the reason and timestamp. Useful for identifying gaps
+ * in the collection and diagnosing systematic issues.
+ *
+ * @param int    $number  The hymn number that was skipped
+ * @param string $label   Book label (e.g. "SDAH", "CH")
+ * @param string $reason  Human-readable explanation of why it was skipped
+ * @param string $bookDir Directory path where the log file should be written
+ *
+ * @return void
+ *
+ * Log format (one line per skipped hymn):
+ *     [2026-03-13 14:30:00]  SDAH042  --  fetch failed or no title found
+ */
+function logSkip(int $number, string $label, string $reason, string $bookDir): void
+{
+    // Ensure the directory exists (in case this is the first file we're writing)
+    if (!is_dir($bookDir)) {
+        mkdir($bookDir, 0755, true);
+    }
+
+    $logPath   = $bookDir . DIRECTORY_SEPARATOR . 'skipped.log';
+    $timestamp = date('Y-m-d H:i:s');
+    $padded    = str_pad((string) $number, 3, '0', STR_PAD_LEFT);
+
+    // Append the skip entry to the log file
+    file_put_contents(
+        $logPath,
+        "[{$timestamp}]  {$label}{$padded}  —  {$reason}\n",
+        FILE_APPEND | LOCK_EX
+    );
+}
+
+
+// ===========================================================================
+// Per-site scrape loop — the main orchestration logic for one hymnal site
+// ===========================================================================
+
+/**
+ * Scrape all hymns from a single site (SDAH or CH).
+ *
+ * This is the main loop that iterates through hymn numbers, fetches each
+ * one, and saves it. It includes several features for robust operation:
+ *
+ * - RESUMABILITY: Scans the output directory for existing files and skips
+ *   hymns that have already been saved (via buildExistingSet).
+ *
+ * - AUTO-DETECTION OF END: When the site redirects a hymn request to the
+ *   homepage (fetchHymn returns null), scraping stops — the hymnal has
+ *   no more hymns beyond this point.
+ *
+ * - CONSECUTIVE SKIP LIMIT: If 10 hymns in a row fail (MAX_CONSEC = 10),
+ *   we assume we've gone past the end of the hymnal and stop. This handles
+ *   the case where the site returns errors rather than redirects for
+ *   non-existent hymns.
+ *
+ * - RATE LIMITING: Pauses for $delay seconds between each request.
+ *
+ * @param string    $siteKey   Site identifier key from the SITES array ("sdah" or "ch")
+ * @param int       $start     First hymn number to scrape (inclusive)
+ * @param int|null  $end       Last hymn number to scrape (inclusive), or null for auto-detect
+ * @param string    $outputDir Base output directory (a book-specific subdir will be created)
+ * @param float     $delay     Seconds to wait between HTTP requests
+ * @param bool      $force     If true, re-download and overwrite existing files
+ *
+ * @return int Number of hymns successfully saved in this run
+ */
+function scrapeSite(string $siteKey, int $start, ?int $end, string $outputDir, float $delay, bool $force = false): int
+{
+    // Look up the site configuration for URLs, label, and subdirectory name
+    $site    = SITES[$siteKey];
+    $label   = $site['label'];
+    $baseUrl = $site['base_url'];
+    $homeUrl = $site['home_url'];
+
+    // Route output into a book-specific subdirectory within the base output dir
+    // e.g. "./hymns/Seventh-day Adventist Hymnal [SDAH]/"
+    $bookDir = $outputDir . DIRECTORY_SEPARATOR . $site['subdir'];
+
+    // Print a banner with configuration details for this scrape run
+    $separator = str_repeat('=', 50);
+    echo "\n{$separator}\n";
+    echo "  Scraping: {$baseUrl}  [{$label}]\n";
+    echo "  Output  : " . realpath($outputDir) . DIRECTORY_SEPARATOR . $site['subdir'] . "\n";
+    echo "  Range   : {$start} to " . ($end !== null ? $end : 'auto-detect') . "\n";
+    echo "{$separator}\n\n";
+
+    // Scan the output directory for already-saved hymns to enable resumability.
+    // When --force is set, we skip this check and re-download everything.
+    $existing = $force ? [] : buildExistingSet($label, $bookDir);
+    if ($force) {
+        echo "  Force mode: will re-download and overwrite existing files.\n\n";
+    } elseif (!empty($existing)) {
+        echo "  Found " . count($existing) . " existing {$label} hymns — will skip.\n\n";
+    }
+
+    // Counters for the final summary
+    $saved      = 0;     // Successfully saved hymns
+    $skipped    = 0;     // Hymns that were skipped due to errors
+    $number     = $start; // Current hymn number being processed
+
+    // Consecutive skip detection: if we encounter MAX_CONSEC failures in a row,
+    // we assume we've gone past the end of the hymnal. This is a safety net
+    // for sites that don't redirect to the homepage for non-existent hymns.
+    $maxConsec  = 10;
+    $consecSkip = 0;
+
+    while (true) {
+        // Check if we've reached the user-specified end hymn
+        if ($end !== null && $number > $end) {
+            echo "\nReached end hymn ({$end}). Done.\n";
+            break;
+        }
+
+        // Skip hymns that are already saved (detected during initial scan)
+        if (isset($existing[$number])) {
+            echo "  Hymn " . str_pad((string) $number, 4, ' ', STR_PAD_LEFT) . ": >>  already exists, skipping.\n";
+            $number++;
+            continue;  // No delay needed — no network request was made
+        }
+
+        // Fetch and parse the hymn page
+        echo "  Hymn " . str_pad((string) $number, 4, ' ', STR_PAD_LEFT) . ": fetching... ";
+
+        $hymn = fetchHymn($number, $baseUrl, $homeUrl);
+
+        if ($hymn === null) {
+            // The site redirected to the homepage — we've reached the end of
+            // the hymnal. This is the normal termination condition.
+            echo "\n";
+            break;
+        }
+
+        if ($hymn === 'SKIP') {
+            // This hymn couldn't be scraped — log it and continue
+            echo "X  skipped.\n";
+            logSkip($number, $label, 'fetch failed or no title found', $bookDir);
+            $skipped++;
+            $consecSkip++;
+
+            // Safety net: too many consecutive failures suggests we're past
+            // the end rather than hitting intermittent errors
+            if ($consecSkip >= $maxConsec) {
+                echo "  {$maxConsec} consecutive errors — assuming end of hymnal.\n";
+                break;
+            }
+
+            $number++;
+            usleep((int) ($delay * 1_000_000));  // Rate limit even on failures
+            continue;
+        }
+
+        // Success — reset the consecutive skip counter and save the hymn
+        $consecSkip = 0;
+        $path       = saveHymn($hymn, $label, $bookDir);
+        $saved++;
+        echo "OK  " . basename($path) . "\n";
+
+        $number++;
+        usleep((int) ($delay * 1_000_000));  // Rate limit between successful requests
+    }
+
+    // Print a summary for this site
+    echo "\n{$label}: {$saved} hymns saved, {$skipped} skipped.\n";
+    return $saved;
+}
+
+
+// ===========================================================================
+// CLI argument parsing
+// ===========================================================================
+
+/**
+ * Parse command-line arguments into a structured options array.
+ *
+ * Supports the following arguments:
+ *     --site {sdah|ch|both}  Which site to scrape (default: both)
+ *     --start {N}            First hymn number (default: 1)
+ *     --end {N}              Last hymn number (default: auto-detect)
+ *     --output {path}        Output folder (default: ./hymns)
+ *     --delay {N}            Seconds between requests (default: 1.0)
+ *     --force                Re-download existing files
+ *     --debug                Dump HTML responses for debugging
+ *     --help / -h / -?       Show usage information
+ *
+ * @param array $argv The raw CLI arguments array (global $argv)
+ *
+ * @return array Associative array of parsed options with keys:
+ *               site, start, end, output, delay, force, debug
+ */
+function parseArgs(array $argv): array
+{
+    // Default option values
+    $options = [
+        'site'   => 'both',
+        'start'  => 1,
+        'end'    => null,
+        'output' => DEFAULT_OUTPUT_DIR,
+        'delay'  => DEFAULT_DELAY,
+        'force'  => false,
+        'debug'  => false,
+    ];
+
+    // Check for help flags first — display usage and exit
+    if (in_array('--help', $argv, true) || in_array('-h', $argv, true) || in_array('-?', $argv, true)) {
+        printUsage();
+        exit(0);
+    }
+
+    // Parse arguments by iterating through the argv array.
+    // Skip $argv[0] which is the script name itself.
+    $i = 1;
+    while ($i < count($argv)) {
+        $arg = $argv[$i];
+
+        switch ($arg) {
+            case '--site':
+                $i++;
+                if ($i >= count($argv)) {
+                    fwrite(STDERR, "Error: --site requires a value (sdah, ch, or both)\n");
+                    exit(1);
+                }
+                $value = strtolower($argv[$i]);
+                if (!in_array($value, ['sdah', 'ch', 'both'], true)) {
+                    fwrite(STDERR, "Error: --site must be one of: sdah, ch, both\n");
+                    exit(1);
+                }
+                $options['site'] = $value;
+                break;
+
+            case '--start':
+                $i++;
+                if ($i >= count($argv) || !ctype_digit($argv[$i])) {
+                    fwrite(STDERR, "Error: --start requires a positive integer\n");
+                    exit(1);
+                }
+                $options['start'] = (int) $argv[$i];
+                break;
+
+            case '--end':
+                $i++;
+                if ($i >= count($argv) || !ctype_digit($argv[$i])) {
+                    fwrite(STDERR, "Error: --end requires a positive integer\n");
+                    exit(1);
+                }
+                $options['end'] = (int) $argv[$i];
+                break;
+
+            case '--output':
+                $i++;
+                if ($i >= count($argv)) {
+                    fwrite(STDERR, "Error: --output requires a path\n");
+                    exit(1);
+                }
+                $options['output'] = $argv[$i];
+                break;
+
+            case '--delay':
+                $i++;
+                if ($i >= count($argv) || !is_numeric($argv[$i])) {
+                    fwrite(STDERR, "Error: --delay requires a numeric value\n");
+                    exit(1);
+                }
+                $options['delay'] = (float) $argv[$i];
+                break;
+
+            case '--force':
+                $options['force'] = true;
+                break;
+
+            case '--debug':
+                $options['debug'] = true;
+                break;
+
+            default:
+                fwrite(STDERR, "Unknown argument: {$arg}\n");
+                fwrite(STDERR, "Use --help to see available options.\n");
+                exit(1);
+        }
+
+        $i++;
+    }
+
+    return $options;
+}
+
+
+/**
+ * Print the usage/help information for the script.
+ *
+ * Displays a comprehensive help message including all available options,
+ * usage examples, output format description, and operational notes.
+ *
+ * @return void
+ */
+function printUsage(): void
+{
+    $scriptName = basename(__FILE__);
+    echo <<<USAGE
+Hymnal scraper — SDAH + CH (no Composer required)
+
+Usage:
+  php {$scriptName} [OPTIONS]
+
+Options:
+  --site {sdah|ch|both}   Which site to scrape (default: both)
+  --start {N}             First hymn number to scrape (default: 1)
+  --end {N}               Last hymn number to scrape (default: auto-detect)
+  --output {path}         Output folder path (default: ./hymns)
+  --delay {N}             Seconds between HTTP requests (default: 1.0)
+  --force                 Force re-download of all hymns, even if files exist
+  --debug                 Dump raw HTML responses for debugging
+  --help, -h, -?          Show this help message
+
+Examples:
+  php {$scriptName}                         Scrape both sites from hymn 1
+  php {$scriptName} --site sdah             Only scrape sdahymnal.org (SDAH)
+  php {$scriptName} --site ch               Only scrape hymnal.xyz (CH)
+  php {$scriptName} --start 50              Resume scraping from hymn 50
+  php {$scriptName} --start 1 --end 100     Scrape a specific range of hymns
+  php {$scriptName} --output ~/Desktop/hymns
+                                            Save output to a custom folder
+  php {$scriptName} --delay 2.0             Increase delay to 2s between requests
+
+Output:
+  Files are saved as plain text in book-specific subdirectories:
+    hymns/Seventh-day Adventist Hymnal [SDAH]/001 (SDAH) - Praise To The Lord.txt
+    hymns/The Church Hymnal [CH]/001 (CH) - Praise To The Lord.txt
+
+  The scraper is resumable — existing files are detected and skipped.
+  Skipped hymns (errors, missing data) are logged to skipped.log.
+
+Notes:
+  - No Composer dependencies — uses only built-in PHP extensions (cURL, mbstring).
+  - Both sites share the same HTML structure, so one parser handles both.
+  - The scraper auto-detects the end of the hymnal (no --end needed).
+  - Rate limiting is handled automatically (pauses 60s, retries once).
+
+USAGE;
+}
+
+
+// ===========================================================================
+// Main — CLI entry point and orchestration
+// ===========================================================================
+
+/**
+ * Main function: parse CLI arguments and orchestrate the scraping process.
+ *
+ * Supports scraping one or both sites, specifying a hymn number range,
+ * custom output directory, and adjustable request delay. If --site is
+ * "both" (the default), scrapes SDAH first, then CH sequentially.
+ *
+ * @return void
+ */
+function main(): void
+{
+    global $argv, $DEBUG;
+
+    // Verify that the cURL extension is available (required for HTTP requests)
+    if (!function_exists('curl_init')) {
+        fwrite(STDERR, "Error: PHP cURL extension is required but not available.\n");
+        fwrite(STDERR, "Install it with: sudo apt install php-curl (Linux) or enable in php.ini\n");
+        exit(1);
+    }
+
+    // Verify that the mbstring extension is available (required for encoding handling)
+    if (!function_exists('mb_check_encoding')) {
+        fwrite(STDERR, "Error: PHP mbstring extension is required but not available.\n");
+        fwrite(STDERR, "Install it with: sudo apt install php-mbstring (Linux) or enable in php.ini\n");
+        exit(1);
+    }
+
+    // Parse command-line arguments
+    $options = parseArgs($argv);
+
+    // Set the global debug flag
+    $DEBUG = $options['debug'];
+
+    // Determine which sites to scrape based on the --site argument
+    if ($options['site'] === 'both') {
+        $sitesToRun = ['sdah', 'ch'];
+    } else {
+        $sitesToRun = [$options['site']];
+    }
+
+    $total = 0;
+
+    // Scrape each site sequentially, accumulating the total saved count
+    foreach ($sitesToRun as $siteKey) {
+        $total += scrapeSite(
+            $siteKey,
+            $options['start'],
+            $options['end'],
+            $options['output'],
+            $options['delay'],
+            $options['force']
+        );
+    }
+
+    // Resolve the output path for the summary message
+    $absOutput = realpath($options['output']);
+    if ($absOutput === false) {
+        $absOutput = $options['output'];
+    }
+    echo "\nAll done! {$total} hymns total saved to: {$absOutput}\n";
+}
+
+
+// ---------------------------------------------------------------------------
+// Script entry point — only execute when run directly (not when included)
+// ---------------------------------------------------------------------------
+// PHP doesn't have a direct equivalent of Python's `if __name__ == "__main__"`,
+// but we can check if the current file is the main script being executed by
+// comparing realpath(__FILE__) with the script that was invoked. This allows
+// the file to be included/required by other scripts for testing without
+// triggering the main scrape loop.
+// ---------------------------------------------------------------------------
+if (realpath(__FILE__) === realpath($argv[0] ?? '')) {
+    main();
+}

--- a/.importers/scrapers/SDAHymnals_SDAHymnal.org.ps1
+++ b/.importers/scrapers/SDAHymnals_SDAHymnal.org.ps1
@@ -1,0 +1,1616 @@
+<#
+.SYNOPSIS
+    SDAHymnals_SDAHymnal.org.ps1
+    importers/scrapers/SDAHymnals_SDAHymnal.org.ps1
+
+    Hymnal Scraper — scrapes both sdahymnal.org (SDAH) and hymnal.xyz (CH).
+    Copyright 2025-2026 MWBM Partners Ltd.
+
+.DESCRIPTION
+    This scraper fetches hymn lyrics from two Seventh-day Adventist hymnal
+    websites that share the same underlying codebase (identical HTML structure
+    and CSS class names). It iterates through hymn numbers sequentially,
+    parses the HTML to extract the title, section indicators (e.g. "Verse 1",
+    "Chorus"), and lyrics text, then saves each hymn as a plain-text file.
+
+    The scraper is designed to be resumable: it scans the output directory for
+    existing files on startup and skips hymns that have already been saved.
+    It also handles rate limiting, server errors, and auto-detects the end
+    of the hymnal when the site redirects to the homepage.
+
+    When double-clicked from Explorer (no CLI arguments), an interactive menu
+    is displayed allowing the user to configure parameters before starting.
+
+.PARAMETER Site
+    Which site to scrape: "sdah" (sdahymnal.org), "ch" (hymnal.xyz),
+    or "both" (default). Both sites share the same HTML structure.
+
+.PARAMETER Start
+    First hymn number to scrape (inclusive). Default: 1.
+
+.PARAMETER End
+    Last hymn number to scrape (inclusive). Default: auto-detect end of hymnal.
+    If not specified, the scraper continues until the site redirects to the
+    homepage or 10 consecutive failures are encountered.
+
+.PARAMETER Output
+    Output folder path where hymn files will be saved. Default: ./hymns.
+    Book-specific subdirectories are created automatically:
+      hymns/Seventh-day Adventist Hymnal [SDAH]/
+      hymns/The Church Hymnal [CH]/
+
+.PARAMETER Delay
+    Seconds to wait between HTTP requests to avoid overwhelming the server
+    and triggering rate limits. Default: 1.0.
+
+.PARAMETER Help
+    Show usage information and exit (alias for -?).
+
+.PARAMETER Force
+    Force mode: re-download and overwrite all hymn files, even if they
+    already exist in the output directory. Bypasses the resumability check.
+
+.EXAMPLE
+    .\SDAHymnals_SDAHymnal.org.ps1
+    # Scrape both sites from hymn 1 (or interactive menu if double-clicked)
+
+.EXAMPLE
+    .\SDAHymnals_SDAHymnal.org.ps1 -Site sdah
+    # Only scrape sdahymnal.org (SDAH)
+
+.EXAMPLE
+    .\SDAHymnals_SDAHymnal.org.ps1 -Site ch
+    # Only scrape hymnal.xyz (CH)
+
+.EXAMPLE
+    .\SDAHymnals_SDAHymnal.org.ps1 -Start 50
+    # Resume scraping from hymn 50
+
+.EXAMPLE
+    .\SDAHymnals_SDAHymnal.org.ps1 -Start 1 -End 100
+    # Scrape a specific range of hymns
+
+.EXAMPLE
+    .\SDAHymnals_SDAHymnal.org.ps1 -Output "$HOME\Desktop\hymns"
+    # Save output to a custom folder
+
+.EXAMPLE
+    .\SDAHymnals_SDAHymnal.org.ps1 -Delay 2.0
+    # Increase delay to 2 seconds between requests
+
+.EXAMPLE
+    .\SDAHymnals_SDAHymnal.org.ps1 -Force
+    # Re-download all hymns, overwriting existing files
+
+.EXAMPLE
+    .\SDAHymnals_SDAHymnal.org.ps1 -Site sdah -Start 1 -End 50 -Force
+    # Force re-download of SDAH hymns 1-50
+
+.NOTES
+    Dependencies:
+        None — uses only PowerShell built-in cmdlets (no modules required).
+        Requires PowerShell 5.1+ (Windows PowerShell) or PowerShell 7+ (cross-platform).
+
+    Output format:
+        Each hymn is saved as a UTF-8 plain-text file with the naming convention:
+            {number zero-padded to 3 digits} ({LABEL}) - {Title Case Title}.txt
+        e.g.: "001 (SDAH) - Praise To The Lord.txt"
+
+        Files are organised into book-specific subdirectories:
+            hymns/Seventh-day Adventist Hymnal [SDAH]/
+            hymns/The Church Hymnal [CH]/
+
+    HTML Parsing:
+        Uses regex-based parsing to extract:
+        - Title:      div.block-heading-four > *.wedding-heading > strong
+        - Indicators: div.block-heading-three (e.g. "Verse 1", "Chorus")
+        - Lyrics:     div.block-heading-five (with <br> as line breaks)
+
+    Resumability:
+        The scraper scans the output directory for existing files on startup
+        and skips hymns that have already been saved.
+
+    Error handling:
+        - HTTP 500: Retries up to 3 times with 3-second backoff
+        - Rate limiting: Pauses 60 seconds and retries once
+        - Homepage redirect: Stops scraping (end of hymnal detected)
+        - 10 consecutive failures: Stops scraping (safety net)
+
+    Author: MWBM Partners Ltd.
+    Version: 2.0
+#>
+
+# ---------------------------------------------------------------------------
+# Parameter block — defines the command-line arguments this script accepts.
+# These mirror the Python version's argparse arguments exactly.
+# CmdletBinding enables -Verbose, -Debug, and other common parameters.
+# ---------------------------------------------------------------------------
+[CmdletBinding()]
+param(
+    # Which site to scrape: "sdah" for sdahymnal.org, "ch" for hymnal.xyz,
+    # or "both" (default) to scrape both sites sequentially.
+    [ValidateSet("sdah", "ch", "both")]
+    [string]$Site = "",
+
+    # First hymn number to scrape (inclusive). Default is 1.
+    [int]$Start = 0,
+
+    # Last hymn number to scrape (inclusive). 0 means auto-detect the end
+    # of the hymnal by watching for homepage redirects.
+    [int]$End = 0,
+
+    # Output folder path. Default is ./hymns relative to the current directory.
+    [string]$Output = "",
+
+    # Seconds to wait between HTTP requests. Default is 1.0 seconds.
+    [double]$Delay = 0,
+
+    # Show help/usage information and exit.
+    [Alias("?")]
+    [switch]$Help,
+
+    # Force mode: re-download and overwrite existing hymn files instead of
+    # skipping them. When set, the existing-hymn scan is bypassed (an empty
+    # set is used), so every hymn in the requested range is fetched fresh.
+    [switch]$Force
+)
+
+# ---------------------------------------------------------------------------
+# Site configuration — both sites share the same HTML structure
+# ---------------------------------------------------------------------------
+# Both sdahymnal.org and hymnal.xyz are built on the same web platform,
+# so they use identical CSS class names and page layouts. This allows us
+# to use a single parsing function for both sites. Each site entry defines:
+#   - base_url:  The hymn page URL template (hymn number passed as ?no=N)
+#   - home_url:  The site homepage (used to detect end-of-hymnal redirects)
+#   - label:     Short identifier used in output filenames, e.g. "SDAH"
+#   - subdir:    Human-readable subdirectory name for organised output
+#   - lang:      ISO 639-1 language code for the songbook's language (e.g. "en")
+$script:SITES = @{
+    "sdah" = @{
+        base_url = "https://www.sdahymnal.org/Hymn"
+        home_url = "https://www.sdahymnal.org"
+        label    = "SDAH"
+        subdir   = "Seventh-day Adventist Hymnal [SDAH]"
+        lang     = "en"   # ISO 639-1: English
+    }
+    "ch" = @{
+        base_url = "https://www.hymnal.xyz/Hymn"
+        home_url = "https://www.hymnal.xyz"
+        label    = "CH"
+        subdir   = "The Church Hymnal [CH]"
+        lang     = "en"   # ISO 639-1: English
+    }
+}
+
+# Default output directory (relative to where the script is run from)
+$script:DEFAULT_OUTPUT_DIR = ".\hymns"
+
+# Default delay in seconds between HTTP requests to be respectful to the
+# server and avoid triggering rate limits. 1.0s is a reasonable balance
+# between speed and politeness.
+$script:DEFAULT_DELAY = 1.0
+
+# Maximum consecutive skips before assuming we've passed the end of the hymnal.
+# This is a safety net for sites that don't redirect to the homepage for
+# non-existent hymns but instead return errors.
+$script:MAX_CONSEC = 10
+
+# User-Agent header identifying the scraper. This is the same polite
+# User-Agent used by the Python version.
+$script:USER_AGENT = "Mozilla/5.0 (compatible; HymnScraper/2.0; personal use)"
+
+
+# ---------------------------------------------------------------------------
+# HTML Entity decoder — converts HTML entities to Unicode characters
+# ---------------------------------------------------------------------------
+
+function ConvertFrom-HtmlEntity {
+    <#
+    .SYNOPSIS
+        Convert an HTML entity string to its Unicode character equivalent.
+
+    .DESCRIPTION
+        Handles both named entities (e.g. &amp;, &rsquo;) and numeric
+        character references (e.g. &#8217;, &#x2019;). This is needed
+        because our regex-based parser encounters raw entity strings that
+        need to be resolved to display characters. Covers the most frequently
+        encountered entities in hymn lyrics: standard XML entities,
+        typographic quotes, non-breaking spaces, and dashes.
+
+    .PARAMETER Entity
+        The full entity string including & and ; (e.g. "&amp;", "&#8217;", "&#x2019;").
+
+    .OUTPUTS
+        [string] The corresponding Unicode character, or empty string if not recognised.
+    #>
+    param(
+        [string]$Entity
+    )
+
+    # Strip the leading & and trailing ; to get the entity body
+    $body = $Entity.TrimStart("&").TrimEnd(";")
+
+    # --- Numeric character references (decimal or hex) ---
+    if ($body.StartsWith("#")) {
+        $numPart = $body.Substring(1)  # Remove the '#' prefix
+
+        try {
+            if ($numPart.StartsWith("x") -or $numPart.StartsWith("X")) {
+                # Hexadecimal reference: &#x2019; → $numPart = "x2019"
+                $codePoint = [Convert]::ToInt32($numPart.Substring(1), 16)
+            }
+            else {
+                # Decimal reference: &#8217; → $numPart = "8217"
+                $codePoint = [int]$numPart
+            }
+            # Windows-1252 remapping: code points 128-159 are C1 control
+            # characters in Unicode, but many legacy web pages use them to
+            # mean the Windows-1252 characters (smart quotes, dashes, etc.).
+            # Web browsers perform this remapping automatically; we do the
+            # same here so that &#145; becomes a left single quote, etc.
+            # Reference: https://html.spec.whatwg.org/#numeric-character-reference-end-state
+            $win1252Map = @{
+                145 = [char]0x2018   # left single quotation mark
+                146 = [char]0x2019   # right single quotation mark
+                147 = [char]0x201C   # left double quotation mark
+                148 = [char]0x201D   # right double quotation mark
+                150 = [char]0x2013   # en dash
+                151 = [char]0x2014   # em dash
+            }
+            if ($win1252Map.ContainsKey($codePoint)) {
+                return $win1252Map[$codePoint]
+            }
+            # Convert the code point to a Unicode character
+            return [char]$codePoint
+        }
+        catch {
+            # Malformed or out-of-range character reference — return empty
+            return ""
+        }
+    }
+
+    # --- Named entities ---
+    # Map common HTML entities to their Unicode characters.
+    # This covers the most frequently encountered entities in hymn lyrics:
+    # standard XML entities, typographic quotes, and dashes.
+    $namedEntities = @{
+        "amp"    = "&"
+        "lt"     = "<"
+        "gt"     = ">"
+        "quot"   = '"'
+        "apos"   = "'"
+        "nbsp"   = " "            # non-breaking space → regular space
+        "rsquo"  = [char]0x2019   # right single smart quote '
+        "lsquo"  = [char]0x2018   # left single smart quote '
+        "rdquo"  = [char]0x201D   # right double smart quote "
+        "ldquo"  = [char]0x201C   # left double smart quote "
+        "mdash"  = [char]0x2014   # em dash —
+        "ndash"  = [char]0x2013   # en dash –
+    }
+
+    if ($namedEntities.ContainsKey($body)) {
+        return $namedEntities[$body]
+    }
+
+    # Unknown entity — return empty string
+    return ""
+}
+
+
+# ---------------------------------------------------------------------------
+# HTML Parser — regex-based extraction of hymn data from page HTML
+# ---------------------------------------------------------------------------
+# Both sdahymnal.org and hymnal.xyz share the same underlying codebase, so
+# they use identical CSS class names for their hymn page structure. This
+# function navigates the HTML using regex patterns to extract:
+#
+# 1. TITLE: Found inside a <strong> tag, nested within an element with class
+#    "wedding-heading", which is itself inside a <div> with class
+#    "block-heading-four".
+#
+# 2. SECTION INDICATORS: Found in <div class="block-heading-three">.
+#    These are labels like "Verse 1", "Chorus", "Verse 2", etc.
+#
+# 3. LYRICS TEXT: Found in <div class="block-heading-five">.
+#    Line breaks within lyrics are represented by <br> tags, which we
+#    convert to newline characters.
+#
+# The function pairs each indicator with its following lyrics block,
+# producing an array of objects with .indicator and .lyrics properties.
+# ---------------------------------------------------------------------------
+
+function Parse-HymnHtml {
+    <#
+    .SYNOPSIS
+        Parse hymn HTML to extract title and lyrics sections.
+
+    .DESCRIPTION
+        Uses regex patterns to extract the hymn title, section indicators
+        (e.g. "Verse 1", "Chorus"), and lyrics text from the HTML of a
+        hymn page on sdahymnal.org or hymnal.xyz.
+
+        HTML structure being parsed:
+            <div class="block-heading-four">        — title container
+                <h3 class="wedding-heading">        — title wrapper
+                    <strong>Hymn Title Here</strong> — actual title text
+                </h3>
+            </div>
+            <div class="block-heading-three">       — section indicator
+                Verse 1                              — e.g. "Verse 1", "Chorus"
+            </div>
+            <div class="block-heading-five">        — lyrics block
+                First line of lyrics<br>             — <br> = line break
+                Second line of lyrics<br>
+            </div>
+
+    .PARAMETER Html
+        The raw HTML string of the hymn page.
+
+    .OUTPUTS
+        [hashtable] with keys:
+            title    [string]: The extracted hymn title (empty if not found)
+            sections [array]:  Array of objects with .indicator and .lyrics properties
+    #>
+    param(
+        [string]$Html
+    )
+
+    # Initialise return data structure
+    $result = @{
+        title    = ""
+        sections = @()
+    }
+
+    # -----------------------------------------------------------------------
+    # STEP 1: Extract the hymn title
+    # -----------------------------------------------------------------------
+    # The title is nested: div.block-heading-four > *.wedding-heading > <strong>
+    # We use a multi-step regex approach:
+    #   1. Find the block-heading-four div and capture its inner content
+    #   2. Within that, find the wedding-heading element and its content
+    #   3. Within that, find the first <strong> tag and extract the text
+    #
+    # Pattern explanation for block-heading-four extraction:
+    #   <div[^>]*class="[^"]*block-heading-four[^"]*"[^>]*>  — opening div with class
+    #   ([\s\S]*?)                                             — non-greedy capture of inner HTML
+    #   </div>                                                 — closing div tag
+    # Note: [\s\S]*? matches any character including newlines (non-greedy)
+    # -----------------------------------------------------------------------
+
+    # Step 1a: Extract the content inside the block-heading-four div
+    $bh4Pattern = '<div[^>]*class="[^"]*block-heading-four[^"]*"[^>]*>([\s\S]*?)</div>'
+    $bh4Match = [regex]::Match($Html, $bh4Pattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+
+    if ($bh4Match.Success) {
+        $bh4Content = $bh4Match.Groups[1].Value
+
+        # Step 1b: Within block-heading-four, find the wedding-heading element
+        # The wedding-heading class can be on any tag (h3, h2, p, etc.)
+        # Pattern: any tag with class containing "wedding-heading", capture inner content
+        $whPattern = '<[^>]*class="[^"]*wedding-heading[^"]*"[^>]*>([\s\S]*?)</[^>]+>'
+        $whMatch = [regex]::Match($bh4Content, $whPattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+
+        if ($whMatch.Success) {
+            $whContent = $whMatch.Groups[1].Value
+
+            # Step 1c: Within wedding-heading, find the first <strong> tag
+            # Pattern: <strong> followed by any content, captured non-greedy, then </strong>
+            $strongPattern = '<strong[^>]*>([\s\S]*?)</strong>'
+            $strongMatch = [regex]::Match($whContent, $strongPattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+
+            if ($strongMatch.Success) {
+                # Extract the raw title text from the <strong> tag
+                $rawTitle = $strongMatch.Groups[1].Value
+
+                # Strip any remaining HTML tags from the title (there shouldn't be any,
+                # but this is a safety measure for edge cases)
+                $rawTitle = [regex]::Replace($rawTitle, '<[^>]+>', '')
+
+                # Decode HTML entities in the title (e.g. &amp; → &, &#8217; → ')
+                # Pattern matches: &name; or &#digits; or &#xhex;
+                $rawTitle = [regex]::Replace($rawTitle, '&(#?[a-zA-Z0-9]+);', {
+                    param($m)
+                    $entity = $m.Value
+                    $decoded = ConvertFrom-HtmlEntity -Entity $entity
+                    if ($decoded) { return $decoded }
+                    return $entity  # Return the raw entity if decoding fails
+                })
+
+                # Trim whitespace from the title
+                $result.title = $rawTitle.Trim()
+            }
+        }
+    }
+
+    # -----------------------------------------------------------------------
+    # STEP 2: Extract section indicators and lyrics
+    # -----------------------------------------------------------------------
+    # Indicators and lyrics are sibling div elements with specific classes.
+    # We find all block-heading-three and block-heading-five divs in order,
+    # then pair each indicator with the lyrics block that follows it.
+    #
+    # Strategy: Use a single regex to match both types of blocks, preserving
+    # their order of appearance. Each match is tagged as either "indicator"
+    # or "lyrics" based on the class name found.
+    # -----------------------------------------------------------------------
+
+    # Combined pattern to match both indicator and lyrics div blocks.
+    # Uses alternation (|) to match either class, with a named group to
+    # identify which type was matched.
+    # The [\s\S]*? non-greedy match captures everything inside the div
+    # up to the first closing </div> tag.
+    $sectionPattern = '<div[^>]*class="[^"]*(?<type>block-heading-three|block-heading-five)[^"]*"[^>]*>([\s\S]*?)</div>'
+    $sectionMatches = [regex]::Matches($Html, $sectionPattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+
+    # Track the most recently seen indicator text, to pair with the next lyrics block
+    $currentIndicator = ""
+
+    # Temporary list to accumulate sections (PowerShell arrays are immutable,
+    # so we use an ArrayList for efficient appending)
+    $sectionsList = [System.Collections.ArrayList]::new()
+
+    foreach ($sMatch in $sectionMatches) {
+        # Determine if this is an indicator or lyrics block based on the class name
+        $blockType = $sMatch.Groups["type"].Value
+        # The inner content is in capture group 2 (group 1 is the named "type" group)
+        $innerHtml = $sMatch.Groups[2].Value
+
+        if ($blockType -eq "block-heading-three") {
+            # --- INDICATOR BLOCK ---
+            # Contains text like "Verse 1", "Chorus", "Verse 2", etc.
+
+            # Strip HTML tags from the indicator text
+            $indicatorText = [regex]::Replace($innerHtml, '<[^>]+>', '')
+
+            # Decode HTML entities in the indicator
+            $indicatorText = [regex]::Replace($indicatorText, '&(#?[a-zA-Z0-9]+);', {
+                param($m)
+                $decoded = ConvertFrom-HtmlEntity -Entity $m.Value
+                if ($decoded) { return $decoded }
+                return $m.Value
+            })
+
+            # Store the indicator text to pair with the next lyrics block
+            $currentIndicator = $indicatorText.Trim()
+        }
+        elseif ($blockType -eq "block-heading-five") {
+            # --- LYRICS BLOCK ---
+            # Contains the actual hymn lyrics with <br> tags for line breaks
+
+            # Step 2a: Convert <br> and <br/> tags to newline characters
+            # The sites use <br> for line breaks within verses
+            $lyricsText = [regex]::Replace($innerHtml, '<br\s*/?>', "`n")
+
+            # Step 2b: Strip all remaining HTML tags from the lyrics
+            $lyricsText = [regex]::Replace($lyricsText, '<[^>]+>', '')
+
+            # Step 2c: Decode HTML entities in the lyrics
+            $lyricsText = [regex]::Replace($lyricsText, '&(#?[a-zA-Z0-9]+);', {
+                param($m)
+                $decoded = ConvertFrom-HtmlEntity -Entity $m.Value
+                if ($decoded) { return $decoded }
+                return $m.Value
+            })
+
+            # Step 2d: Collapse runs of 3+ newlines down to 2
+            # (clean up excessive whitespace from empty <br> tags in the source)
+            $lyricsText = [regex]::Replace($lyricsText, '\n{3,}', "`n`n")
+
+            # Trim leading/trailing whitespace
+            $lyricsText = $lyricsText.Trim()
+
+            # Pair this lyrics block with its indicator and add to sections list
+            [void]$sectionsList.Add([PSCustomObject]@{
+                indicator = $currentIndicator
+                lyrics    = $lyricsText
+            })
+
+            # Reset indicator for the next verse (some verses may not have one)
+            $currentIndicator = ""
+        }
+    }
+
+    # Convert the ArrayList to a standard array for the return value
+    $result.sections = @($sectionsList)
+
+    return $result
+}
+
+
+# ---------------------------------------------------------------------------
+# Title Case — convert a string to Title Case with correct apostrophe handling
+# ---------------------------------------------------------------------------
+
+function ConvertTo-TitleCaseCustom {
+    <#
+    .SYNOPSIS
+        Convert a string to Title Case, with correct handling of apostrophes.
+
+    .DESCRIPTION
+        PowerShell's built-in (Get-Culture).TextInfo.ToTitleCase() method and
+        similar approaches can treat apostrophes as word boundaries, producing
+        incorrect results like "Don'T" instead of "Don't". This function uses
+        a regex to match whole words (including apostrophe contractions like
+        "don't", "it's", "o'er") and capitalises each word correctly.
+
+        The regex matches:
+            [a-zA-Z]+                   One or more letters (the main word)
+            (['\u2019\u2018]            Optionally an apostrophe (ASCII, right-curly, or left-curly)
+             [a-zA-Z]+)?               followed by more letters (contraction suffix)
+
+        We include Unicode curly/smart apostrophes (\u2019 RIGHT SINGLE QUOTATION
+        MARK and \u2018 LEFT SINGLE QUOTATION MARK) because HTML entities like
+        &rsquo; decode to \u2019. Without this, "Eagle\u2019s" would be split into
+        separate words, producing "Eagle'S" instead of "Eagle's".
+
+        For each match, the first character is uppercased and the rest are
+        lowercased — producing correct Title Case for contractions.
+
+    .PARAMETER InputString
+        The input string to convert to Title Case.
+
+    .OUTPUTS
+        [string] The Title Cased string.
+
+    .EXAMPLE
+        ConvertTo-TitleCaseCustom "AMAZING GRACE"
+        # Returns: "Amazing Grace"
+
+    .EXAMPLE
+        ConvertTo-TitleCaseCustom "don't let me down"
+        # Returns: "Don't Let Me Down"
+
+    .EXAMPLE
+        ConvertTo-TitleCaseCustom "o'er the hills"
+        # Returns: "O'er The Hills"
+    #>
+    param(
+        [string]$InputString
+    )
+
+    # Regex pattern matches a "word" which may contain an apostrophe contraction.
+    # [a-zA-Z]+ matches one or more letters (the base word).
+    # (['\u2019\u2018][a-zA-Z]+)? optionally matches an apostrophe (ASCII or Unicode
+    # curly quotes) followed by more letters (e.g. "'t" in "don't", "'er" in "o'er").
+    # Unicode \u2019 (RIGHT SINGLE QUOTATION MARK) and \u2018 (LEFT SINGLE QUOTATION
+    # MARK) are included because HTML entity &rsquo; decodes to \u2019.
+    $pattern = "[a-zA-Z]+(['\u2019\u2018][a-zA-Z]+)?"
+
+    # Use [regex]::Replace with a script block evaluator to capitalise each word.
+    # The script block receives each match object, extracts the full matched word,
+    # then uppercases the first character and lowercases the rest.
+    $result = [regex]::Replace($InputString, $pattern, {
+        param($match)
+        $word = $match.Value
+        if ($word.Length -eq 0) { return $word }
+
+        # Capitalise: first char uppercase, remaining chars lowercase
+        # This correctly handles "DON'T" → "Don't" because the entire
+        # contraction is treated as one word (not split at the apostrophe)
+        return $word.Substring(0, 1).ToUpper() + $word.Substring(1).ToLower()
+    })
+
+    return $result
+}
+
+
+# ---------------------------------------------------------------------------
+# Sanitize — remove invalid filename characters
+# ---------------------------------------------------------------------------
+
+function Get-SanitizedFilename {
+    <#
+    .SYNOPSIS
+        Remove characters that are invalid in filenames across operating systems.
+
+    .DESCRIPTION
+        Strips the following characters which are forbidden in Windows filenames
+        and/or could cause issues on other platforms:
+            \ / * ? : " < > |
+
+    .PARAMETER Name
+        The raw string to sanitize (typically a hymn title).
+
+    .OUTPUTS
+        [string] The sanitized string with invalid characters removed and
+        leading/trailing whitespace stripped.
+    #>
+    param(
+        [string]$Name
+    )
+
+    # Remove characters that are invalid in Windows filenames: \ / * ? : " < > |
+    # The regex character class includes each forbidden character.
+    # Note: the backslash must be escaped in the regex as \\
+    $sanitized = [regex]::Replace($Name, '[\\/*?:"<>|]', '')
+
+    # Strip leading/trailing whitespace that may remain after character removal
+    return $sanitized.Trim()
+}
+
+
+# ---------------------------------------------------------------------------
+# Format hymn — convert parsed hymn data to plain-text output
+# ---------------------------------------------------------------------------
+
+function Format-HymnText {
+    <#
+    .SYNOPSIS
+        Format a parsed hymn hashtable into a clean plain-text string for saving.
+
+    .DESCRIPTION
+        The output format is:
+            "Hymn Title"
+                                        — blank line after title
+            Verse 1                     — indicator (if present)
+            First line of lyrics        — lyrics text
+            Second line of lyrics
+                                        — blank line between sections
+            Chorus                      — next indicator
+            Chorus lyrics here
+            ...
+
+    .PARAMETER Hymn
+        Hashtable with keys:
+            title    [string]: The hymn title
+            sections [array]:  Array of objects with .indicator and .lyrics properties
+
+    .OUTPUTS
+        [string] The formatted plain-text hymn content.
+    #>
+    param(
+        [hashtable]$Hymn
+    )
+
+    # Start with the quoted title and a blank line
+    $lines = [System.Collections.ArrayList]::new()
+    [void]$lines.Add('"' + $Hymn.title + '"')
+    [void]$lines.Add("")
+
+    # Append each section (indicator + lyrics) with blank line separators
+    foreach ($section in $Hymn.sections) {
+        if ($section.indicator) {
+            # Add the section indicator (e.g. "Verse 1", "Chorus")
+            [void]$lines.Add($section.indicator)
+        }
+        if ($section.lyrics) {
+            # Add the verse/chorus text
+            [void]$lines.Add($section.lyrics)
+        }
+        # Blank line between sections for visual separation
+        [void]$lines.Add("")
+    }
+
+    # Remove trailing blank lines (cleaner file ending)
+    while ($lines.Count -gt 0 -and $lines[$lines.Count - 1] -eq "") {
+        $lines.RemoveAt($lines.Count - 1)
+    }
+
+    # Join all lines with newline characters and return
+    return ($lines -join "`n")
+}
+
+
+# ---------------------------------------------------------------------------
+# Build existing set — scan output directory for already-saved hymns
+# ---------------------------------------------------------------------------
+
+function Get-ExistingHymnNumbers {
+    <#
+    .SYNOPSIS
+        Scan the output directory to find hymn numbers that have already been saved.
+
+    .DESCRIPTION
+        This enables the scraper to resume from where it left off without
+        re-downloading hymns. It looks for files matching the naming pattern
+        "{number} ({label}) - {title}.txt" and extracts the hymn number from
+        each matching filename.
+
+    .PARAMETER Label
+        The book label to filter by (e.g. "SDAH", "CH").
+
+    .PARAMETER OutputDir
+        Path to the directory to scan for existing files.
+
+    .OUTPUTS
+        [System.Collections.Generic.HashSet[int]] A set of hymn numbers already saved.
+        Empty set if the directory doesn't exist or has no matching files.
+
+    .EXAMPLE
+        If OutputDir contains:
+            "001 (SDAH) - Praise To The Lord.txt"
+            "042 (SDAH) - A Mighty Fortress.txt"
+        Returns a set containing: 1, 42
+    #>
+    param(
+        [string]$Label,
+        [string]$OutputDir
+    )
+
+    # Use a HashSet for O(1) lookups when checking if a hymn number exists
+    $existing = [System.Collections.Generic.HashSet[int]]::new()
+
+    # Check if the output directory exists before trying to scan it
+    if (Test-Path -Path $OutputDir -PathType Container) {
+        # Build the prefix tag to filter files belonging to this specific book
+        # e.g. "(SDAH) -" to match "001 (SDAH) - Praise To The Lord.txt"
+        $prefixTag = "($Label) -"
+
+        # Get all .txt files in the directory that contain the book label
+        $files = Get-ChildItem -Path $OutputDir -Filter "*.txt" -File -ErrorAction SilentlyContinue
+
+        foreach ($file in $files) {
+            # Check if this file belongs to the current book by looking for the label tag
+            if ($file.Name.Contains($prefixTag)) {
+                # Extract the hymn number from the start of the filename
+                # (the zero-padded number before the first space)
+                $parts = $file.Name.Split(" ")
+                $numStr = $parts[0]
+
+                # Verify it's a valid number and add to the set
+                $num = 0
+                if ([int]::TryParse($numStr, [ref]$num)) {
+                    [void]$existing.Add($num)
+                }
+            }
+        }
+    }
+
+    return $existing
+}
+
+
+# ---------------------------------------------------------------------------
+# Save hymn — write formatted hymn text to a file
+# ---------------------------------------------------------------------------
+
+function Save-Hymn {
+    <#
+    .SYNOPSIS
+        Save a parsed hymn to a plain-text file in the output directory.
+
+    .DESCRIPTION
+        Creates the output directory if it doesn't exist, formats the hymn
+        content, and writes it to a file with the standard naming convention:
+            {number zero-padded to 3} ({label}) - {Title Case Title}.txt
+
+    .PARAMETER Hymn
+        Hashtable with "number" (int), "title" (str), and "sections" (array).
+
+    .PARAMETER Label
+        Book label for the filename (e.g. "SDAH", "CH").
+
+    .PARAMETER OutputDir
+        Directory path where the file should be saved.
+
+    .OUTPUTS
+        [string] The full file path of the saved file.
+    #>
+    param(
+        [hashtable]$Hymn,
+        [string]$Label,
+        [string]$OutputDir
+    )
+
+    # Ensure the output directory exists (creates parent dirs too if needed)
+    if (-not (Test-Path -Path $OutputDir)) {
+        New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
+    }
+
+    # Zero-pad the hymn number to 3 digits for consistent sorting
+    # (e.g. 1 → "001", 42 → "042", 695 → "695")
+    $padded = $Hymn.number.ToString().PadLeft(3, '0')
+
+    # Build the filename: sanitize the title to remove invalid chars,
+    # then convert to Title Case for consistent, readable filenames
+    $safeTitle = Get-SanitizedFilename -Name $Hymn.title
+    $titleCased = ConvertTo-TitleCaseCustom -InputString $safeTitle
+    $filename = "$padded ($Label) - $titleCased.txt"
+    $filepath = Join-Path -Path $OutputDir -ChildPath $filename
+
+    # Format the hymn content as plain text
+    $content = Format-HymnText -Hymn $Hymn
+
+    # Write the formatted hymn text to the file with UTF-8 encoding (no BOM)
+    # Using .NET StreamWriter to ensure UTF-8 without BOM (PowerShell 5.1's
+    # Out-File and Set-Content add a BOM by default, which can cause issues)
+    $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+    [System.IO.File]::WriteAllText($filepath, $content, $utf8NoBom)
+
+    return $filepath
+}
+
+
+# ---------------------------------------------------------------------------
+# Log skip — record skipped hymns to a log file
+# ---------------------------------------------------------------------------
+
+function Write-SkipLog {
+    <#
+    .SYNOPSIS
+        Record a skipped hymn entry in the skipped.log file for later review.
+
+    .DESCRIPTION
+        Creates a persistent log of hymns that couldn't be scraped, along with
+        the reason and timestamp. Useful for identifying gaps in the collection
+        and diagnosing systematic issues.
+
+    .PARAMETER Number
+        The hymn number that was skipped.
+
+    .PARAMETER Label
+        Book label (e.g. "SDAH", "CH").
+
+    .PARAMETER Reason
+        Human-readable explanation of why it was skipped.
+
+    .PARAMETER BookDir
+        Directory path where the log file should be written.
+
+    .NOTES
+        Log format (one line per skipped hymn):
+            [2026-03-13 14:30:00]  SDAH042  —  fetch failed or no title found
+    #>
+    param(
+        [int]$Number,
+        [string]$Label,
+        [string]$Reason,
+        [string]$BookDir
+    )
+
+    # Ensure the directory exists (in case this is the first file we're writing)
+    if (-not (Test-Path -Path $BookDir)) {
+        New-Item -ItemType Directory -Path $BookDir -Force | Out-Null
+    }
+
+    $logPath   = Join-Path -Path $BookDir -ChildPath "skipped.log"
+    $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+    $padded    = $Number.ToString().PadLeft(3, '0')
+    $logLine   = "[$timestamp]  $Label$padded  —  $Reason"
+
+    # Append the log line to the file (creates the file if it doesn't exist)
+    # Use .NET to ensure UTF-8 without BOM and proper newline handling
+    $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+    [System.IO.File]::AppendAllText($logPath, "$logLine`n", $utf8NoBom)
+}
+
+
+# ---------------------------------------------------------------------------
+# Fetch hymn — HTTP request handling and hymn data extraction
+# ---------------------------------------------------------------------------
+
+function Fetch-Hymn {
+    <#
+    .SYNOPSIS
+        Fetch a single hymn page from the website and parse it into structured data.
+
+    .DESCRIPTION
+        Makes an HTTP GET request to the hymn URL, handles various error conditions
+        (server errors, rate limiting, redirects), and returns parsed hymn data.
+
+        The function includes several resilience features:
+        - Retries up to 3 times on HTTP 500 errors (with 3-second delays)
+        - Detects rate-limiting pages and pauses 60 seconds before retrying
+        - Detects end-of-hymnal by checking if the site redirects to the homepage
+        - Falls back to latin-1 encoding if UTF-8 decoding fails
+        - 15-second timeout for HTTP requests
+
+    .PARAMETER Number
+        The hymn number to fetch (e.g. 1, 42, 695).
+
+    .PARAMETER BaseUrl
+        The site's hymn page base URL (e.g. "https://www.sdahymnal.org/Hymn").
+
+    .PARAMETER HomeUrl
+        The site's homepage URL (used to detect end-of-hymnal redirects).
+
+    .OUTPUTS
+        [hashtable] with keys "number", "title", "sections" on success.
+        [string] "SKIP" if the hymn should be skipped (server error, no title).
+        $null if scraping should stop entirely (end of hymnal or persistent rate limiting).
+    #>
+    param(
+        [int]$Number,
+        [string]$BaseUrl,
+        [string]$HomeUrl
+    )
+
+    # Construct the hymn page URL using the query parameter format used by both sites
+    $url = "$BaseUrl`?no=$Number"
+
+    # Variable to hold the response object and raw content
+    $rawContent = $null
+    $finalUrl   = $null
+
+    # Retry loop: attempt up to 3 times on HTTP 500 errors
+    for ($attempt = 1; $attempt -le 3; $attempt++) {
+        try {
+            # Make the HTTP request with a polite User-Agent and 15-second timeout.
+            # -UseBasicParsing avoids dependency on Internet Explorer COM objects
+            # (required for PowerShell 5.1 compatibility on some systems).
+            # -MaximumRedirection 5 allows following redirects (needed to detect
+            # homepage redirects that signal end-of-hymnal).
+            $response = Invoke-WebRequest -Uri $url `
+                -UserAgent $script:USER_AGENT `
+                -TimeoutSec 15 `
+                -UseBasicParsing `
+                -MaximumRedirection 5 `
+                -ErrorAction Stop
+
+            # Capture the final URL after any redirects
+            # Invoke-WebRequest stores the base response URI which reflects redirects
+            $finalUrl = $response.BaseResponse.ResponseUri
+            if ($null -eq $finalUrl) {
+                # PowerShell 7+ uses a different property for the final URI
+                # The BaseResponse in PS7 is HttpResponseMessage, which has RequestMessage.RequestUri
+                try {
+                    $finalUrl = $response.BaseResponse.RequestMessage.RequestUri
+                }
+                catch {
+                    # Fallback: if we can't get the final URL, use the original
+                    $finalUrl = $url
+                }
+            }
+            $finalUrlStr = $finalUrl.ToString().TrimEnd("/")
+
+            # Check if the server redirected us to the homepage — this means
+            # the requested hymn number doesn't exist (we've gone past the
+            # end of the hymnal). We only check for number > 1 because
+            # hymn 1 should always exist.
+            if (-not $finalUrlStr.Contains("Hymn") -and $Number -gt 1) {
+                Write-Host ""
+                Write-Host "  Hymn ${Number}: redirected to home — reached end." -ForegroundColor Yellow
+                return $null  # Signal to stop scraping entirely
+            }
+
+            # Get the raw content as string
+            $rawContent = $response.Content
+            break  # Success — exit the retry loop
+        }
+        catch {
+            $errorRecord = $_
+
+            # Check if this is an HTTP error with a status code
+            $statusCode = 0
+            if ($errorRecord.Exception -is [System.Net.WebException]) {
+                $webResponse = $errorRecord.Exception.Response
+                if ($null -ne $webResponse) {
+                    $statusCode = [int]$webResponse.StatusCode
+                }
+            }
+            elseif ($errorRecord.Exception.Message -match '(\d{3})') {
+                # PowerShell 7+ may wrap the status code differently;
+                # try to extract it from the error message
+                $statusCode = [int]$Matches[1]
+            }
+
+            if ($statusCode -eq 500) {
+                # Server error — may be transient, so retry with backoff
+                if ($attempt -lt 3) {
+                    Write-Host "  Hymn ${Number}: server error (500), retrying ($attempt/3)..." -NoNewline -ForegroundColor Yellow
+                    Start-Sleep -Seconds 3  # Wait before retrying
+                }
+                else {
+                    # All 3 attempts failed — skip this hymn
+                    Write-Host "  server error (500) after 3 attempts." -ForegroundColor Red
+                    return "SKIP"
+                }
+            }
+            else {
+                # Other HTTP errors (404, 403, etc.) or network errors — don't retry, just skip
+                $errMsg = if ($statusCode -gt 0) { "HTTP $statusCode" } else { "error: $($errorRecord.Exception.Message)" }
+                Write-Host "  $errMsg" -ForegroundColor Red
+                return "SKIP"
+            }
+        }
+    }
+
+    # If rawContent is still null, all retry attempts were exhausted without success
+    if ($null -eq $rawContent) {
+        return "SKIP"
+    }
+
+    # Note on encoding: Invoke-WebRequest in PowerShell automatically handles
+    # content decoding based on the Content-Type header. The .Content property
+    # returns a decoded string. If the server doesn't specify encoding, PowerShell
+    # defaults to ISO-8859-1 (latin-1) which is a safe fallback (every byte maps
+    # to a valid character). This mirrors the Python version's UTF-8 → latin-1 fallback.
+    $htmlText = $rawContent
+
+    # --- Rate limit detection ---
+    # Both sites show a "reached limit for today" message when you've made
+    # too many requests. If detected, pause for 60 seconds and try once more.
+    $htmlLower = $htmlText.ToLower()
+    if ($htmlLower.Contains("reached limit for today") -or $htmlLower.Contains("we are sorry")) {
+        Write-Host "  rate limit hit — pausing 60s..." -ForegroundColor Magenta
+        Start-Sleep -Seconds 60
+
+        # One retry after the cooldown period
+        try {
+            $retryResponse = Invoke-WebRequest -Uri $url `
+                -UserAgent $script:USER_AGENT `
+                -TimeoutSec 15 `
+                -UseBasicParsing `
+                -MaximumRedirection 5 `
+                -ErrorAction Stop
+
+            $htmlText2 = $retryResponse.Content
+
+            # Check if we're still rate limited after waiting
+            if ($htmlText2.ToLower().Contains("reached limit for today")) {
+                Write-Host "  Still rate limited — stopping. Try again tomorrow." -ForegroundColor Red
+                return $null  # Stop entirely — no point continuing today
+            }
+
+            # Rate limit cleared — use the fresh response
+            $htmlText = $htmlText2
+        }
+        catch {
+            # Network error during retry — stop scraping
+            return $null
+        }
+    }
+
+    # Parse the HTML to extract hymn data
+    $parsed = Parse-HymnHtml -Html $htmlText
+
+    # Validate that the parser found a title (indicates a valid hymn page)
+    if (-not $parsed.title) {
+        Write-Host "  no title found." -ForegroundColor Red
+        return "SKIP"
+    }
+
+    # Return the structured hymn data
+    return @{
+        number   = $Number
+        title    = $parsed.title
+        sections = $parsed.sections
+    }
+}
+
+
+# ---------------------------------------------------------------------------
+# Per-site scrape loop — the main orchestration logic for one hymnal site
+# ---------------------------------------------------------------------------
+
+function Start-SiteScrape {
+    <#
+    .SYNOPSIS
+        Scrape all hymns from a single site (SDAH or CH).
+
+    .DESCRIPTION
+        This is the main loop that iterates through hymn numbers, fetches each
+        one, and saves it. It includes several features for robust operation:
+
+        - RESUMABILITY: Scans the output directory for existing files and skips
+          hymns that have already been saved (via Get-ExistingHymnNumbers).
+
+        - AUTO-DETECTION OF END: When the site redirects a hymn request to the
+          homepage (Fetch-Hymn returns $null), scraping stops.
+
+        - CONSECUTIVE SKIP LIMIT: If 10 hymns in a row fail (MAX_CONSEC = 10),
+          we assume we've gone past the end of the hymnal and stop.
+
+        - RATE LIMITING: Pauses for $Delay seconds between each request.
+
+    .PARAMETER SiteKey
+        Site identifier key from the SITES hashtable ("sdah" or "ch").
+
+    .PARAMETER StartNum
+        First hymn number to scrape (inclusive).
+
+    .PARAMETER EndNum
+        Last hymn number to scrape (inclusive), or 0 for auto-detect.
+
+    .PARAMETER OutputDir
+        Base output directory (a book-specific subdir will be created).
+
+    .PARAMETER DelaySeconds
+        Seconds to wait between HTTP requests.
+
+    .PARAMETER ForceMode
+        When $true, skip building the existing-hymn set and re-download
+        all hymns, overwriting any files already on disk.
+
+    .OUTPUTS
+        [int] Number of hymns successfully saved in this run.
+    #>
+    param(
+        [string]$SiteKey,
+        [int]$StartNum,
+        [int]$EndNum,
+        [string]$OutputDir,
+        [double]$DelaySeconds,
+        [bool]$ForceMode = $false
+    )
+
+    # Look up the site configuration for URLs, label, and subdirectory name
+    $siteConfig = $script:SITES[$SiteKey]
+    $label      = $siteConfig.label
+    $baseUrl    = $siteConfig.base_url
+    $homeUrl    = $siteConfig.home_url
+
+    # Route output into a book-specific subdirectory within the base output dir
+    # e.g. "./hymns/Seventh-day Adventist Hymnal [SDAH]/"
+    $bookDir = Join-Path -Path $OutputDir -ChildPath $siteConfig.subdir
+
+    # Resolve the full absolute path for display purposes
+    $bookDirFull = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($bookDir)
+
+    # Print a banner with configuration details for this scrape run
+    $separator = "=" * 50
+    Write-Host ""
+    Write-Host $separator -ForegroundColor Cyan
+    Write-Host "  Scraping: $baseUrl  [$label]" -ForegroundColor Cyan
+    Write-Host "  Output  : $bookDirFull" -ForegroundColor Cyan
+    $endDisplay = if ($EndNum -gt 0) { $EndNum } else { "auto-detect" }
+    Write-Host "  Range   : $StartNum to $endDisplay" -ForegroundColor Cyan
+    Write-Host $separator -ForegroundColor Cyan
+    Write-Host ""
+
+    # Scan the output directory for already-saved hymns to enable resumability.
+    # When force mode is active, skip the scan and use an empty set so that
+    # every hymn in the range is fetched fresh and existing files are overwritten.
+    if ($ForceMode) {
+        Write-Host "  Force mode: will re-download and overwrite existing files." -ForegroundColor Magenta
+        Write-Host ""
+        $existing = [System.Collections.Generic.HashSet[int]]::new()
+    }
+    else {
+        $existing = Get-ExistingHymnNumbers -Label $label -OutputDir $bookDir
+        if ($existing.Count -gt 0) {
+            Write-Host "  Found $($existing.Count) existing $label hymns — will skip." -ForegroundColor Green
+            Write-Host ""
+        }
+    }
+
+    # Counters for the final summary
+    $saved      = 0     # Successfully saved hymns
+    $skipped    = 0     # Hymns that were skipped due to errors
+    $number     = $StartNum  # Current hymn number being processed
+
+    # Consecutive skip detection: if we encounter MAX_CONSEC failures in a row,
+    # we assume we've gone past the end of the hymnal. This is a safety net
+    # for sites that don't redirect to the homepage for non-existent hymns.
+    $consecSkip = 0
+
+    while ($true) {
+        # Check if we've reached the user-specified end hymn
+        if ($EndNum -gt 0 -and $number -gt $EndNum) {
+            Write-Host ""
+            Write-Host "Reached end hymn ($EndNum). Done." -ForegroundColor Green
+            break
+        }
+
+        # Skip hymns that are already saved (detected during initial scan)
+        if ($existing.Contains($number)) {
+            Write-Host "  Hymn $($number.ToString().PadLeft(4)): >>  already exists, skipping." -ForegroundColor DarkGray
+            $number++
+            continue  # No delay needed — no network request was made
+        }
+
+        # Fetch and parse the hymn page
+        Write-Host "  Hymn $($number.ToString().PadLeft(4)): fetching..." -NoNewline
+
+        $hymn = Fetch-Hymn -Number $number -BaseUrl $baseUrl -HomeUrl $homeUrl
+
+        if ($null -eq $hymn) {
+            # The site redirected to the homepage — we've reached the end of
+            # the hymnal. This is the normal termination condition.
+            Write-Host ""
+            break
+        }
+
+        if ($hymn -eq "SKIP") {
+            # This hymn couldn't be scraped — log it and continue
+            Write-Host " X  skipped." -ForegroundColor Red
+            Write-SkipLog -Number $number -Label $label -Reason "fetch failed or no title found" -BookDir $bookDir
+            $skipped++
+            $consecSkip++
+
+            # Safety net: too many consecutive failures suggests we're past
+            # the end rather than hitting intermittent errors
+            if ($consecSkip -ge $script:MAX_CONSEC) {
+                Write-Host "  $($script:MAX_CONSEC) consecutive errors — assuming end of hymnal." -ForegroundColor Yellow
+                break
+            }
+
+            $number++
+            # Rate limit even on failures
+            Start-Sleep -Milliseconds ([int]($DelaySeconds * 1000))
+            continue
+        }
+
+        # Success — reset the consecutive skip counter and save the hymn
+        $consecSkip = 0
+        $path = Save-Hymn -Hymn $hymn -Label $label -OutputDir $bookDir
+        $saved++
+        $basename = Split-Path -Path $path -Leaf
+        Write-Host " OK  $basename" -ForegroundColor Green
+
+        $number++
+        # Rate limit between successful requests
+        Start-Sleep -Milliseconds ([int]($DelaySeconds * 1000))
+    }
+
+    # Print a summary for this site
+    Write-Host ""
+    Write-Host "${label}: $saved hymns saved, $skipped skipped." -ForegroundColor Cyan
+    return $saved
+}
+
+
+# ---------------------------------------------------------------------------
+# Show help — display usage information
+# ---------------------------------------------------------------------------
+
+function Show-Help {
+    <#
+    .SYNOPSIS
+        Display usage information and examples to the console.
+
+    .DESCRIPTION
+        Prints a formatted help screen with parameter descriptions, usage
+        examples, and output format details. Called when -Help is specified
+        or from the interactive menu.
+    #>
+
+    Write-Host ""
+    Write-Host "  SDAHymnals_SDAHymnal.org.ps1" -ForegroundColor White
+    Write-Host "  Hymnal Scraper — SDAH + CH (no modules required)" -ForegroundColor Gray
+    Write-Host "  Copyright 2025-2026 MWBM Partners Ltd." -ForegroundColor Gray
+    Write-Host ""
+    Write-Host "  PARAMETERS:" -ForegroundColor Yellow
+    Write-Host "    -Site <string>    Which site to scrape: sdah, ch, or both (default: both)"
+    Write-Host "    -Start <int>      First hymn number to scrape (default: 1)"
+    Write-Host "    -End <int>        Last hymn number to scrape (default: auto-detect)"
+    Write-Host "    -Output <string>  Output folder path (default: .\hymns)"
+    Write-Host "    -Delay <float>    Seconds between requests (default: 1.0)"
+    Write-Host "    -Force            Re-download all hymns, overwriting existing files"
+    Write-Host "    -Help / -?        Show this help message"
+    Write-Host ""
+    Write-Host "  EXAMPLES:" -ForegroundColor Yellow
+    Write-Host "    .\SDAHymnals_SDAHymnal.org.ps1                       # Both sites from hymn 1"
+    Write-Host "    .\SDAHymnals_SDAHymnal.org.ps1 -Site sdah            # Only sdahymnal.org"
+    Write-Host "    .\SDAHymnals_SDAHymnal.org.ps1 -Site ch              # Only hymnal.xyz"
+    Write-Host "    .\SDAHymnals_SDAHymnal.org.ps1 -Start 50             # Resume from hymn 50"
+    Write-Host "    .\SDAHymnals_SDAHymnal.org.ps1 -Start 1 -End 100    # Specific range"
+    Write-Host "    .\SDAHymnals_SDAHymnal.org.ps1 -Output ~\Desktop\hymns"
+    Write-Host "    .\SDAHymnals_SDAHymnal.org.ps1 -Delay 2.0           # Slower requests"
+    Write-Host "    .\SDAHymnals_SDAHymnal.org.ps1 -Force               # Overwrite existing files"
+    Write-Host ""
+    Write-Host "  OUTPUT:" -ForegroundColor Yellow
+    Write-Host "    Files are saved as plain text in book-specific subdirectories:"
+    Write-Host "      hymns\Seventh-day Adventist Hymnal [SDAH]\001 (SDAH) - Praise To The Lord.txt"
+    Write-Host "      hymns\The Church Hymnal [CH]\001 (CH) - Praise To The Lord.txt"
+    Write-Host ""
+    Write-Host "    The scraper is resumable — existing files are detected and skipped."
+    Write-Host "    Use -Force to re-download and overwrite existing files."
+    Write-Host "    Skipped hymns (errors, missing data) are logged to skipped.log."
+    Write-Host ""
+    Write-Host "  NOTES:" -ForegroundColor Yellow
+    Write-Host "    - No modules required — uses only PowerShell built-in cmdlets."
+    Write-Host "    - Both sites share the same HTML structure, so one parser handles both."
+    Write-Host "    - The scraper auto-detects the end of the hymnal (no -End needed)."
+    Write-Host "    - Rate limiting is handled automatically (pauses 60s, retries once)."
+    Write-Host "    - Use -Force to bypass the existing-file check and re-download everything."
+    Write-Host ""
+}
+
+
+# ---------------------------------------------------------------------------
+# Interactive menu — displayed when the script is double-clicked from Explorer
+# ---------------------------------------------------------------------------
+
+function Show-InteractiveMenu {
+    <#
+    .SYNOPSIS
+        Display an interactive menu when the script is run without CLI arguments.
+
+    .DESCRIPTION
+        When a PowerShell script is double-clicked from Windows Explorer, it
+        runs without any command-line arguments. This function detects that
+        scenario and presents a user-friendly menu that:
+        1. Shows the script name, description, and copyright
+        2. Displays help/usage information
+        3. Prompts the user for parameters (site, start, end, output, delay)
+        4. Offers an option to accept defaults and start immediately
+
+        Uses Read-Host for input and Write-Host with colors for the menu.
+        All input is validated before proceeding.
+
+    .OUTPUTS
+        [hashtable] with keys: Site, Start, End, Output, Delay
+        Represents the user's chosen configuration parameters.
+    #>
+
+    # Clear the screen for a clean presentation
+    Clear-Host
+
+    # -----------------------------------------------------------------------
+    # Header — script identification and copyright
+    # -----------------------------------------------------------------------
+    Write-Host ""
+    Write-Host "  ================================================================" -ForegroundColor Cyan
+    Write-Host "   SDAHymnals_SDAHymnal.org.ps1" -ForegroundColor White
+    Write-Host "   Hymnal Scraper — SDAH + CH" -ForegroundColor Gray
+    Write-Host "   Copyright 2025-2026 MWBM Partners Ltd." -ForegroundColor Gray
+    Write-Host "  ================================================================" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "  This scraper downloads hymn lyrics from sdahymnal.org (SDAH) and" -ForegroundColor White
+    Write-Host "  hymnal.xyz (CH) and saves them as plain-text files." -ForegroundColor White
+    Write-Host ""
+    Write-Host "  Features:" -ForegroundColor Yellow
+    Write-Host "    - Resumable: skips already-downloaded hymns"
+    Write-Host "    - Auto-detects end of hymnal"
+    Write-Host "    - Handles rate limiting and server errors"
+    Write-Host "    - Organised output in book-specific subdirectories"
+    Write-Host ""
+
+    # -----------------------------------------------------------------------
+    # Main menu — offer choices to the user
+    # -----------------------------------------------------------------------
+    # Track force mode state for the interactive menu (default: off).
+    # Only initialise on first call — subsequent recursive calls (e.g. after
+    # toggling force mode or showing help) preserve the current value.
+    if ($null -eq $script:interactiveForce) {
+        $script:interactiveForce = $false
+    }
+
+    Write-Host "  CURRENT SETTINGS:" -ForegroundColor Yellow
+    $forceDisplay = if ($script:interactiveForce) { "ON" } else { "OFF" }
+    Write-Host "    Force mode : $forceDisplay"
+    Write-Host ""
+    Write-Host "  OPTIONS:" -ForegroundColor Yellow
+    Write-Host "    [1] Start with default settings (both sites, from hymn 1)"
+    Write-Host "    [2] Configure parameters before starting"
+    Write-Host "    [3] Show detailed help"
+    Write-Host "    [4] Toggle force mode (currently: $forceDisplay)"
+    Write-Host "    [5] Exit"
+    Write-Host ""
+
+    $choice = Read-Host "  Enter your choice (1-5)"
+
+    switch ($choice) {
+        "3" {
+            # Show detailed help, then re-display the menu
+            Show-Help
+            Write-Host "  Press Enter to return to the menu..." -ForegroundColor Gray
+            Read-Host | Out-Null
+            return Show-InteractiveMenu
+        }
+        "4" {
+            # Toggle force mode on/off and re-display the menu
+            $script:interactiveForce = -not $script:interactiveForce
+            $state = if ($script:interactiveForce) { "ON" } else { "OFF" }
+            Write-Host ""
+            Write-Host "  Force mode toggled: $state" -ForegroundColor Magenta
+            Start-Sleep -Seconds 1
+            return Show-InteractiveMenu
+        }
+        "5" {
+            # User chose to exit
+            Write-Host ""
+            Write-Host "  Exiting. Goodbye!" -ForegroundColor Green
+            Write-Host ""
+            exit 0
+        }
+        "1" {
+            # Accept all defaults — return the default configuration
+            return @{
+                Site   = "both"
+                Start  = 1
+                End    = 0
+                Output = $script:DEFAULT_OUTPUT_DIR
+                Delay  = $script:DEFAULT_DELAY
+                Force  = $script:interactiveForce
+            }
+        }
+        "2" {
+            # Configure parameters interactively
+            Write-Host ""
+            Write-Host "  CONFIGURE PARAMETERS" -ForegroundColor Yellow
+            Write-Host "  (Press Enter to accept the default shown in brackets)" -ForegroundColor Gray
+            Write-Host ""
+
+            # --- Site selection ---
+            Write-Host "  Site to scrape:" -ForegroundColor White
+            Write-Host "    sdah  = sdahymnal.org (Seventh-day Adventist Hymnal)"
+            Write-Host "    ch    = hymnal.xyz (The Church Hymnal)"
+            Write-Host "    both  = both sites"
+            $siteInput = Read-Host "  Site [both]"
+            if ([string]::IsNullOrWhiteSpace($siteInput)) { $siteInput = "both" }
+            $siteInput = $siteInput.ToLower().Trim()
+            # Validate the site input
+            if ($siteInput -notin @("sdah", "ch", "both")) {
+                Write-Host "  Invalid site '$siteInput'. Using default: both" -ForegroundColor Red
+                $siteInput = "both"
+            }
+
+            # --- Start hymn number ---
+            $startInput = Read-Host "  Start hymn number [1]"
+            if ([string]::IsNullOrWhiteSpace($startInput)) { $startInput = "1" }
+            $startNum = 0
+            if (-not [int]::TryParse($startInput, [ref]$startNum) -or $startNum -lt 1) {
+                Write-Host "  Invalid start number '$startInput'. Using default: 1" -ForegroundColor Red
+                $startNum = 1
+            }
+
+            # --- End hymn number ---
+            $endInput = Read-Host "  End hymn number [auto-detect]"
+            $endNum = 0
+            if (-not [string]::IsNullOrWhiteSpace($endInput)) {
+                if (-not [int]::TryParse($endInput, [ref]$endNum) -or $endNum -lt 1) {
+                    Write-Host "  Invalid end number '$endInput'. Using auto-detect." -ForegroundColor Red
+                    $endNum = 0
+                }
+            }
+
+            # --- Output directory ---
+            $outputInput = Read-Host "  Output directory [.\hymns]"
+            if ([string]::IsNullOrWhiteSpace($outputInput)) { $outputInput = $script:DEFAULT_OUTPUT_DIR }
+
+            # --- Delay ---
+            $delayInput = Read-Host "  Delay between requests in seconds [1.0]"
+            $delayVal = 0.0
+            if ([string]::IsNullOrWhiteSpace($delayInput)) {
+                $delayVal = $script:DEFAULT_DELAY
+            }
+            elseif (-not [double]::TryParse($delayInput, [ref]$delayVal) -or $delayVal -lt 0) {
+                Write-Host "  Invalid delay '$delayInput'. Using default: 1.0" -ForegroundColor Red
+                $delayVal = $script:DEFAULT_DELAY
+            }
+
+            # --- Confirmation ---
+            Write-Host ""
+            Write-Host "  CONFIGURATION SUMMARY:" -ForegroundColor Yellow
+            Write-Host "    Site   : $siteInput"
+            Write-Host "    Start  : $startNum"
+            $endDisplay = if ($endNum -gt 0) { $endNum } else { "auto-detect" }
+            Write-Host "    End    : $endDisplay"
+            Write-Host "    Output : $outputInput"
+            Write-Host "    Delay  : $delayVal seconds"
+            $forceDisplay = if ($script:interactiveForce) { "ON" } else { "OFF" }
+            Write-Host "    Force  : $forceDisplay"
+            Write-Host ""
+            $confirm = Read-Host "  Proceed with these settings? (Y/n)"
+            if ($confirm -match "^[nN]") {
+                # User declined — re-show the menu
+                return Show-InteractiveMenu
+            }
+
+            return @{
+                Site   = $siteInput
+                Start  = $startNum
+                End    = $endNum
+                Output = $outputInput
+                Delay  = $delayVal
+                Force  = $script:interactiveForce
+            }
+        }
+        default {
+            # Invalid choice — re-show the menu
+            Write-Host "  Invalid choice. Please enter 1, 2, 3, 4, or 5." -ForegroundColor Red
+            Start-Sleep -Seconds 1
+            return Show-InteractiveMenu
+        }
+    }
+}
+
+
+# ===========================================================================
+# MAIN — Entry point: detect interactive vs CLI mode and start scraping
+# ===========================================================================
+
+# Show help if -Help switch was specified
+if ($Help) {
+    Show-Help
+    exit 0
+}
+
+# ---------------------------------------------------------------------------
+# Detect whether the script was invoked with CLI arguments or double-clicked.
+# If no meaningful parameters were provided (all at their default "empty"
+# values), we check the invocation context to decide whether to show the
+# interactive menu or proceed with defaults.
+#
+# The param block uses "empty" sentinel defaults (empty string for strings,
+# 0 for numbers) so we can distinguish "user didn't provide this parameter"
+# from "user explicitly set it to the default value".
+# ---------------------------------------------------------------------------
+
+# Check if ANY parameter was explicitly provided by the user on the command line
+$hasCliArgs = $PSBoundParameters.Count -gt 0
+
+if (-not $hasCliArgs) {
+    # No CLI arguments were provided. Determine if we're running interactively
+    # (e.g. double-clicked from Explorer) or in a non-interactive context
+    # (e.g. piped, scheduled task).
+    #
+    # [Environment]::UserInteractive checks if the process has a user interface.
+    # This is true when double-clicked from Explorer or run from a PowerShell
+    # console, but false in non-interactive contexts.
+    #
+    # We also check if stdin is redirected — if it is, we can't prompt for input.
+
+    $isInteractive = [Environment]::UserInteractive
+
+    # Additional check: if the script was launched directly (not from an existing
+    # PowerShell console), the parent process will be Explorer or similar.
+    # In that case, we definitely want the interactive menu.
+    # If running from a PowerShell console with no args, we still show the menu
+    # since the user might have just typed the script name without arguments.
+
+    if ($isInteractive) {
+        # Show the interactive menu and get user-chosen parameters
+        $config = Show-InteractiveMenu
+
+        # Apply the user's choices (including force mode from the interactive toggle)
+        $Site   = $config.Site
+        $Start  = $config.Start
+        $End    = $config.End
+        $Output = $config.Output
+        $Delay  = $config.Delay
+        $Force  = [switch]$config.Force
+    }
+    else {
+        # Non-interactive context — use all defaults silently
+        $Site   = "both"
+        $Start  = 1
+        $End    = 0
+        $Output = $script:DEFAULT_OUTPUT_DIR
+        $Delay  = $script:DEFAULT_DELAY
+    }
+}
+else {
+    # CLI arguments were provided — apply defaults for any parameters not specified.
+    # This handles partial argument sets like: -Site sdah (with Start, End, etc. unset)
+    if ([string]::IsNullOrEmpty($Site))   { $Site   = "both" }
+    if ($Start -eq 0)                     { $Start  = 1 }
+    # $End = 0 is the sentinel for "auto-detect" — no change needed
+    if ([string]::IsNullOrEmpty($Output)) { $Output = $script:DEFAULT_OUTPUT_DIR }
+    if ($Delay -eq 0)                     { $Delay  = $script:DEFAULT_DELAY }
+}
+
+# ---------------------------------------------------------------------------
+# Determine which sites to scrape based on the -Site argument
+# ---------------------------------------------------------------------------
+$sitesToRun = if ($Site -eq "both") {
+    @("sdah", "ch")
+}
+else {
+    @($Site)
+}
+
+# Accumulator for total hymns saved across all sites
+$total = 0
+
+# Scrape each site sequentially, accumulating the total saved count.
+# Pass the Force switch value as a boolean to the per-site scrape function.
+foreach ($siteKey in $sitesToRun) {
+    $total += Start-SiteScrape -SiteKey $siteKey `
+        -StartNum $Start `
+        -EndNum $End `
+        -OutputDir $Output `
+        -DelaySeconds $Delay `
+        -ForceMode ([bool]$Force)
+}
+
+# Resolve the full absolute path for the final summary message
+$outputFull = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Output)
+
+# Print the final summary
+Write-Host ""
+Write-Host "All done! $total hymns total saved to: $outputFull" -ForegroundColor Green
+Write-Host ""
+
+# ---------------------------------------------------------------------------
+# If the script was double-clicked (no CLI args in an interactive session),
+# pause before closing so the user can read the output. Without this, the
+# PowerShell window would close immediately after the script finishes.
+# ---------------------------------------------------------------------------
+if (-not $hasCliArgs -and [Environment]::UserInteractive) {
+    Write-Host "Press Enter to exit..." -ForegroundColor Gray
+    Read-Host | Out-Null
+}

--- a/.importers/scrapers/SDAHymnals_SDAHymnal.org.py
+++ b/.importers/scrapers/SDAHymnals_SDAHymnal.org.py
@@ -1,0 +1,968 @@
+#!/usr/bin/env python3
+"""
+SDAHymnals_SDAHymnal.org.py
+importers/scrapers/SDAHymnals_SDAHymnal.org.py
+
+Hymnal Scraper — scrapes both sdahymnal.org (SDAH) and hymnal.xyz (CH).
+Copyright 2025-2026 MWBM Partners Ltd.
+
+Overview:
+    This scraper fetches hymn lyrics from two Seventh-day Adventist hymnal
+    websites that share the same underlying codebase (identical HTML structure
+    and CSS class names). It iterates through hymn numbers sequentially,
+    parses the HTML to extract the title, section indicators (e.g. "Verse 1",
+    "Chorus"), and lyrics text, then saves each hymn as a plain-text file.
+
+    The scraper is designed to be resumable: it scans the output directory for
+    existing files on startup and skips hymns that have already been saved.
+    It also handles rate limiting, server errors, and auto-detects the end
+    of the hymnal when the site redirects to the homepage.
+
+Dependencies:
+    None — uses only Python standard library modules (no pip install needed).
+    This is intentional so the script can run on any system with Python 3.6+.
+
+Output format:
+    Each hymn is saved as a plain-text file with the naming convention:
+        {number zero-padded to 3 digits} ({LABEL}) - {Title Case Title}.txt
+    e.g.: "001 (SDAH) - Praise To The Lord.txt"
+
+    Files are organised into book-specific subdirectories:
+        hymns/Seventh-day Adventist Hymnal [SDAH]/
+        hymns/The Church Hymnal [CH]/
+
+Usage:
+    python3 sdah_scraper.py                         # Scrape both sites from hymn 1
+    python3 sdah_scraper.py --site sdah             # Only sdahymnal.org
+    python3 sdah_scraper.py --site ch               # Only hymnal.xyz
+    python3 sdah_scraper.py --start 50              # Resume from hymn 50
+    python3 sdah_scraper.py --start 1 --end 100     # Specific range
+    python3 sdah_scraper.py --output ~/Desktop/hymns
+"""
+
+# ---------------------------------------------------------------------------
+# Standard library imports (no third-party dependencies required)
+# ---------------------------------------------------------------------------
+import urllib.request   # For making HTTP requests to fetch hymn pages
+import urllib.error     # For handling HTTP error responses (404, 500, etc.)
+import html.parser      # Base class for our custom HTML parser (no BeautifulSoup needed)
+import sys
+
+# Force line-buffered stdout so progress messages appear immediately in the
+# terminal, even when output is piped or redirected to a file. Without this,
+# Python buffers stdout in block mode when not connected to a TTY, which
+# means the user wouldn't see real-time progress updates.
+sys.stdout.reconfigure(line_buffering=True)
+
+import os               # File system operations (makedirs, path joining, etc.)
+import re               # Regular expressions for text cleaning and parsing
+import time             # For rate-limiting delays between requests
+import argparse         # Command-line argument parsing
+
+
+# ---------------------------------------------------------------------------
+# Site configuration — both sites share the same HTML structure
+# ---------------------------------------------------------------------------
+# Both sdahymnal.org and hymnal.xyz are built on the same web platform,
+# so they use identical CSS class names and page layouts. This allows us
+# to use a single parser class (HymnParser) for both sites. Each site
+# entry defines:
+#   - base_url:  The hymn page URL template (hymn number passed as ?no=N)
+#   - home_url:  The site homepage (used to detect end-of-hymnal redirects)
+#   - label:     Short identifier used in output filenames, e.g. "SDAH"
+#   - subdir:    Human-readable subdirectory name for organised output
+#   - lang:      ISO 639-1 language code for the songbook's language (e.g. "en")
+SITES = {
+    "sdah": {
+        "base_url":  "https://www.sdahymnal.org/Hymn",
+        "home_url":  "https://www.sdahymnal.org",
+        "label":     "SDAH",
+        "subdir":    "Seventh-day Adventist Hymnal [SDAH]",
+        "lang":      "en",   # ISO 639-1: English
+    },
+    "ch": {
+        "base_url":  "https://www.hymnal.xyz/Hymn",
+        "home_url":  "https://www.hymnal.xyz",
+        "label":     "CH",
+        "subdir":    "The Church Hymnal [CH]",
+        "lang":      "en",   # ISO 639-1: English
+    },
+}
+
+# Default output directory (relative to where the script is run from)
+DEFAULT_OUTPUT_DIR = "./hymns"
+
+# Delay in seconds between HTTP requests to be respectful to the server
+# and avoid triggering rate limits. 1.0s is a reasonable balance between
+# speed and politeness.
+DELAY              = 1.0
+
+
+# ---------------------------------------------------------------------------
+# HTML Parser
+# ---------------------------------------------------------------------------
+# Both sdahymnal.org and hymnal.xyz share the same underlying codebase, so
+# they use identical CSS class names for their hymn page structure. This
+# parser navigates the DOM hierarchy using depth tracking to extract:
+#
+# 1. TITLE: Found inside a <strong> tag, nested within an <h3> with class
+#    "wedding-heading", which is itself inside a <div> with class
+#    "block-heading-four". We track this nested path using boolean flags
+#    and depth counters.
+#
+# 2. SECTION INDICATORS: Found in <div class="block-heading-three">.
+#    These are labels like "Verse 1", "Chorus", "Verse 2", etc.
+#
+# 3. LYRICS TEXT: Found in <div class="block-heading-five">.
+#    Line breaks within lyrics are represented by <br> tags, which we
+#    convert to newline characters.
+#
+# The parser pairs each indicator with its following lyrics block,
+# producing a list of (indicator, lyrics) tuples in self.sections.
+# ---------------------------------------------------------------------------
+
+class HymnParser(html.parser.HTMLParser):
+    """
+    Custom HTML parser for sdahymnal.org / hymnal.xyz hymn pages.
+
+    Extracts the hymn title and lyrics sections from the page HTML by
+    tracking specific CSS class names used by the site's template.
+
+    HTML structure being parsed:
+        <div class="block-heading-four">        ← title container
+            <h3 class="wedding-heading">        ← title wrapper
+                <strong>Hymn Title Here</strong> ← actual title text
+            </h3>
+        </div>
+        <div class="block-heading-three">       ← section indicator
+            Verse 1                              ← e.g. "Verse 1", "Chorus"
+        </div>
+        <div class="block-heading-five">        ← lyrics block
+            First line of lyrics<br>             ← <br> = line break
+            Second line of lyrics<br>
+        </div>
+
+    Attributes:
+        title (str):    The extracted hymn title (empty string if not found)
+        sections (list): List of (indicator, lyrics) tuples where:
+                         - indicator is a string like "Verse 1" or "" if none
+                         - lyrics is the verse text with \n for line breaks
+    """
+
+    def __init__(self):
+        super().__init__()
+        # --- Public output attributes ---
+        self.title      = ""    # The hymn title, extracted from <strong> in title path
+        self.sections   = []    # List of (indicator_text, lyrics_text) tuples
+
+        # --- Title extraction state ---
+        # The title is deeply nested: div.block-heading-four > *.wedding-heading > strong
+        # We need to track each nesting level to know when we've reached the <strong>.
+        self._in_bh4    = False  # True when inside a div.block-heading-four element
+        self._bh4_depth = 0      # Depth counter for tags inside block-heading-four;
+                                  # when this reaches 0 again, we've exited the container
+        self._in_wh     = False  # True when inside the .wedding-heading child element
+        self._wh_depth  = 0      # Depth counter for tags inside wedding-heading
+        self._in_strong = False  # True when inside the <strong> tag that holds the title
+
+        # --- Lyrics / indicator extraction state ---
+        # Indicators (div.block-heading-three) and lyrics (div.block-heading-five)
+        # are sibling elements. We process them sequentially: when we encounter
+        # an indicator, we store its text; when we encounter a lyrics block, we
+        # pair it with the most recently seen indicator.
+        self._current   = None   # Which section we're currently inside:
+                                  #   "indicator" (block-heading-three) or
+                                  #   "lyrics"    (block-heading-five) or
+                                  #   None        (not inside either)
+        self._depth     = 0      # Depth counter for tags inside the current section;
+                                  # when this reaches 0 we've exited the section div
+        self._buf       = []     # Text accumulation buffer for the current section
+        self._indicator = ""     # Stores the most recently parsed indicator text,
+                                  # to be paired with the next lyrics block
+
+    def _classes(self, attrs):
+        """
+        Extract CSS class names from an HTML tag's attribute list.
+
+        Args:
+            attrs: List of (name, value) tuples from the HTML parser
+
+        Returns:
+            List of class name strings (empty list if no class attribute)
+
+        Example:
+            attrs = [("class", "block-heading-four wedding-heading"), ("id", "h1")]
+            → ["block-heading-four", "wedding-heading"]
+        """
+        return dict(attrs).get("class", "").split()
+
+    def _flush(self):
+        """
+        Drain the text buffer and return its contents as a stripped string.
+
+        This is called when we've finished collecting text for a section
+        (title, indicator, or lyrics) and need to extract the accumulated text.
+
+        Returns:
+            str: The concatenated and stripped buffer contents
+        """
+        text = "".join(self._buf).strip()
+        self._buf = []
+        return text
+
+    def handle_starttag(self, tag, attrs):
+        """
+        Called by HTMLParser for each opening HTML tag.
+
+        This method handles two independent tracking paths:
+
+        1. TITLE PATH: Tracks entry into div.block-heading-four → *.wedding-heading
+           → <strong>, using nested boolean flags and depth counters.
+
+        2. LYRICS PATH: Detects div.block-heading-three (indicators) and
+           div.block-heading-five (lyrics), tracking their depth to know
+           when we've fully exited each container.
+
+        Args:
+            tag:   The HTML tag name (e.g. "div", "strong", "br")
+            attrs: List of (attribute_name, attribute_value) tuples
+        """
+        cls = self._classes(attrs)
+
+        # --- TITLE PATH ---
+        # Step 1: Enter the title container (div.block-heading-four)
+        if "block-heading-four" in cls:
+            self._in_bh4    = True
+            self._bh4_depth = 1       # We're 1 level deep (the container itself)
+        elif self._in_bh4:
+            # We're inside block-heading-four; track depth of nested tags
+            self._bh4_depth += 1
+
+            # Step 2: Look for the wedding-heading wrapper inside bh4
+            if "wedding-heading" in cls and not self._in_wh:
+                self._in_wh    = True
+                self._wh_depth = 0    # Will increment as child tags are encountered
+            elif self._in_wh:
+                # We're inside wedding-heading; track its child depth
+                self._wh_depth += 1
+
+                # Step 3: Look for the <strong> tag that contains the actual title
+                # Only capture if we haven't already found a title (first match wins)
+                if tag == "strong" and not self.title:
+                    self._in_strong = True
+
+        # --- LYRICS PATH ---
+        # If we're already inside a lyrics or indicator section, just track depth.
+        # Also convert <br> tags to newlines within lyrics blocks.
+        if self._current:
+            self._depth += 1
+            # Convert <br> tags to newline characters within lyrics sections
+            # (the site uses <br> for line breaks within verses)
+            if tag == "br" and self._current == "lyrics":
+                self._buf.append("\n")
+            return  # Don't check for new sections while inside one
+
+        # Check if this tag opens a new indicator or lyrics section
+        if "block-heading-three" in cls:
+            # Indicator section: contains text like "Verse 1", "Chorus", etc.
+            self._current = "indicator"
+            self._depth   = 1
+        elif "block-heading-five" in cls:
+            # Lyrics section: contains the actual hymn lyrics text
+            self._current = "lyrics"
+            self._depth   = 1
+
+    def handle_endtag(self, tag):
+        """
+        Called by HTMLParser for each closing HTML tag.
+
+        Manages depth tracking for both the title path and lyrics path.
+        When a section's depth reaches 0, we've fully exited it and can
+        process the accumulated text.
+
+        Args:
+            tag: The HTML tag name being closed
+        """
+        # --- TITLE PATH ---
+        # When the </strong> tag closes, extract the title text
+        if self._in_strong and tag == "strong":
+            self._in_strong = False
+            if not self.title:
+                # First <strong> inside the title path — this is our hymn title
+                self.title = self._flush()
+            else:
+                # Subsequent <strong> tags (shouldn't happen, but be safe) — discard
+                self._buf = []
+
+        # Track depth within block-heading-four to detect when we leave it
+        if self._in_bh4:
+            self._bh4_depth -= 1
+            if self._bh4_depth == 0:
+                # We've fully exited the block-heading-four container
+                self._in_bh4   = False
+                self._in_wh    = False
+                self._wh_depth = 0
+            elif self._in_wh and self._wh_depth > 0:
+                # Closing a child tag within wedding-heading
+                self._wh_depth -= 1
+
+        # --- LYRICS PATH ---
+        if not self._current:
+            return  # Not inside any lyrics/indicator section
+
+        self._depth -= 1
+        if self._depth == 0:
+            # We've fully exited the current section div — process the text
+            text = self._flush()
+
+            if self._current == "indicator":
+                # Store the indicator text (e.g. "Verse 1") to pair with
+                # the next lyrics block that follows it
+                self._indicator = text
+
+            elif self._current == "lyrics":
+                # Collapse runs of 3+ newlines down to 2 (clean up excessive whitespace
+                # that can occur from empty <br> tags in the source HTML)
+                text = re.sub(r'\n{3,}', '\n\n', text).strip()
+                # Pair this lyrics block with its indicator and add to sections list
+                self.sections.append((self._indicator, text))
+                # Reset indicator for the next verse (some verses may not have one)
+                self._indicator = ""
+
+            # Mark that we've exited the section
+            self._current = None
+
+    def handle_data(self, data):
+        """
+        Called by HTMLParser for plain text content between HTML tags.
+
+        Routes text to the appropriate buffer depending on what we're
+        currently tracking (title extraction vs lyrics/indicator content).
+
+        Args:
+            data: The text content string
+        """
+        if self._in_strong and not self.title:
+            # We're inside the <strong> tag in the title path — collect title text
+            self._buf.append(data)
+        elif self._current:
+            # We're inside an indicator or lyrics section — collect section text
+            self._buf.append(data)
+
+    def _entity_char(self, name=None, num=None):
+        """
+        Convert an HTML entity to its Unicode character equivalent.
+
+        Handles both named entities (e.g. &amp;, &rsquo;) and numeric
+        character references (e.g. &#8217;, &#x2019;). This is needed
+        because html.parser doesn't automatically convert all entities
+        to characters — we need to handle them manually to preserve
+        special characters like smart quotes and em dashes in the lyrics.
+
+        Args:
+            name: Named entity string (e.g. "amp", "rsquo") — mutually
+                  exclusive with num
+            num:  Numeric character code (e.g. 8217 for right single quote)
+
+        Returns:
+            str: The corresponding Unicode character, or "" if not recognised
+        """
+        # Handle numeric character references (e.g. &#8217; or &#x2019;)
+        if num is not None:
+            # Windows-1252 remapping: code points 128–159 are C1 control
+            # characters in Unicode, but many legacy web pages use them to
+            # mean the Windows-1252 characters (smart quotes, dashes, etc.).
+            # Web browsers perform this remapping automatically; we do the
+            # same here so that &#145; becomes a left single quote, etc.
+            # Reference: https://html.spec.whatwg.org/#numeric-character-reference-end-state
+            _WIN1252_MAP = {
+                145: "\u2018",  # left single quotation mark
+                146: "\u2019",  # right single quotation mark
+                147: "\u201c",  # left double quotation mark
+                148: "\u201d",  # right double quotation mark
+                150: "\u2013",  # en dash
+                151: "\u2014",  # em dash
+            }
+            if num in _WIN1252_MAP:
+                return _WIN1252_MAP[num]
+            try:
+                return chr(num)
+            except (ValueError, OverflowError):
+                return ""
+
+        # Handle named entities — map common HTML entities to their characters
+        # This covers the most frequently encountered entities in hymn lyrics:
+        # standard XML entities, typographic quotes, and dashes
+        entities = {
+            "amp": "&", "lt": "<", "gt": ">", "quot": '"', "apos": "'",
+            "nbsp": " ",                                # non-breaking space → regular space
+            "rsquo": "\u2019", "lsquo": "\u2018",      # right/left single smart quotes
+            "rdquo": "\u201d", "ldquo": "\u201c",      # right/left double smart quotes
+            "mdash": "\u2014", "ndash": "\u2013",      # em dash (—) and en dash (–)
+        }
+        return entities.get(name, "")
+
+    def handle_entityref(self, name):
+        """
+        Called by HTMLParser for named HTML entities like &amp; or &rsquo;.
+
+        Converts the entity to a character and appends it to the appropriate
+        buffer if we're currently collecting text (title or lyrics section).
+
+        Args:
+            name: The entity name without & and ; (e.g. "amp", "rsquo")
+        """
+        ch = self._entity_char(name=name)
+        if ch:
+            # Route the character to the correct buffer based on parsing state
+            if self._in_strong and not self.title:
+                self._buf.append(ch)
+            elif self._current:
+                self._buf.append(ch)
+
+    def handle_charref(self, name):
+        """
+        Called by HTMLParser for numeric character references like &#8217; or &#x2019;.
+
+        Parses the numeric value (decimal or hex), converts it to a character,
+        and appends it to the appropriate buffer.
+
+        Args:
+            name: The character reference without &# and ; (e.g. "8217" or "x2019")
+        """
+        try:
+            # Hex references start with 'x' (e.g. &#x2019;), others are decimal
+            num = int(name[1:], 16) if name.startswith("x") else int(name)
+        except ValueError:
+            return  # Malformed character reference — skip it
+        ch = self._entity_char(num=num)
+        if ch:
+            # Route the character to the correct buffer based on parsing state
+            if self._in_strong and not self.title:
+                self._buf.append(ch)
+            elif self._current:
+                self._buf.append(ch)
+
+
+# ---------------------------------------------------------------------------
+# Fetch & parse — HTTP request handling and hymn data extraction
+# ---------------------------------------------------------------------------
+
+def fetch_hymn(number, base_url, home_url):
+    """
+    Fetch a single hymn page from the website and parse it into structured data.
+
+    Makes an HTTP GET request to the hymn URL, handles various error conditions
+    (server errors, rate limiting, redirects), and returns parsed hymn data.
+
+    The function includes several resilience features:
+    - Retries up to 3 times on HTTP 500 errors (with 3-second delays)
+    - Detects rate-limiting pages and pauses 60 seconds before retrying
+    - Detects end-of-hymnal by checking if the site redirects to the homepage
+    - Falls back to latin-1 encoding if UTF-8 decoding fails
+
+    Args:
+        number:   The hymn number to fetch (e.g. 1, 42, 695)
+        base_url: The site's hymn page base URL (e.g. "https://www.sdahymnal.org/Hymn")
+        home_url: The site's homepage URL (used to detect end-of-hymnal redirects)
+
+    Returns:
+        dict:  {"number": int, "title": str, "sections": [(indicator, lyrics), ...]}
+               on success
+        "SKIP": If the hymn should be skipped (server error, no title found)
+        None:   If scraping should stop entirely (reached end of hymnal or
+                persistent rate limiting)
+    """
+    # Construct the hymn page URL using the query parameter format used by both sites
+    url = f"{base_url}?no={number}"
+
+    # Create a request with a polite User-Agent identifying the scraper
+    req = urllib.request.Request(
+        url,
+        headers={"User-Agent": "Mozilla/5.0 (compatible; HymnScraper/2.0; personal use)"}
+    )
+
+    raw = None  # Will hold the raw response bytes if the request succeeds
+
+    # Retry loop: attempt up to 3 times on HTTP 500 errors
+    for attempt in range(1, 4):
+        try:
+            with urllib.request.urlopen(req, timeout=15) as resp:
+                # Check if the server redirected us to the homepage — this means
+                # the requested hymn number doesn't exist (we've gone past the
+                # end of the hymnal). We only check for number > 1 because
+                # hymn 1 should always exist.
+                final_url = resp.url.rstrip("/")
+                if "Hymn" not in final_url and number > 1:
+                    print(f"\n  Hymn {number}: redirected to home — reached end.")
+                    return None  # Signal to stop scraping entirely
+
+                raw = resp.read()
+            break  # Success — exit the retry loop
+
+        except urllib.error.HTTPError as e:
+            if e.code == 500:
+                # Server error — may be transient, so retry with backoff
+                if attempt < 3:
+                    print(f"  Hymn {number}: server error (500), retrying ({attempt}/3)...", end=" ", flush=True)
+                    time.sleep(3)  # Wait before retrying
+                else:
+                    # All 3 attempts failed — skip this hymn
+                    print(f"  server error (500) after 3 attempts.")
+                    return "SKIP"
+            else:
+                # Other HTTP errors (404, 403, etc.) — don't retry, just skip
+                print(f"  HTTP {e.code}.")
+                return "SKIP"
+
+        except Exception as e:
+            # Network errors, timeouts, etc. — skip this hymn
+            print(f"  error: {e}")
+            return "SKIP"
+
+    # If raw is still None, all retry attempts were exhausted without success
+    if raw is None:
+        return "SKIP"
+
+    # Decode the response bytes to text. Try UTF-8 first (standard for modern
+    # websites), fall back to latin-1 if UTF-8 fails (latin-1 never raises
+    # errors as every byte maps to a valid character).
+    try:
+        html_text = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        html_text = raw.decode("latin-1")
+
+    # Parse the HTML to extract hymn data
+    parser = HymnParser()
+    parser.feed(html_text)
+
+    # --- Rate limit detection ---
+    # Both sites show a "reached limit for today" message when you've made
+    # too many requests. If detected, pause for 60 seconds and try once more.
+    if "reached limit for today" in html_text.lower() or "we are sorry" in html_text.lower():
+        print(f"  rate limit hit — pausing 60s...", flush=True)
+        time.sleep(60)
+
+        # One retry after the cooldown period
+        try:
+            with urllib.request.urlopen(req, timeout=15) as resp:
+                raw2 = resp.read()
+            html_text2 = raw2.decode("utf-8", errors="replace")
+
+            # Check if we're still rate limited after waiting
+            if "reached limit for today" in html_text2.lower():
+                print(f"  Still rate limited — stopping. Try again tomorrow.")
+                return None   # Stop entirely — no point continuing today
+
+            # Rate limit cleared — re-parse with the fresh response
+            html_text = html_text2
+            parser = HymnParser()
+            parser.feed(html_text)
+        except Exception:
+            return None  # Network error during retry — stop scraping
+
+    # Validate that the parser found a title (indicates a valid hymn page)
+    if not parser.title:
+        print(f"  no title found.")
+        return "SKIP"
+
+    # Return the structured hymn data
+    return {"number": number, "title": parser.title, "sections": parser.sections}
+
+
+# ---------------------------------------------------------------------------
+# Format & save — text formatting and file output
+# ---------------------------------------------------------------------------
+
+def format_hymn(hymn):
+    """
+    Format a parsed hymn dict into a clean plain-text string for saving.
+
+    The output format is:
+        "Hymn Title"
+                                    ← blank line after title
+        Verse 1                     ← indicator (if present)
+        First line of lyrics        ← lyrics text
+        Second line of lyrics
+                                    ← blank line between sections
+        Chorus                      ← next indicator
+        Chorus lyrics here
+        ...
+
+    Args:
+        hymn: Dict with keys "title" (str) and "sections" (list of tuples).
+              Each section tuple is (indicator_str, lyrics_str).
+
+    Returns:
+        str: The formatted plain-text hymn content
+    """
+    # Start with the quoted title and a blank line
+    lines = [f'"{hymn["title"]}"', ""]
+
+    # Append each section (indicator + lyrics) with blank line separators
+    for indicator, lyrics in hymn["sections"]:
+        if indicator:
+            lines.append(indicator)   # e.g. "Verse 1", "Chorus"
+        if lyrics:
+            lines.append(lyrics)      # The verse/chorus text
+        lines.append("")              # Blank line between sections
+
+    # Remove trailing blank lines (cleaner file ending)
+    while lines and lines[-1] == "":
+        lines.pop()
+
+    return "\n".join(lines)
+
+
+def sanitize(name):
+    """
+    Remove characters that are invalid in filenames across operating systems.
+
+    Strips the following characters which are forbidden in Windows filenames
+    and/or could cause issues on other platforms:
+        \\ / * ? : " < > |
+
+    Args:
+        name: The raw string to sanitize (typically a hymn title)
+
+    Returns:
+        str: The sanitized string with invalid characters removed and
+             leading/trailing whitespace stripped
+    """
+    return re.sub(r'[\\/*?:"<>|]', "", name).strip()
+
+
+def title_case(s):
+    """
+    Convert a string to Title Case, with correct handling of apostrophes.
+
+    Python's built-in str.title() method treats apostrophes as word boundaries,
+    producing incorrect results like "Don'T" instead of "Don't". This function
+    uses a regex to match whole words (including apostrophe contractions like
+    "don't", "it's", "o'er") and capitalises each word correctly.
+
+    The regex matches:
+        [a-zA-Z]+              One or more letters (the main word)
+        (['\u2019\u2018]       Optionally an apostrophe (ASCII ', right ' or left ')
+         [a-zA-Z]+)?           followed by more letters (contraction suffix)
+
+    We include Unicode curly/smart apostrophes (\u2019 RIGHT SINGLE QUOTATION
+    MARK and \u2018 LEFT SINGLE QUOTATION MARK) because the HTML entity decoder
+    converts &rsquo; to \u2019. Without this, "Eagle\u2019s" would be split into
+    separate words, producing "Eagle'S" instead of "Eagle's".
+
+    str.capitalize() is used on each match, which uppercases the first char
+    and lowercases the rest — perfect for Title Case.
+
+    Args:
+        s: The input string to convert
+
+    Returns:
+        str: The Title Cased string
+
+    Examples:
+        "AMAZING GRACE"      → "Amazing Grace"
+        "don't let me down"  → "Don't Let Me Down"
+        "o'er the hills"     → "O'er The Hills"
+        "EAGLE\u2019S WINGS" → "Eagle\u2019s Wings"
+    """
+    return re.sub(r"[a-zA-Z]+(['\u2019\u2018][a-zA-Z]+)?", lambda m: m.group(0).capitalize(), s)
+
+
+def build_existing_set(label, output_dir):
+    """
+    Scan the output directory to find hymn numbers that have already been saved.
+
+    This enables the scraper to resume from where it left off without
+    re-downloading hymns. It looks for files matching the naming pattern
+    "{number} ({label}) - {title}.txt" and extracts the hymn number from
+    each matching filename.
+
+    Args:
+        label:      The book label to filter by (e.g. "SDAH", "CH")
+        output_dir: Path to the directory to scan for existing files
+
+    Returns:
+        set: A set of integers representing hymn numbers already saved.
+             Empty set if the directory doesn't exist or has no matching files.
+
+    Example:
+        If output_dir contains:
+            "001 (SDAH) - Praise To The Lord.txt"
+            "042 (SDAH) - A Mighty Fortress.txt"
+        Returns: {1, 42}
+    """
+    existing = set()
+    if os.path.isdir(output_dir):
+        # Build the prefix tag to filter files belonging to this specific book
+        prefix_tag = f"({label}) -"
+        for fname in os.listdir(output_dir):
+            # Match files that contain the book label and have .txt extension
+            if prefix_tag in fname and fname.endswith(".txt"):
+                # Extract the hymn number from the start of the filename
+                # (the zero-padded number before the first space)
+                num_str = fname.split()[0]
+                if num_str.isdigit():
+                    existing.add(int(num_str))
+    return existing
+
+
+def save_hymn(hymn, label, output_dir):
+    """
+    Save a parsed hymn to a plain-text file in the output directory.
+
+    Creates the output directory if it doesn't exist, formats the hymn
+    content, and writes it to a file with the standard naming convention:
+        {number zero-padded to 3} ({label}) - {Title Case Title}.txt
+
+    Args:
+        hymn:       Dict with "number" (int), "title" (str), and "sections" (list)
+        label:      Book label for the filename (e.g. "SDAH", "CH")
+        output_dir: Directory path where the file should be saved
+
+    Returns:
+        str: The full file path of the saved file
+    """
+    # Ensure the output directory exists (creates parent dirs too if needed)
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Zero-pad the hymn number to 3 digits for consistent sorting
+    # (e.g. 1 → "001", 42 → "042", 695 → "695")
+    padded = str(hymn["number"]).zfill(3)
+
+    # Build the filename: sanitize the title to remove invalid chars,
+    # then convert to Title Case for consistent, readable filenames
+    filename = f"{padded} ({label}) - {title_case(sanitize(hymn['title']))}.txt"
+    filepath = os.path.join(output_dir, filename)
+
+    # Write the formatted hymn text to the file
+    with open(filepath, "w", encoding="utf-8") as f:
+        f.write(format_hymn(hymn))
+
+    return filepath
+
+
+def log_skip(number, label, reason, book_dir):
+    """
+    Record a skipped hymn entry in the skipped.log file for later review.
+
+    This creates a persistent log of hymns that couldn't be scraped,
+    along with the reason and timestamp. Useful for identifying gaps
+    in the collection and diagnosing systematic issues.
+
+    Args:
+        number:   The hymn number that was skipped
+        label:    Book label (e.g. "SDAH", "CH")
+        reason:   Human-readable explanation of why it was skipped
+        book_dir: Directory path where the log file should be written
+
+    Log format (one line per skipped hymn):
+        [2026-03-13 14:30:00]  SDAH042  —  fetch failed or no title found
+    """
+    # Ensure the directory exists (in case this is the first file we're writing)
+    os.makedirs(book_dir, exist_ok=True)
+    log_path  = os.path.join(book_dir, "skipped.log")
+    timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
+    padded    = str(number).zfill(3)
+    with open(log_path, "a", encoding="utf-8") as f:
+        f.write(f"[{timestamp}]  {label}{padded}  —  {reason}\n")
+
+
+# ---------------------------------------------------------------------------
+# Per-site scrape loop — the main orchestration logic for one hymnal site
+# ---------------------------------------------------------------------------
+
+
+def scrape_site(site_key, start, end, output_dir, delay, force=False):
+    """
+    Scrape all hymns from a single site (SDAH or CH).
+
+    This is the main loop that iterates through hymn numbers, fetches each
+    one, and saves it. It includes several features for robust operation:
+
+    - RESUMABILITY: Scans the output directory for existing files and skips
+      hymns that have already been saved (via build_existing_set).
+
+    - AUTO-DETECTION OF END: When the site redirects a hymn request to the
+      homepage (fetch_hymn returns None), scraping stops — the hymnal has
+      no more hymns beyond this point.
+
+    - CONSECUTIVE SKIP LIMIT: If 10 hymns in a row fail (MAX_CONSEC = 10),
+      we assume we've gone past the end of the hymnal and stop. This handles
+      the case where the site returns errors rather than redirects for
+      non-existent hymns.
+
+    - RATE LIMITING: Pauses for `delay` seconds between each request.
+
+    Args:
+        site_key:   Site identifier key from the SITES dict ("sdah" or "ch")
+        start:      First hymn number to scrape (inclusive)
+        end:        Last hymn number to scrape (inclusive), or None for auto-detect
+        output_dir: Base output directory (a book-specific subdir will be created)
+        delay:      Seconds to wait between HTTP requests
+        force:      If True, re-download and overwrite existing files
+
+    Returns:
+        int: Number of hymns successfully saved in this run
+    """
+    # Look up the site configuration for URLs, label, and subdirectory name
+    site     = SITES[site_key]
+    label    = site["label"]
+    base_url = site["base_url"]
+    home_url = site["home_url"]
+
+    # Route output into a book-specific subdirectory within the base output dir
+    # e.g. "./hymns/Seventh-day Adventist Hymnal [SDAH]/"
+    book_dir = os.path.join(output_dir, site["subdir"])
+
+    # Print a banner with configuration details for this scrape run
+    print(f"\n{'='*50}")
+    print(f"  Scraping: {base_url}  [{label}]")
+    print(f"  Output  : {os.path.abspath(book_dir)}")
+    print(f"  Range   : {start} to {end or 'auto-detect'}")
+    print(f"{'='*50}\n")
+
+    # Scan the output directory for already-saved hymns to enable resumability.
+    # When --force is set, we skip this check and re-download everything.
+    existing     = set() if force else build_existing_set(label, book_dir)
+    if force:
+        print(f"  Force mode: will re-download and overwrite existing files.\n")
+    elif existing:
+        print(f"  Found {len(existing)} existing {label} hymns — will skip.\n")
+
+    # Counters for the final summary
+    saved        = 0     # Successfully saved hymns
+    skipped      = 0     # Hymns that were skipped due to errors
+    number       = start # Current hymn number being processed
+
+    # Consecutive skip detection: if we encounter MAX_CONSEC failures in a row,
+    # we assume we've gone past the end of the hymnal. This is a safety net
+    # for sites that don't redirect to the homepage for non-existent hymns.
+    MAX_CONSEC   = 10
+    consec_skip  = 0
+
+    while True:
+        # Check if we've reached the user-specified end hymn
+        if end and number > end:
+            print(f"\nReached end hymn ({end}). Done.")
+            break
+
+        # Skip hymns that are already saved (detected during initial scan)
+        if number in existing:
+            print(f"  Hymn {number:>4}: ⏭  already exists, skipping.")
+            number += 1
+            continue  # No delay needed — no network request was made
+
+        # Fetch and parse the hymn page
+        print(f"  Hymn {number:>4}: fetching...", end=" ", flush=True)
+        hymn = fetch_hymn(number, base_url, home_url)
+
+        if hymn is None:
+            # The site redirected to the homepage — we've reached the end of
+            # the hymnal. This is the normal termination condition.
+            print()
+            break
+
+        if hymn == "SKIP":
+            # This hymn couldn't be scraped — log it and continue
+            print("✗  skipped.")
+            log_skip(number, label, "fetch failed or no title found", book_dir)
+            skipped     += 1
+            consec_skip += 1
+
+            # Safety net: too many consecutive failures suggests we're past
+            # the end rather than hitting intermittent errors
+            if consec_skip >= MAX_CONSEC:
+                print(f"  {MAX_CONSEC} consecutive errors — assuming end of hymnal.")
+                break
+
+            number += 1
+            time.sleep(delay)   # Rate limit even on failures
+            continue
+
+        # Success — reset the consecutive skip counter and save the hymn
+        consec_skip = 0
+        path = save_hymn(hymn, label, book_dir)
+        saved += 1
+        print(f"✓  {os.path.basename(path)}")
+
+        number += 1
+        time.sleep(delay)  # Rate limit between successful requests
+
+    # Print a summary for this site
+    print(f"\n{label}: {saved} hymns saved, {skipped} skipped.")
+    return saved
+
+
+# ---------------------------------------------------------------------------
+# Main — CLI entry point and argument parsing
+# ---------------------------------------------------------------------------
+
+def main():
+    """
+    Parse command-line arguments and orchestrate the scraping process.
+
+    Supports scraping one or both sites, specifying a hymn number range,
+    custom output directory, and adjustable request delay. If --site is
+    "both" (the default), scrapes SDAH first, then CH sequentially.
+    """
+    # Support -? as an alias for --help (common on Windows and DOS-style CLIs).
+    # We intercept it here because argparse doesn't natively support '?' in
+    # option strings. Note: users may need to quote or escape -? in their shell
+    # (e.g. '-?' or -\?) since ? is a glob wildcard character in most shells.
+    if "-?" in sys.argv:
+        sys.argv[sys.argv.index("-?")] = "--help"
+
+    ap = argparse.ArgumentParser(
+        description="Hymnal scraper — SDAH + CH (no pip required)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""examples:
+  python3 %(prog)s                         Scrape both sites from hymn 1
+  python3 %(prog)s --site sdah             Only scrape sdahymnal.org (SDAH)
+  python3 %(prog)s --site ch               Only scrape hymnal.xyz (CH)
+  python3 %(prog)s --start 50              Resume scraping from hymn 50
+  python3 %(prog)s --start 1 --end 100     Scrape a specific range of hymns
+  python3 %(prog)s --output ~/Desktop/hymns
+                                           Save output to a custom folder
+  python3 %(prog)s --delay 2.0             Increase delay to 2s between requests
+
+output:
+  Files are saved as plain text in book-specific subdirectories:
+    hymns/Seventh-day Adventist Hymnal [SDAH]/001 (SDAH) - Praise To The Lord.txt
+    hymns/The Church Hymnal [CH]/001 (CH) - Praise To The Lord.txt
+
+  The scraper is resumable — existing files are detected and skipped.
+  Skipped hymns (errors, missing data) are logged to skipped.log.
+
+notes:
+  - No dependencies required — uses only Python standard library modules.
+  - Both sites share the same HTML structure, so one parser handles both.
+  - The scraper auto-detects the end of the hymnal (no --end needed).
+  - Rate limiting is handled automatically (pauses 60s, retries once).""")
+    ap.add_argument("--site",   choices=["sdah", "ch", "both"], default="both",
+                    help="which site to scrape (default: both)")
+    ap.add_argument("--start",  type=int,   default=1,
+                    help="first hymn number to scrape (default: 1)")
+    ap.add_argument("--end",    type=int,   default=None,
+                    help="last hymn number to scrape (default: auto-detect end of hymnal)")
+    ap.add_argument("--output", type=str,   default=DEFAULT_OUTPUT_DIR,
+                    help="output folder path (default: ./hymns)")
+    ap.add_argument("--delay",  type=float, default=DELAY,
+                    help="seconds to wait between HTTP requests (default: 1.0)")
+    ap.add_argument("--force",  action="store_true", default=False,
+                    help="force re-download of all hymns, even if files already exist")
+    args = ap.parse_args()
+
+    # Determine which sites to scrape based on the --site argument
+    sites_to_run = ["sdah", "ch"] if args.site == "both" else [args.site]
+    total = 0
+
+    # Scrape each site sequentially, accumulating the total saved count
+    for site_key in sites_to_run:
+        total += scrape_site(site_key, args.start, args.end, args.output, args.delay, args.force)
+
+    print(f"\nAll done! {total} hymns total saved to: {os.path.abspath(args.output)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/appWeb/public_html/.htaccess
+++ b/appWeb/public_html/.htaccess
@@ -61,6 +61,9 @@ RewriteRule (^|/)\.(?!well-known) - [F,L]
 
 RewriteRule ^api$ api.php [QSA,L]
 
+# /og-image → og-image.php (hides PHP extension from OG meta tags)
+RewriteRule ^og-image$ og-image.php [QSA,L]
+
 # ==========================================================================
 # SERVICE WORKER ROUTING (#81)
 #

--- a/appWeb/public_html/includes/SongData.php
+++ b/appWeb/public_html/includes/SongData.php
@@ -69,17 +69,55 @@ function toTitleCase(string $str): string
 
 class SongData
 {
-    /** MySQLi connection */
-    private mysqli $db;
+    /** MySQLi connection (null when using JSON fallback) */
+    private ?mysqli $db = null;
+
+    /** JSON fallback data (used when MySQL is not configured) */
+    private ?array $jsonData = null;
+
+    /** Whether we're using JSON fallback mode */
+    private bool $jsonMode = false;
 
     /**
-     * Constructor — establishes MySQL connection.
+     * Constructor — connects to MySQL, or falls back to JSON file.
      *
-     * @throws RuntimeException If the database connection fails
+     * When MySQL credentials are not configured (e.g., fresh deployment
+     * before database setup), the class falls back to reading songs.json
+     * so the app remains functional.
      */
     public function __construct()
     {
-        $this->db = getDbMysqli();
+        try {
+            $this->db = getDbMysqli();
+        } catch (\Throwable $e) {
+            /* MySQL not available — fall back to JSON file */
+            $this->jsonMode = true;
+            $this->_loadJsonFallback();
+        }
+    }
+
+    /**
+     * Load song data from the JSON file as a fallback.
+     */
+    private function _loadJsonFallback(): void
+    {
+        $candidates = [
+            defined('APP_DATA_FILE') ? APP_DATA_FILE : '',
+            dirname(__DIR__, 2) . '/data_share/song_data/songs.json',
+            dirname(__DIR__, 3) . '/data/songs.json',
+        ];
+
+        foreach ($candidates as $path) {
+            if ($path !== '' && file_exists($path)) {
+                $json = file_get_contents($path);
+                if ($json !== false) {
+                    $this->jsonData = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+                    return;
+                }
+            }
+        }
+
+        throw new \RuntimeException('Song data not available: MySQL not configured and songs.json not found.');
     }
 
     /* =====================================================================
@@ -93,6 +131,10 @@ class SongData
      */
     public function getMeta(): array
     {
+        if ($this->jsonMode) {
+            return $this->jsonData['meta'] ?? [];
+        }
+
         $stmt = $this->db->prepare("SELECT COUNT(*) AS total FROM tblSongs");
         $stmt->execute();
         $result = $stmt->get_result();
@@ -124,6 +166,12 @@ class SongData
      */
     public function getSongbooks(): array
     {
+        if ($this->jsonMode) {
+            $books = $this->jsonData['songbooks'] ?? [];
+            usort($books, fn($a, $b) => strcmp($a['name'] ?? '', $b['name'] ?? ''));
+            return $books;
+        }
+
         $stmt = $this->db->prepare(
             "SELECT Abbreviation AS id, Name AS name, SongCount AS songCount
              FROM tblSongbooks
@@ -149,6 +197,12 @@ class SongData
     public function getSongbook(string $id): ?array
     {
         $id = strtoupper(trim($id));
+        if ($this->jsonMode) {
+            foreach ($this->jsonData['songbooks'] ?? [] as $book) {
+                if (strtoupper($book['id']) === $id) return $book;
+            }
+            return null;
+        }
         $stmt = $this->db->prepare(
             "SELECT Abbreviation AS id, Name AS name, SongCount AS songCount
              FROM tblSongbooks
@@ -182,6 +236,15 @@ class SongData
      */
     public function getSongs(?string $songbookId = null): array
     {
+        if ($this->jsonMode) {
+            $songs = $this->jsonData['songs'] ?? [];
+            if ($songbookId !== null) {
+                $songbookId = strtoupper(trim($songbookId));
+                $songs = array_values(array_filter($songs, fn($s) => strtoupper($s['songbook']) === $songbookId));
+            }
+            return $songs;
+        }
+
         $where = [];
         $params = [];
         $types = '';
@@ -251,6 +314,16 @@ class SongData
     {
         $id = strtoupper(trim($id));
 
+        if ($this->jsonMode) {
+            foreach ($this->jsonData['songs'] ?? [] as $song) {
+                if (strtoupper($song['id']) === $id) return $song;
+            }
+            if (preg_match('/^([A-Z]+)-0*(\d+)$/', $id, $m)) {
+                return $this->getSongByNumber($m[1], (int)$m[2]);
+            }
+            return null;
+        }
+
         /* Try exact match first (fast path) */
         $song = $this->_fetchSongRow($id);
 
@@ -274,6 +347,12 @@ class SongData
     public function getSongByNumber(string $songbook, int $number): ?array
     {
         $songbook = strtoupper(trim($songbook));
+        if ($this->jsonMode) {
+            foreach ($this->jsonData['songs'] ?? [] as $song) {
+                if (strtoupper($song['songbook']) === $songbook && (int)$song['number'] === $number) return $song;
+            }
+            return null;
+        }
 
         $stmt = $this->db->prepare(
             "SELECT SongId FROM tblSongs WHERE SongbookAbbr = ? AND Number = ? LIMIT 1"
@@ -311,6 +390,24 @@ class SongData
         $query = trim($query);
         if ($query === '') {
             return [];
+        }
+
+        /* JSON fallback: simple substring search */
+        if ($this->jsonMode) {
+            $q = mb_strtolower($query);
+            $songs = $this->getSongs($songbookId);
+            $results = [];
+            foreach ($songs as $song) {
+                if (mb_stripos($song['title'] ?? '', $q) !== false) { $results[] = $song; continue; }
+                foreach ($song['writers'] ?? [] as $w) { if (mb_stripos($w, $q) !== false) { $results[] = $song; continue 2; } }
+                foreach ($song['composers'] ?? [] as $c) { if (mb_stripos($c, $q) !== false) { $results[] = $song; continue 2; } }
+                foreach ($song['components'] ?? [] as $comp) {
+                    foreach ($comp['lines'] ?? [] as $line) {
+                        if (mb_stripos($line, $q) !== false) { $results[] = $song; continue 3; }
+                    }
+                }
+            }
+            return $limit > 0 ? array_slice($results, 0, $limit) : $results;
         }
 
         $results = [];
@@ -432,6 +529,11 @@ class SongData
             return [];
         }
 
+        if ($this->jsonMode) {
+            $songs = $this->getSongs($songbookId);
+            return array_values(array_filter($songs, fn($s) => str_starts_with((string)$s['number'], $number)));
+        }
+
         /* Use LIKE for prefix matching on the number cast to string */
         $likeNumber = $number . '%';
         $stmt = $this->db->prepare(
@@ -478,6 +580,10 @@ class SongData
      */
     public function getRandomSong(?string $songbookId = null): ?array
     {
+        if ($this->jsonMode) {
+            $songs = $this->getSongs($songbookId);
+            return empty($songs) ? null : $songs[random_int(0, count($songs) - 1)];
+        }
         if ($songbookId !== null) {
             $songbookId = strtoupper(trim($songbookId));
             $stmt = $this->db->prepare(

--- a/appWeb/public_html/index.php
+++ b/appWeb/public_html/index.php
@@ -138,7 +138,7 @@ $canonicalUrl = getCanonicalUrl();
 $ogTitle       = $appName . ' — Christian Hymns & Worship Songs';
 $ogDescription = $appDesc;
 $ogType        = 'website';
-$ogImage       = getCanonicalUrl('/og-image.php');
+$ogImage       = getCanonicalUrl('/og-image');
 $ogImageAlt    = $appName . ' logo';
 
 /* JSON-LD structured data — built during OG detection, rendered in <head> */
@@ -170,7 +170,7 @@ try {
                 $ogDescription .= '. "' . implode(' / ', $firstLines) . '..."';
             }
             $ogType = 'article';
-            $ogImage = getCanonicalUrl('/og-image.php?song=' . urlencode($matches[1]));
+            $ogImage = getCanonicalUrl('/og-image?song=' . urlencode($matches[1]));
             $ogImageAlt = 'Preview of "' . $ogSong['title'] . '" from ' . $ogSong['songbookName'];
 
             /* JSON-LD: MusicComposition */
@@ -218,7 +218,7 @@ try {
             $ogTitle = htmlspecialchars($ogBook['name']) . ' — ' . $appName;
             $ogDescription = 'Browse ' . number_format($ogBook['songCount'])
                            . ' songs from ' . $ogBook['name'] . ' on ' . $appName;
-            $ogImage = getCanonicalUrl('/og-image.php?songbook=' . urlencode($matches[1]));
+            $ogImage = getCanonicalUrl('/og-image?songbook=' . urlencode($matches[1]));
             $ogImageAlt = $ogBook['name'] . ' songbook on ' . $appName;
 
             /* Breadcrumb: Home > Songbooks > Songbook Name */
@@ -243,7 +243,7 @@ try {
                 $ogDescription = 'A curated set list with ' . $setlistSongCount
                                . ' ' . ($setlistSongCount === 1 ? 'song' : 'songs')
                                . ' on ' . $appName;
-                $ogImage = getCanonicalUrl('/og-image.php?setlist=' . urlencode($shareId));
+                $ogImage = getCanonicalUrl('/og-image?setlist=' . urlencode($shareId));
                 $ogImageAlt = 'Set list "' . $setlistName . '" on ' . $appName;
             }
         }

--- a/appWeb/public_html/manage/.htaccess
+++ b/appWeb/public_html/manage/.htaccess
@@ -33,6 +33,17 @@ RewriteRule ^setup$ setup.php [L]
 # /manage/users → users.php (admin-only user management)
 RewriteRule ^users$ users.php [L]
 
+# /manage/setup-database → setup-database.php (DB setup dashboard)
+RewriteRule ^setup-database$ setup-database.php [L]
+
+# /manage/editor/api → /manage/editor/api.php (editor API)
+RewriteRule ^editor/api$ editor/api.php [QSA,L]
+
+# Block direct .php access in /manage/ (hide PHP from URLs)
+RewriteCond %{THE_REQUEST} \.php[\s?/] [NC]
+RewriteCond %{REQUEST_URI} !^/manage/includes/ [NC]
+RewriteRule ^(.+)\.php$ /manage/$1 [R=301,L]
+
 # /manage/ root → serve dashboard (index.php via DirectoryIndex)
 # No rewrite needed — DirectoryIndex handles it
 

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -28,14 +28,14 @@ var songData = {
  * Primary load/save endpoint — the editor's PHP API reads/writes
  * directly from/to appWeb/data_share/song_data/songs.json (#154).
  */
-var EDITOR_API_URL = 'api.php';
+var EDITOR_API_URL = 'api';
 
 /**
  * Fallback relative paths for loading songs.json when the PHP API
  * is not available (e.g., running the editor without PHP).
  */
 var SONGS_URL_CANDIDATES = [
-    'api.php?action=load',                    /* Primary: PHP API reads from data_share/ */
+    'api?action=load',                        /* Primary: PHP API reads from data_share/ */
     '../data/songs.json',                     /* Deployed server: data/ inside private_html/ */
     '../../data/songs.json',                  /* Alternative: data/ one up from private_html/ */
     '../../../data/songs.json',               /* Local dev: relative to appWeb/private_html/editor/ → appWeb/data/ */


### PR DESCRIPTION
## Summary

### JSON Fallback for SongData (#critical)
- `SongData.php` now gracefully falls back to loading `songs.json` when MySQL is not configured
- Prevents app crash on fresh deployments before database setup
- All critical methods have JSON fallback implementations (getMeta, getSongbooks, getSongs, getSongById, searchSongs, getRandomSong, etc.)

### Hide .php from URLs (security hardening)
- `/og-image` rewrite added (was `/og-image.php` in OG meta tags)
- `/manage/setup-database` rewrite added
- `/manage/editor/api` rewrite added
- Editor JS: `api.php` → `api`
- Direct `.php` access blocked in `/manage/` area
- All OG image URLs in `index.php` updated to clean paths

### Importers
- Moved `.importers/` scrapers from iLyricsDB repo

## Test plan
- [ ] Verify app loads on alpha without MySQL configured (JSON fallback)
- [ ] Verify OG image URLs don't contain `.php`
- [ ] Verify `/manage/setup-database` loads without `.php` extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)