### PR TITLE
fix(auth+editor): Settings Account card state + clearer Save button in editor

### DIFF
--- a/appWeb/public_html/includes/pages/settings.php
+++ b/appWeb/public_html/includes/pages/settings.php
@@ -40,8 +40,15 @@ declare(strict_types=1);
                 Account
             </h2>
 
+            <!--
+                Both states default to d-none so that if JS fails to toggle
+                (e.g. module load error, service worker cache stale),
+                we show nothing rather than the wrong thing. settings.js
+                reveals the correct one via refreshAccountSection(), and
+                re-applies whenever ihymns:auth-changed fires.
+            -->
             <!-- Logged-out state -->
-            <div id="auth-logged-out">
+            <div id="auth-logged-out" class="d-none">
                 <p class="text-muted small mb-3">
                     Sign in to sync your set lists across devices. Your favourites
                     and settings stay on this device.

--- a/appWeb/public_html/js/modules/router.js
+++ b/appWeb/public_html/js/modules/router.js
@@ -423,6 +423,18 @@ export class Router {
             this.app.settings.initSettingsPage();
         }
 
+        /* After the new page HTML is in the DOM, broadcast the current auth
+           state so any just-injected markup (Account card, sync bars, etc.)
+           lands in the correct logged-in/logged-out state. */
+        try {
+            document.dispatchEvent(new CustomEvent('ihymns:auth-changed', {
+                detail: {
+                    loggedIn: !!this.app.userAuth?.isLoggedIn(),
+                    user: this.app.userAuth?.getUser() ?? null,
+                },
+            }));
+        } catch { /* legacy browsers — ignore */ }
+
         /* Initialise set list page controls (#94) */
         if (page === 'setlist') {
             this.app.setList.initSetListPage();

--- a/appWeb/public_html/js/modules/setlist.js
+++ b/appWeb/public_html/js/modules/setlist.js
@@ -36,8 +36,15 @@ export class SetList {
         this.activeSetListId = null;
     }
 
-    /** Initialise — nothing needed on startup */
-    init() {}
+    /** Initialise — re-render the sync bar whenever auth state flips. */
+    init() {
+        document.addEventListener('ihymns:auth-changed', () => {
+            /* Only re-render if the sync bar is currently in the DOM. */
+            if (document.getElementById('setlist-sync-bar')) {
+                this.renderSyncBar();
+            }
+        });
+    }
 
     /* =====================================================================
      * CRUD OPERATIONS

--- a/appWeb/public_html/js/modules/settings.js
+++ b/appWeb/public_html/js/modules/settings.js
@@ -96,6 +96,38 @@ export class Settings {
                 }
             });
         }
+
+        /* Re-apply the Account section whenever auth state changes, even if
+           the user is on the Settings page (no navigation triggered). */
+        document.addEventListener('ihymns:auth-changed', () => {
+            this.refreshAccountSection();
+        });
+    }
+
+    /**
+     * Refresh the Account section visibility based on current auth state.
+     * Safe to call at any time; no-ops if the Settings page markup is not
+     * currently in the DOM. Idempotent — only the class toggles run; click
+     * handlers are (re)bound inside _initAccountSection.
+     */
+    refreshAccountSection() {
+        const loggedOutEl = document.getElementById('auth-logged-out');
+        const loggedInEl  = document.getElementById('auth-logged-in');
+        if (!loggedOutEl && !loggedInEl) return;
+
+        const auth = this.app.userAuth;
+        const loggedIn = !!auth?.isLoggedIn();
+
+        loggedOutEl?.classList.toggle('d-none', loggedIn);
+        loggedInEl?.classList.toggle('d-none', !loggedIn);
+
+        if (loggedIn) {
+            const user = auth.getUser();
+            const nameEl = document.getElementById('auth-display-name-text');
+            const userEl = document.getElementById('auth-username-text');
+            if (nameEl) nameEl.textContent = user?.display_name || user?.username || '';
+            if (userEl) userEl.textContent = '@' + (user?.username || '');
+        }
     }
 
     /* =====================================================================
@@ -1012,21 +1044,8 @@ export class Settings {
         const auth = this.app.userAuth;
         if (!auth) return;
 
-        const loggedOutEl = document.getElementById('auth-logged-out');
-        const loggedInEl  = document.getElementById('auth-logged-in');
-
-        if (auth.isLoggedIn()) {
-            const user = auth.getUser();
-            loggedOutEl?.classList.add('d-none');
-            loggedInEl?.classList.remove('d-none');
-            const nameEl = document.getElementById('auth-display-name-text');
-            const userEl = document.getElementById('auth-username-text');
-            if (nameEl) nameEl.textContent = user?.display_name || user?.username || '';
-            if (userEl) userEl.textContent = '@' + (user?.username || '');
-        } else {
-            loggedOutEl?.classList.remove('d-none');
-            loggedInEl?.classList.add('d-none');
-        }
+        /* Apply current auth state to the card */
+        this.refreshAccountSection();
 
         /* Sign In button */
         document.getElementById('btn-auth-login')?.addEventListener('click', () => {

--- a/appWeb/public_html/js/modules/user-auth.js
+++ b/appWeb/public_html/js/modules/user-auth.js
@@ -62,6 +62,27 @@ export class UserAuth {
     }
 
     /**
+     * Fire the global `ihymns:auth-changed` event so any UI that depends
+     * on signed-in state can refresh itself (header menu, settings page
+     * Account card, setlist sync bar, etc.). The detail payload is the
+     * current user object, or null when signed out.
+     */
+    _broadcastAuthChanged() {
+        try {
+            document.dispatchEvent(new CustomEvent('ihymns:auth-changed', {
+                detail: {
+                    loggedIn: this.isLoggedIn(),
+                    user: this.getUser(),
+                },
+            }));
+        } catch { /* IE/legacy — ignore */ }
+        /* Also refresh the header and settings account card immediately so
+           callers don't have to wait for event handlers to bind. */
+        this._updateHeaderState();
+        this.app.settings?.refreshAccountSection?.();
+    }
+
+    /**
      * Save auth credentials to localStorage.
      * @param {string} token Bearer token
      * @param {object} user  User info { id, username, display_name }
@@ -69,6 +90,7 @@ export class UserAuth {
     saveCredentials(token, user) {
         localStorage.setItem(STORAGE_AUTH_TOKEN, token);
         localStorage.setItem(STORAGE_AUTH_USER, JSON.stringify(user));
+        this._broadcastAuthChanged();
     }
 
     /**
@@ -77,6 +99,7 @@ export class UserAuth {
     clearCredentials() {
         localStorage.removeItem(STORAGE_AUTH_TOKEN);
         localStorage.removeItem(STORAGE_AUTH_USER);
+        this._broadcastAuthChanged();
     }
 
     /**

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -194,14 +194,18 @@ function _fetchAndParseSongs(target) {
 }
 
 /**
- * saveSongsToFile()
- * -----------------
- * Serialises the current `songData` to a pretty-printed JSON string and saves
- * it directly to the server via the editor PHP API (#154). This writes to the
- * canonical appWeb/data_share/song_data/songs.json file. Falls back to a
- * browser download if the server save fails.
+ * saveSongs()
+ * -----------
+ * Primary save action for the editor. Writes the current `songData` to the
+ * MySQL database via the editor PHP API (POST api.php?action=save).
+ *
+ * If the server is unreachable or the DB is not configured, the editor falls
+ * back to a browser download of songs.json so the admin never loses changes.
+ *
+ * Invoked by the toolbar "Save" button (#btn-save) and by saveToJSON()
+ * (legacy alias used by the validation flow).
  */
-function saveSongsToFile() {
+function saveSongs() {
     /* Run validation first; abort if the data is not valid. */
     var errors = validateSongData();
     if (errors.length > 0) {
@@ -218,7 +222,7 @@ function saveSongsToFile() {
     /* Serialise with 2-space indentation for human readability. */
     var jsonString = JSON.stringify(songData, null, 2);
 
-    /* Try saving via the PHP API first (writes directly to data_share/) */
+    /* Primary path: save to MySQL via the editor API. */
     fetch(EDITOR_API_URL + '?action=save', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -227,28 +231,40 @@ function saveSongsToFile() {
     .then(function (response) {
         return response.json().then(function (data) {
             if (response.ok && data.success) {
-                /* Server save succeeded */
+                /* DB save succeeded */
                 lastSaveTime = new Date();
                 modifiedSongIds.clear();
                 renderSongList();
                 updateStatusBar();
                 showToast(
-                    'Saved ' + data.songs + ' songs to server (' + Math.round(data.bytes / 1024) + ' KB).',
+                    'Saved ' + data.songs + ' songs to the database.',
                     'success'
                 );
             } else {
-                /* Server returned an error — fall back to download */
-                showToast('Server save failed: ' + (data.error || 'Unknown error') + '. Downloading instead.', 'warning');
+                /* Server reachable but the DB save failed — fall back to a
+                   JSON download so the admin can recover the work manually. */
+                showToast(
+                    'Database save failed: ' + (data.error || 'Unknown error') +
+                    '. Downloading a JSON backup so you don\u2019t lose changes.',
+                    'warning'
+                );
                 downloadSongsJson(jsonString);
             }
         });
     })
     .catch(function (err) {
-        /* Network error — fall back to browser download */
-        showToast('Server unavailable: ' + err.message + '. Downloading instead.', 'warning');
+        /* Network error / server unavailable — fall back to browser download. */
+        showToast(
+            'Server unavailable: ' + err.message +
+            '. Downloading a JSON backup so you don\u2019t lose changes.',
+            'warning'
+        );
         downloadSongsJson(jsonString);
     });
 }
+
+/* Backwards-compatible alias for the old function name. */
+var saveSongsToFile = saveSongs;
 
 /**
  * downloadSongsJson(jsonString)
@@ -2344,11 +2360,11 @@ function bindGlobalEventListeners() {
         });
     }
 
-    /* ---- Save / Export JSON button ---- */
+    /* ---- Save button — writes to MySQL, falls back to JSON download ---- */
     var saveBtn = document.getElementById('btn-save');
     if (saveBtn) {
         saveBtn.addEventListener('click', function () {
-            saveSongsToFile();
+            saveSongs();
         });
     }
 

--- a/appWeb/public_html/manage/editor/index.php
+++ b/appWeb/public_html/manage/editor/index.php
@@ -534,14 +534,16 @@ $currentUser = getCurrentUser();
                 <i class="bi bi-link-45deg me-1"></i>Load URL
             </button>
 
-            <!-- SAVE JSON — Saves the current state back to a downloadable JSON file -->
+            <!-- SAVE — Writes all songs to MySQL (primary path). If the DB
+                 is unavailable, the editor falls back to a JSON download so
+                 you never lose changes. -->
             <button
                 type="button"
                 class="btn btn-sm btn-amber-solid"
                 id="btn-save"
-                title="Download the current songs as a JSON file"
+                title="Save all changes to the database"
             >
-                <i class="bi bi-download me-1"></i>Save JSON
+                <i class="bi bi-floppy me-1"></i>Save
             </button>
 
             <!-- VALIDATE — Check all songs for data quality issues (#235) -->


### PR DESCRIPTION
## Summary

Two small but user-visible fixes on the same branch.

---

### 1. Settings Account card reflects signed-in state consistently

Settings kept showing **Sign In / Create Account** buttons even when the user was clearly signed in as admin (the header dropdown correctly showed "admin · Global Admin" at the same time).

**Root cause** — the `d-none` toggle in `_initAccountSection()` only ran inside `initSettingsPage()`, and only on navigation to `/settings`. Any auth change happening elsewhere (magic link, login modal on another page, credential sync) or DOM re-injection left the card stuck in its default state. The template defaulted the logged-out view to visible, so the wrong UI appeared first and never self-corrected.

**Fix — a small auth event bus + safer defaults**

1. **`user-auth.js`** fires a global `ihymns:auth-changed` CustomEvent from `saveCredentials()` and `clearCredentials()`, and synchronously invokes `_updateHeaderState()` + `settings.refreshAccountSection()`.
2. **`settings.js`** exposes `refreshAccountSection()` — idempotent, safe to call anywhere, no-ops if Settings markup isn't in the DOM. The module subscribes to `ihymns:auth-changed` in `init()` so any auth change anywhere re-skins Settings without needing navigation.
3. **`router.js`** fires `ihymns:auth-changed` at the end of `afterPageLoad()` so freshly-injected HTML (Account card, Setlist sync bar, etc.) lands in the correct state on first paint.
4. **`setlist.js`** listens for `ihymns:auth-changed` and re-renders `#setlist-sync-bar` if present.
5. **`settings.php`** defaults BOTH `#auth-logged-out` and `#auth-logged-in` to `d-none` — if JS fails, the app shows nothing rather than the wrong thing.

---

### 2. Editor: rename "Save JSON" → "Save", clarify DB-first save path

The editor's primary save button was labelled **"Save JSON"** with a download icon, which read as an export action even though `saveSongsToFile()` already POSTs to `api.php?action=save` and writes to MySQL as its primary path. Since v0.10.0 uses MySQL, the "JSON" terminology was doubly misleading.

- `#btn-save` relabelled to **"Save"** with a `bi-floppy` icon; tooltip says "Save all changes to the database."
- JS function renamed to `saveSongs()`; `saveSongsToFile` kept as a backwards-compat alias for `exportJSON()` and other callers.
- Success toast: "Saved N songs to the database."
- Failure / network-error toasts now explicitly say the JSON download is a **backup** so changes aren't lost — not the intent.
- Behaviour otherwise unchanged: MySQL remains primary, browser-download is the fallback.

## Test plan

### Auth state
- [ ] Signed in as admin → navigate to Settings — Account card shows "Signed In" badge + display name (never Sign In / Create Account)
- [ ] While on Settings, click **Sign Out** — card flips to logged-out state immediately without reload
- [ ] Set Lists page — sync bar flips live between "Sign in to sync" and "Signed in as X" on login/logout
- [ ] Hit `/settings` directly as a guest — logged-out card renders as expected

### Editor save
- [ ] Click **Save** — success toast reads "Saved N songs to the database."
- [ ] With DB unreachable, clicking Save shows a warning toast explaining the JSON download is a backup
- [ ] Existing **Export JSON** button still triggers a pure JSON download

https://claude.ai/code/session_01XUtkSVBVB3ez9HqHaTQb7r