### PR TITLE
feat(batch): 11 closed + 4 deferred — auth, editor, search, PWA, admin

### DIFF
--- a/appWeb/.sql/migrate-json.php
+++ b/appWeb/.sql/migrate-json.php
@@ -214,9 +214,17 @@ try {
 
     foreach ($data['songs'] as $i => $song) {
         $songId       = $song['id'];
-        $number       = (int)$song['number'];
-        $title        = $song['title'];
         $songbookAbbr = $song['songbook'];
+
+        /* Number is NULL for Misc (unstructured collection) or when the
+           source simply doesn't have one (#392). Anything else is stored
+           as its integer value. */
+        $rawNumber = $song['number'] ?? null;
+        $number    = ($songbookAbbr === 'Misc' || $rawNumber === null || $rawNumber === '' || (int)$rawNumber <= 0)
+            ? null
+            : (int)$rawNumber;
+
+        $title        = $song['title'];
         $songbookName = $song['songbookName'] ?? '';
         $language     = $song['language'] ?? 'en';
         $copyright    = $song['copyright'] ?? '';

--- a/appWeb/.sql/schema.sql
+++ b/appWeb/.sql/schema.sql
@@ -49,7 +49,7 @@ CREATE TABLE IF NOT EXISTS tblSongbooks (
 CREATE TABLE IF NOT EXISTS tblSongs (
     Id                  INT UNSIGNED    AUTO_INCREMENT PRIMARY KEY,
     SongId              VARCHAR(20)     NOT NULL UNIQUE COMMENT 'Canonical ID, e.g. CP-0001',
-    Number              INT UNSIGNED    NOT NULL COMMENT 'Song number within its songbook',
+    Number              INT UNSIGNED    NULL DEFAULT NULL COMMENT 'Song number within its songbook; NULL for Misc (unstructured collection)',
     Title               VARCHAR(500)    NOT NULL,
     SongbookAbbr        VARCHAR(10)     NOT NULL COMMENT 'FK to tblSongbooks.Abbreviation',
     SongbookName        VARCHAR(255)    NOT NULL COMMENT 'Denormalised songbook name for convenience',
@@ -1008,3 +1008,19 @@ CREATE TABLE IF NOT EXISTS tblLoginAttempts (
     INDEX idx_Ip        (IpAddress),
     INDEX idx_IpTime    (IpAddress, AttemptedAt)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+-- ============================================================================
+-- IN-PLACE MIGRATIONS (safe to re-run)
+-- These run after the CREATE TABLE IF NOT EXISTS statements so existing
+-- deployments upgrade without manual DB work. Each statement is idempotent:
+-- MySQL treats a no-op ALTER (column already matches) as a successful
+-- metadata-only operation.
+-- ============================================================================
+
+-- Make tblSongs.Number nullable so the Misc ("unsorted") songbook can hold
+-- songs without a songbook number (#392).
+ALTER TABLE tblSongs MODIFY Number INT UNSIGNED NULL DEFAULT NULL;
+
+-- Zero out any existing Misc song numbers (historic placeholders).
+UPDATE tblSongs SET Number = NULL WHERE SongbookAbbr = 'Misc' AND Number IS NOT NULL;

--- a/appWeb/public_html/css/app.css
+++ b/appWeb/public_html/css/app.css
@@ -885,6 +885,18 @@ body.banner-visible.search-open .main-content {
     text-shadow: 0 1px 2px rgba(0,0,0,0.5); /* #263 — improve contrast in dark mode */
 }
 
+/* Misc / unnumbered songs: badge is kept for list alignment but renders a
+   small book glyph instead of a song number (#392). Applied automatically
+   whenever the badge ends up empty (e.g. Misc songs with Number IS NULL). */
+.song-number-badge:empty::before,
+.song-number-badge-lg:empty::before {
+    content: '\f02d'; /* Font Awesome "book" */
+    font-family: 'Font Awesome 6 Free', 'FontAwesome';
+    font-weight: 900;
+    opacity: 0.8;
+    font-size: 0.9em;
+}
+
 /* Songbook-specific badge colours + contrast-safe text (#98, #152) */
 .song-number-badge[data-songbook="CP"]   { background: var(--songbook-CP);   color: var(--songbook-CP-text); }
 .song-number-badge[data-songbook="JP"]   { background: var(--songbook-JP);   color: var(--songbook-JP-text); }

--- a/appWeb/public_html/includes/pages/home.php
+++ b/appWeb/public_html/includes/pages/home.php
@@ -219,7 +219,7 @@ $songbooks = $songData->getSongbooks();
                     var book = s.songbook || id.split('-')[0] || '';
                     var bookName = SONGBOOK_NAMES[book] || book;
                     return '<a href="/song/' + esc(id) + '" data-navigate="song" data-song-id="' + esc(id) + '" class="list-group-item list-group-item-action song-list-item">' +
-                        '<span class="song-number-badge" data-songbook="' + esc(book) + '">' + (s.number || '?') + '</span>' +
+                        '<span class="song-number-badge" data-songbook="' + esc(book) + '">' + (s.number ?? '') + '</span>' +
                         '<div class="song-info flex-grow-1">' +
                             '<span class="song-title">' + esc(title) + '</span>' +
                             '<small class="text-muted d-block"><span class="songbook-name-full">' + esc(bookName) + '</span><span class="songbook-name-abbr">' + esc(book) + '</span></small>' +

--- a/appWeb/public_html/includes/pages/search.php
+++ b/appWeb/public_html/includes/pages/search.php
@@ -142,7 +142,8 @@ $songbooks = $songData->getSongbooks();
                 </label>
                 <select class="form-select form-select-lg" id="page-numpad-songbook" aria-label="Select songbook for number search">
                     <?php foreach ($songbooks as $book): ?>
-                        <?php if (($book['songCount'] ?? 0) > 0): ?>
+                        <?php /* Exclude Misc — it has no numbering (#392) */ ?>
+                        <?php if (($book['songCount'] ?? 0) > 0 && $book['id'] !== 'Misc'): ?>
                             <option value="<?= htmlspecialchars($book['id']) ?>">
                                 <?= htmlspecialchars($book['name']) ?> (<?= htmlspecialchars($book['id']) ?>)
                             </option>

--- a/appWeb/public_html/includes/pages/settings.php
+++ b/appWeb/public_html/includes/pages/settings.php
@@ -272,7 +272,7 @@ declare(strict_types=1);
             </div>
 
             <!-- Reduce transparency toggle -->
-            <div class="form-check form-switch mb-0">
+            <div class="form-check form-switch mb-3">
                 <input class="form-check-input"
                        type="checkbox"
                        id="setting-reduce-transparency"
@@ -282,6 +282,22 @@ declare(strict_types=1);
                     <strong>Reduce Transparency</strong>
                     <small class="text-muted d-block">
                         Removes glass-like blur effects for improved readability.
+                    </small>
+                </label>
+            </div>
+
+            <!-- Keyboard shortcuts toggle (#406) -->
+            <div class="form-check form-switch mb-0">
+                <input class="form-check-input"
+                       type="checkbox"
+                       id="setting-keyboard-shortcuts"
+                       role="switch"
+                       aria-label="Enable keyboard shortcuts">
+                <label class="form-check-label" for="setting-keyboard-shortcuts">
+                    <strong>Keyboard Shortcuts</strong>
+                    <small class="text-muted d-block">
+                        Press <kbd>?</kbd> to view all shortcuts, <kbd>/</kbd> to focus search,
+                        arrow keys to navigate songs, and more.
                     </small>
                 </label>
             </div>

--- a/appWeb/public_html/includes/pages/song.php
+++ b/appWeb/public_html/includes/pages/song.php
@@ -31,8 +31,9 @@ if ($song === null) {
     return;
 }
 
-/* Extract metadata for convenience */
-$songNumber  = (int)$song['number'];
+/* Extract metadata for convenience — Number is null for Misc songs (#392) */
+$rawSongNumber = $song['number'] ?? null;
+$songNumber    = ($rawSongNumber === null || $rawSongNumber === '') ? null : (int)$rawSongNumber;
 $songTitle   = toTitleCase($song['title'] ?? 'Untitled');
 $songbook    = $song['songbook'] ?? '';
 $bookName    = $song['songbookName'] ?? '';
@@ -81,8 +82,9 @@ $components  = $song['components'] ?? [];
         <div class="card-body">
             <!-- Song number and title -->
             <div class="d-flex align-items-start gap-3 mb-3">
-                <span class="song-number-badge-lg" data-songbook="<?= htmlspecialchars($songbook) ?>" aria-label="Song number <?= $songNumber ?>">
-                    <?= $songNumber ?>
+                <span class="song-number-badge-lg" data-songbook="<?= htmlspecialchars($songbook) ?>"
+                      aria-label="<?= $songNumber === null ? 'Unnumbered song' : 'Song number ' . (int)$songNumber ?>">
+                    <?= $songNumber === null ? '' : (int)$songNumber ?>
                 </span>
                 <div class="flex-grow-1">
                     <h1 class="h4 mb-1"><?= htmlspecialchars($songTitle) ?><?php if (!empty($song['verified'])): ?><span class="verified-badge" title="Verified lyrics" aria-label="Verified lyrics"><svg viewBox="0 0 24 24" fill="none" aria-hidden="true"><circle cx="12" cy="12" r="10" fill="currentColor" opacity="0.15"/><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="1.5" fill="none"/><path d="M7.5 12.5L10.5 15.5L16.5 9" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg></span><?php endif; ?></h1>

--- a/appWeb/public_html/js/app.js
+++ b/appWeb/public_html/js/app.js
@@ -333,6 +333,11 @@ class iHymnsApp {
             const tag = (e.target.tagName || '').toLowerCase();
             if (tag === 'input' || tag === 'textarea' || tag === 'select') return;
 
+            /* Honour the user's "Enable keyboard shortcuts" setting (#406).
+               Off by default means all shortcuts — including the `?` help
+               overlay — are disabled. Users can toggle in Settings → Input. */
+            if (this.settings && this.settings.get('keyboardShortcuts') === false) return;
+
             /* Quick-jump: capture digit keys (#96) */
             if (e.key >= '0' && e.key <= '9') {
                 e.preventDefault();

--- a/appWeb/public_html/js/modules/favorites.js
+++ b/appWeb/public_html/js/modules/favorites.js
@@ -428,7 +428,7 @@ export class Favorites {
                            data-song-id="${escapeHtml(fav.id)}"
                            aria-label="Select ${escapeHtml(toTitleCase(fav.title))}"
                            onclick="event.stopPropagation()">
-                    <span class="song-number-badge" data-songbook="${escapeHtml(fav.songbook)}">${fav.number || '?'}</span>
+                    <span class="song-number-badge" data-songbook="${escapeHtml(fav.songbook)}">${fav.number ?? ''}</span>
                     <div class="song-info flex-grow-1">
                         <span class="song-title">${escapeHtml(toTitleCase(fav.title))}${verifiedBadge(fav)}</span>
                         <small class="text-muted d-block">${songbookLabel(fav.songbook)}${tagsHtml}</small>

--- a/appWeb/public_html/js/modules/history.js
+++ b/appWeb/public_html/js/modules/history.js
@@ -132,7 +132,7 @@ export class History {
                        class="list-group-item list-group-item-action song-list-item"
                        data-navigate="song"
                        data-song-id="${escapeHtml(h.id)}">
-                        <span class="song-number-badge" data-songbook="${escapeHtml(h.songbook)}">${h.number || '?'}</span>
+                        <span class="song-number-badge" data-songbook="${escapeHtml(h.songbook)}">${h.number ?? ''}</span>
                         <div class="song-info flex-grow-1">
                             <span class="song-title">${escapeHtml(toTitleCase(h.title))}${verifiedBadge(h)}</span>
                             <small class="text-muted d-block">${songbookLabel(h.songbook)}</small>

--- a/appWeb/public_html/js/modules/numpad.js
+++ b/appWeb/public_html/js/modules/numpad.js
@@ -303,8 +303,10 @@ export class Numpad {
             const data = await response.json();
 
             if (data.songbooks) {
+                /* Exclude Misc — songs in that collection have no songbook
+                   number, so "jump by number" makes no sense there (#392). */
                 select.innerHTML = data.songbooks
-                    .filter(b => b.songCount > 0)
+                    .filter(b => b.songCount > 0 && b.id !== 'Misc')
                     .map(b => `<option value="${escapeHtml(b.id)}">${escapeHtml(b.name)} (${escapeHtml(b.id)})</option>`)
                     .join('');
 

--- a/appWeb/public_html/js/modules/router.js
+++ b/appWeb/public_html/js/modules/router.js
@@ -641,7 +641,7 @@ export class Router {
                     <div class="d-flex align-items-center gap-2 mb-2">
                         <a href="/song/${escapeHtml(s.id)}" class="text-decoration-none flex-grow-1 text-truncate"
                            data-navigate="song" data-song-id="${escapeHtml(s.id)}">
-                            <span class="song-number-badge song-number-badge-sm" data-songbook="${escapeHtml(s.songbook)}">${s.number || '?'}</span>
+                            <span class="song-number-badge song-number-badge-sm" data-songbook="${escapeHtml(s.songbook)}">${s.number ?? ''}</span>
                             <span class="ms-1">${escapeHtml(toTitleCase(s.title))}</span>
                         </a>
                         <div class="stats-bar-wrap">
@@ -848,7 +848,7 @@ export class Router {
                    data-navigate="song"
                    data-song-id="${escapeHtml(song.id)}"
                    role="listitem">
-                    <span class="song-number-badge" data-songbook="${escapeHtml(song.songbook)}">${song.number || '?'}</span>
+                    <span class="song-number-badge" data-songbook="${escapeHtml(song.songbook)}">${song.number ?? ''}</span>
                     <div class="song-info flex-grow-1">
                         <span class="song-title">${escapeHtml(toTitleCase(song.title))}${verifiedBadge(song)}</span>
                         <small class="text-muted d-block">${songbookLabel(song.songbook, song.songbookName)}</small>

--- a/appWeb/public_html/js/modules/setlist.js
+++ b/appWeb/public_html/js/modules/setlist.js
@@ -356,7 +356,7 @@ export class SetList {
                              data-song-id="${escapeHtml(song.id)}" data-index="${index}"
                              draggable="true">
                             <span class="text-muted fw-bold me-1" style="min-width:24px">${index + 1}.</span>
-                            <span class="song-number-badge" data-songbook="${escapeHtml(song.songbook)}">${song.number || '?'}</span>
+                            <span class="song-number-badge" data-songbook="${escapeHtml(song.songbook)}">${song.number ?? ''}</span>
                             <div class="flex-grow-1">
                                 <a href="/song/${escapeHtml(song.id)}" data-navigate="song"
                                    class="text-decoration-none">${escapeHtml(toTitleCase(song.title))}${verifiedBadge(song)}</a>
@@ -1584,7 +1584,7 @@ export class SetList {
                     if (titleEl) titleEl.textContent = toTitleCase(json.song.title) || songId;
                     if (metaEl) metaEl.textContent = json.song.songbook || '';
                     if (badge) {
-                        badge.textContent = json.song.number || '?';
+                        badge.textContent = json.song.number ?? '';
                         badge.dataset.songbook = json.song.songbook || '';
                     }
                 } catch {
@@ -1722,7 +1722,7 @@ export class SetList {
 
         /* Build running order summary */
         const orderSummary = list.songs.map((song, i) =>
-            `<tr><td class="pe-3 text-muted">${i + 1}.</td><td>${escapeHtml(toTitleCase(song.title))}</td><td class="text-muted">${escapeHtml(SONGBOOK_NAMES[song.songbook] || song.songbook)} #${song.number || '?'}</td></tr>`
+            `<tr><td class="pe-3 text-muted">${i + 1}.</td><td>${escapeHtml(toTitleCase(song.title))}</td><td class="text-muted">${escapeHtml(SONGBOOK_NAMES[song.songbook] || song.songbook)}${song.number != null ? ' #' + song.number : ''}</td></tr>`
         ).join('');
 
         /* Build individual song pages */
@@ -1734,7 +1734,7 @@ export class SetList {
                     <div class="print-song-header">
                         <span class="print-song-order">${index + 1}</span>
                         <h2>${escapeHtml(toTitleCase(page.song.title))}</h2>
-                        <p class="print-song-meta">${escapeHtml(SONGBOOK_NAMES[page.song.songbook] || page.song.songbook)} #${page.song.number || '?'}</p>
+                        <p class="print-song-meta">${escapeHtml(SONGBOOK_NAMES[page.song.songbook] || page.song.songbook)}${page.song.number != null ? ' #' + page.song.number : ''}</p>
                     </div>
                     <div class="print-song-content">${page.html}</div>
                 </div>`;

--- a/appWeb/public_html/js/modules/settings.js
+++ b/appWeb/public_html/js/modules/settings.js
@@ -38,6 +38,7 @@ export class Settings {
             reduceMotion: false,      /* Animations enabled by default */
             reduceTransparency: false,
             fontSize: 18,
+            keyboardShortcuts: true,  /* '?' opens help, '/' focuses search, etc. (#406) */
         };
 
         /**
@@ -414,6 +415,16 @@ export class Settings {
             transparencyToggle.addEventListener('change', () => {
                 this.set('reduceTransparency', transparencyToggle.checked);
                 this.applyReduceTransparency(transparencyToggle.checked);
+            });
+        }
+
+        /* Keyboard shortcuts toggle (#406). Takes effect on next keydown —
+           app.js reads the setting at event time, no rebind needed. */
+        const shortcutsToggle = document.getElementById('setting-keyboard-shortcuts');
+        if (shortcutsToggle) {
+            shortcutsToggle.checked = this.get('keyboardShortcuts') !== false;
+            shortcutsToggle.addEventListener('change', () => {
+                this.set('keyboardShortcuts', shortcutsToggle.checked);
             });
         }
 

--- a/appWeb/public_html/js/modules/user-auth.js
+++ b/appWeb/public_html/js/modules/user-auth.js
@@ -535,7 +535,10 @@ export class UserAuth {
                                 Forgot password?
                             </small>
                         </div>
-                        <div class="text-center mt-2" id="auth-email-toggle-wrapper" style="display:${mode === 'register' ? 'none' : ''}">
+                        <!-- Legacy "Sign in with email instead" link kept for the
+                             register-flow fallback path; hidden for login because
+                             magic-link email is now the primary sign-in path (#395). -->
+                        <div class="text-center mt-2" id="auth-email-toggle-wrapper" style="display:none">
                             <small id="auth-email-toggle" role="button" class="text-primary" style="cursor:pointer">
                                 <i class="fa-solid fa-envelope me-1" aria-hidden="true"></i>Sign in with email instead
                             </small>
@@ -574,7 +577,7 @@ export class UserAuth {
                             </div>
                             <div class="text-center mt-2">
                                 <small id="auth-back-to-password" role="button" class="text-primary" style="cursor:pointer">
-                                    Back to password sign-in
+                                    <i class="fa-solid fa-key me-1" aria-hidden="true"></i>Sign in with a password instead
                                 </small>
                             </div>
                         </div>
@@ -624,6 +627,17 @@ export class UserAuth {
         const bsModal = new bootstrap.Modal(modal);
 
         let currentMode = mode;
+
+        /* Promote magic-link email as the primary sign-in path (#395).
+           For the login flow we hide the password form and reveal the
+           email section on open. Users can click "Sign in with a password
+           instead" to fall back to the username/password form. */
+        if (mode === 'login') {
+            modal.querySelector('#auth-form').style.display = 'none';
+            modal.querySelector('#auth-email-section')?.classList.remove('d-none');
+            modal.querySelector('#auth-toggle').style.display = 'none';
+            modal.querySelector('#auth-forgot-link-wrapper').style.display = 'none';
+        }
 
         /* Toggle between login and register */
         modal.querySelector('#auth-toggle')?.addEventListener('click', () => {

--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -167,9 +167,16 @@ switch ($action) {
             /* Insert songs */
             foreach ($data['songs'] as $song) {
                 $songId       = $song['id'];
-                $number       = (int)$song['number'];
-                $title        = $song['title'];
                 $songbookAbbr = $song['songbook'];
+
+                /* Misc songs (and anything without a meaningful number)
+                   persist Number as NULL (#392). */
+                $rawNumber = $song['number'] ?? null;
+                $number    = ($songbookAbbr === 'Misc' || $rawNumber === null || $rawNumber === '' || (int)$rawNumber <= 0)
+                    ? null
+                    : (int)$rawNumber;
+
+                $title        = $song['title'];
                 $songbookName = $song['songbookName'] ?? '';
                 $language     = $song['language'] ?? 'en';
                 $copyright    = $song['copyright'] ?? '';

--- a/appWeb/public_html/service-worker.js.php
+++ b/appWeb/public_html/service-worker.js.php
@@ -223,21 +223,22 @@ self.addEventListener('install', (event) => {
             })
             .then(() => {
                 /*
-                 * Activate immediately so critical fixes (e.g., offline/CDN
-                 * caching) take effect on the very next page load.
+                 * Let the new SW enter the "waiting" state instead of
+                 * skipWaiting immediately (#396). app.js picks up the
+                 * `updatefound` → statechange === 'installed' transition
+                 * and shows a "New version available — Refresh" toast.
+                 * The user clicks Refresh → client posts SKIP_WAITING
+                 * below → SW activates → controllerchange → page reloads.
                  *
-                 * Previously (#83) skipWaiting was omitted to let users control
-                 * when updates activate via the "Refresh" notification. However,
-                 * this caused the old SW (which doesn't cache CDN resources) to
-                 * remain in control indefinitely, leaving offline support broken
-                 * until the user happened to close every tab.
+                 * This gives users agency over reloads mid-session (they
+                 * don't lose unsaved setlist edits to an abrupt reload)
+                 * while still being able to roll out critical fixes fast.
                  *
-                 * The controllerchange listener in app.js will auto-reload the
-                 * page when this new SW takes over, ensuring fresh HTML + cached
-                 * CDN assets are served.
+                 * If the user dismisses the toast without refreshing,
+                 * the new SW stays "waiting" until every tab of the app
+                 * is closed, at which point it activates naturally.
                  */
-                console.log('[SW] Activating immediately via skipWaiting');
-                return self.skipWaiting();
+                console.log('[SW] Installed; awaiting user confirmation to activate');
             })
     );
 });


### PR DESCRIPTION
## Summary

Batch of small/medium polish + feature commits. Eleven closed issues (four deferred with substantive status comments on their own issues).

Linted clean: `php -l` across every PHP file + `node --check` across every JS file both pass with zero output.

### Closes in this PR

| # | Feature |
|---|---|
| #392 | Misc songbook holds unnumbered songs |
| #394 | Editor debounced auto-save (safety net — per-song endpoint is a follow-up) |
| #395 | Magic-link sign-in promoted as the primary auth path |
| #396 | "New version — Refresh" SW update toast restored |
| #397 | Search expands common scripture-ref abbreviations (`Ps 23` → `Psalm 23`) |
| #401 | PWA caches audio + sheet music on-demand for offline playback |
| #402 | Practice / memorisation mode (Full → Dimmed → Hidden + tap-to-reveal) |
| #403 | Song-request submission form + rate-limited API |
| #404 | Admin analytics dashboard at `/manage/analytics` |
| #405 | Restore-from-backup action on the Setup dashboard |
| #406 | Settings toggle to enable/disable global keyboard shortcuts |

### Deferred with issue comments

| # | Status |
|---|---|
| #398 Setlist collaboration + schedules | Deferred — needs dedicated PR (UI + API + invitation flow). Schema is ready. |
| #399 Editor bulk operations | Deferred — needs dedicated PR (multi-select UI + transactional per-action endpoints). |
| #400 Song revision history | Deferred — depends on #394's per-song save endpoint; logging every full-save would flood `tblSongRevisions`. |

## Files touched

- `api.php` — new endpoint `song_request_submit`, new page route `request-a-song`, auth cookie helpers, sliding expiry, scripture-search integration
- `service-worker.js.php` — restored SW update handshake, on-demand audio cache
- `includes/SongData.php` — `expandScriptureReference()` helper + integration
- `includes/pages/{request-a-song,song,settings,search,home}.php` — UI changes
- `js/modules/{user-auth,settings,display,router,setlist,favorites,history,numpad}.js` — auth flow + new UI wiring + null-number handling
- `manage/{analytics,setup-database,index}.php` — analytics dashboard, backup-restore UI, dashboard link
- `manage/.htaccess` — `/manage/analytics` route
- `manage/editor/{editor.js,api.php,index.php}` — auto-save, save-rename follow-through
- `css/{app,admin}.css` — admin reskin, practice-mode styles, empty-badge book glyph
- `.sql/{schema.sql,migrate-json.php,restore.php,drop-legacy-tables.php}` — Misc null numbers, restore script, legacy-table drop

## Test plan (per feature)

### #392 Misc songbook
- `IS_NULLABLE = YES` on `tblSongs.Number` after installer
- Numpad + search number panel don't list Misc; shuffle still does
- Misc song detail shows book-glyph badge, not `#null`

### #395 Magic-link primary
- Sign In opens on email form; magic-link code flow works
- "Sign in with a password instead" reveals the password form

### #396 SW update toast
- Deploying a no-op to alpha → active tab shows the Refresh toast within ~60 s

### #397 Scripture search
- `Ps 23` and `Psalm 23` return the same songs; `1 Cor 13` expands correctly

### #394 Auto-save
- Editing any field → after 3 s quiet, status bar shows "Auto-saving…" and a save happens
- Manual Save still force-saves immediately

### #401 Audio cache
- Play a song online, go offline, replay → audio plays from cache

### #402 Practice mode
- "Practice" button cycles Full → Dimmed → Hidden; tapping a hidden line reveals it

### #403 Song request
- `/request-a-song` form submits, returns tracking ID, writes to `tblSongRequests`
- 5+ submissions from the same IP within 24 h → 429

### #404 Analytics
- `/manage/analytics` requires admin; top-15 songs + songbook + login counts render

### #405 Restore
- Backup dropdown lists recent `.sql.gz` files; Preview dry-runs; Restore requires typed `RESTORE`

### #406 Shortcuts toggle
- Toggle off → `?`, `/`, arrow-nav no-op
- Toggle on → shortcuts work again

### Cross-cutting sanity
- All PHP files lint clean (`php -l`)
- All JS files parse clean (`node --check`)
- No orphan require/include paths
- `getDb()` (PDO) vs `getDbMysqli()` (mysqli) usage is consistent with the respective helper's contract

https://claude.ai/code/session_01XUtkSVBVB3ez9HqHaTQb7r