### PR TITLE
Admin surface: shared footer, Song Editor back-links, final casing fixes

### DIFF
--- a/appWeb/public_html/css/admin.css
+++ b/appWeb/public_html/css/admin.css
@@ -47,6 +47,18 @@ a:not(.btn):not(.nav-link):not(.dropdown-item):hover {
     box-shadow: var(--card-shadow);
 }
 
+/* Admin footer — static variant of the main app's .footer-info strip.
+   Admin pages don't have the fixed bottom tab-bar so this just sits at
+   the natural end of the document with a light separator + breathing
+   room above. */
+.admin-footer-static {
+    margin-top: 2rem;
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+    border-top: 1px solid var(--card-border);
+    min-height: auto;
+}
+
 .navbar-admin .navbar-brand,
 .navbar-editor .navbar-brand {
     background: linear-gradient(135deg, var(--accent-start), var(--accent-end));

--- a/appWeb/public_html/manage/analytics.php
+++ b/appWeb/public_html/manage/analytics.php
@@ -327,5 +327,7 @@ try {
     </p>
 
 </div>
+
+<?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>
 </body>
 </html>

--- a/appWeb/public_html/manage/editor/index.php
+++ b/appWeb/public_html/manage/editor/index.php
@@ -101,12 +101,29 @@ $currentUser = getCurrentUser();
          ================================================================= -->
     <nav class="navbar navbar-editor d-flex align-items-center">
 
-        <!-- Brand / logo area -->
-        <a class="navbar-brand d-flex align-items-center gap-2 me-auto" href="#">
-            <!-- Music note icon representing the iHymns brand -->
+        <!-- Brand / logo area. Clicking returns to the admin dashboard —
+             important in PWA mode where there's no browser chrome. -->
+        <a class="navbar-brand d-flex align-items-center gap-2" href="/manage/"
+           title="Back to Admin Dashboard">
             <i class="bi bi-music-note-beamed"></i>
             iHymns Song Editor
         </a>
+
+        <!-- Quick navigation links. `/manage/` returns to the admin dashboard;
+             `/` returns to the public iHymns app (important in PWA mode
+             where there's no browser Back button). -->
+        <div class="d-flex align-items-center gap-2 me-auto ms-2">
+            <a href="/manage/"
+               class="btn btn-sm btn-outline-secondary"
+               title="Back to Admin Dashboard">
+                <i class="bi bi-speedometer2 me-1"></i>Dashboard
+            </a>
+            <a href="/"
+               class="btn btn-sm btn-outline-secondary"
+               title="Back to the iHymns app home">
+                <i class="bi bi-house me-1"></i>Home
+            </a>
+        </div>
 
         <!-- Action buttons group — aligned to the right -->
         <div class="d-flex align-items-center gap-2">
@@ -1184,5 +1201,6 @@ $currentUser = getCurrentUser();
          is handled in this separate file to keep concerns separated -->
     <script src="editor.js"></script>
 
+    <?php require dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>
 </body>
 </html>

--- a/appWeb/public_html/manage/entitlements.php
+++ b/appWeb/public_html/manage/entitlements.php
@@ -221,5 +221,7 @@ foreach (ENTITLEMENTS as $n => $_) {
     </p>
 
 </div>
+
+<?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>
 </body>
 </html>

--- a/appWeb/public_html/manage/includes/admin-footer.php
+++ b/appWeb/public_html/manage/includes/admin-footer.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Shared Admin Footer
+ *
+ * Renders the same small copyright / version / Terms-Privacy strip
+ * that lives at the bottom of the main app pages (index.php line
+ * 911), adapted for the static layout of the /manage/ pages — no
+ * fixed-position, no tab buttons, just the info line.
+ *
+ * USAGE:
+ *   // Near the bottom of any /manage/*.php page (before </body>):
+ *   require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php';
+ */
+
+/* Prevent direct access */
+if (basename($_SERVER['SCRIPT_FILENAME'] ?? '') === basename(__FILE__)) {
+    http_response_code(403);
+    exit('Access denied.');
+}
+
+require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'infoAppVer.php';
+
+/* Mirror the $versionDisplay composition in public_html/index.php so
+   the admin footer stays in lock-step with the main app footer. */
+$_adminFooterVersion = $app['Application']['Version']['Number'] ?? '';
+if (!empty($app['Application']['Version']['Development']['Status'])) {
+    $_adminFooterVersion .= ' ' . $app['Application']['Version']['Development']['Status'];
+}
+$_adminFooterCommitDate = $app['Application']['Version']['Repo']['Commit']['Date'] ?? null;
+if (($app['Application']['Version']['Development']['Status'] ?? null) === 'Alpha' && $_adminFooterCommitDate !== null) {
+    $_adminFooterBuildStamp = preg_replace('/[^0-9]/', '', (string)$_adminFooterCommitDate);
+    if (strlen($_adminFooterBuildStamp) >= 12) {
+        $_adminFooterVersion .= ' · ' . substr($_adminFooterBuildStamp, 0, 14);
+    }
+}
+?>
+<footer class="footer-info admin-footer-static" role="contentinfo">
+    <small>
+        <?= $app['Application']['Copyright']['Full'] ?? '' ?>
+        &nbsp;|&nbsp;
+        v<?= htmlspecialchars($_adminFooterVersion) ?>
+        &nbsp;|&nbsp;
+        <a href="/terms" class="footer-link">Terms</a>
+        &nbsp;|&nbsp;
+        <a href="/privacy" class="footer-link">Privacy</a>
+    </small>
+</footer>

--- a/appWeb/public_html/manage/includes/auth.php
+++ b/appWeb/public_html/manage/includes/auth.php
@@ -361,13 +361,15 @@ function updateUserRole(int $userId, string $newRole, array $actingUser): bool
     }
 
     $db = getDb();
-    $stmt = $db->prepare('SELECT Id, Role FROM tblUsers WHERE Id = ?');
+    /* $actingUser comes from getCurrentUser() which is lowercase-
+       aliased; match that shape when reading role. */
+    $stmt = $db->prepare('SELECT Role AS role FROM tblUsers WHERE Id = ?');
     $stmt->execute([$userId]);
     $target = $stmt->fetch(PDO::FETCH_ASSOC);
     if (!$target) throw new \RuntimeException('User not found.');
 
-    $actingLevel = roleLevel($actingUser['Role']);
-    $targetLevel = roleLevel($target['Role']);
+    $actingLevel = roleLevel($actingUser['role']);
+    $targetLevel = roleLevel($target['role']);
     $newLevel    = roleLevel($newRole);
 
     /* Cannot promote above your own level */
@@ -376,12 +378,12 @@ function updateUserRole(int $userId, string $newRole, array $actingUser): bool
     }
 
     /* Cannot demote someone at or above your level (unless you are global_admin) */
-    if ($targetLevel >= $actingLevel && $actingUser['Role'] !== 'global_admin') {
+    if ($targetLevel >= $actingLevel && $actingUser['role'] !== 'global_admin') {
         throw new \RuntimeException('Cannot modify a user at or above your role level.');
     }
 
     /* Only global_admin can assign global_admin */
-    if ($newRole === 'global_admin' && $actingUser['Role'] !== 'global_admin') {
+    if ($newRole === 'global_admin' && $actingUser['role'] !== 'global_admin') {
         throw new \RuntimeException('Only Global Admin can assign Global Admin role.');
     }
 
@@ -634,8 +636,19 @@ function deleteUser(int $userId): bool
 function getUserById(int $userId): ?array
 {
     $db = getDb();
+    /* Aliased to lowercase keys so callers in manage/users.php can read
+       $target['role'] / ['username'] / ['is_active'] consistently with
+       getCurrentUser() and the main user listing query. */
     $stmt = $db->prepare(
-        'SELECT Id, Username, DisplayName, Email, Role, GroupId, IsActive, CreatedAt, UpdatedAt
+        'SELECT Id AS id,
+                Username AS username,
+                DisplayName AS display_name,
+                Email AS email,
+                Role AS role,
+                GroupId AS group_id,
+                IsActive AS is_active,
+                CreatedAt AS created_at,
+                UpdatedAt AS updated_at
          FROM tblUsers WHERE Id = ?'
     );
     $stmt->execute([$userId]);

--- a/appWeb/public_html/manage/index.php
+++ b/appWeb/public_html/manage/index.php
@@ -324,5 +324,7 @@ $csrf = csrfToken();
         </div>
 
     </div>
+
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>
 </body>
 </html>

--- a/appWeb/public_html/manage/login.php
+++ b/appWeb/public_html/manage/login.php
@@ -110,5 +110,7 @@ $csrf = csrfToken();
             </button>
         </form>
     </div>
+
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>
 </body>
 </html>

--- a/appWeb/public_html/manage/requests.php
+++ b/appWeb/public_html/manage/requests.php
@@ -250,5 +250,6 @@ try {
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-zKzgIZcXU99qF1nNW9g+x1znB5NhCPs9qZeGzUnnFOaHJF9jCCKySBjq3vIKabk/"
         crossorigin="anonymous"></script>
+<?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>
 </body>
 </html>

--- a/appWeb/public_html/manage/revisions.php
+++ b/appWeb/public_html/manage/revisions.php
@@ -194,5 +194,7 @@ try {
 
 </div>
 
+<?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>
+
 </body>
 </html>

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -693,6 +693,8 @@ if ($hasCredentials && defined('DB_HOST')) {
         <?php endif; ?>
     </p>
 </div>
+
+<?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>
 </body>
 </html>
 <?php

--- a/appWeb/public_html/manage/setup.php
+++ b/appWeb/public_html/manage/setup.php
@@ -147,5 +147,7 @@ $csrf = csrfToken();
             </form>
         <?php endif; ?>
     </div>
+
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>
 </body>
 </html>

--- a/appWeb/public_html/manage/users.php
+++ b/appWeb/public_html/manage/users.php
@@ -551,5 +551,6 @@ function canManage(array $target, array $actor): bool {
             setTimeout(() => { input.focus(); input.select(); }, 200);
         }
     </script>
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Three related pieces on the admin surface:

### 1. Shared admin footer
New `manage/includes/admin-footer.php` renders the same copyright / version / Terms-Privacy strip used on the main app's fixed-bottom bar, but static (no tab-nav duplication — admin pages don't need one). Included on every admin page:
- `/manage/` (dashboard), `/manage/users`, `/manage/entitlements`, `/manage/analytics`, `/manage/requests`, `/manage/revisions`, `/manage/setup`, `/manage/setup-database`, `/manage/login`, `/manage/editor/`
- Small CSS tweak in `admin.css` adds a thin separator and margin so the strip sits naturally at document end.

### 2. Song Editor back-links (PWA-friendly)
The editor navbar was a dead end when opened as a PWA — no browser Back button, no way back to the main app. Now has:
- **Brand link** → `/manage/` (was `href="#"`).
- **Dashboard** button → `/manage/` (icon: speedometer).
- **Home** button → `/` (icon: house).

Labelled **"Home"** (not "Main Site") because the host context is an app, not a website.

### 3. Column-casing hotfix — follow-up to #418
PR #418 was merged before my follow-up commit (`getUserById` alias + `updateUserRole` lowercase) arrived on the branch, so those fixes never made it into `alpha`. Every POST handler in `/manage/users` — update_profile, rename_user, reset_password, toggle_active, delete, change_role — was therefore 500'ing on submit. Reapplied here:
- `getUserById()` SELECT aliased to lowercase keys matching `getCurrentUser()`.
- `updateUserRole()` reads `$actingUser['role']` (× 4) and its local `$target` SELECT is aliased.

Other PascalCase references in auth.php are inside self-contained helpers (`attemptLogin`, password-reset flow, API-token registration) that do their own `SELECT` — left untouched on purpose.

Confirmed via codebase sweep: no remaining `$currentUser|$target|$actor|$actingUser['<PascalCase>']` reads anywhere in the tree; `php -l` clean on every admin page.

## Test plan
- [ ] Admin footer visible on `/manage/`, `/manage/users`, `/manage/entitlements`, `/manage/analytics`, `/manage/requests`, `/manage/revisions`, `/manage/setup-database`, `/manage/login`, `/manage/editor/` with correct version string + Terms/Privacy links.
- [ ] In the Song Editor: clicking the brand, **Dashboard** button, or **Home** button navigates correctly.
- [ ] In the Song Editor opened as a PWA (standalone display-mode), the **Home** and **Dashboard** buttons give a way out without relying on browser chrome.
- [ ] On `/manage/users`: Edit Profile, Rename, Reset Password, Change Role, Toggle Active, and Delete all succeed without 500.
- [ ] Role guards still reject appropriately (non-admin on `/manage/users` → 403, not 500; non-editor on `/manage/editor/` → 403).

https://claude.ai/code/session_01LVu9oYy2LbeYjXfys5EhoF

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVu9oYy2LbeYjXfys5EhoF)_