### PR TITLE
Temporarily disable channel gate while admin accounts are sorted

### DIFF
--- a/appWeb/public_html/includes/channel_gate.php
+++ b/appWeb/public_html/includes/channel_gate.php
@@ -62,6 +62,21 @@ function enforceChannelGate(?string $devStatus): void
         return; /* Production — never gated. */
     }
 
+    /* ----------------------------------------------------------------
+     * TEMPORARILY DISABLED
+     * ----------------------------------------------------------------
+     * The gate is off while admin accounts and role/entitlement
+     * mappings are being set up properly (the first admin account was
+     * created as `admin` rather than an email address, and nobody can
+     * sign in through the gate until that's fixed).
+     *
+     * To re-enable invite-only gating once setup is complete:
+     *   1. Delete this early return.
+     *   2. Visit /manage/entitlements and flick the "Enforce
+     *      invite-only access" switch on.
+     * ---------------------------------------------------------------- */
+    return;
+
     /* Bootstrap mode: the gate stays open until an admin explicitly
        turns it on, so the first admin in can sign in and configure
        role-based access without locking themselves out. */


### PR DESCRIPTION
## Summary
- Temporarily short-circuits `enforceChannelGate()` with an explicit early return so nobody is gated out of alpha while admin accounts and role/entitlement mappings are being sorted out. (The first admin was created with username `admin` rather than an email, so nobody can currently sign in through the gate to configure things — a belt-and-braces disable is safer than relying on the flag.)
- Clear comment in-place explains how to re-enable: delete the early return, then flip the "Enforce invite-only access" toggle on `/manage/entitlements`.
- The default-off `channel_gate_enabled` bootstrap flag merged in #413 is kept intact as the ongoing mechanism once the gate is switched back on.

## Test plan
- [ ] Visit `alpha.ihymns.app` without an auth cookie — the app loads normally, no gate page is rendered.
- [ ] Visit `alpha.ihymns.app` with the `channel_gate_enabled` setting flipped on (the flag that would normally force gating) — still no gate, because the hardcoded early return runs first.
- [ ] Production (`ihymns.app`) still short-circuits on non-Alpha/Beta `devStatus`; unaffected.
- [ ] Sign in to `/manage/entitlements` as `global_admin` and fix admin accounts.
- [ ] Once setup is done: remove the early return, flip the toggle, verify gating works again.

https://claude.ai/code/session_01LVu9oYy2LbeYjXfys5EhoF

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVu9oYy2LbeYjXfys5EhoF)_