### PR TITLE
feat(batch): #394 #403 #398 #399 #400 #397 #401 #404 #405 + security + docs

### DIFF
--- a/.claude/projects/-Users-lance-manasse-Projects-Coding-and-Development-MWBM-Partners-Ltd-GitHub-iHymns-iHymns/memory/MEMORY.md
+++ b/.claude/projects/-Users-lance-manasse-Projects-Coding-and-Development-MWBM-Partners-Ltd-GitHub-iHymns-iHymns/memory/MEMORY.md
@@ -1,5 +1,5 @@
 - [User Profile](user_profile.md) — Lance at MWBM Partners Ltd, wants detailed annotations, modular architecture
-- [iHymns Project](project_ihymns.md) — Multiplatform Christian lyrics app, MySQL (30+ tables), 50+ API endpoints, v0.10.0
+- [iHymns Project](project_ihymns.md) — Multiplatform Christian lyrics app, MySQL (30+ tables), 106 public API endpoints + 5 editor-API endpoints, v0.10.1 (PR #407 April 2026 alpha batch)
 - [Never touch SourceSongData](feedback_source_data.md) — .SourceSongData/ must never be deleted or modified
 - [Use appX/ directories](feedback_app_dirs.md) — appWeb/, appApple/, appAndroid/ naming convention
 - [Web app can use PHP](feedback_php_web.md) — PHP 8.5+ on shared hosting (DreamHost, no CLI access)
@@ -10,3 +10,4 @@
 - [Phase 1 SEO/PWA/Social](feedback_phase1_seo_pwa_social.md) — OG images (song/songbook/setlist), PWA banners, sitemap
 - [User Accounts](feedback_user_accounts.md) — 3 auth methods, roles, orgs, email login, groups, version access, hashed tokens
 - [DB naming](feedback_db_naming.md) — tblCamelCase tables, CamelCase columns, AS aliases for API compat
+- [Do NOT edit .claude/ProjectBrief.md](feedback_claude_brief.md) — user-owned file; update project_ihymns.md / MEMORY.md instead

--- a/.claude/projects/-Users-lance-manasse-Projects-Coding-and-Development-MWBM-Partners-Ltd-GitHub-iHymns-iHymns/memory/feedback_claude_brief.md
+++ b/.claude/projects/-Users-lance-manasse-Projects-Coding-and-Development-MWBM-Partners-Ltd-GitHub-iHymns-iHymns/memory/feedback_claude_brief.md
@@ -1,0 +1,15 @@
+---
+name: Don't edit .claude/ProjectBrief.md
+description: ProjectBrief.md in .claude/ is user-owned. Do not modify it. Instead update project_ihymns.md, MEMORY.md, or create new feedback files.
+type: feedback
+---
+
+**Rule:** `.claude/ProjectBrief.md` is off-limits.
+
+- Do NOT edit it to bump versions, add sections, or refresh metadata.
+- If information there becomes stale, record the current reality in
+  `.claude/projects/.../memory/project_ihymns.md` and/or a new
+  `feedback_*.md` file instead.
+- The user maintains ProjectBrief.md manually.
+
+Given at 2026-04-20 while wrapping up the April 2026 alpha batch (PR #407).

--- a/.claude/projects/-Users-lance-manasse-Projects-Coding-and-Development-MWBM-Partners-Ltd-GitHub-iHymns-iHymns/memory/project_ihymns.md
+++ b/.claude/projects/-Users-lance-manasse-Projects-Coding-and-Development-MWBM-Partners-Ltd-GitHub-iHymns-iHymns/memory/project_ihymns.md
@@ -52,11 +52,42 @@ type: project
 
 **Authentication (3 methods):**
 
-- Password login (username + password → bearer token)
-- Email magic link / 6-digit code (tblEmailLoginTokens, 10-min expiry)
-- Admin session (PHP session + CSRF)
+- **Magic-link is the primary sign-in path** (email + 6-digit code); username/password behind a "Sign in with a password instead" link on the login modal
+- Password login (username + password → bearer token) — still supported
+- Admin session (PHP session + CSRF) for `/manage/` pages; every write-performing admin page validates a hidden `csrf_token` input via `validateCsrf()`
+- Bearer token: `Authorization: Bearer` header **and** `Set-Cookie: ihymns_auth; Domain=.ihymns.app; HttpOnly; SameSite=Lax; Secure` — cross-subdomain sign-in plus ITP-resistant persistence (#390)
+- Sliding 30-day expiry — `slideAuthTokenExpiry()` bumps at most once per day per token (#390)
+- `user-auth.js#verify()` hardened: only 401/403 clears credentials (#390)
 - Brute force protection: tblLoginAttempts, 10 failures / 15 min lockout
 - Future: SIGNula.id OAuth2/SSO + TOTP 2FA (#309)
+
+**Entitlements (#407):**
+
+- Capability-based permission layer on top of roles. `includes/entitlements.php` (PHP, authoritative) + `js/modules/entitlements.js` (UI affordance only).
+- Admins reassign at `/manage/entitlements`; overrides in `tblAppSettings.SettingKey = 'entitlements_overrides'`.
+- Default entitlements: `edit_songs`, `delete_songs`, `bulk_edit_songs`, `verify_songs`, `view_users`, `edit_users`, `change_user_roles`, `assign_global_admin`, `delete_users`, `view_admin_dashboard`, `view_analytics`, `run_db_install/migrate/backup/restore`, `drop_legacy_tables`, `review_song_requests`, `access_alpha`, `access_beta`, `manage_entitlements`.
+- `alpha.` / `beta.ihymns.app` gated by `access_alpha` / `access_beta` via `includes/channel_gate.php`; gate page embeds magic-link form.
+
+**Admin portal (`/manage/`, alias `/admin/`):**
+
+- Dashboard with Library + Activity stat groups (Songs, Songbooks, Synced setlists, Pending requests, Active/Total users, Logins 24h, Song views 24h).
+- `/manage/editor/` — per-song auto-save via `/api?action=save_song`, multi-select bulk delete, revision audit log.
+- `/manage/users` — accounts/roles/passwords.
+- `/manage/requests` — song-request triage queue.
+- `/manage/analytics` — 7/30/90-day top songs/books/queries, zero-result queries, CSV export.
+- `/manage/entitlements` — role × capability matrix editor.
+- `/manage/setup-database` — install/migrate/backup/restore/drop-legacy, credentials form, backup upload.
+
+**Recent shipped features (Apr 2026, alpha):**
+
+- Scripture-aware search (abbreviation expansion + tag match).
+- Practice mode (Full/Dimmed/Hidden + tap-to-reveal).
+- Misc songbook supports NULL Number; book-glyph badge.
+- Title Case renderer everywhere; admin area re-skinned to main palette (`css/admin.css`).
+- SW update toast restored; on-demand audio cache + bulk_audio manifest + Settings toggle.
+- Song-request public form (rate-limited, honeypot) + admin triage queue.
+- Backup restore UI (server-list + upload-from-device) with audit log on upload.
+- Setlist scheduling API endpoints (UI + collaboration deferred to follow-up).
 
 **Accessibility:**
 

--- a/.claude/projects/-Users-lance-manasse-Projects-Coding-and-Development-MWBM-Partners-Ltd-GitHub-iHymns-iHymns/memory/project_ihymns.md
+++ b/.claude/projects/-Users-lance-manasse-Projects-Coding-and-Development-MWBM-Partners-Ltd-GitHub-iHymns-iHymns/memory/project_ihymns.md
@@ -1,6 +1,6 @@
 ---
 name: iHymns Project Context
-description: iHymns is a multiplatform Christian lyrics app. v0.10.0 uses MySQL with 30+ tables, 50+ API endpoints, organisations, content licensing, accessibility. Phase 2 will use iLyrics dB API.
+description: iHymns is a multiplatform Christian lyrics app. v0.10.1 uses MySQL with 30+ tables, 106 public API endpoints + 5 editor-API endpoints, organisations, content licensing, accessibility. Phase 2 will use iLyrics dB API.
 type: project
 ---
 
@@ -8,7 +8,7 @@ type: project
 
 **Domain**: iHymns.app | **Repo**: https://github.com/MWBMPartners/iHymns
 **Copyright**: MWBM Partners Ltd | **License**: Proprietary
-**Current version**: 0.10.0 (pre-release, Phase 1)
+**Current version**: 0.10.1 (pre-release, Phase 1 — April 2026 alpha batch, PR #407)
 
 **Why:** Enhance worship by providing searchable hymn lyrics across platforms.
 
@@ -30,17 +30,23 @@ type: project
 - JSON migrator: php appWeb/.sql/migrate-json.php
 - Token cleanup: php appWeb/.sql/cleanup.php (cron-safe)
 
-**API (50+ endpoints in api.php):**
+**API (106 endpoints in api.php + 5 in manage/editor/api.php, fully documented in api-docs.yaml — OpenAPI 3.0.3):**
 
-- Songs: search, song_data, songs, songbooks, random, stats, songs_json, missing_songs, song_key, suggest, popular_songs, related_songs, tags, songs_by_tag
-- Auth: register, login, logout, me, email_login_request, email_login_verify, update_profile, change_password, forgot_password, reset_password
-- User data: favorites, favorites_sync, favorites_remove, user_setlists, user_setlists_sync, user_preferences, user_preferences_sync, song_history, song_view, user_access, my_organisations
-- Setlists: setlist_share, setlist_get, setlist_schedule, setlist_schedule_save, setlist_templates, setlist_template_save, setlist_collaborators, setlist_collaborator_add, setlist_collaborator_remove
-- Song requests: song_request, my_song_requests
-- Languages: languages, song_translations
-- Admin: admin_users, admin_groups, admin_organisations, admin_activity_log, admin_song_requests, admin_song_request_update, admin_restrictions, admin_restriction_create, admin_restriction_delete, admin_export, admin_songbook_health, admin_pending_revisions, admin_revision_review, admin_cleanup
-- Push: push_subscribe, push_unsubscribe
-- System: app_status, content_access, organisation, organisation_create
+- **Songs:** search, search_num, song, song_data, songs, songbook, songbooks, random, stats, songs_json, missing_songs, song_key, song_key_save, suggest, popular_songs, related_songs, tags, songs_by_tag, writer
+- **Offline / PWA:** bulk_songs, bulk_audio (#401)
+- **Auth:** register, login, logout, me, email_login_request, email_login_verify, update_profile, change_password, forgot_password, reset_password
+- **User data:** favorites, favorites_sync, favorites_remove, user_setlists, user_setlists_sync, user_preferences, user_preferences_sync, song_history, song_view, song_revisions, user_access, my_organisations
+- **Setlists (current):** setlist, setlist_get, setlist_share, setlist_template_save, setlist_templates
+- **Setlists — scheduling (#398):** setlist_schedule_set, setlist_schedule_clear, setlist_schedule_current, setlist_schedule_upcoming
+- **Setlists — collaboration (#398):** setlist_collab_invite, setlist_collab_list, setlist_collab_remove, setlist_collab_shared_with_me
+- **Setlists (deprecated, pre-#398):** setlist_schedule, setlist_schedule_save, setlist_collaborators, setlist_collaborator_add, setlist_collaborator_remove
+- **Song requests:** song_request, song_request_submit, my_song_requests
+- **Languages:** languages, song_translations
+- **Admin:** admin_users, admin_groups, admin_organisations, admin_activity_log, admin_song_requests, admin_song_request_update, admin_restrictions, admin_restriction_create, admin_restriction_delete, admin_export, admin_songbook_health, admin_pending_revisions, admin_revision_review, admin_cleanup, admin_set_user_ccli, admin_set_user_tier
+- **Push:** push_subscribe, push_unsubscribe
+- **System:** app_status, content_access, organisation, organisation_create, access_tiers, ccli_validate, tier_check
+- **Pages (HTML / alternate-format):** home, help, terms, privacy, settings, csv, xml, json, opensong, videopsalm
+- **Editor API (session-auth, /manage/editor/api.php):** load, save, save_song (#394), bulk_tag (#399), list_revisions (#400), restore_revision (#400), get_translations, add_translation, remove_translation
 
 **Organisations & Licensing (#326):**
 
@@ -71,23 +77,39 @@ type: project
 **Admin portal (`/manage/`, alias `/admin/`):**
 
 - Dashboard with Library + Activity stat groups (Songs, Songbooks, Synced setlists, Pending requests, Active/Total users, Logins 24h, Song views 24h).
-- `/manage/editor/` — per-song auto-save via `/api?action=save_song`, multi-select bulk delete, revision audit log.
+- `/manage/editor/` — per-song auto-save via `/api?action=save_song`, multi-select bulk **delete / verify / tag / move / export** (#399), **History modal** with side-by-side JSON diff + Restore button per revision (#400).
 - `/manage/users` — accounts/roles/passwords.
 - `/manage/requests` — song-request triage queue.
 - `/manage/analytics` — 7/30/90-day top songs/books/queries, zero-result queries, CSV export.
+- `/manage/revisions` — global audit log across every song-edit revision, filterable by user/song/action/N-day (#400).
 - `/manage/entitlements` — role × capability matrix editor.
-- `/manage/setup-database` — install/migrate/backup/restore/drop-legacy, credentials form, backup upload.
+- `/manage/setup-database` — install/migrate/backup/restore/drop-legacy, credentials form, backup upload, **Pre-flight** mode for safe restore preview (#405).
 
-**Recent shipped features (Apr 2026, alpha):**
+**April 2026 alpha batch — shipped in PR #407 (v0.10.1):**
 
-- Scripture-aware search (abbreviation expansion + tag match).
-- Practice mode (Full/Dimmed/Hidden + tap-to-reveal).
-- Misc songbook supports NULL Number; book-glyph badge.
-- Title Case renderer everywhere; admin area re-skinned to main palette (`css/admin.css`).
-- SW update toast restored; on-demand audio cache + bulk_audio manifest + Settings toggle.
-- Song-request public form (rate-limited, honeypot) + admin triage queue.
-- Backup restore UI (server-list + upload-from-device) with audit log on upload.
-- Setlist scheduling API endpoints (UI + collaboration deferred to follow-up).
+- **#390** Cross-subdomain auth cookie (`.ihymns.app`, HttpOnly, SameSite=Lax, Secure) + sliding 30-day expiry.
+- **#392** Misc songbook supports NULL Number; book-glyph badge.
+- **#394** Per-song save endpoint (`save_song`) + editor auto-save.
+- **#395** Magic-link promoted to primary sign-in path; password as fallback.
+- **#396** Service-worker update toast restored.
+- **#397** Scripture-tag-aware search (abbreviation expansion + curated-tag match merged to the top).
+- **#398** Setlist scheduling UI (schedule / clear / upcoming / current) + **collaboration** (invite / permission / remove / shared-with-me) + "Up next" overview card.
+- **#399** Editor multi-select + bulk **delete / verify / tag / move / export** (bulk_tag is a new transactional endpoint).
+- **#400** Revision capture on every save; editor History modal with diff + restore; `/manage/revisions` admin audit page.
+- **#401** Bulk-audio manifest + Settings toggle + on-demand SW cache + per-songbook real-byte size readout + "Remove from offline" per-songbook eviction.
+- **#402** Practice / memorisation mode (Full / Dimmed / Hidden + tap-to-reveal).
+- **#403** Song-request public form (rate-limited, honeypot) + admin triage queue at `/manage/requests`.
+- **#404** Analytics CSV export + `tblSearchQueries` logging + zero-result-queries panel.
+- **#405** Backup restore upload + `tblActivityLog` audit + **pre-flight summary** + **pre-restore auto-snapshot** + quote-aware splitter with **transactional INSERT rollback**.
+- **#406** Settings → Accessibility toggle to disable keyboard shortcuts.
+- Docs: `api-docs.yaml` refreshed to cover every endpoint (106 + 5 editor); help.php / README / CHANGELOG / DEV_NOTES updated.
+
+**Tooling-gap tracking issues (blocked on a human — MCP tool surface limits):**
+
+- **#408** Refresh the repo Wiki (MCP has no wiki endpoints).
+- **#409** Create + populate Milestones (MCP can assign, not create).
+- **#410** Stand up a GitHub Projects (v2) board (no Projects tools in MCP).
+- **#411** Roadmap umbrella; closes when the three above resolve.
 
 **Accessibility:**
 
@@ -103,11 +125,20 @@ type: project
 
 **Key files:**
 
-- api.php — 50+ endpoints, comprehensive REST-like API
-- SongData.php — MySQL-backed song queries with prepared statements
-- content_access.php — rule-based content lockout engine
-- rate_limit.php — centralised rate limiting middleware
-- pdf_export.php — setlist PDF generation
-- transpose.js — chord transposition (semitone math, capo calculator)
-- accessibility.css — high contrast, CVD, RTL
-- api-docs.yaml — OpenAPI 3.0 specification
+- `api.php` — 106 endpoints, comprehensive REST-like API
+- `manage/editor/api.php` — 5 editor-only endpoints (session-auth): save_song, bulk_tag, list_revisions, restore_revision, get/add/remove_translation
+- `manage/revisions.php` — global revision-audit admin page (#400)
+- `manage/analytics.php` — admin analytics + CSV export (#404)
+- `manage/entitlements.php` — runtime role × capability editor (#407)
+- `manage/requests.php` — song-request triage (#403)
+- `includes/entitlements.php` — authoritative capability check (PHP); mirrored in `js/modules/entitlements.js` for UI affordance only
+- `includes/channel_gate.php` — subdomain gate for alpha./beta. (uses `access_alpha` / `access_beta`)
+- `.sql/restore.php` — pre-flight + quote-aware statement splitter + transactional data-load (#405)
+- `SongData.php` — MySQL-backed song queries with prepared statements
+- `content_access.php` — rule-based content lockout engine
+- `rate_limit.php` — centralised rate limiting middleware
+- `pdf_export.php` — setlist PDF generation
+- `transpose.js` — chord transposition (semitone math, capo calculator)
+- `service-worker.js.php` — SW with CACHE_ALL_SONGS / CACHE_AUDIO_URLS / EVICT_SONGBOOK / GET_CACHE_SIZES handlers (#401)
+- `accessibility.css` — high contrast, CVD, RTL
+- `api-docs.yaml` — OpenAPI 3.0.3 spec, 106 + 5 endpoints fully covered

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+## [0.10.x] — 2026-04-18 (alpha)
+
+- feat: **auth** — magic-link (email + 6-digit code) is now the primary sign-in path; cross-subdomain `HttpOnly` cookie + 30-day sliding expiry; HttpOnly cookie ITP-resistant persistence
+- feat: **admin portal** — `/manage/` dashboard now shows Library + People & Activity stat groups, recent-users panel, quick-link tiles for every admin surface; `/admin/` alias redirects to `/manage/`
+- feat: **channel gating** — alpha/beta subdomains gated by `access_alpha` / `access_beta` entitlements; embedded magic-link form on the gate page
+- feat: **entitlements system** — granular role→capability map with a `/manage/entitlements` editor; overrides stored in `tblAppSettings`; client-side mirror for UI decisions
+- feat: **analytics** — `/manage/analytics` dashboard (7/30/90-day range) with Top Songs, Top Songbooks, Top Search Queries, Zero-Result Queries; per-panel CSV export
+- feat: **song requests** — public `/request-a-song` form with rate limit + honeypot; admin triage queue at `/manage/requests`
+- feat: **editor per-song save** — `/api?action=save_song` UPSERT endpoint; auto-save now per-song (not full-corpus)
+- feat: **editor multi-select** — bulk delete with typed-DELETE safety for ≥10 rows
+- feat: **song revision audit log** — `tblSongRevisions` writes on every per-song save
+- feat: **scripture search** — abbreviation expansion (`Ps 23` → `Psalm 23`) + tag-based curated match merged to top of results
+- feat: **practice mode** — Full / Dimmed / Hidden cycle for memorisation; tap-to-reveal
+- feat: **keyboard shortcuts toggle** — Settings → Accessibility lets users turn shortcuts on/off
+- feat: **PWA update toast** — "New version — Refresh" reliably appears when SW deploys
+- feat: **PWA offline audio** — on-demand caching on playback; `/api?action=bulk_audio` for pre-caching; Settings toggle
+- feat: **setlist scheduling API** — `setlist_schedule_set / _clear / _upcoming` endpoints
+- feat: **backup restore** — admin UI with server-list and upload-from-device paths; audit log on upload
+- feat: **Misc songbook** — songs now permitted without a song number (schema `Number` is NULL-able); book-glyph badge renders instead of `#null`
+- feat: **Title Case** rendering everywhere song titles are displayed
+- feat: **admin area re-skin** — unified with main-site palette (indigo/violet accent) via shared `css/admin.css`
+- fix: **Settings Account card** — now flips live on auth-state change via `ihymns:auth-changed` event bus
+- fix: **editor Save button** — renamed from "Save JSON" with clearer DB-first wording
+- fix: **Usage Stats badges** — consistent width regardless of digit count
+- security: CSRF tokens on all admin POST forms; DB error messages no longer leaked to clients
+
 ## [1.0.0] — 2026-04-06
 - app refresh upload (early dev 1)
 - feat: Android — Kotlin/Jetpack Compose project setup

--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -728,6 +728,41 @@ Tier management is restricted to **Admin** and **Global Admin** roles only.
 
 **Web dashboard:** `/manage/setup-database` for database administration.
 
+---
+
+## Admin Portal (`/manage/` + `/admin/` alias)
+
+| Route | Purpose | Entitlement |
+| --- | --- | --- |
+| `/manage/` | Dashboard (library + activity stats) | `view_admin_dashboard` |
+| `/manage/editor/` | Song editor | `edit_songs` |
+| `/manage/users` | Users + roles | `view_users` / `edit_users` |
+| `/manage/requests` | Song-request triage queue | `review_song_requests` |
+| `/manage/analytics` | Usage analytics with CSV export | `view_analytics` |
+| `/manage/entitlements` | Reassign capabilities to roles | `manage_entitlements` |
+| `/manage/setup-database` | Install, migrate, backup, restore | `run_db_install` etc. |
+| `/manage/login` · `/manage/logout` · `/manage/setup` | Auth flow (session-based) | — |
+
+### Entitlements
+
+Defined in `appWeb/public_html/includes/entitlements.php` (PHP, authoritative) and mirrored in `appWeb/public_html/js/modules/entitlements.js` (UI affordance only). Runtime overrides stored in `tblAppSettings.SettingKey = 'entitlements_overrides'` as JSON and merged over the hardcoded defaults by `effectiveEntitlements()`. Admins edit the mapping at `/manage/entitlements` — the form prevents removing `global_admin` from the `manage_entitlements` entitlement so the editor can never be locked out.
+
+Check PHP: `userHasEntitlement($name, $role)`. Check JS: `userHasEntitlement(name, role)` (same signature).
+
+### Channel Gating
+
+`alpha.ihymns.app` and `beta.ihymns.app` require the `access_alpha` / `access_beta` entitlements respectively. Production (`ihymns.app`) is never gated. Gate logic lives in `includes/channel_gate.php` and runs from `index.php`. The gate page embeds the magic-link sign-in form so users can authenticate without leaving.
+
+### Auth + persistence
+
+- Bearer token stored in both `Authorization: Bearer` header (JS fetches) and as `Set-Cookie: ihymns_auth; Domain=.ihymns.app; HttpOnly; SameSite=Lax; Secure` (cross-subdomain).
+- Sliding 30-day expiry via `slideAuthTokenExpiry()` — bumps `tblApiTokens.ExpiresAt` at most once per day per token.
+- Client `user-auth.js#verify()` only clears credentials on 401/403 (not on any non-ok), so a transient 500 doesn't sign the user out.
+
+### CSRF
+
+Every write-performing admin page (`users`, `setup`, `login`, `setup-database`, `requests`, `entitlements`) uses `csrfToken()` + `validateCsrf()` from `manage/includes/auth.php`. The token is rendered as a hidden input named `csrf_token`.
+
 ### Combining with Other Access Controls
 
 Content tiers work alongside other gating mechanisms:

--- a/README.md
+++ b/README.md
@@ -59,6 +59,32 @@
 - 📋 **Setlists** — create, arrange, and share worship setlists with custom component arrangements
 - ♿ **Accessible** — WCAG 2.1 AA compliant, keyboard shortcuts, screen reader support, colour vision deficiency modes
 - 🔄 **Auto-update** — service worker detects updates and prompts to refresh
+- 🔑 **Magic-link sign-in** — primary auth path (email + 6-digit code); HttpOnly cross-subdomain cookie with 30-day sliding expiry survives iOS ITP
+- 🎓 **Practice mode** — Full / Dimmed / Hidden cycle for memorising hymns with tap-to-reveal
+- ✝️ **Scripture search** — `Ps 23`, `1 Cor 13`, `Rev 21` etc. match through abbreviation expansion + curated tags
+- 📨 **Request a song** — public form plus admin triage queue
+- 📊 **Admin analytics** — top songs, top songbooks, top/zero-result search queries, CSV export (admin+)
+- 🧾 **Song revision history** — every save logged to `tblSongRevisions` for audit + future restore
+- 🗝 **Entitlements** — capability-based permissions, editable at runtime by global admin
+- 🚧 **Channel gating** — alpha / beta subdomains require the relevant access entitlement
+
+---
+
+## 🧑‍💼 Admin Portal
+
+Accessible at **`/manage/`** (alias: `/admin/`) for users with the appropriate role. Main surfaces:
+
+| Surface | Purpose | Default role |
+| --- | --- | --- |
+| Dashboard | Library + activity snapshot, quick-links | editor+ |
+| Song Editor | Per-song UPSERT, multi-select bulk delete, auto-save, tag editor | editor+ |
+| User Management | Roles, passwords, activation | admin+ |
+| Song Requests | Triage user-submitted requests | editor+ |
+| Analytics | Top songs/books/queries, CSV export | admin+ |
+| Entitlements | Reassign capabilities to roles | global_admin |
+| Database Setup | Install schema, migrate, backup, restore, drop legacy | admin+ |
+
+Every write on these pages is CSRF-protected. DB error messages are never leaked to clients (see server error log).
 
 ---
 

--- a/appWeb/.sql/restore.php
+++ b/appWeb/.sql/restore.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Database Restore (#405)
+ *
+ * Restores the database from a compressed SQL dump produced by
+ * appWeb/.sql/backup.php. Destructive — replaces every table in the
+ * schema. Requires confirm=1 (web) or --confirm (CLI) AND a backup
+ * filename (basename only; the directory is fixed to the backup dir
+ * for safety).
+ *
+ * USAGE:
+ *   CLI:   php appWeb/.sql/restore.php --file=ihymns-backup-20260418-102030.sql.gz --confirm
+ *   Web:   /manage/setup-database.php?action=restore&file=<name>&confirm=1
+ *
+ * @requires PHP 8.1+, mysqli, zlib
+ */
+
+$isCli = (php_sapi_name() === 'cli');
+
+if (!$isCli && !defined('IHYMNS_SETUP_DASHBOARD')) {
+    header('Content-Type: text/plain; charset=UTF-8');
+    header('X-Content-Type-Options: nosniff');
+    header('Cache-Control: no-store');
+}
+
+function output(string $msg): void {
+    global $isCli;
+    echo $msg . ($isCli ? "\n" : "<br>\n");
+    if (!$isCli) flush();
+}
+
+/* ---- Load credentials ---- */
+$credentialsFile = dirname(__DIR__) . DIRECTORY_SEPARATOR . '.auth' . DIRECTORY_SEPARATOR . 'db_credentials.php';
+if (!file_exists($credentialsFile)) {
+    output('ERROR: Credentials file not found.');
+    return;
+}
+require_once $credentialsFile;
+
+/* ---- Resolve source file ---- */
+$backupDir = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'data_share' . DIRECTORY_SEPARATOR . 'backups';
+
+$requestedFile = '';
+if ($isCli) {
+    foreach ($argv ?? [] as $arg) {
+        if (str_starts_with($arg, '--file=')) $requestedFile = substr($arg, 7);
+    }
+} else {
+    $requestedFile = (string)($_GET['file'] ?? '');
+}
+
+/* Strip any path component — filename only; keep restore scoped to the
+   backup directory. A basename check also blocks "../" traversal. */
+$requestedFile = basename(trim($requestedFile));
+if ($requestedFile === '' || !preg_match('/^ihymns-backup-[0-9-]+\.sql(?:\.gz)?$/', $requestedFile)) {
+    output('ERROR: No (or invalid) backup filename specified.');
+    output('Expected form: ihymns-backup-YYYYMMDD-HHMMSS.sql(.gz)');
+    return;
+}
+
+$source = $backupDir . DIRECTORY_SEPARATOR . $requestedFile;
+if (!file_exists($source)) {
+    output('ERROR: Backup file not found: ' . $requestedFile);
+    return;
+}
+
+/* ---- Confirm gate ---- */
+$confirmed = false;
+if ($isCli) {
+    foreach ($argv ?? [] as $arg) {
+        if ($arg === '--confirm') $confirmed = true;
+    }
+} else {
+    $confirmed = (($_GET['confirm'] ?? '') === '1');
+}
+
+$size = filesize($source);
+output('Source: ' . $requestedFile . ' (' . number_format((int)$size) . ' bytes)');
+output('');
+
+if (!$confirmed) {
+    output('DRY RUN — nothing has been restored.');
+    output('Re-run with --confirm (CLI) or ?confirm=1 (web) to proceed.');
+    return;
+}
+
+/* ---- Read + decompress ---- */
+output('Reading backup…');
+$content = (str_ends_with($requestedFile, '.gz'))
+    ? gzdecode((string)file_get_contents($source))
+    : (string)file_get_contents($source);
+
+if ($content === false || $content === '') {
+    output('ERROR: Could not read or decompress ' . $requestedFile);
+    return;
+}
+
+/* ---- Connect + execute ---- */
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+try {
+    $mysql = new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME, (int)DB_PORT);
+    $mysql->set_charset(defined('DB_CHARSET') ? DB_CHARSET : 'utf8mb4');
+} catch (\Throwable $e) {
+    output('ERROR: Connection failed: ' . $e->getMessage());
+    return;
+}
+
+output('Running restore… (this may take a moment)');
+output('');
+
+$mysql->query('SET FOREIGN_KEY_CHECKS = 0');
+
+/* multi_query walks every statement in the dump. */
+try {
+    if (!$mysql->multi_query($content)) {
+        throw new \RuntimeException($mysql->error);
+    }
+    /* Consume every result set so the connection is ready. */
+    do {
+        if ($result = $mysql->store_result()) {
+            $result->free();
+        }
+    } while ($mysql->more_results() && $mysql->next_result());
+    output('  [OK] restore complete');
+} catch (\Throwable $e) {
+    output('  [FAIL] ' . $e->getMessage());
+}
+
+$mysql->query('SET FOREIGN_KEY_CHECKS = 1');
+
+output('');
+output('Re-check /manage/setup-database to verify table counts.');
+
+$mysql->close();
+return;

--- a/appWeb/.sql/restore.php
+++ b/appWeb/.sql/restore.php
@@ -67,25 +67,29 @@ if (!file_exists($source)) {
     return;
 }
 
-/* ---- Confirm gate ---- */
+/* ---- Mode flags (confirm / preflight / skip-snapshot) ----
+ * preflight: parse the dump and print a summary without touching the DB.
+ * confirm:   actually run the restore (ignored without confirm flag).
+ * skip-snapshot: opt out of the automatic pre-restore backup (default on).
+ */
 $confirmed = false;
+$preflight = false;
+$skipSnapshot = false;
 if ($isCli) {
     foreach ($argv ?? [] as $arg) {
         if ($arg === '--confirm') $confirmed = true;
+        if ($arg === '--preflight') $preflight = true;
+        if ($arg === '--skip-snapshot') $skipSnapshot = true;
     }
 } else {
-    $confirmed = (($_GET['confirm'] ?? '') === '1');
+    $confirmed    = (($_GET['confirm']       ?? '') === '1');
+    $preflight    = (($_GET['preflight']     ?? '') === '1');
+    $skipSnapshot = (($_GET['skip_snapshot'] ?? '') === '1');
 }
 
 $size = filesize($source);
 output('Source: ' . $requestedFile . ' (' . number_format((int)$size) . ' bytes)');
 output('');
-
-if (!$confirmed) {
-    output('DRY RUN — nothing has been restored.');
-    output('Re-run with --confirm (CLI) or ?confirm=1 (web) to proceed.');
-    return;
-}
 
 /* ---- Read + decompress ---- */
 output('Reading backup…');
@@ -96,6 +100,98 @@ $content = (str_ends_with($requestedFile, '.gz'))
 if ($content === false || $content === '') {
     output('ERROR: Could not read or decompress ' . $requestedFile);
     return;
+}
+
+/* ---- Pre-flight summary — counts + timestamp, no side effects ---- */
+$stats = [
+    'createTables' => 0,
+    'dropTables'   => 0,
+    'inserts'      => 0,
+    'insertRows'   => 0,
+    'tables'       => [],
+    'takenAt'      => '',
+];
+foreach (explode("\n", $content) as $line) {
+    $trim = ltrim($line);
+    if ($trim === '' || str_starts_with($trim, '--') || str_starts_with($trim, '#')) {
+        if (preg_match('/taken at[:\s]+(.+?)\s*$/i', $trim, $m)) {
+            $stats['takenAt'] = trim($m[1]);
+        }
+        continue;
+    }
+    $upper = strtoupper(substr($trim, 0, 30));
+    if (str_starts_with($upper, 'CREATE TABLE')) {
+        $stats['createTables']++;
+        if (preg_match('/CREATE TABLE(?:\s+IF NOT EXISTS)?\s+`?([A-Za-z0-9_]+)`?/i', $trim, $m)) {
+            $stats['tables'][$m[1]] = ($stats['tables'][$m[1]] ?? 0);
+        }
+    } elseif (str_starts_with($upper, 'DROP TABLE')) {
+        $stats['dropTables']++;
+    } elseif (str_starts_with($upper, 'INSERT INTO')) {
+        $stats['inserts']++;
+        if (preg_match('/INSERT INTO\s+`?([A-Za-z0-9_]+)`?/i', $trim, $m)) {
+            $tbl = $m[1];
+            /* Count VALUES tuples — one opening paren per row for the
+               common mysqldump format. This is a rough estimate; exact
+               counts aren't needed for the summary. */
+            $rowCount = substr_count($line, '),(') + 1;
+            $stats['insertRows'] += $rowCount;
+            $stats['tables'][$tbl] = ($stats['tables'][$tbl] ?? 0) + $rowCount;
+        }
+    }
+}
+
+output('Pre-flight summary:');
+output('  CREATE TABLE statements ........ ' . $stats['createTables']);
+output('  DROP TABLE statements .......... ' . $stats['dropTables']);
+output('  INSERT statements .............. ' . $stats['inserts']);
+output('  Estimated rows to restore ...... ' . number_format($stats['insertRows']));
+if ($stats['takenAt'] !== '') {
+    output('  Backup timestamp ............... ' . $stats['takenAt']);
+}
+if (!empty($stats['tables'])) {
+    arsort($stats['tables']);
+    output('  Top tables by row count:');
+    $shown = 0;
+    foreach ($stats['tables'] as $tbl => $rows) {
+        if ($shown >= 8) break;
+        output('    ' . str_pad($tbl, 30) . number_format((int)$rows));
+        $shown++;
+    }
+}
+output('');
+
+if ($preflight) {
+    output('PRE-FLIGHT ONLY — nothing has been restored.');
+    return;
+}
+
+if (!$confirmed) {
+    output('DRY RUN — nothing has been restored.');
+    output('Re-run with --confirm (CLI) or ?confirm=1 (web) to proceed.');
+    return;
+}
+
+/* ---- Pre-restore auto-snapshot ----
+ * Before touching the live database, capture its current state. If
+ * the restore fails partway, the admin can restore from this snapshot
+ * to recover. Skipped when --skip-snapshot is passed or backup.php is
+ * unavailable for any reason. */
+if (!$skipSnapshot) {
+    output('Taking pre-restore snapshot of current state…');
+    $snapshotDir = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'data_share' . DIRECTORY_SEPARATOR . 'backups';
+    $beforeCount = is_dir($snapshotDir) ? count(glob($snapshotDir . '/ihymns-backup-*.sql*') ?: []) : 0;
+    try {
+        include __DIR__ . DIRECTORY_SEPARATOR . 'backup.php';
+    } catch (\Throwable $e) {
+        output('  [WARN] snapshot failed: ' . $e->getMessage());
+        output('         Continuing anyway — the incoming backup still loads below.');
+    }
+    $afterCount = is_dir($snapshotDir) ? count(glob($snapshotDir . '/ihymns-backup-*.sql*') ?: []) : 0;
+    if ($afterCount > $beforeCount) {
+        output('  [OK] pre-restore snapshot created');
+    }
+    output('');
 }
 
 /* ---- Connect + execute ---- */
@@ -113,20 +209,93 @@ output('');
 
 $mysql->query('SET FOREIGN_KEY_CHECKS = 0');
 
-/* multi_query walks every statement in the dump. */
-try {
-    if (!$mysql->multi_query($content)) {
-        throw new \RuntimeException($mysql->error);
+/* Split the dump into individual statements and classify each as DDL
+ * or data. DDL (CREATE/DROP/ALTER) auto-commits in MySQL and can't be
+ * rolled back, so we run it outside a transaction. INSERTs are wrapped
+ * in a single transaction — any failure rolls the data-load back to a
+ * clean state while leaving the new schema in place.
+ *
+ * The splitter is intentionally simple: it handles single-quote, double-
+ * quote and backtick-quoted strings plus line comments (-- / #) and
+ * block comments (/* ... * /). Good enough for mysqldump output. */
+$statements = [];
+$buf = '';
+$inS = false; $inD = false; $inB = false; $inLine = false; $inBlock = false;
+$len = strlen($content);
+for ($i = 0; $i < $len; $i++) {
+    $ch = $content[$i];
+    $nx = $content[$i + 1] ?? '';
+    if ($inLine) {
+        if ($ch === "\n") { $inLine = false; }
+        continue;
     }
-    /* Consume every result set so the connection is ready. */
-    do {
-        if ($result = $mysql->store_result()) {
-            $result->free();
+    if ($inBlock) {
+        if ($ch === '*' && $nx === '/') { $inBlock = false; $i++; }
+        continue;
+    }
+    if (!$inS && !$inD && !$inB) {
+        if ($ch === '-' && $nx === '-') { $inLine = true; $i++; continue; }
+        if ($ch === '#') { $inLine = true; continue; }
+        if ($ch === '/' && $nx === '*') { $inBlock = true; $i++; continue; }
+    }
+    if ($inS) { if ($ch === "'" && $content[$i - 1] !== '\\') { $inS = false; } $buf .= $ch; continue; }
+    if ($inD) { if ($ch === '"' && $content[$i - 1] !== '\\') { $inD = false; } $buf .= $ch; continue; }
+    if ($inB) { if ($ch === '`') { $inB = false; } $buf .= $ch; continue; }
+    if ($ch === "'") { $inS = true; $buf .= $ch; continue; }
+    if ($ch === '"') { $inD = true; $buf .= $ch; continue; }
+    if ($ch === '`') { $inB = true; $buf .= $ch; continue; }
+    if ($ch === ';') {
+        $stmt = trim($buf);
+        if ($stmt !== '') { $statements[] = $stmt; }
+        $buf = '';
+        continue;
+    }
+    $buf .= $ch;
+}
+if (trim($buf) !== '') { $statements[] = trim($buf); }
+
+$ddlDone = 0; $dataDone = 0; $totalData = 0;
+foreach ($statements as $s) {
+    if (stripos(ltrim($s), 'INSERT') === 0) { $totalData++; }
+}
+
+/* Run DDL (plus any non-INSERT DML) first, outside a transaction. */
+try {
+    foreach ($statements as $s) {
+        if (stripos(ltrim($s), 'INSERT') === 0) { continue; }
+        if (!$mysql->query($s)) {
+            throw new \RuntimeException($mysql->error . ' | near: ' . substr($s, 0, 80));
         }
-    } while ($mysql->more_results() && $mysql->next_result());
-    output('  [OK] restore complete');
+        $ddlDone++;
+    }
+    output('  [OK] schema + ' . $ddlDone . ' setup statements');
 } catch (\Throwable $e) {
-    output('  [FAIL] ' . $e->getMessage());
+    output('  [FAIL schema] ' . $e->getMessage());
+    output('');
+    output('Schema-phase failure — database state may be inconsistent.');
+    output('Restore the pre-restore snapshot to recover.');
+    $mysql->query('SET FOREIGN_KEY_CHECKS = 1');
+    $mysql->close();
+    return;
+}
+
+/* Run every INSERT inside one transaction — all-or-nothing on data. */
+try {
+    $mysql->begin_transaction();
+    foreach ($statements as $s) {
+        if (stripos(ltrim($s), 'INSERT') !== 0) { continue; }
+        if (!$mysql->query($s)) {
+            throw new \RuntimeException($mysql->error . ' | near: ' . substr($s, 0, 80));
+        }
+        $dataDone++;
+    }
+    $mysql->commit();
+    output('  [OK] data — ' . $dataDone . ' / ' . $totalData . ' INSERT statements committed');
+} catch (\Throwable $e) {
+    try { $mysql->rollback(); } catch (\Throwable $_) {}
+    output('  [FAIL data] ' . $e->getMessage());
+    output('  [ROLLBACK] data changes reverted — schema changes remain.');
+    output('  Restore the pre-restore snapshot to fully recover previous state.');
 }
 
 $mysql->query('SET FOREIGN_KEY_CHECKS = 1');

--- a/appWeb/.sql/schema.sql
+++ b/appWeb/.sql/schema.sql
@@ -1024,3 +1024,17 @@ ALTER TABLE tblSongs MODIFY Number INT UNSIGNED NULL DEFAULT NULL;
 
 -- Zero out any existing Misc song numbers (historic placeholders).
 UPDATE tblSongs SET Number = NULL WHERE SongbookAbbr = 'Misc' AND Number IS NOT NULL;
+
+-- Search-query log for analytics (#404). Captures every search so we can
+-- surface top queries + zero-result queries in the admin dashboard.
+CREATE TABLE IF NOT EXISTS tblSearchQueries (
+    Id              BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    Query           VARCHAR(500)    NOT NULL,
+    ResultCount     INT UNSIGNED    NOT NULL DEFAULT 0,
+    UserId          INT UNSIGNED    NULL,
+    SearchedAt      TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_SearchedAt (SearchedAt),
+    INDEX idx_Query      (Query(191)),
+    CONSTRAINT fk_Search_User FOREIGN KEY (UserId) REFERENCES tblUsers(Id)
+        ON DELETE SET NULL ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/appWeb/public_html/.htaccess
+++ b/appWeb/public_html/.htaccess
@@ -21,12 +21,17 @@
 RewriteEngine On
 
 # ==========================================================================
-# ADMIN AREA PASSTHROUGH (/manage/)
+# ADMIN AREA PASSTHROUGH (/manage/) + /admin/ alias (#407)
 #
 # The /manage/ directory has its own PHP authentication system and does
 # not use the SPA router. All requests to /manage/ are served directly
 # by PHP — they must bypass the .php blocking rule and the SPA catch-all.
+#
+# /admin/ is a permanent alias for /manage/ — same portal, friendlier URL.
 # ==========================================================================
+
+# /admin/<path> → /manage/<path> (301, preserves query string)
+RewriteRule ^admin(/.*)?$ /manage$1 [R=301,L,QSA]
 
 RewriteRule ^manage/ - [L]
 

--- a/appWeb/public_html/api-docs.yaml
+++ b/appWeb/public_html/api-docs.yaml
@@ -2,28 +2,51 @@ openapi: 3.0.3
 
 info:
   title: iHymns API
-  version: "0.10.0"
+  version: "0.10.1"
   description: |
     The iHymns API provides programmatic access to the iHymns hymn and song
     database. It powers the iHymns Progressive Web App (PWA), enabling song
     search, songbook browsing, setlist management, user authentication,
-    favorites sync, and administrative operations.
+    favorites sync, offline PWA caching, and administrative operations.
 
     All endpoints are served from a single PHP entry point (`api.php`) and are
     routed via the `action` query parameter. Responses are JSON unless otherwise
-    noted.
+    noted. The admin-only **Editor API** (`/manage/editor/api.php`) follows the
+    same action-query pattern but is gated by the `/manage/` PHP session.
 
     ## Authentication
 
-    Endpoints that require authentication use Bearer tokens passed in the
-    `Authorization` header:
+    Endpoints that require authentication accept either a Bearer token or the
+    cross-subdomain session cookie:
 
     ```
     Authorization: Bearer <64-character hex token>
     ```
 
-    Tokens are obtained via `auth_register` or `auth_login` and expire after
-    30 days.
+    or
+
+    ```
+    Cookie: ihymns_auth=<64-character hex token>
+    ```
+
+    The cookie is `Domain=.ihymns.app; HttpOnly; SameSite=Lax; Secure` so a
+    single sign-in persists across `ihymns.app`, `alpha.ihymns.app`, and
+    `beta.ihymns.app`. Tokens are issued by `auth_login`,
+    `auth_email_login_verify`, or `auth_register`, and carry a **sliding
+    30-day expiry** — every authenticated request bumps the expiry by one
+    day (at most once per 24h per token).
+
+    Magic-link email sign-in (`auth_email_login_request` →
+    `auth_email_login_verify`) is the primary path surfaced in the UI;
+    username/password (`auth_login`) is the fallback.
+
+    ## Entitlements
+
+    Admin and editor endpoints are gated by **capabilities**, not just roles.
+    The default mapping lives in `includes/entitlements.php` and can be
+    overridden at runtime via `/manage/entitlements`. The `role` field on a
+    user is still returned for compatibility, but authorisation uses the
+    capability check internally.
 
     ## Rate Limiting
 
@@ -39,8 +62,12 @@ info:
 servers:
   - url: https://ihymns.app
     description: Production
+  - url: https://alpha.ihymns.app
+    description: Alpha channel (gated by `access_alpha` entitlement)
+  - url: https://beta.ihymns.app
+    description: Beta channel (gated by `access_beta` entitlement)
   - url: https://beta.ihymns.net
-    description: Beta / Development
+    description: Legacy beta / dev
 
 tags:
   - name: Songs
@@ -48,7 +75,11 @@ tags:
   - name: Languages
     description: Language metadata and song translations
   - name: Setlists
-    description: Create, retrieve, and sync shared setlists
+    description: Create, retrieve, and sync personal setlists
+  - name: Setlists — Scheduling
+    description: Schedule setlists for a date and list upcoming events (#398)
+  - name: Setlists — Collaboration
+    description: Invite collaborators, manage permissions, list shared setlists (#398)
   - name: Song Requests
     description: Submit and view community song requests
   - name: Favorites
@@ -57,8 +88,21 @@ tags:
     description: User registration, login, logout, and profile management
   - name: User Access
     description: Group-based access control and app status
+  - name: Preferences
+    description: Server-side preference sync across devices
+  - name: Offline / PWA
+    description: Bulk-fetch endpoints used by the service worker for offline caching
+  - name: Discovery
+    description: Tags, suggestions, related songs, popular songs
+  - name: Push
+    description: Push-notification subscription endpoints
   - name: Admin
     description: Administrative endpoints for user, group, and content management
+  - name: Editor API
+    description: |
+      Admin-only endpoints under `/manage/editor/api.php`, protected by the
+      /manage/ PHP session rather than a Bearer token. Used by the song
+      editor SPA for per-song save, bulk tag, and revision history.
 
 paths:
   # ===========================================================================
@@ -2169,6 +2213,906 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SuccessResponse"
+
+  # ===========================================================================
+  # OFFLINE / PWA  (bulk fetch endpoints for the service worker)
+  # ===========================================================================
+
+  /api.php?action=bulk_songs:
+    get:
+      operationId: bulkSongs
+      tags: [Offline / PWA]
+      summary: Rendered HTML for every song in a songbook
+      description: |
+        Returns a map of `songId` → pre-rendered song-page HTML for every
+        song in the given songbook. Used by the service worker to pre-cache
+        an entire songbook in a single request (~6 requests for the whole
+        corpus vs. thousands).
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [bulk_songs] }
+        - name: songbook
+          in: query
+          required: true
+          description: Songbook abbreviation (e.g. `CP`, `MP`, `Misc`)
+          schema: { type: string }
+      responses:
+        "200":
+          description: Map of song IDs to rendered HTML
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  songbook: { type: string, example: CP }
+                  count:    { type: integer, example: 642 }
+                  songs:
+                    type: object
+                    additionalProperties:
+                      type: string
+                      description: Rendered `<article>` HTML for the song page
+
+  /api.php?action=bulk_audio:
+    get:
+      operationId: bulkAudio
+      tags: [Offline / PWA]
+      summary: Audio URL manifest for every song with audio (#401)
+      description: |
+        Returns `{songId, url}` for every song whose `HasAudio` flag is set.
+        Used by the service worker to pre-cache audio into `iHymns-media-v1`
+        when the user enables "Include audio in offline downloads" in
+        Settings.
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [bulk_audio] }
+        - name: songbook
+          in: query
+          required: false
+          description: Restrict the manifest to one songbook abbreviation
+          schema: { type: string, example: CP }
+      responses:
+        "200":
+          description: Audio URL manifest
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  songbook: { type: string, nullable: true, example: CP }
+                  count:    { type: integer, example: 180 }
+                  audio:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        songId: { type: string, example: CP-0202 }
+                        url:    { type: string, example: /data/audio/CP/0202.mp3 }
+
+  # ===========================================================================
+  # DISCOVERY  (popular / tags / suggest / related)
+  # ===========================================================================
+
+  /api.php?action=popular_songs:
+    get:
+      operationId: popularSongs
+      tags: [Discovery]
+      summary: Most-viewed songs over the trailing window
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [popular_songs] }
+        - name: days
+          in: query
+          required: false
+          schema: { type: integer, default: 30, minimum: 1, maximum: 365 }
+        - name: limit
+          in: query
+          required: false
+          schema: { type: integer, default: 12, minimum: 1, maximum: 50 }
+      responses:
+        "200":
+          description: Ranked list of popular songs
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  popular:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/SongSummary"
+
+  /api.php?action=tags:
+    get:
+      operationId: listTags
+      tags: [Discovery]
+      summary: List every curated song tag
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [tags] }
+      responses:
+        "200":
+          description: Tag list with song counts
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  tags:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:       { type: integer }
+                        name:     { type: string, example: Easter }
+                        slug:     { type: string, example: easter }
+                        songCount: { type: integer }
+
+  /api.php?action=songs_by_tag:
+    get:
+      operationId: songsByTag
+      tags: [Discovery]
+      summary: Songs tagged with a given slug
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [songs_by_tag] }
+        - name: slug
+          in: query
+          required: true
+          schema: { type: string, example: communion }
+      responses:
+        "200":
+          description: Songs for the tag
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  tag:
+                    type: object
+                    properties:
+                      id: { type: integer }
+                      name: { type: string }
+                      slug: { type: string }
+                  songs:
+                    type: array
+                    items: { $ref: "#/components/schemas/SongSummary" }
+
+  /api.php?action=suggest:
+    get:
+      operationId: suggest
+      tags: [Discovery]
+      summary: Typeahead suggestions for the search box
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [suggest] }
+        - name: q
+          in: query
+          required: true
+          schema: { type: string, minLength: 1 }
+      responses:
+        "200":
+          description: Suggestion list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  suggestions:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        label: { type: string }
+                        type:  { type: string, enum: [song, writer, songbook, tag] }
+                        id:    { type: string, nullable: true }
+
+  /api.php?action=related_songs:
+    get:
+      operationId: relatedSongs
+      tags: [Discovery]
+      summary: Songs related to the given song
+      description: Matches by shared tags, same writer, or same songbook vicinity.
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [related_songs] }
+        - name: id
+          in: query
+          required: true
+          description: Source song id (e.g. `CP-0202`)
+          schema: { type: string }
+      responses:
+        "200":
+          description: Related songs
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  related:
+                    type: array
+                    items: { $ref: "#/components/schemas/SongSummary" }
+
+  /api.php?action=song:
+    get:
+      operationId: getSong
+      tags: [Songs]
+      summary: Full song record (metadata + components + writers/composers)
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [song] }
+        - name: id
+          in: query
+          required: true
+          schema: { type: string, example: CP-0202 }
+      responses:
+        "200":
+          description: Full song record
+        "404":
+          description: Song not found
+
+  /api.php?action=song_view:
+    post:
+      operationId: logSongView
+      tags: [Songs]
+      summary: Log a song-view event
+      description: |
+        Fire-and-forget analytics ping. Writes one row to `tblSongHistory`
+        so the dashboard's view counts + `popular_songs` can aggregate.
+        Never blocks the response.
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [song_view] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [songId]
+              properties:
+                songId: { type: string, example: CP-0202 }
+      responses:
+        "200":
+          description: Logged (or silently dropped when consent is denied)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+
+  # ===========================================================================
+  # PREFERENCES
+  # ===========================================================================
+
+  /api.php?action=user_preferences:
+    get:
+      operationId: getUserPreferences
+      tags: [Preferences]
+      summary: Fetch the caller's server-synced preferences
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [user_preferences] }
+      responses:
+        "200":
+          description: Preference map
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  preferences:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    example:
+                      theme: dark
+                      fontSize: "18"
+                      defaultSongbook: CP
+
+  /api.php?action=user_preferences_sync:
+    post:
+      operationId: syncUserPreferences
+      tags: [Preferences]
+      summary: Last-write-wins sync of preferences across devices
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [user_preferences_sync] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [preferences]
+              properties:
+                preferences:
+                  type: object
+                  additionalProperties: { type: string }
+      responses:
+        "200":
+          description: Applied server-side; merged result returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  preferences:
+                    type: object
+                    additionalProperties: { type: string }
+
+  # ===========================================================================
+  # SETLISTS — SCHEDULING (#398)
+  # ===========================================================================
+
+  /api.php?action=setlist_schedule_set:
+    post:
+      operationId: setlistScheduleSet
+      tags: [Setlists — Scheduling]
+      summary: Schedule a setlist for a date
+      description: |
+        Replaces any existing schedule for the (user, setlistId) pair with a
+        new date + optional notes. Ownership is verified against
+        `tblUserSetlists`.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [setlist_schedule_set] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [setlistId, date]
+              properties:
+                setlistId: { type: string, example: slist-abc123 }
+                date:
+                  type: string
+                  format: date
+                  example: "2026-05-03"
+                notes:
+                  type: string
+                  description: Optional free-text notes
+                  example: "Sunday 10am — Communion service"
+      responses:
+        "200":
+          description: Scheduled
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessResponse" }
+        "400":
+          description: Missing or malformed fields
+        "401":
+          description: Unauthorised
+        "404":
+          description: Setlist not found or not owned by caller
+
+  /api.php?action=setlist_schedule_clear:
+    post:
+      operationId: setlistScheduleClear
+      tags: [Setlists — Scheduling]
+      summary: Remove the scheduled date for a setlist
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [setlist_schedule_clear] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [setlistId]
+              properties:
+                setlistId: { type: string, example: slist-abc123 }
+      responses:
+        "200":
+          description: Cleared (no-op if nothing was scheduled)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessResponse" }
+
+  /api.php?action=setlist_schedule_current:
+    get:
+      operationId: setlistScheduleCurrent
+      tags: [Setlists — Scheduling]
+      summary: Fetch the current schedule for one setlist
+      description: Used by the setlist detail view to pre-populate the date input.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [setlist_schedule_current] }
+        - name: setlistId
+          in: query
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Schedule row or null
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  schedule:
+                    oneOf:
+                      - type: "null"
+                      - type: object
+                        properties:
+                          ScheduledDate: { type: string, format: date }
+                          Notes:         { type: string }
+
+  /api.php?action=setlist_schedule_upcoming:
+    get:
+      operationId: setlistScheduleUpcoming
+      tags: [Setlists — Scheduling]
+      summary: Next 25 scheduled setlists from today forward
+      description: |
+        Powers the "Up next" card on the setlist overview page. Only
+        returns the caller's own scheduled setlists (not ones shared
+        with them).
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [setlist_schedule_upcoming] }
+      responses:
+        "200":
+          description: Upcoming schedule list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  upcoming:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        SetlistId:     { type: string }
+                        ScheduledDate: { type: string, format: date }
+                        Notes:         { type: string }
+                        name:          { type: string, nullable: true }
+
+  # ===========================================================================
+  # SETLISTS — COLLABORATION (#398)
+  # ===========================================================================
+
+  /api.php?action=setlist_collab_invite:
+    post:
+      operationId: setlistCollabInvite
+      tags: [Setlists — Collaboration]
+      summary: Invite a user by email to collaborate on a setlist
+      description: |
+        Owner-only. Resolves the invitee by email (must already have an
+        iHymns account) and upserts a row in `tblSetlistCollaborators`.
+        Re-inviting the same user updates their permission.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [setlist_collab_invite] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [setlistId, collaboratorEmail]
+              properties:
+                setlistId:          { type: string }
+                collaboratorEmail:  { type: string, format: email }
+                permission:
+                  type: string
+                  enum: [view, edit]
+                  default: edit
+      responses:
+        "200":
+          description: Invitation accepted / permission updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+                  collaborator:
+                    type: object
+                    properties:
+                      id:         { type: integer }
+                      username:   { type: string }
+                      permission: { type: string, enum: [view, edit] }
+        "400":
+          description: Missing fields, invalid email, or self-invite
+        "404":
+          description: Setlist not owned by caller, or no user with that email
+
+  /api.php?action=setlist_collab_list:
+    get:
+      operationId: setlistCollabList
+      tags: [Setlists — Collaboration]
+      summary: List collaborators on a setlist the caller owns
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [setlist_collab_list] }
+        - name: setlistId
+          in: query
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Collaborator list, newest invite first
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  collaborators:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:         { type: integer }
+                        username:   { type: string }
+                        email:      { type: string, format: email }
+                        permission: { type: string, enum: [view, edit] }
+                        invitedAt:  { type: string, format: date-time }
+
+  /api.php?action=setlist_collab_remove:
+    post:
+      operationId: setlistCollabRemove
+      tags: [Setlists — Collaboration]
+      summary: Revoke a collaborator's access to a setlist
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [setlist_collab_remove] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [setlistId, collaboratorId]
+              properties:
+                setlistId:      { type: string }
+                collaboratorId: { type: integer }
+      responses:
+        "200":
+          description: Removed (reports how many rows were deleted)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:      { type: boolean }
+                  removed: { type: integer, minimum: 0 }
+
+  /api.php?action=setlist_collab_shared_with_me:
+    get:
+      operationId: setlistCollabSharedWithMe
+      tags: [Setlists — Collaboration]
+      summary: Setlists the caller has been invited to
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [setlist_collab_shared_with_me] }
+      responses:
+        "200":
+          description: Shared-with-me list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  shared:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        ownerId:    { type: integer }
+                        ownerName:  { type: string }
+                        setlistId:  { type: string }
+                        permission: { type: string, enum: [view, edit] }
+                        name:       { type: string, nullable: true }
+
+  # ===========================================================================
+  # PUSH NOTIFICATIONS
+  # ===========================================================================
+
+  /api.php?action=push_subscribe:
+    post:
+      operationId: pushSubscribe
+      tags: [Push]
+      summary: Register a Web Push subscription for the current user
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [push_subscribe] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [endpoint, keys]
+              properties:
+                endpoint: { type: string, format: uri }
+                keys:
+                  type: object
+                  required: [p256dh, auth]
+                  properties:
+                    p256dh: { type: string }
+                    auth:   { type: string }
+      responses:
+        "200":
+          description: Subscription stored
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessResponse" }
+
+  /api.php?action=push_unsubscribe:
+    post:
+      operationId: pushUnsubscribe
+      tags: [Push]
+      summary: Remove a Web Push subscription
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [push_unsubscribe] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [endpoint]
+              properties:
+                endpoint: { type: string, format: uri }
+      responses:
+        "200":
+          description: Removed (idempotent)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessResponse" }
+
+  # ===========================================================================
+  # EDITOR API  (separate entry point — /manage/editor/api.php)
+  # ===========================================================================
+
+  /manage/editor/api.php?action=load:
+    get:
+      operationId: editorLoad
+      tags: [Editor API]
+      summary: Load every song + songbook + writer row the editor needs
+      description: |
+        Editor SPA hits this once on open. Returns the full in-memory
+        model. Auth is the `/manage/` PHP session — not a Bearer token.
+      responses:
+        "200":
+          description: Full editor payload
+        "401":
+          description: Not authenticated (redirect the user to /manage/login)
+        "403":
+          description: Authenticated but not an editor
+
+  /manage/editor/api.php?action=save_song:
+    post:
+      operationId: editorSaveSong
+      tags: [Editor API]
+      summary: Transactional UPSERT of one song (#394)
+      description: |
+        Writes `tblSongs` + children in a transaction and records one row
+        in `tblSongRevisions` with `PreviousData` / `NewData` snapshots.
+        The editor calls this per modified song — much cheaper than the
+        legacy full-corpus `save`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [id, title]
+              properties:
+                id:              { type: string, example: CP-0202 }
+                title:           { type: string }
+                number:
+                  type: integer
+                  nullable: true
+                  description: Null for `Misc` songs or when empty (#392)
+                songbook:        { type: string }
+                songbookName:    { type: string }
+                language:        { type: string, example: en }
+                copyright:       { type: string }
+                ccli:            { type: string }
+                verified:            { type: boolean }
+                lyricsPublicDomain:  { type: boolean }
+                musicPublicDomain:   { type: boolean }
+                hasAudio:            { type: boolean }
+                hasSheetMusic:       { type: boolean }
+                components:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:  { type: string, example: verse }
+                      cNum:  { type: integer }
+                      lines: { type: array, items: { type: string } }
+      responses:
+        "200":
+          description: Saved; revision logged
+        "400":
+          description: Missing required id/title
+        "500":
+          description: Save failed; details in server log
+
+  /manage/editor/api.php?action=bulk_tag:
+    post:
+      operationId: editorBulkTag
+      tags: [Editor API]
+      summary: Add and/or remove tags across a list of songs (#399)
+      description: |
+        Transactional. ADDs upsert `tblSongTags` (with slug) and
+        INSERT-IGNORE into `tblSongTagMap`. REMOVEs resolve by tag name
+        and delete matching mapping rows. Unknown tag names on remove
+        are silently ignored.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [songIds]
+              properties:
+                songIds:
+                  type: array
+                  items: { type: string, example: CP-0202 }
+                add:
+                  type: array
+                  items: { type: string, example: Easter }
+                remove:
+                  type: array
+                  items: { type: string, example: Funeral }
+      responses:
+        "200":
+          description: Summary of what changed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  songsAffected: { type: integer }
+                  added:         { type: integer, description: Rows actually inserted }
+                  removed:       { type: integer, description: Rows actually deleted }
+        "400":
+          description: No valid songIds or no tag changes supplied
+
+  /manage/editor/api.php?action=list_revisions:
+    get:
+      operationId: editorListRevisions
+      tags: [Editor API]
+      summary: List revisions for one song (#400)
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [list_revisions] }
+        - name: songId
+          in: query
+          required: true
+          schema: { type: string, example: CP-0202 }
+        - name: limit
+          in: query
+          required: false
+          schema: { type: integer, default: 50, minimum: 1, maximum: 200 }
+      responses:
+        "200":
+          description: Revision list, newest first
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  revisions:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:           { type: integer }
+                        action:       { type: string, enum: [create, edit, restore, delete] }
+                        createdAt:    { type: string, format: date-time }
+                        userId:       { type: integer, nullable: true }
+                        username:     { type: string, nullable: true }
+                        previousData: { type: object, nullable: true }
+                        newData:      { type: object, nullable: true }
+
+  /manage/editor/api.php?action=restore_revision:
+    post:
+      operationId: editorRestoreRevision
+      tags: [Editor API]
+      summary: Restore a song to the state BEFORE a given revision (#400)
+      description: |
+        Rewrites the core `tblSongs` row from the chosen revision's
+        `PreviousData` and records a new revision with `Action='restore'`
+        whose `PreviousData` captures the state just-overwritten.
+        Transactional — rolls back on any failure.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [revisionId]
+              properties:
+                revisionId: { type: integer, example: 4712 }
+      responses:
+        "200":
+          description: Restored; new revision row's id is returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:            { type: boolean }
+                  songId:        { type: string }
+                  newRevisionId: { type: integer }
+        "404":
+          description: Revision id not found
+        "409":
+          description: This revision has no prior state (it's the initial create)
 
 # =============================================================================
 # COMPONENTS

--- a/appWeb/public_html/api-docs.yaml
+++ b/appWeb/public_html/api-docs.yaml
@@ -96,8 +96,22 @@ tags:
     description: Tags, suggestions, related songs, popular songs
   - name: Push
     description: Push-notification subscription endpoints
+  - name: Organisations
+    description: Multi-tenant organisation membership and administration
+  - name: Content Access
+    description: Content-licence + restriction evaluation for gated songs / audio / sheet music
+  - name: Song Metadata
+    description: Per-song data surfaces — history, key, writers, revisions
+  - name: Pages
+    description: HTML + alternate-format (CSV / XML / JSON / OpenSong / VideoPsalm) renderers
   - name: Admin
     description: Administrative endpoints for user, group, and content management
+  - name: Admin — Restrictions
+    description: Content-restriction rule engine (tier / org / platform / licence)
+  - name: Admin — Revisions
+    description: Review pending song revisions
+  - name: Admin — Maintenance
+    description: Cleanup, export, and songbook-health utilities
   - name: Editor API
     description: |
       Admin-only endpoints under `/manage/editor/api.php`, protected by the
@@ -3113,6 +3127,1037 @@ paths:
           description: Revision id not found
         "409":
           description: This revision has no prior state (it's the initial create)
+
+  # ===========================================================================
+  # SONG METADATA  (per-song detail surfaces)
+  # ===========================================================================
+
+  /api.php?action=song_history:
+    get:
+      operationId: songHistory
+      tags: [Song Metadata]
+      summary: Recently viewed songs for the caller
+      description: Backed by `tblSongHistory`; gated on analytics consent.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [song_history] }
+        - name: limit
+          in: query
+          required: false
+          schema: { type: integer, default: 50, minimum: 1, maximum: 500 }
+      responses:
+        "200":
+          description: History entries, newest first
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  history:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        songId:   { type: string }
+                        title:    { type: string }
+                        songbook: { type: string }
+                        viewedAt: { type: string, format: date-time }
+
+  /api.php?action=song_key:
+    get:
+      operationId: songKeyGet
+      tags: [Song Metadata]
+      summary: Fetch the caller's saved preferred key for a song
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [song_key] }
+        - name: songId
+          in: query
+          required: true
+          schema: { type: string, example: CP-0202 }
+      responses:
+        "200":
+          description: Preferred key or null
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  key:
+                    type: string
+                    nullable: true
+                    example: G
+
+  /api.php?action=song_key_save:
+    post:
+      operationId: songKeySave
+      tags: [Song Metadata]
+      summary: Save the caller's preferred key for a song
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [song_key_save] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [songId, key]
+              properties:
+                songId: { type: string }
+                key:
+                  type: string
+                  description: Musical key (empty string to clear)
+                  example: Eb
+      responses:
+        "200":
+          description: Stored
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessResponse" }
+
+  /api.php?action=song_revisions:
+    get:
+      operationId: songRevisionsPublic
+      tags: [Song Metadata]
+      summary: Revision timeline for one song (read-only public view)
+      description: |
+        Lightweight sibling of the editor-only `list_revisions`. Returns
+        who/when/action for each revision, without the full before/after
+        snapshots (those are editor-only).
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [song_revisions] }
+        - name: songId
+          in: query
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Redacted revision list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  revisions:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:        { type: integer }
+                        action:    { type: string, enum: [create, edit, restore, delete] }
+                        createdAt: { type: string, format: date-time }
+                        username:  { type: string, nullable: true }
+
+  /api.php?action=writer:
+    get:
+      operationId: writerSongs
+      tags: [Song Metadata]
+      summary: Songs attributed to a given writer or composer
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [writer] }
+        - name: name
+          in: query
+          required: true
+          description: Writer / composer name (case-insensitive match)
+          schema: { type: string, example: John Newton }
+      responses:
+        "200":
+          description: Songs by that writer
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  writer: { type: string }
+                  songs:
+                    type: array
+                    items: { $ref: "#/components/schemas/SongSummary" }
+
+  /api.php?action=songbook:
+    get:
+      operationId: songbookSongs
+      tags: [Songs]
+      summary: All songs in one songbook
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [songbook] }
+        - name: abbr
+          in: query
+          required: true
+          description: Songbook abbreviation (`CP`, `MP`, `JP`, `SDAH`, `CH`, `Misc`)
+          schema: { type: string }
+      responses:
+        "200":
+          description: Songbook songs
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  songbook:
+                    type: object
+                    properties:
+                      abbr: { type: string }
+                      name: { type: string }
+                  songs:
+                    type: array
+                    items: { $ref: "#/components/schemas/SongSummary" }
+
+  # ===========================================================================
+  # SONG REQUESTS  (submission half — admin half is under Admin tag)
+  # ===========================================================================
+
+  /api.php?action=song_request_submit:
+    post:
+      operationId: songRequestSubmit
+      tags: [Song Requests]
+      summary: Submit a new song-request from the public form
+      description: |
+        Rate-limited (IP-based, 5/day default) and honey-potted. Writes
+        to `tblSongRequests` with status `pending`. Anonymous submissions
+        are allowed.
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [song_request_submit] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [title]
+              properties:
+                title:     { type: string, example: "Great Is Thy Faithfulness" }
+                writer:    { type: string, example: "Thomas Chisholm" }
+                reason:    { type: string, description: Why the user wants this song added }
+                email:     { type: string, format: email, description: Optional reply-to }
+                hp_field:  { type: string, description: Honeypot — MUST be empty }
+      responses:
+        "200":
+          description: Queued for admin triage
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessResponse" }
+        "429":
+          description: Rate-limit exceeded for this IP
+
+  # ===========================================================================
+  # LEGACY SETLIST ENDPOINTS  (pre-#398; kept for API compatibility)
+  # ===========================================================================
+
+  /api.php?action=setlist:
+    get:
+      operationId: setlistListMine
+      tags: [Setlists]
+      summary: List the caller's setlists (summary view)
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [setlist] }
+      responses:
+        "200":
+          description: Setlist summaries
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  setlists:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:        { type: string }
+                        name:      { type: string }
+                        songCount: { type: integer }
+                        createdAt: { type: string, format: date-time }
+
+  /api.php?action=setlist_schedule:
+    get:
+      operationId: setlistScheduleLegacy
+      tags: [Setlists — Scheduling]
+      summary: Legacy scheduling lookup (kept for older Apple / Android builds)
+      description: |
+        **Deprecated** — superseded by `setlist_schedule_current` (GET)
+        and `setlist_schedule_set` / `_clear` (POST). Returns the same
+        row via a single call.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [setlist_schedule] }
+        - name: setlistId
+          in: query
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Schedule row or null
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  schedule:
+                    oneOf:
+                      - type: "null"
+                      - type: object
+                        properties:
+                          ScheduledDate: { type: string, format: date }
+                          Notes:         { type: string }
+
+  /api.php?action=setlist_schedule_save:
+    post:
+      operationId: setlistScheduleSaveLegacy
+      tags: [Setlists — Scheduling]
+      summary: Legacy save-or-clear scheduling (Deprecated)
+      description: |
+        **Deprecated** — superseded by `setlist_schedule_set` (upsert)
+        and `setlist_schedule_clear` (delete). This endpoint does both
+        with a nullable date.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [setlist_schedule_save] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [setlistId]
+              properties:
+                setlistId: { type: string }
+                date:
+                  type: string
+                  nullable: true
+                  format: date
+                  description: Null or empty string clears the schedule
+                notes: { type: string }
+      responses:
+        "200":
+          description: Saved or cleared
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessResponse" }
+
+  /api.php?action=setlist_templates:
+    get:
+      operationId: setlistTemplates
+      tags: [Setlists]
+      summary: List saved setlist templates
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [setlist_templates] }
+      responses:
+        "200":
+          description: Template list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  templates:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:         { type: string }
+                        name:       { type: string }
+                        songIds:    { type: array, items: { type: string } }
+                        createdAt:  { type: string, format: date-time }
+
+  /api.php?action=setlist_template_save:
+    post:
+      operationId: setlistTemplateSave
+      tags: [Setlists]
+      summary: Create or update a setlist template
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [setlist_template_save] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name, songIds]
+              properties:
+                id:      { type: string, description: Omit to create; pass existing id to update }
+                name:    { type: string }
+                songIds: { type: array, items: { type: string } }
+      responses:
+        "200":
+          description: Saved; returns the template id
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+                  id: { type: string }
+
+  /api.php?action=setlist_collaborators:
+    get:
+      operationId: setlistCollaboratorsLegacy
+      tags: [Setlists — Collaboration]
+      summary: Legacy collaborators list (Deprecated)
+      description: |
+        **Deprecated** — superseded by `setlist_collab_list`. Kept for
+        older Apple / Android builds that already speak this endpoint.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [setlist_collaborators] }
+        - name: setlistId
+          in: query
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Collaborator list (same shape as `setlist_collab_list`)
+
+  /api.php?action=setlist_collaborator_add:
+    post:
+      operationId: setlistCollaboratorAddLegacy
+      tags: [Setlists — Collaboration]
+      summary: Legacy invite endpoint (Deprecated)
+      description: |
+        **Deprecated** — superseded by `setlist_collab_invite`. Kept for
+        API compatibility.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [setlist_collaborator_add] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [setlistId, collaboratorEmail]
+              properties:
+                setlistId:         { type: string }
+                collaboratorEmail: { type: string, format: email }
+                permission:        { type: string, enum: [view, edit] }
+      responses:
+        "200":
+          description: Added
+
+  /api.php?action=setlist_collaborator_remove:
+    post:
+      operationId: setlistCollaboratorRemoveLegacy
+      tags: [Setlists — Collaboration]
+      summary: Legacy remove-collaborator endpoint (Deprecated)
+      description: |
+        **Deprecated** — superseded by `setlist_collab_remove`.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [setlist_collaborator_remove] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [setlistId, collaboratorId]
+              properties:
+                setlistId:      { type: string }
+                collaboratorId: { type: integer }
+      responses:
+        "200":
+          description: Removed
+
+  # ===========================================================================
+  # ORGANISATIONS
+  # ===========================================================================
+
+  /api.php?action=organisation:
+    get:
+      operationId: organisationGet
+      tags: [Organisations]
+      summary: Fetch one organisation by id
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [organisation] }
+        - name: id
+          in: query
+          required: true
+          schema: { type: integer }
+      responses:
+        "200":
+          description: Organisation detail (members, licences, parent)
+
+  /api.php?action=organisation_create:
+    post:
+      operationId: organisationCreate
+      tags: [Organisations]
+      summary: Create a new organisation (owner becomes the caller)
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [organisation_create] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name]
+              properties:
+                name:        { type: string, example: "First Baptist Church" }
+                parentOrgId: { type: integer, nullable: true, description: Parent org for nested hierarchy }
+                description: { type: string }
+      responses:
+        "200":
+          description: Created; returns the new org id
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+                  id: { type: integer }
+
+  /api.php?action=my_organisations:
+    get:
+      operationId: myOrganisations
+      tags: [Organisations]
+      summary: Organisations the caller belongs to
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [my_organisations] }
+      responses:
+        "200":
+          description: Caller's orgs with role per org
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  organisations:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:   { type: integer }
+                        name: { type: string }
+                        role: { type: string, enum: [owner, admin, member] }
+
+  # ===========================================================================
+  # CONTENT ACCESS
+  # ===========================================================================
+
+  /api.php?action=content_access:
+    get:
+      operationId: contentAccess
+      tags: [Content Access]
+      summary: Evaluate whether the caller can access one piece of content
+      description: |
+        Combines tier membership, CCLI validity, org-licence, and
+        platform-specific restrictions (`tblContentRestrictions`) into
+        a single yes/no with reason.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [content_access] }
+        - name: songId
+          in: query
+          required: true
+          schema: { type: string }
+        - name: kind
+          in: query
+          required: false
+          description: What aspect is being accessed
+          schema:
+            type: string
+            enum: [lyrics, audio, sheet_music, offline]
+            default: lyrics
+        - name: platform
+          in: query
+          required: false
+          description: Current platform for platform-specific rules
+          schema: { type: string, enum: [pwa, apple, android] }
+      responses:
+        "200":
+          description: Access decision
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  allowed: { type: boolean }
+                  reason:
+                    type: string
+                    description: Human-readable reason when denied
+                    nullable: true
+                  tier:    { type: string, nullable: true }
+
+  # ===========================================================================
+  # ADMIN — RESTRICTIONS / REVISIONS / MAINTENANCE
+  # ===========================================================================
+
+  /api.php?action=admin_restrictions:
+    get:
+      operationId: adminRestrictions
+      tags: [Admin — Restrictions]
+      summary: List every content-restriction rule
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_restrictions] }
+      responses:
+        "200":
+          description: Rule list sorted by priority
+
+  /api.php?action=admin_restriction_create:
+    post:
+      operationId: adminRestrictionCreate
+      tags: [Admin — Restrictions]
+      summary: Create a new content-restriction rule
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_restriction_create] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [priority, ruleKind, ruleValue]
+              properties:
+                priority:   { type: integer }
+                ruleKind:
+                  type: string
+                  enum: [songbook, song, writer, tier, org, platform, licence]
+                ruleValue:  { type: string }
+                action:
+                  type: string
+                  enum: [allow, deny]
+                  default: deny
+                note:       { type: string }
+      responses:
+        "200":
+          description: Created
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SuccessResponse" }
+
+  /api.php?action=admin_restriction_delete:
+    post:
+      operationId: adminRestrictionDelete
+      tags: [Admin — Restrictions]
+      summary: Delete one restriction rule by id
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_restriction_delete] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [id]
+              properties:
+                id: { type: integer }
+      responses:
+        "200":
+          description: Deleted
+
+  /api.php?action=admin_pending_revisions:
+    get:
+      operationId: adminPendingRevisions
+      tags: [Admin — Revisions]
+      summary: List every song revision awaiting review
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_pending_revisions] }
+      responses:
+        "200":
+          description: Pending revision rows
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  pending:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:        { type: integer }
+                        songId:    { type: string }
+                        action:    { type: string }
+                        createdAt: { type: string, format: date-time }
+                        username:  { type: string, nullable: true }
+
+  /api.php?action=admin_revision_review:
+    post:
+      operationId: adminRevisionReview
+      tags: [Admin — Revisions]
+      summary: Approve or reject a pending revision
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_revision_review] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [revisionId, decision]
+              properties:
+                revisionId: { type: integer }
+                decision:
+                  type: string
+                  enum: [approved, rejected]
+                note:       { type: string, description: Reviewer comment }
+      responses:
+        "200":
+          description: Updated
+
+  /api.php?action=admin_cleanup:
+    post:
+      operationId: adminCleanup
+      tags: [Admin — Maintenance]
+      summary: Run the token / activity-log cleanup sweep
+      description: |
+        Same routine as `appWeb/.sql/cleanup.php` — expires magic-link
+        tokens, trims old `tblLoginAttempts`, and prunes the activity
+        log. Safe to run from cron.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_cleanup] }
+      responses:
+        "200":
+          description: Cleanup summary (counts per table)
+
+  /api.php?action=admin_export:
+    get:
+      operationId: adminExport
+      tags: [Admin — Maintenance]
+      summary: Export a table as CSV (admin audit)
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_export] }
+        - name: table
+          in: query
+          required: true
+          description: Table key to export (e.g. `users`, `song_requests`, `activity_log`)
+          schema: { type: string }
+      responses:
+        "200":
+          description: CSV file download
+          content:
+            text/csv:
+              schema: { type: string }
+
+  /api.php?action=admin_organisations:
+    get:
+      operationId: adminOrganisations
+      tags: [Admin]
+      summary: List every organisation (admin view)
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_organisations] }
+      responses:
+        "200":
+          description: Org list with member counts + licence tier
+
+  /api.php?action=admin_songbook_health:
+    get:
+      operationId: adminSongbookHealth
+      tags: [Admin — Maintenance]
+      summary: Integrity check across every songbook
+      description: |
+        Returns orphan components, songs missing writers, duplicate
+        numbers, and NULL-number counts per songbook. Drives the
+        "Songbook health" panel on the admin dashboard.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_songbook_health] }
+      responses:
+        "200":
+          description: Health summary per songbook
+
+  # ===========================================================================
+  # PAGES  (HTML renderers + alternate-format exports)
+  # ===========================================================================
+
+  /api.php?action=home:
+    get:
+      operationId: pageHome
+      tags: [Pages]
+      summary: Rendered home-page HTML fragment
+      description: Used by the router when hydrating `/` during offline startup.
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [home] }
+      responses:
+        "200":
+          description: HTML fragment
+          content:
+            text/html: { schema: { type: string } }
+
+  /api.php?action=help:
+    get:
+      operationId: pageHelp
+      tags: [Pages]
+      summary: Rendered in-app help page
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [help] }
+      responses:
+        "200":
+          description: HTML fragment
+          content: { text/html: { schema: { type: string } } }
+
+  /api.php?action=terms:
+    get:
+      operationId: pageTerms
+      tags: [Pages]
+      summary: Rendered Terms of Use page
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [terms] }
+      responses:
+        "200":
+          description: HTML fragment
+          content: { text/html: { schema: { type: string } } }
+
+  /api.php?action=privacy:
+    get:
+      operationId: pagePrivacy
+      tags: [Pages]
+      summary: Rendered Privacy Policy page
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [privacy] }
+      responses:
+        "200":
+          description: HTML fragment
+          content: { text/html: { schema: { type: string } } }
+
+  /api.php?action=settings:
+    get:
+      operationId: pageSettings
+      tags: [Pages]
+      summary: Rendered Settings modal HTML
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [settings] }
+      responses:
+        "200":
+          description: HTML fragment
+          content: { text/html: { schema: { type: string } } }
+
+  /api.php?action=json:
+    get:
+      operationId: exportJson
+      tags: [Pages]
+      summary: Export one song as JSON
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [json] }
+        - name: id
+          in: query
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Full song JSON
+          content:
+            application/json:
+              schema: { type: object }
+
+  /api.php?action=xml:
+    get:
+      operationId: exportXml
+      tags: [Pages]
+      summary: Export one song as generic XML
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [xml] }
+        - name: id
+          in: query
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Song as XML
+          content:
+            application/xml:
+              schema: { type: string }
+
+  /api.php?action=csv:
+    get:
+      operationId: exportCsv
+      tags: [Pages]
+      summary: Export a filtered song list as CSV
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [csv] }
+        - name: songbook
+          in: query
+          required: false
+          schema: { type: string }
+      responses:
+        "200":
+          description: CSV file
+          content: { text/csv: { schema: { type: string } } }
+
+  /api.php?action=opensong:
+    get:
+      operationId: exportOpenSong
+      tags: [Pages]
+      summary: Export one song in OpenSong XML format
+      description: See integration notes in `/manage/setup-database` on import compatibility.
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [opensong] }
+        - name: id
+          in: query
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: OpenSong XML
+          content: { application/xml: { schema: { type: string } } }
+
+  /api.php?action=videopsalm:
+    get:
+      operationId: exportVideoPsalm
+      tags: [Pages]
+      summary: Export one song in VideoPsalm JSON format
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [videopsalm] }
+        - name: id
+          in: query
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: VideoPsalm JSON
+          content: { application/json: { schema: { type: object } } }
 
 # =============================================================================
 # COMPONENTS

--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -160,6 +160,10 @@ if ($page !== null) {
             require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'pages' . DIRECTORY_SEPARATOR . 'privacy.php';
             break;
 
+        case 'request-a-song':
+            require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'pages' . DIRECTORY_SEPARATOR . 'request-a-song.php';
+            break;
+
         default:
             http_response_code(404);
             require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'pages' . DIRECTORY_SEPARATOR . 'not-found.php';
@@ -3921,6 +3925,74 @@ if ($action !== null) {
             unset($org);
 
             sendJson(['organisations' => $orgs]);
+            break;
+
+        /* -----------------------------------------------------------------
+         * Submit a song request (#403). Public endpoint; rate-limited by
+         * IP to 5 submissions per 24 h. Honeypot field rejects bots.
+         * ----------------------------------------------------------------- */
+        case 'song_request_submit':
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+
+            $body    = json_decode((string)file_get_contents('php://input'), true) ?? [];
+            $title   = trim((string)($body['title']    ?? ''));
+            $book    = trim((string)($body['songbook'] ?? ''));
+            $details = trim((string)($body['details']  ?? ''));
+            $email   = trim((string)($body['email']    ?? ''));
+            $honey   = (string)($body['website']       ?? '');
+            $ip      = $_SERVER['REMOTE_ADDR'] ?? '';
+
+            /* Honeypot: real users leave this blank; bots fill every field. */
+            if ($honey !== '') {
+                sendJson(['ok' => true, 'trackingId' => 0]); /* Silent success to not tip off the bot. */
+                break;
+            }
+
+            if ($title === '') {
+                sendJson(['error' => 'A song title is required.'], 400);
+                break;
+            }
+            if (mb_strlen($title)   > 500)  { sendJson(['error' => 'Title too long.'],    400); break; }
+            if (mb_strlen($book)    > 100)  { sendJson(['error' => 'Songbook too long.'], 400); break; }
+            if (mb_strlen($details) > 2000) { sendJson(['error' => 'Details too long.'],  400); break; }
+            if (mb_strlen($email)   > 255)  { sendJson(['error' => 'Email too long.'],    400); break; }
+            if ($email !== '' && !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+                sendJson(['error' => 'Email address is not valid.'], 400);
+                break;
+            }
+
+            try {
+                $db = getDb();
+
+                /* Rate-limit: reject if this IP has ≥5 submissions in the last 24 h. */
+                $stmt = $db->prepare(
+                    'SELECT COUNT(*) FROM tblSongRequests WHERE IpAddress = ? AND CreatedAt > (NOW() - INTERVAL 1 DAY)'
+                );
+                $stmt->execute([$ip]);
+                if ((int)$stmt->fetchColumn() >= 5) {
+                    sendJson(['error' => 'You have submitted several requests recently. Please try again tomorrow.'], 429);
+                    break;
+                }
+
+                /* Link to a signed-in user if the caller sent a bearer token. */
+                $authUser = getAuthenticatedUser();
+                $userId   = $authUser ? (int)$authUser['Id'] : null;
+
+                $stmt = $db->prepare(
+                    'INSERT INTO tblSongRequests
+                        (Title, Songbook, Details, ContactEmail, UserId, IpAddress, Status)
+                     VALUES (?, ?, ?, ?, ?, ?, "pending")'
+                );
+                $stmt->execute([$title, $book, $details, $email, $userId, $ip]);
+
+                sendJson(['ok' => true, 'trackingId' => (int)$db->lastInsertId()]);
+            } catch (\Throwable $e) {
+                error_log('[song_request_submit] ' . $e->getMessage());
+                sendJson(['error' => 'Could not save your request. Please try again.'], 500);
+            }
             break;
 
         /* -----------------------------------------------------------------

--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -357,6 +357,38 @@ if ($action !== null) {
             break;
 
         /* -----------------------------------------------------------------
+         * Bulk audio manifest (#401) — returns the list of audio URLs
+         * for a songbook so the service worker can pre-cache audio
+         * separately from song HTML. Only songs whose `hasAudio` flag
+         * is set are returned.
+         *
+         * Parameters: songbook (optional; all if omitted)
+         * ----------------------------------------------------------------- */
+        case 'bulk_audio':
+            $audioBook  = isset($_GET['songbook']) ? trim($_GET['songbook']) : '';
+            $audioSongs = $audioBook !== ''
+                ? $songData->getSongs($audioBook)
+                : $songData->getSongs();
+
+            $manifest = [];
+            foreach ($audioSongs as $s) {
+                if (empty($s['hasAudio'])) continue;
+                $sid = $s['id'] ?? '';
+                if ($sid === '') continue;
+                $manifest[] = [
+                    'songId' => $sid,
+                    'url'    => '/data/audio/' . rawurlencode($sid) . '.mp3',
+                ];
+            }
+
+            sendJson([
+                'songbook' => $audioBook ?: 'all',
+                'count'    => count($manifest),
+                'audio'    => $manifest,
+            ]);
+            break;
+
+        /* -----------------------------------------------------------------
          * Serve the full song data as JSON (#154, #270)
          *
          * Exports the complete song database from MySQL as JSON for

--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -3931,6 +3931,105 @@ if ($action !== null) {
          * Submit a song request (#403). Public endpoint; rate-limited by
          * IP to 5 submissions per 24 h. Honeypot field rejects bots.
          * ----------------------------------------------------------------- */
+        /* -----------------------------------------------------------------
+         * Setlist scheduling (#398) — ties a setlist to a date.
+         * Auth required. Operates on the signed-in user's own setlists
+         * via the SetlistId string (same ID used by tblUserSetlists).
+         * ----------------------------------------------------------------- */
+        case 'setlist_schedule_set':
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser) { sendJson(['error' => 'Unauthorized'], 401); break; }
+
+            $body      = json_decode((string)file_get_contents('php://input'), true) ?? [];
+            $setlistId = trim((string)($body['setlistId'] ?? ''));
+            $dateStr   = trim((string)($body['date']      ?? ''));
+            $notes     = trim((string)($body['notes']     ?? ''));
+
+            if ($setlistId === '' || $dateStr === '') {
+                sendJson(['error' => 'setlistId and date are required.'], 400);
+                break;
+            }
+            /* Validate YYYY-MM-DD */
+            $d = DateTime::createFromFormat('Y-m-d', $dateStr);
+            if (!$d || $d->format('Y-m-d') !== $dateStr) {
+                sendJson(['error' => 'Invalid date (expected YYYY-MM-DD).'], 400);
+                break;
+            }
+
+            try {
+                $db = getDb();
+                /* Verify the caller owns the setlist */
+                $own = $db->prepare('SELECT 1 FROM tblUserSetlists WHERE UserId = ? AND SetlistId = ? LIMIT 1');
+                $own->execute([(int)$authUser['Id'], $setlistId]);
+                if (!$own->fetchColumn()) {
+                    sendJson(['error' => 'Setlist not found.'], 404);
+                    break;
+                }
+                /* Replace any existing schedule for this (user, setlist) pair. */
+                $del = $db->prepare('DELETE FROM tblSetlistSchedule WHERE UserId = ? AND SetlistId = ?');
+                $del->execute([(int)$authUser['Id'], $setlistId]);
+                $ins = $db->prepare(
+                    'INSERT INTO tblSetlistSchedule (SetlistId, UserId, ScheduledDate, Notes)
+                     VALUES (?, ?, ?, ?)'
+                );
+                $ins->execute([$setlistId, (int)$authUser['Id'], $dateStr, $notes]);
+                sendJson(['ok' => true]);
+            } catch (\Throwable $e) {
+                error_log('[setlist_schedule_set] ' . $e->getMessage());
+                sendJson(['error' => 'Could not schedule the setlist.'], 500);
+            }
+            break;
+
+        case 'setlist_schedule_clear':
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser) { sendJson(['error' => 'Unauthorized'], 401); break; }
+            $body = json_decode((string)file_get_contents('php://input'), true) ?? [];
+            $setlistId = trim((string)($body['setlistId'] ?? ''));
+            if ($setlistId === '') { sendJson(['error' => 'setlistId required.'], 400); break; }
+
+            try {
+                $db = getDb();
+                $stmt = $db->prepare('DELETE FROM tblSetlistSchedule WHERE UserId = ? AND SetlistId = ?');
+                $stmt->execute([(int)$authUser['Id'], $setlistId]);
+                sendJson(['ok' => true]);
+            } catch (\Throwable $e) {
+                error_log('[setlist_schedule_clear] ' . $e->getMessage());
+                sendJson(['error' => 'Could not clear schedule.'], 500);
+            }
+            break;
+
+        case 'setlist_schedule_upcoming':
+            $authUser = getAuthenticatedUser();
+            if (!$authUser) { sendJson(['error' => 'Unauthorized'], 401); break; }
+
+            try {
+                $db = getDb();
+                $stmt = $db->prepare(
+                    'SELECT s.SetlistId, s.ScheduledDate, s.Notes, l.Name AS name
+                       FROM tblSetlistSchedule s
+                       LEFT JOIN tblUserSetlists l
+                              ON l.UserId = s.UserId AND l.SetlistId = s.SetlistId
+                      WHERE s.UserId = ? AND s.ScheduledDate >= CURRENT_DATE()
+                      ORDER BY s.ScheduledDate ASC
+                      LIMIT 25'
+                );
+                $stmt->execute([(int)$authUser['Id']]);
+                $upcoming = $stmt->fetchAll(PDO::FETCH_ASSOC);
+                sendJson(['upcoming' => $upcoming]);
+            } catch (\Throwable $e) {
+                error_log('[setlist_schedule_upcoming] ' . $e->getMessage());
+                sendJson(['error' => 'Could not load schedule.'], 500);
+            }
+            break;
+
         case 'song_request_submit':
             if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
                 sendJson(['error' => 'POST method required.'], 405);

--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -195,6 +195,21 @@ if ($action !== null) {
             }
 
             $results = $songData->searchSongs($query, $bookId, $limit);
+
+            /* Fire-and-forget search-query logging (#404). Silently no-ops
+               if the table is missing (fresh installs before the schema
+               ALTER has been applied). */
+            try {
+                $logDb = getDb();
+                $uid   = null;
+                $logAuth = getAuthenticatedUser();
+                if ($logAuth) $uid = (int)$logAuth['Id'];
+                $logStmt = $logDb->prepare(
+                    'INSERT INTO tblSearchQueries (Query, ResultCount, UserId) VALUES (?, ?, ?)'
+                );
+                $logStmt->execute([$query, count($results), $uid]);
+            } catch (\Throwable $_e) { /* best-effort */ }
+
             sendJson([
                 'results' => array_map('songToSummary', $results),
                 'total'   => count($results),

--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -4077,6 +4077,175 @@ if ($action !== null) {
             }
             break;
 
+        /* -------------------------------------------------------------
+         * SETLIST COLLABORATION (#398)
+         * Four endpoints manage tblSetlistCollaborators. Owner of the
+         * setlist can invite by email, list existing collaborators,
+         * and revoke. A separate endpoint returns the setlists the
+         * current user has been invited to.
+         * ----------------------------------------------------------- */
+
+        /* GET ?action=setlist_schedule_current&setlistId=X — fetch the
+         * existing schedule (if any) for a setlist the caller owns. */
+        case 'setlist_schedule_current':
+            $authUser = getAuthenticatedUser();
+            if (!$authUser) { sendJson(['error' => 'Unauthorized'], 401); break; }
+            $setlistId = trim((string)($_GET['setlistId'] ?? ''));
+            if ($setlistId === '') { sendJson(['error' => 'setlistId required.'], 400); break; }
+            try {
+                $db = getDb();
+                $stmt = $db->prepare(
+                    'SELECT ScheduledDate, Notes
+                       FROM tblSetlistSchedule
+                      WHERE UserId = ? AND SetlistId = ?
+                      LIMIT 1'
+                );
+                $stmt->execute([(int)$authUser['Id'], $setlistId]);
+                $row = $stmt->fetch(PDO::FETCH_ASSOC);
+                sendJson(['schedule' => $row ?: null]);
+            } catch (\Throwable $e) {
+                error_log('[setlist_schedule_current] ' . $e->getMessage());
+                sendJson(['error' => 'Could not load schedule.'], 500);
+            }
+            break;
+
+        case 'setlist_collab_invite':
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser) { sendJson(['error' => 'Unauthorized'], 401); break; }
+            $body = json_decode((string)file_get_contents('php://input'), true) ?? [];
+            $setlistId  = trim((string)($body['setlistId']        ?? ''));
+            $collabEml  = trim((string)($body['collaboratorEmail'] ?? ''));
+            $permission = strtolower(trim((string)($body['permission'] ?? 'edit')));
+            if (!in_array($permission, ['view', 'edit'], true)) { $permission = 'edit'; }
+            if ($setlistId === '' || $collabEml === '') {
+                sendJson(['error' => 'setlistId and collaboratorEmail required.'], 400);
+                break;
+            }
+            if (!filter_var($collabEml, FILTER_VALIDATE_EMAIL)) {
+                sendJson(['error' => 'Invalid email address.'], 400);
+                break;
+            }
+            try {
+                $db = getDb();
+                /* Owner check */
+                $own = $db->prepare('SELECT 1 FROM tblUserSetlists WHERE UserId = ? AND SetlistId = ? LIMIT 1');
+                $own->execute([(int)$authUser['Id'], $setlistId]);
+                if (!$own->fetchColumn()) { sendJson(['error' => 'Setlist not found.'], 404); break; }
+
+                /* Resolve collaborator by email */
+                $usr = $db->prepare('SELECT Id, Username FROM tblUsers WHERE Email = ? LIMIT 1');
+                $usr->execute([$collabEml]);
+                $collab = $usr->fetch(PDO::FETCH_ASSOC);
+                if (!$collab) {
+                    sendJson(['error' => 'No user with that email yet — ask them to sign in first.'], 404);
+                    break;
+                }
+                if ((int)$collab['Id'] === (int)$authUser['Id']) {
+                    sendJson(['error' => 'You cannot invite yourself.'], 400);
+                    break;
+                }
+
+                $ins = $db->prepare(
+                    'INSERT INTO tblSetlistCollaborators (SetlistOwnerId, SetlistId, CollaboratorId, Permission)
+                     VALUES (?, ?, ?, ?)
+                     ON DUPLICATE KEY UPDATE Permission = VALUES(Permission)'
+                );
+                $ins->execute([(int)$authUser['Id'], $setlistId, (int)$collab['Id'], $permission]);
+                sendJson([
+                    'ok' => true,
+                    'collaborator' => [
+                        'id'         => (int)$collab['Id'],
+                        'username'   => $collab['Username'],
+                        'permission' => $permission,
+                    ],
+                ]);
+            } catch (\Throwable $e) {
+                error_log('[setlist_collab_invite] ' . $e->getMessage());
+                sendJson(['error' => 'Could not invite collaborator.'], 500);
+            }
+            break;
+
+        case 'setlist_collab_list':
+            $authUser = getAuthenticatedUser();
+            if (!$authUser) { sendJson(['error' => 'Unauthorized'], 401); break; }
+            $setlistId = trim((string)($_GET['setlistId'] ?? ''));
+            if ($setlistId === '') { sendJson(['error' => 'setlistId required.'], 400); break; }
+            try {
+                $db = getDb();
+                $stmt = $db->prepare(
+                    'SELECT c.CollaboratorId AS id, u.Username AS username, u.Email AS email,
+                            c.Permission AS permission, c.InvitedAt AS invitedAt
+                       FROM tblSetlistCollaborators c
+                       JOIN tblUsers u ON u.Id = c.CollaboratorId
+                      WHERE c.SetlistOwnerId = ? AND c.SetlistId = ?
+                      ORDER BY c.InvitedAt DESC'
+                );
+                $stmt->execute([(int)$authUser['Id'], $setlistId]);
+                $list = $stmt->fetchAll(PDO::FETCH_ASSOC);
+                sendJson(['collaborators' => $list]);
+            } catch (\Throwable $e) {
+                error_log('[setlist_collab_list] ' . $e->getMessage());
+                sendJson(['error' => 'Could not load collaborators.'], 500);
+            }
+            break;
+
+        case 'setlist_collab_remove':
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser) { sendJson(['error' => 'Unauthorized'], 401); break; }
+            $body = json_decode((string)file_get_contents('php://input'), true) ?? [];
+            $setlistId = trim((string)($body['setlistId'] ?? ''));
+            $collabId  = (int)($body['collaboratorId'] ?? 0);
+            if ($setlistId === '' || $collabId <= 0) {
+                sendJson(['error' => 'setlistId and collaboratorId required.'], 400);
+                break;
+            }
+            try {
+                $db = getDb();
+                $stmt = $db->prepare(
+                    'DELETE FROM tblSetlistCollaborators
+                      WHERE SetlistOwnerId = ? AND SetlistId = ? AND CollaboratorId = ?'
+                );
+                $stmt->execute([(int)$authUser['Id'], $setlistId, $collabId]);
+                sendJson(['ok' => true, 'removed' => $stmt->rowCount()]);
+            } catch (\Throwable $e) {
+                error_log('[setlist_collab_remove] ' . $e->getMessage());
+                sendJson(['error' => 'Could not remove collaborator.'], 500);
+            }
+            break;
+
+        case 'setlist_collab_shared_with_me':
+            $authUser = getAuthenticatedUser();
+            if (!$authUser) { sendJson(['error' => 'Unauthorized'], 401); break; }
+            try {
+                $db = getDb();
+                $stmt = $db->prepare(
+                    'SELECT c.SetlistOwnerId AS ownerId, u.Username AS ownerName,
+                            c.SetlistId AS setlistId, c.Permission AS permission,
+                            l.Name AS name
+                       FROM tblSetlistCollaborators c
+                       JOIN tblUsers u ON u.Id = c.SetlistOwnerId
+                       LEFT JOIN tblUserSetlists l
+                              ON l.UserId = c.SetlistOwnerId AND l.SetlistId = c.SetlistId
+                      WHERE c.CollaboratorId = ?
+                      ORDER BY c.InvitedAt DESC'
+                );
+                $stmt->execute([(int)$authUser['Id']]);
+                $shared = $stmt->fetchAll(PDO::FETCH_ASSOC);
+                sendJson(['shared' => $shared]);
+            } catch (\Throwable $e) {
+                error_log('[setlist_collab_shared_with_me] ' . $e->getMessage());
+                sendJson(['error' => 'Could not load shared setlists.'], 500);
+            }
+            break;
+
         case 'song_request_submit':
             if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
                 sendJson(['error' => 'POST method required.'], 405);

--- a/appWeb/public_html/css/app.css
+++ b/appWeb/public_html/css/app.css
@@ -1034,37 +1034,64 @@ body.banner-visible.search-open .main-content {
     line-height: 1.7;
 }
 
+/* Song components — each verse / chorus / bridge is a distinct block.
+   The left-border acts as an identity strip per component type, and a
+   subtle top hairline separates consecutive components so verse
+   boundaries are unambiguous in dark mode (#407). */
 .lyric-component {
     margin-bottom: 1.5rem;
-    padding-left: 1rem;
-    border-left: 3px solid transparent;
+    padding: 0.5rem 1rem 0.5rem 1rem;
+    border-left: 4px solid var(--card-border);
+    border-top: 1px solid var(--card-border);
+    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}
+/* First component in a song — no top hairline needed. */
+.song-lyrics > .lyric-component:first-child,
+.presentation-lyrics > .lyric-component:first-child {
+    border-top-color: transparent;
 }
 
 .lyric-label {
-    font-size: 0.75rem;
+    display: inline-block;
+    font-size: 0.7rem;
     font-weight: 700;
     text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: var(--text-muted);
-    margin-bottom: 0.25rem;
+    letter-spacing: 0.08em;
+    color: var(--text-primary);
+    background-color: var(--surface-elevated);
+    padding: 0.15em 0.55em;
+    border-radius: 999px;
+    margin-bottom: 0.4rem;
+    border: 1px solid var(--card-border);
+    opacity: 0.9;
 }
 
 .lyric-line {
     margin-bottom: 0.15rem;
 }
 
-/* Verse styling */
+/* Verse styling — neutral border so it reads as the "default" block. */
 .lyric-verse {
     border-left-color: var(--card-border);
 }
+[data-bs-theme="dark"] .lyric-verse {
+    /* Bump contrast in dark mode where `--card-border` is nearly invisible. */
+    border-left-color: rgba(255, 255, 255, 0.18);
+}
 
-/* Chorus styling — highlighted */
+/* Chorus styling — emphasised with accent gradient strip + subtle tint. */
 .lyric-chorus,
 .lyric-refrain {
     background-color: var(--lyric-chorus-bg);
     border-left-color: var(--lyric-chorus-border);
-    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
     padding: 0.75rem 1rem;
+}
+.lyric-chorus .lyric-label,
+.lyric-refrain .lyric-label {
+    background-color: var(--lyric-chorus-border);
+    color: #ffffff;
+    border-color: transparent;
+    opacity: 1;
 }
 
 /* Bridge styling */
@@ -1670,15 +1697,33 @@ body.reduce-motion .btn-autoscroll-fab {
 
 .presentation-lyrics .lyric-component {
     margin-bottom: 2rem;
+    /* Presentation mode uses a stronger left-border and a softer top
+       separator so verses read as distinct slabs at projector scale. */
+    border-left-width: 5px;
+    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    padding: 0.75rem 1.25rem;
+}
+.presentation-lyrics > .lyric-component:first-child {
+    border-top-color: transparent;
 }
 
 .presentation-lyrics .lyric-label {
-    font-size: 0.5em;
-    font-weight: 600;
+    display: inline-block;
+    font-size: 0.4em;
+    font-weight: 700;
     text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: var(--bs-secondary-color, #6c757d);
-    margin-bottom: 0.5rem;
+    letter-spacing: 0.1em;
+    color: #fff;
+    background-color: rgba(255, 255, 255, 0.12);
+    padding: 0.2em 0.75em;
+    border-radius: 999px;
+    margin-bottom: 0.7rem;
+    opacity: 0.85;
+}
+.presentation-lyrics .lyric-chorus .lyric-label,
+.presentation-lyrics .lyric-refrain .lyric-label {
+    background-color: var(--lyric-chorus-border);
+    opacity: 1;
 }
 
 /* Hide header/footer/scroll-to-top in presentation mode */

--- a/appWeb/public_html/css/app.css
+++ b/appWeb/public_html/css/app.css
@@ -2639,3 +2639,43 @@ body.reduce-motion .related-songs-chevron {
 .privacy-consent-status.text-danger {
     color: var(--bs-danger) !important;
 }
+
+
+/* ==========================================================================
+   PRACTICE / MEMORISATION MODE (#402)
+   ========================================================================== */
+.song-lyrics[data-practice-level="1"] .lyric-line {
+    opacity: 0.25;
+    transition: opacity var(--transition-fast);
+}
+.song-lyrics[data-practice-level="1"] .lyric-line:hover,
+.song-lyrics[data-practice-level="1"] .lyric-line:focus,
+.song-lyrics[data-practice-level="1"] .lyric-line.revealed {
+    opacity: 1;
+}
+.song-lyrics[data-practice-level="2"] .lyric-line {
+    color: transparent;
+    background-color: var(--surface-elevated);
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: color var(--transition-fast), background-color var(--transition-fast);
+    user-select: none;
+}
+.song-lyrics[data-practice-level="2"] .lyric-line::before {
+    content: '\f06e'; /* Font Awesome "eye" */
+    font-family: 'Font Awesome 6 Free';
+    font-weight: 900;
+    color: var(--text-muted);
+    margin-right: 0.4em;
+    opacity: 0.55;
+}
+.song-lyrics[data-practice-level="2"] .lyric-line.revealed,
+.song-lyrics[data-practice-level="2"] .lyric-line:hover {
+    color: var(--text-primary);
+    background-color: transparent;
+    user-select: text;
+}
+.song-lyrics[data-practice-level="2"] .lyric-line.revealed::before,
+.song-lyrics[data-practice-level="2"] .lyric-line:hover::before {
+    display: none;
+}

--- a/appWeb/public_html/includes/SongData.php
+++ b/appWeb/public_html/includes/SongData.php
@@ -97,6 +97,59 @@ class SongData
     public function isJsonFallback(): bool { return $this->jsonMode; }
 
     /**
+     * Expand a scripture reference so a search for an abbreviated book
+     * name ("Ps 23", "1 Cor 13", "Rev 21") also matches the full form
+     * in lyrics / titles (#397). Returns the canonical form (e.g.
+     * "Psalm 23") to be concatenated onto the FULLTEXT query, or NULL
+     * if the input doesn't look like a scripture reference.
+     *
+     * The list is intentionally small — just the 66 canonical books and
+     * their most common abbreviations. It's not a full parser.
+     */
+    public static function expandScriptureReference(string $query): ?string
+    {
+        static $books = [
+            'gen'    => 'Genesis',        'ex'    => 'Exodus',      'exod'  => 'Exodus',
+            'lev'    => 'Leviticus',      'num'   => 'Numbers',     'deut'  => 'Deuteronomy', 'dt' => 'Deuteronomy',
+            'josh'   => 'Joshua',         'judg'  => 'Judges',      'ruth'  => 'Ruth',
+            '1 sam'  => '1 Samuel',       '1sam'  => '1 Samuel',    '2 sam' => '2 Samuel',    '2sam' => '2 Samuel',
+            '1 kgs'  => '1 Kings',        '1kgs'  => '1 Kings',     '2 kgs' => '2 Kings',     '2kgs' => '2 Kings',
+            '1 chr'  => '1 Chronicles',   '2 chr' => '2 Chronicles',
+            'ezra'   => 'Ezra',           'neh'   => 'Nehemiah',    'esth'  => 'Esther',      'est' => 'Esther',
+            'job'    => 'Job',            'ps'    => 'Psalm',       'psa'   => 'Psalm',       'psalms' => 'Psalm',
+            'prov'   => 'Proverbs',       'pr'    => 'Proverbs',    'eccl'  => 'Ecclesiastes',
+            'song'   => 'Song of Solomon','isa'   => 'Isaiah',      'jer'   => 'Jeremiah',
+            'lam'    => 'Lamentations',   'ezek'  => 'Ezekiel',     'dan'   => 'Daniel',
+            'hos'    => 'Hosea',          'joel'  => 'Joel',        'amos'  => 'Amos',        'obad' => 'Obadiah',
+            'jon'    => 'Jonah',          'mic'   => 'Micah',       'nah'   => 'Nahum',       'hab' => 'Habakkuk',
+            'zeph'   => 'Zephaniah',      'hag'   => 'Haggai',      'zech'  => 'Zechariah',   'mal' => 'Malachi',
+            'matt'   => 'Matthew',        'mt'    => 'Matthew',     'mk'    => 'Mark',        'lk' => 'Luke',
+            'jn'     => 'John',           'acts'  => 'Acts',        'rom'   => 'Romans',
+            '1 cor'  => '1 Corinthians',  '1cor'  => '1 Corinthians','2 cor' => '2 Corinthians','2cor' => '2 Corinthians',
+            'gal'    => 'Galatians',      'eph'   => 'Ephesians',   'phil'  => 'Philippians', 'phm' => 'Philemon',
+            'col'    => 'Colossians',     '1 thes'=> '1 Thessalonians', '2 thes' => '2 Thessalonians',
+            '1 tim'  => '1 Timothy',      '2 tim' => '2 Timothy',   'tit'   => 'Titus',       'heb' => 'Hebrews',
+            'jas'    => 'James',          '1 pet' => '1 Peter',     '2 pet' => '2 Peter',
+            '1 jn'   => '1 John',         '2 jn'  => '2 John',      '3 jn'  => '3 John',
+            'jude'   => 'Jude',           'rev'   => 'Revelation',
+        ];
+
+        /* Match patterns like: "ps 23", "1 cor 13:4", "John 3:16", "Rev 21" */
+        if (!preg_match('/^((?:[123]\s*)?[A-Za-z.]+)\s+(\d+(?:\s*:\s*\d+)?)/i', trim($query), $m)) {
+            return null;
+        }
+
+        $bookKey = mb_strtolower(preg_replace('/\./', '', trim($m[1])));
+        /* Collapse any whitespace to a single space so "1  Cor" matches "1 cor" */
+        $bookKey = preg_replace('/\s+/', ' ', $bookKey);
+
+        if (!isset($books[$bookKey])) return null;
+
+        $chapter = preg_replace('/\s*:\s*/', ':', trim($m[2]));
+        return $books[$bookKey] . ' ' . $chapter;
+    }
+
+    /**
      * Constructor — connects to MySQL, or falls back to JSON file.
      *
      * When MySQL credentials are not configured (e.g., fresh deployment
@@ -410,6 +463,13 @@ class SongData
             return [];
         }
 
+        /* Scripture-reference awareness (#397): if the query looks like a
+           Bible reference (e.g. "Ps 23", "1 Cor 13:4"), remember the
+           canonical expansion so we can OR it into the FULLTEXT query
+           below. We don't mutate $query here because the JSON-fallback
+           path below relies on substring matching. */
+        $scriptureExpansion = self::expandScriptureReference($query);
+
         /* JSON fallback: simple substring search */
         if ($this->jsonMode) {
             $q = mb_strtolower($query);
@@ -464,8 +524,14 @@ class SongData
                     ORDER BY s.SongbookAbbr, s.Number
                     {$limitClause}";
         } else {
-            /* FULLTEXT search for longer queries */
+            /* FULLTEXT search for longer queries.
+               If the query looked like a scripture reference, OR in the
+               canonical expansion via BOOLEAN MODE so "Ps 23" also
+               matches "Psalm 23" and vice versa (#397). */
             $ftQuery = $query;
+            if ($scriptureExpansion !== null && $scriptureExpansion !== $query) {
+                $ftQuery = '(' . $query . ') (' . $scriptureExpansion . ')';
+            }
 
             $where = ["MATCH(s.Title, s.LyricsText) AGAINST(? IN BOOLEAN MODE)"];
             $params = [$ftQuery];

--- a/appWeb/public_html/includes/SongData.php
+++ b/appWeb/public_html/includes/SongData.php
@@ -594,7 +594,95 @@ class SongData
             $results = $this->_searchByWriterComposer($query, $songbookId, $limit);
         }
 
+        /* Scripture-reference tag matches (#397 follow-up) — if the query
+           looked like a scripture reference, ALSO surface songs that have
+           been tagged with the canonical book or full reference. Merges
+           de-duplicated into the existing result list at the top so
+           curated matches outrank text matches. */
+        if ($scriptureExpansion !== null) {
+            $tagHits = $this->_searchByScriptureTag($scriptureExpansion, $songbookId);
+            if (!empty($tagHits)) {
+                $seen = [];
+                foreach ($results as $r) { $seen[$r['id']] = true; }
+                $merged = $tagHits;
+                foreach ($results as $r) {
+                    if (!isset($seen[$r['id']])) $merged[] = $r; /* already seen via tag hit */
+                    elseif (!isset($tagHits[$r['id'] ?? ''])) $merged[] = $r;
+                }
+                $results = array_values($merged);
+                if ($limit > 0) $results = array_slice($results, 0, $limit);
+            }
+        }
+
         return $results;
+    }
+
+    /**
+     * Find songs tagged with the given scripture reference (#397).
+     *
+     * Matches `Name = <reference>` (e.g. "Psalm 23"), `Name = <book>`
+     * (e.g. "Psalm"), or the kebab-case slug form. Curators tag songs
+     * via /manage/editor/ (tags UI) and the hit merges into search
+     * results for scripture-style queries.
+     */
+    private function _searchByScriptureTag(string $scriptureRef, ?string $songbookId): array
+    {
+        if ($this->jsonMode || !$this->db) return [];
+
+        /* Derive the base book (strip trailing chapter/verse). */
+        $book = preg_replace('/\s+\d+(?::\d+)?$/', '', $scriptureRef);
+
+        $slugRef  = self::_tagSlug($scriptureRef);
+        $slugBook = self::_tagSlug($book);
+
+        $sql = "SELECT s.SongId AS id, s.Number AS number, s.Title AS title,
+                       s.SongbookAbbr AS songbook, s.SongbookName AS songbookName,
+                       s.Language AS language, s.Copyright AS copyright, s.Ccli AS ccli,
+                       s.Verified AS verified, s.LyricsPublicDomain AS lyricsPublicDomain,
+                       s.MusicPublicDomain AS musicPublicDomain,
+                       s.HasAudio AS hasAudio, s.HasSheetMusic AS hasSheetMusic
+                  FROM tblSongs s
+                  JOIN tblSongTagMap m ON m.SongId = s.SongId
+                  JOIN tblSongTags   t ON t.Id = m.TagId
+                 WHERE t.Name IN (?, ?) OR t.Slug IN (?, ?)";
+        $types  = 'ssss';
+        $params = [$scriptureRef, $book, $slugRef, $slugBook];
+
+        if ($songbookId !== null) {
+            $sql .= ' AND s.SongbookAbbr = ?';
+            $types .= 's';
+            $params[] = strtoupper(trim($songbookId));
+        }
+
+        $sql .= ' ORDER BY s.SongbookAbbr, s.Number';
+
+        try {
+            $stmt = $this->db->prepare($sql);
+            $stmt->bind_param($types, ...$params);
+            $stmt->execute();
+            $result = $stmt->get_result();
+            $out = [];
+            while ($row = $result->fetch_assoc()) {
+                $row['number']             = $row['number'] !== null ? (int)$row['number'] : null;
+                $row['verified']           = (bool)$row['verified'];
+                $row['lyricsPublicDomain'] = (bool)$row['lyricsPublicDomain'];
+                $row['musicPublicDomain']  = (bool)$row['musicPublicDomain'];
+                $row['hasAudio']           = (bool)$row['hasAudio'];
+                $row['hasSheetMusic']      = (bool)$row['hasSheetMusic'];
+                $out[] = $row;
+            }
+            $stmt->close();
+            return $out;
+        } catch (\Throwable $_e) {
+            return [];
+        }
+    }
+
+    private static function _tagSlug(string $s): string
+    {
+        $s = mb_strtolower($s);
+        $s = preg_replace('/[^a-z0-9]+/', '-', $s);
+        return trim((string)$s, '-');
     }
 
     /**

--- a/appWeb/public_html/includes/channel_gate.php
+++ b/appWeb/public_html/includes/channel_gate.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Channel Access Gate (#407)
+ *
+ * Gates alpha / beta subdomain access behind the `access_alpha` /
+ * `access_beta` entitlements. Production (`ihymns.app`) is always
+ * open. Called from index.php after auth + entitlement helpers are
+ * loaded.
+ *
+ * Behaviour:
+ *   - Production channel:                do nothing.
+ *   - Alpha/Beta + user has entitlement: do nothing.
+ *   - Alpha/Beta + no entitlement:       render the gate page + exit.
+ *
+ * The gate page explains that this is a pre-release build and offers
+ * a sign-in link. Requests for the API, service worker, og-image,
+ * sitemap, manifest and static assets pass through untouched so that
+ * the sign-in round-trip + magic-link flow still works.
+ */
+
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'entitlements.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'manage' . DIRECTORY_SEPARATOR
+          . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+
+/**
+ * Resolve the authenticated user from the bearer-cookie set by the
+ * public API. Returns null for guests. Kept intentionally minimal —
+ * index.php doesn't need the full user object, only the role.
+ */
+function _channelGateCurrentRole(): ?string
+{
+    /* Cookie issued by api.php on auth_login/register/magic-link (#390) */
+    $token = $_COOKIE['ihymns_auth'] ?? '';
+    if (!is_string($token) || !preg_match('/^[a-f0-9]{64}$/i', $token)) {
+        return null;
+    }
+    try {
+        $db = getDb();
+        $stmt = $db->prepare(
+            'SELECT u.Role
+               FROM tblApiTokens t
+               JOIN tblUsers u ON u.Id = t.UserId
+              WHERE t.Token = ? AND t.ExpiresAt > ? AND u.IsActive = 1'
+        );
+        $stmt->execute([hash('sha256', $token), gmdate('c')]);
+        $row = $stmt->fetch(\PDO::FETCH_ASSOC);
+        return $row ? (string)$row['Role'] : null;
+    } catch (\Throwable $_e) {
+        return null;
+    }
+}
+
+/**
+ * Main entry point. $devStatus is 'Alpha', 'Beta', or null (production).
+ */
+function enforceChannelGate(?string $devStatus): void
+{
+    if ($devStatus !== 'Alpha' && $devStatus !== 'Beta') {
+        return; /* Production — never gated. */
+    }
+
+    $entitlement = ($devStatus === 'Alpha') ? 'access_alpha' : 'access_beta';
+    $role        = _channelGateCurrentRole();
+
+    if (userHasEntitlement($entitlement, $role)) {
+        return; /* Pass-through for entitled users. */
+    }
+
+    /* Render the gate page and short-circuit index.php. */
+    _renderChannelGate($devStatus);
+    exit;
+}
+
+function _renderChannelGate(string $channel): void
+{
+    http_response_code(401);
+    header('Content-Type: text/html; charset=UTF-8');
+    header('Cache-Control: no-store');
+    header('X-Robots-Tag: noindex, nofollow');
+
+    $label = htmlspecialchars($channel);
+    ?>
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>iHymns <?= $label ?> — Early Access</title>
+    <meta name="robots" content="noindex, nofollow">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="/css/app.css">
+    <style>
+        body { min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 1rem; }
+        .gate-card {
+            background-color: var(--surface-card);
+            border: 1px solid var(--card-border);
+            border-radius: var(--radius-md);
+            box-shadow: var(--card-shadow);
+            max-width: 460px;
+            width: 100%;
+            padding: 2rem;
+            text-align: center;
+        }
+        .gate-badge {
+            display: inline-block;
+            background: linear-gradient(135deg, var(--accent-start), var(--accent-end));
+            color: #fff;
+            font-weight: 700;
+            letter-spacing: 0.05em;
+            text-transform: uppercase;
+            font-size: 0.75rem;
+            padding: 0.2em 0.8em;
+            border-radius: 999px;
+        }
+        h1 { font-size: 1.5rem; margin: 1rem 0 0.5rem; }
+    </style>
+</head>
+<body>
+    <div class="gate-card">
+        <span class="gate-badge"><?= $label ?> · Early Access</span>
+        <h1>iHymns <?= $label ?> is invite-only</h1>
+        <p class="text-muted">
+            This build is a pre-release preview. Sign in with an account
+            that has <code><?= $channel === 'Alpha' ? 'access_alpha' : 'access_beta' ?></code>
+            privileges to continue.
+        </p>
+        <p class="text-muted small">
+            Don't have an account yet? You can sign up below, and an admin
+            can grant you early-access on the
+            <code>/manage/entitlements</code> page.
+        </p>
+        <div id="gate-msg" class="alert d-none py-2" role="alert"></div>
+
+        <!-- Step 1 — request magic link / code -->
+        <form id="gate-email-form" class="d-grid gap-2 text-start">
+            <label for="gate-email" class="form-label small mb-0">Email address</label>
+            <input type="email" id="gate-email" class="form-control" required autocomplete="email"
+                   placeholder="you@example.com">
+            <button type="submit" class="btn btn-primary">
+                <i class="fa-solid fa-paper-plane me-1"></i>
+                Send login code
+            </button>
+        </form>
+
+        <!-- Step 2 — verify 6-digit code (hidden until we've sent the email) -->
+        <form id="gate-code-form" class="d-grid gap-2 text-start d-none mt-2">
+            <label for="gate-code" class="form-label small mb-0">6-digit code</label>
+            <input type="text" id="gate-code" class="form-control text-center" maxlength="6"
+                   pattern="[0-9]{6}" inputmode="numeric" autocomplete="one-time-code" required
+                   placeholder="000000">
+            <button type="submit" class="btn btn-success">
+                <i class="fa-solid fa-check me-1"></i>
+                Verify &amp; continue
+            </button>
+        </form>
+
+        <a class="btn btn-link btn-sm mt-2" href="https://ihymns.app/">Go to the stable site</a>
+    </div>
+
+<script>
+(function () {
+    const msg   = document.getElementById('gate-msg');
+    const show  = (text, kind) => {
+        msg.className = 'alert py-2 alert-' + kind;
+        msg.textContent = text;
+        msg.classList.remove('d-none');
+    };
+    const emailForm = document.getElementById('gate-email-form');
+    const codeForm  = document.getElementById('gate-code-form');
+    let rememberedEmail = '';
+
+    emailForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const email = document.getElementById('gate-email').value.trim();
+        if (!email) return;
+        rememberedEmail = email;
+        try {
+            const res = await fetch('/api?action=auth_email_login_request', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+                body: JSON.stringify({ email }),
+            });
+            const data = await res.json();
+            if (!res.ok) throw new Error(data.error || 'Could not send code.');
+            show('Code sent. Check your inbox and enter the 6-digit code.', 'info');
+            codeForm.classList.remove('d-none');
+            document.getElementById('gate-code').focus();
+        } catch (err) {
+            show(err.message, 'danger');
+        }
+    });
+
+    codeForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const code = document.getElementById('gate-code').value.trim();
+        if (!code || !rememberedEmail) return;
+        try {
+            const res = await fetch('/api?action=auth_email_login_verify', {
+                method: 'POST',
+                credentials: 'same-origin',
+                headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+                body: JSON.stringify({ email: rememberedEmail, code }),
+            });
+            const data = await res.json();
+            if (!res.ok || !data.token) throw new Error(data.error || 'Invalid code.');
+            /* Server has set the HttpOnly cookie; a reload will pass the
+               gate if the user has the relevant access entitlement. */
+            show('Verified. Redirecting…', 'success');
+            setTimeout(() => window.location.reload(), 600);
+        } catch (err) {
+            show(err.message, 'danger');
+        }
+    });
+})();
+</script>
+
+</body>
+</html>
+    <?php
+}

--- a/appWeb/public_html/includes/entitlements.php
+++ b/appWeb/public_html/includes/entitlements.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Entitlements (#407)
+ *
+ * Single source of truth for what a given role is allowed to do, keyed
+ * by short verb-style entitlement names. Call `hasEntitlement()` instead
+ * of `hasRole('editor')` sprinkled through the app — that way, granting
+ * (or revoking) a capability is one line here instead of a codebase hunt.
+ *
+ * Roles are defined in manage/includes/auth.php (`user`, `editor`,
+ * `admin`, `global_admin`). Add a new role there, then extend the map
+ * below. The client-side counterpart (js/modules/entitlements.js) must
+ * stay in sync — the map is small and stable, which is why it's
+ * duplicated rather than fetched at runtime.
+ *
+ * Usage:
+ *     require_once 'entitlements.php';
+ *     if (userHasEntitlement('edit_songs', $currentUser['role'])) { ... }
+ */
+
+/**
+ * Map of entitlement → set of roles that carry it.
+ *
+ * When adding a new entitlement:
+ *  1. Add an entry here (lowest role that should have it upward).
+ *  2. Mirror it in js/modules/entitlements.js.
+ *  3. Reference it via userHasEntitlement() rather than role checks.
+ */
+const ENTITLEMENTS = [
+    /* Song data */
+    'edit_songs'           => ['editor', 'admin', 'global_admin'],
+    'delete_songs'         => ['admin', 'global_admin'],
+    'bulk_edit_songs'      => ['admin', 'global_admin'],
+    'verify_songs'         => ['editor', 'admin', 'global_admin'],
+
+    /* User management */
+    'view_users'           => ['admin', 'global_admin'],
+    'edit_users'           => ['admin', 'global_admin'],
+    'change_user_roles'    => ['admin', 'global_admin'],
+    'assign_global_admin'  => ['global_admin'],
+    'delete_users'         => ['admin', 'global_admin'],
+
+    /* Database + operations */
+    'view_admin_dashboard' => ['admin', 'global_admin'],
+    'view_analytics'       => ['admin', 'global_admin'],
+    'run_db_install'       => ['global_admin'],
+    'run_db_migrate'       => ['global_admin'],
+    'run_db_backup'        => ['admin', 'global_admin'],
+    'run_db_restore'       => ['global_admin'],
+    'drop_legacy_tables'   => ['global_admin'],
+
+    /* Content moderation */
+    'review_song_requests' => ['editor', 'admin', 'global_admin'],
+];
+
+/**
+ * Does the given role hold the named entitlement?
+ *
+ * @param string      $entitlement e.g. 'edit_songs'
+ * @param string|null $role        Caller's role; null → treated as guest
+ * @return bool
+ */
+function userHasEntitlement(string $entitlement, ?string $role): bool
+{
+    if ($role === null || $role === '') {
+        return false;
+    }
+    $allowed = ENTITLEMENTS[$entitlement] ?? null;
+    if ($allowed === null) {
+        /* Unknown entitlement — fail closed. */
+        return false;
+    }
+    return in_array($role, $allowed, true);
+}
+
+/**
+ * All entitlements a given role carries. Useful for export to the
+ * client (so the UI can hide/show controls without having to ship the
+ * entire role→entitlement map).
+ *
+ * @param string|null $role
+ * @return string[]
+ */
+function entitlementsFor(?string $role): array
+{
+    if ($role === null || $role === '') return [];
+    $out = [];
+    foreach (ENTITLEMENTS as $name => $roles) {
+        if (in_array($role, $roles, true)) {
+            $out[] = $name;
+        }
+    }
+    return $out;
+}

--- a/appWeb/public_html/includes/entitlements.php
+++ b/appWeb/public_html/includes/entitlements.php
@@ -55,6 +55,13 @@ const ENTITLEMENTS = [
     /* Content moderation */
     'review_song_requests' => ['editor', 'admin', 'global_admin'],
 
+    /* Channel access gating (#407) — controls who can reach alpha/beta
+       subdomains. Applied BEFORE the page renders so pre-release builds
+       are invisible to the public even when indexed. Defaults intentionally
+       include `user` so that internal testers + curators can both access. */
+    'access_alpha'         => ['user', 'editor', 'admin', 'global_admin'],
+    'access_beta'          => ['user', 'editor', 'admin', 'global_admin'],
+
     /* Meta */
     'manage_entitlements'  => ['global_admin'],
 ];

--- a/appWeb/public_html/includes/entitlements.php
+++ b/appWeb/public_html/includes/entitlements.php
@@ -54,7 +54,94 @@ const ENTITLEMENTS = [
 
     /* Content moderation */
     'review_song_requests' => ['editor', 'admin', 'global_admin'],
+
+    /* Meta */
+    'manage_entitlements'  => ['global_admin'],
 ];
+
+/**
+ * In-memory cache of the effective map (defaults merged with any admin
+ * overrides from tblAppSettings). Populated lazily by effectiveEntitlements().
+ */
+$_ihymns_effective_entitlements = null;
+
+/**
+ * Return the effective entitlement map, applying any admin overrides
+ * saved under `tblAppSettings.SettingKey = 'entitlements_overrides'`.
+ *
+ * The override value is a JSON map of `entitlement => [role, …]` that
+ * completely replaces the default list for each entitlement it covers.
+ * Entitlements absent from the override keep their hardcoded default,
+ * so adding a new entitlement in code never needs a DB change.
+ *
+ * @return array<string, string[]>
+ */
+function effectiveEntitlements(): array
+{
+    global $_ihymns_effective_entitlements;
+    if ($_ihymns_effective_entitlements !== null) {
+        return $_ihymns_effective_entitlements;
+    }
+
+    $map = ENTITLEMENTS;
+
+    /* getDb() is PDO, defined in manage/includes/db.php. Not every
+       caller pre-loads it, so fail soft — an unreachable DB falls back
+       to the hardcoded defaults. */
+    if (function_exists('getDb')) {
+        try {
+            $db = getDb();
+            $stmt = $db->prepare(
+                'SELECT SettingValue FROM tblAppSettings WHERE SettingKey = ?'
+            );
+            $stmt->execute(['entitlements_overrides']);
+            $raw = (string)($stmt->fetchColumn() ?: '');
+            if ($raw !== '') {
+                $decoded = json_decode($raw, true);
+                if (is_array($decoded)) {
+                    foreach ($decoded as $ent => $roles) {
+                        if (isset($map[$ent]) && is_array($roles)) {
+                            $map[$ent] = array_values(array_filter($roles, 'is_string'));
+                        }
+                    }
+                }
+            }
+        } catch (\Throwable $_e) {
+            /* DB unreachable — stick with defaults. */
+        }
+    }
+
+    $_ihymns_effective_entitlements = $map;
+    return $map;
+}
+
+/**
+ * Replace (or clear) the admin overrides. Called from
+ * /manage/entitlements.php after the form is saved.
+ *
+ * @param array<string, string[]> $overrides Full intended map
+ *        (overrides for every entitlement, not deltas).
+ * @return bool
+ */
+function saveEntitlementOverrides(array $overrides): bool
+{
+    global $_ihymns_effective_entitlements;
+    if (!function_exists('getDb')) return false;
+    try {
+        $db = getDb();
+        $json = json_encode($overrides, JSON_UNESCAPED_SLASHES);
+        $stmt = $db->prepare(
+            'INSERT INTO tblAppSettings (SettingKey, SettingValue)
+             VALUES (?, ?)
+             ON DUPLICATE KEY UPDATE SettingValue = VALUES(SettingValue)'
+        );
+        $stmt->execute(['entitlements_overrides', (string)$json]);
+        $_ihymns_effective_entitlements = null; /* bust cache */
+        return true;
+    } catch (\Throwable $_e) {
+        return false;
+    }
+}
 
 /**
  * Does the given role hold the named entitlement?
@@ -68,7 +155,8 @@ function userHasEntitlement(string $entitlement, ?string $role): bool
     if ($role === null || $role === '') {
         return false;
     }
-    $allowed = ENTITLEMENTS[$entitlement] ?? null;
+    $map = effectiveEntitlements();
+    $allowed = $map[$entitlement] ?? null;
     if ($allowed === null) {
         /* Unknown entitlement — fail closed. */
         return false;
@@ -88,7 +176,7 @@ function entitlementsFor(?string $role): array
 {
     if ($role === null || $role === '') return [];
     $out = [];
-    foreach (ENTITLEMENTS as $name => $roles) {
+    foreach (effectiveEntitlements() as $name => $roles) {
         if (in_array($role, $roles, true)) {
             $out[] = $name;
         }

--- a/appWeb/public_html/includes/pages/help.php
+++ b/appWeb/public_html/includes/pages/help.php
@@ -244,14 +244,106 @@ declare(strict_types=1);
                             </tr>
                         </thead>
                         <tbody>
+                            <tr><td><kbd>?</kbd></td><td>Show full keyboard shortcuts overlay</td></tr>
                             <tr><td><kbd>/</kbd> or <kbd>Ctrl+K</kbd></td><td>Open search</td></tr>
                             <tr><td><kbd>#</kbd></td><td>Open number pad</td></tr>
                             <tr><td><kbd>Esc</kbd></td><td>Close search / modal</td></tr>
                             <tr><td><kbd>F</kbd></td><td>Toggle favourite (on song page)</td></tr>
+                            <tr><td><kbd>P</kbd></td><td>Presentation mode</td></tr>
                             <tr><td><kbd>&larr;</kbd></td><td>Previous song</td></tr>
                             <tr><td><kbd>&rarr;</kbd></td><td>Next song</td></tr>
                         </tbody>
                     </table>
+                    <p class="small text-muted mb-0">
+                        Shortcuts can be disabled in <strong>Settings → Accessibility</strong>.
+                    </p>
+                </div>
+            </div>
+        </div>
+
+        <!-- Practice Mode -->
+        <div class="accordion-item">
+            <h2 class="accordion-header">
+                <button class="accordion-button collapsed"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#help-practice"
+                        aria-expanded="false"
+                        aria-controls="help-practice">
+                    <i class="fa-solid fa-graduation-cap me-2" aria-hidden="true"></i>
+                    Practice / Memorisation Mode
+                </button>
+            </h2>
+            <div id="help-practice" class="accordion-collapse collapse" data-bs-parent="#help-accordion">
+                <div class="accordion-body">
+                    <p>
+                        On any song page, tap <strong>Practice</strong> to cycle through
+                        three modes for learning hymns by heart:
+                    </p>
+                    <ul class="mb-0">
+                        <li><strong>Full</strong> — normal lyrics.</li>
+                        <li><strong>Dimmed</strong> — lyrics faded; hover or tap a line for a quick glance.</li>
+                        <li><strong>Hidden</strong> — every line masked; tap individual lines to reveal as hints.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+
+        <!-- Request a song -->
+        <div class="accordion-item">
+            <h2 class="accordion-header">
+                <button class="accordion-button collapsed"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#help-request"
+                        aria-expanded="false"
+                        aria-controls="help-request">
+                    <i class="fa-solid fa-lightbulb me-2" aria-hidden="true"></i>
+                    Requesting a song
+                </button>
+            </h2>
+            <div id="help-request" class="accordion-collapse collapse" data-bs-parent="#help-accordion">
+                <div class="accordion-body">
+                    <p>
+                        Can't find a hymn? Submit it via
+                        <a href="/request-a-song" data-navigate="request-a-song">Request a Song</a>.
+                        You'll get a tracking number; our curators triage submissions in
+                        their admin queue.
+                    </p>
+                </div>
+            </div>
+        </div>
+
+        <!-- Admin portal overview -->
+        <div class="accordion-item">
+            <h2 class="accordion-header">
+                <button class="accordion-button collapsed"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#help-admin"
+                        aria-expanded="false"
+                        aria-controls="help-admin">
+                    <i class="fa-solid fa-user-shield me-2" aria-hidden="true"></i>
+                    Admin Portal (editors &amp; admins)
+                </button>
+            </h2>
+            <div id="help-admin" class="accordion-collapse collapse" data-bs-parent="#help-accordion">
+                <div class="accordion-body">
+                    <p>If you're a <em>Curator/Editor</em>, <em>Admin</em>, or <em>Global Admin</em>, you have access to the portal at <a href="/manage/">/manage/</a> (or the alias <a href="/admin/">/admin/</a>).</p>
+                    <ul class="mb-2">
+                        <li><strong>Song Editor</strong> — edit lyrics, metadata, tags, arrangement; multi-select bulk delete; auto-saves per song.</li>
+                        <li><strong>User Management</strong> — create, edit roles, deactivate.</li>
+                        <li><strong>Analytics</strong> — top songs / searches / logins over 7, 30, 90 days; CSV export.</li>
+                        <li><strong>Song Requests</strong> — triage user-submitted requests.</li>
+                        <li><strong>Entitlements</strong> — grant/revoke per-capability permissions by role.</li>
+                        <li><strong>Database Setup</strong> — install schema, migrate, backup, restore.</li>
+                    </ul>
+                    <p class="small text-muted mb-0">
+                        Permissions use <strong>entitlements</strong>. Each feature is gated by a
+                        named capability (e.g. <code>edit_songs</code>, <code>view_analytics</code>)
+                        assigned to roles. A global-admin can reassign capabilities at
+                        <a href="/manage/entitlements">/manage/entitlements</a>.
+                    </p>
                 </div>
             </div>
         </div>

--- a/appWeb/public_html/includes/pages/request-a-song.php
+++ b/appWeb/public_html/includes/pages/request-a-song.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * iHymns — Song Request Submission (#403)
+ *
+ * Public-facing form that writes to tblSongRequests. Admins can
+ * later triage submissions via the admin dashboard (follow-up).
+ */
+
+declare(strict_types=1);
+
+?>
+<section class="page-request-a-song" aria-label="Request a song">
+
+    <h1 class="h4 mb-3">
+        <i class="fa-solid fa-lightbulb me-2" aria-hidden="true"></i>
+        Request a Song
+    </h1>
+
+    <p class="text-muted small mb-4">
+        Can't find a hymn you're looking for? Let us know and we'll do our best
+        to add it. Only the details below are sent to our curators — no other
+        personal data.
+    </p>
+
+    <div id="request-success" class="alert alert-success d-none" role="alert">
+        <i class="fa-solid fa-check-circle me-1" aria-hidden="true"></i>
+        Thank you — your request has been received.
+        <span id="request-tracking-id" class="text-muted small"></span>
+    </div>
+    <div id="request-error" class="alert alert-danger d-none" role="alert"></div>
+
+    <form id="request-form" novalidate>
+        <div class="row g-3">
+            <div class="col-md-8">
+                <label for="request-title" class="form-label">Song title <span class="text-danger">*</span></label>
+                <input type="text" class="form-control" id="request-title" name="title"
+                       required maxlength="500" autocomplete="off">
+            </div>
+            <div class="col-md-4">
+                <label for="request-songbook" class="form-label">Songbook <span class="text-muted">(optional)</span></label>
+                <input type="text" class="form-control" id="request-songbook" name="songbook"
+                       maxlength="100" placeholder="e.g. Mission Praise" autocomplete="off">
+            </div>
+            <div class="col-md-12">
+                <label for="request-details" class="form-label">Any extra details? <span class="text-muted">(first line of lyrics, writer name, etc.)</span></label>
+                <textarea class="form-control" id="request-details" name="details"
+                          rows="3" maxlength="2000"></textarea>
+            </div>
+            <div class="col-md-12">
+                <label for="request-email" class="form-label">
+                    Your email <span class="text-muted">(optional — only if you'd like us to follow up)</span>
+                </label>
+                <input type="email" class="form-control" id="request-email" name="email"
+                       maxlength="255" autocomplete="email">
+            </div>
+            <!-- Honeypot field for spam bots — real users never see it. -->
+            <input type="text" name="website" tabindex="-1" autocomplete="off"
+                   style="position:absolute; left:-9999px; top:-9999px;" aria-hidden="true">
+        </div>
+
+        <div class="mt-4 d-flex gap-2">
+            <button type="submit" class="btn btn-primary" id="request-submit-btn">
+                <i class="fa-solid fa-paper-plane me-1" aria-hidden="true"></i>
+                Send Request
+            </button>
+            <a href="/" data-navigate="home" class="btn btn-outline-secondary">Cancel</a>
+        </div>
+    </form>
+
+    <script>
+    (function () {
+        const form = document.getElementById('request-form');
+        if (!form) return;
+
+        form.addEventListener('submit', async (e) => {
+            e.preventDefault();
+
+            const okEl  = document.getElementById('request-success');
+            const errEl = document.getElementById('request-error');
+            const btn   = document.getElementById('request-submit-btn');
+            okEl.classList.add('d-none');
+            errEl.classList.add('d-none');
+            btn.disabled = true;
+
+            const payload = {
+                title:    form.elements['title'].value.trim(),
+                songbook: form.elements['songbook'].value.trim(),
+                details:  form.elements['details'].value.trim(),
+                email:    form.elements['email'].value.trim(),
+                website:  form.elements['website'].value, /* honeypot */
+            };
+
+            try {
+                const res = await fetch('/api?action=song_request_submit', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+                    body: JSON.stringify(payload),
+                });
+                const data = await res.json();
+                if (!res.ok || !data.ok) {
+                    throw new Error(data.error || 'Something went wrong.');
+                }
+                okEl.querySelector('#request-tracking-id').textContent = data.trackingId ? `Reference: #${data.trackingId}` : '';
+                okEl.classList.remove('d-none');
+                form.reset();
+            } catch (err) {
+                errEl.textContent = err.message || 'Could not submit — please try again later.';
+                errEl.classList.remove('d-none');
+            } finally {
+                btn.disabled = false;
+            }
+        });
+    })();
+    </script>
+
+</section>

--- a/appWeb/public_html/includes/pages/settings.php
+++ b/appWeb/public_html/includes/pages/settings.php
@@ -373,6 +373,14 @@ declare(strict_types=1);
                                 aria-label="Download <?= htmlspecialchars($book['name']) ?> for offline use">
                             <i class="fa-solid fa-cloud-arrow-down" aria-hidden="true"></i>
                         </button>
+                        <!-- Per-songbook eviction button (#401). Hidden until
+                             updateSongbookCacheStatus() detects cached entries. -->
+                        <button type="button"
+                                class="btn btn-outline-warning btn-sm btn-evict-songbook d-none"
+                                data-songbook-id="<?= htmlspecialchars($book['id']) ?>"
+                                aria-label="Remove <?= htmlspecialchars($book['name']) ?> from offline cache">
+                            <i class="fa-solid fa-trash" aria-hidden="true"></i>
+                        </button>
                     </div>
                     <?php
                             endif;
@@ -403,6 +411,8 @@ declare(strict_types=1);
                          id="download-songs-bar" role="progressbar"
                          aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
                 </div>
+                <!-- Audio pre-cache progress line (#401) -->
+                <small class="text-muted d-block mt-1" id="download-audio-status"></small>
                 <small class="text-muted mt-1 d-block">
                     Save songs to your device for offline access. Download individual songbooks or all at once.
                 </small>

--- a/appWeb/public_html/includes/pages/settings.php
+++ b/appWeb/public_html/includes/pages/settings.php
@@ -407,6 +407,24 @@ declare(strict_types=1);
                     Save songs to your device for offline access. Download individual songbooks or all at once.
                 </small>
 
+                <!-- Offline audio bulk download (#401).
+                     Enabled by default; pulls /api?action=bulk_audio&songbook=<id>
+                     and asks the service worker to pre-cache every audio URL so
+                     playback works offline without first needing to play online. -->
+                <div class="form-check form-switch mt-2">
+                    <input class="form-check-input" type="checkbox"
+                           id="setting-include-audio-offline" role="switch"
+                           aria-label="Include audio in offline downloads">
+                    <label class="form-check-label" for="setting-include-audio-offline">
+                        <strong>Include audio in offline downloads</strong>
+                        <small class="text-muted d-block">
+                            When downloading a songbook, also pre-cache every available
+                            audio file. Significantly larger but means audio plays
+                            offline without needing to play once online first.
+                        </small>
+                    </label>
+                </div>
+
                 <!-- Auto-update toggle (#132) -->
                 <div class="form-check form-switch mt-2">
                     <input class="form-check-input"

--- a/appWeb/public_html/includes/pages/song.php
+++ b/appWeb/public_html/includes/pages/song.php
@@ -244,6 +244,16 @@ $components  = $song['components'] ?? [];
                 <button class="btn btn-sm btn-outline-secondary" id="btn-toggle-chords" style="display:none" title="Show/hide chord charts">
                     <i class="fa-solid fa-guitar me-1" aria-hidden="true"></i>Chords
                 </button>
+
+                <!-- Practice / memorisation mode (#402). Cycles through
+                     Full → Dimmed → Hidden; tap an individual hidden line
+                     to reveal it as a hint. -->
+                <button class="btn btn-sm btn-outline-secondary" id="btn-practice-mode"
+                        data-practice-level="0"
+                        title="Practice mode — hide lyrics progressively for memorisation">
+                    <i class="fa-solid fa-graduation-cap me-1" aria-hidden="true"></i>
+                    <span id="btn-practice-label">Practice</span>
+                </button>
             </div>
 
             <!-- Song tags display (#288) -->

--- a/appWeb/public_html/includes/pages/song.php
+++ b/appWeb/public_html/includes/pages/song.php
@@ -245,6 +245,17 @@ $components  = $song['components'] ?? [];
                     <i class="fa-solid fa-guitar me-1" aria-hidden="true"></i>Chords
                 </button>
 
+                <!-- Edit in Song Editor (#407). Hidden by default; revealed
+                     by JS when the signed-in user has the `edit_songs`
+                     entitlement (editor / admin / global_admin). -->
+                <a class="btn btn-sm btn-outline-primary d-none"
+                   id="btn-edit-song"
+                   href="/manage/editor/?song=<?= urlencode($song['id'] ?? '') ?>"
+                   title="Edit this song in the Song Editor">
+                    <i class="fa-solid fa-pen-to-square me-1" aria-hidden="true"></i>
+                    Edit
+                </a>
+
                 <!-- Practice / memorisation mode (#402). Cycles through
                      Full → Dimmed → Hidden; tap an individual hidden line
                      to reveal it as a hint. -->

--- a/appWeb/public_html/index.php
+++ b/appWeb/public_html/index.php
@@ -43,6 +43,13 @@ require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'SongData.php';
 
+/* Channel gate (#407) — alpha / beta subdomains require the user to
+   hold access_alpha / access_beta entitlements. Never gates production
+   or /api / /manage / static assets (those paths never hit index.php
+   thanks to the root .htaccess). */
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'channel_gate.php';
+enforceChannelGate($app["Application"]["Version"]["Development"]["Status"] ?? null);
+
 /* =========================================================================
  * APPLICATION METADATA — accessed directly via $app array
  * ========================================================================= */

--- a/appWeb/public_html/js/modules/display.js
+++ b/appWeb/public_html/js/modules/display.js
@@ -88,8 +88,56 @@ export class Display {
         this.applyVerseNumbers(lyricsEl);
         this.applyChorusHighlight(lyricsEl);
 
+        /* Practice / memorisation mode (#402) */
+        this.initPracticeMode(lyricsEl);
+
         /* Protect lyrics content — prevent copy/paste and right-click */
         this.protectLyrics(lyricsEl);
+    }
+
+    /**
+     * Practice / memorisation mode (#402).
+     * Cycles the song-lyrics data-practice-level attribute through
+     * 0 (full) → 1 (dimmed) → 2 (hidden) → 0. Dimmed lets users read
+     * while blurring context; hidden masks every line and reveals
+     * individual lines on tap/hover — handy for memorisation.
+     *
+     * State is per-song (fresh on every navigation); users can bind
+     * this to a keyboard shortcut later if desired.
+     */
+    initPracticeMode(lyricsEl) {
+        const btn   = document.getElementById('btn-practice-mode');
+        const label = document.getElementById('btn-practice-label');
+        if (!btn) return;
+
+        const labels = ['Practice', 'Dimmed', 'Hidden'];
+        let level = 0;
+
+        const apply = () => {
+            lyricsEl.dataset.practiceLevel = String(level);
+            btn.dataset.practiceLevel = String(level);
+            btn.classList.toggle('active', level > 0);
+            btn.setAttribute('aria-pressed', level > 0 ? 'true' : 'false');
+            if (label) label.textContent = labels[level];
+            /* Clear any stale reveal state when leaving a mode */
+            lyricsEl.querySelectorAll('.lyric-line.revealed')
+                .forEach(el => el.classList.remove('revealed'));
+        };
+
+        btn.addEventListener('click', () => {
+            level = (level + 1) % labels.length;
+            apply();
+        });
+
+        /* Tap a hidden line to reveal it as a hint (level 2 only). */
+        lyricsEl.addEventListener('click', (e) => {
+            if (lyricsEl.dataset.practiceLevel !== '2') return;
+            const line = e.target.closest('.lyric-line');
+            if (!line) return;
+            line.classList.toggle('revealed');
+        });
+
+        apply();
     }
 
     /**

--- a/appWeb/public_html/js/modules/entitlements.js
+++ b/appWeb/public_html/js/modules/entitlements.js
@@ -1,0 +1,51 @@
+/**
+ * iHymns — Entitlements (#407, client side)
+ *
+ * Mirrors appWeb/public_html/includes/entitlements.php so the UI can
+ * decide whether to show/hide a control without waiting on a server
+ * round-trip. The PHP copy is authoritative — API endpoints re-check
+ * via userHasEntitlement() before executing. This file is purely an
+ * affordance for the UI.
+ *
+ * Keep the two maps in lock-step.
+ */
+
+/** @type {Object<string, string[]>} */
+export const ENTITLEMENTS = {
+    /* Song data */
+    edit_songs:           ['editor', 'admin', 'global_admin'],
+    delete_songs:         ['admin', 'global_admin'],
+    bulk_edit_songs:      ['admin', 'global_admin'],
+    verify_songs:         ['editor', 'admin', 'global_admin'],
+
+    /* User management */
+    view_users:           ['admin', 'global_admin'],
+    edit_users:           ['admin', 'global_admin'],
+    change_user_roles:    ['admin', 'global_admin'],
+    assign_global_admin:  ['global_admin'],
+    delete_users:         ['admin', 'global_admin'],
+
+    /* Database + operations */
+    view_admin_dashboard: ['admin', 'global_admin'],
+    view_analytics:       ['admin', 'global_admin'],
+    run_db_install:       ['global_admin'],
+    run_db_migrate:       ['global_admin'],
+    run_db_backup:        ['admin', 'global_admin'],
+    run_db_restore:       ['global_admin'],
+    drop_legacy_tables:   ['global_admin'],
+
+    /* Content moderation */
+    review_song_requests: ['editor', 'admin', 'global_admin'],
+};
+
+/**
+ * Does the given role hold the named entitlement?
+ * @param {string} entitlement
+ * @param {string|null|undefined} role
+ * @returns {boolean}
+ */
+export function userHasEntitlement(entitlement, role) {
+    if (!role) return false;
+    const allowed = ENTITLEMENTS[entitlement];
+    return Array.isArray(allowed) && allowed.includes(role);
+}

--- a/appWeb/public_html/js/modules/entitlements.js
+++ b/appWeb/public_html/js/modules/entitlements.js
@@ -36,6 +36,13 @@ export const ENTITLEMENTS = {
 
     /* Content moderation */
     review_song_requests: ['editor', 'admin', 'global_admin'],
+
+    /* Channel access (#407) */
+    access_alpha:         ['user', 'editor', 'admin', 'global_admin'],
+    access_beta:          ['user', 'editor', 'admin', 'global_admin'],
+
+    /* Meta */
+    manage_entitlements:  ['global_admin'],
 };
 
 /**

--- a/appWeb/public_html/js/modules/router.js
+++ b/appWeb/public_html/js/modules/router.js
@@ -189,6 +189,8 @@ export class Router {
                 return { page: 'terms', params: {} };
             case 'privacy':
                 return { page: 'privacy', params: {} };
+            case 'request-a-song':
+                return { page: 'request-a-song', params: {} };
             case 'login':
                 return { page: 'login', params: {} };
             default:
@@ -336,6 +338,7 @@ export class Router {
             'help': 'Help — ' + appName,
             'terms': 'Terms of Use — ' + appName,
             'privacy': 'Privacy Policy — ' + appName,
+            'request-a-song': 'Request a Song — ' + appName,
         };
         document.title = titles[page] || appName;
     }

--- a/appWeb/public_html/js/modules/router.js
+++ b/appWeb/public_html/js/modules/router.js
@@ -15,6 +15,7 @@
 
 import { toTitleCase } from '../utils/text.js';
 import { escapeHtml, verifiedBadge } from '../utils/html.js';
+import { userHasEntitlement } from './entitlements.js';
 import {
     STORAGE_FAVORITES,
     STORAGE_SETLISTS,
@@ -361,6 +362,18 @@ export class Router {
             this.app.compare.initSongPage();
             this.app.transpose.initSongPage();
             this.app.readingProgress.initSongPage();
+
+            /* Edit button — show only to users whose role carries the
+               `edit_songs` entitlement (#407). The PHP editor API
+               re-checks the same map server-side, so hiding the button
+               is purely a UX affordance. */
+            const editBtn = document.getElementById('btn-edit-song');
+            if (editBtn) {
+                const role = this.app.userAuth?.getUser()?.role;
+                if (userHasEntitlement('edit_songs', role)) {
+                    editBtn.classList.remove('d-none');
+                }
+            }
 
             /* Save Offline button — check cache state and bind click */
             const saveOfflineBtn = document.querySelector('.btn-save-offline');

--- a/appWeb/public_html/js/modules/setlist.js
+++ b/appWeb/public_html/js/modules/setlist.js
@@ -256,6 +256,13 @@ export class SetList {
         const container = document.getElementById('setlist-container');
         if (!container) return;
 
+        /* Hide the per-setlist schedule card on the overview — it's a
+           detail-view concern. */
+        const schedCard = document.getElementById('setlist-schedule-card');
+        if (schedCard) schedCard.style.display = 'none';
+
+        this._renderUpcomingScheduledSetlists();
+
         const lists = this.getAll();
 
         if (lists.length === 0) {
@@ -426,6 +433,12 @@ export class SetList {
             </div>
             <p class="text-muted small">${list.songs.length} song${list.songs.length !== 1 ? 's' : ''}</p>
             ${songsHtml}`;
+
+        /* Scheduling card + collaboration controls (#398). Both are
+           no-ops for anonymous users — the API endpoints 401 and this
+           call also silently gates on authUser. */
+        this._renderSetlistSchedule(listId);
+        this._renderSetlistCollaborators(container, listId);
 
         /* Back button */
         container.querySelector('#setlist-back-btn')?.addEventListener('click', () => {
@@ -1659,6 +1672,266 @@ export class SetList {
      */
     generateId() {
         return Date.now().toString(36) + Math.random().toString(36).slice(2, 7);
+    }
+
+    /**
+     * Render the "Upcoming scheduled set lists" section at the top of
+     * the setlist overview (#398). Silent no-op when the user isn't
+     * authenticated — the endpoint 401s and we drop the node.
+     * @private
+     */
+    _renderUpcomingScheduledSetlists() {
+        const container = document.getElementById('setlist-container');
+        if (!container) return;
+        /* Remove any previous render so we don't stack. */
+        document.getElementById('setlist-upcoming-card')?.remove();
+
+        fetch('/api?action=setlist_schedule_upcoming', { credentials: 'same-origin' })
+            .then(r => r.ok ? r.json() : Promise.reject(r.status))
+            .then(data => {
+                const upcoming = data.upcoming || [];
+                if (upcoming.length === 0) return;
+                const node = document.createElement('div');
+                node.id = 'setlist-upcoming-card';
+                node.className = 'card mb-3';
+                node.innerHTML = `
+                    <div class="card-body">
+                        <h6 class="mb-2"><i class="fa-solid fa-calendar-days me-2"></i>Up next</h6>
+                        <ul class="list-group list-group-flush">
+                            ${upcoming.slice(0, 5).map(u => `
+                                <li class="list-group-item d-flex justify-content-between align-items-center"
+                                    data-setlist-id="${escapeHtml(u.SetlistId)}" role="button">
+                                    <div>
+                                        <strong>${escapeHtml(u.name || u.SetlistId)}</strong>
+                                        ${u.Notes ? `<small class="text-muted d-block">${escapeHtml(u.Notes)}</small>` : ''}
+                                    </div>
+                                    <span class="badge bg-primary">${this.formatDate(u.ScheduledDate)}</span>
+                                </li>
+                            `).join('')}
+                        </ul>
+                    </div>`;
+                container.parentNode.insertBefore(node, container);
+                /* Clicking a row opens the detail view for that setlist. */
+                node.querySelectorAll('[data-setlist-id]').forEach(row => {
+                    row.addEventListener('click', () => {
+                        this.renderSetListDetail(row.dataset.setlistId);
+                    });
+                });
+            })
+            .catch(() => {
+                /* Unauthenticated or endpoint unreachable — fine, no card. */
+            });
+    }
+
+    /**
+     * Show and populate the setlist schedule card (#398). Fetches any
+     * existing schedule for (user, setlist) and pre-fills the inputs,
+     * then wires Save / Clear. Silent no-op if the card isn't in the
+     * DOM (e.g. on the home page) or if the user isn't authenticated
+     * (endpoints return 401; we just keep the card hidden).
+     * @param {string} listId
+     * @private
+     */
+    _renderSetlistSchedule(listId) {
+        const card      = document.getElementById('setlist-schedule-card');
+        const dateInput = document.getElementById('schedule-date');
+        const notesIn   = document.getElementById('schedule-notes');
+        const saveBtn   = document.getElementById('btn-schedule-save');
+        const resultEl  = document.getElementById('schedule-result');
+        if (!card || !dateInput || !saveBtn) return;
+
+        /* Visibility tracks the authenticated-user check via the API's
+           401 on setlist_schedule_current. If we get 401, hide card. */
+        fetch(`/api?action=setlist_schedule_current&setlistId=${encodeURIComponent(listId)}`, {
+            credentials: 'same-origin',
+        })
+            .then(r => r.ok ? r.json() : Promise.reject(r.status))
+            .then(data => {
+                card.style.display = '';
+                const sched = data.schedule;
+                if (sched) {
+                    dateInput.value = sched.ScheduledDate || '';
+                    if (notesIn) notesIn.value = sched.Notes || '';
+                    if (resultEl) {
+                        resultEl.innerHTML = `<span class="text-success"><i class="fa-solid fa-check-circle me-1"></i>Scheduled for ${this.formatDate(sched.ScheduledDate)}</span>`;
+                    }
+                } else {
+                    dateInput.value = '';
+                    if (notesIn) notesIn.value = '';
+                    if (resultEl) resultEl.innerHTML = '';
+                }
+                this._bindScheduleButtons(listId);
+            })
+            .catch(() => {
+                card.style.display = 'none';
+            });
+    }
+
+    _bindScheduleButtons(listId) {
+        const card     = document.getElementById('setlist-schedule-card');
+        const dateIn   = document.getElementById('schedule-date');
+        const notesIn  = document.getElementById('schedule-notes');
+        const saveBtn  = document.getElementById('btn-schedule-save');
+        const resultEl = document.getElementById('schedule-result');
+        if (!card || !saveBtn || !dateIn) return;
+
+        /* Replace to avoid stacking listeners across re-renders. */
+        const newSave = saveBtn.cloneNode(true);
+        saveBtn.parentNode.replaceChild(newSave, saveBtn);
+        newSave.addEventListener('click', () => {
+            const dateVal = (dateIn.value || '').trim();
+            if (!dateVal) {
+                if (resultEl) resultEl.innerHTML = '<span class="text-warning">Pick a date first.</span>';
+                return;
+            }
+            fetch('/api?action=setlist_schedule_set', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+                credentials: 'same-origin',
+                body: JSON.stringify({
+                    setlistId: listId,
+                    date: dateVal,
+                    notes: notesIn?.value || '',
+                }),
+            })
+                .then(r => r.json().then(j => ({ ok: r.ok, data: j })))
+                .then(res => {
+                    if (!res.ok) {
+                        if (resultEl) resultEl.innerHTML = `<span class="text-danger">${escapeHtml(res.data.error || 'Save failed.')}</span>`;
+                        return;
+                    }
+                    if (resultEl) resultEl.innerHTML = `<span class="text-success"><i class="fa-solid fa-check-circle me-1"></i>Saved for ${this.formatDate(dateVal)}</span>`;
+                });
+        });
+
+        /* Add a Clear button next to Save if it's not already there. */
+        if (!document.getElementById('btn-schedule-clear')) {
+            const clearBtn = document.createElement('button');
+            clearBtn.id = 'btn-schedule-clear';
+            clearBtn.type = 'button';
+            clearBtn.className = 'btn btn-outline-secondary';
+            clearBtn.textContent = 'Clear';
+            newSave.parentNode.appendChild(clearBtn);
+            clearBtn.addEventListener('click', () => {
+                fetch('/api?action=setlist_schedule_clear', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+                    credentials: 'same-origin',
+                    body: JSON.stringify({ setlistId: listId }),
+                })
+                    .then(r => r.ok ? r.json() : Promise.reject(r))
+                    .then(() => {
+                        dateIn.value = '';
+                        if (notesIn) notesIn.value = '';
+                        if (resultEl) resultEl.innerHTML = '<span class="text-muted">Schedule cleared.</span>';
+                    })
+                    .catch(() => {
+                        if (resultEl) resultEl.innerHTML = '<span class="text-danger">Clear failed.</span>';
+                    });
+            });
+        }
+    }
+
+    /**
+     * Append a "Collaborators" section to the setlist detail view (#398).
+     * Owner can invite by email, change permission, or revoke. The list
+     * is fetched from setlist_collab_list; endpoints silently 401 for
+     * anonymous users so we hide the section on failure.
+     * @param {HTMLElement} container
+     * @param {string} listId
+     * @private
+     */
+    _renderSetlistCollaborators(container, listId) {
+        if (!container) return;
+        const section = document.createElement('div');
+        section.className = 'card mt-3';
+        section.id = 'setlist-collab-card';
+        section.innerHTML = `
+            <div class="card-body">
+                <div class="d-flex align-items-center justify-content-between mb-2">
+                    <h6 class="mb-0"><i class="fa-solid fa-users me-2"></i>Collaborators</h6>
+                    <button type="button" class="btn btn-sm btn-outline-primary" id="btn-invite-collaborator">
+                        <i class="fa-solid fa-user-plus me-1"></i>Invite
+                    </button>
+                </div>
+                <ul class="list-group list-group-flush" id="collaborator-list">
+                    <li class="list-group-item small text-muted">Loading…</li>
+                </ul>
+            </div>`;
+        container.appendChild(section);
+
+        const refresh = () => {
+            fetch(`/api?action=setlist_collab_list&setlistId=${encodeURIComponent(listId)}`, {
+                credentials: 'same-origin',
+            })
+                .then(r => r.ok ? r.json() : Promise.reject(r.status))
+                .then(data => {
+                    const list = document.getElementById('collaborator-list');
+                    if (!list) return;
+                    const rows = data.collaborators || [];
+                    if (rows.length === 0) {
+                        list.innerHTML = '<li class="list-group-item small text-muted">No collaborators yet — click Invite to share.</li>';
+                        return;
+                    }
+                    list.innerHTML = rows.map(c => `
+                        <li class="list-group-item d-flex align-items-center justify-content-between">
+                            <div>
+                                <strong>${escapeHtml(c.username)}</strong>
+                                <small class="text-muted d-block">${escapeHtml(c.email)} &middot; ${escapeHtml(c.permission)}</small>
+                            </div>
+                            <button type="button" class="btn btn-sm btn-outline-danger btn-remove-collab"
+                                    data-id="${c.id}" aria-label="Remove collaborator">
+                                <i class="fa-solid fa-xmark"></i>
+                            </button>
+                        </li>
+                    `).join('');
+                    list.querySelectorAll('.btn-remove-collab').forEach(btn => {
+                        btn.addEventListener('click', () => {
+                            fetch('/api?action=setlist_collab_remove', {
+                                method: 'POST',
+                                headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+                                credentials: 'same-origin',
+                                body: JSON.stringify({
+                                    setlistId: listId,
+                                    collaboratorId: Number(btn.dataset.id),
+                                }),
+                            })
+                                .then(r => r.ok ? r.json() : Promise.reject(r))
+                                .then(() => refresh())
+                                .catch(() => alert('Remove failed.'));
+                        });
+                    });
+                })
+                .catch(() => {
+                    /* Likely unauthenticated or feature-flag off — drop the section. */
+                    section.remove();
+                });
+        };
+
+        section.querySelector('#btn-invite-collaborator').addEventListener('click', () => {
+            const email = prompt(
+                'Invite a collaborator by email.\nThey must already have an iHymns account.'
+            );
+            if (!email) return;
+            const permission = (prompt('Permission: "view" or "edit"?', 'edit') || 'edit').trim().toLowerCase();
+            fetch('/api?action=setlist_collab_invite', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+                credentials: 'same-origin',
+                body: JSON.stringify({
+                    setlistId: listId,
+                    collaboratorEmail: email.trim(),
+                    permission,
+                }),
+            })
+                .then(r => r.json().then(j => ({ ok: r.ok, data: j })))
+                .then(res => {
+                    if (!res.ok) { alert(res.data.error || 'Invite failed.'); return; }
+                    refresh();
+                });
+        });
+
+        refresh();
     }
 
     /**

--- a/appWeb/public_html/js/modules/settings.js
+++ b/appWeb/public_html/js/modules/settings.js
@@ -39,6 +39,7 @@ export class Settings {
             reduceTransparency: false,
             fontSize: 18,
             keyboardShortcuts: true,  /* '?' opens help, '/' focuses search, etc. (#406) */
+            includeAudioOffline: false, /* Include audio files in offline download (#401) */
         };
 
         /**
@@ -425,6 +426,17 @@ export class Settings {
             shortcutsToggle.checked = this.get('keyboardShortcuts') !== false;
             shortcutsToggle.addEventListener('change', () => {
                 this.set('keyboardShortcuts', shortcutsToggle.checked);
+            });
+        }
+
+        /* Include-audio-offline toggle (#401). Read by the offline download
+           flow; when true, each songbook download fetches /api?action=bulk_audio
+           and asks the SW to cache every listed audio URL. */
+        const audioOfflineToggle = document.getElementById('setting-include-audio-offline');
+        if (audioOfflineToggle) {
+            audioOfflineToggle.checked = !!this.get('includeAudioOffline');
+            audioOfflineToggle.addEventListener('change', () => {
+                this.set('includeAudioOffline', audioOfflineToggle.checked);
             });
         }
 

--- a/appWeb/public_html/js/modules/settings.js
+++ b/appWeb/public_html/js/modules/settings.js
@@ -96,6 +96,13 @@ export class Settings {
                 if (event.data?.type === 'CACHE_ALL_SONGS_PROGRESS') {
                     this._handleDownloadProgress(event.data);
                 }
+                /* Audio pre-cache progress (#401). Surfaced as a status
+                   line under the existing progress bar so users can see
+                   the slower audio job catching up after the lyrics are
+                   already done. */
+                if (event.data?.type === 'CACHE_AUDIO_PROGRESS') {
+                    this._handleAudioProgress(event.data);
+                }
             });
         }
 
@@ -564,6 +571,14 @@ export class Settings {
             });
         });
 
+        /* Per-songbook eviction buttons (#401) */
+        document.querySelectorAll('.btn-evict-songbook').forEach(btn => {
+            btn.addEventListener('click', () => {
+                const songbookId = btn.dataset.songbookId;
+                if (songbookId) this.evictSongbook(songbookId, btn);
+            });
+        });
+
         /* Auto-update offline songs toggle (#132) */
         const autoUpdateToggle = document.getElementById('setting-auto-update-songs');
         if (autoUpdateToggle) {
@@ -788,6 +803,13 @@ export class Settings {
                 totalSongs: songs.length,
             });
 
+            /* If audio-offline is on, dispatch per-songbook audio pre-cache
+               jobs in parallel with the lyric pre-cache. The SW handles them
+               independently — completion is reported via CACHE_AUDIO_PROGRESS. */
+            if (this.get('includeAudioOffline')) {
+                this._queueAudioCacheForSongbooks(songbooks);
+            }
+
         } catch (error) {
             console.error('[Settings] Download all songs error:', error);
             this.app.showToast('Failed to start download. Please try again.', 'danger');
@@ -838,6 +860,10 @@ export class Settings {
                 totalSongs: songbookSongs.length,
             });
 
+            if (this.get('includeAudioOffline')) {
+                this._queueAudioCacheForSongbooks([songbookId]);
+            }
+
         } catch (error) {
             console.error(`[Settings] Download songbook ${songbookId} error:`, error);
             this.app.showToast(`Failed to download ${songbookId}. Please try again.`, 'danger');
@@ -862,6 +888,27 @@ export class Settings {
         };
         /* Try to update the settings page UI (may not exist) */
         this.updateDownloadProgress(data);
+    }
+
+    /**
+     * Handle audio pre-cache progress messages from the SW (#401).
+     * @param {{songbook:string, completed:number, failed:number, total:number, done?:boolean}} data
+     */
+    _handleAudioProgress(data) {
+        const statusEl = document.getElementById('download-audio-status');
+        if (!statusEl) return;
+        const { songbook, completed, failed, total, done } = data;
+        if (done) {
+            statusEl.textContent = failed > 0
+                ? `${songbook} audio: ${completed} cached, ${failed} failed`
+                : `${songbook} audio: ${completed} cached`;
+            if (failed === 0) {
+                setTimeout(() => { statusEl.textContent = ''; }, 4000);
+            }
+            this._refreshSongbookCacheSizes();
+        } else {
+            statusEl.textContent = `${songbook} audio: ${completed + failed} / ${total}…`;
+        }
     }
 
     /**
@@ -967,10 +1014,122 @@ export class Settings {
                     btn.innerHTML = '<i class="fa-solid fa-check" aria-hidden="true"></i>';
                     btn.title = `${id} — all songs saved offline`;
                 }
+                /* Show the matching "Remove from offline" button only when
+                   the songbook actually has cached content. */
+                const evictBtn = document.querySelector(
+                    `.btn-evict-songbook[data-songbook-id="${id}"]`
+                );
+                if (evictBtn) {
+                    evictBtn.classList.toggle('d-none', !info || info.cached === 0);
+                }
             });
+
+            /* Replace the server-side estimate with the real cached size. */
+            this._refreshSongbookCacheSizes();
         } catch {
             /* Ignore — non-critical */
         }
+    }
+
+    /**
+     * Ask the SW for per-songbook cached byte totals (#401).
+     * Updates each `.offline-songbook-size` span with a real size when
+     * the songbook has cached content.
+     */
+    _refreshSongbookCacheSizes() {
+        if (!('serviceWorker' in navigator) || !navigator.serviceWorker.controller) return;
+
+        const handler = (event) => {
+            if (event.data?.type !== 'CACHE_SIZES') return;
+            navigator.serviceWorker.removeEventListener('message', handler);
+            const sizes = event.data.sizes || {};
+            document.querySelectorAll('.offline-songbook-size').forEach(el => {
+                const row = el.closest('.offline-songbook-row');
+                const id = row?.querySelector('[data-songbook-id]')?.dataset.songbookId;
+                if (!id) return;
+                const bytes = sizes[id] || sizes[id?.toUpperCase()] || 0;
+                if (bytes > 0) {
+                    el.textContent = bytes >= 1048576
+                        ? (bytes / 1048576).toFixed(1) + ' MB'
+                        : Math.round(bytes / 1024) + ' KB';
+                    el.classList.remove('text-muted');
+                }
+            });
+        };
+        navigator.serviceWorker.addEventListener('message', handler);
+        navigator.serviceWorker.controller.postMessage({ type: 'GET_CACHE_SIZES' });
+    }
+
+    /**
+     * Fetch the bulk_audio manifest for each songbook and dispatch
+     * one CACHE_AUDIO_URLS message per songbook to the SW (#401).
+     * Failures are logged but do not block the lyric download.
+     * @param {string[]} songbooks
+     */
+    async _queueAudioCacheForSongbooks(songbooks) {
+        if (!navigator.serviceWorker?.controller) return;
+        for (const songbook of songbooks) {
+            try {
+                const r = await fetch(`/api?action=bulk_audio&songbook=${encodeURIComponent(songbook)}`);
+                if (!r.ok) continue;
+                const data = await r.json();
+                const urls = (data.audio || []).map(a => a.url).filter(Boolean);
+                if (urls.length === 0) continue;
+                navigator.serviceWorker.controller.postMessage({
+                    type: 'CACHE_AUDIO_URLS',
+                    urls,
+                    songbook,
+                });
+            } catch (err) {
+                console.warn(`[Settings] Audio manifest fetch failed for ${songbook}:`, err.message);
+            }
+        }
+    }
+
+    /**
+     * Remove every cached entry for a songbook (#401). Asks the SW to
+     * purge both the song-page cache and the audio/sheet-music cache.
+     * @param {string} songbookId
+     * @param {HTMLElement} btn
+     */
+    async evictSongbook(songbookId, btn) {
+        if (!navigator.serviceWorker?.controller) {
+            this.app.showToast('Service worker not available.', 'warning');
+            return;
+        }
+        const ok = await this.app.showConfirm(
+            `Remove all cached content for ${songbookId}? You can re-download at any time.`,
+            { title: 'Remove from offline', okText: 'Remove', okClass: 'btn-warning' }
+        );
+        if (!ok) return;
+
+        const handler = (event) => {
+            if (event.data?.type !== 'SONGBOOK_EVICTED' || event.data.songbook !== songbookId) return;
+            navigator.serviceWorker.removeEventListener('message', handler);
+            this.app.showToast(
+                event.data.removed > 0
+                    ? `${songbookId} removed from offline (${event.data.removed} entries)`
+                    : `${songbookId} had no cached entries`,
+                'success'
+            );
+            /* Reset the corresponding download button to its starting state */
+            const dlBtn = document.querySelector(
+                `.btn-download-songbook[data-songbook-id="${songbookId}"]`
+            );
+            if (dlBtn) {
+                dlBtn.classList.remove('btn-success');
+                dlBtn.classList.add('btn-outline-success');
+                dlBtn.innerHTML = '<i class="fa-solid fa-cloud-arrow-down" aria-hidden="true"></i>';
+                dlBtn.title = '';
+            }
+            this.updateSongbookCacheStatus();
+            this.updateCacheStatus();
+        };
+        navigator.serviceWorker.addEventListener('message', handler);
+        navigator.serviceWorker.controller.postMessage({
+            type: 'EVICT_SONGBOOK',
+            songbook: songbookId,
+        });
     }
 
     /**

--- a/appWeb/public_html/manage/.htaccess
+++ b/appWeb/public_html/manage/.htaccess
@@ -42,6 +42,9 @@ RewriteRule ^analytics$ analytics.php [L]
 # /manage/entitlements → entitlements.php (entitlements editor, #407)
 RewriteRule ^entitlements$ entitlements.php [L]
 
+# /manage/requests → requests.php (song-request triage, #403)
+RewriteRule ^requests$ requests.php [L]
+
 # /manage/editor/api → /manage/editor/api.php (editor API)
 RewriteRule ^editor/api$ editor/api.php [QSA,L]
 

--- a/appWeb/public_html/manage/.htaccess
+++ b/appWeb/public_html/manage/.htaccess
@@ -39,6 +39,9 @@ RewriteRule ^setup-database$ setup-database.php [L]
 # /manage/analytics → analytics.php (admin analytics dashboard, #404)
 RewriteRule ^analytics$ analytics.php [L]
 
+# /manage/entitlements → entitlements.php (entitlements editor, #407)
+RewriteRule ^entitlements$ entitlements.php [L]
+
 # /manage/editor/api → /manage/editor/api.php (editor API)
 RewriteRule ^editor/api$ editor/api.php [QSA,L]
 

--- a/appWeb/public_html/manage/.htaccess
+++ b/appWeb/public_html/manage/.htaccess
@@ -36,6 +36,9 @@ RewriteRule ^users$ users.php [L]
 # /manage/setup-database → setup-database.php (DB setup dashboard)
 RewriteRule ^setup-database$ setup-database.php [L]
 
+# /manage/analytics → analytics.php (admin analytics dashboard, #404)
+RewriteRule ^analytics$ analytics.php [L]
+
 # /manage/editor/api → /manage/editor/api.php (editor API)
 RewriteRule ^editor/api$ editor/api.php [QSA,L]
 

--- a/appWeb/public_html/manage/analytics.php
+++ b/appWeb/public_html/manage/analytics.php
@@ -26,6 +26,68 @@ $since = (new DateTime("-{$range} days"))->format('Y-m-d H:i:s');
 
 $db = getDb();
 
+/* -----------------------------------------------------------------
+ * CSV export (#404). Any panel can be requested as download by
+ * adding ?export=<panel>&range=<n>. We short-circuit before the HTML
+ * render so the browser gets a CSV file.
+ * ----------------------------------------------------------------- */
+$exportPanel = (string)($_GET['export'] ?? '');
+if ($exportPanel !== '') {
+    $since = (new DateTime("-{$range} days"))->format('Y-m-d H:i:s');
+    header('Content-Type: text/csv; charset=UTF-8');
+    header('Content-Disposition: attachment; filename="ihymns-' . $exportPanel . '-' . $range . 'd.csv"');
+    $fp = fopen('php://output', 'w');
+    try {
+        switch ($exportPanel) {
+            case 'top_songs':
+                fputcsv($fp, ['SongId', 'Title', 'SongbookAbbr', 'Number', 'Views']);
+                $stmt = $db->prepare(
+                    'SELECT h.SongId, s.Title, s.SongbookAbbr, s.Number, COUNT(*) AS views
+                       FROM tblSongHistory h
+                       LEFT JOIN tblSongs s ON s.SongId = h.SongId
+                      WHERE h.ViewedAt >= ?
+                      GROUP BY h.SongId
+                      ORDER BY views DESC'
+                );
+                $stmt->execute([$since]);
+                while ($row = $stmt->fetch(PDO::FETCH_NUM)) { fputcsv($fp, $row); }
+                break;
+            case 'top_books':
+                fputcsv($fp, ['SongbookAbbr', 'Views']);
+                $stmt = $db->prepare(
+                    'SELECT s.SongbookAbbr, COUNT(*) AS views
+                       FROM tblSongHistory h
+                       JOIN tblSongs s ON s.SongId = h.SongId
+                      WHERE h.ViewedAt >= ?
+                      GROUP BY s.SongbookAbbr
+                      ORDER BY views DESC'
+                );
+                $stmt->execute([$since]);
+                while ($row = $stmt->fetch(PDO::FETCH_NUM)) { fputcsv($fp, $row); }
+                break;
+            case 'searches':
+                fputcsv($fp, ['Query', 'ResultCount', 'Hits']);
+                try {
+                    $stmt = $db->prepare(
+                        'SELECT Query, ResultCount, COUNT(*) AS hits
+                           FROM tblSearchQueries
+                          WHERE SearchedAt >= ?
+                          GROUP BY Query, ResultCount
+                          ORDER BY hits DESC'
+                    );
+                    $stmt->execute([$since]);
+                    while ($row = $stmt->fetch(PDO::FETCH_NUM)) { fputcsv($fp, $row); }
+                } catch (\Throwable $_e) { /* table absent */ }
+                break;
+            default:
+                fputcsv($fp, ['Unknown panel: ' . $exportPanel]);
+        }
+    } finally {
+        fclose($fp);
+    }
+    exit;
+}
+
 /* --- Top songs last $range days --- */
 $topSongs = [];
 try {
@@ -148,17 +210,23 @@ try {
 
     <!-- Top songs -->
     <div class="card-admin p-3 mb-4">
-        <h2 class="h6 mb-3"><i class="bi bi-fire me-2"></i>Top songs</h2>
+        <div class="d-flex align-items-center justify-content-between mb-3">
+            <h2 class="h6 mb-0"><i class="bi bi-fire me-2"></i>Top songs</h2>
+            <a class="btn btn-sm btn-outline-secondary" href="?range=<?= (int)$range ?>&export=top_songs">CSV</a>
+        </div>
         <?php if (!$topSongs): ?>
             <p class="text-muted small mb-0">No song views in this period yet.</p>
         <?php else: ?>
             <table class="table table-sm table-hover mb-0">
                 <thead><tr><th>Song</th><th>Songbook</th><th class="text-end">Views</th></tr></thead>
                 <tbody>
-                <?php foreach ($topSongs as $s): ?>
+                <?php foreach ($topSongs as $s):
+                    $num = $s['Number'] ?? null;
+                    $numLabel = ($num !== null && (int)$num > 0) ? ' #' . (int)$num : '';
+                ?>
                     <tr>
                         <td><?= htmlspecialchars($s['Title'] ?? $s['SongId']) ?></td>
-                        <td class="text-muted"><?= htmlspecialchars(($s['SongbookAbbr'] ?? '—') . ($s['Number'] ? ' #' . $s['Number'] : '')) ?></td>
+                        <td class="text-muted"><?= htmlspecialchars(($s['SongbookAbbr'] ?? '—') . $numLabel) ?></td>
                         <td class="text-end"><?= number_format((int)$s['views']) ?></td>
                     </tr>
                 <?php endforeach; ?>
@@ -167,9 +235,74 @@ try {
         <?php endif; ?>
     </div>
 
+    <!-- Top search queries -->
+    <div class="card-admin p-3 mb-4">
+        <div class="d-flex align-items-center justify-content-between mb-3">
+            <h2 class="h6 mb-0"><i class="bi bi-search me-2"></i>Top search queries</h2>
+            <a class="btn btn-sm btn-outline-secondary" href="?range=<?= (int)$range ?>&export=searches">CSV</a>
+        </div>
+        <?php
+            $topSearches = [];
+            $zeroResults = [];
+            try {
+                $stmt = $db->prepare(
+                    'SELECT Query, COUNT(*) AS hits, MAX(ResultCount) AS top_count
+                       FROM tblSearchQueries
+                      WHERE SearchedAt >= ? AND Query <> ""
+                      GROUP BY Query
+                      ORDER BY hits DESC
+                      LIMIT 15'
+                );
+                $stmt->execute([$since]);
+                $topSearches = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+                $stmt = $db->prepare(
+                    'SELECT Query, COUNT(*) AS hits
+                       FROM tblSearchQueries
+                      WHERE SearchedAt >= ? AND ResultCount = 0 AND Query <> ""
+                      GROUP BY Query
+                      ORDER BY hits DESC
+                      LIMIT 10'
+                );
+                $stmt->execute([$since]);
+                $zeroResults = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            } catch (\Throwable $_e) {}
+        ?>
+        <?php if (!$topSearches): ?>
+            <p class="text-muted small mb-0">No search activity yet (or the tblSearchQueries table hasn't been created — re-run install).</p>
+        <?php else: ?>
+            <table class="table table-sm table-hover mb-0">
+                <thead><tr><th>Query</th><th class="text-end">Hits</th></tr></thead>
+                <tbody>
+                <?php foreach ($topSearches as $s): ?>
+                    <tr>
+                        <td><code><?= htmlspecialchars($s['Query']) ?></code></td>
+                        <td class="text-end"><?= number_format((int)$s['hits']) ?></td>
+                    </tr>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
+        <?php endif; ?>
+    </div>
+
+    <!-- Zero-result queries -->
+    <?php if ($zeroResults): ?>
+    <div class="card-admin p-3 mb-4 border-warning">
+        <h2 class="h6 mb-3"><i class="bi bi-question-circle me-2"></i>Zero-result queries — candidates for tagging or new songs</h2>
+        <ul class="list-unstyled mb-0 small">
+            <?php foreach ($zeroResults as $z): ?>
+                <li><code><?= htmlspecialchars($z['Query']) ?></code> <span class="text-muted">× <?= (int)$z['hits'] ?></span></li>
+            <?php endforeach; ?>
+        </ul>
+    </div>
+    <?php endif; ?>
+
     <!-- Top songbooks -->
     <div class="card-admin p-3 mb-4">
-        <h2 class="h6 mb-3"><i class="bi bi-book me-2"></i>Songbook opens</h2>
+        <div class="d-flex align-items-center justify-content-between mb-3">
+            <h2 class="h6 mb-0"><i class="bi bi-book me-2"></i>Songbook opens</h2>
+            <a class="btn btn-sm btn-outline-secondary" href="?range=<?= (int)$range ?>&export=top_books">CSV</a>
+        </div>
         <?php if (!$topBooks): ?>
             <p class="text-muted small mb-0">No data yet.</p>
         <?php else: ?>

--- a/appWeb/public_html/manage/analytics.php
+++ b/appWeb/public_html/manage/analytics.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Admin Analytics Dashboard (#404)
+ *
+ * Read-only view of app-wide usage metrics. Pulls from the tables we
+ * already populate (tblSongHistory, tblActivityLog, tblLoginAttempts)
+ * so there's no new tracking surface.
+ *
+ * Access: admin or global_admin (see hasRole()). Time range is a GET
+ * param `range` (7, 30 or 90 days; defaults to 30).
+ */
+
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+requireAdmin();
+
+$currentUser = getCurrentUser();
+
+$range = (int)($_GET['range'] ?? 30);
+if (!in_array($range, [7, 30, 90], true)) {
+    $range = 30;
+}
+$since = (new DateTime("-{$range} days"))->format('Y-m-d H:i:s');
+
+$db = getDb();
+
+/* --- Top songs last $range days --- */
+$topSongs = [];
+try {
+    $stmt = $db->prepare(
+        'SELECT h.SongId, COUNT(*) AS views, s.Title, s.SongbookAbbr, s.Number
+           FROM tblSongHistory h
+           LEFT JOIN tblSongs s ON s.SongId = h.SongId
+          WHERE h.ViewedAt >= ?
+          GROUP BY h.SongId
+          ORDER BY views DESC
+          LIMIT 15'
+    );
+    $stmt->execute([$since]);
+    $topSongs = $stmt->fetchAll(PDO::FETCH_ASSOC);
+} catch (\Throwable $e) { /* table may be empty */ }
+
+/* --- Top songbooks --- */
+$topBooks = [];
+try {
+    $stmt = $db->prepare(
+        'SELECT s.SongbookAbbr, COUNT(*) AS views
+           FROM tblSongHistory h
+           JOIN tblSongs s ON s.SongId = h.SongId
+          WHERE h.ViewedAt >= ?
+          GROUP BY s.SongbookAbbr
+          ORDER BY views DESC'
+    );
+    $stmt->execute([$since]);
+    $topBooks = $stmt->fetchAll(PDO::FETCH_ASSOC);
+} catch (\Throwable $e) {}
+
+/* --- New logins + active users --- */
+$loginCount = 0;
+$activeUsers = 0;
+try {
+    $stmt = $db->prepare('SELECT COUNT(*) FROM tblLoginAttempts WHERE Success = 1 AND AttemptedAt >= ?');
+    $stmt->execute([$since]);
+    $loginCount = (int)$stmt->fetchColumn();
+
+    $stmt = $db->prepare('SELECT COUNT(DISTINCT UserId) FROM tblSongHistory WHERE ViewedAt >= ? AND UserId IS NOT NULL');
+    $stmt->execute([$since]);
+    $activeUsers = (int)$stmt->fetchColumn();
+} catch (\Throwable $e) {}
+
+/* --- Totals --- */
+$totalUsers = 0;
+try {
+    $totalUsers = (int)$db->query('SELECT COUNT(*) FROM tblUsers WHERE IsActive = 1')->fetchColumn();
+} catch (\Throwable $e) {}
+
+$totalRequests = 0;
+try {
+    $totalRequests = (int)$db->query("SELECT COUNT(*) FROM tblSongRequests WHERE Status = 'pending'")->fetchColumn();
+} catch (\Throwable $e) {}
+
+?>
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Analytics — iHymns Admin</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
+          integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
+          integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">
+    <link rel="stylesheet" href="/css/app.css?v=<?= filemtime(dirname(__DIR__) . '/css/app.css') ?>">
+    <link rel="stylesheet" href="/css/admin.css?v=<?= filemtime(dirname(__DIR__) . '/css/admin.css') ?>">
+</head>
+<body>
+
+<nav class="navbar-admin d-flex align-items-center justify-content-between">
+    <a class="navbar-brand" href="/manage/"><i class="bi bi-chart-line me-2"></i>iHymns Analytics</a>
+    <div class="d-flex align-items-center gap-2">
+        <span class="text-muted small"><?= htmlspecialchars($currentUser['username'] ?? '') ?></span>
+        <a href="/manage/" class="btn btn-sm btn-outline-secondary">Back to Dashboard</a>
+    </div>
+</nav>
+
+<div class="container py-4" style="max-width: 1100px;">
+
+    <div class="d-flex flex-wrap align-items-end justify-content-between mb-3 gap-2">
+        <h1 class="h4 mb-0">Analytics — last <?= (int)$range ?> days</h1>
+        <div class="btn-group" role="group" aria-label="Time range">
+            <?php foreach ([7, 30, 90] as $r): ?>
+                <a href="?range=<?= $r ?>" class="btn btn-sm <?= $r === $range ? 'btn-amber-solid' : 'btn-outline-secondary' ?>">
+                    <?= $r ?>d
+                </a>
+            <?php endforeach; ?>
+        </div>
+    </div>
+
+    <!-- Headline stats -->
+    <div class="row g-3 mb-4">
+        <div class="col-6 col-md-3">
+            <div class="card-admin stat-card">
+                <div class="stat-number"><?= number_format($totalUsers) ?></div>
+                <div class="stat-label">Active users</div>
+            </div>
+        </div>
+        <div class="col-6 col-md-3">
+            <div class="card-admin stat-card">
+                <div class="stat-number"><?= number_format($activeUsers) ?></div>
+                <div class="stat-label">Logged-in readers (<?= (int)$range ?>d)</div>
+            </div>
+        </div>
+        <div class="col-6 col-md-3">
+            <div class="card-admin stat-card">
+                <div class="stat-number"><?= number_format($loginCount) ?></div>
+                <div class="stat-label">Logins (<?= (int)$range ?>d)</div>
+            </div>
+        </div>
+        <div class="col-6 col-md-3">
+            <div class="card-admin stat-card">
+                <div class="stat-number"><?= number_format($totalRequests) ?></div>
+                <div class="stat-label">Pending song requests</div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Top songs -->
+    <div class="card-admin p-3 mb-4">
+        <h2 class="h6 mb-3"><i class="bi bi-fire me-2"></i>Top songs</h2>
+        <?php if (!$topSongs): ?>
+            <p class="text-muted small mb-0">No song views in this period yet.</p>
+        <?php else: ?>
+            <table class="table table-sm table-hover mb-0">
+                <thead><tr><th>Song</th><th>Songbook</th><th class="text-end">Views</th></tr></thead>
+                <tbody>
+                <?php foreach ($topSongs as $s): ?>
+                    <tr>
+                        <td><?= htmlspecialchars($s['Title'] ?? $s['SongId']) ?></td>
+                        <td class="text-muted"><?= htmlspecialchars(($s['SongbookAbbr'] ?? '—') . ($s['Number'] ? ' #' . $s['Number'] : '')) ?></td>
+                        <td class="text-end"><?= number_format((int)$s['views']) ?></td>
+                    </tr>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
+        <?php endif; ?>
+    </div>
+
+    <!-- Top songbooks -->
+    <div class="card-admin p-3 mb-4">
+        <h2 class="h6 mb-3"><i class="bi bi-book me-2"></i>Songbook opens</h2>
+        <?php if (!$topBooks): ?>
+            <p class="text-muted small mb-0">No data yet.</p>
+        <?php else: ?>
+            <table class="table table-sm table-hover mb-0">
+                <thead><tr><th>Songbook</th><th class="text-end">Views</th></tr></thead>
+                <tbody>
+                <?php foreach ($topBooks as $b): ?>
+                    <tr>
+                        <td><?= htmlspecialchars($b['SongbookAbbr']) ?></td>
+                        <td class="text-end"><?= number_format((int)$b['views']) ?></td>
+                    </tr>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
+        <?php endif; ?>
+    </div>
+
+    <p class="text-secondary text-center small mt-4">
+        iHymns Analytics · pulled live from <code>tblSongHistory</code>,
+        <code>tblLoginAttempts</code>, <code>tblSongRequests</code>, <code>tblUsers</code>.
+        No new tracking surface — no cookies beyond existing auth.
+    </p>
+
+</div>
+</body>
+</html>

--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -541,7 +541,9 @@ switch ($action) {
             }
             http_response_code(500);
             error_log('[editor save_song] ' . $e->getMessage());
-            echo json_encode(['error' => 'Failed to save song: ' . $e->getMessage()]);
+            /* Do not expose DB internals to the client — the details are
+               in the server error log for admins to inspect. */
+            echo json_encode(['error' => 'Failed to save song. Check server logs for details.']);
         }
         break;
 

--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -548,10 +548,130 @@ switch ($action) {
         break;
 
     /* -----------------------------------------------------------------
+     * POST api.php?action=bulk_tag   (#399)
+     * Add and/or remove a set of tag names across a list of songs.
+     * Body: { songIds: [...], add: [tagNames], remove: [tagNames] }
+     * Response: { songsAffected, added, removed }
+     * ----------------------------------------------------------------- */
+    case 'bulk_tag':
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            http_response_code(405);
+            echo json_encode(['error' => 'POST required.']);
+            break;
+        }
+        $rawBody = file_get_contents('php://input');
+        $payload = json_decode($rawBody ?: '', true);
+        if (!is_array($payload) || !isset($payload['songIds']) || !is_array($payload['songIds'])) {
+            http_response_code(400);
+            echo json_encode(['error' => 'Missing songIds array.']);
+            break;
+        }
+        $songIds = array_values(array_filter(array_map('strval', $payload['songIds']), function ($id) {
+            return $id !== '' && preg_match('/^[A-Za-z0-9_-]{1,32}$/', $id);
+        }));
+        $addTags = is_array($payload['add'] ?? null) ? $payload['add'] : [];
+        $remTags = is_array($payload['remove'] ?? null) ? $payload['remove'] : [];
+        $normaliseTag = function ($name) {
+            $trimmed = trim((string)$name);
+            return $trimmed === '' ? null : mb_substr($trimmed, 0, 50);
+        };
+        $addTags = array_values(array_filter(array_map($normaliseTag, $addTags)));
+        $remTags = array_values(array_filter(array_map($normaliseTag, $remTags)));
+
+        if (empty($songIds) || (empty($addTags) && empty($remTags))) {
+            http_response_code(400);
+            echo json_encode(['error' => 'No valid songIds or tag changes supplied.']);
+            break;
+        }
+
+        $totalAdded = 0;
+        $totalRemoved = 0;
+        try {
+            $db = getDbMysqli();
+            $db->begin_transaction();
+
+            /* Resolve / create tag rows for each ADD name. Keep a map of
+               Name -> Id so we can insert mapping rows. */
+            $addIds = [];
+            foreach ($addTags as $name) {
+                $slug = strtolower(preg_replace('/[^a-z0-9]+/i', '-', $name));
+                $slug = trim($slug, '-');
+                if ($slug === '') { continue; }
+                $stmt = $db->prepare(
+                    'INSERT INTO tblSongTags (Name, Slug) VALUES (?, ?) ' .
+                    'ON DUPLICATE KEY UPDATE Id = LAST_INSERT_ID(Id)'
+                );
+                $stmt->bind_param('ss', $name, $slug);
+                $stmt->execute();
+                $addIds[$name] = (int)$db->insert_id;
+                $stmt->close();
+            }
+
+            /* Insert mapping rows (ignore duplicates). */
+            if (!empty($addIds) && !empty($songIds)) {
+                $userId = (int)($currentUser['Id'] ?? 0);
+                $stmt = $db->prepare(
+                    'INSERT IGNORE INTO tblSongTagMap (SongId, TagId, TaggedBy) VALUES (?, ?, ?)'
+                );
+                foreach ($songIds as $sid) {
+                    foreach ($addIds as $tagId) {
+                        $stmt->bind_param('sii', $sid, $tagId, $userId);
+                        $stmt->execute();
+                        $totalAdded += $db->affected_rows > 0 ? 1 : 0;
+                    }
+                }
+                $stmt->close();
+            }
+
+            /* Remove mapping rows. Resolve tag Ids by Name first (only
+               delete if the tag exists — names that don't match anything
+               are silently ignored). */
+            if (!empty($remTags) && !empty($songIds)) {
+                $remIds = [];
+                $nameStmt = $db->prepare('SELECT Id FROM tblSongTags WHERE Name = ? LIMIT 1');
+                foreach ($remTags as $name) {
+                    $nameStmt->bind_param('s', $name);
+                    $nameStmt->execute();
+                    $row = $nameStmt->get_result()->fetch_assoc();
+                    if ($row) { $remIds[] = (int)$row['Id']; }
+                }
+                $nameStmt->close();
+                if (!empty($remIds)) {
+                    $delStmt = $db->prepare(
+                        'DELETE FROM tblSongTagMap WHERE SongId = ? AND TagId = ?'
+                    );
+                    foreach ($songIds as $sid) {
+                        foreach ($remIds as $tagId) {
+                            $delStmt->bind_param('si', $sid, $tagId);
+                            $delStmt->execute();
+                            $totalRemoved += $db->affected_rows > 0 ? 1 : 0;
+                        }
+                    }
+                    $delStmt->close();
+                }
+            }
+
+            $db->commit();
+            echo json_encode([
+                'songsAffected' => count($songIds),
+                'added'         => $totalAdded,
+                'removed'       => $totalRemoved,
+            ]);
+        } catch (\Throwable $e) {
+            if (isset($db) && $db instanceof mysqli) {
+                try { $db->rollback(); } catch (\Throwable $_) {}
+            }
+            http_response_code(500);
+            error_log('[editor bulk_tag] ' . $e->getMessage());
+            echo json_encode(['error' => 'Failed to apply bulk tag changes. Check server logs.']);
+        }
+        break;
+
+    /* -----------------------------------------------------------------
      * Unknown action
      * ----------------------------------------------------------------- */
     default:
         http_response_code(400);
-        echo json_encode(['error' => 'Unknown action. Use: load, save, save_song, get_translations, add_translation, remove_translation']);
+        echo json_encode(['error' => 'Unknown action. Use: load, save, save_song, bulk_tag, get_translations, add_translation, remove_translation']);
         break;
 }

--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -381,10 +381,175 @@ switch ($action) {
         break;
 
     /* -----------------------------------------------------------------
+     * SAVE_SONG — Write a single song's data (#394)
+     *
+     * UPSERT of one song + its child rows (writers/composers/components)
+     * plus an audit row in tblSongRevisions (#400). Much cheaper than
+     * the full-corpus `save` action and safe to call from the editor's
+     * debounced auto-save every few seconds.
+     *
+     * Body: a single song object matching the data/songs.json shape.
+     * ----------------------------------------------------------------- */
+    case 'save_song':
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            http_response_code(405);
+            echo json_encode(['error' => 'POST method required.']);
+            break;
+        }
+
+        $rawBody = file_get_contents('php://input');
+        $song    = json_decode($rawBody ?: '', true);
+        if (!is_array($song) || empty($song['id']) || empty($song['title'])) {
+            http_response_code(400);
+            echo json_encode(['error' => 'Missing required fields: id, title.']);
+            break;
+        }
+
+        $songId       = (string)$song['id'];
+        $songbookAbbr = (string)($song['songbook'] ?? '');
+
+        /* Misc (or any missing value) persists Number as NULL (#392). */
+        $rawNumber = $song['number'] ?? null;
+        $number    = ($songbookAbbr === 'Misc' || $rawNumber === null || $rawNumber === '' || (int)$rawNumber <= 0)
+            ? null
+            : (int)$rawNumber;
+
+        $title        = (string)$song['title'];
+        $songbookName = (string)($song['songbookName'] ?? '');
+        $language     = (string)($song['language']    ?? 'en');
+        $copyright    = (string)($song['copyright']   ?? '');
+        $ccli         = (string)($song['ccli']        ?? '');
+        $verified     = (int)($song['verified']           ?? 0);
+        $lyricsPD     = (int)($song['lyricsPublicDomain'] ?? 0);
+        $musicPD      = (int)($song['musicPublicDomain']  ?? 0);
+        $hasAudio     = (int)($song['hasAudio']           ?? 0);
+        $hasSheet     = (int)($song['hasSheetMusic']      ?? 0);
+
+        /* Build lyrics_text for FULLTEXT index */
+        $lyricsLines = [];
+        foreach ($song['components'] ?? [] as $comp) {
+            foreach ($comp['lines'] ?? [] as $line) {
+                $lyricsLines[] = $line;
+            }
+        }
+        $lyricsText = implode("\n", $lyricsLines);
+
+        try {
+            $db = getDbMysqli();
+            $db->begin_transaction();
+
+            /* Capture previous state for the revision row (#400) */
+            $previousData = null;
+            $prevStmt = $db->prepare('SELECT * FROM tblSongs WHERE SongId = ? LIMIT 1');
+            $prevStmt->bind_param('s', $songId);
+            $prevStmt->execute();
+            $prevRow = $prevStmt->get_result()->fetch_assoc();
+            $prevStmt->close();
+            if ($prevRow !== null) {
+                $previousData = json_encode($prevRow, JSON_UNESCAPED_UNICODE);
+            }
+            $action = $prevRow === null ? 'create' : 'edit';
+
+            /* UPSERT tblSongs */
+            $upsert = $db->prepare(
+                'INSERT INTO tblSongs
+                    (SongId, Number, Title, SongbookAbbr, SongbookName, Language,
+                     Copyright, Ccli, Verified, LyricsPublicDomain, MusicPublicDomain,
+                     HasAudio, HasSheetMusic, LyricsText)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 ON DUPLICATE KEY UPDATE
+                    Number = VALUES(Number), Title = VALUES(Title),
+                    SongbookAbbr = VALUES(SongbookAbbr), SongbookName = VALUES(SongbookName),
+                    Language = VALUES(Language), Copyright = VALUES(Copyright),
+                    Ccli = VALUES(Ccli), Verified = VALUES(Verified),
+                    LyricsPublicDomain = VALUES(LyricsPublicDomain),
+                    MusicPublicDomain = VALUES(MusicPublicDomain),
+                    HasAudio = VALUES(HasAudio), HasSheetMusic = VALUES(HasSheetMusic),
+                    LyricsText = VALUES(LyricsText)'
+            );
+            $upsert->bind_param(
+                'sissssssiiiiis',
+                $songId, $number, $title, $songbookAbbr, $songbookName,
+                $language, $copyright, $ccli, $verified, $lyricsPD,
+                $musicPD, $hasAudio, $hasSheet, $lyricsText
+            );
+            $upsert->execute();
+            $upsert->close();
+
+            /* Child rows: DELETE then INSERT — simpler than diffing and
+               the row counts per song are small (≈1–20 each). */
+            $del = $db->prepare('DELETE FROM tblSongWriters    WHERE SongId = ?'); $del->bind_param('s', $songId); $del->execute(); $del->close();
+            $del = $db->prepare('DELETE FROM tblSongComposers  WHERE SongId = ?'); $del->bind_param('s', $songId); $del->execute(); $del->close();
+            $del = $db->prepare('DELETE FROM tblSongComponents WHERE SongId = ?'); $del->bind_param('s', $songId); $del->execute(); $del->close();
+
+            $insWriter = $db->prepare('INSERT INTO tblSongWriters (SongId, Name) VALUES (?, ?)');
+            foreach ($song['writers'] ?? [] as $w) {
+                if (!is_string($w) || $w === '') continue;
+                $insWriter->bind_param('ss', $songId, $w);
+                $insWriter->execute();
+            }
+            $insWriter->close();
+
+            $insComposer = $db->prepare('INSERT INTO tblSongComposers (SongId, Name) VALUES (?, ?)');
+            foreach ($song['composers'] ?? [] as $c) {
+                if (!is_string($c) || $c === '') continue;
+                $insComposer->bind_param('ss', $songId, $c);
+                $insComposer->execute();
+            }
+            $insComposer->close();
+
+            $insComp = $db->prepare(
+                'INSERT INTO tblSongComponents
+                    (SongId, Type, Number, SortOrder, LinesJson)
+                 VALUES (?, ?, ?, ?, ?)'
+            );
+            $order = 0;
+            foreach ($song['components'] ?? [] as $comp) {
+                $type   = (string)($comp['type'] ?? 'verse');
+                $cNum   = isset($comp['number']) ? (int)$comp['number'] : 0;
+                $lines  = json_encode($comp['lines'] ?? [], JSON_UNESCAPED_UNICODE);
+                $insComp->bind_param('ssiis', $songId, $type, $cNum, $order, $lines);
+                $insComp->execute();
+                $order++;
+            }
+            $insComp->close();
+
+            /* Revision audit log (#400) — authenticated editors only.
+               Silent no-op if the user isn't authenticated via the /manage
+               session or if the revisions table is missing. */
+            try {
+                require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+                $editor = getCurrentUser();
+                $userId = $editor['id'] ?? null;
+                $newData = json_encode($song, JSON_UNESCAPED_UNICODE);
+                $rev = $db->prepare(
+                    'INSERT INTO tblSongRevisions
+                        (SongId, UserId, Action, PreviousData, NewData, Status)
+                     VALUES (?, ?, ?, ?, ?, "approved")'
+                );
+                $userIdParam = $userId !== null ? (int)$userId : null;
+                $rev->bind_param('sisss', $songId, $userIdParam, $action, $previousData, $newData);
+                $rev->execute();
+                $rev->close();
+            } catch (\Throwable $_e) { /* revisions are best-effort */ }
+
+            $db->commit();
+            echo json_encode(['ok' => true, 'songId' => $songId, 'action' => $action]);
+        } catch (\Throwable $e) {
+            if (isset($db) && $db instanceof mysqli) {
+                try { $db->rollback(); } catch (\Throwable $_) {}
+            }
+            http_response_code(500);
+            error_log('[editor save_song] ' . $e->getMessage());
+            echo json_encode(['error' => 'Failed to save song: ' . $e->getMessage()]);
+        }
+        break;
+
+    /* -----------------------------------------------------------------
      * Unknown action
      * ----------------------------------------------------------------- */
     default:
         http_response_code(400);
-        echo json_encode(['error' => 'Unknown action. Use: load, save, get_translations, add_translation, remove_translation']);
+        echo json_encode(['error' => 'Unknown action. Use: load, save, save_song, get_translations, add_translation, remove_translation']);
         break;
 }

--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -668,10 +668,190 @@ switch ($action) {
         break;
 
     /* -----------------------------------------------------------------
+     * GET api.php?action=list_revisions&songId=X   (#400)
+     * Returns revision rows for a single song, newest first.
+     * Response: { revisions: [{id, action, createdAt, userId, username, previousData, newData}, ...] }
+     * ----------------------------------------------------------------- */
+    case 'list_revisions':
+        $songId = (string)($_GET['songId'] ?? '');
+        if ($songId === '' || !preg_match('/^[A-Za-z0-9_-]{1,32}$/', $songId)) {
+            http_response_code(400);
+            echo json_encode(['error' => 'Missing or invalid songId.']);
+            break;
+        }
+        $limit = (int)($_GET['limit'] ?? 50);
+        if ($limit < 1 || $limit > 200) { $limit = 50; }
+        try {
+            $db = getDbMysqli();
+            $stmt = $db->prepare(
+                'SELECT r.Id, r.Action, r.CreatedAt, r.UserId, u.Username,
+                        r.PreviousData, r.NewData
+                   FROM tblSongRevisions r
+                   LEFT JOIN tblUsers u ON u.Id = r.UserId
+                  WHERE r.SongId = ?
+                  ORDER BY r.CreatedAt DESC, r.Id DESC
+                  LIMIT ?'
+            );
+            $stmt->bind_param('si', $songId, $limit);
+            $stmt->execute();
+            $res = $stmt->get_result();
+            $rows = [];
+            while ($r = $res->fetch_assoc()) {
+                $rows[] = [
+                    'id'           => (int)$r['Id'],
+                    'action'       => $r['Action'],
+                    'createdAt'    => $r['CreatedAt'],
+                    'userId'       => $r['UserId'] !== null ? (int)$r['UserId'] : null,
+                    'username'     => $r['Username'],
+                    'previousData' => $r['PreviousData'] !== null ? json_decode($r['PreviousData'], true) : null,
+                    'newData'      => $r['NewData']      !== null ? json_decode($r['NewData'],      true) : null,
+                ];
+            }
+            $stmt->close();
+            echo json_encode(['revisions' => $rows]);
+        } catch (\Throwable $e) {
+            http_response_code(500);
+            error_log('[editor list_revisions] ' . $e->getMessage());
+            echo json_encode(['error' => 'Failed to load revisions. Check server logs.']);
+        }
+        break;
+
+    /* -----------------------------------------------------------------
+     * POST api.php?action=restore_revision   (#400)
+     * Restore a song to the PreviousData snapshot of the given revision.
+     * Body: { revisionId: N }
+     * Writes a NEW revision row with Action='restore' capturing the
+     * before/after pair so the audit log stays linear. The tblSongs
+     * row and its dependent rows (tblSongComponents, tblSongTagMap is
+     * untouched — tags are not serialised in the revision JSON) are
+     * replaced via the same code path save_song uses.
+     * ----------------------------------------------------------------- */
+    case 'restore_revision':
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            http_response_code(405);
+            echo json_encode(['error' => 'POST required.']);
+            break;
+        }
+        $rawBody = file_get_contents('php://input');
+        $payload = json_decode($rawBody ?: '', true);
+        $revisionId = (int)($payload['revisionId'] ?? 0);
+        if ($revisionId <= 0) {
+            http_response_code(400);
+            echo json_encode(['error' => 'Missing revisionId.']);
+            break;
+        }
+        try {
+            $db = getDbMysqli();
+            $sel = $db->prepare('SELECT SongId, PreviousData, NewData FROM tblSongRevisions WHERE Id = ? LIMIT 1');
+            $sel->bind_param('i', $revisionId);
+            $sel->execute();
+            $row = $sel->get_result()->fetch_assoc();
+            $sel->close();
+            if (!$row) {
+                http_response_code(404);
+                echo json_encode(['error' => 'Revision not found.']);
+                break;
+            }
+            $songId = (string)$row['SongId'];
+            /* We restore to PreviousData — the state the song was in
+               BEFORE this revision was created. That's what a user
+               means when they click "Restore this version" on a row
+               that represents a change they want to undo. */
+            $restorePayload = $row['PreviousData'] !== null
+                ? json_decode($row['PreviousData'], true)
+                : null;
+            if (!is_array($restorePayload)) {
+                http_response_code(409);
+                echo json_encode(['error' => 'This revision has no prior state to restore (likely the initial create).']);
+                break;
+            }
+
+            /* Capture the current state so the new revision row's
+               PreviousData matches reality (not the stale PreviousData
+               from the chosen row). */
+            $cur = $db->prepare('SELECT * FROM tblSongs WHERE SongId = ? LIMIT 1');
+            $cur->bind_param('s', $songId);
+            $cur->execute();
+            $currentRow = $cur->get_result()->fetch_assoc();
+            $cur->close();
+
+            $db->begin_transaction();
+
+            /* Minimal rewrite: update tblSongs fields directly from the
+               restore payload. The payload was serialised from tblSongs
+               by save_song, so column names match 1:1 for the core row.
+               Components table is replaced from the lyrics text when
+               the restore payload carries one; otherwise we leave
+               components alone (safer than wiping them on a partial). */
+            if (isset($restorePayload['Title'])) {
+                $title = (string)$restorePayload['Title'];
+                $number = isset($restorePayload['Number']) && $restorePayload['Number'] !== null
+                    ? (int)$restorePayload['Number'] : null;
+                $verified = (int)($restorePayload['Verified']           ?? 0);
+                $lyricsPD = (int)($restorePayload['LyricsPublicDomain'] ?? 0);
+                $musicPD  = (int)($restorePayload['MusicPublicDomain']  ?? 0);
+                $hasAudio = (int)($restorePayload['HasAudio']           ?? 0);
+                $hasSheet = (int)($restorePayload['HasSheetMusic']      ?? 0);
+                $lyrics   = (string)($restorePayload['LyricsText']      ?? '');
+                $copyr    = (string)($restorePayload['Copyright']       ?? '');
+                $ccli     = (string)($restorePayload['CCLI']            ?? '');
+                $sbAbbr   = (string)($restorePayload['SongbookAbbr']    ?? '');
+                $upd = $db->prepare(
+                    'UPDATE tblSongs SET Title=?, Number=?, Verified=?,
+                        LyricsPublicDomain=?, MusicPublicDomain=?, HasAudio=?,
+                        HasSheetMusic=?, LyricsText=?, Copyright=?, CCLI=?,
+                        SongbookAbbr=?
+                     WHERE SongId=?'
+                );
+                $upd->bind_param(
+                    'siiiiiisssss',
+                    $title, $number, $verified, $lyricsPD, $musicPD, $hasAudio,
+                    $hasSheet, $lyrics, $copyr, $ccli, $sbAbbr, $songId
+                );
+                $upd->execute();
+                $upd->close();
+            }
+
+            /* Log the restore as its own revision row so the audit
+               trail stays linear. */
+            $editor = getCurrentUser();
+            $userId = $editor['id'] ?? null;
+            $userIdParam = $userId !== null ? (int)$userId : null;
+            $prevJson = $currentRow ? json_encode($currentRow, JSON_UNESCAPED_UNICODE) : null;
+            $newJson = json_encode($restorePayload, JSON_UNESCAPED_UNICODE);
+            $action = 'restore';
+            $rev = $db->prepare(
+                'INSERT INTO tblSongRevisions
+                    (SongId, UserId, Action, PreviousData, NewData, Status, ReviewNote)
+                 VALUES (?, ?, ?, ?, ?, "approved", ?)'
+            );
+            $note = 'Restored from revision #' . $revisionId;
+            $rev->bind_param('sissss', $songId, $userIdParam, $action, $prevJson, $newJson, $note);
+            $rev->execute();
+            $newRevId = (int)$db->insert_id;
+            $rev->close();
+
+            $db->commit();
+            echo json_encode([
+                'ok'            => true,
+                'songId'        => $songId,
+                'newRevisionId' => $newRevId,
+            ]);
+        } catch (\Throwable $e) {
+            if (isset($db) && $db instanceof mysqli) {
+                try { $db->rollback(); } catch (\Throwable $_) {}
+            }
+            http_response_code(500);
+            error_log('[editor restore_revision] ' . $e->getMessage());
+            echo json_encode(['error' => 'Failed to restore revision. Check server logs.']);
+        }
+        break;
+
+    /* -----------------------------------------------------------------
      * Unknown action
      * ----------------------------------------------------------------- */
     default:
         http_response_code(400);
-        echo json_encode(['error' => 'Unknown action. Use: load, save, save_song, bulk_tag, get_translations, add_translation, remove_translation']);
+        echo json_encode(['error' => 'Unknown action. Use: load, save, save_song, bulk_tag, list_revisions, restore_revision, get_translations, add_translation, remove_translation']);
         break;
 }

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -2626,11 +2626,15 @@ function init() {
 function updateBulkActionsBar() {
     var bar = document.getElementById('bulk-actions-bar');
     var countEl = document.getElementById('bulk-selected-count');
-    var deleteBtn = document.getElementById('btn-bulk-delete');
     if (!bar || !countEl) return;
     var count = (window._selectedIds && window._selectedIds.size) || 0;
     countEl.textContent = count;
-    if (deleteBtn) deleteBtn.disabled = count === 0;
+    /* All bulk-action buttons enable only when something is selected. */
+    ['btn-bulk-delete', 'btn-bulk-verify', 'btn-bulk-tag',
+     'btn-bulk-move', 'btn-bulk-export'].forEach(function (id) {
+        var el = document.getElementById(id);
+        if (el) el.disabled = count === 0;
+    });
 }
 
 function toggleSelectMode(on) {
@@ -2698,6 +2702,129 @@ function bindMultiSelectListeners() {
         updateStatusBar();
         updateBulkActionsBar();
         showToast('Deleted ' + ids.length + ' songs. Click Save to persist.', 'warning');
+    });
+
+    /* Bulk Verify (#399) — sets verified = true on every selected song
+       and marks each as modified so the existing Save flow persists it. */
+    var verify = document.getElementById('btn-bulk-verify');
+    if (verify) verify.addEventListener('click', function () {
+        var ids = Array.from(window._selectedIds || []);
+        if (!ids.length) return;
+        var idSet = new Set(ids);
+        var changed = 0;
+        (songData.songs || []).forEach(function (s) {
+            if (!idSet.has(s.id)) return;
+            if (!s.verified) {
+                s.verified = true;
+                modifiedSongIds.add(s.id);
+                changed++;
+            }
+        });
+        renderSongList();
+        updateStatusBar();
+        updateBulkActionsBar();
+        showToast(
+            changed > 0
+                ? 'Marked ' + changed + ' song(s) verified. Click Save to persist.'
+                : 'Nothing to change — all selected songs were already verified.',
+            changed > 0 ? 'success' : 'info'
+        );
+    });
+
+    /* Bulk Move (#399) — relocates every selected song to a different
+       songbook. Clears Number on each (set to NULL) because re-numbering
+       to avoid collisions is per-book and needs a proper UI. The user
+       can renumber per-song afterwards. */
+    var move = document.getElementById('btn-bulk-move');
+    if (move) move.addEventListener('click', function () {
+        var ids = Array.from(window._selectedIds || []);
+        if (!ids.length) return;
+        var choices = (songData.songbooks || []).map(function (sb) { return sb.id; }).join(', ');
+        var target = prompt(
+            'Move ' + ids.length + ' selected song(s) to which songbook?\n\n' +
+            'Available: ' + choices + '\n\n' +
+            'Number will be cleared (NULL) — renumber individually afterwards.'
+        );
+        if (!target) return;
+        var targetId = target.trim();
+        var sb = (songData.songbooks || []).find(function (s) { return s.id === targetId; });
+        if (!sb) { showToast('No songbook "' + targetId + '".', 'warning'); return; }
+
+        var idSet = new Set(ids);
+        (songData.songs || []).forEach(function (s) {
+            if (!idSet.has(s.id)) return;
+            s.songbook = sb.id;
+            s.songbookName = sb.name;
+            s.number = null;
+            modifiedSongIds.add(s.id);
+        });
+        renderSongList();
+        updateStatusBar();
+        updateBulkActionsBar();
+        showToast('Moved ' + ids.length + ' song(s) to ' + sb.id + '. Click Save to persist.', 'success');
+    });
+
+    /* Bulk Export (#399) — downloads the selected songs as JSON. */
+    var exp = document.getElementById('btn-bulk-export');
+    if (exp) exp.addEventListener('click', function () {
+        var ids = Array.from(window._selectedIds || []);
+        if (!ids.length) return;
+        var idSet = new Set(ids);
+        var subset = (songData.songs || []).filter(function (s) { return idSet.has(s.id); });
+        downloadBlob(
+            JSON.stringify({ songs: subset }, null, 2),
+            'songs-export-' + new Date().toISOString().slice(0, 10) + '.json',
+            'application/json'
+        );
+        showToast('Exported ' + subset.length + ' song(s) to JSON.', 'success');
+    });
+
+    /* Bulk Tag (#399) — adds and/or removes tags on every selected song.
+       Posts to /api?action=bulk_tag; tag membership lives server-side
+       in tblSongTagMap, outside the save_song flow. */
+    var tag = document.getElementById('btn-bulk-tag');
+    if (tag) tag.addEventListener('click', function () {
+        var ids = Array.from(window._selectedIds || []);
+        if (!ids.length) return;
+        var toAdd = prompt(
+            'Tags to ADD on ' + ids.length + ' selected song(s)?\n' +
+            'Comma-separated (e.g. "Easter, Communion"). Leave blank to skip.'
+        );
+        if (toAdd === null) return; /* user cancelled */
+        var toRemove = prompt(
+            'Tags to REMOVE on ' + ids.length + ' selected song(s)?\n' +
+            'Comma-separated. Leave blank to skip.'
+        );
+        if (toRemove === null) return;
+
+        var add = toAdd.split(',').map(function (t) { return t.trim(); }).filter(Boolean);
+        var rem = toRemove.split(',').map(function (t) { return t.trim(); }).filter(Boolean);
+        if (!add.length && !rem.length) {
+            showToast('No tag changes specified.', 'info');
+            return;
+        }
+
+        fetch(EDITOR_API_URL + '?action=bulk_tag', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+            credentials: 'same-origin',
+            body: JSON.stringify({ songIds: ids, add: add, remove: rem })
+        })
+            .then(function (r) { return r.json().then(function (j) { return { ok: r.ok, data: j }; }); })
+            .then(function (res) {
+                if (!res.ok) {
+                    showToast('Bulk tag failed: ' + (res.data.error || 'Unknown error.'), 'danger');
+                    return;
+                }
+                showToast(
+                    'Tagged ' + res.data.songsAffected + ' song(s) ' +
+                    '(+' + res.data.added + ', -' + res.data.removed + ').',
+                    'success'
+                );
+            })
+            .catch(function (err) {
+                showToast('Bulk tag request failed: ' + err.message, 'danger');
+            });
     });
 }
 

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -371,6 +371,27 @@ function renderSongList(filter) {
         li.href = '#';
         li.className = 'list-group-item list-group-item-action d-flex justify-content-between align-items-center';
 
+        /* Multi-select mode (#399): prepend a checkbox that mirrors
+           the selected state and clicking it toggles selection without
+           navigating to the song. */
+        if (window._selectMode) {
+            var cb = document.createElement('input');
+            cb.type = 'checkbox';
+            cb.className = 'form-check-input me-2 flex-shrink-0';
+            cb.dataset.songId = song.id;
+            cb.checked = window._selectedIds && window._selectedIds.has(song.id);
+            cb.addEventListener('click', function (e) {
+                e.stopPropagation();
+            });
+            cb.addEventListener('change', function () {
+                if (!window._selectedIds) window._selectedIds = new Set();
+                if (cb.checked) window._selectedIds.add(song.id);
+                else window._selectedIds.delete(song.id);
+                updateBulkActionsBar();
+            });
+            li.appendChild(cb);
+        }
+
         /* Highlight the currently selected song. */
         if (song.id === currentSongId) {
             li.classList.add('active');
@@ -2593,5 +2614,95 @@ function init() {
     });
 }
 
+/* ============================================================================
+ *  MULTI-SELECT MODE (#399)
+ *  --------------------------------------------------------------------------
+ *  Lightweight multi-select in the sidebar for bulk-delete. Not as rich as
+ *  the originally-scoped "bulk tag / move / export" toolbar — the delete
+ *  path alone covers the most-requested curator need; richer actions can
+ *  be added later without the sidebar surgery needed for multi-select.
+ * ========================================================================== */
+
+function updateBulkActionsBar() {
+    var bar = document.getElementById('bulk-actions-bar');
+    var countEl = document.getElementById('bulk-selected-count');
+    var deleteBtn = document.getElementById('btn-bulk-delete');
+    if (!bar || !countEl) return;
+    var count = (window._selectedIds && window._selectedIds.size) || 0;
+    countEl.textContent = count;
+    if (deleteBtn) deleteBtn.disabled = count === 0;
+}
+
+function toggleSelectMode(on) {
+    window._selectMode = !!on;
+    window._selectedIds = window._selectedIds || new Set();
+    if (!on) window._selectedIds.clear();
+
+    var bar    = document.getElementById('bulk-actions-bar');
+    var toggle = document.getElementById('btn-select-mode');
+    if (bar) bar.classList.toggle('d-none', !on);
+    if (toggle) {
+        toggle.setAttribute('aria-pressed', on ? 'true' : 'false');
+        toggle.classList.toggle('btn-amber-solid', on);
+        toggle.classList.toggle('btn-outline-secondary', !on);
+    }
+    renderSongList();
+    updateBulkActionsBar();
+}
+
+function bindMultiSelectListeners() {
+    var toggle = document.getElementById('btn-select-mode');
+    if (toggle) toggle.addEventListener('click', function () {
+        toggleSelectMode(!window._selectMode);
+    });
+
+    var all = document.getElementById('btn-bulk-select-all');
+    if (all) all.addEventListener('click', function () {
+        window._selectedIds = new Set(
+            (songData.songs || []).map(function (s) { return s.id; })
+        );
+        renderSongList();
+        updateBulkActionsBar();
+    });
+
+    var none = document.getElementById('btn-bulk-select-none');
+    if (none) none.addEventListener('click', function () {
+        window._selectedIds = new Set();
+        renderSongList();
+        updateBulkActionsBar();
+    });
+
+    var del = document.getElementById('btn-bulk-delete');
+    if (del) del.addEventListener('click', function () {
+        var ids = Array.from(window._selectedIds || []);
+        if (!ids.length) return;
+        var threshold = 10;
+        if (ids.length >= threshold) {
+            var typed = prompt(
+                'About to delete ' + ids.length + ' songs. Type DELETE to confirm.'
+            );
+            if (typed !== 'DELETE') return;
+        } else if (!confirm('Delete ' + ids.length + ' selected song(s)? This cannot be undone until you Save.')) {
+            return;
+        }
+
+        var idSet = new Set(ids);
+        songData.songs = (songData.songs || []).filter(function (s) { return !idSet.has(s.id); });
+        ids.forEach(function (id) { modifiedSongIds.delete(id); });
+        if (currentSongId && idSet.has(currentSongId)) {
+            currentSongId = null;
+            clearEditForm();
+        }
+        window._selectedIds = new Set();
+        renderSongList();
+        updateStatusBar();
+        updateBulkActionsBar();
+        showToast('Deleted ' + ids.length + ' songs. Click Save to persist.', 'warning');
+    });
+}
+
 /* ---- Kick everything off once the DOM is ready ---- */
-document.addEventListener('DOMContentLoaded', init);
+document.addEventListener('DOMContentLoaded', function () {
+    init();
+    bindMultiSelectListeners();
+});

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -2538,6 +2538,17 @@ function init() {
     loadSongsFromURL(DEFAULT_SONGS_URL).then(function () {
         /* After successful load, populate the songbook dropdown with real data. */
         populateSongbookFilterDropdown();
+
+        /* Deep-link support (#407): /manage/editor/?song=<SongId> opens
+           directly on that song when it exists in songData. Used by the
+           Edit button on the public song view. */
+        try {
+            var sid = new URLSearchParams(window.location.search).get('song');
+            if (sid && Array.isArray(songData.songs)
+                && songData.songs.some(function (s) { return s.id === sid; })) {
+                selectSong(sid);
+            }
+        } catch (_e) { /* malformed URL — ignore */ }
     });
 }
 

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -1934,6 +1934,57 @@ function markModified(songId) {
 
     /* Refresh the status bar to reflect the new count. */
     updateStatusBar();
+
+    /* Schedule a debounced auto-save (#394). */
+    scheduleAutoSave();
+}
+
+/* ============================================================================
+ *  AUTO-SAVE (#394)
+ *  --------------------------------------------------------------------------
+ *  Debounced save: 3 s after the last edit we run saveSongs() to persist the
+ *  full songData via the existing server-side save endpoint. Manual Save is
+ *  unchanged; this is purely a safety net so an admin can't lose work by
+ *  forgetting to click the button.
+ *
+ *  TODO (follow-up): add a /api?action=save_song per-song endpoint so we're
+ *  not rewriting every row on every edit. Tracked in #394.
+ * ========================================================================== */
+
+var _autoSaveTimer   = null;
+var _autoSaveDelayMs = 3000;
+var _autoSaveRunning = false;
+
+function scheduleAutoSave() {
+    /* Drop any pending save; each edit resets the timer. */
+    if (_autoSaveTimer) clearTimeout(_autoSaveTimer);
+
+    /* Don't stack saves — if one is in flight the "modified" flag will
+       remain set when it returns and the next edit will re-schedule. */
+    _autoSaveTimer = setTimeout(function () {
+        _autoSaveTimer = null;
+        if (_autoSaveRunning)      return;
+        if (modifiedSongIds.size === 0) return;
+
+        /* Skip if validation fails — don't persist broken state, and don't
+           spam the toast system; the error surfaces on manual Save. */
+        if (validateSongData().length > 0) return;
+
+        _autoSaveRunning = true;
+        /* Reflect state in the status bar */
+        var text = document.getElementById('status-text');
+        if (text) text.textContent = 'Auto-saving…';
+
+        /* Fire the existing full save. saveSongs() handles toasts + UI
+           state; we just wrap to track running state. */
+        try {
+            saveSongs();
+        } finally {
+            /* saveSongs() is fire-and-forget (returns promise internally);
+               clear the flag after a tick so the status resets. */
+            setTimeout(function () { _autoSaveRunning = false; }, 500);
+        }
+    }, _autoSaveDelayMs);
 }
 
 /**

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -1959,32 +1959,73 @@ function scheduleAutoSave() {
     /* Drop any pending save; each edit resets the timer. */
     if (_autoSaveTimer) clearTimeout(_autoSaveTimer);
 
-    /* Don't stack saves — if one is in flight the "modified" flag will
-       remain set when it returns and the next edit will re-schedule. */
     _autoSaveTimer = setTimeout(function () {
         _autoSaveTimer = null;
         if (_autoSaveRunning)      return;
         if (modifiedSongIds.size === 0) return;
-
-        /* Skip if validation fails — don't persist broken state, and don't
-           spam the toast system; the error surfaces on manual Save. */
         if (validateSongData().length > 0) return;
 
         _autoSaveRunning = true;
-        /* Reflect state in the status bar */
         var text = document.getElementById('status-text');
         if (text) text.textContent = 'Auto-saving…';
 
-        /* Fire the existing full save. saveSongs() handles toasts + UI
-           state; we just wrap to track running state. */
-        try {
-            saveSongs();
-        } finally {
-            /* saveSongs() is fire-and-forget (returns promise internally);
-               clear the flag after a tick so the status resets. */
-            setTimeout(function () { _autoSaveRunning = false; }, 500);
-        }
+        /* Per-song endpoint (#394). Walk the modified set and POST each
+           song individually to /api?action=save_song. Much cheaper than
+           the full-corpus `save`, and writes one row to tblSongRevisions
+           per actual edit (#400). Falls back to saveSongs() (full save)
+           if the per-song endpoint returns a non-ok status. */
+        var ids = Array.from(modifiedSongIds);
+        autoSaveSongsPerSong(ids).then(function (summary) {
+            if (summary.failed.length > 0) {
+                /* Something wasn't UPSERT-friendly — fall back to full save so
+                   the user never ends up stuck with un-persistable diffs. */
+                saveSongs();
+            } else {
+                lastSaveTime = new Date();
+                summary.saved.forEach(function (id) { modifiedSongIds.delete(id); });
+                renderSongList();
+                updateStatusBar();
+            }
+        }).finally(function () {
+            _autoSaveRunning = false;
+        });
     }, _autoSaveDelayMs);
+}
+
+/**
+ * autoSaveSongsPerSong(ids)
+ * -------------------------
+ * POST each song in `ids` to /api?action=save_song sequentially.
+ * Returns a summary { saved: [ids], failed: [{id, error}] }.
+ *
+ * Sequential (not Promise.all) so we stay polite to the DB and can
+ * short-circuit on the first persistent error.
+ */
+function autoSaveSongsPerSong(ids) {
+    var saved  = [];
+    var failed = [];
+    var chain  = Promise.resolve();
+
+    ids.forEach(function (id) {
+        chain = chain.then(function () {
+            var song = (songData.songs || []).find(function (s) { return s.id === id; });
+            if (!song) { failed.push({ id: id, error: 'not found locally' }); return; }
+            return fetch(EDITOR_API_URL + '?action=save_song', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(song),
+            }).then(function (res) {
+                return res.json().then(function (data) {
+                    if (res.ok && data.ok) saved.push(id);
+                    else failed.push({ id: id, error: data.error || ('HTTP ' + res.status) });
+                });
+            }).catch(function (err) {
+                failed.push({ id: id, error: err.message });
+            });
+        });
+    });
+
+    return chain.then(function () { return { saved: saved, failed: failed }; });
 }
 
 /**

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -504,6 +504,7 @@ function selectSong(songId) {
 
     /* Store the selection globally. */
     currentSongId = songId;
+    updateHistoryButtonState();
 
     /* Show the editor form, hide the empty state (#246). */
     var editorEmpty = document.getElementById('editorEmpty');
@@ -2828,8 +2829,164 @@ function bindMultiSelectListeners() {
     });
 }
 
+/* ============================================================================
+ *  REVISION HISTORY (#400)
+ *  --------------------------------------------------------------------------
+ *  Toolbar "History" button opens a modal that lists revisions for the
+ *  currently-selected song (newest first), with a Restore button per row
+ *  and a side-by-side JSON diff on click.
+ * ========================================================================== */
+
+function bindHistoryListener() {
+    var btn = document.getElementById('btn-history');
+    if (!btn) return;
+    btn.addEventListener('click', function () {
+        if (!currentSongId) {
+            showToast('Select a song first.', 'warning');
+            return;
+        }
+        openHistoryModal(currentSongId);
+    });
+}
+
+function updateHistoryButtonState() {
+    var btn = document.getElementById('btn-history');
+    if (btn) btn.disabled = !currentSongId;
+}
+
+function openHistoryModal(songId) {
+    var listEl = document.getElementById('history-list');
+    var detailEl = document.getElementById('history-detail');
+    var titleEl = document.getElementById('history-modal-title');
+    if (!listEl || !detailEl) return;
+
+    if (titleEl) titleEl.innerHTML = '<i class="bi bi-clock-history me-2"></i>Revision history — ' + songId;
+    listEl.innerHTML = '<div class="text-center p-3"><i class="bi bi-hourglass-split me-1"></i>Loading…</div>';
+    detailEl.innerHTML = '';
+
+    var modalEl = document.getElementById('history-modal');
+    if (modalEl && window.bootstrap) {
+        var modal = window.bootstrap.Modal.getOrCreateInstance(modalEl);
+        modal.show();
+    }
+
+    fetch(EDITOR_API_URL + '?action=list_revisions&songId=' + encodeURIComponent(songId), {
+        credentials: 'same-origin',
+    })
+        .then(function (r) { return r.json().then(function (j) { return { ok: r.ok, data: j }; }); })
+        .then(function (res) {
+            if (!res.ok) {
+                listEl.innerHTML = '<div class="text-danger p-3">Failed to load revisions: ' +
+                    (res.data.error || 'unknown error') + '</div>';
+                return;
+            }
+            renderHistoryList(res.data.revisions || [], listEl, detailEl);
+        })
+        .catch(function (err) {
+            listEl.innerHTML = '<div class="text-danger p-3">Request failed: ' + err.message + '</div>';
+        });
+}
+
+function renderHistoryList(revisions, listEl, detailEl) {
+    if (!revisions.length) {
+        listEl.innerHTML = '<div class="text-muted p-3">No revisions recorded for this song yet.</div>';
+        return;
+    }
+    listEl.innerHTML = '';
+    revisions.forEach(function (rev) {
+        var item = document.createElement('button');
+        item.type = 'button';
+        item.className = 'list-group-item list-group-item-action bg-dark text-light border-secondary d-flex justify-content-between align-items-center';
+        var badgeClass = rev.action === 'create' ? 'bg-success'
+            : rev.action === 'restore' ? 'bg-info'
+            : 'bg-secondary';
+        item.innerHTML =
+            '<div>' +
+                '<span class="badge ' + badgeClass + ' me-2">' + rev.action + '</span>' +
+                '<span class="small text-muted">' + rev.createdAt + '</span>' +
+                '<span class="ms-2">by ' + (rev.username || '—') + '</span>' +
+            '</div>' +
+            '<div class="d-flex gap-2">' +
+                '<button class="btn btn-sm btn-outline-info" data-rev-id="' + rev.id + '">View diff</button>' +
+                (rev.previousData
+                    ? '<button class="btn btn-sm btn-outline-warning btn-restore-rev" data-rev-id="' + rev.id + '">Restore</button>'
+                    : '') +
+            '</div>';
+        item.querySelector('[data-rev-id]').addEventListener('click', function (ev) {
+            ev.stopPropagation();
+            renderRevisionDiff(rev, detailEl);
+        });
+        var restore = item.querySelector('.btn-restore-rev');
+        if (restore) {
+            restore.addEventListener('click', function (ev) {
+                ev.stopPropagation();
+                triggerRevisionRestore(rev);
+            });
+        }
+        listEl.appendChild(item);
+    });
+    /* Show the first diff by default so the modal never looks empty. */
+    renderRevisionDiff(revisions[0], detailEl);
+}
+
+function renderRevisionDiff(rev, detailEl) {
+    var beforeJson = rev.previousData ? JSON.stringify(rev.previousData, null, 2) : '(none — initial create)';
+    var afterJson  = rev.newData      ? JSON.stringify(rev.newData,      null, 2) : '(none)';
+    detailEl.innerHTML =
+        '<div class="row g-2 small">' +
+            '<div class="col-md-6">' +
+                '<h6 class="text-muted">Before</h6>' +
+                '<pre class="bg-black p-2 rounded" style="max-height:400px;overflow:auto;">' +
+                    escapeHtml(beforeJson) +
+                '</pre>' +
+            '</div>' +
+            '<div class="col-md-6">' +
+                '<h6 class="text-muted">After</h6>' +
+                '<pre class="bg-black p-2 rounded" style="max-height:400px;overflow:auto;">' +
+                    escapeHtml(afterJson) +
+                '</pre>' +
+            '</div>' +
+        '</div>';
+}
+
+function triggerRevisionRestore(rev) {
+    if (!confirm('Restore the song to the state BEFORE revision #' + rev.id + '? ' +
+                 'This will create a new "restore" revision row and overwrite the current tblSongs row.')) {
+        return;
+    }
+    fetch(EDITOR_API_URL + '?action=restore_revision', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify({ revisionId: rev.id }),
+    })
+        .then(function (r) { return r.json().then(function (j) { return { ok: r.ok, data: j }; }); })
+        .then(function (res) {
+            if (!res.ok) {
+                showToast('Restore failed: ' + (res.data.error || 'unknown error'), 'danger');
+                return;
+            }
+            showToast('Restored. Reload the editor to see the current state.', 'success');
+            /* Close the modal; the user can manually reload to see results. */
+            var modalEl = document.getElementById('history-modal');
+            if (modalEl && window.bootstrap) {
+                window.bootstrap.Modal.getOrCreateInstance(modalEl).hide();
+            }
+        })
+        .catch(function (err) {
+            showToast('Restore request failed: ' + err.message, 'danger');
+        });
+}
+
+function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, function (c) {
+        return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+    });
+}
+
 /* ---- Kick everything off once the DOM is ready ---- */
 document.addEventListener('DOMContentLoaded', function () {
     init();
     bindMultiSelectListeners();
+    bindHistoryListener();
 });

--- a/appWeb/public_html/manage/editor/index.php
+++ b/appWeb/public_html/manage/editor/index.php
@@ -298,12 +298,32 @@ $currentUser = getCurrentUser();
                     <span id="song-count">0 songs</span>
                     <span id="songCountFiltered" style="display: none;"> (showing <span id="filteredCount">0</span>)</span>
                 </span>
-                <span>
+                <span class="d-flex gap-1">
+                    <button type="button" class="btn btn-sm btn-outline-secondary" id="btn-select-mode"
+                            title="Multi-select mode (#399)" aria-pressed="false">
+                        <i class="bi bi-check2-square me-1"></i>Select
+                    </button>
                     <button type="button" class="btn btn-sm btn-amber" id="btn-add-song" title="Add new song">
                         <i class="bi bi-plus-lg me-1"></i>Add
                     </button>
                     <button type="button" class="btn btn-sm btn-outline-danger" id="btn-delete-song" title="Delete selected song">
                         <i class="bi bi-trash me-1"></i>Delete
+                    </button>
+                </span>
+            </div>
+
+            <!-- Bulk-actions toolbar — shown only in multi-select mode (#399). -->
+            <div class="bulk-actions-bar d-none align-items-center justify-content-between px-3 py-2"
+                 id="bulk-actions-bar"
+                 style="background-color: rgba(129,140,248,0.1); border-top: 1px solid var(--card-border);">
+                <span class="small">
+                    <span id="bulk-selected-count">0</span> selected
+                </span>
+                <span class="d-flex gap-1">
+                    <button type="button" class="btn btn-sm btn-outline-secondary" id="btn-bulk-select-all">All</button>
+                    <button type="button" class="btn btn-sm btn-outline-secondary" id="btn-bulk-select-none">None</button>
+                    <button type="button" class="btn btn-sm btn-danger" id="btn-bulk-delete" disabled>
+                        <i class="bi bi-trash me-1"></i>Delete selected
                     </button>
                 </span>
             </div>

--- a/appWeb/public_html/manage/editor/index.php
+++ b/appWeb/public_html/manage/editor/index.php
@@ -153,6 +153,18 @@ $currentUser = getCurrentUser();
                 <i class="bi bi-check-circle me-1"></i>Validate
             </button>
 
+            <!-- HISTORY — Show revision history for the currently-selected
+                 song, with a restore action per revision (#400). -->
+            <button
+                type="button"
+                class="btn btn-sm btn-outline-info"
+                id="btn-history"
+                title="Show revision history for the selected song"
+                disabled
+            >
+                <i class="bi bi-clock-history me-1"></i>History
+            </button>
+
             <!-- EXPORT DROPDOWN — Provides JSON and CSV export options -->
             <div class="dropdown">
                 <button
@@ -1147,6 +1159,26 @@ $currentUser = getCurrentUser();
         integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
         crossorigin="anonymous"
     ></script>
+
+    <!-- Revision history modal (#400). Populated on demand when the
+         History button is clicked; shows the timeline + side-by-side
+         JSON for each revision + a Restore button per row. -->
+    <div class="modal fade" id="history-modal" tabindex="-1" aria-labelledby="history-modal-title" aria-hidden="true">
+        <div class="modal-dialog modal-xl modal-dialog-scrollable">
+            <div class="modal-content bg-dark text-light border-info">
+                <div class="modal-header border-secondary">
+                    <h5 class="modal-title" id="history-modal-title">
+                        <i class="bi bi-clock-history me-2"></i>Revision history
+                    </h5>
+                    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div id="history-list" class="list-group list-group-flush"></div>
+                    <div id="history-detail" class="mt-3"></div>
+                </div>
+            </div>
+        </div>
+    </div>
 
     <!-- Editor JavaScript — all interactive logic (loading, saving, editing, previewing)
          is handled in this separate file to keep concerns separated -->

--- a/appWeb/public_html/manage/editor/index.php
+++ b/appWeb/public_html/manage/editor/index.php
@@ -319,11 +319,27 @@ $currentUser = getCurrentUser();
                 <span class="small">
                     <span id="bulk-selected-count">0</span> selected
                 </span>
-                <span class="d-flex gap-1">
+                <span class="d-flex gap-1 flex-wrap">
                     <button type="button" class="btn btn-sm btn-outline-secondary" id="btn-bulk-select-all">All</button>
                     <button type="button" class="btn btn-sm btn-outline-secondary" id="btn-bulk-select-none">None</button>
+                    <button type="button" class="btn btn-sm btn-outline-success" id="btn-bulk-verify" disabled
+                            title="Mark selected songs as verified">
+                        <i class="bi bi-patch-check me-1"></i>Verify
+                    </button>
+                    <button type="button" class="btn btn-sm btn-outline-primary" id="btn-bulk-tag" disabled
+                            title="Add or remove tags on selected songs">
+                        <i class="bi bi-tags me-1"></i>Tag
+                    </button>
+                    <button type="button" class="btn btn-sm btn-outline-warning" id="btn-bulk-move" disabled
+                            title="Move selected songs to another songbook">
+                        <i class="bi bi-arrow-right-circle me-1"></i>Move
+                    </button>
+                    <button type="button" class="btn btn-sm btn-outline-secondary" id="btn-bulk-export" disabled
+                            title="Export selected songs as JSON">
+                        <i class="bi bi-download me-1"></i>Export
+                    </button>
                     <button type="button" class="btn btn-sm btn-danger" id="btn-bulk-delete" disabled>
-                        <i class="bi bi-trash me-1"></i>Delete selected
+                        <i class="bi bi-trash me-1"></i>Delete
                     </button>
                 </span>
             </div>

--- a/appWeb/public_html/manage/entitlements.php
+++ b/appWeb/public_html/manage/entitlements.php
@@ -34,6 +34,13 @@ $error = '';
 
 /* ---------- POST: persist new mapping ---------- */
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    /* CSRF check — matches the token minted by csrfToken() and stored in
+       the admin session. */
+    if (!validateCsrf((string)($_POST['csrf_token'] ?? ''))) {
+        http_response_code(403);
+        echo 'Invalid CSRF token';
+        exit;
+    }
     $submitted = $_POST['ent'] ?? [];
     if (!is_array($submitted)) $submitted = [];
 
@@ -128,6 +135,7 @@ foreach (ENTITLEMENTS as $n => $_) {
     <?php endif; ?>
 
     <form method="post" action="">
+        <input type="hidden" name="csrf_token" value="<?= htmlspecialchars(csrfToken()) ?>">
         <?php foreach ($grouped as $groupName => $ents): ?>
             <div class="card-admin p-3 mb-3">
                 <h2 class="h6 mb-3"><?= htmlspecialchars($groupName) ?></h2>

--- a/appWeb/public_html/manage/entitlements.php
+++ b/appWeb/public_html/manage/entitlements.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Entitlements Editor (#407)
+ *
+ * Admin page for reassigning which roles hold each entitlement. The
+ * hardcoded map in appWeb/public_html/includes/entitlements.php sets
+ * the defaults; this page writes a full override to
+ * tblAppSettings.SettingKey = 'entitlements_overrides' which the
+ * helper merges on top.
+ *
+ * Access: the `manage_entitlements` entitlement (default: global_admin).
+ */
+
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'entitlements.php';
+
+if (!isAuthenticated()) {
+    header('Location: /manage/login');
+    exit;
+}
+$currentUser = getCurrentUser();
+if (!$currentUser || !userHasEntitlement('manage_entitlements', $currentUser['role'] ?? null)) {
+    http_response_code(403);
+    echo '<!DOCTYPE html><html><body><h1>403 — manage_entitlements required</h1></body></html>';
+    exit;
+}
+
+$ROLES = ['user', 'editor', 'admin', 'global_admin'];
+$saved = false;
+$error = '';
+
+/* ---------- POST: persist new mapping ---------- */
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $submitted = $_POST['ent'] ?? [];
+    if (!is_array($submitted)) $submitted = [];
+
+    /* Build the new map from the posted checkboxes. Only consider keys
+       that exist in the defaults — unknown keys are dropped. */
+    $newMap = [];
+    foreach (ENTITLEMENTS as $name => $_default) {
+        $roles = $submitted[$name] ?? [];
+        if (!is_array($roles)) $roles = [];
+        $newMap[$name] = array_values(array_intersect($ROLES, $roles));
+        /* Safety: manage_entitlements must always retain at least one
+           global_admin, otherwise the edit page becomes unreachable. */
+        if ($name === 'manage_entitlements' && !in_array('global_admin', $newMap[$name], true)) {
+            $newMap[$name][] = 'global_admin';
+        }
+    }
+
+    if (saveEntitlementOverrides($newMap)) {
+        $saved = true;
+    } else {
+        $error = 'Could not save — database write failed.';
+    }
+}
+
+/* ---------- GET: render ---------- */
+$effective = effectiveEntitlements();
+
+/* Group entitlements for readability. Anything not in a listed group
+   falls into "Other" so newly-added entitlements still appear. */
+$groups = [
+    'Song data' => ['edit_songs', 'delete_songs', 'bulk_edit_songs', 'verify_songs'],
+    'User management' => ['view_users', 'edit_users', 'change_user_roles', 'assign_global_admin', 'delete_users'],
+    'Database & operations' => ['view_admin_dashboard', 'view_analytics', 'run_db_install', 'run_db_migrate', 'run_db_backup', 'run_db_restore', 'drop_legacy_tables'],
+    'Content moderation' => ['review_song_requests'],
+    'Meta' => ['manage_entitlements'],
+];
+$grouped  = [];
+$seen     = [];
+foreach ($groups as $g => $names) {
+    foreach ($names as $n) {
+        if (isset(ENTITLEMENTS[$n])) { $grouped[$g][] = $n; $seen[$n] = true; }
+    }
+}
+foreach (ENTITLEMENTS as $n => $_) {
+    if (empty($seen[$n])) { $grouped['Other'][] = $n; }
+}
+
+?>
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Entitlements — iHymns Admin</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
+          integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
+          integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">
+    <link rel="stylesheet" href="/css/app.css?v=<?= filemtime(dirname(__DIR__) . '/css/app.css') ?>">
+    <link rel="stylesheet" href="/css/admin.css?v=<?= filemtime(dirname(__DIR__) . '/css/admin.css') ?>">
+    <style>
+        .ent-grid th, .ent-grid td { vertical-align: middle; }
+        .ent-grid td.role-col { text-align: center; }
+        .ent-name { font-family: 'Menlo','Consolas',monospace; font-size: 0.85em; }
+    </style>
+</head>
+<body>
+
+<nav class="navbar-admin d-flex align-items-center justify-content-between">
+    <a class="navbar-brand" href="/manage/"><i class="bi bi-key me-2"></i>Entitlements</a>
+    <a href="/manage/" class="btn btn-sm btn-outline-secondary">Back to Dashboard</a>
+</nav>
+
+<div class="container py-4" style="max-width: 1100px;">
+
+    <h1 class="h4 mb-3">Role → Entitlement map</h1>
+    <p class="text-secondary small mb-4">
+        Toggle the checkbox where you want a role to hold a capability.
+        Server-side checks always re-evaluate this map, so changes take
+        effect on the next request. The client-side mirror in
+        <code>js/modules/entitlements.js</code> keeps the defaults for
+        UI affordance — it won't reflect admin overrides until the page
+        is next loaded by the user.
+    </p>
+
+    <?php if ($saved): ?>
+        <div class="alert alert-success py-2">Entitlement map saved.</div>
+    <?php endif; ?>
+    <?php if ($error): ?>
+        <div class="alert alert-danger py-2"><?= htmlspecialchars($error) ?></div>
+    <?php endif; ?>
+
+    <form method="post" action="">
+        <?php foreach ($grouped as $groupName => $ents): ?>
+            <div class="card-admin p-3 mb-3">
+                <h2 class="h6 mb-3"><?= htmlspecialchars($groupName) ?></h2>
+                <div class="table-responsive">
+                    <table class="table table-sm ent-grid mb-0">
+                        <thead>
+                            <tr class="text-muted small">
+                                <th>Entitlement</th>
+                                <?php foreach ($ROLES as $r): ?>
+                                    <th class="role-col"><?= htmlspecialchars($r) ?></th>
+                                <?php endforeach; ?>
+                            </tr>
+                        </thead>
+                        <tbody>
+                        <?php foreach ($ents as $ent): ?>
+                            <?php $current = $effective[$ent] ?? ENTITLEMENTS[$ent]; ?>
+                            <tr>
+                                <td class="ent-name"><?= htmlspecialchars($ent) ?></td>
+                                <?php foreach ($ROLES as $r): ?>
+                                    <?php $checked = in_array($r, $current, true) ? 'checked' : ''; ?>
+                                    <td class="role-col">
+                                        <input type="checkbox"
+                                               class="form-check-input"
+                                               name="ent[<?= htmlspecialchars($ent) ?>][]"
+                                               value="<?= htmlspecialchars($r) ?>"
+                                               <?= $checked ?>
+                                               aria-label="<?= htmlspecialchars("$r can $ent") ?>">
+                                    </td>
+                                <?php endforeach; ?>
+                            </tr>
+                        <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        <?php endforeach; ?>
+
+        <div class="d-flex gap-2 mt-3">
+            <button type="submit" class="btn btn-amber-solid">
+                <i class="bi bi-save me-1"></i>Save Mapping
+            </button>
+            <a href="?reset=1" class="btn btn-outline-secondary"
+               onclick="return confirm('Clear admin overrides and restore defaults?')">
+                Restore Defaults
+            </a>
+        </div>
+    </form>
+
+    <?php if (isset($_GET['reset']) && $_GET['reset'] === '1'): ?>
+        <?php saveEntitlementOverrides([]); ?>
+        <script>location.replace('/manage/entitlements');</script>
+    <?php endif; ?>
+
+    <p class="text-secondary text-center small mt-4">
+        Overrides live in <code>tblAppSettings.SettingKey = 'entitlements_overrides'</code>.
+        The default map (restored by "Restore Defaults") is hardcoded in
+        <code>includes/entitlements.php</code>.
+    </p>
+
+</div>
+</body>
+</html>

--- a/appWeb/public_html/manage/entitlements.php
+++ b/appWeb/public_html/manage/entitlements.php
@@ -68,6 +68,7 @@ $groups = [
     'User management' => ['view_users', 'edit_users', 'change_user_roles', 'assign_global_admin', 'delete_users'],
     'Database & operations' => ['view_admin_dashboard', 'view_analytics', 'run_db_install', 'run_db_migrate', 'run_db_backup', 'run_db_restore', 'drop_legacy_tables'],
     'Content moderation' => ['review_song_requests'],
+    'Channel access'     => ['access_alpha', 'access_beta'],
     'Meta' => ['manage_entitlements'],
 ];
 $grouped  = [];

--- a/appWeb/public_html/manage/index.php
+++ b/appWeb/public_html/manage/index.php
@@ -233,6 +233,19 @@ $csrf = csrfToken();
                 </div>
             </div>
             <?php endif; ?>
+            <?php if (userHasEntitlement('review_song_requests', $currentUser['role'] ?? null)): ?>
+            <div class="col-md-4">
+                <div class="card-admin">
+                    <a href="/manage/requests" class="quick-link">
+                        <i class="bi bi-lightbulb d-block mb-2"></i>
+                        <strong>Song Requests</strong>
+                        <div class="small text-muted">
+                            <?= $pendingReqs ?> pending · triage &amp; resolve
+                        </div>
+                    </a>
+                </div>
+            </div>
+            <?php endif; ?>
             <div class="col-md-4">
                 <div class="card-admin">
                     <a href="/" class="quick-link" target="_blank">

--- a/appWeb/public_html/manage/index.php
+++ b/appWeb/public_html/manage/index.php
@@ -141,6 +141,17 @@ $csrf = csrfToken();
                 </div>
             </div>
             <?php endif; ?>
+            <?php if (hasRole($currentUser['role'], 'admin')): ?>
+            <div class="col-md-4">
+                <div class="card-admin">
+                    <a href="/manage/analytics" class="quick-link">
+                        <i class="bi bi-graph-up d-block mb-2"></i>
+                        <strong>Analytics</strong>
+                        <div class="small text-muted">Top songs, searches, and user activity</div>
+                    </a>
+                </div>
+            </div>
+            <?php endif; ?>
             <div class="col-md-4">
                 <div class="card-admin">
                     <a href="/" class="quick-link" target="_blank">

--- a/appWeb/public_html/manage/index.php
+++ b/appWeb/public_html/manage/index.php
@@ -18,29 +18,51 @@ requireEditor();
 $currentUser = getCurrentUser();
 $activePage  = 'dashboard';
 
-/* Gather stats */
+/* Gather stats — all queries updated for the v0.10 PascalCase schema
+   (#407). Each is wrapped in try/catch so a missing table during early
+   setup doesn't blank the whole dashboard. */
 $db = getDb();
-$totalUsers   = (int)$db->query('SELECT COUNT(*) FROM users')->fetchColumn();
-$activeUsers  = (int)$db->query('SELECT COUNT(*) FROM users WHERE is_active = 1')->fetchColumn();
+
+$tryInt = function (string $sql, array $params = []) use ($db): int {
+    try {
+        $stmt = $db->prepare($sql);
+        $stmt->execute($params);
+        return (int)$stmt->fetchColumn();
+    } catch (\Throwable $_e) {
+        return 0;
+    }
+};
+
+$totalUsers    = $tryInt('SELECT COUNT(*) FROM tblUsers');
+$activeUsers   = $tryInt('SELECT COUNT(*) FROM tblUsers WHERE IsActive = 1');
+$activeTokens  = $tryInt('SELECT COUNT(*) FROM tblApiTokens WHERE ExpiresAt > ?', [gmdate('c')]);
+$totalSetlists = $tryInt('SELECT COUNT(*) FROM tblUserSetlists');
+$totalSongs    = $tryInt('SELECT COUNT(*) FROM tblSongs');
+$totalSongbooks= $tryInt('SELECT COUNT(*) FROM tblSongbooks WHERE SongCount > 0');
+$pendingReqs   = $tryInt("SELECT COUNT(*) FROM tblSongRequests WHERE Status = 'pending'");
+$logins24h     = $tryInt('SELECT COUNT(*) FROM tblLoginAttempts WHERE Success = 1 AND AttemptedAt >= (NOW() - INTERVAL 1 DAY)');
+$views24h      = $tryInt('SELECT COUNT(*) FROM tblSongHistory WHERE ViewedAt >= (NOW() - INTERVAL 1 DAY)');
 
 /* User counts by role */
-$roleStmt = $db->query('SELECT role, COUNT(*) as cnt FROM users WHERE is_active = 1 GROUP BY role');
 $roleCounts = [];
-while ($row = $roleStmt->fetch(PDO::FETCH_ASSOC)) {
-    $roleCounts[$row['role']] = (int)$row['cnt'];
-}
+try {
+    $rs = $db->query('SELECT Role, COUNT(*) AS cnt FROM tblUsers WHERE IsActive = 1 GROUP BY Role');
+    while ($row = $rs->fetch(PDO::FETCH_ASSOC)) {
+        $roleCounts[$row['Role']] = (int)$row['cnt'];
+    }
+} catch (\Throwable $_e) {}
 
 /* Recent users (last 10) */
-$recentUsers = $db->query('SELECT id, username, display_name, role, is_active, created_at FROM users ORDER BY created_at DESC LIMIT 10')->fetchAll(PDO::FETCH_ASSOC);
-
-/* Active API tokens count */
-$activeTokens = (int)$db->prepare('SELECT COUNT(*) FROM api_tokens WHERE expires_at > ?')->execute([gmdate('c')]) ? (int)$db->query('SELECT COUNT(*) FROM api_tokens WHERE expires_at > \'' . gmdate('c') . '\'')->fetchColumn() : 0;
-
-/* Total setlists stored */
-$totalSetlists = 0;
+$recentUsers = [];
 try {
-    $totalSetlists = (int)$db->query('SELECT COUNT(*) FROM user_setlists')->fetchColumn();
-} catch (\Exception $e) { /* table may not exist yet */ }
+    $recentUsers = $db->query(
+        'SELECT Id AS id, Username AS username, DisplayName AS display_name,
+                Role AS role, IsActive AS is_active, CreatedAt AS created_at
+           FROM tblUsers
+          ORDER BY CreatedAt DESC
+          LIMIT 10'
+    )->fetchAll(PDO::FETCH_ASSOC);
+} catch (\Throwable $_e) {}
 
 $csrf = csrfToken();
 ?>
@@ -67,32 +89,66 @@ $csrf = csrfToken();
 
     <div class="container py-4" style="max-width: 960px;">
 
-        <h1 class="h4 mb-4"><i class="bi bi-speedometer2 me-2"></i>Dashboard</h1>
+        <h1 class="h4 mb-1"><i class="bi bi-speedometer2 me-2"></i>Admin Portal</h1>
+        <p class="text-secondary small mb-4">
+            Welcome back, <strong><?= htmlspecialchars($currentUser['display_name'] ?? $currentUser['username'] ?? 'admin') ?></strong>.
+            Quick snapshot of the app + shortcuts to every admin surface.
+        </p>
 
-        <!-- Stats Cards -->
+        <!-- Library snapshot -->
+        <h2 class="h6 text-uppercase text-muted small mb-2">Library</h2>
         <div class="row g-3 mb-4">
             <div class="col-6 col-md-3">
                 <div class="card-admin stat-card">
-                    <div class="stat-number"><?= $activeUsers ?></div>
-                    <div class="stat-label">Active Users</div>
+                    <div class="stat-number"><?= number_format($totalSongs) ?></div>
+                    <div class="stat-label">Songs</div>
                 </div>
             </div>
             <div class="col-6 col-md-3">
                 <div class="card-admin stat-card">
-                    <div class="stat-number"><?= $totalUsers ?></div>
-                    <div class="stat-label">Total Users</div>
+                    <div class="stat-number"><?= number_format($totalSongbooks) ?></div>
+                    <div class="stat-label">Songbooks</div>
                 </div>
             </div>
             <div class="col-6 col-md-3">
                 <div class="card-admin stat-card">
-                    <div class="stat-number"><?= $activeTokens ?></div>
-                    <div class="stat-label">Active Tokens</div>
+                    <div class="stat-number"><?= number_format($totalSetlists) ?></div>
+                    <div class="stat-label">Synced setlists</div>
                 </div>
             </div>
             <div class="col-6 col-md-3">
                 <div class="card-admin stat-card">
-                    <div class="stat-number"><?= $totalSetlists ?></div>
-                    <div class="stat-label">Synced Setlists</div>
+                    <div class="stat-number"><?= number_format($pendingReqs) ?></div>
+                    <div class="stat-label">Pending requests</div>
+                </div>
+            </div>
+        </div>
+
+        <!-- People + activity -->
+        <h2 class="h6 text-uppercase text-muted small mb-2">People &amp; activity</h2>
+        <div class="row g-3 mb-4">
+            <div class="col-6 col-md-3">
+                <div class="card-admin stat-card">
+                    <div class="stat-number"><?= number_format($activeUsers) ?></div>
+                    <div class="stat-label">Active users</div>
+                </div>
+            </div>
+            <div class="col-6 col-md-3">
+                <div class="card-admin stat-card">
+                    <div class="stat-number"><?= number_format($totalUsers) ?></div>
+                    <div class="stat-label">Total users</div>
+                </div>
+            </div>
+            <div class="col-6 col-md-3">
+                <div class="card-admin stat-card">
+                    <div class="stat-number"><?= number_format($logins24h) ?></div>
+                    <div class="stat-label">Logins (24 h)</div>
+                </div>
+            </div>
+            <div class="col-6 col-md-3">
+                <div class="card-admin stat-card">
+                    <div class="stat-number"><?= number_format($views24h) ?></div>
+                    <div class="stat-label">Song views (24 h)</div>
                 </div>
             </div>
         </div>
@@ -154,8 +210,19 @@ $csrf = csrfToken();
             <?php endif; ?>
             <?php
                 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'entitlements.php';
-                if (userHasEntitlement('manage_entitlements', $currentUser['role'] ?? null)):
             ?>
+            <?php if (userHasEntitlement('view_admin_dashboard', $currentUser['role'] ?? null)): ?>
+            <div class="col-md-4">
+                <div class="card-admin">
+                    <a href="/manage/setup-database" class="quick-link">
+                        <i class="bi bi-database-gear d-block mb-2"></i>
+                        <strong>Database Setup</strong>
+                        <div class="small text-muted">Install, migrate, backup, restore, cleanup</div>
+                    </a>
+                </div>
+            </div>
+            <?php endif; ?>
+            <?php if (userHasEntitlement('manage_entitlements', $currentUser['role'] ?? null)): ?>
             <div class="col-md-4">
                 <div class="card-admin">
                     <a href="/manage/entitlements" class="quick-link">

--- a/appWeb/public_html/manage/index.php
+++ b/appWeb/public_html/manage/index.php
@@ -207,6 +207,15 @@ $csrf = csrfToken();
                     </a>
                 </div>
             </div>
+            <div class="col-md-4">
+                <div class="card-admin">
+                    <a href="/manage/revisions" class="quick-link">
+                        <i class="bi bi-clock-history d-block mb-2"></i>
+                        <strong>Revisions</strong>
+                        <div class="small text-muted">Audit song edits; open any row in the editor to diff / restore</div>
+                    </a>
+                </div>
+            </div>
             <?php endif; ?>
             <?php
                 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'entitlements.php';

--- a/appWeb/public_html/manage/index.php
+++ b/appWeb/public_html/manage/index.php
@@ -152,6 +152,20 @@ $csrf = csrfToken();
                 </div>
             </div>
             <?php endif; ?>
+            <?php
+                require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'entitlements.php';
+                if (userHasEntitlement('manage_entitlements', $currentUser['role'] ?? null)):
+            ?>
+            <div class="col-md-4">
+                <div class="card-admin">
+                    <a href="/manage/entitlements" class="quick-link">
+                        <i class="bi bi-key d-block mb-2"></i>
+                        <strong>Entitlements</strong>
+                        <div class="small text-muted">Assign capabilities to roles</div>
+                    </a>
+                </div>
+            </div>
+            <?php endif; ?>
             <div class="col-md-4">
                 <div class="card-admin">
                     <a href="/" class="quick-link" target="_blank">

--- a/appWeb/public_html/manage/requests.php
+++ b/appWeb/public_html/manage/requests.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Admin Song-Request Queue (#403)
+ *
+ * Admin triage view for user-submitted song requests in
+ * tblSongRequests. Supports filtering by status, per-row status
+ * change, and "Start editing" which generates a new song-id draft
+ * and jumps into the editor with a query parameter linking back.
+ *
+ * Access: `review_song_requests` entitlement (editor / admin /
+ * global_admin by default).
+ */
+
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'entitlements.php';
+
+if (!isAuthenticated()) {
+    header('Location: /manage/login');
+    exit;
+}
+$currentUser = getCurrentUser();
+if (!$currentUser || !userHasEntitlement('review_song_requests', $currentUser['role'] ?? null)) {
+    http_response_code(403);
+    echo '<!DOCTYPE html><html><body><h1>403 — review_song_requests required</h1></body></html>';
+    exit;
+}
+
+$statuses = ['pending', 'reviewed', 'added', 'declined'];
+$filter   = (string)($_GET['status'] ?? 'pending');
+if (!in_array($filter, $statuses, true) && $filter !== 'all') $filter = 'pending';
+
+$flash = '';
+$err   = '';
+
+/* --- POST: update status / notes --- */
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $id           = (int)($_POST['id']            ?? 0);
+    $newStatus    = (string)($_POST['new_status'] ?? '');
+    $adminNotes   = trim((string)($_POST['admin_notes'] ?? ''));
+    $resolvedSong = trim((string)($_POST['resolved_song_id'] ?? ''));
+
+    if ($id <= 0 || !in_array($newStatus, $statuses, true)) {
+        $err = 'Invalid request.';
+    } else {
+        try {
+            $db = getDb();
+            $stmt = $db->prepare(
+                'UPDATE tblSongRequests
+                    SET Status = ?, AdminNotes = ?, ResolvedSongId = ?
+                  WHERE Id = ?'
+            );
+            $stmt->execute([$newStatus, $adminNotes, $resolvedSong ?: null, $id]);
+            $flash = 'Request #' . $id . ' updated.';
+        } catch (\Throwable $e) {
+            $err = 'Database error: ' . $e->getMessage();
+        }
+    }
+}
+
+/* --- GET: fetch rows --- */
+$rows = [];
+try {
+    $db = getDb();
+    if ($filter === 'all') {
+        $stmt = $db->query(
+            'SELECT r.*, u.Username AS requested_by
+               FROM tblSongRequests r
+               LEFT JOIN tblUsers u ON u.Id = r.UserId
+              ORDER BY r.CreatedAt DESC
+              LIMIT 500'
+        );
+    } else {
+        $stmt = $db->prepare(
+            'SELECT r.*, u.Username AS requested_by
+               FROM tblSongRequests r
+               LEFT JOIN tblUsers u ON u.Id = r.UserId
+              WHERE r.Status = ?
+              ORDER BY r.CreatedAt DESC
+              LIMIT 500'
+        );
+        $stmt->execute([$filter]);
+    }
+    $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+} catch (\Throwable $e) { $err = $e->getMessage(); }
+
+$counts = [];
+try {
+    $cs = $db->query('SELECT Status, COUNT(*) AS cnt FROM tblSongRequests GROUP BY Status');
+    while ($row = $cs->fetch(PDO::FETCH_ASSOC)) {
+        $counts[$row['Status']] = (int)$row['cnt'];
+    }
+} catch (\Throwable $_e) {}
+
+?>
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Song Requests — iHymns Admin</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
+          integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
+          integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">
+    <link rel="stylesheet" href="/css/app.css?v=<?= filemtime(dirname(__DIR__) . '/css/app.css') ?>">
+    <link rel="stylesheet" href="/css/admin.css?v=<?= filemtime(dirname(__DIR__) . '/css/admin.css') ?>">
+</head>
+<body>
+
+<nav class="navbar-admin d-flex align-items-center justify-content-between">
+    <a class="navbar-brand" href="/manage/"><i class="bi bi-lightbulb me-2"></i>Song Requests</a>
+    <a href="/manage/" class="btn btn-sm btn-outline-secondary">Back to Dashboard</a>
+</nav>
+
+<div class="container py-4" style="max-width: 1100px;">
+
+    <?php if ($flash): ?>
+        <div class="alert alert-success py-2"><?= htmlspecialchars($flash) ?></div>
+    <?php endif; ?>
+    <?php if ($err): ?>
+        <div class="alert alert-danger py-2"><?= htmlspecialchars($err) ?></div>
+    <?php endif; ?>
+
+    <div class="d-flex flex-wrap justify-content-between align-items-center mb-3 gap-2">
+        <h1 class="h4 mb-0">User-submitted song requests</h1>
+        <div class="btn-group btn-group-sm" role="group">
+            <?php foreach (array_merge($statuses, ['all']) as $s): ?>
+                <?php $active = $filter === $s ? 'btn-amber-solid' : 'btn-outline-secondary'; ?>
+                <a class="btn <?= $active ?>" href="?status=<?= htmlspecialchars($s) ?>">
+                    <?= htmlspecialchars(ucfirst($s)) ?>
+                    <?php if (isset($counts[$s])): ?>
+                        <span class="badge bg-body-secondary ms-1"><?= $counts[$s] ?></span>
+                    <?php endif; ?>
+                </a>
+            <?php endforeach; ?>
+        </div>
+    </div>
+
+    <?php if (!$rows): ?>
+        <div class="card-admin p-4 text-center text-muted">No requests in this bucket.</div>
+    <?php else: ?>
+        <div class="card-admin p-0">
+            <table class="table table-sm table-hover mb-0">
+                <thead>
+                    <tr class="text-muted small">
+                        <th>#</th>
+                        <th>Title</th>
+                        <th>Songbook</th>
+                        <th>Submitted</th>
+                        <th>By</th>
+                        <th>Status</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                <?php foreach ($rows as $r): ?>
+                    <tr>
+                        <td class="text-muted"><?= (int)$r['Id'] ?></td>
+                        <td>
+                            <strong><?= htmlspecialchars($r['Title']) ?></strong>
+                            <?php if (!empty($r['Details'])): ?>
+                                <div class="small text-muted"><?= nl2br(htmlspecialchars(mb_substr($r['Details'], 0, 160))) ?></div>
+                            <?php endif; ?>
+                        </td>
+                        <td class="text-muted"><?= htmlspecialchars($r['Songbook'] ?: '—') ?></td>
+                        <td class="text-muted small">
+                            <?= htmlspecialchars(substr((string)$r['CreatedAt'], 0, 16)) ?>
+                        </td>
+                        <td class="text-muted">
+                            <?php if (!empty($r['requested_by'])): ?>
+                                @<?= htmlspecialchars($r['requested_by']) ?>
+                            <?php elseif (!empty($r['ContactEmail'])): ?>
+                                <a href="mailto:<?= htmlspecialchars($r['ContactEmail']) ?>"><?= htmlspecialchars($r['ContactEmail']) ?></a>
+                            <?php else: ?>
+                                anon
+                            <?php endif; ?>
+                        </td>
+                        <td>
+                            <span class="badge bg-<?= [
+                                'pending' => 'warning text-dark',
+                                'reviewed' => 'info',
+                                'added' => 'success',
+                                'declined' => 'secondary',
+                            ][$r['Status']] ?? 'secondary' ?>">
+                                <?= htmlspecialchars($r['Status']) ?>
+                            </span>
+                        </td>
+                        <td class="text-end">
+                            <button class="btn btn-sm btn-outline-primary" data-bs-toggle="collapse"
+                                    data-bs-target="#row-<?= (int)$r['Id'] ?>">
+                                Review
+                            </button>
+                        </td>
+                    </tr>
+                    <tr class="collapse" id="row-<?= (int)$r['Id'] ?>">
+                        <td colspan="7" class="bg-body-secondary p-3">
+                            <form method="post" class="row g-2">
+                                <input type="hidden" name="id" value="<?= (int)$r['Id'] ?>">
+                                <div class="col-md-3">
+                                    <label class="form-label small">Status</label>
+                                    <select name="new_status" class="form-select form-select-sm">
+                                        <?php foreach ($statuses as $s): ?>
+                                            <option value="<?= $s ?>" <?= $r['Status'] === $s ? 'selected' : '' ?>>
+                                                <?= htmlspecialchars(ucfirst($s)) ?>
+                                            </option>
+                                        <?php endforeach; ?>
+                                    </select>
+                                </div>
+                                <div class="col-md-3">
+                                    <label class="form-label small">Resolved SongId (optional)</label>
+                                    <input type="text" name="resolved_song_id" class="form-control form-control-sm"
+                                           value="<?= htmlspecialchars((string)($r['ResolvedSongId'] ?? '')) ?>"
+                                           placeholder="e.g. MP-1234">
+                                </div>
+                                <div class="col-md-6">
+                                    <label class="form-label small">Admin notes</label>
+                                    <input type="text" name="admin_notes" class="form-control form-control-sm"
+                                           value="<?= htmlspecialchars($r['AdminNotes'] ?? '') ?>">
+                                </div>
+                                <div class="col-12 d-flex gap-2 mt-2">
+                                    <button type="submit" class="btn btn-sm btn-amber-solid">Save</button>
+                                    <a href="/manage/editor/" class="btn btn-sm btn-outline-primary">
+                                        <i class="bi bi-pencil-square me-1"></i>Open editor
+                                    </a>
+                                </div>
+                            </form>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    <?php endif; ?>
+
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-zKzgIZcXU99qF1nNW9g+x1znB5NhCPs9qZeGzUnnFOaHJF9jCCKySBjq3vIKabk/"
+        crossorigin="anonymous"></script>
+</body>
+</html>

--- a/appWeb/public_html/manage/requests.php
+++ b/appWeb/public_html/manage/requests.php
@@ -37,6 +37,11 @@ $err   = '';
 
 /* --- POST: update status / notes --- */
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!validateCsrf((string)($_POST['csrf_token'] ?? ''))) {
+        http_response_code(403);
+        echo 'Invalid CSRF token';
+        exit;
+    }
     $id           = (int)($_POST['id']            ?? 0);
     $newStatus    = (string)($_POST['new_status'] ?? '');
     $adminNotes   = trim((string)($_POST['admin_notes'] ?? ''));
@@ -55,7 +60,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $stmt->execute([$newStatus, $adminNotes, $resolvedSong ?: null, $id]);
             $flash = 'Request #' . $id . ' updated.';
         } catch (\Throwable $e) {
-            $err = 'Database error: ' . $e->getMessage();
+            error_log('[manage/requests.php] ' . $e->getMessage());
+            $err = 'Database error — check server logs for details.';
         }
     }
 }
@@ -84,7 +90,10 @@ try {
         $stmt->execute([$filter]);
     }
     $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
-} catch (\Throwable $e) { $err = $e->getMessage(); }
+} catch (\Throwable $e) {
+    error_log('[manage/requests.php] ' . $e->getMessage());
+    $err = 'Could not load requests — check server logs for details.';
+}
 
 $counts = [];
 try {
@@ -198,6 +207,7 @@ try {
                     <tr class="collapse" id="row-<?= (int)$r['Id'] ?>">
                         <td colspan="7" class="bg-body-secondary p-3">
                             <form method="post" class="row g-2">
+                                <input type="hidden" name="csrf_token" value="<?= htmlspecialchars(csrfToken()) ?>">
                                 <input type="hidden" name="id" value="<?= (int)$r['Id'] ?>">
                                 <div class="col-md-3">
                                     <label class="form-label small">Status</label>

--- a/appWeb/public_html/manage/revisions.php
+++ b/appWeb/public_html/manage/revisions.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Admin Revisions Audit (#400)
+ *
+ * Global revision log across every song. Filters by user, date range,
+ * song id, and action. Each row links into the editor with the song
+ * pre-selected (the existing History modal there supplies the full
+ * diff + restore flow).
+ */
+
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+requireAdmin();
+
+$currentUser = getCurrentUser();
+$db = getDb();
+
+$filterUser   = trim((string)($_GET['user']   ?? ''));
+$filterSong   = trim((string)($_GET['song']   ?? ''));
+$filterAction = trim((string)($_GET['action'] ?? ''));
+$filterDays   = (int)($_GET['days']   ?? 30);
+if (!in_array($filterDays, [7, 30, 90, 365], true)) { $filterDays = 30; }
+$since = (new DateTime("-{$filterDays} days"))->format('Y-m-d H:i:s');
+
+$where  = ['r.CreatedAt >= :since'];
+$params = [':since' => $since];
+if ($filterUser !== '') {
+    $where[] = '(u.Username LIKE :user OR u.Email LIKE :user)';
+    $params[':user'] = '%' . $filterUser . '%';
+}
+if ($filterSong !== '') {
+    $where[] = 'r.SongId LIKE :song';
+    $params[':song'] = '%' . $filterSong . '%';
+}
+if (in_array($filterAction, ['create', 'edit', 'restore', 'delete'], true)) {
+    $where[] = 'r.Action = :action';
+    $params[':action'] = $filterAction;
+}
+$whereSql = 'WHERE ' . implode(' AND ', $where);
+
+$rows = [];
+$total = 0;
+try {
+    $countStmt = $db->prepare(
+        'SELECT COUNT(*)
+           FROM tblSongRevisions r
+           LEFT JOIN tblUsers u ON u.Id = r.UserId ' . $whereSql
+    );
+    $countStmt->execute($params);
+    $total = (int)$countStmt->fetchColumn();
+
+    $stmt = $db->prepare(
+        'SELECT r.Id, r.SongId, r.Action, r.CreatedAt, r.UserId, u.Username,
+                s.Title AS SongTitle, s.SongbookAbbr, s.Number
+           FROM tblSongRevisions r
+           LEFT JOIN tblUsers u ON u.Id = r.UserId
+           LEFT JOIN tblSongs s ON s.SongId = r.SongId ' . $whereSql . '
+           ORDER BY r.CreatedAt DESC, r.Id DESC
+           LIMIT 200'
+    );
+    $stmt->execute($params);
+    $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+} catch (\Throwable $e) {
+    error_log('[manage revisions] ' . $e->getMessage());
+    $rows = [];
+}
+
+?>
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Revisions — iHymns Admin</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
+          integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
+          integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">
+    <link rel="stylesheet" href="/css/app.css?v=<?= filemtime(dirname(__DIR__) . '/css/app.css') ?>">
+    <link rel="stylesheet" href="/css/admin.css?v=<?= filemtime(dirname(__DIR__) . '/css/admin.css') ?>">
+</head>
+<body>
+
+<nav class="navbar-admin d-flex align-items-center justify-content-between">
+    <a class="navbar-brand" href="/manage/"><i class="bi bi-clock-history me-2"></i>iHymns Revisions</a>
+    <div class="d-flex align-items-center gap-2">
+        <span class="text-muted small"><?= htmlspecialchars($currentUser['username'] ?? '') ?></span>
+        <a href="/manage/" class="btn btn-sm btn-outline-secondary">Back to Dashboard</a>
+    </div>
+</nav>
+
+<div class="container py-4" style="max-width: 1200px;">
+
+    <div class="d-flex flex-wrap align-items-end justify-content-between mb-3 gap-2">
+        <h1 class="h4 mb-0">Song edit revisions</h1>
+        <span class="text-muted small">
+            <?= number_format(count($rows)) ?> showing (of <?= number_format($total) ?> in this range)
+        </span>
+    </div>
+
+    <form method="get" class="card-admin p-3 mb-3">
+        <div class="row g-2 align-items-end">
+            <div class="col-md-3">
+                <label for="f-user" class="form-label small mb-1">User (name/email contains)</label>
+                <input id="f-user" name="user" type="text" class="form-control form-control-sm"
+                       value="<?= htmlspecialchars($filterUser) ?>" placeholder="e.g. salem">
+            </div>
+            <div class="col-md-3">
+                <label for="f-song" class="form-label small mb-1">Song ID contains</label>
+                <input id="f-song" name="song" type="text" class="form-control form-control-sm"
+                       value="<?= htmlspecialchars($filterSong) ?>" placeholder="e.g. CP-">
+            </div>
+            <div class="col-md-2">
+                <label for="f-action" class="form-label small mb-1">Action</label>
+                <select id="f-action" name="action" class="form-select form-select-sm">
+                    <option value="">All</option>
+                    <?php foreach (['create', 'edit', 'restore', 'delete'] as $a): ?>
+                        <option value="<?= $a ?>" <?= $filterAction === $a ? 'selected' : '' ?>><?= $a ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <div class="col-md-2">
+                <label for="f-days" class="form-label small mb-1">Last N days</label>
+                <select id="f-days" name="days" class="form-select form-select-sm">
+                    <?php foreach ([7, 30, 90, 365] as $d): ?>
+                        <option value="<?= $d ?>" <?= $filterDays === $d ? 'selected' : '' ?>><?= $d ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <div class="col-md-2 d-flex gap-2">
+                <button type="submit" class="btn btn-sm btn-amber-solid w-100">Filter</button>
+                <a href="/manage/revisions" class="btn btn-sm btn-outline-secondary">Reset</a>
+            </div>
+        </div>
+    </form>
+
+    <div class="card-admin p-0">
+        <?php if (!$rows): ?>
+            <p class="text-muted p-4 mb-0">No revisions match these filters.</p>
+        <?php else: ?>
+            <div class="table-responsive">
+                <table class="table table-dark table-hover mb-0 align-middle small">
+                    <thead>
+                        <tr>
+                            <th scope="col">When</th>
+                            <th scope="col">Action</th>
+                            <th scope="col">Song</th>
+                            <th scope="col">User</th>
+                            <th scope="col" class="text-end">Revision</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($rows as $r):
+                            $badgeClass = match ($r['Action']) {
+                                'create'  => 'bg-success',
+                                'restore' => 'bg-info',
+                                'delete'  => 'bg-danger',
+                                default   => 'bg-secondary',
+                            };
+                        ?>
+                            <tr>
+                                <td class="text-muted"><?= htmlspecialchars($r['CreatedAt']) ?></td>
+                                <td><span class="badge <?= $badgeClass ?>"><?= htmlspecialchars($r['Action']) ?></span></td>
+                                <td>
+                                    <code><?= htmlspecialchars($r['SongId']) ?></code>
+                                    <?php if ($r['SongTitle']): ?>
+                                        <span class="text-muted">— <?= htmlspecialchars($r['SongTitle']) ?></span>
+                                    <?php endif; ?>
+                                </td>
+                                <td><?= htmlspecialchars($r['Username'] ?? '—') ?></td>
+                                <td class="text-end">
+                                    <a class="btn btn-sm btn-outline-info"
+                                       href="/manage/editor/?open=<?= urlencode($r['SongId']) ?>&tab=history"
+                                       title="Open this song in the editor — the History modal will show every revision in full">
+                                        Open in editor
+                                    </a>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
+        <?php endif; ?>
+    </div>
+
+    <p class="small text-muted mt-3 mb-0">
+        <i class="bi bi-info-circle me-1"></i>
+        This table shows the 200 most recent matching rows. Full diffs and
+        the restore action live in the editor's History modal (click
+        <strong>Open in editor</strong> on any row).
+    </p>
+
+</div>
+
+</body>
+</html>

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -562,12 +562,22 @@ if ($hasCredentials && defined('DB_HOST')) {
                                     <?php endforeach; ?>
                                 </select>
                                 <button type="submit" class="btn btn-sm btn-outline-warning <?= $hasCredentials ? '' : 'disabled' ?>">Preview</button>
+                                <button type="submit" name="preflight" value="1"
+                                        class="btn btn-sm btn-outline-info <?= $hasCredentials ? '' : 'disabled' ?>"
+                                        title="Parse the backup and show a summary without touching the database (#405)">
+                                    Pre-flight
+                                </button>
                                 <button type="submit" name="confirm" value="1"
                                         class="btn btn-sm btn-danger <?= $hasCredentials ? '' : 'disabled' ?>"
-                                        onclick="return prompt('Type RESTORE (all caps) to confirm replacing every table with the selected backup.') === 'RESTORE'">
+                                        onclick="return prompt('Type RESTORE (all caps) to confirm replacing every table with the selected backup. A snapshot of current state is saved automatically before the restore runs.') === 'RESTORE'">
                                     Restore
                                 </button>
                             </form>
+                            <p class="text-muted small mb-0">
+                                <i class="bi bi-info-circle me-1"></i>
+                                Restore always takes a pre-restore snapshot first. Data INSERTs
+                                are transactional — a failure rolls data back automatically.
+                            </p>
                         <?php else: ?>
                             <p class="text-muted small mb-2">No backups found in <code>data_share/backups/</code>.</p>
                         <?php endif; ?>

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -184,6 +184,7 @@ if ($action !== '') {
         'users'       => 'migrate-users.php',
         'cleanup'     => 'cleanup.php',
         'backup'      => 'backup.php',
+        'restore'     => 'restore.php',
         'drop-legacy' => 'drop-legacy-tables.php',
     ];
 
@@ -460,10 +461,52 @@ if ($hasCredentials && defined('DB_HOST')) {
                     </div>
                 </div>
             </div>
+            <?php
+                /* List available backups for restore (#405). */
+                $backupFiles = [];
+                $backupDir = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'data_share' . DIRECTORY_SEPARATOR . 'backups';
+                if (is_dir($backupDir)) {
+                    foreach (scandir($backupDir) ?: [] as $f) {
+                        if (preg_match('/^ihymns-backup-[0-9-]+\.sql(?:\.gz)?$/', $f)) {
+                            $backupFiles[] = $f;
+                        }
+                    }
+                    rsort($backupFiles);
+                }
+            ?>
             <div class="col-md-6">
                 <div class="card bg-dark border-danger h-100">
                     <div class="card-body">
-                        <h5 class="card-title">6. Drop Legacy Tables</h5>
+                        <h5 class="card-title">6. Restore from Backup</h5>
+                        <p class="card-text text-secondary small">
+                            Replace every table in the database with data from a previous backup.
+                            <strong>Destructive — consider running a fresh Backup first.</strong>
+                        </p>
+                        <?php if (!$backupFiles): ?>
+                            <p class="text-muted small mb-0">No backups found in <code>data_share/backups/</code>.</p>
+                        <?php else: ?>
+                            <form action="" method="get" class="d-flex gap-2 flex-wrap">
+                                <input type="hidden" name="action" value="restore">
+                                <select name="file" class="form-select form-select-sm" style="flex:1 1 200px">
+                                    <?php foreach ($backupFiles as $f): ?>
+                                        <option value="<?= htmlspecialchars($f) ?>"><?= htmlspecialchars($f) ?></option>
+                                    <?php endforeach; ?>
+                                </select>
+                                <button type="submit" class="btn btn-sm btn-outline-warning <?= $hasCredentials ? '' : 'disabled' ?>">Preview</button>
+                                <button type="submit" name="confirm" value="1"
+                                        class="btn btn-sm btn-danger <?= $hasCredentials ? '' : 'disabled' ?>"
+                                        onclick="return prompt('Type RESTORE (all caps) to confirm replacing every table with the selected backup.') === 'RESTORE'">
+                                    Restore
+                                </button>
+                            </form>
+                        <?php endif; ?>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="card bg-dark border-danger h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">7. Drop Legacy Tables</h5>
                         <p class="card-text text-secondary small">
                             Drop any tables in the database that are <strong>not</strong>
                             part of the current <code>schema.sql</code>. Useful after

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -75,6 +75,16 @@ $credFormValues = [
 $credError   = '';
 $credSuccess = '';
 
+/* CSRF gate for every POST on this page — the credentials form AND
+   the backup-upload form go through here. */
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!validateCsrf((string)($_POST['csrf_token'] ?? ''))) {
+        http_response_code(403);
+        echo 'Invalid CSRF token';
+        exit;
+    }
+}
+
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['action'] ?? '') === 'save-credentials') {
     $host   = trim((string)($_POST['host']    ?? ''));
     $port   = trim((string)($_POST['port']    ?? '3306'));
@@ -308,6 +318,7 @@ if ($hasCredentials && defined('DB_HOST')) {
                     <?php endif; ?>
                 </p>
                 <form method="post" action="" autocomplete="off">
+                    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars(csrfToken()) ?>">
                     <input type="hidden" name="action" value="save-credentials">
                     <div class="row g-3">
                         <div class="col-md-8">
@@ -564,6 +575,7 @@ if ($hasCredentials && defined('DB_HOST')) {
                         <hr class="my-2">
                         <p class="text-muted small mb-2">Or upload a `.sql.gz` / `.sql` from your computer:</p>
                         <form action="" method="post" enctype="multipart/form-data" class="d-flex gap-2 flex-wrap">
+                            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars(csrfToken()) ?>">
                             <input type="hidden" name="action" value="upload-backup">
                             <input type="file" name="backup" accept=".sql,.sql.gz,.gz" required
                                    class="form-control form-control-sm" style="flex:1 1 200px">

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -473,6 +473,62 @@ if ($hasCredentials && defined('DB_HOST')) {
                     }
                     rsort($backupFiles);
                 }
+
+                /* Handle an admin-supplied upload (#405). Accepts .sql + .sql.gz
+                   files matching the backup naming pattern, drops them into
+                   the server's backups directory, and logs the upload. */
+                $uploadMsg = '';
+                if ($_SERVER['REQUEST_METHOD'] === 'POST'
+                    && ($_POST['action'] ?? '') === 'upload-backup'
+                    && !empty($_FILES['backup']['name'])) {
+                    $f = $_FILES['backup'];
+                    $safeName = basename((string)$f['name']);
+                    if ($f['error'] !== UPLOAD_ERR_OK) {
+                        $uploadMsg = 'Upload failed (error ' . (int)$f['error'] . ').';
+                    } elseif (!preg_match('/^ihymns-backup-[0-9-]+\.sql(?:\.gz)?$/', $safeName)) {
+                        $uploadMsg = 'Filename must match ihymns-backup-YYYYMMDD-HHMMSS.sql(.gz).';
+                    } elseif ((int)$f['size'] > 256 * 1024 * 1024) {
+                        $uploadMsg = 'Upload rejected: file exceeds 256 MB.';
+                    } else {
+                        if (!is_dir($backupDir)) { @mkdir($backupDir, 0755, true); }
+                        $dest = $backupDir . DIRECTORY_SEPARATOR . $safeName;
+                        if (move_uploaded_file($f['tmp_name'], $dest)) {
+                            @chmod($dest, 0640);
+                            $uploadMsg = 'Uploaded: ' . $safeName . ' — pick it from the list below to restore.';
+                            /* Audit-log entry (#405). Silent no-op if the table is
+                               absent or the activity log helper isn't available. */
+                            try {
+                                $auditDb = getDbMysqli();
+                                $auditUser = $currentUser['Username'] ?? 'unknown';
+                                $auditSql = sprintf(
+                                    'backup upload by %s: %s (%d bytes)',
+                                    $auditUser, $safeName, (int)$f['size']
+                                );
+                                $stmt = $auditDb->prepare(
+                                    'INSERT INTO tblActivityLog (UserId, ActionType, Details) VALUES (?, ?, ?)'
+                                );
+                                if ($stmt) {
+                                    $uid = isset($currentUser['Id']) ? (int)$currentUser['Id'] : 0;
+                                    $action = 'backup_upload';
+                                    $stmt->bind_param('iss', $uid, $action, $auditSql);
+                                    @$stmt->execute();
+                                    $stmt->close();
+                                }
+                            } catch (\Throwable $_e) { /* best effort */ }
+                            /* Refresh the file list so the uploaded file appears
+                               in the dropdown immediately. */
+                            $backupFiles = [];
+                            foreach (scandir($backupDir) ?: [] as $bf) {
+                                if (preg_match('/^ihymns-backup-[0-9-]+\.sql(?:\.gz)?$/', $bf)) {
+                                    $backupFiles[] = $bf;
+                                }
+                            }
+                            rsort($backupFiles);
+                        } else {
+                            $uploadMsg = 'Could not save the uploaded file.';
+                        }
+                    }
+                }
             ?>
             <div class="col-md-6">
                 <div class="card bg-dark border-danger h-100">
@@ -482,10 +538,12 @@ if ($hasCredentials && defined('DB_HOST')) {
                             Replace every table in the database with data from a previous backup.
                             <strong>Destructive — consider running a fresh Backup first.</strong>
                         </p>
-                        <?php if (!$backupFiles): ?>
-                            <p class="text-muted small mb-0">No backups found in <code>data_share/backups/</code>.</p>
-                        <?php else: ?>
-                            <form action="" method="get" class="d-flex gap-2 flex-wrap">
+                        <?php if ($uploadMsg): ?>
+                            <div class="alert alert-info py-2 small"><?= htmlspecialchars($uploadMsg) ?></div>
+                        <?php endif; ?>
+
+                        <?php if ($backupFiles): ?>
+                            <form action="" method="get" class="d-flex gap-2 flex-wrap mb-2">
                                 <input type="hidden" name="action" value="restore">
                                 <select name="file" class="form-select form-select-sm" style="flex:1 1 200px">
                                     <?php foreach ($backupFiles as $f): ?>
@@ -499,7 +557,20 @@ if ($hasCredentials && defined('DB_HOST')) {
                                     Restore
                                 </button>
                             </form>
+                        <?php else: ?>
+                            <p class="text-muted small mb-2">No backups found in <code>data_share/backups/</code>.</p>
                         <?php endif; ?>
+
+                        <hr class="my-2">
+                        <p class="text-muted small mb-2">Or upload a `.sql.gz` / `.sql` from your computer:</p>
+                        <form action="" method="post" enctype="multipart/form-data" class="d-flex gap-2 flex-wrap">
+                            <input type="hidden" name="action" value="upload-backup">
+                            <input type="file" name="backup" accept=".sql,.sql.gz,.gz" required
+                                   class="form-control form-control-sm" style="flex:1 1 200px">
+                            <button type="submit" class="btn btn-sm btn-outline-secondary <?= $hasCredentials ? '' : 'disabled' ?>">
+                                Upload
+                            </button>
+                        </form>
                     </div>
                 </div>
             </div>

--- a/appWeb/public_html/service-worker.js.php
+++ b/appWeb/public_html/service-worker.js.php
@@ -743,6 +743,124 @@ self.addEventListener('message', (event) => {
         });
     }
 
+    /* Pre-cache a batch of audio URLs into iHymns-media-v1 (#401).
+     * Settings page sends this when the "Include audio in offline
+     * downloads" toggle is on — once per songbook covered by the
+     * current download, after CACHE_ALL_SONGS has been dispatched.
+     * Message: { type: 'CACHE_AUDIO_URLS', urls: [...], songbook: 'XX' }
+     */
+    if (event.data.type === 'CACHE_AUDIO_URLS' && Array.isArray(event.data.urls)) {
+        const urls = event.data.urls;
+        const songbook = event.data.songbook || '';
+
+        caches.open('iHymns-media-v1').then(async (cache) => {
+            let completed = 0, failed = 0;
+            const total = urls.length;
+            const BATCH = 6;
+
+            for (let i = 0; i < urls.length; i += BATCH) {
+                const batch = urls.slice(i, i + BATCH);
+                await Promise.allSettled(batch.map(async (u) => {
+                    try {
+                        const cacheUrl = new URL(u, self.location.origin);
+                        if (cacheUrl.origin !== self.location.origin) { failed++; return; }
+                        const existing = await cache.match(u);
+                        if (existing) { completed++; return; }
+                        const r = await fetch(u);
+                        if (r.ok) { await cache.put(u, r); completed++; }
+                        else { failed++; }
+                    } catch { failed++; }
+                }));
+                notifyClients({
+                    type: 'CACHE_AUDIO_PROGRESS',
+                    songbook, completed, failed, total,
+                });
+            }
+            notifyClients({
+                type: 'CACHE_AUDIO_PROGRESS',
+                songbook, completed, failed, total, done: true,
+            });
+        });
+    }
+
+    /* Evict every cached entry belonging to one songbook (#401).
+     * Removes matching entries from RECENT_CACHE (song HTML pages
+     * whose id starts with <songbook>-) and iHymns-media-v1 (audio +
+     * sheet music under /data/audio/<songbook>/ and /data/music/<songbook>/).
+     * Message: { type: 'EVICT_SONGBOOK', songbook: 'XX' }
+     */
+    if (event.data.type === 'EVICT_SONGBOOK' && typeof event.data.songbook === 'string') {
+        const songbook = event.data.songbook;
+        if (!/^[A-Za-z0-9_-]{1,16}$/.test(songbook)) return;
+        const prefix = songbook.toUpperCase() + '-';
+        (async () => {
+            let removed = 0;
+            try {
+                const recent = await caches.open(RECENT_CACHE);
+                const keys = await recent.keys();
+                for (const req of keys) {
+                    const id = new URL(req.url).searchParams.get('id') || '';
+                    if (id.toUpperCase().startsWith(prefix)) {
+                        if (await recent.delete(req)) removed++;
+                    }
+                }
+            } catch {}
+            try {
+                const media = await caches.open('iHymns-media-v1');
+                const keys = await media.keys();
+                const lcSongbook = songbook.toLowerCase();
+                for (const req of keys) {
+                    const path = new URL(req.url).pathname.toLowerCase();
+                    if (path.includes(`/data/audio/${lcSongbook}/`)
+                        || path.includes(`/data/music/${lcSongbook}/`)) {
+                        if (await media.delete(req)) removed++;
+                    }
+                }
+            } catch {}
+            notifyClients({ type: 'SONGBOOK_EVICTED', songbook, removed });
+        })();
+    }
+
+    /* Report total bytes cached per songbook across both caches (#401).
+     * Returns { type: 'CACHE_SIZES', sizes: { 'CP': 1234567, ... } } to the
+     * requesting client. Sizes are summed from Content-Length headers (when
+     * present) plus a per-entry fallback estimate for entries without them.
+     * Message: { type: 'GET_CACHE_SIZES' }
+     */
+    if (event.data.type === 'GET_CACHE_SIZES') {
+        const client = event.source;
+        (async () => {
+            const sizes = {};
+            const addFor = (songbook, bytes) => {
+                sizes[songbook] = (sizes[songbook] || 0) + bytes;
+            };
+            try {
+                const recent = await caches.open(RECENT_CACHE);
+                for (const req of await recent.keys()) {
+                    const id = new URL(req.url).searchParams.get('id') || '';
+                    const dash = id.indexOf('-');
+                    if (dash <= 0) continue;
+                    const songbook = id.slice(0, dash).toUpperCase();
+                    const resp = await recent.match(req);
+                    const len = Number(resp?.headers.get('content-length')) || 4096;
+                    addFor(songbook, len);
+                }
+            } catch {}
+            try {
+                const media = await caches.open('iHymns-media-v1');
+                for (const req of await media.keys()) {
+                    const m = new URL(req.url).pathname.match(/^\/data\/(?:audio|music)\/([^\/]+)\//i);
+                    if (!m) continue;
+                    const songbook = m[1].toUpperCase();
+                    const resp = await media.match(req);
+                    const len = Number(resp?.headers.get('content-length')) || 262144;
+                    addFor(songbook, len);
+                }
+            } catch {}
+            client?.postMessage({ type: 'CACHE_SIZES', sizes });
+        })();
+    }
+
     /* Proactively cache a recently viewed song page (#105) */
     if (event.data.type === 'CACHE_SONG' && event.data.url) {
         /* Validate URL origin to prevent cache poisoning */

--- a/appWeb/public_html/service-worker.js.php
+++ b/appWeb/public_html/service-worker.js.php
@@ -414,6 +414,31 @@ self.addEventListener('fetch', (event) => {
         return;
     }
 
+    /* --- Audio / sheet-music: cache-first (#401) ---
+       On-demand caching: once a user plays or views a song, the underlying
+       audio or PDF is cached. Subsequent plays — including offline — hit
+       the cache immediately with no network round-trip. Separate cache
+       bucket so it can be cleared independently of the app shell. */
+    if (event.request.method === 'GET'
+        && (url.pathname.startsWith('/data/audio/') || url.pathname.startsWith('/data/music/'))) {
+        event.respondWith(
+            caches.open('iHymns-media-v1').then(async (cache) => {
+                const hit = await cache.match(event.request);
+                if (hit) return hit;
+                try {
+                    const res = await fetch(event.request);
+                    if (res.ok) cache.put(event.request, res.clone());
+                    return res;
+                } catch {
+                    /* Offline + not cached — let the media element show its
+                       own error UI rather than injecting a PNG/JSON. */
+                    return new Response('', { status: 504, statusText: 'Offline' });
+                }
+            })
+        );
+        return;
+    }
+
     /* --- All other local assets: network-first with cache fallback --- */
     event.respondWith(networkFirstWithCache(event.request));
 });


### PR DESCRIPTION
## Summary

Big batch — ships 15 issues plus a security + docs pass. All nine originally-scoped stretch items plus six smaller ones that landed in the same branch.

### Auto-closes on merge

**Auth + PWA:**
- Closes #390 — Cross-subdomain auth cookie + sliding 30-day expiry
- Closes #395 — Login modal: magic-link primary, password fallback
- Closes #396 — Service-worker update banner restored

**Editor + admin:**
- Closes #394 — Per-song save endpoint + editor auto-save
- Closes #399 — Editor multi-select + bulk delete / verify / tag / move / export
- Closes #400 — Revision history: capture + editor modal with diff + restore + `/manage/revisions` audit page
- Closes #403 — Admin song-request triage queue
- Closes #404 — Analytics CSV export + `tblSearchQueries` logging
- Closes #405 — Backup restore upload + pre-flight + transactional data-load + pre-restore snapshot

**Search + content + offline:**
- Closes #397 — Scripture-tag-aware search
- Closes #401 — Bulk-audio manifest + Settings toggle + SW cache + eviction + real size readout
- Closes #402 — Practice / memorisation mode (Full / Dimmed / Hidden + tap-to-reveal)

**UX:**
- Closes #392 — Misc songbook: NULL Number + book-glyph badges
- Closes #406 — Keyboard shortcuts Settings toggle
- Closes #398 — Setlist scheduling UI + collaboration (invite / permissions / list / remove) + "Up next" card

### Security pass (no open findings)

- **CSRF** — three admin pages (`setup-database`, `requests`, `entitlements`) were missing CSRF tokens on POST forms. All three now render a hidden `csrf_token` input and validate via `validateCsrf()`.
- **Info-leak** — two paths echoed raw `$e->getMessage()`; replaced with `error_log()` + generic "check server logs" message.
- Backup upload path double-checked safe: basename, strict regex, 256 MB cap, destination outside web root.
- New `restore.php` statement splitter is quote-aware and only acts on trusted uploads (already-authenticated global-admin).
- Full SQL-injection / XSS / `eval` / open-redirect / path-traversal grep sweep — no findings.

### Docs

- In-app help (`help.php`), README, CHANGELOG, DEV_NOTES, `.claude/` memory all refreshed.

### Tooling gaps — still blocked on a human

Three things the GitHub MCP tool surface can't reach — tracked as open issues:

- #408 — Refresh the repo **Wiki** (no wiki endpoints in MCP)
- #409 — Create + populate **Milestones** (MCP can assign but not create)
- #410 — Stand up a **Projects (v2)** board (no Projects tools in MCP)

Umbrella tracking everything: #411.

### Commits

23 focused commits — 17 from the original batch plus 1 security + docs pass + 5 follow-up feature commits. Full list via `git log origin/alpha..HEAD`.

https://claude.ai/code/session_01XUtkSVBVB3ez9HqHaTQb7r