### PR TITLE
Settings tabs (Profile + App) + entitlement-driven header menu

### DIFF
--- a/appWeb/public_html/includes/pages/settings.php
+++ b/appWeb/public_html/includes/pages/settings.php
@@ -31,6 +31,37 @@ declare(strict_types=1);
     </h1>
 
     <!-- ============================================================
+         SETTINGS TABS — Profile (per-user) vs App (per-device)
+         ============================================================ -->
+    <ul class="nav nav-tabs mb-3" role="tablist" id="settings-tabs">
+        <li class="nav-item" role="presentation">
+            <button class="nav-link" id="tab-profile-btn" type="button"
+                    role="tab" data-bs-toggle="tab"
+                    data-bs-target="#tab-profile" aria-controls="tab-profile"
+                    aria-selected="false">
+                <i class="fa-solid fa-user me-1" aria-hidden="true"></i>
+                Account &amp; Profile
+            </button>
+        </li>
+        <li class="nav-item" role="presentation">
+            <button class="nav-link active" id="tab-app-btn" type="button"
+                    role="tab" data-bs-toggle="tab"
+                    data-bs-target="#tab-app" aria-controls="tab-app"
+                    aria-selected="true">
+                <i class="fa-solid fa-sliders me-1" aria-hidden="true"></i>
+                App Settings
+            </button>
+        </li>
+    </ul>
+
+    <div class="tab-content">
+
+    <!-- ============================================================
+         TAB: ACCOUNT & PROFILE
+         ============================================================ -->
+    <div class="tab-pane fade" id="tab-profile" role="tabpanel" aria-labelledby="tab-profile-btn">
+
+    <!-- ============================================================
          ACCOUNT SECTION — User authentication for cross-device sync
          ============================================================ -->
     <div class="card card-settings mb-3">
@@ -67,13 +98,72 @@ declare(strict_types=1);
 
             <!-- Logged-in state -->
             <div id="auth-logged-in" class="d-none">
-                <div class="d-flex align-items-center justify-content-between mb-2">
+                <div class="d-flex align-items-center justify-content-between mb-3">
                     <div>
                         <strong id="auth-display-name-text"></strong>
                         <small class="text-muted d-block" id="auth-username-text"></small>
                     </div>
                     <span class="badge bg-success"><i class="fa-solid fa-check me-1" aria-hidden="true"></i>Signed In</span>
                 </div>
+
+                <!-- Profile edit form — display name + email -->
+                <form id="profile-form" class="mb-3" autocomplete="off">
+                    <div id="profile-msg" class="alert d-none py-2 small" role="alert"></div>
+
+                    <div class="mb-2">
+                        <label for="profile-username" class="form-label small mb-1">Username</label>
+                        <input type="text" id="profile-username" class="form-control" readonly
+                               aria-describedby="profile-username-help">
+                        <small id="profile-username-help" class="text-muted d-block mt-1">
+                            Usernames cannot be changed. Contact an administrator if you need a rename.
+                        </small>
+                    </div>
+
+                    <div class="mb-2">
+                        <label for="profile-display-name" class="form-label small mb-1">Display name</label>
+                        <input type="text" id="profile-display-name" class="form-control"
+                               maxlength="100" autocomplete="name">
+                    </div>
+
+                    <div class="mb-2">
+                        <label for="profile-email" class="form-label small mb-1">Email address</label>
+                        <input type="email" id="profile-email" class="form-control"
+                               maxlength="255" autocomplete="email">
+                    </div>
+
+                    <button type="submit" class="btn btn-primary btn-sm" id="profile-save-btn">
+                        <i class="fa-solid fa-floppy-disk me-1" aria-hidden="true"></i>
+                        Save profile
+                    </button>
+                </form>
+
+                <!-- Change password form -->
+                <form id="password-form" class="mb-3" autocomplete="off">
+                    <h3 class="h6 mb-2">Change password</h3>
+                    <div id="password-msg" class="alert d-none py-2 small" role="alert"></div>
+
+                    <div class="mb-2">
+                        <label for="password-current" class="form-label small mb-1">Current password</label>
+                        <input type="password" id="password-current" class="form-control"
+                               autocomplete="current-password">
+                    </div>
+                    <div class="mb-2">
+                        <label for="password-new" class="form-label small mb-1">New password</label>
+                        <input type="password" id="password-new" class="form-control"
+                               minlength="8" maxlength="128" autocomplete="new-password">
+                    </div>
+                    <div class="mb-2">
+                        <label for="password-confirm" class="form-label small mb-1">Confirm new password</label>
+                        <input type="password" id="password-confirm" class="form-control"
+                               minlength="8" maxlength="128" autocomplete="new-password">
+                    </div>
+
+                    <button type="submit" class="btn btn-outline-primary btn-sm" id="password-save-btn">
+                        <i class="fa-solid fa-key me-1" aria-hidden="true"></i>
+                        Change password
+                    </button>
+                </form>
+
                 <div class="d-flex gap-2">
                     <button type="button" class="btn btn-outline-primary btn-sm" id="btn-auth-sync">
                         <i class="fa-solid fa-arrows-rotate me-1" aria-hidden="true"></i>
@@ -113,6 +203,13 @@ declare(strict_types=1);
             </div>
         </div>
     </div>
+
+    </div> <!-- /tab-profile -->
+
+    <!-- ============================================================
+         TAB: APP SETTINGS
+         ============================================================ -->
+    <div class="tab-pane fade show active" id="tab-app" role="tabpanel" aria-labelledby="tab-app-btn">
 
     <!-- ============================================================
          APPEARANCE SECTION
@@ -599,5 +696,9 @@ declare(strict_types=1);
             </dl>
         </div>
     </div>
+
+    </div> <!-- /tab-app -->
+
+    </div> <!-- /tab-content -->
 
 </section>

--- a/appWeb/public_html/index.php
+++ b/appWeb/public_html/index.php
@@ -596,9 +596,6 @@ if (!empty($breadcrumbItems)) {
                         <li><a class="dropdown-item" href="/stats" data-navigate="stats">
                             <i class="fa-solid fa-chart-simple me-2" aria-hidden="true"></i> Statistics
                         </a></li>
-                        <li><a class="dropdown-item" href="/settings" data-navigate="settings">
-                            <i class="fa-solid fa-gear me-2" aria-hidden="true"></i> Settings
-                        </a></li>
                         <li><a class="dropdown-item" href="/help" data-navigate="help">
                             <i class="fa-solid fa-circle-question me-2" aria-hidden="true"></i> Help
                         </a></li>
@@ -684,14 +681,35 @@ if (!empty($breadcrumbItems)) {
                                     <i class="fa-solid fa-user-plus me-2" aria-hidden="true"></i> Create Account
                                 </button>
                             </li>
-                            <!-- Logged-in state (hidden by default, shown by JS) -->
+                            <!-- ============================================
+                                 Logged-in state (hidden by default; visibility
+                                 toggled by user-auth.js based on signed-in
+                                 state and per-entitlement checks).
+
+                                 Sections:
+                                   • Account   — always visible to signed-in users
+                                   • Curator   — visible if user holds any of
+                                                 edit_songs / review_song_requests
+                                                 / verify_songs
+                                   • Admin     — visible if user holds any of
+                                                 view_admin_dashboard / view_users /
+                                                 manage_entitlements / view_analytics /
+                                                 run_db_install / run_db_migrate
+                                 ============================================ -->
                             <li id="header-user-name" class="d-none">
                                 <span class="dropdown-item-text fw-semibold" id="header-user-display-name"></span>
                             </li>
                             <li id="header-user-role-li" class="d-none">
                                 <span class="dropdown-item-text small text-muted" id="header-user-role-text"></span>
                             </li>
+
+                            <!-- ── Account ── -->
                             <li id="header-user-divider" class="d-none"><hr class="dropdown-divider"></li>
+                            <li id="header-user-settings-li" class="d-none">
+                                <a class="dropdown-item" href="/settings" data-navigate="settings">
+                                    <i class="fa-solid fa-gear me-2" aria-hidden="true"></i> Settings
+                                </a>
+                            </li>
                             <li id="header-user-setlists-li" class="d-none">
                                 <a class="dropdown-item" href="/setlist" data-navigate="setlist">
                                     <i class="fa-solid fa-list-ol me-2" aria-hidden="true"></i> My Set Lists
@@ -702,23 +720,60 @@ if (!empty($breadcrumbItems)) {
                                     <i class="fa-solid fa-arrows-rotate me-2" aria-hidden="true"></i> Sync Set Lists
                                 </button>
                             </li>
-                            <li id="header-user-settings-li" class="d-none">
-                                <a class="dropdown-item" href="/settings" data-navigate="settings">
-                                    <i class="fa-solid fa-gear me-2" aria-hidden="true"></i> Account Settings
-                                </a>
+
+                            <!-- ── Curator ── -->
+                            <li id="header-curator-divider" class="d-none"><hr class="dropdown-divider"></li>
+                            <li id="header-curator-header" class="d-none">
+                                <h6 class="dropdown-header">Curator</h6>
                             </li>
-                            <!-- Admin/Editor links (shown by JS based on role) -->
-                            <li id="header-user-admin-divider" class="d-none"><hr class="dropdown-divider"></li>
                             <li id="header-user-editor-li" class="d-none">
                                 <a class="dropdown-item" href="/manage/editor/">
                                     <i class="fa-solid fa-pen-to-square me-2" aria-hidden="true"></i> Song Editor
                                 </a>
                             </li>
-                            <li id="header-user-dashboard-li" class="d-none">
-                                <a class="dropdown-item" href="/manage/">
-                                    <i class="fa-solid fa-gauge-high me-2" aria-hidden="true"></i> Dashboard
+                            <li id="header-curator-requests-li" class="d-none">
+                                <a class="dropdown-item" href="/manage/requests">
+                                    <i class="fa-solid fa-inbox me-2" aria-hidden="true"></i> Song Requests
                                 </a>
                             </li>
+                            <li id="header-curator-revisions-li" class="d-none">
+                                <a class="dropdown-item" href="/manage/revisions">
+                                    <i class="fa-solid fa-clock-rotate-left me-2" aria-hidden="true"></i> Revisions Audit
+                                </a>
+                            </li>
+
+                            <!-- ── Administration ── -->
+                            <li id="header-admin-divider" class="d-none"><hr class="dropdown-divider"></li>
+                            <li id="header-admin-header" class="d-none">
+                                <h6 class="dropdown-header">Administration</h6>
+                            </li>
+                            <li id="header-user-dashboard-li" class="d-none">
+                                <a class="dropdown-item" href="/manage/">
+                                    <i class="fa-solid fa-gauge-high me-2" aria-hidden="true"></i> Admin Dashboard
+                                </a>
+                            </li>
+                            <li id="header-admin-users-li" class="d-none">
+                                <a class="dropdown-item" href="/manage/users">
+                                    <i class="fa-solid fa-users me-2" aria-hidden="true"></i> User Management
+                                </a>
+                            </li>
+                            <li id="header-admin-entitlements-li" class="d-none">
+                                <a class="dropdown-item" href="/manage/entitlements">
+                                    <i class="fa-solid fa-key me-2" aria-hidden="true"></i> Entitlements &amp; Gating
+                                </a>
+                            </li>
+                            <li id="header-admin-analytics-li" class="d-none">
+                                <a class="dropdown-item" href="/manage/analytics">
+                                    <i class="fa-solid fa-chart-line me-2" aria-hidden="true"></i> Analytics
+                                </a>
+                            </li>
+                            <li id="header-admin-db-li" class="d-none">
+                                <a class="dropdown-item" href="/manage/setup-database">
+                                    <i class="fa-solid fa-database me-2" aria-hidden="true"></i> Database Setup
+                                </a>
+                            </li>
+
+                            <!-- ── Sign out ── -->
                             <li id="header-user-divider2" class="d-none"><hr class="dropdown-divider"></li>
                             <li id="header-user-signout-li" class="d-none">
                                 <button class="dropdown-item" type="button" id="header-signout-btn">

--- a/appWeb/public_html/js/modules/settings.js
+++ b/appWeb/public_html/js/modules/settings.js
@@ -136,6 +136,14 @@ export class Settings {
             const userEl = document.getElementById('auth-username-text');
             if (nameEl) nameEl.textContent = user?.display_name || user?.username || '';
             if (userEl) userEl.textContent = '@' + (user?.username || '');
+
+            /* Populate the profile edit form with current values. */
+            const profUsername = document.getElementById('profile-username');
+            const profDisplay  = document.getElementById('profile-display-name');
+            const profEmail    = document.getElementById('profile-email');
+            if (profUsername) profUsername.value = user?.username || '';
+            if (profDisplay)  profDisplay.value  = user?.display_name || '';
+            if (profEmail)    profEmail.value    = user?.email || '';
         }
     }
 
@@ -1254,5 +1262,66 @@ export class Settings {
             /* Refresh account section display */
             this._initAccountSection();
         });
+
+        /* Profile save — update display name + email */
+        const profileForm = document.getElementById('profile-form');
+        if (profileForm && !profileForm.dataset.bound) {
+            profileForm.dataset.bound = '1';
+            profileForm.addEventListener('submit', async (e) => {
+                e.preventDefault();
+                const displayName = document.getElementById('profile-display-name').value.trim();
+                const email       = document.getElementById('profile-email').value.trim();
+                const msg = document.getElementById('profile-msg');
+                const show = (text, kind) => {
+                    if (!msg) return;
+                    msg.className = 'alert py-2 small alert-' + kind;
+                    msg.textContent = text;
+                    msg.classList.remove('d-none');
+                };
+                const result = await auth.updateProfile({ displayName, email });
+                if (result.success) {
+                    show('Profile saved.', 'success');
+                } else {
+                    show(result.error || 'Could not save profile.', 'danger');
+                }
+            });
+        }
+
+        /* Change password */
+        const passwordForm = document.getElementById('password-form');
+        if (passwordForm && !passwordForm.dataset.bound) {
+            passwordForm.dataset.bound = '1';
+            passwordForm.addEventListener('submit', async (e) => {
+                e.preventDefault();
+                const cur  = document.getElementById('password-current').value;
+                const next = document.getElementById('password-new').value;
+                const conf = document.getElementById('password-confirm').value;
+                const msg  = document.getElementById('password-msg');
+                const show = (text, kind) => {
+                    if (!msg) return;
+                    msg.className = 'alert py-2 small alert-' + kind;
+                    msg.textContent = text;
+                    msg.classList.remove('d-none');
+                };
+                if (next.length < 8) {
+                    show('New password must be at least 8 characters.', 'danger');
+                    return;
+                }
+                if (next !== conf) {
+                    show('New password and confirmation do not match.', 'danger');
+                    return;
+                }
+                const result = await auth.changePassword({
+                    currentPassword: cur,
+                    newPassword: next,
+                });
+                if (result.success) {
+                    show('Password changed.', 'success');
+                    passwordForm.reset();
+                } else {
+                    show(result.error || 'Could not change password.', 'danger');
+                }
+            });
+        }
     }
 }

--- a/appWeb/public_html/js/modules/user-auth.js
+++ b/appWeb/public_html/js/modules/user-auth.js
@@ -14,6 +14,7 @@
  */
 
 import { escapeHtml } from '../utils/html.js';
+import { userHasEntitlement } from './entitlements.js';
 
 /** @type {string} localStorage key for the auth token */
 const STORAGE_AUTH_TOKEN = 'ihymns_auth_token';
@@ -405,27 +406,30 @@ export class UserAuth {
 
     /**
      * Update the header dropdown to reflect current auth state.
-     * Shows/hides appropriate menu items.
+     *
+     * Account section is visible to any signed-in user. Curator and
+     * Administration sections (each with a label header + divider)
+     * are toggled per-entitlement via userHasEntitlement(); the section
+     * label collapses with the items so a user with no curator/admin
+     * privileges sees a clean menu.
      */
     _updateHeaderState() {
         const loggedIn = this.isLoggedIn();
         const user = this.getUser();
+        const role = user?.role || null;
 
         /* Guest items (sign in / register) */
-        const guestIds = ['header-user-guest', 'header-user-register-li'];
-        /* Logged-in items */
-        const authIds = [
-            'header-user-name', 'header-user-role-li', 'header-user-divider',
-            'header-user-setlists-li', 'header-user-sync-li',
-            'header-user-settings-li', 'header-user-divider2', 'header-user-signout-li',
-        ];
-
-        guestIds.forEach(id => {
+        ['header-user-guest', 'header-user-register-li'].forEach(id => {
             const el = document.getElementById(id);
             if (el) el.classList.toggle('d-none', loggedIn);
         });
 
-        authIds.forEach(id => {
+        /* Always-on items for signed-in users (Account section) */
+        [
+            'header-user-name', 'header-user-role-li', 'header-user-divider',
+            'header-user-settings-li', 'header-user-setlists-li', 'header-user-sync-li',
+            'header-user-divider2', 'header-user-signout-li',
+        ].forEach(id => {
             const el = document.getElementById(id);
             if (el) el.classList.toggle('d-none', !loggedIn);
         });
@@ -438,18 +442,39 @@ export class UserAuth {
             if (roleEl) roleEl.textContent = this._roleLabel(user.role || 'user');
         }
 
-        /* Admin/Editor links — show based on role privilege */
-        const role = user?.role || 'user';
-        const roleLevel = { 'user': 1, 'editor': 2, 'admin': 3, 'global_admin': 4 }[role] || 0;
-        const isEditor = loggedIn && roleLevel >= 2;
-        const isAdmin  = loggedIn && roleLevel >= 3;
+        /* Per-entitlement items. Each entry: [elementId, entitlement-name].
+           When the user is signed out, every gated item is hidden. */
+        const entItems = {
+            curator: [
+                ['header-user-editor-li',         'edit_songs'],
+                ['header-curator-requests-li',    'review_song_requests'],
+                ['header-curator-revisions-li',   'verify_songs'],
+            ],
+            admin: [
+                ['header-user-dashboard-li',      'view_admin_dashboard'],
+                ['header-admin-users-li',         'view_users'],
+                ['header-admin-entitlements-li',  'manage_entitlements'],
+                ['header-admin-analytics-li',     'view_analytics'],
+                ['header-admin-db-li',            'run_db_install'],
+            ],
+        };
 
-        const editorEl = document.getElementById('header-user-editor-li');
-        const dashEl   = document.getElementById('header-user-dashboard-li');
-        const divEl    = document.getElementById('header-user-admin-divider');
-        if (editorEl) editorEl.classList.toggle('d-none', !isEditor);
-        if (dashEl)   dashEl.classList.toggle('d-none', !isAdmin);
-        if (divEl)    divEl.classList.toggle('d-none', !isEditor);
+        const applySection = (items, dividerId, headerId) => {
+            let anyVisible = false;
+            items.forEach(([id, ent]) => {
+                const visible = loggedIn && userHasEntitlement(ent, role);
+                const el = document.getElementById(id);
+                if (el) el.classList.toggle('d-none', !visible);
+                if (visible) anyVisible = true;
+            });
+            const dEl = document.getElementById(dividerId);
+            const hEl = document.getElementById(headerId);
+            if (dEl) dEl.classList.toggle('d-none', !anyVisible);
+            if (hEl) hEl.classList.toggle('d-none', !anyVisible);
+        };
+
+        applySection(entItems.curator, 'header-curator-divider', 'header-curator-header');
+        applySection(entItems.admin,   'header-admin-divider',   'header-admin-header');
 
         /* Update icon style */
         const icon = document.getElementById('header-user-icon');

--- a/appWeb/public_html/js/modules/user-auth.js
+++ b/appWeb/public_html/js/modules/user-auth.js
@@ -297,6 +297,66 @@ export class UserAuth {
         }
     }
 
+    /**
+     * Update the signed-in user's display name and email.
+     * @param {{ displayName: string, email: string }} fields
+     * @returns {Promise<{ success: boolean, user?: object, error?: string }>}
+     */
+    async updateProfile({ displayName, email }) {
+        if (!this.isLoggedIn()) return { success: false, error: 'Not signed in.' };
+        try {
+            const res = await fetch(`${this.app.config.apiUrl}?action=auth_update_profile`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest',
+                    ...this.authHeaders(),
+                },
+                body: JSON.stringify({ display_name: displayName, email }),
+            });
+            const data = await res.json();
+            if (!res.ok) return { success: false, error: data.error || 'Could not save profile.' };
+
+            /* Update the cached user so the header + account card re-render
+               immediately with the new display name. */
+            if (data.user) {
+                localStorage.setItem(STORAGE_AUTH_USER, JSON.stringify(data.user));
+                this._broadcastAuthChanged();
+            }
+            return { success: true, user: data.user };
+        } catch {
+            return { success: false, error: 'Network error. Please try again.' };
+        }
+    }
+
+    /**
+     * Change the signed-in user's password.
+     * @param {{ currentPassword: string, newPassword: string }} fields
+     * @returns {Promise<{ success: boolean, error?: string }>}
+     */
+    async changePassword({ currentPassword, newPassword }) {
+        if (!this.isLoggedIn()) return { success: false, error: 'Not signed in.' };
+        try {
+            const res = await fetch(`${this.app.config.apiUrl}?action=auth_change_password`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest',
+                    ...this.authHeaders(),
+                },
+                body: JSON.stringify({
+                    current_password: currentPassword,
+                    new_password: newPassword,
+                }),
+            });
+            const data = await res.json();
+            if (!res.ok) return { success: false, error: data.error || 'Could not change password.' };
+            return { success: true };
+        } catch {
+            return { success: false, error: 'Network error. Please try again.' };
+        }
+    }
+
     /* =====================================================================
      * HEADER USER MENU — Toggle logged-in / logged-out state
      * ===================================================================== */


### PR DESCRIPTION
## Summary

Two distinct commits, each addresses a separate concern:

### Phase 1 — `/settings` tabs + profile editing
The settings page is split into **Account & Profile** and **App Settings** tabs:
- **Account & Profile** — display name, email, change password (all wired to existing `auth_update_profile` / `auth_change_password` endpoints), plus Sync Set Lists toggle. Username shown read-only with a note that admins handle renames.
- **App Settings** — Appearance, Accessibility, Data & Storage, Privacy, About. Default tab on load.

Two new methods on `UserAuth`: `updateProfile()` and `changePassword()`. Cached user object is updated on profile save so the header re-renders the new display name immediately.

### Phase 2 — Header menu rework with entitlement-driven visibility
The user-account dropdown is restructured into three sections, each gated by the **specific entitlement** rather than a role hierarchy:

```
[name + role badge]
─── Account ───              (always for signed-in)
  Settings · My Set Lists · Sync Set Lists
─── Curator ───              (any of: edit_songs, review_song_requests, verify_songs)
  Song Editor · Song Requests · Revisions Audit
─── Administration ───       (any of: view_admin_dashboard, view_users, manage_entitlements, view_analytics, run_db_install)
  Admin Dashboard · User Management · Entitlements & Gating · Analytics · Database Setup
Sign Out
```

If an admin reassigns an entitlement on `/manage/entitlements`, the menu adapts on the next page load — no separate UI-gating to maintain.

The duplicate **Settings** link is removed from the left app-name dropdown. The left menu stays as public navigation (Home, Songbooks, Favourites, Set Lists, Statistics, Help) — same to signed-out and signed-in users.

## Out of scope (follow-ups)
- **Settings sync** of device-local prefs (theme, font, accessibility) to user profile when signed in. Needs schema, conflict resolution, opt-in toggle.
- **Shared set lists** still write/read JSON files under `APP_SETLIST_SHARE_DIR`. Migrating to MySQL requires schema + back-fill of existing share-link IDs.
- **Songbook CRUD** — no admin page exists at all today; current `/songbooks` is read-only.
- **Username self-rename** — still admin-only by design (UNIQUE column, no API endpoint). The note on the Profile tab tells users to contact an admin.

## Test plan
- [ ] Visit `/settings` while signed out — App Settings tab is active by default; Account tab shows Sign In / Create Account prompts.
- [ ] Visit `/settings` while signed in — App Settings tab still default; click Account tab and see username (read-only), display name + email (editable), change-password form.
- [ ] Edit display name + email, click Save — toast shows success, header re-renders with new display name.
- [ ] Change password with wrong current password — error shown, no change.
- [ ] Change password where new ≠ confirm — client-side error, no API call.
- [ ] Change password successfully — success message, current session keeps working, other tokens invalidated server-side.
- [ ] As `user` role: header dropdown shows Account section + Sign Out only — no Curator / Administration headings visible.
- [ ] As `editor` role: Curator section appears (Song Editor, Song Requests, Revisions Audit). Administration section hidden.
- [ ] As `admin` role: both Curator and Administration sections appear; all five admin links are visible.
- [ ] As `global_admin`: same as admin (current entitlements grant all the same items).
- [ ] On `/manage/entitlements`, remove `edit_songs` from `editor` role and save. Re-load any page as an editor — Song Editor link disappears from the dropdown.
- [ ] Confirm Settings is no longer in the left app-name dropdown but is in the user dropdown.

https://claude.ai/code/session_01LVu9oYy2LbeYjXfys5EhoF

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVu9oYy2LbeYjXfys5EhoF)_