### PR TITLE
Render song titles in Title Case consistently across all surfaces

### DIFF
--- a/appWeb/public_html/includes/SongData.php
+++ b/appWeb/public_html/includes/SongData.php
@@ -46,21 +46,36 @@ function toTitleCase(string $str): string
     $minor = ['a','an','and','as','at','but','by','for','in','nor','of','on','or','so','the','to','up','yet'];
     $words = preg_split('/\s+/', mb_strtolower(trim($str)));
     $lastIndex = count($words) - 1;
+
+    /* Capitalise the first Unicode letter in a word, skipping any leading
+       quotes or punctuation (e.g. "come → "Come). */
+    $capFirstLetter = function (string $word): string {
+        if (preg_match('/^([^\p{L}]*)(\p{L})(.*)$/u', $word, $m)) {
+            return $m[1] . mb_strtoupper($m[2]) . $m[3];
+        }
+        return $word;
+    };
+
+    /* Strip non-letter/digit chars (except apostrophes) so that "and,"
+       compares equal to "and" for the minor-words check. */
+    $stripPunct = fn(string $w) => preg_replace('/[^\p{L}\p{N}\']/u', '', $w);
+
     foreach ($words as $i => &$word) {
         /* Handle hyphenated words — capitalise each part */
         if (strpos($word, '-') !== false) {
             $word = implode('-', array_map(
-                fn($p) => mb_strtoupper(mb_substr($p, 0, 1)) . mb_substr($p, 1),
+                fn($p) => $capFirstLetter($p),
                 explode('-', $word)
             ));
-            /* Still apply first/last rule to the whole hyphenated word */
-            if ($i !== 0 && $i !== $lastIndex) {
-                continue;
-            }
+            continue;
         }
-        /* Always capitalise first and last word; capitalise non-minor words */
-        if ($i === 0 || $i === $lastIndex || !in_array($word, $minor)) {
-            $word = mb_strtoupper(mb_substr($word, 0, 1)) . mb_substr($word, 1);
+        $prev = $i > 0 ? $words[$i - 1] : '';
+        /* Word following ., !, ?, :, em/en dash starts a new clause and is
+           always capitalised regardless of the minor-word rule. */
+        $newClause = $i > 0 && preg_match('/[.!?:—–]$/u', $prev);
+        $isMinor = in_array($stripPunct($word), $minor, true);
+        if ($i === 0 || $i === $lastIndex || $newClause || !$isMinor) {
+            $word = $capFirstLetter($word);
         }
     }
     unset($word);

--- a/appWeb/public_html/includes/pages/home.php
+++ b/appWeb/public_html/includes/pages/home.php
@@ -172,6 +172,21 @@ $songbooks = $songData->getSongbooks();
     (function() {
         var esc = function(s) { return (s||'').replace(/[&<>"']/g, function(c){return{'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]}); };
         var SONGBOOK_NAMES = {CP:'Carol Praise',JP:'Junior Praise',MP:'Mission Praise',SDAH:'Seventh-day Adventist Hymnal',CH:'The Church Hymnal',Misc:'Miscellaneous'};
+        /* Minimal title-case for this inline script — mirrors utils/text.js toTitleCase. */
+        var MINOR = {a:1,an:1,and:1,as:1,at:1,but:1,by:1,for:1,in:1,nor:1,of:1,on:1,or:1,so:1,the:1,to:1,up:1,yet:1};
+        var titleCase = function(s) {
+            if (!s) return s || '';
+            var w = String(s).toLowerCase().split(/\s+/), last = w.length - 1;
+            return w.map(function(word, i) {
+                var prev = i > 0 ? w[i - 1] : '';
+                var newClause = i > 0 && /[.!?:\u2014\u2013]$/.test(prev);
+                var bare = word.replace(/[^\p{L}\p{N}']/gu, '');
+                if (i === 0 || i === last || newClause || !MINOR[bare]) {
+                    word = word.replace(/^([^\p{L}]*)(\p{L})/u, function(_, p, c){ return p + c.toUpperCase(); });
+                }
+                return word.replace(/-\w/g, function(m){ return m.toUpperCase(); });
+            }).join(' ');
+        };
 
         // #303 — Popular Songs (server or client-side fallback)
         fetch('/api?action=popular_songs&period=month&limit=10')
@@ -200,7 +215,7 @@ $songbooks = $songData->getSongbooks();
 
                 el.innerHTML = songs.map(function(s) {
                     var id = s.songId || s.id || '';
-                    var title = s.title || id;
+                    var title = titleCase(s.title || id);
                     var book = s.songbook || id.split('-')[0] || '';
                     var bookName = SONGBOOK_NAMES[book] || book;
                     return '<a href="/song/' + esc(id) + '" data-navigate="song" data-song-id="' + esc(id) + '" class="list-group-item list-group-item-action song-list-item">' +

--- a/appWeb/public_html/includes/pages/song.php
+++ b/appWeb/public_html/includes/pages/song.php
@@ -369,7 +369,7 @@ $components  = $song['components'] ?? [];
                    class="btn btn-outline-secondary btn-sm"
                    data-navigate="song"
                    data-song-id="<?= htmlspecialchars($prevSong['id']) ?>"
-                   aria-label="Previous song: <?= htmlspecialchars($prevSong['title']) ?>">
+                   aria-label="Previous song: <?= htmlspecialchars(toTitleCase($prevSong['title'])) ?>">
                     <i class="fa-solid fa-chevron-left me-1" aria-hidden="true"></i>
                     #<?= (int)$prevSong['number'] ?>
                 </a>
@@ -382,7 +382,7 @@ $components  = $song['components'] ?? [];
                    class="btn btn-outline-secondary btn-sm"
                    data-navigate="song"
                    data-song-id="<?= htmlspecialchars($nextSong['id']) ?>"
-                   aria-label="Next song: <?= htmlspecialchars($nextSong['title']) ?>">
+                   aria-label="Next song: <?= htmlspecialchars(toTitleCase($nextSong['title'])) ?>">
                     #<?= (int)$nextSong['number'] ?>
                     <i class="fa-solid fa-chevron-right ms-1" aria-hidden="true"></i>
                 </a>

--- a/appWeb/public_html/includes/pages/writer.php
+++ b/appWeb/public_html/includes/pages/writer.php
@@ -157,14 +157,14 @@ $composerCount = count(array_filter($matchedSongs, fn($m) => $m['isComposer']));
                        data-navigate="song"
                        data-song-id="<?= htmlspecialchars($song['id']) ?>"
                        role="listitem"
-                       aria-label="Song <?= (int)$song['number'] ?>: <?= htmlspecialchars($song['title']) ?>">
+                       aria-label="Song <?= (int)$song['number'] ?>: <?= htmlspecialchars(toTitleCase($song['title'])) ?>">
                         <!-- Song number badge -->
                         <span class="song-number-badge" data-songbook="<?= htmlspecialchars($bookId) ?>" aria-hidden="true">
                             <?= (int)$song['number'] ?>
                         </span>
                         <!-- Song info -->
                         <div class="song-info flex-grow-1">
-                            <span class="song-title"><?= htmlspecialchars($song['title']) ?></span>
+                            <span class="song-title"><?= htmlspecialchars(toTitleCase($song['title'])) ?></span>
                             <small class="text-muted d-block">
                                 <?php if ($match['isWriter'] && $match['isComposer']): ?>
                                     <i class="fa-solid fa-pen-fancy me-1" aria-hidden="true"></i>Words &amp; Music

--- a/appWeb/public_html/js/modules/compare.js
+++ b/appWeb/public_html/js/modules/compare.js
@@ -9,6 +9,7 @@
  * Responsive: side-by-side on desktop, tabbed on mobile.
  */
 import { escapeHtml } from '../utils/html.js';
+import { toTitleCase } from '../utils/text.js';
 
 export class Compare {
     /**
@@ -101,7 +102,7 @@ export class Compare {
                         <button type="button" class="list-group-item list-group-item-action compare-pick"
                                 data-song-id="${escapeHtml(s.id)}">
                             <span class="song-number-badge me-2" data-songbook="${escapeHtml(s.songbook || '')}">${s.number}</span>
-                            <strong>${escapeHtml(s.title)}</strong>
+                            <strong>${escapeHtml(toTitleCase(s.title))}</strong>
                             <small class="text-muted ms-1">${escapeHtml(s.songbookName || '')}</small>
                         </button>`).join('');
 

--- a/appWeb/public_html/js/modules/favorites.js
+++ b/appWeb/public_html/js/modules/favorites.js
@@ -426,7 +426,7 @@ export class Favorites {
                    role="listitem">
                     <input type="checkbox" class="form-check-input fav-select-check d-none me-2"
                            data-song-id="${escapeHtml(fav.id)}"
-                           aria-label="Select ${escapeHtml(fav.title)}"
+                           aria-label="Select ${escapeHtml(toTitleCase(fav.title))}"
                            onclick="event.stopPropagation()">
                     <span class="song-number-badge" data-songbook="${escapeHtml(fav.songbook)}">${fav.number || '?'}</span>
                     <div class="song-info flex-grow-1">

--- a/appWeb/public_html/js/modules/history.js
+++ b/appWeb/public_html/js/modules/history.js
@@ -14,6 +14,7 @@
  *   Ordered by most recent first.
  */
 import { escapeHtml, verifiedBadge } from '../utils/html.js';
+import { toTitleCase } from '../utils/text.js';
 import { STORAGE_HISTORY, songbookLabel } from '../constants.js';
 
 export class History {
@@ -133,7 +134,7 @@ export class History {
                        data-song-id="${escapeHtml(h.id)}">
                         <span class="song-number-badge" data-songbook="${escapeHtml(h.songbook)}">${h.number || '?'}</span>
                         <div class="song-info flex-grow-1">
-                            <span class="song-title">${escapeHtml(h.title)}${verifiedBadge(h)}</span>
+                            <span class="song-title">${escapeHtml(toTitleCase(h.title))}${verifiedBadge(h)}</span>
                             <small class="text-muted d-block">${songbookLabel(h.songbook)}</small>
                         </div>
                         <i class="fa-solid fa-chevron-right text-muted" aria-hidden="true"></i>

--- a/appWeb/public_html/js/modules/numpad.js
+++ b/appWeb/public_html/js/modules/numpad.js
@@ -9,6 +9,7 @@
  * Performs live search-as-you-type against the API.
  */
 import { escapeHtml, verifiedBadge } from '../utils/html.js';
+import { toTitleCase } from '../utils/text.js';
 import { STORAGE_DEFAULT_SONGBOOK, STORAGE_NUMPAD_LIVE_SEARCH } from '../constants.js';
 
 export class Numpad {
@@ -243,7 +244,7 @@ export class Numpad {
                             <a href="/song/${song.id}"
                                class="list-group-item list-group-item-action py-2"
                                data-navigate="song" data-song-id="${song.id}">
-                                <strong>#${song.number}</strong> — ${escapeHtml(song.title)}${verifiedBadge(song)}
+                                <strong>#${song.number}</strong> — ${escapeHtml(toTitleCase(song.title))}${verifiedBadge(song)}
                             </a>
                         `).join('') + '</div>';
 

--- a/appWeb/public_html/js/modules/search.js
+++ b/appWeb/public_html/js/modules/search.js
@@ -18,6 +18,7 @@
  *   5. Offline search works when songs.json is cached by service worker.
  */
 import { escapeHtml, verifiedBadge } from '../utils/html.js';
+import { toTitleCase } from '../utils/text.js';
 import { STORAGE_SEARCH_LYRICS, songbookLabel } from '../constants.js';
 
 export class Search {
@@ -519,7 +520,7 @@ export class Search {
                    data-song-id="${escapeHtml(song.id)}">
                     <span class="song-number-badge" data-songbook="${escapeHtml(song.songbook || '')}">${song.number}</span>
                     <div class="song-info flex-grow-1">
-                        <span class="song-title">${escapeHtml(song.title)}${verifiedBadge(song)}</span>
+                        <span class="song-title">${escapeHtml(toTitleCase(song.title))}${verifiedBadge(song)}</span>
                         <small class="text-muted d-block">
                             ${songbookLabel(song.songbook, song.songbookName)}
                             ${writers ? ' &middot; ' + escapeHtml(writers) : ''}
@@ -602,7 +603,7 @@ export class Search {
                        data-index="${i}"
                        role="option">
                         <span class="song-num">${escapeHtml(song.songbook || '')} ${song.number || ''}</span>
-                        <span>${escapeHtml(song.title || '')}</span>
+                        <span>${escapeHtml(toTitleCase(song.title || ''))}</span>
                     </a>`;
         }).join('');
 

--- a/appWeb/public_html/js/modules/share.js
+++ b/appWeb/public_html/js/modules/share.js
@@ -16,6 +16,7 @@
  * Note: In future iterations (v2+), additional permalink formats
  * may be supported (e.g., /s/CP-0001 for short links).
  */
+import { toTitleCase } from '../utils/text.js';
 
 export class Share {
     constructor(app) {
@@ -179,7 +180,7 @@ export class Share {
      * @returns {string} Formatted text
      */
     buildShareText(meta, permalink) {
-        let text = `"${meta.title}"`;
+        let text = `"${toTitleCase(meta.title || '')}"`;
         if (meta.songbook && meta.number) {
             text += ` (${meta.songbook} #${meta.number})`;
         }

--- a/appWeb/public_html/js/modules/song-of-the-day.js
+++ b/appWeb/public_html/js/modules/song-of-the-day.js
@@ -11,6 +11,7 @@
  * by keyword matching instead.
  */
 import { escapeHtml, verifiedBadge } from '../utils/html.js';
+import { toTitleCase } from '../utils/text.js';
 
 export class SongOfTheDay {
     /**
@@ -150,7 +151,7 @@ export class SongOfTheDay {
                                class="text-decoration-none"
                                data-navigate="song"
                                data-song-id="${escapeHtml(song.id)}">
-                                <h5 class="card-title mb-1">${escapeHtml(song.title)}${verifiedBadge(song)}</h5>
+                                <h5 class="card-title mb-1">${escapeHtml(toTitleCase(song.title))}${verifiedBadge(song)}</h5>
                             </a>
                             <p class="text-muted small mb-1">
                                 <span class="badge bg-body-secondary" data-songbook="${escapeHtml(song.songbook || '')}">${escapeHtml(song.songbook || '')}</span>

--- a/appWeb/public_html/js/utils/text.js
+++ b/appWeb/public_html/js/utils/text.js
@@ -20,15 +20,30 @@ const MINOR_WORDS = new Set([
     'of','on','or','so','the','to','up','yet',
 ]);
 
+/* Words following these punctuation marks start a new clause and are capitalised
+   regardless of the minor-word rule (e.g. "Alas! And Did My Saviour Bleed?"). */
+const CLAUSE_BREAK = /[.!?:—–]$/;
+
+function capFirstLetter(word) {
+    /* Skip leading quotes/punctuation (e.g. "come → "Come) and uppercase the first letter. */
+    const m = word.match(/^([^\p{L}]*)(\p{L})(.*)$/u);
+    return m ? m[1] + m[2].toUpperCase() + m[3] : word;
+}
+
+function stripPunct(word) {
+    return word.replace(/[^\p{L}\p{N}']/gu, '');
+}
+
 export function toTitleCase(str) {
     if (!str) return str || '';
-    return str
-        .toLowerCase()
-        .split(/\s+/)
-        .map((word, i, arr) => {
-            /* Always capitalise first and last word */
-            if (i === 0 || i === arr.length - 1 || !MINOR_WORDS.has(word)) {
-                word = word.charAt(0).toUpperCase() + word.slice(1);
+    const words = str.toLowerCase().split(/\s+/);
+    const last = words.length - 1;
+    return words
+        .map((word, i) => {
+            const newClause = i > 0 && CLAUSE_BREAK.test(words[i - 1]);
+            const isMinor = MINOR_WORDS.has(stripPunct(word));
+            if (i === 0 || i === last || newClause || !isMinor) {
+                word = capFirstLetter(word);
             }
             /* Capitalise each part of hyphenated words */
             return word.replace(/-\w/g, m => m.toUpperCase());


### PR DESCRIPTION
## Summary

Fix #372 — song titles are now rendered in Title Case everywhere, consistently.

**Helper updates (`utils/text.js` + `SongData.php`)**
- Capitalise word following `.`, `!`, `?`, `:`, em/en dash (new-clause rule) — `"alas! and did my saviour bleed?"` → `"Alas! And Did My Saviour Bleed?"`
- Strip trailing punctuation before the minor-word check (so `"and,"` still matches `and`)
- Skip leading quotes/punctuation when capitalising (e.g. `"come` → `"Come`)
- Unicode-aware regex for accents / non-Latin letters
- Handles ALL-CAPS and mixed-case inputs (`"ISN'T HE WONDERFUL"` → `"Isn't He Wonderful"`)

**Display call-sites wrapped in `toTitleCase`**
- Song of the Day card
- Recently Viewed
- Popular Songs (home.php inline script — mirrors helper inline)
- Search results + autocomplete suggestions
- Numpad search results
- Compare modal song picker
- Native Web Share / copy text
- Writer page song list + aria-label
- Previous / Next aria-labels on song page
- Favourites checkbox aria-label

Non-display `.title` uses (data-* attributes, search index text, lowercase matching) intentionally untouched.

## Test plan

- [ ] Song of the Day shows "O Come, All You Faithful" (not "O come, all you faithful")
- [ ] Recently Viewed still renders correctly (regression check)
- [ ] "Alas! And Did My Saviour Bleed?" — word after `!` is capitalised
- [ ] Minor words like `and`, `the`, `as` stay lowercase mid-title
- [ ] Search results, autocomplete, numpad results, compare picker all show Title Case
- [ ] Previous/Next aria-labels read Title Case via screen reader
- [ ] Share/copy text produces Title Case song title in the output

Closes #372.

https://claude.ai/code/session_01XUtkSVBVB3ez9HqHaTQb7r