### PR TITLE
Physical keyboard numpad, Popular Songs fallback, responsive songbook names, docs rewrite

### DIFF
--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -440,134 +440,181 @@ test: add or update tests          → patch version bump
 
 ## MySQL Database Setup (v0.10.0+)
 
-Starting with v0.10.0, iHymns uses MySQL as the primary data store for songs, replacing the flat-file `songs.json` approach. This provides better searchability (full-text indexing), concurrent write safety, and scalability.
+Starting with v0.10.0, iHymns uses MySQL as the primary data store, with JSON fallback for environments without a database. MySQL provides full-text search indexing, concurrent write safety, user accounts, and features like popular songs, song tags, and translation linking.
 
 ### Prerequisites
 
 - **MySQL 5.7+** or **MariaDB 10.3+** with InnoDB support
 - **PHP 8.1+** with the `mysqli` extension enabled
-- A MySQL database created for iHymns (e.g., `ihymns`)
+- A MySQL database created for iHymns:
+  ```sql
+  CREATE DATABASE ihymns CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+  ```
 
-### Step 1: Run the Interactive Installer
+### Step-by-Step Installation
 
-The installer prompts for your MySQL credentials, tests the connection, writes them to `appWeb/.auth/db_credentials.php`, and then creates all database tables:
+#### Step 1: Run the Interactive Installer
 
 ```bash
-# From the project root
 php appWeb/.sql/install.php
 ```
 
-The wizard will prompt for:
+The wizard prompts for:
 
 | Prompt | Default | Description |
 | --- | --- | --- |
 | MySQL Host | `127.0.0.1` | Server hostname or IP |
 | MySQL Port | `3306` | Server port |
 | Database Name | `ihymns` | Must already exist |
-| Username | `ihymns_user` | MySQL user with access to the database |
+| Username | `ihymns_user` | MySQL user with full privileges on the DB |
 | Password | _(none)_ | Hidden input on supported terminals |
 | Table Prefix | _(none)_ | Optional prefix (e.g., `ih_`) for shared databases |
 
 The installer will:
 
 1. Test the connection before writing anything
-2. Write credentials to `appWeb/.auth/db_credentials.php` (permissions set to `0600`)
-3. Create all tables from `schema.sql`
-4. Seed default user groups (Developers, Beta Testers, RC Testers, Public)
+2. Write credentials to `appWeb/.auth/db_credentials.php` (permissions `0600`)
+3. Create all 30+ tables from `schema.sql` (idempotent — safe to re-run)
+4. Seed default data: user groups, 14 languages, 5 access tiers, app settings
 
-> **Note:** If you cannot use the interactive installer (e.g., non-interactive shell), copy `appWeb/.auth/db_credentials.example.php` to `appWeb/.auth/db_credentials.php` and edit it manually. Then re-run the installer to create tables.
-> The installer is idempotent — safe to re-run. Existing tables are skipped.
+> **Manual setup:** Copy `appWeb/.auth/db_credentials.example.php` to `db_credentials.php`, edit it, then re-run the installer.
 
-### Step 3: Migrate Song Data from JSON
-
-After the tables are created, import the song data from `songs.json`:
+#### Step 2: Migrate Song Data from JSON
 
 ```bash
-# Uses default path (data/songs.json or appWeb/data_share/song_data/songs.json)
 php appWeb/.sql/migrate-json.php
-
-# Or specify a custom path
-php appWeb/.sql/migrate-json.php --json=/path/to/songs.json
 ```
 
-Expected output:
+This imports all songs from `data/songs.json` into MySQL:
+- Clears existing song data and re-imports (transaction-wrapped)
+- Populates: songbooks, songs, writers, composers, components
+- Imports translation links from `songs[].translations` array
+- Builds `LyricsText` column for MySQL FULLTEXT search
 
-```text
-=== iHymns JSON-to-MySQL Migration ===
+> Specify a custom path: `php appWeb/.sql/migrate-json.php --json=/path/to/songs.json`
 
-Loading: /path/to/data/songs.json
-Found: 6 songbooks, 3612 songs
+#### Step 3: Create Initial Admin User
 
-Connecting to MySQL...
-Connected.
+Navigate to `/manage/setup` in the browser. The first account becomes the **Global Admin**.
 
-Clearing existing data...
-Inserting songbooks...
-  Inserted 6 songbooks.
-Inserting songs...
-  ... 10% (361/3612 songs)
-  ... 20% (722/3612 songs)
-  ...
-  ... 100% (3612/3612 songs)
+#### Step 4: Verify Installation
 
---- Migration Complete ---
-  Songs:      3612
-  Songbooks:  6
-  Writers:    2847
-  Composers:  2634
-  Components: 14891
+Navigate to `/manage/setup-database.php` to see:
+- Database connection status
+- Table row counts
+- Run additional migrations (users, cleanup, backup)
 
-Migration successful.
+#### Web-Based Setup (No CLI Required)
+
+For shared hosting without SSH:
+
+1. Copy `appWeb/.auth/db_credentials.example.php` to `db_credentials.php` and edit
+2. Navigate to `/manage/setup-database.php`
+3. Click **Run Install** (creates tables)
+4. Click **Run Song Migration** (imports songs)
+5. Visit `/manage/setup` (create admin account)
+
+#### One-Shot Alternative
+
+```bash
+mysql -u user -p ihymns < appWeb/.sql/.fulldata/ihymns-full.sql
 ```
 
-> The migration clears all existing data and re-imports. It is transaction-wrapped — if any error occurs, all changes are rolled back.
+### JSON Fallback Mode
+
+When MySQL is unavailable, the application automatically falls back to reading `data/songs.json`:
+
+| Feature | MySQL Mode | JSON Fallback |
+| --- | --- | --- |
+| Song browsing & search | FULLTEXT index | Fuse.js client-side |
+| Popular songs | Server view counts | Client localStorage history |
+| Browse by theme (tags) | Tag tables | Hidden (no data) |
+| Song view tracking | tblSongHistory | Silently skipped |
+| User accounts | Full auth system | Not available |
+| Translation links | tblSongTranslations | From songs.json |
+| Song editor | Full CRUD | Read-only |
+| Offline downloads | Bulk API | Per-song fallback |
+
+API endpoints gracefully return empty arrays with `fallback: true` flag when the database is unavailable.
 
 ### Database Schema Overview
 
-**Song Data:**
+**Song Data (6 tables):**
 
 | Table | Purpose |
 | --- | --- |
-| `songbooks` | Songbook definitions (CP, JP, MP, SDAH, CH, Misc) |
-| `songs` | Core song metadata + `lyrics_text` for full-text search |
-| `song_writers` | Song lyricist credits (many-to-one) |
-| `song_composers` | Song composer credits (many-to-one) |
-| `song_components` | Verses, choruses with lyrics as JSON lines array |
+| `tblSongbooks` | Songbook definitions (CP, JP, MP, SDAH, CH, Misc) |
+| `tblSongs` | Core metadata + `LyricsText` for FULLTEXT search |
+| `tblSongWriters` | Lyricist credits (many-to-one) |
+| `tblSongComposers` | Composer credits (many-to-one) |
+| `tblSongComponents` | Verses, choruses with lyrics as JSON lines array |
+| `tblSongTranslations` | Links songs to translations in other languages |
 
-**User Accounts & Access Control:**
+**Discovery & Community (4 tables):**
 
 | Table | Purpose |
 | --- | --- |
-| `user_groups` | Groups with version channel access flags (Alpha/Beta/RC/RTW) |
-| `users` | User accounts with role (global_admin/admin/editor/user) and group link |
-| `sessions` | Server-side admin panel sessions |
-| `api_tokens` | Bearer tokens for PWA/native app authentication |
-| `password_reset_tokens` | Single-use password reset tokens (1-hour expiry) |
-| `user_group_members` | Many-to-many user-to-group membership |
-| `user_permissions` | Fine-grained per-user permission overrides |
-| `user_setlists` | Server-side setlist storage for cross-device sync |
-| `migrations` | Schema migration tracking |
+| `tblSongHistory` | View tracking for popular songs ranking |
+| `tblSongTags` | Thematic tag definitions (Easter, Advent, etc.) |
+| `tblSongTagMap` | Song-to-tag mapping |
+| `tblSongRequests` | User-submitted song requests |
 
-The full schema is in `appWeb/.sql/schema.sql`.
+**Languages (1 table):**
+
+| Table | Purpose |
+| --- | --- |
+| `tblLanguages` | 14 supported languages with text direction (ltr/rtl) |
+
+**User Accounts & Access (10+ tables):**
+
+| Table | Purpose |
+| --- | --- |
+| `tblUsers` | Accounts with role-based access |
+| `tblUserGroups` | Version channel access (Alpha/Beta/RC/RTW) |
+| `tblSessions` / `tblApiTokens` | Admin panel sessions and API auth tokens |
+| `tblAccessTiers` | Content gating levels (public → pro) |
+| `tblOrganisations` | Church/organisation licensing |
+| `tblUserSetlists` | Cross-device setlist sync |
+| `tblActivityLog` | Audit trail |
+
+Full schema: `appWeb/.sql/schema.sql` (30+ tables, ~50 KB)
+
+### Key API Endpoints
+
+| Endpoint | Description |
+| --- | --- |
+| `?action=bulk_songs&songbook=X` | Bulk download: all rendered HTML for a songbook in one response |
+| `?action=songs_json` | Full songs.json export with ETag caching |
+| `?action=song_translations&id=X` | Bidirectional translation lookup |
+| `?action=popular_songs&period=month` | Popular songs by view count |
+| `?action=tags` | All thematic tags |
+| `?page=song&id=X` | Rendered song page HTML (cached by service worker) |
 
 ### File Structure
 
 ```text
 appWeb/
 ├── .auth/
-│   ├── .htaccess                      ← Blocks web access (defense-in-depth)
-│   ├── db_credentials.example.php     ← Template (tracked in git)
-│   └── db_credentials.php             ← Your credentials (NOT in git)
-│
+│   ├── .htaccess                      # Blocks web access
+│   ├── db_credentials.example.php     # Template (tracked in git)
+│   └── db_credentials.php             # Credentials (NOT in git)
 ├── .sql/
-│   ├── schema.sql                     ← Full MySQL schema
-│   ├── install.php                    ← Database table installer
-│   └── migrate-json.php              ← JSON-to-MySQL data migration
-│
+│   ├── schema.sql                     # Full MySQL schema
+│   ├── install.php                    # Interactive table installer
+│   ├── migrate-json.php              # JSON → MySQL migration
+│   ├── migrate-users.php             # User/setlist migration
+│   ├── cleanup.php                    # Token/session cleanup
+│   ├── backup.php                     # Database backup
+│   └── .fulldata/
+│       ├── generate-full-sql.php      # One-shot SQL generator
+│       └── ihymns-full.sql            # Pre-built full SQL (~6.8 MB)
 └── public_html/
-    └── includes/
-        ├── db_mysql.php               ← MySQLi connection factory
-        └── SongData.php               ← Song data handler (MySQL-backed)
+    ├── includes/
+    │   ├── db_mysql.php               # MySQLi connection factory
+    │   └── SongData.php               # Song data (MySQL + JSON fallback)
+    └── manage/
+        ├── setup.php                  # Initial admin setup
+        └── setup-database.php         # Web DB admin dashboard
 ```
 
 ### Troubleshooting
@@ -577,26 +624,27 @@ appWeb/
 | "Database credentials file not found" | Copy `db_credentials.example.php` to `db_credentials.php` |
 | "Failed to connect to MySQL" | Check host, port, username, password in credentials file |
 | "Unknown database 'ihymns'" | Create the database: `CREATE DATABASE ihymns CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;` |
-| "Table already exists" | This is normal — the installer uses `CREATE TABLE IF NOT EXISTS` |
-| "Migration failed — all changes rolled back" | Check the error message; fix the issue and re-run |
+| "Table already exists" | Normal — the installer uses `CREATE TABLE IF NOT EXISTS` |
+| "Migration failed — all changes rolled back" | Check error message; fix and re-run |
+| Popular Songs shows "Loading..." | Database required for server-side view tracking; falls back to localStorage |
+| Browse by Theme missing | Tags must be populated in `tblSongTags` via the admin tools |
 
-### Architecture Decision: Why MySQL?
+### Architecture: Why MySQL + JSON Fallback?
 
-The move from JSON to MySQL is driven by:
+MySQL is the primary store for:
+1. **Full-text search** — FULLTEXT indexes on title and lyrics
+2. **Concurrent writes** — Multiple editors can safely modify data
+3. **User accounts** — Relational storage for users, groups, permissions
+4. **View tracking** — Popular songs ranking from `tblSongHistory`
+5. **Tags & translations** — Structured relational data
 
-1. **Full-text search** — MySQL's FULLTEXT indexes replace the in-memory substring search
-2. **Concurrent writes** — Multiple editors can safely modify data simultaneously
-3. **Scalability** — Database handles growth better than loading a ~5MB JSON into memory
-4. **Structured queries** — Complex filtering (by songbook, by writer, etc.) is more efficient
-5. **Editor safety** — Transaction-wrapped saves with automatic rollback on failure
-6. **User accounts** — Proper relational storage for users, groups, permissions, and sessions
-7. **Version access control** — Group-based gating for Alpha/Beta/RC/RTW release channels
-
-The application still exports JSON for the PWA client-side cache (Fuse.js fuzzy search), maintaining full offline support.
+JSON fallback ensures the app works everywhere:
+- Shared hosting without MySQL
+- Development without database setup
+- Offline via service worker cached `songs.json`
+- The PWA client always has `songs.json` for Fuse.js fuzzy search
 
 ### User Groups & Version Access
-
-The database includes a built-in version access control system via `user_groups`:
 
 | Group | Alpha | Beta | RC | RTW |
 | --- | --- | --- | --- | --- |
@@ -605,7 +653,7 @@ The database includes a built-in version access control system via `user_groups`
 | RC Testers | No | No | Yes | Yes |
 | Public | No | No | No | Yes |
 
-Users inherit access from their group. The application checks group permissions to gate access to non-production deployment channels (Alpha = `dev.ihymns.app`, Beta = `beta.ihymns.app`).
+Users inherit access from their group. The app checks group permissions to gate access to deployment channels (Alpha = `dev.ihymns.app`, Beta = `beta.ihymns.app`).
 
 ---
 
@@ -741,4 +789,4 @@ The most restrictive rule wins when multiple systems overlap.
 
 ---
 
-Last updated: 2026-04-13
+Last updated: 2026-04-16

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 📖 iHymns
+# iHymns
 
 > **A multiplatform Christian lyrics application for worship enhancement**
 
@@ -9,145 +9,294 @@
 
 ---
 
-## 🎯 About
+## About
 
 **iHymns** provides searchable hymn and worship song lyrics from multiple songbooks, designed to enhance Christian worship across all devices. Browse, search, and save your favourite hymns — online or offline.
 
-🌐 **Website**: [iHymns.app](https://ihymns.app)
+**Website**: [iHymns.app](https://ihymns.app) | **Alpha**: [dev.iHymns.app](https://dev.ihymns.app) | **Beta**: [beta.iHymns.app](https://beta.ihymns.app)
 
 ---
 
-## 📚 Song Library
+## Song Library
 
-| Songbook | Abbreviation | Songs | Audio | Sheet Music |
-| --- | --- | --- | --- | --- |
-| Carol Praise | CP | 714 | ✅ | ✅ |
-| Junior Praise | JP | 1,787 | ✅ | ✅ |
-| Mission Praise | MP | 3,517 | ✅ | ✅ |
+| Songbook | Abbr | Songs | Audio | Sheet Music |
+| --- | --- | ---: | :---: | :---: |
+| Carol Praise | CP | 243 | MIDI | PDF |
+| Junior Praise | JP | 617 | MIDI | PDF |
+| Mission Praise | MP | 1,355 | MIDI | PDF |
 | Seventh-day Adventist Hymnal | SDAH | 695 | — | — |
 | The Church Hymnal | CH | 702 | — | — |
-| **Total** | | **~7,415** | | |
+| **Total** | | **3,612** | | |
 
 ---
 
-## 🖥 Platforms
+## Platforms
 
 | Platform | Technology | Status |
 | --- | --- | --- |
-| 🌐 Web PWA | HTML5, CSS3, Bootstrap 5.3, Vanilla JS | ✅ Alpha |
-| 🍎 iOS / iPadOS / tvOS | Swift 6.3, SwiftUI | 🔧 In Progress |
-| 🤖 Android | Kotlin, Jetpack Compose | 🔲 Planned |
+| Web PWA | HTML5, CSS3, Bootstrap 5.3, Vanilla JS, PHP 8.1+ | **Alpha** |
+| iOS / iPadOS / tvOS | Swift 6.3, SwiftUI | In Progress |
+| Android / Fire OS | Kotlin, Jetpack Compose | Planned |
 
 ---
 
-## ✨ Features
+## Features
 
-- 🔍 **Full-text search** — by title, lyrics, songbook, song number, writer, composer
-- 📚 **Songbook browser** — organised by songbook with alphabetical index
-- 📖 **Formatted lyrics** — verse, chorus, refrain, bridge with optional numbering
-- ⭐ **Favourites** — save songs with custom tags for quick access
-- 🎵 **Audio playback** — MIDI files where available
-- 📄 **Sheet music** — PDF viewer where available
-- 🌙 **Themes** — light, dark, high contrast, and system-adaptive modes
-- 📴 **Offline mode** — download individual songbooks or all songs for offline use; bulk download completes in seconds via optimised API
-- 🔢 **Number search** — numeric keypad with configurable live search (off by default) and default songbook
-- 🔀 **Shuffle** — random song from any songbook, pre-selects your default songbook
-- 🎤 **Presentation mode** — fullscreen lyrics display with auto-scroll
-- 🌐 **Translation linking** — songs linked to translations in other languages
-- 🔥 **Popular songs** — homepage shows trending songs (server-side) with client-side fallback
-- 🏷️ **Browse by theme** — filter songs by thematic tags
-- 📋 **Setlists** — create, arrange, and share worship setlists with custom component arrangements
-- ♿ **Accessible** — WCAG 2.1 AA compliant, keyboard shortcuts, screen reader support, colour vision deficiency modes
-- 🔄 **Auto-update** — service worker detects updates and prompts to refresh
+### Song Browsing & Search
+- **Full-text search** — by title, lyrics, songbook, song number, writer, composer (Fuse.js client-side + MySQL FULLTEXT)
+- **Songbook browser** — organised by songbook with alphabetical index
+- **Number search** — numeric keypad with physical keyboard support; configurable live search (off by default)
+- **Default songbook** — pre-selects in number search, keyboard quick-jump, and shuffle
+- **Formatted lyrics** — verse, chorus, refrain, bridge with optional numbering and chorus highlighting
+
+### Worship Tools
+- **Favourites** — save songs with custom tags for quick access
+- **Setlists** — create, arrange, and share worship setlists with custom component arrangements
+- **Presentation mode** — fullscreen lyrics display with configurable auto-scroll
+- **Shuffle** — random song from any songbook, highlights your default songbook
+- **Translation linking** — songs linked to equivalent translations in other languages
+- **Audio playback** — MIDI files where available
+- **Sheet music** — PDF viewer where available
+- **Transpose** — shift song key up/down (persisted per song)
+
+### Discovery
+- **Popular songs** — homepage shows trending songs (server-side view counts with client-side fallback)
+- **Browse by theme** — filter songs by thematic tags
+- **Related songs** — content-based similarity matching using TF-IDF cosine similarity
+- **Song of the Day** — daily featured song on homepage
+- **Recently viewed** — quick access to your recent songs
+
+### Offline & PWA
+- **Offline downloads** — download individual songbooks or all at once (~14 MB)
+- **Bulk download API** — optimised endpoint fetches entire songbooks in ~6 requests (not 3,612 individual requests)
+- **Background downloads** — continue when navigating away from Settings
+- **Storage estimates** — shows ~X MB per songbook before downloading
+- **Auto-update** — optional automatic update of saved offline songs
+- **Service worker** — precaches all app assets for instant offline access
+- **Offline indicator** — shows connection status in UI
+- **JSON fallback** — full functionality when MySQL is unavailable
+
+### Appearance & Accessibility
+- **Themes** — light, dark, high contrast, and system-adaptive modes
+- **Colour vision deficiency** — accessible palette with pattern-based songbook indicators
+- **WCAG 2.1 AA** — keyboard shortcuts, screen reader support, ARIA landmarks
+- **Responsive songbook names** — full name by default, abbreviation on narrow screens
+- **Adjustable font size** — lyrics scale from 14px to 28px
+- **Reduced motion** — respects `prefers-reduced-motion` and manual toggle
+- **Safe areas** — respects device notch, camera cutout, and home indicator on all screens
+
+### Administration
+- **User accounts** — sign in/register with role-based access (Global Admin, Admin, Editor, User)
+- **Song editor** — web-based editor for lyrics, metadata, translations, and arrangements
+- **Database setup** — web-accessible installer at `/manage/setup-database.php`
+- **Content access tiers** — public, free, CCLI, premium, pro with organisation licensing
+- **Activity logging** — audit trail for significant actions
+- **Analytics** — GA4, Plausible, Clarity, Matomo, Fathom with GDPR consent
 
 ---
 
-## 🏗 Project Structure
+## Quick Start
+
+### Prerequisites
+
+- **PHP 8.1+** with `mysqli` extension
+- **MySQL 5.7+** or **MariaDB 10.3+**
+- **Node.js** v22+ (for build tools)
+- **npm** v10+
+
+### 1. Clone & Install
+
+```bash
+git clone https://github.com/MWBMPartners/iHymns.git
+cd iHymns
+npm install
+```
+
+### 2. Generate Song Data
+
+```bash
+npm run parse-songs    # Generates data/songs.json from .SourceSongData/
+```
+
+### 3. Set Up Database
+
+```bash
+# Interactive installer — prompts for MySQL credentials, creates tables
+php appWeb/.sql/install.php
+
+# Import song data from songs.json into MySQL
+php appWeb/.sql/migrate-json.php
+```
+
+Or use the **web-based installer** at `/manage/setup-database.php` (accessible during initial setup or as a global admin).
+
+**One-shot alternative** (schema + all data in one command):
+
+```bash
+mysql -u user -p ihymns < appWeb/.sql/.fulldata/ihymns-full.sql
+```
+
+See [Database Setup](#-database-setup) below for detailed instructions.
+
+### 4. Create Admin User
+
+Visit `/manage/setup` in the browser to create the initial admin account.
+
+### 5. Start Development Server
+
+```bash
+npm run dev    # Starts PHP dev server at http://localhost:8000
+```
+
+---
+
+## Database Setup
+
+### Prerequisites
+
+- **MySQL 5.7+** or **MariaDB 10.3+** with InnoDB support
+- **PHP 8.1+** with `mysqli` extension
+- A MySQL database created for iHymns:
+  ```sql
+  CREATE DATABASE ihymns CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+  ```
+
+### Step 1: Run the Interactive Installer
+
+```bash
+php appWeb/.sql/install.php
+```
+
+The wizard prompts for:
+
+| Prompt | Default | Description |
+| --- | --- | --- |
+| MySQL Host | `127.0.0.1` | Server hostname or IP |
+| MySQL Port | `3306` | Server port |
+| Database Name | `ihymns` | Must already exist |
+| Username | `ihymns_user` | MySQL user with full privileges on the database |
+| Password | _(none)_ | Hidden input on supported terminals |
+| Table Prefix | _(none)_ | Optional prefix for shared databases |
+
+The installer will:
+1. Test the connection before writing anything
+2. Write credentials to `appWeb/.auth/db_credentials.php` (permissions `0600`)
+3. Create all 30+ tables from `schema.sql` (idempotent — safe to re-run)
+4. Seed default data: user groups, languages (14), access tiers, app settings
+
+> **Manual credentials**: If you can't use the interactive installer, copy `appWeb/.auth/db_credentials.example.php` to `db_credentials.php` and edit it, then re-run the installer.
+
+### Step 2: Import Song Data
+
+```bash
+php appWeb/.sql/migrate-json.php
+```
+
+This imports all songs from `data/songs.json` into MySQL. The migration:
+- Clears existing song data and re-imports (transaction-wrapped, rolls back on error)
+- Populates: songbooks, songs, writers, composers, components, translation links
+- Builds `LyricsText` column for MySQL FULLTEXT search
+
+### Step 3: Create Initial Admin User
+
+Navigate to `/manage/setup` in the browser. The first account created becomes the **Global Admin**.
+
+### Step 4: Verify via Web Dashboard
+
+Navigate to `/manage/setup-database.php` to see database connection status, table row counts, and run maintenance tasks.
+
+### Web-Based Setup (No CLI Required)
+
+For shared hosting without SSH access:
+
+1. Copy `appWeb/.auth/db_credentials.example.php` to `db_credentials.php` and edit with your MySQL details
+2. Navigate to `/manage/setup-database.php`
+3. Click **Run Install** to create tables
+4. Click **Run Song Migration** to import song data
+5. Visit `/manage/setup` to create the admin account
+
+### File Structure
+
+```text
+appWeb/
+├── .auth/
+│   ├── .htaccess                      # Blocks web access (defense-in-depth)
+│   ├── db_credentials.example.php     # Template (tracked in git)
+│   └── db_credentials.php             # Your credentials (NOT in git)
+├── .sql/
+│   ├── schema.sql                     # Full MySQL schema (30+ tables)
+│   ├── install.php                    # Interactive DB installer
+│   ├── migrate-json.php              # JSON-to-MySQL data migration
+│   ├── migrate-users.php             # User/setlist migration
+│   ├── cleanup.php                    # Token/session cleanup
+│   ├── backup.php                     # Database backup
+│   └── .fulldata/
+│       ├── generate-full-sql.php      # Generates one-shot SQL dump
+│       └── ihymns-full.sql            # Pre-built full SQL (~6.8 MB)
+└── public_html/
+    ├── includes/
+    │   ├── db_mysql.php               # MySQLi connection factory
+    │   └── SongData.php               # Song data (MySQL with JSON fallback)
+    └── manage/
+        └── setup-database.php         # Web-based DB admin dashboard
+```
+
+---
+
+## Environments
+
+| Branch | Subdomain | Purpose |
+| --- | --- | --- |
+| `alpha` | dev.ihymns.app | Development / Alpha testing |
+| `beta` | beta.ihymns.app | Beta testing |
+| `main` | ihymns.app | Production |
+
+Deployment is automated via GitHub Actions (SFTP). See [DEV_NOTES.md](DEV_NOTES.md) for full deployment architecture.
+
+---
+
+## Project Structure
 
 ```text
 iHymns/
 ├── .claude/              # Claude AI context & project brief
-├── .github/workflows/    # CI/CD: deploy, version bump, changelog, tests
+├── .github/workflows/    # CI/CD: deploy, version bump, changelog
 ├── .SourceSongData/      # Raw song text files (source of truth)
 ├── tools/                # Build tools & song data parser
-├── data/                 # Generated song data (JSON)
+├── data/                 # Generated song data (songs.json, schema)
 ├── appWeb/               # Web PWA application
-│   ├── public_html/      #   Web app source (deployed to all environments)
+│   ├── .auth/            #   Database credentials (not in git)
+│   ├── .sql/             #   Schema, installers, migrations
+│   ├── public_html/      #   Web app source (deployed)
 │   ├── data_share/       #   Shared data (songs.json, setlists)
-│   └── private_html/     #   Private (admin tools, song editor)
+│   └── private_html/     #   Admin tools, song editor
 ├── appApple/             # Native Apple app (Swift/SwiftUI)
-├── appAndroid/           # Android app (future)
+├── appAndroid/           # Android app (Kotlin/Compose)
+├── wiki/                 # GitHub wiki pages
 ├── help/                 # User documentation
 ├── Project_Plan.md       # Detailed project plan
 ├── PROJECT_STATUS.md     # Current status tracker
 ├── CHANGELOG.md          # Change log
-└── DEV_NOTES.md          # Developer notes
+└── DEV_NOTES.md          # Developer notes & deployment setup
 ```
 
 ---
 
-## 📋 Project Plan
+## Documentation
 
-See [Project_Plan.md](Project_Plan.md) for the full plan including:
-
-- Technology stack details
-- Architecture decisions
-- Milestones and roadmap
-- Development standards
-
----
-
-## 📊 Current Status
-
-See [PROJECT_STATUS.md](PROJECT_STATUS.md) for real-time project status.
-
-**Current Phase**: Phase ONE (local song data)
-**Current Milestone**: Project Setup & Data Pipeline
-**Version**: 0.1.0-planning
+| Document | Description |
+| --- | --- |
+| [Project Plan](Project_Plan.md) | Architecture, milestones, tech stack |
+| [Project Status](PROJECT_STATUS.md) | Current progress |
+| [Changelog](CHANGELOG.md) | All changes |
+| [Developer Notes](DEV_NOTES.md) | Deployment, secrets, architecture decisions |
+| [Wiki](wiki/) | Comprehensive developer & user documentation |
 
 ---
 
-## 🛠 Development
+## License
 
-### Prerequisites
-
-- **Node.js** v22+ (LTS)
-- **npm** v10+
-- **Xcode** 16+ (for Apple development)
-- **VS Code** (recommended editor)
-
-### Getting Started
-
-```bash
-# Clone the repository
-git clone https://github.com/MWBMPartners/iHymns.git
-cd iHymns
-
-# Install dependencies (once project is set up)
-npm install
-
-# Parse song data
-npm run parse-songs
-
-# Start web dev server
-npm run dev
-```
-
----
-
-## 📖 Documentation
-
-- [Project Plan](Project_Plan.md) — Architecture, milestones, tech stack
-- [Project Status](PROJECT_STATUS.md) — Current progress
-- [Changelog](CHANGELOG.md) — All changes
-- [Developer Notes](DEV_NOTES.md) — Technical decisions & notes
-- [Help Documentation](help/) — User-facing docs & FAQs
-
----
-
-## 📜 License
-
-Copyright © 2026 MWBM Partners Ltd. All rights reserved.
+Copyright (c) 2026 MWBM Partners Ltd. All rights reserved.
 
 This software is proprietary. Unauthorized copying, modification, or distribution is strictly prohibited.
 
@@ -155,7 +304,7 @@ Third-party components retain their respective licenses (MIT, Apache 2.0, etc.).
 
 ---
 
-## 👥 Credits
+## Credits
 
 - **MWBM Partners Ltd** — Development & maintenance
 - Song data sourced from published hymnals and songbooks


### PR DESCRIPTION
## Summary

New work since PR #361 was merged:

- **Physical keyboard support for number search keypad** — digits, Backspace, Enter (Go), and Escape now work alongside on-screen buttons in both the numpad modal and the search page number panel.
- **Popular Songs & Browse by Theme work in JSON fallback / offline mode** — wraps the 5 DB-dependent endpoints (`popular_songs`, `tags`, `song_history`, `song_view`, `songs_by_tag`) in try/catch so they return empty arrays with `fallback:true` instead of breaking. Home page falls back to `localStorage` history for a local popularity ranking.
- **Numpad live search off by default** — users press Go to navigate; a new Settings toggle re-enables live search. Numpad songbook dropdown and shuffle modal now respect the default songbook setting.
- **Responsive songbook names** — song lists now show the full songbook name (e.g. "Mission Praise") by default, falling back to the abbreviation below 360px. Applied across Recently Viewed, Favourites, Related Songs, Search results, and Setlists (interactive + print).
- **Docs rewrite** — comprehensive README and DEV_NOTES update: accurate 3,612 song count, full feature inventory, Quick Start, Database Setup with CLI + web flows, environment/branch table, updated project structure, MySQL schema overview, API endpoints table, and troubleshooting additions. In-app help and wiki updated with offline downloads, default songbook, number search changes, safe areas, and translation linking.

## Test plan

- [ ] Physical keyboard (0-9, Backspace, Enter) controls numpad modal and search page panel
- [ ] Popular Songs / Themes render correctly in JSON fallback mode and offline
- [ ] Numpad live search off by default; toggle in Settings re-enables it
- [ ] Shuffle modal highlights default songbook; numpad pre-selects it
- [ ] Song lists show full songbook name, collapsing to abbreviation below 360px
- [ ] README and DEV_NOTES render correctly on GitHub

https://claude.ai/code/session_01Nax1jtxmmpVqrW8EBoNUvu