### PR TITLE
Username rename + settings sync + shared-setlist MySQL move

### DIFF
--- a/appWeb/.sql/migrate-account-sync.php
+++ b/appWeb/.sql/migrate-account-sync.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Account Sync + Shared Setlists Migration
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Brings an existing iHymns deployment up to the schema required by
+ * the per-user settings-sync feature and the shared-setlists move
+ * from disk to MySQL. Specifically:
+ *   1. tblUsers gets a `Settings` JSON column (synced UI prefs).
+ *   2. tblSharedSetlists is created if missing.
+ *   3. Any JSON files left in APP_SETLIST_SHARE_DIR (the legacy store)
+ *      are imported into the new table, keyed by their filename so
+ *      every existing share URL keeps resolving.
+ *
+ * Idempotent — re-running is safe; columns/tables that already exist
+ * are skipped, and rows already imported are not duplicated.
+ *
+ * USAGE:
+ *   CLI:  php appWeb/.sql/migrate-account-sync.php
+ *   Web:  /manage/setup-database → "Account Sync Migration" button
+ *         (entry point requires global_admin)
+ *
+ * PREREQUISITES:
+ *   - install.php has been run (tables tblUsers + tblSharedSetlists exist
+ *     in the canonical schema; this script handles existing deployments
+ *     where they predate this migration).
+ *
+ * @requires PHP 8.1+ with mysqli extension
+ */
+
+$isCli = (php_sapi_name() === 'cli');
+
+if (!$isCli && !defined('IHYMNS_SETUP_DASHBOARD')) {
+    /* Standalone web mode only — skip these headers when included by
+     * the Setup dashboard so its HTML response isn't hijacked. */
+    header('Content-Type: text/plain; charset=UTF-8');
+    header('X-Content-Type-Options: nosniff');
+    header('Cache-Control: no-store');
+}
+
+function _migAccSync_output(string $msg): void {
+    global $isCli;
+    echo $msg . ($isCli ? "\n" : "<br>\n");
+    if (!$isCli) flush();
+}
+
+/* =========================================================================
+ * LOAD MYSQL CREDENTIALS
+ * ========================================================================= */
+
+$credFile = dirname(__DIR__) . DIRECTORY_SEPARATOR . '.auth' . DIRECTORY_SEPARATOR . 'db_credentials.php';
+if (!file_exists($credFile)) {
+    _migAccSync_output("ERROR: MySQL credentials not found. Run install.php first.");
+    return;
+}
+require_once $credFile;
+
+/* =========================================================================
+ * CONNECT TO MYSQL
+ * ========================================================================= */
+
+_migAccSync_output("");
+_migAccSync_output("=== iHymns — Account Sync + Shared Setlists Migration ===");
+_migAccSync_output("");
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+try {
+    $mysql = new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME, (int)DB_PORT);
+    $mysql->set_charset(defined('DB_CHARSET') ? DB_CHARSET : 'utf8mb4');
+} catch (\mysqli_sql_exception $e) {
+    _migAccSync_output("ERROR: MySQL connection failed: " . $e->getMessage());
+    return;
+}
+_migAccSync_output("Connected to MySQL: " . DB_NAME);
+
+/* =========================================================================
+ * STEP 1: Add tblUsers.Settings column (idempotent)
+ * ========================================================================= */
+
+_migAccSync_output("");
+_migAccSync_output("--- Step 1: tblUsers.Settings column ---");
+
+try {
+    $res = $mysql->query("SHOW COLUMNS FROM tblUsers LIKE 'Settings'");
+    if ($res && $res->num_rows > 0) {
+        _migAccSync_output("  [SKIP] Settings column already exists.");
+    } else {
+        $mysql->query(
+            "ALTER TABLE tblUsers
+             ADD COLUMN Settings JSON NULL DEFAULT NULL
+                 COMMENT 'Synced per-user app preferences (theme, font, accessibility, etc.)'
+             AFTER LoginCount"
+        );
+        _migAccSync_output("  [OK] Added Settings column to tblUsers.");
+    }
+} catch (\Throwable $e) {
+    _migAccSync_output("  [ERROR] Could not add Settings column: " . $e->getMessage());
+}
+
+/* =========================================================================
+ * STEP 2: Create tblSharedSetlists (idempotent)
+ * ========================================================================= */
+
+_migAccSync_output("");
+_migAccSync_output("--- Step 2: tblSharedSetlists table ---");
+
+try {
+    $mysql->query(
+        "CREATE TABLE IF NOT EXISTS tblSharedSetlists (
+            ShareId         VARCHAR(16)     NOT NULL PRIMARY KEY,
+            Data            JSON            NOT NULL,
+            CreatedBy       INT UNSIGNED    NULL DEFAULT NULL,
+            CreatedAt       TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            UpdatedAt       TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            ViewCount       INT UNSIGNED    NOT NULL DEFAULT 0,
+            INDEX idx_CreatedBy (CreatedBy),
+            INDEX idx_CreatedAt (CreatedAt),
+            CONSTRAINT fk_SharedSetlists_User FOREIGN KEY (CreatedBy) REFERENCES tblUsers(Id)
+                ON DELETE SET NULL ON UPDATE CASCADE
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci"
+    );
+    _migAccSync_output("  [OK] tblSharedSetlists ready.");
+} catch (\Throwable $e) {
+    _migAccSync_output("  [ERROR] Could not create tblSharedSetlists: " . $e->getMessage());
+    $mysql->close();
+    return;
+}
+
+/* =========================================================================
+ * STEP 3: Import existing JSON files from APP_SETLIST_SHARE_DIR
+ * ========================================================================= */
+
+_migAccSync_output("");
+_migAccSync_output("--- Step 3: Import shared setlists from disk ---");
+
+/* Resolve the legacy directory the same way includes/config.php does
+ * (data_share/setlist_json relative to appWeb/). Hard-coded here so
+ * the script works without bootstrapping the whole app. */
+$shareDir = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'data_share' . DIRECTORY_SEPARATOR . 'setlist_json';
+
+$imported = 0;
+$skipped  = 0;
+$invalid  = 0;
+
+if (!is_dir($shareDir)) {
+    _migAccSync_output("  No legacy directory found at {$shareDir} — nothing to import.");
+} else {
+    $files = glob($shareDir . DIRECTORY_SEPARATOR . '*.json') ?: [];
+    _migAccSync_output("  Found " . count($files) . " JSON file(s).");
+
+    $checkStmt  = $mysql->prepare("SELECT 1 FROM tblSharedSetlists WHERE ShareId = ?");
+    $insertStmt = $mysql->prepare(
+        "INSERT INTO tblSharedSetlists (ShareId, Data) VALUES (?, ?)"
+    );
+
+    foreach ($files as $file) {
+        $shareId = basename($file, '.json');
+        if (!preg_match('/^[a-f0-9]{6,32}$/i', $shareId)) {
+            $invalid++;
+            continue; /* Skip non-share files (.gitkeep, etc.) */
+        }
+
+        $raw = file_get_contents($file);
+        if ($raw === false) {
+            _migAccSync_output("  [WARN] Could not read {$shareId}.json — skipped.");
+            $invalid++;
+            continue;
+        }
+        $decoded = json_decode($raw, true);
+        if (!is_array($decoded)) {
+            _migAccSync_output("  [WARN] Invalid JSON in {$shareId}.json — skipped.");
+            $invalid++;
+            continue;
+        }
+
+        $checkStmt->bind_param('s', $shareId);
+        $checkStmt->execute();
+        $checkStmt->store_result();
+        if ($checkStmt->num_rows > 0) {
+            $checkStmt->free_result();
+            $skipped++;
+            continue;
+        }
+        $checkStmt->free_result();
+
+        $jsonNormalised = json_encode($decoded, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $insertStmt->bind_param('ss', $shareId, $jsonNormalised);
+        $insertStmt->execute();
+        $imported++;
+    }
+
+    $checkStmt->close();
+    $insertStmt->close();
+}
+
+/* =========================================================================
+ * SUMMARY
+ * ========================================================================= */
+
+_migAccSync_output("");
+_migAccSync_output("--- Summary ---");
+_migAccSync_output("  Shared setlists imported: {$imported}");
+_migAccSync_output("  Shared setlists skipped:  {$skipped} (already in MySQL)");
+_migAccSync_output("  Invalid / non-share files: {$invalid}");
+_migAccSync_output("");
+_migAccSync_output("Migration complete. Original JSON files were left in place; you can");
+_migAccSync_output("delete them from {$shareDir} once you've verified the import.");
+
+$mysql->close();
+return;

--- a/appWeb/.sql/schema.sql
+++ b/appWeb/.sql/schema.sql
@@ -183,6 +183,7 @@ CREATE TABLE IF NOT EXISTS tblUsers (
     CcliVerified    TINYINT(1)      NOT NULL DEFAULT 0 COMMENT '1 = CCLI number validated',
     LastLoginAt     TIMESTAMP       NULL DEFAULT NULL COMMENT 'Last successful login timestamp',
     LoginCount      INT UNSIGNED    NOT NULL DEFAULT 0 COMMENT 'Total successful login count',
+    Settings        JSON            NULL DEFAULT NULL COMMENT 'Synced per-user app preferences (theme, font, accessibility, etc.)',
     CreatedAt       TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UpdatedAt       TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 
@@ -510,6 +511,29 @@ CREATE TABLE IF NOT EXISTS tblUserSetlists (
     CONSTRAINT fk_Setlists_User
         FOREIGN KEY (UserId) REFERENCES tblUsers(Id)
         ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+-- ----------------------------------------------------------------------------
+-- tblSharedSetlists
+-- Public, link-shared setlists (anyone with the URL can view). Replaces the
+-- legacy file-based store under APP_SETLIST_SHARE_DIR. ShareId stays the
+-- 8-char hex (bin2hex(random_bytes(4))) so existing share URLs keep
+-- working when historical JSON files are imported by the migration.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS tblSharedSetlists (
+    ShareId         VARCHAR(16)     NOT NULL PRIMARY KEY COMMENT '8 hex chars by default; column wider for forward-compat',
+    Data            JSON            NOT NULL COMMENT 'Full setlist payload as written by the share API',
+    CreatedBy       INT UNSIGNED    NULL DEFAULT NULL COMMENT 'FK to tblUsers (NULL for guest creates)',
+    CreatedAt       TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UpdatedAt       TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    ViewCount       INT UNSIGNED    NOT NULL DEFAULT 0 COMMENT 'Incremented on retrieval for share-link analytics',
+
+    INDEX idx_CreatedBy (CreatedBy),
+    INDEX idx_CreatedAt (CreatedAt),
+
+    CONSTRAINT fk_SharedSetlists_User FOREIGN KEY (CreatedBy) REFERENCES tblUsers(Id)
+        ON DELETE SET NULL ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 

--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -481,23 +481,20 @@ if ($action !== null) {
                 break;
             }
 
-            $shareDir = APP_SETLIST_SHARE_DIR;
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'SharedSetlist.php';
 
             /* Determine ID: use existing if updating, generate new otherwise */
-            $shareId = null;
+            $shareId  = null;
+            $existing = null;
             if (!empty($body['id'])) {
-                /* Updating an existing shared setlist */
                 $candidateId = preg_replace('/[^a-f0-9]/', '', strtolower(trim($body['id'])));
-                $existingFile = $shareDir . '/' . $candidateId . '.json';
-
                 if ($candidateId !== '') {
-                    if (!file_exists($existingFile)) {
+                    $existing = sharedSetlistGet($candidateId);
+                    if ($existing === null) {
                         sendJson(['error' => 'Shared set list not found.'], 404);
                         break;
                     }
-                    /* Verify ownership */
-                    $existing = json_decode(file_get_contents($existingFile), true);
-                    if (!is_array($existing) || ($existing['owner'] ?? '') !== $ownerId) {
+                    if (($existing['owner'] ?? '') !== $ownerId) {
                         sendJson(['error' => 'You do not own this shared set list.'], 403);
                         break;
                     }
@@ -509,7 +506,6 @@ if ($action !== null) {
             $arrangements = [];
             if (isset($body['arrangements']) && is_array($body['arrangements'])) {
                 foreach ($body['arrangements'] as $sid => $arr) {
-                    /* Only accept valid song IDs and arrays of non-negative integers */
                     if (!is_string($sid) || !preg_match('/^[A-Za-z]+-\d+$/', $sid)) continue;
                     if (!is_array($arr)) continue;
                     $validArr = array_values(array_filter($arr, fn($v) => is_int($v) && $v >= 0));
@@ -520,7 +516,7 @@ if ($action !== null) {
             }
 
             /* Build the shared setlist object */
-            $now = gmdate('c');
+            $now      = gmdate('c');
             $isUpdate = ($shareId !== null);
             $shareData = [
                 'name'    => $setlistName,
@@ -530,50 +526,31 @@ if ($action !== null) {
                 'updated' => $now,
                 'version' => 2,
             ];
-
-            /* Include arrangements only if any songs have custom arrangements */
             if (!empty($arrangements)) {
                 $shareData['arrangements'] = $arrangements;
             }
 
             if ($isUpdate) {
-                /* Updating existing — write directly */
                 $shareData['id'] = $shareId;
-                $filePath = $shareDir . '/' . $shareId . '.json';
-                $written = file_put_contents(
-                    $filePath,
-                    json_encode($shareData, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT),
-                    LOCK_EX
-                );
-            } else {
-                /* Generate new ID with atomic file creation to prevent TOCTOU race */
-                $written = false;
-                $attempts = 0;
-                do {
-                    $shareId = bin2hex(random_bytes(4)); /* 8 hex chars */
-                    $filePath = $shareDir . '/' . $shareId . '.json';
-                    $shareData['id'] = $shareId;
-                    $jsonEncoded = json_encode($shareData, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
-                    $attempts++;
-
-                    /* fopen 'x' mode fails if file already exists — atomic create */
-                    $fp = @fopen($filePath, 'x');
-                    if ($fp !== false) {
-                        $written = fwrite($fp, $jsonEncoded);
-                        fclose($fp);
-                        break;
-                    }
-                } while ($attempts < 10);
-
-                if ($written === false) {
-                    sendJson(['error' => 'Unable to generate unique ID. Try again.'], 500);
+                if (!sharedSetlistUpdate($shareId, $shareData)) {
+                    sendJson(['error' => 'Failed to save shared set list.'], 500);
                     break;
                 }
-            }
-
-            if ($written === false) {
-                sendJson(['error' => 'Failed to save shared set list.'], 500);
-                break;
+            } else {
+                /* Generate a fresh 8-char hex ID with retry on collision */
+                $created = false;
+                for ($i = 0; $i < 10; $i++) {
+                    $shareId         = bin2hex(random_bytes(4));
+                    $shareData['id'] = $shareId;
+                    $result = sharedSetlistInsert($shareId, $shareData);
+                    if ($result === true)  { $created = true;  break; }
+                    if ($result === null)  { /* hard failure */ break; }
+                    /* false = collision; try a new ID */
+                }
+                if (!$created) {
+                    sendJson(['error' => 'Unable to save shared set list. Try again.'], 500);
+                    break;
+                }
             }
 
             sendJson([
@@ -593,17 +570,14 @@ if ($action !== null) {
                 break;
             }
 
-            $filePath = APP_SETLIST_SHARE_DIR . '/' . $shareId . '.json';
-            if (!file_exists($filePath)) {
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'SharedSetlist.php';
+
+            $data = sharedSetlistGet($shareId);
+            if ($data === null) {
                 sendJson(['error' => 'Shared set list not found.'], 404);
                 break;
             }
-
-            $data = json_decode(file_get_contents($filePath), true);
-            if (!is_array($data)) {
-                sendJson(['error' => 'Invalid set list data.'], 500);
-                break;
-            }
+            sharedSetlistMarkViewed($shareId);
 
             /* Return public-safe fields only (exclude owner UUID) */
             $response = [
@@ -613,8 +587,6 @@ if ($action !== null) {
                 'created' => $data['created'] ?? null,
                 'updated' => $data['updated'] ?? null,
             ];
-
-            /* Include per-song arrangements if present */
             if (!empty($data['arrangements'])) {
                 $response['arrangements'] = $data['arrangements'];
             }
@@ -1036,6 +1008,67 @@ if ($action !== null) {
             }, $mergedRows);
 
             sendJson(['setlists' => $mergedSetlists]);
+            break;
+
+        /* -----------------------------------------------------------------
+         * User app settings — synced across the user's signed-in devices
+         *
+         * GET   /api?action=user_settings
+         *   → { ok: true, settings: { … }, updated_at: '…' }
+         * POST  /api?action=user_settings
+         *   body: { settings: { theme: 'dark', fontSize: 18, … } }
+         *   → { ok: true }
+         *
+         * Stored as a JSON blob in tblUsers.Settings; the client decides
+         * which keys are syncable (a strict whitelist in settings.js) so
+         * we never mirror device-local prefs (analytics consent, install
+         * banner state, etc.) onto the server.
+         * ----------------------------------------------------------------- */
+        case 'user_settings':
+            $authUser = getAuthenticatedUser();
+            if (!$authUser) {
+                sendJson(['error' => 'Not authenticated.'], 401);
+                break;
+            }
+            $db = getDb();
+
+            if ($_SERVER['REQUEST_METHOD'] === 'GET') {
+                $stmt = $db->prepare('SELECT Settings, UpdatedAt FROM tblUsers WHERE Id = ?');
+                $stmt->execute([$authUser['Id']]);
+                $row = $stmt->fetch(\PDO::FETCH_ASSOC);
+                $settingsRaw = $row['Settings'] ?? null;
+                $settings = is_string($settingsRaw) && $settingsRaw !== ''
+                    ? (json_decode($settingsRaw, true) ?: new \stdClass())
+                    : new \stdClass();
+                sendJson([
+                    'ok'         => true,
+                    'settings'   => $settings,
+                    'updated_at' => $row['UpdatedAt'] ?? null,
+                ]);
+                break;
+            }
+
+            if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+                $rawBody = file_get_contents('php://input');
+                $body = json_decode($rawBody, true);
+                $settings = $body['settings'] ?? null;
+                if (!is_array($settings)) {
+                    sendJson(['error' => 'Settings object required.'], 400);
+                    break;
+                }
+                /* Cap payload size — prefs are small; this guards against abuse. */
+                $json = json_encode($settings, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+                if (strlen($json) > 16384) {
+                    sendJson(['error' => 'Settings payload too large.'], 413);
+                    break;
+                }
+                $stmt = $db->prepare('UPDATE tblUsers SET Settings = ?, UpdatedAt = NOW() WHERE Id = ?');
+                $stmt->execute([$json, $authUser['Id']]);
+                sendJson(['ok' => true]);
+                break;
+            }
+
+            sendJson(['error' => 'GET or POST method required.'], 405);
             break;
 
         /* =================================================================

--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -1801,6 +1801,78 @@ if ($action !== null) {
             sendJson(['ok' => true, 'message' => 'Password changed successfully.']);
             break;
 
+        /* -----------------------------------------------------------------
+         * Change authenticated user's username (self-service)
+         *
+         * POST body (JSON):
+         *   { "new_username": "...", "current_password": "..." }
+         * Requires: Authorization: Bearer <token> + correct current password.
+         * Validation mirrors auth_register: lowercase, [a-z0-9_.\-], 3–100 chars.
+         * Username is UNIQUE; a 409 is returned if taken.
+         * ----------------------------------------------------------------- */
+        case 'auth_change_username':
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+
+            $authUser = getAuthenticatedUser();
+            if (!$authUser) {
+                sendJson(['error' => 'Not authenticated.'], 401);
+                break;
+            }
+
+            $rawBody = file_get_contents('php://input');
+            $body = json_decode($rawBody, true);
+
+            $newUsername = mb_strtolower(trim($body['new_username'] ?? ''));
+            $currentPw   = $body['current_password'] ?? '';
+
+            if (strlen($newUsername) < 3
+                || strlen($newUsername) > 100
+                || !preg_match('/^[a-z0-9_.\-]+$/', $newUsername)) {
+                sendJson(['error' => 'Username must be 3–100 characters (letters, numbers, _, -, . only).'], 400);
+                break;
+            }
+            if ($newUsername === mb_strtolower($authUser['Username'])) {
+                sendJson(['error' => 'New username matches your current username.'], 400);
+                break;
+            }
+
+            $db = getDb();
+
+            /* Verify current password before allowing rename */
+            $stmt = $db->prepare('SELECT PasswordHash, Email, DisplayName FROM tblUsers WHERE Id = ?');
+            $stmt->execute([$authUser['Id']]);
+            $row = $stmt->fetch(\PDO::FETCH_ASSOC);
+            if (!$row || !password_verify($currentPw, $row['PasswordHash'])) {
+                sendJson(['error' => 'Current password is incorrect.'], 401);
+                break;
+            }
+
+            /* Uniqueness check (case-insensitive via lowercased compare) */
+            $stmt = $db->prepare('SELECT Id FROM tblUsers WHERE Username = ? AND Id <> ?');
+            $stmt->execute([$newUsername, $authUser['Id']]);
+            if ($stmt->fetch()) {
+                sendJson(['error' => 'Username is already taken.'], 409);
+                break;
+            }
+
+            $stmt = $db->prepare('UPDATE tblUsers SET Username = ?, UpdatedAt = NOW() WHERE Id = ?');
+            $stmt->execute([$newUsername, $authUser['Id']]);
+
+            sendJson([
+                'ok'   => true,
+                'user' => [
+                    'id'           => $authUser['Id'],
+                    'username'     => $newUsername,
+                    'display_name' => $row['DisplayName'],
+                    'email'        => $row['Email'] ?? '',
+                    'role'         => $authUser['Role'],
+                ],
+            ]);
+            break;
+
         /* =================================================================
          * ADMIN USER MANAGEMENT — API endpoints for /manage/ panel
          * Requires: admin+ role via Bearer token

--- a/appWeb/public_html/includes/SharedSetlist.php
+++ b/appWeb/public_html/includes/SharedSetlist.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Shared Setlist Storage Helper
+ *
+ * Encapsulates the storage of public link-shared setlists. Prefers
+ * MySQL (`tblSharedSetlists`); transparently falls back to the legacy
+ * file-based store under APP_SETLIST_SHARE_DIR when the table is
+ * missing — so a deployment that hasn't run migrate-account-sync.php
+ * yet keeps working unchanged until the admin opts in.
+ *
+ * Once migration has run, every read/write flows through MySQL and
+ * the file path becomes dead code. The original JSON files are left
+ * on disk by the migration so admins can verify the import before
+ * deleting them.
+ *
+ * Each helper returns null/false on a clean miss so callers don't have
+ * to differentiate "not found" from "DB unavailable" — that's
+ * intentional, since the fallback handles the latter.
+ */
+
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'config.php';
+
+/**
+ * Load a shared setlist by ID. Returns the decoded payload array or
+ * null if not found in either store.
+ */
+function sharedSetlistGet(string $shareId): ?array
+{
+    /* MySQL first */
+    try {
+        $db   = getDb();
+        $stmt = $db->prepare('SELECT Data FROM tblSharedSetlists WHERE ShareId = ?');
+        $stmt->execute([$shareId]);
+        $raw  = $stmt->fetchColumn();
+        if (is_string($raw) && $raw !== '') {
+            $decoded = json_decode($raw, true);
+            if (is_array($decoded)) return $decoded;
+        }
+    } catch (\Throwable $_e) {
+        /* DB unreachable or table missing — fall through to file lookup */
+    }
+
+    /* Legacy disk fallback */
+    $path = APP_SETLIST_SHARE_DIR . DIRECTORY_SEPARATOR . $shareId . '.json';
+    if (!is_file($path)) return null;
+    $raw = file_get_contents($path);
+    if ($raw === false) return null;
+    $decoded = json_decode($raw, true);
+    return is_array($decoded) ? $decoded : null;
+}
+
+/**
+ * Atomically insert a new shared setlist. Returns true on success,
+ * false on a duplicate-ID collision so the caller can retry with a
+ * fresh ID, or null on a hard failure (caller should surface a 500).
+ */
+function sharedSetlistInsert(string $shareId, array $data): ?bool
+{
+    $json = json_encode($data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+    /* MySQL atomic insert — duplicate-key (SQLSTATE 23000) is the
+       collision signal so the caller can pick another ID. */
+    try {
+        $db   = getDb();
+        $stmt = $db->prepare('INSERT INTO tblSharedSetlists (ShareId, Data) VALUES (?, ?)');
+        $stmt->execute([$shareId, $json]);
+        return true;
+    } catch (\PDOException $e) {
+        if ($e->getCode() === '23000') return false; /* duplicate */
+        /* Other DB error — try disk path below */
+    } catch (\Throwable $_e) {
+        /* DB unavailable — try disk path below */
+    }
+
+    /* Disk fallback — `x` mode is atomic and fails if file exists. */
+    $path = APP_SETLIST_SHARE_DIR . DIRECTORY_SEPARATOR . $shareId . '.json';
+    $fp   = @fopen($path, 'x');
+    if ($fp === false) {
+        return is_file($path) ? false : null;
+    }
+    $written = fwrite($fp, $json);
+    fclose($fp);
+    return $written !== false ? true : null;
+}
+
+/**
+ * Update an existing shared setlist. If the row doesn't exist in MySQL
+ * (e.g. it was historically file-only) we INSERT it — this is the
+ * gradual-migration path: the next save promotes the file's contents
+ * into MySQL. Returns true on success, false otherwise.
+ */
+function sharedSetlistUpdate(string $shareId, array $data): bool
+{
+    $json = json_encode($data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+    try {
+        $db   = getDb();
+        $stmt = $db->prepare('UPDATE tblSharedSetlists SET Data = ?, UpdatedAt = NOW() WHERE ShareId = ?');
+        $stmt->execute([$json, $shareId]);
+        if ($stmt->rowCount() > 0) return true;
+        /* No row matched — promote into MySQL on first edit */
+        $stmt = $db->prepare('INSERT INTO tblSharedSetlists (ShareId, Data) VALUES (?, ?)');
+        $stmt->execute([$shareId, $json]);
+        return true;
+    } catch (\Throwable $_e) {
+        /* Fall through to file write */
+    }
+
+    $path = APP_SETLIST_SHARE_DIR . DIRECTORY_SEPARATOR . $shareId . '.json';
+    return file_put_contents($path, $json, LOCK_EX) !== false;
+}
+
+/**
+ * Increment the view counter on a shared setlist. Best-effort —
+ * silent on failure since the read itself already succeeded.
+ */
+function sharedSetlistMarkViewed(string $shareId): void
+{
+    try {
+        $db = getDb();
+        $stmt = $db->prepare('UPDATE tblSharedSetlists SET ViewCount = ViewCount + 1 WHERE ShareId = ?');
+        $stmt->execute([$shareId]);
+    } catch (\Throwable $_e) {
+        /* Non-critical */
+    }
+}

--- a/appWeb/public_html/includes/pages/settings.php
+++ b/appWeb/public_html/includes/pages/settings.php
@@ -112,11 +112,7 @@ declare(strict_types=1);
 
                     <div class="mb-2">
                         <label for="profile-username" class="form-label small mb-1">Username</label>
-                        <input type="text" id="profile-username" class="form-control" readonly
-                               aria-describedby="profile-username-help">
-                        <small id="profile-username-help" class="text-muted d-block mt-1">
-                            Usernames cannot be changed. Contact an administrator if you need a rename.
-                        </small>
+                        <input type="text" id="profile-username" class="form-control" readonly>
                     </div>
 
                     <div class="mb-2">
@@ -134,6 +130,36 @@ declare(strict_types=1);
                     <button type="submit" class="btn btn-primary btn-sm" id="profile-save-btn">
                         <i class="fa-solid fa-floppy-disk me-1" aria-hidden="true"></i>
                         Save profile
+                    </button>
+                </form>
+
+                <!-- Change username form — separate because it requires
+                     the current password and has its own validation rules. -->
+                <form id="username-form" class="mb-3" autocomplete="off">
+                    <h3 class="h6 mb-2">Change username</h3>
+                    <div id="username-msg" class="alert d-none py-2 small" role="alert"></div>
+
+                    <div class="mb-2">
+                        <label for="username-new" class="form-label small mb-1">New username</label>
+                        <input type="text" id="username-new" class="form-control"
+                               minlength="3" maxlength="100" pattern="[a-z0-9_.\-]+"
+                               autocapitalize="none" autocomplete="off" spellcheck="false">
+                        <small class="text-muted d-block mt-1">
+                            Lowercase letters, numbers, dots, dashes and underscores only.
+                            Must be unique.
+                        </small>
+                    </div>
+                    <div class="mb-2">
+                        <label for="username-current-password" class="form-label small mb-1">
+                            Confirm with current password
+                        </label>
+                        <input type="password" id="username-current-password" class="form-control"
+                               autocomplete="current-password">
+                    </div>
+
+                    <button type="submit" class="btn btn-outline-primary btn-sm" id="username-save-btn">
+                        <i class="fa-solid fa-at me-1" aria-hidden="true"></i>
+                        Change username
                     </button>
                 </form>
 

--- a/appWeb/public_html/includes/pages/settings.php
+++ b/appWeb/public_html/includes/pages/settings.php
@@ -227,6 +227,24 @@ declare(strict_types=1);
                     </small>
                 </label>
             </div>
+
+            <div class="form-check form-switch mb-0">
+                <input class="form-check-input"
+                       type="checkbox"
+                       id="setting-sync-app-settings"
+                       role="switch"
+                       checked
+                       aria-label="Sync app settings across devices">
+                <label class="form-check-label" for="setting-sync-app-settings">
+                    <strong>Sync app settings across devices</strong>
+                    <small class="form-text text-muted d-block">
+                        When signed in, your theme, font size, accessibility and
+                        other UI preferences follow you to other devices.
+                        Device-specific settings (offline downloads, analytics
+                        consent) stay local.
+                    </small>
+                </label>
+            </div>
         </div>
     </div>
 

--- a/appWeb/public_html/index.php
+++ b/appWeb/public_html/index.php
@@ -592,6 +592,13 @@ if (!empty($breadcrumbItems)) {
                         <li><a class="dropdown-item" href="/setlist" data-navigate="setlist">
                             <i class="fa-solid fa-list-ol me-2" aria-hidden="true"></i> Set Lists
                         </a></li>
+                        <!-- Song Editor — visible to users with the edit_songs
+                             entitlement (toggled by user-auth.js). -->
+                        <li id="nav-app-editor-li" class="d-none">
+                            <a class="dropdown-item" href="/manage/editor/">
+                                <i class="fa-solid fa-pen-to-square me-2" aria-hidden="true"></i> Song Editor
+                            </a>
+                        </li>
                         <li><hr class="dropdown-divider"></li>
                         <li><a class="dropdown-item" href="/stats" data-navigate="stats">
                             <i class="fa-solid fa-chart-simple me-2" aria-hidden="true"></i> Statistics
@@ -696,17 +703,21 @@ if (!empty($breadcrumbItems)) {
                                                  manage_entitlements / view_analytics /
                                                  run_db_install / run_db_migrate
                                  ============================================ -->
+                            <!-- Display name + role are clickable shortcuts that
+                                 deep-link to the Account & Profile tab on /settings. -->
                             <li id="header-user-name" class="d-none">
-                                <span class="dropdown-item-text fw-semibold" id="header-user-display-name"></span>
+                                <a class="dropdown-item fw-semibold" href="/settings#tab-profile"
+                                   data-navigate="settings" id="header-user-display-name"></a>
                             </li>
                             <li id="header-user-role-li" class="d-none">
-                                <span class="dropdown-item-text small text-muted" id="header-user-role-text"></span>
+                                <a class="dropdown-item small text-muted py-1" href="/settings#tab-profile"
+                                   data-navigate="settings" id="header-user-role-text"></a>
                             </li>
 
                             <!-- ── Account ── -->
                             <li id="header-user-divider" class="d-none"><hr class="dropdown-divider"></li>
                             <li id="header-user-settings-li" class="d-none">
-                                <a class="dropdown-item" href="/settings" data-navigate="settings">
+                                <a class="dropdown-item" href="/settings#tab-profile" data-navigate="settings">
                                     <i class="fa-solid fa-gear me-2" aria-hidden="true"></i> Settings
                                 </a>
                             </li>

--- a/appWeb/public_html/index.php
+++ b/appWeb/public_html/index.php
@@ -231,19 +231,17 @@ try {
     elseif (preg_match('#^/setlist/shared/([a-f0-9]+)$#', $requestPath, $matches)) {
         $pageType = 'other';
         $shareId = $matches[1];
-        $shareFile = APP_SETLIST_SHARE_DIR . '/' . $shareId . '.json';
-        if (file_exists($shareFile)) {
-            $shareData = json_decode(file_get_contents($shareFile), true);
-            if (is_array($shareData)) {
-                $setlistName = $shareData['name'] ?? 'Shared Set List';
-                $setlistSongCount = count($shareData['songs'] ?? []);
-                $ogTitle = htmlspecialchars($setlistName) . ' — Shared Set List — ' . $app["Application"]["Name"];
-                $ogDescription = 'A curated set list with ' . $setlistSongCount
-                               . ' ' . ($setlistSongCount === 1 ? 'song' : 'songs')
-                               . ' on ' . $app["Application"]["Name"];
-                $ogImage = getCanonicalUrl('/og-image?setlist=' . urlencode($shareId));
-                $ogImageAlt = 'Set list "' . $setlistName . '" on ' . $app["Application"]["Name"];
-            }
+        require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'SharedSetlist.php';
+        $shareData = sharedSetlistGet($shareId);
+        if (is_array($shareData)) {
+            $setlistName = $shareData['name'] ?? 'Shared Set List';
+            $setlistSongCount = count($shareData['songs'] ?? []);
+            $ogTitle = htmlspecialchars($setlistName) . ' — Shared Set List — ' . $app["Application"]["Name"];
+            $ogDescription = 'A curated set list with ' . $setlistSongCount
+                           . ' ' . ($setlistSongCount === 1 ? 'song' : 'songs')
+                           . ' on ' . $app["Application"]["Name"];
+            $ogImage = getCanonicalUrl('/og-image?setlist=' . urlencode($shareId));
+            $ogImageAlt = 'Set list "' . $setlistName . '" on ' . $app["Application"]["Name"];
         }
 
         /* Breadcrumb: Home > Set Lists > Shared */

--- a/appWeb/public_html/js/modules/settings.js
+++ b/appWeb/public_html/js/modules/settings.js
@@ -385,6 +385,13 @@ export class Settings {
         /* Account section — user auth buttons */
         this._initAccountSection();
 
+        /* Tab activation:
+             • #tab-profile or #tab-app in the URL → that tab wins
+             • otherwise → Profile if signed in, App if signed out
+           The static markup defaults to App active, so we only need to
+           switch when one of the above conditions wants Profile. */
+        this._activateInitialSettingsTab();
+
         /* Theme buttons */
         document.querySelectorAll('[data-setting-theme]').forEach(btn => {
             const theme = btn.dataset.settingTheme;
@@ -1227,6 +1234,44 @@ export class Settings {
      * ===================================================================== */
 
     /**
+     * Pick which tab is active on a fresh load of the settings page.
+     * Hash wins; otherwise Profile when signed in, App otherwise.
+     */
+    _activateInitialSettingsTab() {
+        const profileBtn = document.getElementById('tab-profile-btn');
+        const appBtn     = document.getElementById('tab-app-btn');
+        if (!profileBtn || !appBtn) return;
+
+        const hash = (window.location.hash || '').toLowerCase();
+        let target = null;
+        if (hash === '#tab-profile') target = profileBtn;
+        else if (hash === '#tab-app') target = appBtn;
+        else if (this.app.userAuth?.isLoggedIn?.()) target = profileBtn;
+
+        if (!target) return; /* leave default (App) active */
+
+        /* Use Bootstrap's Tab API if available; fall back to manual class
+           toggling so the page still renders correctly without bootstrap.bundle. */
+        const Bs = window.bootstrap;
+        if (Bs?.Tab) {
+            Bs.Tab.getOrCreateInstance(target).show();
+            return;
+        }
+        document.querySelectorAll('#settings-tabs .nav-link').forEach(b => {
+            b.classList.remove('active');
+            b.setAttribute('aria-selected', 'false');
+        });
+        document.querySelectorAll('.tab-content > .tab-pane').forEach(p => {
+            p.classList.remove('active', 'show');
+        });
+        target.classList.add('active');
+        target.setAttribute('aria-selected', 'true');
+        const paneId = target.dataset.bsTarget?.replace('#', '');
+        const pane = paneId && document.getElementById(paneId);
+        pane?.classList.add('active', 'show');
+    }
+
+    /**
      * Initialise the account section in settings.
      * Shows logged-in or logged-out state and binds button handlers.
      */
@@ -1283,6 +1328,37 @@ export class Settings {
                     show('Profile saved.', 'success');
                 } else {
                     show(result.error || 'Could not save profile.', 'danger');
+                }
+            });
+        }
+
+        /* Change username — separate form, requires current password */
+        const usernameForm = document.getElementById('username-form');
+        if (usernameForm && !usernameForm.dataset.bound) {
+            usernameForm.dataset.bound = '1';
+            usernameForm.addEventListener('submit', async (e) => {
+                e.preventDefault();
+                const newUsername     = document.getElementById('username-new').value.trim().toLowerCase();
+                const currentPassword = document.getElementById('username-current-password').value;
+                const msg = document.getElementById('username-msg');
+                const show = (text, kind) => {
+                    if (!msg) return;
+                    msg.className = 'alert py-2 small alert-' + kind;
+                    msg.textContent = text;
+                    msg.classList.remove('d-none');
+                };
+                if (!/^[a-z0-9_.\-]{3,100}$/.test(newUsername)) {
+                    show('Username must be 3–100 characters (letters, numbers, _, -, . only).', 'danger');
+                    return;
+                }
+                const result = await auth.changeUsername({ newUsername, currentPassword });
+                if (result.success) {
+                    show('Username changed.', 'success');
+                    document.getElementById('username-current-password').value = '';
+                    /* Re-populate the username field visible in the profile form */
+                    this.refreshAccountSection();
+                } else {
+                    show(result.error || 'Could not change username.', 'danger');
                 }
             });
         }

--- a/appWeb/public_html/js/modules/settings.js
+++ b/appWeb/public_html/js/modules/settings.js
@@ -22,6 +22,32 @@ import {
     STORAGE_SEARCH_HISTORY,
 } from '../constants.js';
 
+/**
+ * Strict whitelist of localStorage keys that sync to the user's
+ * profile when signed in (and the sync toggle is on). Anything not
+ * listed here stays device-local — that includes analytics consent,
+ * the install banner state, the disclaimer flag, the per-device
+ * owner ID, and the offline-downloads toggles which are tied to
+ * device storage choices rather than UI preferences.
+ */
+const SYNC_PREF_KEYS = Object.freeze([
+    'ihymns_theme',
+    'ihymns_fontSize',
+    'ihymns_reduceMotion',
+    'ihymns_reduceTransparency',
+    'ihymns_transition',
+    'ihymns_default_songbook',
+    'ihymns_auto_update_songs',
+    'ihymns_numpad_live_search',
+    'ihymns_search_lyrics',
+    'ihymns_display',
+    'ihymns_cvd_mode',
+    'ihymns_keyboardShortcuts',
+]);
+
+/** localStorage key for the user's opt-in toggle. Default = on. */
+const SYNC_TOGGLE_KEY = 'ihymns_sync_app_settings';
+
 export class Settings {
     /**
      * @param {object} app Reference to the main iHymnsApp instance
@@ -107,10 +133,105 @@ export class Settings {
         }
 
         /* Re-apply the Account section whenever auth state changes, even if
-           the user is on the Settings page (no navigation triggered). */
-        document.addEventListener('ihymns:auth-changed', () => {
+           the user is on the Settings page (no navigation triggered).
+           When signing in, also pull any synced prefs from the server so
+           the UI reflects choices made on other devices. */
+        document.addEventListener('ihymns:auth-changed', (e) => {
             this.refreshAccountSection();
+            const loggedIn = !!e?.detail?.loggedIn;
+            if (loggedIn && this._isSyncEnabled()) {
+                this._pullSyncedSettings().catch(() => { /* non-fatal */ });
+            }
         });
+    }
+
+    /* =====================================================================
+     * APP-SETTINGS SYNC — push/pull a whitelisted subset of prefs
+     * ===================================================================== */
+
+    /** Is per-user settings sync currently active? */
+    _isSyncEnabled() {
+        if (!this.app.userAuth?.isLoggedIn?.()) return false;
+        /* Default = on; only off when the user has explicitly opted out. */
+        return localStorage.getItem(SYNC_TOGGLE_KEY) !== 'false';
+    }
+
+    /** Snapshot of the syncable prefs currently in localStorage. */
+    _collectSyncableSettings() {
+        const out = {};
+        SYNC_PREF_KEYS.forEach((k) => {
+            const v = localStorage.getItem(k);
+            if (v !== null) out[k] = v;
+        });
+        return out;
+    }
+
+    /**
+     * Schedule a push of synced prefs to the server. Debounced 1.5s
+     * so a flurry of changes (e.g. dragging the font-size slider)
+     * collapses into one POST.
+     */
+    _maybePushSync(fullKey) {
+        if (fullKey && !SYNC_PREF_KEYS.includes(fullKey)) return;
+        if (!this._isSyncEnabled()) return;
+        clearTimeout(this._syncPushTimer);
+        this._syncPushTimer = setTimeout(() => this._pushSyncedSettings(), 1500);
+    }
+
+    async _pushSyncedSettings() {
+        if (!this._isSyncEnabled()) return;
+        try {
+            await fetch(`${this.app.config.apiUrl}?action=user_settings`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest',
+                    ...this.app.userAuth.authHeaders(),
+                },
+                body: JSON.stringify({ settings: this._collectSyncableSettings() }),
+            });
+        } catch { /* offline / network error — non-fatal */ }
+    }
+
+    /**
+     * Fetch synced prefs from the server and apply them to localStorage,
+     * then re-apply visual settings so the UI updates without a reload.
+     */
+    async _pullSyncedSettings() {
+        if (!this.app.userAuth?.isLoggedIn?.()) return;
+        let payload;
+        try {
+            const res = await fetch(`${this.app.config.apiUrl}?action=user_settings`, {
+                headers: {
+                    'X-Requested-With': 'XMLHttpRequest',
+                    ...this.app.userAuth.authHeaders(),
+                },
+            });
+            if (!res.ok) return;
+            payload = await res.json();
+        } catch { return; }
+
+        const remote = payload?.settings;
+        if (!remote || typeof remote !== 'object') return;
+
+        let appliedTheme = false;
+        SYNC_PREF_KEYS.forEach((k) => {
+            if (Object.prototype.hasOwnProperty.call(remote, k)) {
+                const v = String(remote[k] ?? '');
+                if (v === '') {
+                    localStorage.removeItem(k);
+                } else {
+                    localStorage.setItem(k, v);
+                }
+                if (k === 'ihymns_theme') appliedTheme = true;
+            }
+        });
+
+        /* Re-apply the visual settings so the change is immediate. */
+        if (appliedTheme) this.applyTheme(this.get('theme'));
+        this.applyReduceMotion(this.get('reduceMotion'));
+        this.applyReduceTransparency(this.get('reduceTransparency'));
+        this.applyFontSize(this.get('fontSize'));
     }
 
     /**
@@ -284,6 +405,8 @@ export class Settings {
         localStorage.setItem(fullKey, String(value));
         /* Sync to subdomain cookie + iframe bridge (#133) */
         this.app.syncStorage(fullKey);
+        /* Per-user profile sync (whitelisted keys only — no-ops otherwise) */
+        this._maybePushSync(fullKey);
     }
 
     /**
@@ -428,6 +551,7 @@ export class Settings {
             transitionSelect.addEventListener('change', () => {
                 localStorage.setItem(STORAGE_TRANSITION, transitionSelect.value);
                 this.app.syncStorage(STORAGE_TRANSITION);
+                this._maybePushSync(STORAGE_TRANSITION);
             });
         }
 
@@ -489,6 +613,7 @@ export class Settings {
                     localStorage.removeItem(STORAGE_DEFAULT_SONGBOOK);
                 }
                 this.app.syncStorage(STORAGE_DEFAULT_SONGBOOK);
+                this._maybePushSync(STORAGE_DEFAULT_SONGBOOK);
             });
         }
 
@@ -500,6 +625,7 @@ export class Settings {
                 const enabled = liveSearchToggle.checked;
                 localStorage.setItem(STORAGE_NUMPAD_LIVE_SEARCH, String(enabled));
                 this.app.syncStorage(STORAGE_NUMPAD_LIVE_SEARCH);
+                this._maybePushSync(STORAGE_NUMPAD_LIVE_SEARCH);
             });
         }
 
@@ -516,6 +642,7 @@ export class Settings {
                     localStorage.removeItem('ihymns_cvd_mode');
                     document.documentElement.removeAttribute('data-ihymns-cvd');
                 }
+                this._maybePushSync('ihymns_cvd_mode');
             });
         }
 
@@ -602,6 +729,7 @@ export class Settings {
                 const enabled = autoUpdateToggle.checked;
                 localStorage.setItem(STORAGE_AUTO_UPDATE_SONGS, String(enabled));
                 this.app.syncStorage(STORAGE_AUTO_UPDATE_SONGS);
+                this._maybePushSync(STORAGE_AUTO_UPDATE_SONGS);
                 /* Inform the service worker of the new preference */
                 if (navigator.serviceWorker?.controller) {
                     navigator.serviceWorker.controller.postMessage({
@@ -1307,6 +1435,22 @@ export class Settings {
             /* Refresh account section display */
             this._initAccountSection();
         });
+
+        /* App-settings sync toggle. Default = on; storing 'false' opts out. */
+        const syncToggle = document.getElementById('setting-sync-app-settings');
+        if (syncToggle) {
+            syncToggle.checked = localStorage.getItem(SYNC_TOGGLE_KEY) !== 'false';
+            syncToggle.addEventListener('change', () => {
+                if (syncToggle.checked) {
+                    localStorage.removeItem(SYNC_TOGGLE_KEY);
+                    /* Push current local prefs immediately so the server
+                       reflects this device's state once sync is on. */
+                    this._pushSyncedSettings();
+                } else {
+                    localStorage.setItem(SYNC_TOGGLE_KEY, 'false');
+                }
+            });
+        }
 
         /* Profile save — update display name + email */
         const profileForm = document.getElementById('profile-form');

--- a/appWeb/public_html/js/modules/user-auth.js
+++ b/appWeb/public_html/js/modules/user-auth.js
@@ -331,6 +331,42 @@ export class UserAuth {
     }
 
     /**
+     * Change the signed-in user's username. Requires the current
+     * password as a confirmation step. Updates the cached user on
+     * success so the header re-renders the new handle.
+     *
+     * @param {{ newUsername: string, currentPassword: string }} fields
+     * @returns {Promise<{ success: boolean, user?: object, error?: string }>}
+     */
+    async changeUsername({ newUsername, currentPassword }) {
+        if (!this.isLoggedIn()) return { success: false, error: 'Not signed in.' };
+        try {
+            const res = await fetch(`${this.app.config.apiUrl}?action=auth_change_username`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest',
+                    ...this.authHeaders(),
+                },
+                body: JSON.stringify({
+                    new_username: newUsername,
+                    current_password: currentPassword,
+                }),
+            });
+            const data = await res.json();
+            if (!res.ok) return { success: false, error: data.error || 'Could not change username.' };
+
+            if (data.user) {
+                localStorage.setItem(STORAGE_AUTH_USER, JSON.stringify(data.user));
+                this._broadcastAuthChanged();
+            }
+            return { success: true, user: data.user };
+        } catch {
+            return { success: false, error: 'Network error. Please try again.' };
+        }
+    }
+
+    /**
      * Change the signed-in user's password.
      * @param {{ currentPassword: string, newPassword: string }} fields
      * @returns {Promise<{ success: boolean, error?: string }>}
@@ -475,6 +511,14 @@ export class UserAuth {
 
         applySection(entItems.curator, 'header-curator-divider', 'header-curator-header');
         applySection(entItems.admin,   'header-admin-divider',   'header-admin-header');
+
+        /* Left "app name" dropdown also surfaces Song Editor for users
+           who hold edit_songs. Same entitlement check, separate element. */
+        const navEditor = document.getElementById('nav-app-editor-li');
+        if (navEditor) {
+            const canEdit = loggedIn && userHasEntitlement('edit_songs', role);
+            navEditor.classList.toggle('d-none', !canEdit);
+        }
 
         /* Update icon style */
         const icon = document.getElementById('header-user-icon');

--- a/appWeb/public_html/manage/includes/auth.php
+++ b/appWeb/public_html/manage/includes/auth.php
@@ -540,6 +540,41 @@ function updateUserProfile(int $userId, string $displayName, string $email): boo
 }
 
 /**
+ * Rename a user (admin path — no password verification, since the
+ * caller has already been authorised by the surrounding admin check).
+ * Validation mirrors auth_register: lowercased, [a-z0-9_.\-], 3–100
+ * chars. Returns false on validation failure or uniqueness collision;
+ * caller should surface a friendly message.
+ *
+ * @param int    $userId      Target user ID
+ * @param string $newUsername Desired username
+ * @param string &$error      Set to a human-readable message on failure
+ * @return bool
+ */
+function renameUser(int $userId, string $newUsername, ?string &$error = null): bool
+{
+    $newUsername = mb_strtolower(trim($newUsername));
+    if (strlen($newUsername) < 3
+        || strlen($newUsername) > 100
+        || !preg_match('/^[a-z0-9_.\-]+$/', $newUsername)) {
+        $error = 'Username must be 3–100 characters (letters, numbers, _, -, . only).';
+        return false;
+    }
+
+    $db = getDb();
+    $stmt = $db->prepare('SELECT Id FROM tblUsers WHERE Username = ? AND Id <> ?');
+    $stmt->execute([$newUsername, $userId]);
+    if ($stmt->fetch()) {
+        $error = 'Username is already taken.';
+        return false;
+    }
+
+    $stmt = $db->prepare('UPDATE tblUsers SET Username = ?, UpdatedAt = CURRENT_TIMESTAMP WHERE Id = ?');
+    $stmt->execute([$newUsername, $userId]);
+    return true;
+}
+
+/**
  * Activate or deactivate a user account.
  *
  * @param int  $userId   Target user ID

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -192,6 +192,7 @@ if ($action !== '') {
         'install'     => 'install.php',
         'migrate'     => 'migrate-json.php',
         'users'       => 'migrate-users.php',
+        'account-sync'=> 'migrate-account-sync.php',
         'cleanup'     => 'cleanup.php',
         'backup'      => 'backup.php',
         'restore'     => 'restore.php',
@@ -440,6 +441,22 @@ if ($hasCredentials && defined('DB_HOST')) {
                         </p>
                         <a href="?action=users" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
                             Run User Migration
+                        </a>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="card bg-dark border-secondary h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">3a. Account Sync &amp; Shared Setlists</h5>
+                        <p class="card-text text-secondary small">
+                            Adds the <code>Settings</code> column to <code>tblUsers</code>
+                            (per-device prefs sync) and creates <code>tblSharedSetlists</code>,
+                            then imports any legacy share-link JSON files into the new table.
+                            Idempotent — safe to re-run.
+                        </p>
+                        <a href="?action=account-sync" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
+                            Run Account Sync Migration
                         </a>
                     </div>
                 </div>

--- a/appWeb/public_html/manage/users.php
+++ b/appWeb/public_html/manage/users.php
@@ -129,6 +129,26 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 }
                 break;
 
+            /* ----- Rename (username change) ----- */
+            case 'rename_user':
+                $targetId    = (int)($_POST['user_id'] ?? 0);
+                $newUsername = trim($_POST['new_username'] ?? '');
+                $target      = getUserById($targetId);
+                if (!$target) {
+                    $error = 'User not found.';
+                } elseif (roleLevel($target['role']) >= roleLevel($currentUser['role']) && $currentUser['role'] !== 'global_admin' && $targetId !== $currentUser['id']) {
+                    $error = 'Cannot rename a user at or above your role level.';
+                } else {
+                    $renameError = null;
+                    if (renameUser($targetId, $newUsername, $renameError)) {
+                        $success = 'User "' . htmlspecialchars($target['username'])
+                                 . '" renamed to "' . htmlspecialchars(mb_strtolower(trim($newUsername))) . '".';
+                    } else {
+                        $error = $renameError ?? 'Could not rename user.';
+                    }
+                }
+                break;
+
             /* ----- Delete user ----- */
             case 'delete':
                 $targetId = (int)($_POST['user_id'] ?? 0);
@@ -253,6 +273,11 @@ function canManage(array $target, array $actor): bool {
                                     <button class="btn btn-outline-info" title="Edit profile"
                                             onclick="openEditModal(<?= (int)$u['id'] ?>, '<?= htmlspecialchars($u['display_name'], ENT_QUOTES) ?>', '<?= htmlspecialchars($u['email'] ?? '', ENT_QUOTES) ?>')">
                                         <i class="bi bi-pencil"></i>
+                                    </button>
+                                    <!-- Rename (change username) -->
+                                    <button class="btn btn-outline-info" title="Rename user"
+                                            onclick="openRenameModal(<?= (int)$u['id'] ?>, '<?= htmlspecialchars($u['username'], ENT_QUOTES) ?>')">
+                                        <i class="bi bi-at"></i>
                                     </button>
                                     <!-- Change Role (not for self) -->
                                     <?php if (!$isSelf): ?>
@@ -418,6 +443,45 @@ function canManage(array $target, array $actor): bool {
         </div>
     </div>
 
+    <!-- Rename User Modal -->
+    <div class="modal fade" id="renameModal" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content" style="background: var(--ih-surface); color: var(--ih-text); border-color: var(--ih-border);">
+                <form method="POST">
+                    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                    <input type="hidden" name="action" value="rename_user">
+                    <input type="hidden" name="user_id" id="rename-user-id">
+                    <div class="modal-header" style="border-color: var(--ih-border);">
+                        <h5 class="modal-title"><i class="bi bi-at me-2"></i>Rename — <span id="rename-current-username"></span></h5>
+                        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+                    </div>
+                    <div class="modal-body">
+                        <div class="mb-3">
+                            <label class="form-label">New username</label>
+                            <input type="text" class="form-control" name="new_username" id="rename-new-username"
+                                   minlength="3" maxlength="100" pattern="[a-z0-9_.\-]+"
+                                   autocomplete="off" autocapitalize="none" spellcheck="false" required>
+                            <div class="form-text" style="color: var(--ih-text-muted);">
+                                Lowercase letters, numbers, dots, dashes and underscores only. 3–100 characters.
+                                Usernames must be unique.
+                            </div>
+                        </div>
+                        <div class="alert alert-info py-2 small mb-0">
+                            <i class="bi bi-info-circle me-1"></i>
+                            Existing tokens, setlists, favourites and revisions stay tied to the
+                            user. Old login attempts logged under the previous username remain in
+                            the audit history.
+                        </div>
+                    </div>
+                    <div class="modal-footer" style="border-color: var(--ih-border);">
+                        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                        <button type="submit" class="btn btn-amber">Rename</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
     <!-- Reset Password Modal -->
     <div class="modal fade" id="passwordModal" tabindex="-1">
         <div class="modal-dialog">
@@ -475,6 +539,16 @@ function canManage(array $target, array $actor): bool {
             document.getElementById('pw-user-id').value = userId;
             document.getElementById('pw-username').textContent = username;
             new bootstrap.Modal(document.getElementById('passwordModal')).show();
+        }
+
+        /* Open Rename modal */
+        function openRenameModal(userId, currentUsername) {
+            document.getElementById('rename-user-id').value = userId;
+            document.getElementById('rename-current-username').textContent = currentUsername;
+            const input = document.getElementById('rename-new-username');
+            input.value = currentUsername;
+            new bootstrap.Modal(document.getElementById('renameModal')).show();
+            setTimeout(() => { input.focus(); input.select(); }, 200);
         }
     </script>
 </body>

--- a/appWeb/public_html/og-image.php
+++ b/appWeb/public_html/og-image.php
@@ -94,11 +94,9 @@ try {
     } elseif ($setlistId !== null) {
         $cleanId = preg_replace('/[^a-f0-9]/', '', strtolower(trim($setlistId)));
         if ($cleanId !== '' && strlen($cleanId) <= 16) {
-            $filePath = APP_SETLIST_SHARE_DIR . '/' . $cleanId . '.json';
-            if (file_exists($filePath)) {
-                $setlistInfo = json_decode(file_get_contents($filePath), true);
-                if (is_array($setlistInfo)) $mode = 'setlist';
-            }
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'SharedSetlist.php';
+            $setlistInfo = sharedSetlistGet($cleanId);
+            if (is_array($setlistInfo)) $mode = 'setlist';
         }
     }
 } catch (\Throwable $e) {


### PR DESCRIPTION
> Stacks on top of #415. The diff will look incremental once #415 is merged into `alpha`.

Three follow-ups in three commits:

## Phase A — Username rename (self-service + admin) + Profile-tab deep-link
- New `auth_change_username` API. Mirrors `auth_register` validation (lowercased, `[a-z0-9_.\-]`, 3–100 chars) and the `UNIQUE` constraint on `tblUsers.Username`. Requires the **current password** as a confirmation step.
- Admin path: `/manage/users` gets a per-row Rename button + modal. Uses a new `renameUser()` helper in `manage/includes/auth.php` — same validation, no password needed (admin authority).
- Profile-tab UX: display name and role in the user dropdown are now clickable shortcuts to `/settings#tab-profile`. The Settings link also targets that hash. `settings.js` activates the requested tab on load (hash wins, otherwise Profile when signed in / App when signed out).
- Bonus from your request: **Song Editor** added to the left "app name" dropdown, gated by `edit_songs`.

## Phase B — Settings sync (theme/font/accessibility) to user profile
- New `Settings JSON` column on `tblUsers` and a new `user_settings` GET/POST API endpoint.
- Strict client-side whitelist of syncable keys (theme, font size, transitions, motion, transparency, keyboard shortcuts, CVD mode, default songbook, numpad live search, search-lyrics, display). **Device-local** (not synced): analytics consent, disclaimer flag, install banner, offline-download choices, per-device owner ID.
- Push on change (debounced 1.5 s); pull on `ihymns:auth-changed` when signing in. New "Sync app settings across devices" toggle in the Sync section (default on; off opts out).

## Phase C — Shared setlists move from JSON files → MySQL
- New `tblSharedSetlists` table keyed by the existing 8-char hex `ShareId` so **all old share URLs keep working** after import.
- New `includes/SharedSetlist.php` helper used by `api.php` (`setlist_save` + `setlist_get`), `index.php` (share-page meta) and `og-image.php` (preview image). Helper prefers MySQL and **falls back to disk** when the table is missing — so deployments stay working until the migration is run.

## Migration (admin-only, opt-in)
Per your guidance, the new schema does not auto-`ALTER` existing deployments. Instead, a new `appWeb/.sql/migrate-account-sync.php` script:
1. Adds the `Settings` column to `tblUsers` if missing.
2. Creates `tblSharedSetlists` if missing.
3. Imports any legacy JSON files from `APP_SETLIST_SHARE_DIR` into the new table (idempotent, skip-if-exists).

Wired into `/manage/setup-database` as **"Account Sync Migration"**, gated by the page's existing `global_admin` auth check (which is in turn surfaced in the user dropdown's Administration section via the `run_db_install` entitlement). Original JSON files are left on disk so admins can verify the import before deletion.

## Auto-migrate on login
Per-user setlists already auto-sync via the existing `user_setlists_sync` endpoint that runs on each app boot when signed in — no additional work needed. Settings sync and shared-setlist visibility light up automatically the moment a user signs in (and after the migration has been run on the deployment).

## Test plan
- [ ] **Profile tab deep-link**: click your name / role / Settings in the user dropdown → settings page opens on Account & Profile tab. Direct visit to `/settings` while signed out → opens on App Settings.
- [ ] **Username rename (self)**: enter new username + current password on Profile tab → succeeds; header re-renders with new handle. Try invalid chars / a duplicate / wrong password → friendly error.
- [ ] **Username rename (admin)**: on `/manage/users`, click `@` button on a row → modal pre-fills current username → renaming succeeds. Try a duplicate → error surfaces.
- [ ] **Settings sync**: as a signed-in user, change theme + font size → on a second signed-in device (or after sign-out / sign-in), the prefs follow.
- [ ] **Settings sync opt-out**: toggle off → changes stop pushing.
- [ ] **Migration**: as `global_admin` visit `/manage/setup-database`, click **Account Sync Migration**. First run reports the column added + table created. Drop a JSON file in `data_share/setlist_json/` and re-run → row appears in `tblSharedSetlists`. Re-run again → row is skipped.
- [ ] **Shared setlist link backward compat**: pre-migration, visiting `/setlist/shared/<id>` for a file-only share works. Post-migration, after the file is imported, the same URL still works (now from DB) and the file is left in place.
- [ ] **No auto-migration**: re-running the regular `Install` action on an existing DB does **not** add the Settings column or the new table — only the explicit Account Sync Migration does.
- [ ] **Song Editor in left menu**: as a curator (`edit_songs`), the left app dropdown surfaces a Song Editor entry. As a regular user, it's hidden.

https://claude.ai/code/session_01LVu9oYy2LbeYjXfys5EhoF

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVu9oYy2LbeYjXfys5EhoF)_