### PR TITLE
Admin surface: PWA nav + Songbooks/Groups/Orgs UI + Data Health check

### DIFF
--- a/appWeb/.sql/migrate-account-sync.php
+++ b/appWeb/.sql/migrate-account-sync.php
@@ -107,6 +107,45 @@ try {
  * ========================================================================= */
 
 _migAccSync_output("");
+_migAccSync_output("--- Step 1b: tblSongbooks DisplayOrder + Colour columns ---");
+
+foreach ([
+    ['DisplayOrder', "INT UNSIGNED NOT NULL DEFAULT 0 COMMENT 'Explicit sort order for listings / filter dropdowns'"],
+    ['Colour',       "VARCHAR(7) NOT NULL DEFAULT '' COMMENT 'Badge colour hex #RRGGBB (empty = theme default)'"],
+] as [$colName, $colDef]) {
+    try {
+        $res = $mysql->query("SHOW COLUMNS FROM tblSongbooks LIKE '{$colName}'");
+        if ($res && $res->num_rows > 0) {
+            _migAccSync_output("  [SKIP] tblSongbooks.{$colName} already exists.");
+        } else {
+            $mysql->query("ALTER TABLE tblSongbooks ADD COLUMN {$colName} {$colDef}");
+            _migAccSync_output("  [OK] Added {$colName} column to tblSongbooks.");
+        }
+    } catch (\Throwable $e) {
+        _migAccSync_output("  [ERROR] Could not add {$colName}: " . $e->getMessage());
+    }
+}
+
+/* Seed DisplayOrder from alphabetical Name ordering if every row is still 0. */
+try {
+    $stmt = $mysql->query("SELECT COUNT(*) AS c FROM tblSongbooks WHERE DisplayOrder <> 0");
+    $row = $stmt ? $stmt->fetch_assoc() : ['c' => 0];
+    if ((int)$row['c'] === 0) {
+        $rs = $mysql->query("SELECT Id FROM tblSongbooks ORDER BY Name ASC");
+        $order = 10;
+        while ($r = $rs->fetch_assoc()) {
+            $mysql->query("UPDATE tblSongbooks SET DisplayOrder = {$order} WHERE Id = " . (int)$r['Id']);
+            $order += 10;
+        }
+        _migAccSync_output("  [OK] Seeded DisplayOrder from Name (ascending, step 10).");
+    } else {
+        _migAccSync_output("  [SKIP] DisplayOrder already set on at least one row.");
+    }
+} catch (\Throwable $e) {
+    _migAccSync_output("  [WARN] Could not seed DisplayOrder: " . $e->getMessage());
+}
+
+_migAccSync_output("");
 _migAccSync_output("--- Step 2: tblSharedSetlists table ---");
 
 try {

--- a/appWeb/.sql/schema.sql
+++ b/appWeb/.sql/schema.sql
@@ -34,8 +34,12 @@ CREATE TABLE IF NOT EXISTS tblSongbooks (
     Abbreviation    VARCHAR(10)     NOT NULL UNIQUE,
     Name            VARCHAR(255)    NOT NULL,
     SongCount       INT UNSIGNED    NOT NULL DEFAULT 0,
+    DisplayOrder    INT UNSIGNED    NOT NULL DEFAULT 0 COMMENT 'Explicit sort order for listings / filter dropdowns',
+    Colour          VARCHAR(7)      NOT NULL DEFAULT '' COMMENT 'Badge colour hex #RRGGBB (empty = theme default)',
     CreatedAt       TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    UpdatedAt       TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    UpdatedAt       TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    INDEX idx_DisplayOrder (DisplayOrder)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 

--- a/appWeb/public_html/includes/entitlements.php
+++ b/appWeb/public_html/includes/entitlements.php
@@ -55,6 +55,11 @@ const ENTITLEMENTS = [
     /* Content moderation */
     'review_song_requests' => ['editor', 'admin', 'global_admin'],
 
+    /* Content structure — songbook/group/organisation admin surfaces */
+    'manage_songbooks'     => ['admin', 'global_admin'],
+    'manage_user_groups'   => ['admin', 'global_admin'],
+    'manage_organisations' => ['admin', 'global_admin'],
+
     /* Channel access gating (#407) — controls who can reach alpha/beta
        subdomains. Applied BEFORE the page renders so pre-release builds
        are invisible to the public even when indexed. Defaults intentionally

--- a/appWeb/public_html/index.php
+++ b/appWeb/public_html/index.php
@@ -766,6 +766,21 @@ if (!empty($breadcrumbItems)) {
                                     <i class="fa-solid fa-users me-2" aria-hidden="true"></i> User Management
                                 </a>
                             </li>
+                            <li id="header-admin-groups-li" class="d-none">
+                                <a class="dropdown-item" href="/manage/groups">
+                                    <i class="fa-solid fa-user-group me-2" aria-hidden="true"></i> User Groups
+                                </a>
+                            </li>
+                            <li id="header-admin-organisations-li" class="d-none">
+                                <a class="dropdown-item" href="/manage/organisations">
+                                    <i class="fa-solid fa-building me-2" aria-hidden="true"></i> Organisations
+                                </a>
+                            </li>
+                            <li id="header-admin-songbooks-li" class="d-none">
+                                <a class="dropdown-item" href="/manage/songbooks">
+                                    <i class="fa-solid fa-book-open me-2" aria-hidden="true"></i> Songbooks
+                                </a>
+                            </li>
                             <li id="header-admin-entitlements-li" class="d-none">
                                 <a class="dropdown-item" href="/manage/entitlements">
                                     <i class="fa-solid fa-key me-2" aria-hidden="true"></i> Entitlements &amp; Gating
@@ -774,6 +789,11 @@ if (!empty($breadcrumbItems)) {
                             <li id="header-admin-analytics-li" class="d-none">
                                 <a class="dropdown-item" href="/manage/analytics">
                                     <i class="fa-solid fa-chart-line me-2" aria-hidden="true"></i> Analytics
+                                </a>
+                            </li>
+                            <li id="header-admin-health-li" class="d-none">
+                                <a class="dropdown-item" href="/manage/data-health">
+                                    <i class="fa-solid fa-heart-pulse me-2" aria-hidden="true"></i> Data Health
                                 </a>
                             </li>
                             <li id="header-admin-db-li" class="d-none">

--- a/appWeb/public_html/js/modules/entitlements.js
+++ b/appWeb/public_html/js/modules/entitlements.js
@@ -37,6 +37,11 @@ export const ENTITLEMENTS = {
     /* Content moderation */
     review_song_requests: ['editor', 'admin', 'global_admin'],
 
+    /* Content structure — songbook/group/organisation admin surfaces */
+    manage_songbooks:     ['admin', 'global_admin'],
+    manage_user_groups:   ['admin', 'global_admin'],
+    manage_organisations: ['admin', 'global_admin'],
+
     /* Channel access (#407) */
     access_alpha:         ['user', 'editor', 'admin', 'global_admin'],
     access_beta:          ['user', 'editor', 'admin', 'global_admin'],

--- a/appWeb/public_html/js/modules/user-auth.js
+++ b/appWeb/public_html/js/modules/user-auth.js
@@ -489,9 +489,13 @@ export class UserAuth {
             admin: [
                 ['header-user-dashboard-li',      'view_admin_dashboard'],
                 ['header-admin-users-li',         'view_users'],
+                ['header-admin-groups-li',        'manage_user_groups'],
+                ['header-admin-organisations-li', 'manage_organisations'],
+                ['header-admin-songbooks-li',     'manage_songbooks'],
                 ['header-admin-entitlements-li',  'manage_entitlements'],
                 ['header-admin-analytics-li',     'view_analytics'],
                 ['header-admin-db-li',            'run_db_install'],
+                ['header-admin-health-li',        'drop_legacy_tables'],
             ],
         };
 

--- a/appWeb/public_html/manage/analytics.php
+++ b/appWeb/public_html/manage/analytics.php
@@ -162,8 +162,13 @@ try {
 <nav class="navbar-admin d-flex align-items-center justify-content-between">
     <a class="navbar-brand" href="/manage/"><i class="bi bi-chart-line me-2"></i>iHymns Analytics</a>
     <div class="d-flex align-items-center gap-2">
-        <span class="text-muted small"><?= htmlspecialchars($currentUser['username'] ?? '') ?></span>
-        <a href="/manage/" class="btn btn-sm btn-outline-secondary">Back to Dashboard</a>
+        <span class="text-muted small d-none d-md-inline"><?= htmlspecialchars($currentUser['username'] ?? '') ?></span>
+        <a href="/manage/" class="btn btn-sm btn-outline-secondary">
+            <i class="bi bi-speedometer2 me-1"></i>Dashboard
+        </a>
+        <a href="/" class="btn btn-sm btn-outline-secondary" title="Back to the iHymns app home">
+            <i class="bi bi-house me-1"></i>Home
+        </a>
     </div>
 </nav>
 

--- a/appWeb/public_html/manage/data-health.php
+++ b/appWeb/public_html/manage/data-health.php
@@ -1,0 +1,330 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Admin: Data Health Check (global_admin only)
+ *
+ * Lets a global admin confirm MySQL is authoritative for every data
+ * surface before pulling the plug on legacy fallbacks.
+ *
+ * Read-only report plus an opt-in "disconnect legacy fallbacks" action
+ * that renames (not deletes) the on-disk legacy sources to .disabled
+ * so the code paths that fall back to them short-circuit. Fully
+ * reversible — rename back by hand.
+ */
+
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'config.php';
+
+if (!isAuthenticated()) {
+    header('Location: /manage/login');
+    exit;
+}
+$currentUser = getCurrentUser();
+if (!$currentUser || ($currentUser['role'] ?? '') !== 'global_admin') {
+    http_response_code(403);
+    echo '<!DOCTYPE html><html><body><h1>403 — Global Admin access required</h1></body></html>';
+    exit;
+}
+$activePage = 'data-health';
+
+$db      = getDb();
+$flash   = '';
+$error   = '';
+
+/* Legacy paths to inspect / optionally disable */
+$songsJsonPath    = defined('APP_DATA_FILE')          ? APP_DATA_FILE          : '';
+$shareDirPath     = defined('APP_SETLIST_SHARE_DIR')  ? APP_SETLIST_SHARE_DIR  : '';
+$sqliteDbPath     = dirname(APP_ROOT) . DIRECTORY_SEPARATOR . 'data_share'
+                  . DIRECTORY_SEPARATOR . 'SQLite'
+                  . DIRECTORY_SEPARATOR . 'ihymns.db';
+
+/* ---- POST: disconnect-legacy-fallbacks action ---- */
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!validateCsrf((string)($_POST['csrf_token'] ?? ''))) {
+        http_response_code(403);
+        echo 'Invalid CSRF token';
+        exit;
+    }
+    if (($_POST['action'] ?? '') === 'disconnect_fallbacks') {
+        $renamed = [];
+        $skipped = [];
+        $failed  = [];
+        foreach ([
+            'songs_json'   => $songsJsonPath,
+            'setlist_dir'  => $shareDirPath,
+            'sqlite_db'    => $sqliteDbPath,
+        ] as $k => $path) {
+            if ($path === '') { $skipped[] = "{$k} (no path configured)"; continue; }
+            if (!file_exists($path)) { $skipped[] = "{$k} (not present)"; continue; }
+            $target = $path . '.disabled';
+            if (file_exists($target)) { $skipped[] = "{$k} (already disabled)"; continue; }
+            if (@rename($path, $target)) {
+                $renamed[] = "{$k} → " . basename($target);
+            } else {
+                $failed[] = "{$k} (rename failed — check permissions)";
+            }
+        }
+        $parts = [];
+        if ($renamed) $parts[] = 'Renamed: ' . implode('; ', $renamed);
+        if ($skipped) $parts[] = 'Skipped: ' . implode('; ', $skipped);
+        if ($failed)  $parts[] = 'Failed: '  . implode('; ', $failed);
+        if ($failed) {
+            $error = implode(' · ', $parts);
+        } else {
+            $flash = implode(' · ', $parts) ?: 'Nothing to do.';
+        }
+    }
+}
+
+/* ---- Gather health ---- */
+$tableCounts = [];
+foreach (['tblSongs', 'tblSongbooks', 'tblUsers', 'tblUserSetlists',
+          'tblSharedSetlists', 'tblSongRequests', 'tblSongRevisions',
+          'tblUserGroups', 'tblOrganisations'] as $tbl) {
+    try {
+        $tableCounts[$tbl] = (int)$db->query('SELECT COUNT(*) FROM ' . $tbl)->fetchColumn();
+    } catch (\Throwable $_e) {
+        $tableCounts[$tbl] = null; /* missing */
+    }
+}
+
+/* Is SongData on the JSON fallback? Instantiating it runs the probe. */
+$songDataJsonFallback = null;
+try {
+    require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'SongData.php';
+    if (class_exists('\\SongData')) {
+        $probe = new \SongData();
+        $songDataJsonFallback = $probe->isJsonFallback();
+    }
+} catch (\Throwable $e) {
+    error_log('[manage/data-health.php] SongData probe: ' . $e->getMessage());
+}
+
+/* Share directory file vs DB row count */
+$shareFileCount = null;
+$unimportedShareIds = [];
+if ($shareDirPath && is_dir($shareDirPath)) {
+    $files = glob($shareDirPath . DIRECTORY_SEPARATOR . '*.json') ?: [];
+    $shareFileCount = count($files);
+    if ($shareFileCount > 0 && isset($tableCounts['tblSharedSetlists'])) {
+        $idsOnDisk = array_filter(array_map(
+            fn($f) => preg_match('/^[a-f0-9]{6,32}$/i', basename($f, '.json')) ? basename($f, '.json') : null,
+            $files
+        ));
+        try {
+            $stmt = $db->query('SELECT ShareId FROM tblSharedSetlists');
+            $inDb = array_fill_keys(array_column($stmt->fetchAll(PDO::FETCH_ASSOC), 'ShareId'), true);
+            foreach ($idsOnDisk as $id) {
+                if (!isset($inDb[$id])) $unimportedShareIds[] = $id;
+            }
+        } catch (\Throwable $_e) { /* ignore — table absent */ }
+    }
+}
+$sqliteExists = $sqliteDbPath && file_exists($sqliteDbPath);
+$sqliteSize   = $sqliteExists ? @filesize($sqliteDbPath) : 0;
+
+/* Overall green light: MySQL authoritative, no unimported shares, SQLite gone */
+$allGreen = (
+    $songDataJsonFallback === false
+    && $shareFileCount === 0
+    && count($unimportedShareIds) === 0
+    && !$sqliteExists
+    && ($tableCounts['tblSongs'] ?? 0) > 0
+    && ($tableCounts['tblUsers'] ?? 0) > 0
+);
+
+function health_badge(string $state, string $label): string {
+    $cls = match ($state) {
+        'green'  => 'bg-success',
+        'amber'  => 'bg-warning text-dark',
+        'red'    => 'bg-danger',
+        default  => 'bg-secondary',
+    };
+    return '<span class="badge ' . $cls . '">' . htmlspecialchars($label) . '</span>';
+}
+
+$csrf = csrfToken();
+?>
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Data Health — iHymns Admin</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
+          integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
+          integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">
+    <link rel="stylesheet" href="/css/app.css?v=<?= filemtime(dirname(__DIR__) . '/css/app.css') ?>">
+    <link rel="stylesheet" href="/css/admin.css?v=<?= filemtime(dirname(__DIR__) . '/css/admin.css') ?>">
+</head>
+<body>
+
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-nav.php'; ?>
+
+    <div class="container py-4" style="max-width: 1100px;">
+
+        <h1 class="h4 mb-3"><i class="bi bi-activity me-2"></i>Data Health Check</h1>
+        <p class="text-secondary small mb-4">
+            Confirm MySQL is fully authoritative before retiring the legacy
+            <code>songs.json</code>, shared-setlist JSON files and SQLite
+            database used in earlier iterations. Nothing on this page is
+            destructive — "disconnect" renames the legacy sources to
+            <code>*.disabled</code>, which is trivially reversible.
+        </p>
+
+        <?php if ($flash): ?>
+            <div class="alert alert-success py-2"><?= htmlspecialchars($flash) ?></div>
+        <?php endif; ?>
+        <?php if ($error): ?>
+            <div class="alert alert-danger py-2"><?= htmlspecialchars($error) ?></div>
+        <?php endif; ?>
+
+        <!-- MySQL table counts -->
+        <div class="card-admin p-3 mb-3">
+            <h2 class="h6 mb-3"><i class="bi bi-database me-2"></i>MySQL table counts</h2>
+            <table class="table table-sm mb-0 align-middle">
+                <thead>
+                    <tr class="text-muted small">
+                        <th>Table</th>
+                        <th class="text-end">Rows</th>
+                        <th>Status</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($tableCounts as $tbl => $count):
+                        if ($count === null) { $state = 'red';    $lbl = 'missing'; }
+                        elseif ($count === 0 && in_array($tbl, ['tblSongs', 'tblSongbooks', 'tblUsers'], true)) {
+                                              $state = 'red';    $lbl = 'empty (expected data)'; }
+                        elseif ($count === 0){ $state = 'amber';  $lbl = 'empty'; }
+                        else                 { $state = 'green';  $lbl = 'ok'; }
+                    ?>
+                        <tr>
+                            <td><code><?= htmlspecialchars($tbl) ?></code></td>
+                            <td class="text-end"><?= $count === null ? '—' : number_format($count) ?></td>
+                            <td><?= health_badge($state, $lbl) ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+
+        <!-- SongData fallback probe -->
+        <div class="card-admin p-3 mb-3">
+            <h2 class="h6 mb-3"><i class="bi bi-file-earmark-code me-2"></i><code>songs.json</code> fallback</h2>
+            <p class="mb-2 small text-secondary">
+                <code>SongData</code> prefers MySQL. It only reads
+                <code>data_share/song_data/songs.json</code> if the DB query
+                fails to return any songs.
+            </p>
+            <?php if ($songDataJsonFallback === true): ?>
+                <?= health_badge('red', 'SongData is currently using the JSON fallback') ?>
+                <p class="small text-secondary mt-2 mb-0">
+                    This usually means the MySQL song data is missing or
+                    unreachable. Run <a href="/manage/setup-database?action=install">Install</a> /
+                    <a href="/manage/setup-database?action=migrate">Migrate Songs</a>.
+                </p>
+            <?php elseif ($songDataJsonFallback === false): ?>
+                <?= health_badge('green', 'MySQL is authoritative for songs') ?>
+            <?php else: ?>
+                <?= health_badge('amber', 'Could not probe SongData — see logs') ?>
+            <?php endif; ?>
+            <p class="small text-secondary mt-2 mb-0">
+                Legacy file on disk:
+                <?php if ($songsJsonPath && file_exists($songsJsonPath)): ?>
+                    <code><?= htmlspecialchars($songsJsonPath) ?></code> (<?= number_format((int)@filesize($songsJsonPath)) ?> bytes)
+                <?php elseif ($songsJsonPath && file_exists($songsJsonPath . '.disabled')): ?>
+                    <em>already disabled</em>
+                <?php else: ?>
+                    <em>not present</em>
+                <?php endif; ?>
+            </p>
+        </div>
+
+        <!-- Shared setlist JSON files -->
+        <div class="card-admin p-3 mb-3">
+            <h2 class="h6 mb-3"><i class="bi bi-link-45deg me-2"></i>Shared setlist JSON files</h2>
+            <p class="mb-2 small text-secondary">
+                <code>SharedSetlist.php</code> prefers <code>tblSharedSetlists</code>
+                and only falls back to disk when a share isn't present in the DB.
+            </p>
+            <?php if ($shareFileCount === null): ?>
+                <?= health_badge('green', 'Legacy directory not present') ?>
+            <?php elseif ($shareFileCount === 0): ?>
+                <?= health_badge('green', 'Directory exists but is empty') ?>
+            <?php elseif (count($unimportedShareIds) === 0): ?>
+                <?= health_badge('amber', $shareFileCount . ' file(s), all imported into MySQL') ?>
+                <p class="small text-secondary mt-2 mb-0">
+                    Safe to disconnect. Every share URL still resolves from
+                    <code>tblSharedSetlists</code>.
+                </p>
+            <?php else: ?>
+                <?= health_badge('red', count($unimportedShareIds) . ' of ' . $shareFileCount . ' share file(s) NOT yet in MySQL') ?>
+                <p class="small text-secondary mt-2 mb-0">
+                    Run
+                    <a href="/manage/setup-database?action=account-sync">Account Sync Migration</a>
+                    to import them. Unimported IDs:
+                    <code class="small"><?= htmlspecialchars(implode(', ', array_slice($unimportedShareIds, 0, 25))) ?></code>
+                    <?php if (count($unimportedShareIds) > 25): ?>…<?php endif; ?>
+                </p>
+            <?php endif; ?>
+            <p class="small text-secondary mt-2 mb-0">
+                Legacy directory:
+                <?php if ($shareDirPath && is_dir($shareDirPath)): ?>
+                    <code><?= htmlspecialchars($shareDirPath) ?></code>
+                <?php elseif ($shareDirPath && is_dir($shareDirPath . '.disabled')): ?>
+                    <em>already disabled</em>
+                <?php else: ?>
+                    <em>not present</em>
+                <?php endif; ?>
+            </p>
+        </div>
+
+        <!-- Legacy SQLite -->
+        <div class="card-admin p-3 mb-3">
+            <h2 class="h6 mb-3"><i class="bi bi-hdd-stack me-2"></i>Legacy SQLite database</h2>
+            <p class="mb-2 small text-secondary">
+                Used only by <code>migrate-users.php</code> during the one-off
+                user migration — no runtime code path reads from it.
+            </p>
+            <?php if (!$sqliteExists): ?>
+                <?= health_badge('green', 'SQLite database not present') ?>
+            <?php else: ?>
+                <?= health_badge('amber', 'Still present at ' . basename($sqliteDbPath) . ' · ' . number_format((int)$sqliteSize) . ' bytes') ?>
+                <p class="small text-secondary mt-2 mb-0">
+                    Safe to disconnect once you've confirmed all users /
+                    setlists / shared setlists are imported into MySQL.
+                </p>
+            <?php endif; ?>
+        </div>
+
+        <!-- Disconnect action -->
+        <div class="card-admin p-3 mb-3 <?= $allGreen ? '' : 'opacity-75' ?>">
+            <h2 class="h6 mb-3"><i class="bi bi-plug me-2"></i>Disconnect legacy fallbacks</h2>
+            <p class="small mb-3">
+                Renames (does not delete) each legacy source by appending
+                <code>.disabled</code>. The runtime fallbacks now short-circuit
+                and MySQL becomes the only path. Reversible — rename back by hand.
+            </p>
+            <?php if (!$allGreen): ?>
+                <div class="alert alert-warning py-2 small mb-3">
+                    Resolve the amber / red items above first. Disconnect is
+                    disabled until every surface is fully served by MySQL.
+                </div>
+            <?php endif; ?>
+            <form method="POST" onsubmit="return confirm('Disconnect legacy fallbacks by renaming them to *.disabled?')">
+                <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                <input type="hidden" name="action"     value="disconnect_fallbacks">
+                <button type="submit" class="btn btn-danger btn-sm" <?= $allGreen ? '' : 'disabled' ?>>
+                    <i class="bi bi-plug me-1"></i>Disconnect legacy fallbacks
+                </button>
+            </form>
+        </div>
+
+    </div>
+
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>
+</body>
+</html>

--- a/appWeb/public_html/manage/entitlements.php
+++ b/appWeb/public_html/manage/entitlements.php
@@ -77,6 +77,7 @@ $groups = [
     'User management' => ['view_users', 'edit_users', 'change_user_roles', 'assign_global_admin', 'delete_users'],
     'Database & operations' => ['view_admin_dashboard', 'view_analytics', 'run_db_install', 'run_db_migrate', 'run_db_backup', 'run_db_restore', 'drop_legacy_tables'],
     'Content moderation' => ['review_song_requests'],
+    'Content structure'  => ['manage_songbooks', 'manage_user_groups', 'manage_organisations'],
     'Channel access'     => ['access_alpha', 'access_beta'],
     'Meta' => ['manage_entitlements'],
 ];
@@ -114,7 +115,14 @@ foreach (ENTITLEMENTS as $n => $_) {
 
 <nav class="navbar-admin d-flex align-items-center justify-content-between">
     <a class="navbar-brand" href="/manage/"><i class="bi bi-key me-2"></i>Entitlements</a>
-    <a href="/manage/" class="btn btn-sm btn-outline-secondary">Back to Dashboard</a>
+    <div class="d-flex align-items-center gap-2">
+        <a href="/manage/" class="btn btn-sm btn-outline-secondary">
+            <i class="bi bi-speedometer2 me-1"></i>Dashboard
+        </a>
+        <a href="/" class="btn btn-sm btn-outline-secondary" title="Back to the iHymns app home">
+            <i class="bi bi-house me-1"></i>Home
+        </a>
+    </div>
 </nav>
 
 <div class="container py-4" style="max-width: 1100px;">

--- a/appWeb/public_html/manage/groups.php
+++ b/appWeb/public_html/manage/groups.php
@@ -1,0 +1,429 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Admin: User Groups
+ *
+ * Minimal CRUD over `tblUserGroups` plus a two-pane member picker that
+ * writes back to `tblUsers.GroupId`. Gated by `manage_user_groups`.
+ */
+
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'entitlements.php';
+
+if (!isAuthenticated()) {
+    header('Location: /manage/login');
+    exit;
+}
+$currentUser = getCurrentUser();
+if (!$currentUser || !userHasEntitlement('manage_user_groups', $currentUser['role'] ?? null)) {
+    http_response_code(403);
+    echo '<!DOCTYPE html><html><body><h1>403 — manage_user_groups required</h1></body></html>';
+    exit;
+}
+$activePage = 'groups';
+
+$error   = '';
+$success = '';
+$db      = getDb();
+
+/* ----- POST actions ----- */
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!validateCsrf((string)($_POST['csrf_token'] ?? ''))) {
+        http_response_code(403);
+        echo 'Invalid CSRF token';
+        exit;
+    }
+
+    $action = (string)($_POST['action'] ?? '');
+    try {
+        switch ($action) {
+            case 'create': {
+                $name  = trim((string)($_POST['name']         ?? ''));
+                $desc  = trim((string)($_POST['description']  ?? ''));
+                $aA    = !empty($_POST['access_alpha']) ? 1 : 0;
+                $aB    = !empty($_POST['access_beta'])  ? 1 : 0;
+                $aR    = !empty($_POST['access_rc'])    ? 1 : 0;
+                $aW    = !empty($_POST['access_rtw'])   ? 1 : 0;
+                if ($name === '') { $error = 'Name is required.'; break; }
+                if (strlen($name) > 100) { $error = 'Name must be 100 characters or fewer.'; break; }
+
+                $stmt = $db->prepare('SELECT Id FROM tblUserGroups WHERE Name = ?');
+                $stmt->execute([$name]);
+                if ($stmt->fetch()) { $error = 'A group with that name already exists.'; break; }
+
+                $stmt = $db->prepare(
+                    'INSERT INTO tblUserGroups (Name, Description, AccessAlpha, AccessBeta, AccessRc, AccessRtw)
+                     VALUES (?, ?, ?, ?, ?, ?)'
+                );
+                $stmt->execute([$name, $desc, $aA, $aB, $aR, $aW]);
+                $success = "Group '{$name}' created.";
+                break;
+            }
+
+            case 'update': {
+                $id   = (int)($_POST['id'] ?? 0);
+                $name = trim((string)($_POST['name']        ?? ''));
+                $desc = trim((string)($_POST['description'] ?? ''));
+                $aA   = !empty($_POST['access_alpha']) ? 1 : 0;
+                $aB   = !empty($_POST['access_beta'])  ? 1 : 0;
+                $aR   = !empty($_POST['access_rc'])    ? 1 : 0;
+                $aW   = !empty($_POST['access_rtw'])   ? 1 : 0;
+                if ($id <= 0) { $error = 'Group id missing.'; break; }
+                if ($name === '') { $error = 'Name is required.'; break; }
+
+                $stmt = $db->prepare('SELECT Id FROM tblUserGroups WHERE Name = ? AND Id <> ?');
+                $stmt->execute([$name, $id]);
+                if ($stmt->fetch()) { $error = 'Another group already uses that name.'; break; }
+
+                $stmt = $db->prepare(
+                    'UPDATE tblUserGroups
+                        SET Name = ?, Description = ?,
+                            AccessAlpha = ?, AccessBeta = ?, AccessRc = ?, AccessRtw = ?
+                      WHERE Id = ?'
+                );
+                $stmt->execute([$name, $desc, $aA, $aB, $aR, $aW, $id]);
+                $success = "Group '{$name}' updated.";
+                break;
+            }
+
+            case 'delete': {
+                $id = (int)($_POST['id'] ?? 0);
+
+                $stmt = $db->prepare('SELECT Name FROM tblUserGroups WHERE Id = ?');
+                $stmt->execute([$id]);
+                $name = (string)($stmt->fetchColumn() ?: '');
+                if ($name === '') { $error = 'Group not found.'; break; }
+
+                $stmt = $db->prepare('SELECT COUNT(*) FROM tblUsers WHERE GroupId = ?');
+                $stmt->execute([$id]);
+                $members = (int)$stmt->fetchColumn();
+                if ($members > 0) {
+                    $error = "Cannot delete '{$name}': {$members} user(s) still belong to it. Move them to another group first.";
+                    break;
+                }
+
+                $stmt = $db->prepare('DELETE FROM tblUserGroups WHERE Id = ?');
+                $stmt->execute([$id]);
+                $success = "Group '{$name}' deleted.";
+                break;
+            }
+
+            case 'add_member': {
+                $groupId = (int)($_POST['group_id'] ?? 0);
+                $userId  = (int)($_POST['user_id']  ?? 0);
+                if ($groupId <= 0 || $userId <= 0) { $error = 'Invalid request.'; break; }
+                $stmt = $db->prepare('UPDATE tblUsers SET GroupId = ?, UpdatedAt = CURRENT_TIMESTAMP WHERE Id = ?');
+                $stmt->execute([$groupId, $userId]);
+                $success = 'Member added.';
+                break;
+            }
+
+            case 'remove_member': {
+                $userId = (int)($_POST['user_id'] ?? 0);
+                if ($userId <= 0) { $error = 'Invalid request.'; break; }
+                $stmt = $db->prepare('UPDATE tblUsers SET GroupId = NULL, UpdatedAt = CURRENT_TIMESTAMP WHERE Id = ?');
+                $stmt->execute([$userId]);
+                $success = 'Member removed from group.';
+                break;
+            }
+
+            default:
+                $error = 'Unknown action.';
+        }
+    } catch (\Throwable $e) {
+        error_log('[manage/groups.php] ' . $e->getMessage());
+        $error = $error ?: 'Database error — check server logs for details.';
+    }
+}
+
+/* ----- GET: fetch groups + members ----- */
+$groups = [];
+try {
+    $rs = $db->query(
+        'SELECT g.Id, g.Name, g.Description,
+                g.AccessAlpha, g.AccessBeta, g.AccessRc, g.AccessRtw,
+                COUNT(u.Id) AS MemberCount
+           FROM tblUserGroups g
+           LEFT JOIN tblUsers u ON u.GroupId = g.Id
+          GROUP BY g.Id
+          ORDER BY g.Name ASC'
+    );
+    $groups = $rs->fetchAll(PDO::FETCH_ASSOC);
+} catch (\Throwable $e) {
+    error_log('[manage/groups.php] ' . $e->getMessage());
+    $error = $error ?: 'Could not load groups.';
+}
+
+/* If ?edit=<id>, pull the editing group + members + candidates */
+$editGroup = null;
+$editMembers = [];
+$candidates  = [];
+$editId = (int)($_GET['edit'] ?? 0);
+if ($editId > 0) {
+    try {
+        $stmt = $db->prepare('SELECT * FROM tblUserGroups WHERE Id = ?');
+        $stmt->execute([$editId]);
+        $editGroup = $stmt->fetch(PDO::FETCH_ASSOC) ?: null;
+
+        if ($editGroup) {
+            $stmt = $db->prepare(
+                'SELECT Id, Username, DisplayName, Role, IsActive
+                   FROM tblUsers WHERE GroupId = ? ORDER BY Username ASC'
+            );
+            $stmt->execute([$editId]);
+            $editMembers = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+            $stmt = $db->prepare(
+                'SELECT Id, Username, DisplayName, Role
+                   FROM tblUsers
+                  WHERE (GroupId IS NULL OR GroupId <> ?) AND IsActive = 1
+                  ORDER BY Username ASC
+                  LIMIT 500'
+            );
+            $stmt->execute([$editId]);
+            $candidates = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        }
+    } catch (\Throwable $e) {
+        error_log('[manage/groups.php] ' . $e->getMessage());
+    }
+}
+
+$csrf = csrfToken();
+?>
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>User Groups — iHymns Admin</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
+          integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
+          integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">
+    <link rel="stylesheet" href="/css/app.css?v=<?= filemtime(dirname(__DIR__) . '/css/app.css') ?>">
+    <link rel="stylesheet" href="/css/admin.css?v=<?= filemtime(dirname(__DIR__) . '/css/admin.css') ?>">
+</head>
+<body>
+
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-nav.php'; ?>
+
+    <div class="container py-4" style="max-width: 1100px;">
+
+        <h1 class="h4 mb-3"><i class="bi bi-people-fill me-2"></i>User Groups</h1>
+        <p class="text-secondary small mb-4">
+            Define groups for shared access settings (alpha / beta / RC / RTW).
+            Each user belongs to at most one group via <code>tblUsers.GroupId</code>.
+        </p>
+
+        <?php if ($success): ?>
+            <div class="alert alert-success py-2"><?= htmlspecialchars($success) ?></div>
+        <?php endif; ?>
+        <?php if ($error): ?>
+            <div class="alert alert-danger py-2"><?= htmlspecialchars($error) ?></div>
+        <?php endif; ?>
+
+        <?php if (!$editGroup): ?>
+            <!-- List of groups -->
+            <div class="card-admin p-3 mb-4">
+                <h2 class="h6 mb-3">All groups</h2>
+                <table class="table table-sm mb-0 align-middle">
+                    <thead>
+                        <tr class="text-muted small">
+                            <th>Name</th>
+                            <th>Description</th>
+                            <th class="text-center" title="Alpha">α</th>
+                            <th class="text-center" title="Beta">β</th>
+                            <th class="text-center" title="Release Candidate">RC</th>
+                            <th class="text-center" title="Release to Web">RTW</th>
+                            <th class="text-center">Members</th>
+                            <th class="text-end">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($groups as $g): ?>
+                            <tr>
+                                <td><strong><?= htmlspecialchars($g['Name']) ?></strong></td>
+                                <td class="text-muted small"><?= htmlspecialchars(mb_substr((string)$g['Description'], 0, 120)) ?></td>
+                                <?php foreach (['AccessAlpha', 'AccessBeta', 'AccessRc', 'AccessRtw'] as $k): ?>
+                                    <td class="text-center">
+                                        <?= (int)$g[$k] ? '<i class="bi bi-check-circle text-success"></i>' : '<i class="bi bi-dash text-muted"></i>' ?>
+                                    </td>
+                                <?php endforeach; ?>
+                                <td class="text-center"><?= (int)$g['MemberCount'] ?></td>
+                                <td class="text-end">
+                                    <a href="?edit=<?= (int)$g['Id'] ?>" class="btn btn-sm btn-outline-info" title="Edit and manage members">
+                                        <i class="bi bi-pencil"></i>
+                                    </a>
+                                    <?php if ((int)$g['MemberCount'] === 0): ?>
+                                        <form method="POST" class="d-inline" onsubmit="return confirm('Delete group <?= htmlspecialchars($g['Name'], ENT_QUOTES) ?>?')">
+                                            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                                            <input type="hidden" name="action" value="delete">
+                                            <input type="hidden" name="id" value="<?= (int)$g['Id'] ?>">
+                                            <button type="submit" class="btn btn-sm btn-outline-danger" title="Delete (empty group)"><i class="bi bi-trash"></i></button>
+                                        </form>
+                                    <?php else: ?>
+                                        <button type="button" class="btn btn-sm btn-outline-secondary" disabled title="Group has members — move them first"><i class="bi bi-trash"></i></button>
+                                    <?php endif; ?>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                        <?php if (!$groups): ?>
+                            <tr><td colspan="8" class="text-muted text-center py-4">No groups yet. Add one below.</td></tr>
+                        <?php endif; ?>
+                    </tbody>
+                </table>
+            </div>
+
+            <!-- Create -->
+            <form method="POST" class="card-admin p-3 mb-4">
+                <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                <input type="hidden" name="action" value="create">
+                <h2 class="h6 mb-3"><i class="bi bi-plus-circle me-2"></i>Add a group</h2>
+                <div class="row g-2 mb-2">
+                    <div class="col-sm-4">
+                        <label class="form-label small">Name</label>
+                        <input type="text" name="name" class="form-control form-control-sm" maxlength="100" required>
+                    </div>
+                    <div class="col-sm-8">
+                        <label class="form-label small">Description</label>
+                        <input type="text" name="description" class="form-control form-control-sm">
+                    </div>
+                </div>
+                <div class="d-flex flex-wrap gap-3">
+                    <?php foreach ([
+                        'access_alpha' => ['Alpha',  false],
+                        'access_beta'  => ['Beta',   false],
+                        'access_rc'    => ['RC',     false],
+                        'access_rtw'   => ['RTW',    true],
+                    ] as $k => [$lbl, $def]): ?>
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" name="<?= $k ?>" id="new-<?= $k ?>" value="1" <?= $def ? 'checked' : '' ?>>
+                            <label class="form-check-label" for="new-<?= $k ?>"><?= $lbl ?></label>
+                        </div>
+                    <?php endforeach; ?>
+                </div>
+                <button type="submit" class="btn btn-amber-solid btn-sm mt-3">
+                    <i class="bi bi-plus me-1"></i>Create group
+                </button>
+            </form>
+
+        <?php else: ?>
+
+            <!-- Edit Group: settings + members -->
+            <div class="mb-3">
+                <a href="/manage/groups" class="btn btn-sm btn-outline-secondary">
+                    <i class="bi bi-arrow-left me-1"></i>Back to group list
+                </a>
+            </div>
+
+            <form method="POST" class="card-admin p-3 mb-4">
+                <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                <input type="hidden" name="action" value="update">
+                <input type="hidden" name="id" value="<?= (int)$editGroup['Id'] ?>">
+                <h2 class="h6 mb-3"><i class="bi bi-sliders me-2"></i>Settings — <?= htmlspecialchars($editGroup['Name']) ?></h2>
+                <div class="row g-2 mb-2">
+                    <div class="col-sm-4">
+                        <label class="form-label small">Name</label>
+                        <input type="text" name="name" class="form-control form-control-sm" maxlength="100" required
+                               value="<?= htmlspecialchars($editGroup['Name']) ?>">
+                    </div>
+                    <div class="col-sm-8">
+                        <label class="form-label small">Description</label>
+                        <input type="text" name="description" class="form-control form-control-sm"
+                               value="<?= htmlspecialchars($editGroup['Description']) ?>">
+                    </div>
+                </div>
+                <div class="d-flex flex-wrap gap-3">
+                    <?php foreach ([
+                        'access_alpha' => ['Alpha', 'AccessAlpha'],
+                        'access_beta'  => ['Beta',  'AccessBeta'],
+                        'access_rc'    => ['RC',    'AccessRc'],
+                        'access_rtw'   => ['RTW',   'AccessRtw'],
+                    ] as $k => [$lbl, $col]): ?>
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" name="<?= $k ?>" id="edit-<?= $k ?>" value="1"
+                                   <?= (int)$editGroup[$col] ? 'checked' : '' ?>>
+                            <label class="form-check-label" for="edit-<?= $k ?>"><?= $lbl ?></label>
+                        </div>
+                    <?php endforeach; ?>
+                </div>
+                <button type="submit" class="btn btn-amber-solid btn-sm mt-3">
+                    <i class="bi bi-save me-1"></i>Save settings
+                </button>
+            </form>
+
+            <div class="row g-3">
+                <!-- Current members -->
+                <div class="col-md-6">
+                    <div class="card-admin p-3 h-100">
+                        <h2 class="h6 mb-3"><i class="bi bi-people me-2"></i>Members (<?= count($editMembers) ?>)</h2>
+                        <?php if (!$editMembers): ?>
+                            <p class="text-muted small mb-0">No members yet — add from the list on the right.</p>
+                        <?php else: ?>
+                            <ul class="list-group list-group-flush">
+                                <?php foreach ($editMembers as $u): ?>
+                                    <li class="list-group-item d-flex align-items-center justify-content-between"
+                                        style="background: transparent; color: inherit;">
+                                        <span>
+                                            <code><?= htmlspecialchars($u['Username']) ?></code>
+                                            <small class="text-muted ms-1"><?= htmlspecialchars($u['DisplayName']) ?></small>
+                                            <span class="badge bg-secondary ms-1" style="font-size: 0.65rem"><?= htmlspecialchars($u['Role']) ?></span>
+                                        </span>
+                                        <form method="POST" class="d-inline" onsubmit="return confirm('Remove <?= htmlspecialchars($u['Username'], ENT_QUOTES) ?> from this group?')">
+                                            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                                            <input type="hidden" name="action"     value="remove_member">
+                                            <input type="hidden" name="user_id"    value="<?= (int)$u['Id'] ?>">
+                                            <button type="submit" class="btn btn-sm btn-outline-danger" title="Remove from group">
+                                                <i class="bi bi-x"></i>
+                                            </button>
+                                        </form>
+                                    </li>
+                                <?php endforeach; ?>
+                            </ul>
+                        <?php endif; ?>
+                    </div>
+                </div>
+
+                <!-- Add candidates -->
+                <div class="col-md-6">
+                    <div class="card-admin p-3 h-100">
+                        <h2 class="h6 mb-3"><i class="bi bi-person-plus me-2"></i>Add a member</h2>
+                        <?php if (!$candidates): ?>
+                            <p class="text-muted small mb-0">Every active user is already in this group.</p>
+                        <?php else: ?>
+                            <form method="POST" class="d-flex gap-2">
+                                <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                                <input type="hidden" name="action"     value="add_member">
+                                <input type="hidden" name="group_id"   value="<?= (int)$editGroup['Id'] ?>">
+                                <select name="user_id" class="form-select form-select-sm" required>
+                                    <option value="">— pick a user —</option>
+                                    <?php foreach ($candidates as $u): ?>
+                                        <option value="<?= (int)$u['Id'] ?>">
+                                            <?= htmlspecialchars($u['Username']) ?>
+                                            <?php if ($u['DisplayName']): ?> — <?= htmlspecialchars($u['DisplayName']) ?><?php endif; ?>
+                                            (<?= htmlspecialchars($u['Role']) ?>)
+                                        </option>
+                                    <?php endforeach; ?>
+                                </select>
+                                <button type="submit" class="btn btn-sm btn-amber-solid">
+                                    <i class="bi bi-plus"></i>
+                                </button>
+                            </form>
+                        <?php endif; ?>
+                    </div>
+                </div>
+            </div>
+
+        <?php endif; ?>
+
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+            integrity="sha384-zKzgIZcXU99qF1nNW9g+x1znB5NhCPs9qZeGzUnnFOaHJF9jCCKySBjq3vIKabk/"
+            crossorigin="anonymous"></script>
+
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>
+</body>
+</html>

--- a/appWeb/public_html/manage/includes/admin-nav.php
+++ b/appWeb/public_html/manage/includes/admin-nav.php
@@ -57,6 +57,10 @@ if (basename($_SERVER['SCRIPT_FILENAME'] ?? '') === basename(__FILE__)) {
             <?= htmlspecialchars(roleLabel($currentUser['role'])) ?>
         </span>
     </span>
+    <a href="/" class="btn btn-sm btn-outline-secondary ms-1"
+       title="Back to the iHymns app home">
+        <i class="bi bi-house me-1"></i>Home
+    </a>
     <a href="/manage/logout" class="btn btn-sm btn-outline-secondary ms-1">
         <i class="bi bi-box-arrow-right me-1"></i>Logout
     </a>

--- a/appWeb/public_html/manage/index.php
+++ b/appWeb/public_html/manage/index.php
@@ -231,6 +231,17 @@ $csrf = csrfToken();
                 </div>
             </div>
             <?php endif; ?>
+            <?php if (($currentUser['role'] ?? '') === 'global_admin'): ?>
+            <div class="col-md-4">
+                <div class="card-admin">
+                    <a href="/manage/data-health" class="quick-link">
+                        <i class="bi bi-activity d-block mb-2"></i>
+                        <strong>Data Health</strong>
+                        <div class="small text-muted">Confirm MySQL is authoritative; disconnect legacy fallbacks</div>
+                    </a>
+                </div>
+            </div>
+            <?php endif; ?>
             <?php if (userHasEntitlement('manage_entitlements', $currentUser['role'] ?? null)): ?>
             <div class="col-md-4">
                 <div class="card-admin">
@@ -238,6 +249,39 @@ $csrf = csrfToken();
                         <i class="bi bi-key d-block mb-2"></i>
                         <strong>Entitlements</strong>
                         <div class="small text-muted">Assign capabilities to roles</div>
+                    </a>
+                </div>
+            </div>
+            <?php endif; ?>
+            <?php if (userHasEntitlement('manage_songbooks', $currentUser['role'] ?? null)): ?>
+            <div class="col-md-4">
+                <div class="card-admin">
+                    <a href="/manage/songbooks" class="quick-link">
+                        <i class="bi bi-book d-block mb-2"></i>
+                        <strong>Songbooks</strong>
+                        <div class="small text-muted">Create, rename, reorder the songbook catalogue</div>
+                    </a>
+                </div>
+            </div>
+            <?php endif; ?>
+            <?php if (userHasEntitlement('manage_user_groups', $currentUser['role'] ?? null)): ?>
+            <div class="col-md-4">
+                <div class="card-admin">
+                    <a href="/manage/groups" class="quick-link">
+                        <i class="bi bi-people-fill d-block mb-2"></i>
+                        <strong>User Groups</strong>
+                        <div class="small text-muted">Group users for shared access settings</div>
+                    </a>
+                </div>
+            </div>
+            <?php endif; ?>
+            <?php if (userHasEntitlement('manage_organisations', $currentUser['role'] ?? null)): ?>
+            <div class="col-md-4">
+                <div class="card-admin">
+                    <a href="/manage/organisations" class="quick-link">
+                        <i class="bi bi-building d-block mb-2"></i>
+                        <strong>Organisations</strong>
+                        <div class="small text-muted">Manage organisations &amp; their members</div>
                     </a>
                 </div>
             </div>

--- a/appWeb/public_html/manage/organisations.php
+++ b/appWeb/public_html/manage/organisations.php
@@ -1,0 +1,543 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Admin: Organisations
+ *
+ * Minimal CRUD over `tblOrganisations` + member management via
+ * `tblOrganisationMembers`. Gated by `manage_organisations`.
+ */
+
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'entitlements.php';
+
+if (!isAuthenticated()) {
+    header('Location: /manage/login');
+    exit;
+}
+$currentUser = getCurrentUser();
+if (!$currentUser || !userHasEntitlement('manage_organisations', $currentUser['role'] ?? null)) {
+    http_response_code(403);
+    echo '<!DOCTYPE html><html><body><h1>403 — manage_organisations required</h1></body></html>';
+    exit;
+}
+$activePage = 'organisations';
+
+$error   = '';
+$success = '';
+$db      = getDb();
+
+$LICENCE_TYPES  = ['none', 'ihymns_basic', 'ihymns_pro', 'ccli'];
+$MEMBER_ROLES   = ['member', 'admin', 'owner'];
+
+$slugify = function (string $s): string {
+    $s = strtolower(trim($s));
+    $s = preg_replace('/[^a-z0-9]+/', '-', $s);
+    return trim((string)$s, '-');
+};
+
+/* ----- POST actions ----- */
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!validateCsrf((string)($_POST['csrf_token'] ?? ''))) {
+        http_response_code(403);
+        echo 'Invalid CSRF token';
+        exit;
+    }
+
+    $action = (string)($_POST['action'] ?? '');
+    try {
+        switch ($action) {
+            case 'create': {
+                $name        = trim((string)($_POST['name']         ?? ''));
+                $slugInput   = trim((string)($_POST['slug']         ?? ''));
+                $parent      = (int)($_POST['parent_org_id']        ?? 0);
+                $desc        = trim((string)($_POST['description']  ?? ''));
+                $licenceType = (string)($_POST['licence_type']      ?? 'none');
+                $licenceNum  = trim((string)($_POST['licence_number'] ?? ''));
+                $active      = !empty($_POST['is_active']) ? 1 : 0;
+
+                if ($name === '') { $error = 'Name is required.'; break; }
+                $slug = $slugInput !== '' ? $slugify($slugInput) : $slugify($name);
+                if ($slug === '') { $error = 'Slug could not be derived — supply one explicitly.'; break; }
+                if (!in_array($licenceType, $LICENCE_TYPES, true)) { $error = 'Unknown licence type.'; break; }
+
+                $stmt = $db->prepare('SELECT Id FROM tblOrganisations WHERE Slug = ?');
+                $stmt->execute([$slug]);
+                if ($stmt->fetch()) { $error = 'That slug is already in use.'; break; }
+
+                $stmt = $db->prepare(
+                    'INSERT INTO tblOrganisations
+                        (Name, Slug, ParentOrgId, Description, LicenceType, LicenceNumber, IsActive)
+                     VALUES (?, ?, ?, ?, ?, ?, ?)'
+                );
+                $stmt->execute([$name, $slug, $parent ?: null, $desc, $licenceType, $licenceNum, $active]);
+                $success = "Organisation '{$name}' created.";
+                break;
+            }
+
+            case 'update': {
+                $id          = (int)($_POST['id'] ?? 0);
+                $name        = trim((string)($_POST['name']         ?? ''));
+                $slug        = $slugify((string)($_POST['slug']     ?? ''));
+                $parent      = (int)($_POST['parent_org_id']        ?? 0);
+                $desc        = trim((string)($_POST['description']  ?? ''));
+                $licenceType = (string)($_POST['licence_type']      ?? 'none');
+                $licenceNum  = trim((string)($_POST['licence_number'] ?? ''));
+                $active      = !empty($_POST['is_active']) ? 1 : 0;
+                if ($id <= 0) { $error = 'Organisation id missing.'; break; }
+                if ($name === '') { $error = 'Name is required.'; break; }
+                if ($slug === '') { $error = 'Slug is required.'; break; }
+                if (!in_array($licenceType, $LICENCE_TYPES, true)) { $error = 'Unknown licence type.'; break; }
+                if ($parent === $id) { $error = 'An organisation cannot be its own parent.'; break; }
+
+                $stmt = $db->prepare('SELECT Id FROM tblOrganisations WHERE Slug = ? AND Id <> ?');
+                $stmt->execute([$slug, $id]);
+                if ($stmt->fetch()) { $error = 'That slug is already in use.'; break; }
+
+                $stmt = $db->prepare(
+                    'UPDATE tblOrganisations
+                        SET Name = ?, Slug = ?, ParentOrgId = ?, Description = ?,
+                            LicenceType = ?, LicenceNumber = ?, IsActive = ?
+                      WHERE Id = ?'
+                );
+                $stmt->execute([$name, $slug, $parent ?: null, $desc, $licenceType, $licenceNum, $active, $id]);
+                $success = "Organisation updated.";
+                break;
+            }
+
+            case 'delete': {
+                $id = (int)($_POST['id'] ?? 0);
+
+                $stmt = $db->prepare('SELECT Name FROM tblOrganisations WHERE Id = ?');
+                $stmt->execute([$id]);
+                $name = (string)($stmt->fetchColumn() ?: '');
+                if ($name === '') { $error = 'Organisation not found.'; break; }
+
+                $stmt = $db->prepare('SELECT COUNT(*) FROM tblOrganisationMembers WHERE OrgId = ?');
+                $stmt->execute([$id]);
+                $members = (int)$stmt->fetchColumn();
+                if ($members > 0) { $error = "Cannot delete '{$name}': {$members} member(s) still listed."; break; }
+
+                $stmt = $db->prepare('SELECT COUNT(*) FROM tblOrganisations WHERE ParentOrgId = ?');
+                $stmt->execute([$id]);
+                $children = (int)$stmt->fetchColumn();
+                if ($children > 0) { $error = "Cannot delete '{$name}': {$children} sub-organisation(s) still reference it as parent."; break; }
+
+                $stmt = $db->prepare('DELETE FROM tblOrganisations WHERE Id = ?');
+                $stmt->execute([$id]);
+                $success = "Organisation '{$name}' deleted.";
+                break;
+            }
+
+            case 'add_member': {
+                $orgId  = (int)($_POST['org_id'] ?? 0);
+                $userId = (int)($_POST['user_id'] ?? 0);
+                $role   = (string)($_POST['member_role'] ?? 'member');
+                if ($orgId <= 0 || $userId <= 0) { $error = 'Invalid request.'; break; }
+                if (!in_array($role, $MEMBER_ROLES, true)) { $error = 'Unknown member role.'; break; }
+
+                $stmt = $db->prepare(
+                    'INSERT INTO tblOrganisationMembers (UserId, OrgId, Role)
+                     VALUES (?, ?, ?)
+                     ON DUPLICATE KEY UPDATE Role = VALUES(Role)'
+                );
+                $stmt->execute([$userId, $orgId, $role]);
+                $success = 'Member added / updated.';
+                break;
+            }
+
+            case 'update_member_role': {
+                $orgId  = (int)($_POST['org_id'] ?? 0);
+                $userId = (int)($_POST['user_id'] ?? 0);
+                $role   = (string)($_POST['member_role'] ?? 'member');
+                if ($orgId <= 0 || $userId <= 0) { $error = 'Invalid request.'; break; }
+                if (!in_array($role, $MEMBER_ROLES, true)) { $error = 'Unknown member role.'; break; }
+
+                $stmt = $db->prepare('UPDATE tblOrganisationMembers SET Role = ? WHERE OrgId = ? AND UserId = ?');
+                $stmt->execute([$role, $orgId, $userId]);
+                $success = 'Member role updated.';
+                break;
+            }
+
+            case 'remove_member': {
+                $orgId  = (int)($_POST['org_id'] ?? 0);
+                $userId = (int)($_POST['user_id'] ?? 0);
+                if ($orgId <= 0 || $userId <= 0) { $error = 'Invalid request.'; break; }
+                $stmt = $db->prepare('DELETE FROM tblOrganisationMembers WHERE OrgId = ? AND UserId = ?');
+                $stmt->execute([$orgId, $userId]);
+                $success = 'Member removed.';
+                break;
+            }
+
+            default:
+                $error = 'Unknown action.';
+        }
+    } catch (\Throwable $e) {
+        error_log('[manage/organisations.php] ' . $e->getMessage());
+        $error = $error ?: 'Database error — check server logs for details.';
+    }
+}
+
+/* ----- Fetch list ----- */
+$orgs = [];
+try {
+    $rs = $db->query(
+        'SELECT o.*, p.Name AS ParentName,
+                (SELECT COUNT(*) FROM tblOrganisationMembers WHERE OrgId = o.Id) AS MemberCount
+           FROM tblOrganisations o
+           LEFT JOIN tblOrganisations p ON p.Id = o.ParentOrgId
+          ORDER BY o.Name ASC'
+    );
+    $orgs = $rs->fetchAll(PDO::FETCH_ASSOC);
+} catch (\Throwable $e) {
+    error_log('[manage/organisations.php] ' . $e->getMessage());
+    $error = $error ?: 'Could not load organisations.';
+}
+
+/* Edit mode */
+$editOrg     = null;
+$editMembers = [];
+$candidates  = [];
+$editId = (int)($_GET['edit'] ?? 0);
+if ($editId > 0) {
+    try {
+        $stmt = $db->prepare('SELECT * FROM tblOrganisations WHERE Id = ?');
+        $stmt->execute([$editId]);
+        $editOrg = $stmt->fetch(PDO::FETCH_ASSOC) ?: null;
+
+        if ($editOrg) {
+            $stmt = $db->prepare(
+                'SELECT u.Id, u.Username, u.DisplayName, u.Role AS SystemRole,
+                        m.Role AS OrgRole, m.JoinedAt
+                   FROM tblOrganisationMembers m
+                   JOIN tblUsers u ON u.Id = m.UserId
+                  WHERE m.OrgId = ?
+                  ORDER BY m.JoinedAt DESC'
+            );
+            $stmt->execute([$editId]);
+            $editMembers = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+            $stmt = $db->prepare(
+                'SELECT u.Id, u.Username, u.DisplayName
+                   FROM tblUsers u
+                   LEFT JOIN tblOrganisationMembers m ON m.UserId = u.Id AND m.OrgId = ?
+                  WHERE u.IsActive = 1 AND m.UserId IS NULL
+                  ORDER BY u.Username ASC
+                  LIMIT 500'
+            );
+            $stmt->execute([$editId]);
+            $candidates = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        }
+    } catch (\Throwable $e) {
+        error_log('[manage/organisations.php] ' . $e->getMessage());
+    }
+}
+
+$csrf = csrfToken();
+?>
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Organisations — iHymns Admin</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
+          integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
+          integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">
+    <link rel="stylesheet" href="/css/app.css?v=<?= filemtime(dirname(__DIR__) . '/css/app.css') ?>">
+    <link rel="stylesheet" href="/css/admin.css?v=<?= filemtime(dirname(__DIR__) . '/css/admin.css') ?>">
+</head>
+<body>
+
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-nav.php'; ?>
+
+    <div class="container py-4" style="max-width: 1100px;">
+
+        <h1 class="h4 mb-3"><i class="bi bi-building me-2"></i>Organisations</h1>
+        <p class="text-secondary small mb-4">
+            Add and edit organisations (churches / groups), manage their members,
+            and maintain licence metadata.
+        </p>
+
+        <?php if ($success): ?>
+            <div class="alert alert-success py-2"><?= htmlspecialchars($success) ?></div>
+        <?php endif; ?>
+        <?php if ($error): ?>
+            <div class="alert alert-danger py-2"><?= htmlspecialchars($error) ?></div>
+        <?php endif; ?>
+
+        <?php if (!$editOrg): ?>
+
+            <div class="card-admin p-3 mb-4">
+                <h2 class="h6 mb-3">All organisations</h2>
+                <table class="table table-sm mb-0 align-middle">
+                    <thead>
+                        <tr class="text-muted small">
+                            <th>Name</th>
+                            <th>Slug</th>
+                            <th>Parent</th>
+                            <th>Licence</th>
+                            <th class="text-center">Active</th>
+                            <th class="text-center">Members</th>
+                            <th class="text-end">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($orgs as $o): ?>
+                            <tr>
+                                <td><strong><?= htmlspecialchars($o['Name']) ?></strong></td>
+                                <td><code class="small"><?= htmlspecialchars($o['Slug']) ?></code></td>
+                                <td class="text-muted small"><?= htmlspecialchars($o['ParentName'] ?? '—') ?></td>
+                                <td>
+                                    <span class="badge bg-secondary" style="font-size: 0.7rem"><?= htmlspecialchars($o['LicenceType']) ?></span>
+                                    <?php if ($o['LicenceNumber']): ?>
+                                        <small class="text-muted ms-1"><?= htmlspecialchars($o['LicenceNumber']) ?></small>
+                                    <?php endif; ?>
+                                </td>
+                                <td class="text-center">
+                                    <?= (int)$o['IsActive'] ? '<i class="bi bi-check-circle text-success"></i>' : '<i class="bi bi-x-circle text-muted"></i>' ?>
+                                </td>
+                                <td class="text-center"><?= (int)$o['MemberCount'] ?></td>
+                                <td class="text-end">
+                                    <a href="?edit=<?= (int)$o['Id'] ?>" class="btn btn-sm btn-outline-info" title="Edit and manage members">
+                                        <i class="bi bi-pencil"></i>
+                                    </a>
+                                    <?php if ((int)$o['MemberCount'] === 0): ?>
+                                        <form method="POST" class="d-inline" onsubmit="return confirm('Delete organisation <?= htmlspecialchars($o['Name'], ENT_QUOTES) ?>?')">
+                                            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                                            <input type="hidden" name="action" value="delete">
+                                            <input type="hidden" name="id" value="<?= (int)$o['Id'] ?>">
+                                            <button type="submit" class="btn btn-sm btn-outline-danger" title="Delete (empty org)"><i class="bi bi-trash"></i></button>
+                                        </form>
+                                    <?php else: ?>
+                                        <button type="button" class="btn btn-sm btn-outline-secondary" disabled title="Org has members — remove them first"><i class="bi bi-trash"></i></button>
+                                    <?php endif; ?>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                        <?php if (!$orgs): ?>
+                            <tr><td colspan="7" class="text-muted text-center py-4">No organisations yet. Add one below.</td></tr>
+                        <?php endif; ?>
+                    </tbody>
+                </table>
+            </div>
+
+            <form method="POST" class="card-admin p-3 mb-4">
+                <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                <input type="hidden" name="action" value="create">
+                <h2 class="h6 mb-3"><i class="bi bi-plus-circle me-2"></i>Add an organisation</h2>
+                <div class="row g-2 mb-2">
+                    <div class="col-sm-5">
+                        <label class="form-label small">Name</label>
+                        <input type="text" name="name" class="form-control form-control-sm" maxlength="255" required>
+                    </div>
+                    <div class="col-sm-3">
+                        <label class="form-label small">Slug (optional, auto-derived)</label>
+                        <input type="text" name="slug" class="form-control form-control-sm" maxlength="100" placeholder="auto">
+                    </div>
+                    <div class="col-sm-4">
+                        <label class="form-label small">Parent organisation</label>
+                        <select name="parent_org_id" class="form-select form-select-sm">
+                            <option value="">— None —</option>
+                            <?php foreach ($orgs as $o): ?>
+                                <option value="<?= (int)$o['Id'] ?>"><?= htmlspecialchars($o['Name']) ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+                </div>
+                <div class="mb-2">
+                    <label class="form-label small">Description</label>
+                    <input type="text" name="description" class="form-control form-control-sm">
+                </div>
+                <div class="row g-2 mb-2">
+                    <div class="col-sm-4">
+                        <label class="form-label small">Licence type</label>
+                        <select name="licence_type" class="form-select form-select-sm">
+                            <?php foreach ($LICENCE_TYPES as $lt): ?>
+                                <option value="<?= $lt ?>"><?= $lt ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+                    <div class="col-sm-4">
+                        <label class="form-label small">Licence number</label>
+                        <input type="text" name="licence_number" class="form-control form-control-sm" maxlength="100">
+                    </div>
+                    <div class="col-sm-4 d-flex align-items-end">
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" name="is_active" id="new-is-active" value="1" checked>
+                            <label class="form-check-label" for="new-is-active">Active</label>
+                        </div>
+                    </div>
+                </div>
+                <button type="submit" class="btn btn-amber-solid btn-sm mt-2">
+                    <i class="bi bi-plus me-1"></i>Create organisation
+                </button>
+            </form>
+
+        <?php else: ?>
+
+            <div class="mb-3">
+                <a href="/manage/organisations" class="btn btn-sm btn-outline-secondary">
+                    <i class="bi bi-arrow-left me-1"></i>Back to organisation list
+                </a>
+            </div>
+
+            <form method="POST" class="card-admin p-3 mb-4">
+                <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                <input type="hidden" name="action" value="update">
+                <input type="hidden" name="id" value="<?= (int)$editOrg['Id'] ?>">
+                <h2 class="h6 mb-3"><i class="bi bi-sliders me-2"></i>Settings — <?= htmlspecialchars($editOrg['Name']) ?></h2>
+                <div class="row g-2 mb-2">
+                    <div class="col-sm-5">
+                        <label class="form-label small">Name</label>
+                        <input type="text" name="name" class="form-control form-control-sm" maxlength="255" required
+                               value="<?= htmlspecialchars($editOrg['Name']) ?>">
+                    </div>
+                    <div class="col-sm-3">
+                        <label class="form-label small">Slug</label>
+                        <input type="text" name="slug" class="form-control form-control-sm" maxlength="100" required
+                               value="<?= htmlspecialchars($editOrg['Slug']) ?>">
+                    </div>
+                    <div class="col-sm-4">
+                        <label class="form-label small">Parent organisation</label>
+                        <select name="parent_org_id" class="form-select form-select-sm">
+                            <option value="">— None —</option>
+                            <?php foreach ($orgs as $o): ?>
+                                <?php if ((int)$o['Id'] === (int)$editOrg['Id']) continue; /* no self-parent */ ?>
+                                <option value="<?= (int)$o['Id'] ?>" <?= (int)$o['Id'] === (int)$editOrg['ParentOrgId'] ? 'selected' : '' ?>>
+                                    <?= htmlspecialchars($o['Name']) ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+                </div>
+                <div class="mb-2">
+                    <label class="form-label small">Description</label>
+                    <input type="text" name="description" class="form-control form-control-sm"
+                           value="<?= htmlspecialchars($editOrg['Description']) ?>">
+                </div>
+                <div class="row g-2 mb-2">
+                    <div class="col-sm-4">
+                        <label class="form-label small">Licence type</label>
+                        <select name="licence_type" class="form-select form-select-sm">
+                            <?php foreach ($LICENCE_TYPES as $lt): ?>
+                                <option value="<?= $lt ?>" <?= $editOrg['LicenceType'] === $lt ? 'selected' : '' ?>><?= $lt ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+                    <div class="col-sm-4">
+                        <label class="form-label small">Licence number</label>
+                        <input type="text" name="licence_number" class="form-control form-control-sm" maxlength="100"
+                               value="<?= htmlspecialchars($editOrg['LicenceNumber']) ?>">
+                    </div>
+                    <div class="col-sm-4 d-flex align-items-end">
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" name="is_active" id="edit-is-active" value="1" <?= (int)$editOrg['IsActive'] ? 'checked' : '' ?>>
+                            <label class="form-check-label" for="edit-is-active">Active</label>
+                        </div>
+                    </div>
+                </div>
+                <button type="submit" class="btn btn-amber-solid btn-sm mt-2">
+                    <i class="bi bi-save me-1"></i>Save settings
+                </button>
+            </form>
+
+            <div class="row g-3">
+                <div class="col-md-7">
+                    <div class="card-admin p-3 h-100">
+                        <h2 class="h6 mb-3"><i class="bi bi-people me-2"></i>Members (<?= count($editMembers) ?>)</h2>
+                        <?php if (!$editMembers): ?>
+                            <p class="text-muted small mb-0">No members yet.</p>
+                        <?php else: ?>
+                            <table class="table table-sm align-middle mb-0">
+                                <thead>
+                                    <tr class="text-muted small">
+                                        <th>User</th>
+                                        <th>Role</th>
+                                        <th>Joined</th>
+                                        <th class="text-end"></th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <?php foreach ($editMembers as $m): ?>
+                                        <tr>
+                                            <td>
+                                                <code><?= htmlspecialchars($m['Username']) ?></code>
+                                                <small class="text-muted ms-1"><?= htmlspecialchars($m['DisplayName']) ?></small>
+                                            </td>
+                                            <td>
+                                                <form method="POST" class="d-flex gap-1">
+                                                    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                                                    <input type="hidden" name="action" value="update_member_role">
+                                                    <input type="hidden" name="org_id"  value="<?= (int)$editOrg['Id'] ?>">
+                                                    <input type="hidden" name="user_id" value="<?= (int)$m['Id'] ?>">
+                                                    <select name="member_role" class="form-select form-select-sm" onchange="this.form.submit()">
+                                                        <?php foreach ($MEMBER_ROLES as $mr): ?>
+                                                            <option value="<?= $mr ?>" <?= $m['OrgRole'] === $mr ? 'selected' : '' ?>><?= $mr ?></option>
+                                                        <?php endforeach; ?>
+                                                    </select>
+                                                </form>
+                                            </td>
+                                            <td class="text-muted small"><?= htmlspecialchars(substr((string)$m['JoinedAt'], 0, 10)) ?></td>
+                                            <td class="text-end">
+                                                <form method="POST" class="d-inline" onsubmit="return confirm('Remove <?= htmlspecialchars($m['Username'], ENT_QUOTES) ?> from this organisation?')">
+                                                    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                                                    <input type="hidden" name="action"  value="remove_member">
+                                                    <input type="hidden" name="org_id"  value="<?= (int)$editOrg['Id'] ?>">
+                                                    <input type="hidden" name="user_id" value="<?= (int)$m['Id'] ?>">
+                                                    <button type="submit" class="btn btn-sm btn-outline-danger"><i class="bi bi-x"></i></button>
+                                                </form>
+                                            </td>
+                                        </tr>
+                                    <?php endforeach; ?>
+                                </tbody>
+                            </table>
+                        <?php endif; ?>
+                    </div>
+                </div>
+                <div class="col-md-5">
+                    <div class="card-admin p-3 h-100">
+                        <h2 class="h6 mb-3"><i class="bi bi-person-plus me-2"></i>Add a member</h2>
+                        <?php if (!$candidates): ?>
+                            <p class="text-muted small mb-0">Every active user is already a member.</p>
+                        <?php else: ?>
+                            <form method="POST" class="d-flex gap-2 flex-wrap">
+                                <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                                <input type="hidden" name="action"     value="add_member">
+                                <input type="hidden" name="org_id"     value="<?= (int)$editOrg['Id'] ?>">
+                                <select name="user_id" class="form-select form-select-sm" style="min-width: 180px;" required>
+                                    <option value="">— pick a user —</option>
+                                    <?php foreach ($candidates as $u): ?>
+                                        <option value="<?= (int)$u['Id'] ?>">
+                                            <?= htmlspecialchars($u['Username']) ?>
+                                            <?php if ($u['DisplayName']): ?> — <?= htmlspecialchars($u['DisplayName']) ?><?php endif; ?>
+                                        </option>
+                                    <?php endforeach; ?>
+                                </select>
+                                <select name="member_role" class="form-select form-select-sm" style="width: 8rem;">
+                                    <?php foreach ($MEMBER_ROLES as $mr): ?>
+                                        <option value="<?= $mr ?>"><?= $mr ?></option>
+                                    <?php endforeach; ?>
+                                </select>
+                                <button type="submit" class="btn btn-sm btn-amber-solid">
+                                    <i class="bi bi-plus"></i>
+                                </button>
+                            </form>
+                        <?php endif; ?>
+                    </div>
+                </div>
+            </div>
+
+        <?php endif; ?>
+
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+            integrity="sha384-zKzgIZcXU99qF1nNW9g+x1znB5NhCPs9qZeGzUnnFOaHJF9jCCKySBjq3vIKabk/"
+            crossorigin="anonymous"></script>
+
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>
+</body>
+</html>

--- a/appWeb/public_html/manage/requests.php
+++ b/appWeb/public_html/manage/requests.php
@@ -121,7 +121,14 @@ try {
 
 <nav class="navbar-admin d-flex align-items-center justify-content-between">
     <a class="navbar-brand" href="/manage/"><i class="bi bi-lightbulb me-2"></i>Song Requests</a>
-    <a href="/manage/" class="btn btn-sm btn-outline-secondary">Back to Dashboard</a>
+    <div class="d-flex align-items-center gap-2">
+        <a href="/manage/" class="btn btn-sm btn-outline-secondary">
+            <i class="bi bi-speedometer2 me-1"></i>Dashboard
+        </a>
+        <a href="/" class="btn btn-sm btn-outline-secondary" title="Back to the iHymns app home">
+            <i class="bi bi-house me-1"></i>Home
+        </a>
+    </div>
 </nav>
 
 <div class="container py-4" style="max-width: 1100px;">

--- a/appWeb/public_html/manage/revisions.php
+++ b/appWeb/public_html/manage/revisions.php
@@ -86,8 +86,13 @@ try {
 <nav class="navbar-admin d-flex align-items-center justify-content-between">
     <a class="navbar-brand" href="/manage/"><i class="bi bi-clock-history me-2"></i>iHymns Revisions</a>
     <div class="d-flex align-items-center gap-2">
-        <span class="text-muted small"><?= htmlspecialchars($currentUser['username'] ?? '') ?></span>
-        <a href="/manage/" class="btn btn-sm btn-outline-secondary">Back to Dashboard</a>
+        <span class="text-muted small d-none d-md-inline"><?= htmlspecialchars($currentUser['username'] ?? '') ?></span>
+        <a href="/manage/" class="btn btn-sm btn-outline-secondary">
+            <i class="bi bi-speedometer2 me-1"></i>Dashboard
+        </a>
+        <a href="/" class="btn btn-sm btn-outline-secondary" title="Back to the iHymns app home">
+            <i class="bi bi-house me-1"></i>Home
+        </a>
     </div>
 </nav>
 

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -280,6 +280,21 @@ if ($hasCredentials && defined('DB_HOST')) {
     <link rel="stylesheet" href="/css/admin.css?v=<?= filemtime(dirname(__DIR__) . "/css/admin.css") ?>">
 </head>
 <body>
+
+<?php if (!$isInitialSetup): ?>
+<nav class="navbar-admin d-flex align-items-center justify-content-between">
+    <a class="navbar-brand" href="/manage/"><i class="bi bi-database me-2"></i>Database Setup</a>
+    <div class="d-flex align-items-center gap-2">
+        <a href="/manage/" class="btn btn-sm btn-outline-secondary">
+            <i class="bi bi-speedometer2 me-1"></i>Dashboard
+        </a>
+        <a href="/" class="btn btn-sm btn-outline-secondary" title="Back to the iHymns app home">
+            <i class="bi bi-house me-1"></i>Home
+        </a>
+    </div>
+</nav>
+<?php endif; ?>
+
 <div class="container py-4" style="max-width: 900px;">
 
     <h1 class="mb-1">Database Setup</h1>

--- a/appWeb/public_html/manage/songbooks.php
+++ b/appWeb/public_html/manage/songbooks.php
@@ -1,0 +1,456 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Admin: Songbooks
+ *
+ * CRUD surface for `tblSongbooks`. Gated by the `manage_songbooks`
+ * entitlement. Safe-guards:
+ *   - Abbreviation is the natural key on tblSongs.SongbookAbbr — renaming
+ *     it is opt-in and cascades via an explicit "also rename song refs"
+ *     checkbox.
+ *   - Delete refuses if any song still references the abbreviation.
+ *   - DisplayOrder is seeded by migrate-account-sync.php; the UI writes
+ *     back whole-table updates so reordering is atomic.
+ */
+
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'entitlements.php';
+
+if (!isAuthenticated()) {
+    header('Location: /manage/login');
+    exit;
+}
+$currentUser = getCurrentUser();
+if (!$currentUser || !userHasEntitlement('manage_songbooks', $currentUser['role'] ?? null)) {
+    http_response_code(403);
+    echo '<!DOCTYPE html><html><body><h1>403 — manage_songbooks required</h1></body></html>';
+    exit;
+}
+$activePage = 'songbooks';
+
+$error   = '';
+$success = '';
+$db      = getDb();
+
+/* Helpers */
+$validateAbbr = function (string $abbr): ?string {
+    $abbr = trim($abbr);
+    if ($abbr === '') return 'Abbreviation is required.';
+    if (strlen($abbr) > 10) return 'Abbreviation must be 10 characters or fewer.';
+    if (!preg_match('/^[A-Za-z0-9]+$/', $abbr)) return 'Abbreviation must be letters/numbers only (no spaces or punctuation).';
+    return null;
+};
+$validateColour = function (string $c): ?string {
+    if ($c === '') return null;
+    return preg_match('/^#[0-9A-Fa-f]{6}$/', $c) ? null : 'Colour must be a #RRGGBB hex value (or blank).';
+};
+
+/* ----- POST actions ----- */
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!validateCsrf((string)($_POST['csrf_token'] ?? ''))) {
+        http_response_code(403);
+        echo 'Invalid CSRF token';
+        exit;
+    }
+
+    $action = (string)($_POST['action'] ?? '');
+
+    try {
+        switch ($action) {
+            case 'create': {
+                $abbr   = trim((string)($_POST['abbreviation'] ?? ''));
+                $name   = trim((string)($_POST['name']         ?? ''));
+                $colour = trim((string)($_POST['colour']       ?? ''));
+                $order  = (int)($_POST['display_order']        ?? 0);
+
+                if ($e = $validateAbbr($abbr))   { $error = $e; break; }
+                if ($name === '')                { $error = 'Name is required.'; break; }
+                if ($e = $validateColour($colour)) { $error = $e; break; }
+
+                $stmt = $db->prepare('SELECT Id FROM tblSongbooks WHERE Abbreviation = ?');
+                $stmt->execute([$abbr]);
+                if ($stmt->fetch()) { $error = 'Abbreviation already exists.'; break; }
+
+                $stmt = $db->prepare(
+                    'INSERT INTO tblSongbooks (Abbreviation, Name, DisplayOrder, Colour)
+                     VALUES (?, ?, ?, ?)'
+                );
+                $stmt->execute([$abbr, $name, $order ?: 0, $colour]);
+                $success = "Songbook '{$abbr}' created.";
+                break;
+            }
+
+            case 'update': {
+                $id          = (int)($_POST['id'] ?? 0);
+                $name        = trim((string)($_POST['name']         ?? ''));
+                $colour      = trim((string)($_POST['colour']       ?? ''));
+                $order       = (int)($_POST['display_order']        ?? 0);
+                $newAbbr     = trim((string)($_POST['new_abbreviation'] ?? ''));
+                $alsoRename  = !empty($_POST['rename_song_refs']);
+
+                $existing = $db->prepare('SELECT Abbreviation FROM tblSongbooks WHERE Id = ?');
+                $existing->execute([$id]);
+                $oldAbbr = (string)($existing->fetchColumn() ?: '');
+                if ($oldAbbr === '') { $error = 'Songbook not found.'; break; }
+
+                if ($name === '')                  { $error = 'Name is required.'; break; }
+                if ($e = $validateColour($colour)) { $error = $e; break; }
+
+                /* Handle optional abbreviation change */
+                $abbrChanged = $newAbbr !== '' && $newAbbr !== $oldAbbr;
+                if ($abbrChanged) {
+                    if ($e = $validateAbbr($newAbbr)) { $error = $e; break; }
+                    $dup = $db->prepare('SELECT Id FROM tblSongbooks WHERE Abbreviation = ? AND Id <> ?');
+                    $dup->execute([$newAbbr, $id]);
+                    if ($dup->fetch()) { $error = 'That abbreviation is already taken.'; break; }
+                }
+
+                $db->beginTransaction();
+                try {
+                    $stmt = $db->prepare(
+                        'UPDATE tblSongbooks
+                            SET Name = ?, Colour = ?, DisplayOrder = ?
+                          WHERE Id = ?'
+                    );
+                    $stmt->execute([$name, $colour, $order ?: 0, $id]);
+
+                    if ($abbrChanged) {
+                        $stmt = $db->prepare('UPDATE tblSongbooks SET Abbreviation = ? WHERE Id = ?');
+                        $stmt->execute([$newAbbr, $id]);
+                        if ($alsoRename) {
+                            $stmt = $db->prepare('UPDATE tblSongs SET SongbookAbbr = ? WHERE SongbookAbbr = ?');
+                            $stmt->execute([$newAbbr, $oldAbbr]);
+                        }
+                    }
+                    $db->commit();
+                    $success = $abbrChanged
+                        ? "Songbook '{$oldAbbr}' → '{$newAbbr}'" . ($alsoRename ? ' (song references updated).' : ' (song references kept — resolve manually).')
+                        : "Songbook '{$oldAbbr}' updated.";
+                } catch (\Throwable $e) {
+                    $db->rollBack();
+                    throw $e;
+                }
+                break;
+            }
+
+            case 'reorder': {
+                /* Posted as display_order[id] = integer */
+                $orders = $_POST['display_order'] ?? [];
+                if (!is_array($orders)) { $error = 'Invalid reorder payload.'; break; }
+
+                $db->beginTransaction();
+                try {
+                    $stmt = $db->prepare('UPDATE tblSongbooks SET DisplayOrder = ? WHERE Id = ?');
+                    foreach ($orders as $id => $value) {
+                        $stmt->execute([(int)$value, (int)$id]);
+                    }
+                    $db->commit();
+                    $success = 'Display order saved.';
+                } catch (\Throwable $e) {
+                    $db->rollBack();
+                    throw $e;
+                }
+                break;
+            }
+
+            case 'delete': {
+                $id = (int)($_POST['id'] ?? 0);
+
+                $stmt = $db->prepare('SELECT Abbreviation FROM tblSongbooks WHERE Id = ?');
+                $stmt->execute([$id]);
+                $abbr = (string)($stmt->fetchColumn() ?: '');
+                if ($abbr === '') { $error = 'Songbook not found.'; break; }
+
+                $stmt = $db->prepare('SELECT COUNT(*) FROM tblSongs WHERE SongbookAbbr = ?');
+                $stmt->execute([$abbr]);
+                $songCount = (int)$stmt->fetchColumn();
+                if ($songCount > 0) {
+                    $error = "Cannot delete '{$abbr}': {$songCount} song(s) still reference it. Reassign them first.";
+                    break;
+                }
+
+                $stmt = $db->prepare('DELETE FROM tblSongbooks WHERE Id = ?');
+                $stmt->execute([$id]);
+                $success = "Songbook '{$abbr}' deleted.";
+                break;
+            }
+
+            default:
+                $error = 'Unknown action.';
+        }
+    } catch (\Throwable $e) {
+        error_log('[manage/songbooks.php] ' . $e->getMessage());
+        $error = $error ?: 'Database error — check server logs for details.';
+    }
+}
+
+/* ----- GET: list ----- */
+$rows = [];
+try {
+    $rs = $db->query(
+        'SELECT b.Id, b.Abbreviation, b.Name, b.SongCount, b.DisplayOrder, b.Colour,
+                COUNT(s.Id) AS ActualSongCount
+           FROM tblSongbooks b
+           LEFT JOIN tblSongs s ON s.SongbookAbbr = b.Abbreviation
+          GROUP BY b.Id
+          ORDER BY b.DisplayOrder ASC, b.Name ASC'
+    );
+    $rows = $rs->fetchAll(PDO::FETCH_ASSOC);
+} catch (\Throwable $e) {
+    error_log('[manage/songbooks.php] ' . $e->getMessage());
+    $error = $error ?: 'Could not load songbooks — check server logs for details.';
+}
+
+$csrf = csrfToken();
+?>
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Songbooks — iHymns Admin</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
+          integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
+          integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">
+    <link rel="stylesheet" href="/css/app.css?v=<?= filemtime(dirname(__DIR__) . '/css/app.css') ?>">
+    <link rel="stylesheet" href="/css/admin.css?v=<?= filemtime(dirname(__DIR__) . '/css/admin.css') ?>">
+</head>
+<body>
+
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-nav.php'; ?>
+
+    <div class="container py-4" style="max-width: 1100px;">
+
+        <h1 class="h4 mb-3"><i class="bi bi-book me-2"></i>Songbooks</h1>
+        <p class="text-secondary small mb-4">
+            Add, rename, reorder and remove the songbooks users see in filters,
+            search and the Song Editor. Abbreviation is the natural key on each
+            song (<code>tblSongs.SongbookAbbr</code>), so renaming is opt-in.
+        </p>
+
+        <?php if ($success): ?>
+            <div class="alert alert-success py-2"><?= htmlspecialchars($success) ?></div>
+        <?php endif; ?>
+        <?php if ($error): ?>
+            <div class="alert alert-danger py-2"><?= htmlspecialchars($error) ?></div>
+        <?php endif; ?>
+
+        <!-- List + reorder -->
+        <form method="POST" class="card-admin p-3 mb-4">
+            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+            <input type="hidden" name="action" value="reorder">
+            <table class="table table-sm mb-2 align-middle">
+                <thead>
+                    <tr class="text-muted small">
+                        <th style="width:6rem">Order</th>
+                        <th>Abbr</th>
+                        <th>Name</th>
+                        <th class="text-center">Songs</th>
+                        <th>Colour</th>
+                        <th class="text-end">Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($rows as $r): ?>
+                        <tr>
+                            <td>
+                                <input type="number" min="0" step="10"
+                                       class="form-control form-control-sm"
+                                       name="display_order[<?= (int)$r['Id'] ?>]"
+                                       value="<?= (int)$r['DisplayOrder'] ?>">
+                            </td>
+                            <td><code><?= htmlspecialchars($r['Abbreviation']) ?></code></td>
+                            <td><?= htmlspecialchars($r['Name']) ?></td>
+                            <td class="text-center"><?= number_format((int)$r['ActualSongCount']) ?></td>
+                            <td>
+                                <?php if ($r['Colour']): ?>
+                                    <span class="d-inline-block me-1" style="width:1rem;height:1rem;border-radius:50%;background:<?= htmlspecialchars($r['Colour']) ?>"></span>
+                                    <small class="text-muted"><?= htmlspecialchars($r['Colour']) ?></small>
+                                <?php else: ?>
+                                    <small class="text-muted">—</small>
+                                <?php endif; ?>
+                            </td>
+                            <td class="text-end">
+                                <button type="button" class="btn btn-sm btn-outline-info"
+                                        onclick='openEditModal(<?= json_encode([
+                                            'id'           => (int)$r['Id'],
+                                            'abbreviation' => $r['Abbreviation'],
+                                            'name'         => $r['Name'],
+                                            'colour'       => $r['Colour'],
+                                            'display_order'=> (int)$r['DisplayOrder'],
+                                            'song_count'   => (int)$r['ActualSongCount'],
+                                        ]) ?>)'
+                                        title="Edit songbook">
+                                    <i class="bi bi-pencil"></i>
+                                </button>
+                                <?php if ((int)$r['ActualSongCount'] === 0): ?>
+                                <button type="button" class="btn btn-sm btn-outline-danger"
+                                        onclick='openDeleteModal(<?= json_encode(['id' => (int)$r['Id'], 'abbreviation' => $r['Abbreviation']]) ?>)'
+                                        title="Delete songbook (no songs reference it)">
+                                    <i class="bi bi-trash"></i>
+                                </button>
+                                <?php else: ?>
+                                <button type="button" class="btn btn-sm btn-outline-secondary" disabled
+                                        title="<?= (int)$r['ActualSongCount'] ?> song(s) still reference this abbreviation — reassign them first">
+                                    <i class="bi bi-trash"></i>
+                                </button>
+                                <?php endif; ?>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                    <?php if (!$rows): ?>
+                        <tr><td colspan="6" class="text-muted text-center py-4">No songbooks yet. Add one below.</td></tr>
+                    <?php endif; ?>
+                </tbody>
+            </table>
+            <?php if ($rows): ?>
+                <button type="submit" class="btn btn-sm btn-amber-solid">
+                    <i class="bi bi-save me-1"></i>Save display order
+                </button>
+                <small class="text-muted ms-2">Lower numbers render first. Step of 10 lets you insert between two rows.</small>
+            <?php endif; ?>
+        </form>
+
+        <!-- Create -->
+        <form method="POST" class="card-admin p-3 mb-4">
+            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+            <input type="hidden" name="action" value="create">
+            <h2 class="h6 mb-3"><i class="bi bi-plus-circle me-2"></i>Add a songbook</h2>
+            <div class="row g-2">
+                <div class="col-sm-3">
+                    <label class="form-label small">Abbreviation</label>
+                    <input type="text" name="abbreviation" class="form-control form-control-sm"
+                           pattern="[A-Za-z0-9]+" maxlength="10" required
+                           placeholder="e.g. CP">
+                </div>
+                <div class="col-sm-5">
+                    <label class="form-label small">Name</label>
+                    <input type="text" name="name" class="form-control form-control-sm"
+                           maxlength="255" required placeholder="e.g. Church Praise">
+                </div>
+                <div class="col-sm-2">
+                    <label class="form-label small">Colour (hex)</label>
+                    <input type="text" name="colour" class="form-control form-control-sm"
+                           pattern="#[0-9A-Fa-f]{6}" placeholder="#1a73e8">
+                </div>
+                <div class="col-sm-2">
+                    <label class="form-label small">Display order</label>
+                    <input type="number" name="display_order" class="form-control form-control-sm"
+                           min="0" step="10" value="0">
+                </div>
+            </div>
+            <button type="submit" class="btn btn-amber-solid btn-sm mt-3">
+                <i class="bi bi-plus me-1"></i>Create songbook
+            </button>
+        </form>
+
+    </div>
+
+    <!-- Edit Modal -->
+    <div class="modal fade" id="editModal" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content" style="background: var(--ih-surface); color: var(--ih-text); border-color: var(--ih-border);">
+                <form method="POST">
+                    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                    <input type="hidden" name="action" value="update">
+                    <input type="hidden" name="id" id="edit-id">
+                    <div class="modal-header" style="border-color: var(--ih-border);">
+                        <h5 class="modal-title"><i class="bi bi-pencil me-2"></i>Edit songbook — <code id="edit-abbr-label"></code></h5>
+                        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+                    </div>
+                    <div class="modal-body">
+                        <div class="mb-3">
+                            <label class="form-label">Name</label>
+                            <input type="text" class="form-control" name="name" id="edit-name" maxlength="255" required>
+                        </div>
+                        <div class="row g-2 mb-3">
+                            <div class="col-sm-6">
+                                <label class="form-label">Colour (hex)</label>
+                                <input type="text" class="form-control" name="colour" id="edit-colour"
+                                       pattern="#[0-9A-Fa-f]{6}" placeholder="#1a73e8">
+                            </div>
+                            <div class="col-sm-6">
+                                <label class="form-label">Display order</label>
+                                <input type="number" class="form-control" name="display_order" id="edit-order"
+                                       min="0" step="10">
+                            </div>
+                        </div>
+                        <hr>
+                        <div class="mb-3">
+                            <label class="form-label">New abbreviation (optional)</label>
+                            <input type="text" class="form-control" name="new_abbreviation" id="edit-new-abbr"
+                                   pattern="[A-Za-z0-9]+" maxlength="10"
+                                   placeholder="Leave blank to keep current">
+                            <div class="form-text">
+                                Abbreviation is the natural key. Renaming will <strong>not</strong> update songs by default.
+                            </div>
+                        </div>
+                        <div class="form-check" id="edit-rename-refs-wrap">
+                            <input class="form-check-input" type="checkbox" name="rename_song_refs" id="edit-rename-refs" value="1">
+                            <label class="form-check-label" for="edit-rename-refs">
+                                Also update <span id="edit-song-count">0</span> song(s) that reference the old abbreviation.
+                            </label>
+                        </div>
+                    </div>
+                    <div class="modal-footer" style="border-color: var(--ih-border);">
+                        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                        <button type="submit" class="btn btn-amber-solid">Save changes</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <!-- Delete Modal -->
+    <div class="modal fade" id="deleteModal" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content" style="background: var(--ih-surface); color: var(--ih-text); border-color: var(--ih-border);">
+                <form method="POST">
+                    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                    <input type="hidden" name="action" value="delete">
+                    <input type="hidden" name="id" id="delete-id">
+                    <div class="modal-header" style="border-color: var(--ih-border);">
+                        <h5 class="modal-title"><i class="bi bi-trash me-2"></i>Delete — <code id="delete-abbr-label"></code></h5>
+                        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+                    </div>
+                    <div class="modal-body">
+                        <p>Remove this songbook? This is only allowed if no songs reference the abbreviation.</p>
+                    </div>
+                    <div class="modal-footer" style="border-color: var(--ih-border);">
+                        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                        <button type="submit" class="btn btn-danger">Delete</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+            integrity="sha384-zKzgIZcXU99qF1nNW9g+x1znB5NhCPs9qZeGzUnnFOaHJF9jCCKySBjq3vIKabk/"
+            crossorigin="anonymous"></script>
+    <script>
+        function openEditModal(row) {
+            document.getElementById('edit-id').value            = row.id;
+            document.getElementById('edit-abbr-label').textContent = row.abbreviation;
+            document.getElementById('edit-name').value          = row.name;
+            document.getElementById('edit-colour').value        = row.colour || '';
+            document.getElementById('edit-order').value         = row.display_order || 0;
+            document.getElementById('edit-new-abbr').value      = '';
+            document.getElementById('edit-rename-refs').checked = false;
+            document.getElementById('edit-song-count').textContent = row.song_count;
+            document.getElementById('edit-rename-refs-wrap').style.display = row.song_count > 0 ? '' : 'none';
+            new bootstrap.Modal(document.getElementById('editModal')).show();
+        }
+        function openDeleteModal(row) {
+            document.getElementById('delete-id').value = row.id;
+            document.getElementById('delete-abbr-label').textContent = row.abbreviation;
+            new bootstrap.Modal(document.getElementById('deleteModal')).show();
+        }
+    </script>
+
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>
+</body>
+</html>


### PR DESCRIPTION
Closes #427, #428, #429, #430, #431, #432.

Four phases, one reviewable commit.

## Phase 1 — PWA navigation on every admin page (#427)
Home button added to the shared `admin-nav.php` and to every standalone admin navbar (`analytics`, `requests`, `revisions`, `entitlements`, `setup-database`). A proper navbar header was introduced on `setup-database.php` (hidden during initial setup). Dashboard button added where it was missing. Song Editor already had this from #419.

## Phase 2 — New entitlements + menu/dashboard plumbing (#428)
Three new entitlements — `manage_songbooks`, `manage_user_groups`, `manage_organisations` — added to both the PHP authoritative map (`includes/entitlements.php`) and the JS mirror. Grouped under "Content structure" on `/manage/entitlements`. Header user dropdown and admin dashboard quick-links both get Songbooks / User Groups / Organisations gated per entitlement. **Data Health** also added to both surfaces (gated by `drop_legacy_tables`, global-admin by default).

## Phase 3a — Songbooks admin UI (#429)
`/manage/songbooks`. List / create / edit / reorder / delete.

Canonical schema gains `DisplayOrder INT` + `Colour VARCHAR(7)` on `tblSongbooks`. Existing deployments get them via idempotent ALTERs in `migrate-account-sync.php` (uses `SHOW COLUMNS` probe, seeds `DisplayOrder` from alphabetical `Name` ordering in steps of 10).

Edit modal supports an opt-in abbreviation rename with a **"also rename song references"** checkbox — wraps `tblSongbooks.Abbreviation` + `tblSongs.SongbookAbbr` updates in a transaction. Delete refuses if any song still references the abbreviation (count + message).

## Phase 3b — User Groups admin UI (#430)
`/manage/groups`. CRUD on `tblUserGroups` plus two-pane member picker that writes back to `tblUsers.GroupId`. Delete blocked while members remain.

## Phase 3c — Organisations admin UI (#431)
`/manage/organisations`. CRUD on `tblOrganisations` + `tblOrganisationMembers`. Slug is auto-derived from name if blank. Self-parent prevented. Licence type / number / active flag surfaced. Member roles (`member / admin / owner`) toggle inline. Delete blocked when members or child orgs still reference the row.

## Phase 4 — Data Health Check (#432)
`/manage/data-health` — global-admin only. Traffic-light report:
- MySQL row counts across nine tables.
- `SongData::isJsonFallback()` probe (green = MySQL authoritative).
- Shared-setlist file vs DB row count, with per-ID list of unimported shares.
- Legacy SQLite file presence + size.

When all-green, the **"Disconnect legacy fallbacks"** button renames each legacy source to `*.disabled` (reversible, non-destructive). Per-item outcomes reported (renamed / skipped / failed).

## Cross-cutting
- Every new page uses the shared `admin-nav.php` (Home + Dashboard + Editor + Users + Logout) and `admin-footer.php`.
- CSRF tokens on every POST form.
- Friendly errors; database errors logged to `error_log` and surfaced to the user as a short generic message.

## Test plan
- [ ] Sign in as global_admin, dashboard shows quick-link cards for Songbooks, User Groups, Organisations, Data Health.
- [ ] Header user dropdown lists those same four entries under Administration; invisible for non-admins.
- [ ] Run **Account Sync Migration** on a deployment that was installed before this PR — migration reports the new `DisplayOrder` and `Colour` columns as added, then seeded.
- [ ] `/manage/songbooks`: create a new songbook, reorder the list (save display order), try to delete a songbook with songs attached (refused with count), delete an empty one (succeeds). Rename an abbreviation without the checkbox (refs stay; admin warned), then with it (refs update too).
- [ ] `/manage/groups`: create a group, toggle its access flags, add + remove a member, try to delete with a member (refused), empty it and delete.
- [ ] `/manage/organisations`: create an org with a licence, add members, change a member role from `member` to `admin`, remove a member, make a second org and nest the first as its parent, verify self-parent is refused, delete when empty.
- [ ] `/manage/data-health`: after a fresh install + migration, all badges green; Disconnect button enabled; click it; page reloads green with files now `.disabled`. Rename one back manually and confirm the health check notices.
- [ ] In PWA standalone mode, every admin page exposes the Home button to return to `/`.

https://claude.ai/code/session_01LVu9oYy2LbeYjXfys5EhoF

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVu9oYy2LbeYjXfys5EhoF)_