### PR TITLE
fix(setup): don't leak text/plain Content-Type through the Setup dashboard

### DIFF
--- a/appWeb/.sql/backup.php
+++ b/appWeb/.sql/backup.php
@@ -22,7 +22,8 @@ declare(strict_types=1);
 
 $isCli = (php_sapi_name() === 'cli');
 
-if (!$isCli) {
+if (!$isCli && !defined('IHYMNS_SETUP_DASHBOARD')) {
+    /* Standalone web mode only — skip when included by the Setup dashboard. */
     header('Content-Type: text/plain; charset=UTF-8');
     header('Cache-Control: no-store');
 }

--- a/appWeb/.sql/cleanup.php
+++ b/appWeb/.sql/cleanup.php
@@ -30,8 +30,8 @@ declare(strict_types=1);
 
 $isCli = (php_sapi_name() === 'cli');
 
-if (!$isCli) {
-    /* Web mode — works on shared hosting without CLI access */
+if (!$isCli && !defined('IHYMNS_SETUP_DASHBOARD')) {
+    /* Standalone web mode only — skip when included by the Setup dashboard. */
     header('Content-Type: text/plain; charset=UTF-8');
     header('X-Content-Type-Options: nosniff');
     header('Cache-Control: no-store');

--- a/appWeb/.sql/install.php
+++ b/appWeb/.sql/install.php
@@ -33,8 +33,10 @@ declare(strict_types=1);
 
 $isCli = (php_sapi_name() === 'cli');
 
-if (!$isCli) {
-    /* Web mode — works on shared hosting without CLI access (e.g., DreamHost) */
+if (!$isCli && !defined('IHYMNS_SETUP_DASHBOARD')) {
+    /* Standalone web mode — works on shared hosting without CLI access
+     * (e.g., DreamHost). When invoked by the Setup dashboard we skip
+     * these headers so the dashboard's HTML response isn't hijacked. */
     header('Content-Type: text/plain; charset=UTF-8');
     header('X-Content-Type-Options: nosniff');
     header('Cache-Control: no-store');

--- a/appWeb/.sql/migrate-json.php
+++ b/appWeb/.sql/migrate-json.php
@@ -34,7 +34,11 @@ declare(strict_types=1);
 
 $isCli = (php_sapi_name() === 'cli');
 
-if (!$isCli) {
+if (!$isCli && !defined('IHYMNS_SETUP_DASHBOARD')) {
+    /* Only set a plaintext Content-Type when invoked standalone. When the
+     * Setup dashboard includes this script, it renders the captured <br>
+     * output inside its HTML page, so text/plain would corrupt the outer
+     * response on strict browsers (iOS Safari/Edge with nosniff). */
     header('Content-Type: text/plain; charset=UTF-8');
 }
 

--- a/appWeb/.sql/migrate-users.php
+++ b/appWeb/.sql/migrate-users.php
@@ -35,7 +35,9 @@ declare(strict_types=1);
 
 $isCli = (php_sapi_name() === 'cli');
 
-if (!$isCli) {
+if (!$isCli && !defined('IHYMNS_SETUP_DASHBOARD')) {
+    /* Standalone web mode only — skip these headers when included by the
+     * Setup dashboard so its HTML response isn't hijacked. */
     header('Content-Type: text/plain; charset=UTF-8');
     header('X-Content-Type-Options: nosniff');
     header('Cache-Control: no-store');

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -168,6 +168,13 @@ $actionOutput = '';
 $actionSuccess = false;
 
 if ($action !== '') {
+    /* Signal to the included scripts that they're being run from the
+     * dashboard, so they skip `header('Content-Type: text/plain')` which
+     * would otherwise leak to the outer response and cause iOS Safari/Edge
+     * to render this page as raw plaintext (the child's <br> output is
+     * still fine — only the header propagates via buffered output). */
+    define('IHYMNS_SETUP_DASHBOARD', true);
+
     ob_start();
 
     $scriptDir = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . '.sql' . DIRECTORY_SEPARATOR . '';
@@ -210,6 +217,12 @@ if ($action !== '') {
     }
 
     $actionOutput = ob_get_clean();
+
+    /* Defence in depth: if any child script still managed to set a
+     * non-HTML Content-Type (e.g. old cached copy), override it so the
+     * dashboard HTML renders correctly on iOS Safari/Edge. */
+    header('Content-Type: text/html; charset=UTF-8');
+    header_remove('X-Content-Type-Options');
 }
 
 /* =========================================================================


### PR DESCRIPTION
## Summary

Fixes the Setup dashboard rendering as raw source on iOS Safari / Edge after clicking **Migrate Song Data** or **Migrate Users & Setlists**.

**Root cause**
When `/manage/setup-database.php` runs an action, it `require`s the corresponding script from `appWeb/.sql/` while an output buffer is open. Every one of those scripts started with:

```php
if (!$isCli) { header('Content-Type: text/plain; charset=UTF-8'); }
```

The `<br>`-formatted output is captured by `ob_start()` and re-rendered inside the dashboard's HTML, but `header()` **is not buffered** — it mutates the outer response's header list. Combined with `X-Content-Type-Options: nosniff` it forced iOS Safari/Edge to render the whole dashboard page as plaintext. It only surfaced on steps 2 & 3 because step 1 (Install) was previously failing with "Script not found" before the child ever set a header.

## Changes

Two layers of defence so we never leak `text/plain`:

1. **`setup-database.php`** now `define('IHYMNS_SETUP_DASHBOARD', true)` before `require`ing the action script. All five scripts (`install.php`, `migrate-json.php`, `migrate-users.php`, `cleanup.php`, `backup.php`) now gate their `header()` calls on this flag, so they skip them when included from the dashboard.
2. **After `ob_get_clean()`**, `setup-database.php` explicitly sends `Content-Type: text/html; charset=UTF-8` and removes `X-Content-Type-Options`, guaranteeing a correct outer response even if a stale copy of a child script still sets `text/plain`.

Standalone invocation (hitting `/.sql/migrate-users.php` directly) is unchanged — those paths still serve plaintext.

## Test plan

- [ ] On iOS Safari and iOS Edge, clicking **Run Song Migration** in the Setup dashboard renders inside the dashboard's dark HTML layout (not as raw source)
- [ ] Same for **Run User Migration**, **Run Cleanup**, **Run Backup**
- [ ] Output text inside the "Output" log box retains its line breaks (`<br>` → new lines)
- [ ] Re-running an action does not inherit a stale `text/plain` header
- [ ] Installer/migrator scripts still work correctly when hit directly on a dev host (plaintext mode)

https://claude.ai/code/session_01XUtkSVBVB3ez9HqHaTQb7r