### PR TITLE
Fix blank admin dashboard (getCurrentUser column casing mismatch)

### DIFF
--- a/appWeb/public_html/css/app.css
+++ b/appWeb/public_html/css/app.css
@@ -326,6 +326,18 @@
     text-align: center;
 }
 
+/* User-account dropdown can grow tall once a curator / admin has
+   several entitlement-gated items visible, so cap its height to the
+   viewport and let the inner list scroll. Also applied to the left
+   app-name dropdown for the same reason. The 96px reserve covers the
+   header bar + a small breathing gap. */
+#header-user-dropdown .dropdown-menu,
+#logo-nav-btn + .dropdown-menu {
+    max-height: calc(100vh - 96px);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+}
+
 /* ==========================================================================
    2. BASE / RESET STYLES
    ========================================================================== */

--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -41,7 +41,7 @@ if (!isAuthenticated()) {
 }
 
 $currentUser = getCurrentUser();
-if (!$currentUser || !hasRole($currentUser['Role'], 'editor')) {
+if (!$currentUser || !hasRole($currentUser['role'], 'editor')) {
     header('Content-Type: application/json; charset=UTF-8');
     http_response_code(403);
     echo json_encode(['error' => 'Editor access required.']);
@@ -609,7 +609,7 @@ switch ($action) {
 
             /* Insert mapping rows (ignore duplicates). */
             if (!empty($addIds) && !empty($songIds)) {
-                $userId = (int)($currentUser['Id'] ?? 0);
+                $userId = (int)($currentUser['id'] ?? 0);
                 $stmt = $db->prepare(
                     'INSERT IGNORE INTO tblSongTagMap (SongId, TagId, TaggedBy) VALUES (?, ?, ?)'
                 );

--- a/appWeb/public_html/manage/includes/auth.php
+++ b/appWeb/public_html/manage/includes/auth.php
@@ -83,7 +83,21 @@ function getCurrentUser(): ?array
     }
 
     $db = getDb();
-    $stmt = $db->prepare('SELECT Id, Username, DisplayName, Role FROM tblUsers WHERE Id = ? AND IsActive = 1');
+    /* Aliased to lowercase keys so the rest of /manage/ (index.php,
+       users.php, entitlements.php, admin-nav.php, …) can use the
+       $currentUser['role'] / ['username'] / ['display_name'] shape
+       consistently. Passing a null key to the typed hasRole()
+       parameter previously fatal-errored the admin dashboard mid-
+       render. */
+    $stmt = $db->prepare(
+        'SELECT Id AS id,
+                Username AS username,
+                DisplayName AS display_name,
+                Role AS role,
+                Email AS email
+         FROM tblUsers
+         WHERE Id = ? AND IsActive = 1'
+    );
     $stmt->execute([$_SESSION['user_id']]);
     return $stmt->fetch(PDO::FETCH_ASSOC) ?: null;
 }

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -41,7 +41,7 @@ if (!$isInitialSetup) {
         exit;
     }
     $currentUser = getCurrentUser();
-    if (!$currentUser || $currentUser['Role'] !== 'global_admin') {
+    if (!$currentUser || $currentUser['role'] !== 'global_admin') {
         http_response_code(403);
         echo '<!DOCTYPE html><html><body><h1>403 — Global Admin access required</h1></body></html>';
         exit;
@@ -527,7 +527,7 @@ if ($hasCredentials && defined('DB_HOST')) {
                                absent or the activity log helper isn't available. */
                             try {
                                 $auditDb = getDbMysqli();
-                                $auditUser = $currentUser['Username'] ?? 'unknown';
+                                $auditUser = $currentUser['username'] ?? 'unknown';
                                 $auditSql = sprintf(
                                     'backup upload by %s: %s (%d bytes)',
                                     $auditUser, $safeName, (int)$f['size']
@@ -536,7 +536,7 @@ if ($hasCredentials && defined('DB_HOST')) {
                                     'INSERT INTO tblActivityLog (UserId, ActionType, Details) VALUES (?, ?, ?)'
                                 );
                                 if ($stmt) {
-                                    $uid = isset($currentUser['Id']) ? (int)$currentUser['Id'] : 0;
+                                    $uid = isset($currentUser['id']) ? (int)$currentUser['id'] : 0;
                                     $action = 'backup_upload';
                                     $stmt->bind_param('iss', $uid, $action, $auditSql);
                                     @$stmt->execute();
@@ -689,7 +689,7 @@ if ($hasCredentials && defined('DB_HOST')) {
     <p class="text-secondary text-center small">
         iHymns Database Administration &middot; v0.10.0
         <?php if (!$isInitialSetup && isset($currentUser)): ?>
-            &middot; Logged in as <strong><?= htmlspecialchars($currentUser['Username'] ?? '') ?></strong>
+            &middot; Logged in as <strong><?= htmlspecialchars($currentUser['username'] ?? '') ?></strong>
         <?php endif; ?>
     </p>
 </div>


### PR DESCRIPTION
## Summary
- `getCurrentUser()` returned PascalCase keys (`Username`, `Role`, `DisplayName`, `Id`) from its `SELECT`, but the bulk of `/manage/` (index.php, users.php, entitlements.php, admin-nav.php) references the lowercase shape (`$currentUser['role']` etc). On PHP 8, calling `hasRole($currentUser['role'], …)` with a missing key passes `null` to the `string`-typed parameter and throws a fatal TypeError — which is why the dashboard rendered the left logo + Dashboard link and nothing after.
- Fixed by aliasing the SELECT to lowercase in `getCurrentUser()` and updating the small number of PascalCase call sites (`setup-database.php` × 4 and `editor/api.php` × 2) to match.
- Also added `Email` to the returned columns so upcoming profile / contact surfaces don't need an extra query.

## Test plan
- [ ] Sign in to `/manage/` as `global_admin`: full admin-nav renders (Dashboard, Editor, Users, display name + role badge, Logout) and the dashboard body (library stats, people & activity, users-by-role, quick links, recent users) all display.
- [ ] `/manage/users` renders the user table + all row action buttons (Edit, Rename, Role, Reset Password, Toggle Active, Delete).
- [ ] `/manage/entitlements` renders the full entitlement grid and the invite-only gating toggle.
- [ ] `/manage/setup-database` still loads and the 403 guard still rejects non-global-admins.
- [ ] `/manage/editor/` API endpoints still authorise correctly (403 for non-editor).

https://claude.ai/code/session_01LVu9oYy2LbeYjXfys5EhoF

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVu9oYy2LbeYjXfys5EhoF)_