### PR TITLE
Hotfix: requireEditor/Admin/GlobalAdmin still read PascalCase after #417

### DIFF
--- a/appWeb/public_html/manage/includes/auth.php
+++ b/appWeb/public_html/manage/includes/auth.php
@@ -207,7 +207,7 @@ function requireAdmin(): void
 {
     requireAuth();
     $user = getCurrentUser();
-    if ($user === null || !hasRole($user['Role'], 'admin')) {
+    if ($user === null || !hasRole($user['role'], 'admin')) {
         http_response_code(403);
         exit('Access denied. Admin role required.');
     }
@@ -220,7 +220,7 @@ function requireEditor(): void
 {
     requireAuth();
     $user = getCurrentUser();
-    if ($user === null || !hasRole($user['Role'], 'editor')) {
+    if ($user === null || !hasRole($user['role'], 'editor')) {
         http_response_code(403);
         exit('Access denied. Curator/Editor role required.');
     }
@@ -233,7 +233,7 @@ function requireGlobalAdmin(): void
 {
     requireAuth();
     $user = getCurrentUser();
-    if ($user === null || $user['Role'] !== 'global_admin') {
+    if ($user === null || $user['role'] !== 'global_admin') {
         http_response_code(403);
         exit('Access denied. Global Admin role required.');
     }


### PR DESCRIPTION
## Summary
Hotfix for a regression introduced by #417. That PR aliased `getCurrentUser()`'s `SELECT` to lowercase keys so the wider `/manage/` code (index.php, users.php, entitlements.php, admin-nav.php) would work. But **three guard helpers in the same file** still read `$user['Role']` (PascalCase):

- `requireAdmin()` — auth.php:210
- `requireEditor()` — auth.php:223
- `requireGlobalAdmin()` — auth.php:236

After #417, `$user['role']` is set (lowercase) but `$user['Role']` is `null`. `hasRole(null, 'editor')` passes `null` into a typed `string` parameter and throws a fatal TypeError → **HTTP 500 on every protected page**, including `/manage/editor/`.

Lowercased all three. The remaining PascalCase refs in the file (`attemptLogin`, password reset flow, the API-token registration path) are in self-contained helpers that do their own `SELECT` with the original column casing — deliberate and unaffected.

## Test plan
- [ ] Sign in as `global_admin`, visit `/manage/editor/` → editor loads (was 500).
- [ ] `/manage/users`, `/manage/entitlements`, `/manage/setup-database`, `/manage/` all continue to render.
- [ ] Sign in as a non-editor user → `/manage/editor/` 403s cleanly (not 500).
- [ ] Sign out and hit `/manage/editor/` → redirected to `/manage/login` by `requireAuth()`.

https://claude.ai/code/session_01LVu9oYy2LbeYjXfys5EhoF

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVu9oYy2LbeYjXfys5EhoF)_