### PR TITLE
fix(install) + feat(setup): non-interactive install + Drop Legacy Tables action

### DIFF
--- a/appWeb/.sql/drop-legacy-tables.php
+++ b/appWeb/.sql/drop-legacy-tables.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Drop Legacy Tables
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Drops any tables in the iHymns database that are NOT part of the
+ * current schema.sql. The set of "current" tables is parsed from the
+ * live schema.sql at runtime so this script never goes stale.
+ *
+ * Useful after importing an existing MySQL database that still holds
+ * tables from a previous iHymns incarnation (e.g. tblHymnals, tblHymns,
+ * tblComposers, tblPersons, tblRespReadings, tblTunes).
+ *
+ * USAGE:
+ *   CLI preview:  php appWeb/.sql/drop-legacy-tables.php
+ *   CLI execute:  php appWeb/.sql/drop-legacy-tables.php --confirm
+ *   Web execute:  /manage/setup-database.php?action=drop-legacy&confirm=1
+ *
+ * Without --confirm / ?confirm=1 the script lists what WOULD be dropped
+ * and exits without touching the database.
+ *
+ * @requires PHP 8.1+ with mysqli extension
+ */
+
+$isCli = (php_sapi_name() === 'cli');
+
+if (!$isCli && !defined('IHYMNS_SETUP_DASHBOARD')) {
+    header('Content-Type: text/plain; charset=UTF-8');
+    header('X-Content-Type-Options: nosniff');
+    header('Cache-Control: no-store');
+}
+
+function output(string $msg): void {
+    global $isCli;
+    echo $msg . ($isCli ? "\n" : "<br>\n");
+    if (!$isCli) flush();
+}
+
+/* =========================================================================
+ * LOAD CREDENTIALS
+ * ========================================================================= */
+
+$credFile = dirname(__DIR__) . DIRECTORY_SEPARATOR . '.auth' . DIRECTORY_SEPARATOR . 'db_credentials.php';
+if (!file_exists($credFile)) {
+    output("ERROR: Credentials file not found: {$credFile}");
+    return;
+}
+require_once $credFile;
+
+$tablePrefix = defined('DB_PREFIX') ? DB_PREFIX : '';
+
+/* =========================================================================
+ * PARSE schema.sql TO BUILD THE KNOWN-TABLE SET
+ * ========================================================================= */
+
+$schemaFile = __DIR__ . DIRECTORY_SEPARATOR . 'schema.sql';
+if (!file_exists($schemaFile)) {
+    output("ERROR: schema.sql not found: {$schemaFile}");
+    return;
+}
+
+$schemaSql = (string)file_get_contents($schemaFile);
+preg_match_all('/CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?`?(tbl\w+)`?/i', $schemaSql, $m);
+$knownNames = array_unique($m[1] ?? []);
+
+if ($tablePrefix !== '') {
+    /* Apply the same prefix that install.php injects: tbl<Name> → tbl<prefix><Name> */
+    $knownNames = array_map(
+        fn($t) => preg_replace('/^tbl([A-Z])/', 'tbl' . $tablePrefix . '$1', $t),
+        $knownNames
+    );
+}
+
+if (empty($knownNames)) {
+    output("ERROR: Could not parse any table names from schema.sql.");
+    return;
+}
+
+$known = array_flip($knownNames);
+
+/* =========================================================================
+ * CONNECT
+ * ========================================================================= */
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+try {
+    $mysql = new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME, (int)DB_PORT);
+    $mysql->set_charset(defined('DB_CHARSET') ? DB_CHARSET : 'utf8mb4');
+} catch (\Throwable $e) {
+    output("ERROR: Connection failed: " . $e->getMessage());
+    return;
+}
+
+/* =========================================================================
+ * FIND LEGACY TABLES
+ * ========================================================================= */
+
+$legacy = [];
+$result = $mysql->query("SHOW TABLES");
+while ($row = $result->fetch_array()) {
+    $name = $row[0];
+    if (!isset($known[$name])) {
+        $legacy[] = $name;
+    }
+}
+$result->free();
+
+if (empty($legacy)) {
+    output("No legacy tables found. The database contains only schema tables.");
+    $mysql->close();
+    return;
+}
+
+output("Found " . count($legacy) . " legacy table(s) not in schema.sql:");
+output("");
+
+$rowTotals = [];
+foreach ($legacy as $t) {
+    try {
+        $escaped = $mysql->real_escape_string($t);
+        $cr = $mysql->query("SELECT COUNT(*) AS c FROM `{$escaped}`");
+        $count = $cr ? (int)$cr->fetch_assoc()['c'] : 0;
+    } catch (\Throwable $e) {
+        $count = -1;
+    }
+    $rowTotals[$t] = $count;
+    $label = $count === -1 ? '?' : number_format($count);
+    output("  - {$t} ({$label} rows)");
+}
+output("");
+
+/* =========================================================================
+ * CONFIRM GATE
+ * ========================================================================= */
+
+$confirmed = false;
+if ($isCli) {
+    foreach ($argv ?? [] as $arg) {
+        if ($arg === '--confirm') $confirmed = true;
+    }
+} else {
+    $confirmed = (($_GET['confirm'] ?? '') === '1');
+}
+
+if (!$confirmed) {
+    if ($isCli) {
+        output("DRY RUN. Re-run with --confirm to drop the tables listed above.");
+    } else {
+        output("DRY RUN. Re-run with '?action=drop-legacy&confirm=1' to drop these tables.");
+    }
+    $mysql->close();
+    return;
+}
+
+/* =========================================================================
+ * DROP
+ * ========================================================================= */
+
+output("Dropping " . count($legacy) . " table(s)...");
+output("");
+
+$mysql->query("SET FOREIGN_KEY_CHECKS = 0");
+
+$dropped = 0;
+$errors  = 0;
+
+foreach ($legacy as $t) {
+    try {
+        $mysql->query("DROP TABLE `" . $mysql->real_escape_string($t) . "`");
+        output("  [OK]   Dropped {$t}");
+        $dropped++;
+    } catch (\Throwable $e) {
+        output("  [FAIL] {$t} — " . $e->getMessage());
+        $errors++;
+    }
+}
+
+$mysql->query("SET FOREIGN_KEY_CHECKS = 1");
+
+output("");
+output("─── Summary ───");
+output("  Dropped: {$dropped}");
+output("  Errors:  {$errors}");
+
+$mysql->close();
+return;

--- a/appWeb/.sql/install.php
+++ b/appWeb/.sql/install.php
@@ -105,11 +105,22 @@ $credentialsFile = dirname(__DIR__) . DIRECTORY_SEPARATOR . '.auth' . DIRECTORY_
 $credentialsDir  = dirname($credentialsFile);
 $hasExistingCreds = file_exists($credentialsFile);
 
+/* Interactive input is only possible in a real CLI environment with STDIN.
+ * The web dashboard runs this script with IHYMNS_SETUP_DASHBOARD defined;
+ * shared hosting web invocations lack STDIN too. In non-interactive mode
+ * we never prompt — we just honour whatever credentials file is present. */
+$isInteractive = $isCli && defined('STDIN') && is_resource(STDIN);
+
 if ($hasExistingCreds) {
     output("Found existing credentials: " . realpath($credentialsFile));
-    $useExisting = strtolower(prompt("Use existing credentials? (y/n)", "y"));
-    if ($useExisting === 'n' || $useExisting === 'no') {
-        $hasExistingCreds = false;
+    if ($isInteractive) {
+        $useExisting = strtolower(prompt("Use existing credentials? (y/n)", "y"));
+        if ($useExisting === 'n' || $useExisting === 'no') {
+            $hasExistingCreds = false;
+        }
+    } else {
+        output("Using existing credentials (non-interactive mode).");
+        output("");
     }
 }
 
@@ -118,15 +129,12 @@ if ($hasExistingCreds) {
  * ========================================================================= */
 
 if (!$hasExistingCreds) {
-    /* Check if we can read from STDIN interactively */
-    if (!defined('STDIN') || !is_resource(STDIN)) {
-        output("ERROR: Cannot read interactive input.");
+    if (!$isInteractive) {
+        output("ERROR: Cannot prompt for credentials (non-interactive mode).");
         output("");
-        output("To configure credentials manually:");
-        output("  1. Copy appWeb/.auth/db_credentials.example.php");
-        output("     to   appWeb/.auth/db_credentials.php");
-        output("  2. Edit db_credentials.php with your MySQL details");
-        output("  3. Re-run this installer");
+        output("Use the Setup dashboard form at /manage/setup-database.php, or");
+        output("copy appWeb/.auth/db_credentials.example.php to db_credentials.php");
+        output("and edit it by hand, then re-run this installer.");
         return;
     }
 

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -179,11 +179,12 @@ if ($action !== '') {
 
     $scriptDir = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . '.sql' . DIRECTORY_SEPARATOR . '';
     $scriptMap = [
-        'install' => 'install.php',
-        'migrate' => 'migrate-json.php',
-        'users'   => 'migrate-users.php',
-        'cleanup' => 'cleanup.php',
-        'backup'  => 'backup.php',
+        'install'     => 'install.php',
+        'migrate'     => 'migrate-json.php',
+        'users'       => 'migrate-users.php',
+        'cleanup'     => 'cleanup.php',
+        'backup'      => 'backup.php',
+        'drop-legacy' => 'drop-legacy-tables.php',
     ];
 
     $scriptName = $scriptMap[$action] ?? null;
@@ -463,6 +464,28 @@ if ($hasCredentials && defined('DB_HOST')) {
                         <a href="?action=backup" class="btn btn-outline-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
                             Run Backup
                         </a>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="card bg-dark border-danger h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">6. Drop Legacy Tables</h5>
+                        <p class="card-text text-secondary small">
+                            Drop any tables in the database that are <strong>not</strong>
+                            part of the current <code>schema.sql</code>. Useful after
+                            importing an existing MySQL database that still holds tables
+                            from a previous iHymns incarnation.
+                        </p>
+                        <div class="d-flex gap-2 flex-wrap">
+                            <a href="?action=drop-legacy" class="btn btn-outline-warning btn-sm <?= $hasCredentials ? '' : 'disabled' ?>">
+                                Preview
+                            </a>
+                            <a href="?action=drop-legacy&amp;confirm=1" class="btn btn-danger btn-sm <?= $hasCredentials ? '' : 'disabled' ?>"
+                               onclick="return confirm('This will DROP all tables in the database that are not defined in schema.sql.\n\nThis cannot be undone. Run a Backup first.\n\nContinue?')">
+                                Drop Them
+                            </a>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary

Two related fixes and one follow-up feature for the Setup dashboard, rolled into one PR since they share the same branch.

### 1. Fix `install.php` STDIN crash (`install.php:60`)

Clicking **Run Install** from the dashboard with existing credentials produced `ERROR: Undefined constant "STDIN"` because `install.php` prompted `"Use existing credentials? (y/n)"` via `fgets(STDIN)` before its own STDIN guard could run.

Now detects interactivity up front:
```
$isInteractive = $isCli && defined('STDIN') && is_resource(STDIN);
```
- **Creds exist, non-interactive:** silently use them → proceed to schema
- **Creds missing, non-interactive:** bail with a pointer to the dashboard credentials form
- **CLI:** unchanged — the prompt still appears exactly as before

### 2. New action: **Drop Legacy Tables**

After pointing iHymns at an existing MySQL database, legacy tables from a previous incarnation (`tblHymnals`, `tblHymns`, `tblComposers`, `tblPersons`, `tblRespReadings`, `tblTunes`) sit alongside the new schema forever. `schema.sql` is `CREATE TABLE IF NOT EXISTS`-only, so it can't clean them up. None of those legacy names have any reference in the current codebase (`rg` check returned zero results).

Added a sixth card on `/manage/setup-database.php`:
- **Preview** — dry run. Lists every table in the database that is NOT defined in `schema.sql`, with row counts.
- **Drop Them** — JS `confirm()` prompt, passes `?confirm=1`, drops the legacy tables inside `SET FOREIGN_KEY_CHECKS = 0` so FK ordering doesn't matter.

The allowlist is parsed from `schema.sql` at runtime (regex over `CREATE TABLE [IF NOT EXISTS] \`tblX\``) so it never goes stale — adding a new table to `schema.sql` automatically protects it. `DB_PREFIX` handling mirrors `install.php`.

Also callable from CLI:
```
php appWeb/.sql/drop-legacy-tables.php            # preview
php appWeb/.sql/drop-legacy-tables.php --confirm  # execute
```

## Test plan

- [ ] On a host with existing credentials, **Run Install** completes successfully and logs per-table `[OK]` / `[SKIP]` lines
- [ ] `install.php` via raw web request with missing credentials now shows the dashboard-form hint instead of STDIN error
- [ ] CLI `php appWeb/.sql/install.php` still prompts "Use existing credentials? (y/n)"
- [ ] **Preview** lists the 6 legacy tables with row counts and "DRY RUN" footer
- [ ] **Drop Them** → JS confirm → each drop logs `[OK] Dropped tblX`
- [ ] After drop, Database Status shows only schema tables
- [ ] Re-Preview says "No legacy tables found."

https://claude.ai/code/session_01XUtkSVBVB3ez9HqHaTQb7r