### PR TITLE
Admin pages: favicon + fix footer to viewport bottom

### DIFF
--- a/appWeb/public_html/css/admin.css
+++ b/appWeb/public_html/css/admin.css
@@ -47,16 +47,31 @@ a:not(.btn):not(.nav-link):not(.dropdown-item):hover {
     box-shadow: var(--card-shadow);
 }
 
-/* Admin footer — static variant of the main app's .footer-info strip.
-   Admin pages don't have the fixed bottom tab-bar so this just sits at
-   the natural end of the document with a light separator + breathing
-   room above. */
+/* Admin footer — fixed to the bottom of the viewport, mirroring the
+   main app's .app-footer treatment minus the tab-nav. Shares the same
+   blur / shadow / border tokens so both surfaces feel identical. */
 .admin-footer-static {
-    margin-top: 2rem;
-    padding-top: 0.75rem;
-    padding-bottom: 0.75rem;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 1030;
+    padding-top: 0.4rem;
+    padding-bottom: 0.4rem;
+    background: var(--footer-bg);
+    backdrop-filter: blur(16px) saturate(180%);
+    -webkit-backdrop-filter: blur(16px) saturate(180%);
+    box-shadow: var(--footer-shadow);
     border-top: 1px solid var(--card-border);
     min-height: auto;
+}
+
+/* Every admin page loads admin.css, so reserve space under the final
+   row of content so it's never obscured by the fixed footer. Uses the
+   shared --footer-info-height token (28 px normal / 40 px small
+   viewports per app.css media queries). */
+body {
+    padding-bottom: calc(var(--footer-info-height) + 1rem);
 }
 
 .navbar-admin .navbar-brand,

--- a/appWeb/public_html/manage/analytics.php
+++ b/appWeb/public_html/manage/analytics.php
@@ -156,6 +156,7 @@ try {
           integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">
     <link rel="stylesheet" href="/css/app.css?v=<?= filemtime(dirname(__DIR__) . '/css/app.css') ?>">
     <link rel="stylesheet" href="/css/admin.css?v=<?= filemtime(dirname(__DIR__) . '/css/admin.css') ?>">
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-favicon.php'; ?>
 </head>
 <body>
 

--- a/appWeb/public_html/manage/data-health.php
+++ b/appWeb/public_html/manage/data-health.php
@@ -159,6 +159,7 @@ $csrf = csrfToken();
           integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">
     <link rel="stylesheet" href="/css/app.css?v=<?= filemtime(dirname(__DIR__) . '/css/app.css') ?>">
     <link rel="stylesheet" href="/css/admin.css?v=<?= filemtime(dirname(__DIR__) . '/css/admin.css') ?>">
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-favicon.php'; ?>
 </head>
 <body>
 

--- a/appWeb/public_html/manage/editor/index.php
+++ b/appWeb/public_html/manage/editor/index.php
@@ -65,6 +65,7 @@ $currentUser = getCurrentUser();
         /* Shared layout, colours, buttons, cards → /css/admin.css
            Add editor-only tweaks here if truly needed. */
     </style>
+    <?php require dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-favicon.php'; ?>
 </head>
 <body>
 

--- a/appWeb/public_html/manage/entitlements.php
+++ b/appWeb/public_html/manage/entitlements.php
@@ -110,6 +110,7 @@ foreach (ENTITLEMENTS as $n => $_) {
         .ent-grid td.role-col { text-align: center; }
         .ent-name { font-family: 'Menlo','Consolas',monospace; font-size: 0.85em; }
     </style>
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-favicon.php'; ?>
 </head>
 <body>
 

--- a/appWeb/public_html/manage/groups.php
+++ b/appWeb/public_html/manage/groups.php
@@ -204,6 +204,7 @@ $csrf = csrfToken();
           integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">
     <link rel="stylesheet" href="/css/app.css?v=<?= filemtime(dirname(__DIR__) . '/css/app.css') ?>">
     <link rel="stylesheet" href="/css/admin.css?v=<?= filemtime(dirname(__DIR__) . '/css/admin.css') ?>">
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-favicon.php'; ?>
 </head>
 <body>
 

--- a/appWeb/public_html/manage/includes/head-favicon.php
+++ b/appWeb/public_html/manage/includes/head-favicon.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Shared Favicon / App-Icon Head Tags
+ *
+ * Single source of truth for the favicon + apple-touch-icon links
+ * used on admin pages (/manage/*). Mirrors the four lines in
+ * public_html/index.php so both surfaces stay in lock-step if the
+ * asset names change.
+ *
+ * USAGE (inside each admin page's <head>):
+ *   <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-favicon.php'; ?>
+ *
+ * The manifest deliberately isn't included here — admin pages aren't
+ * part of the PWA and shouldn't advertise the installable bundle.
+ */
+
+/* Prevent direct access */
+if (basename($_SERVER['SCRIPT_FILENAME'] ?? '') === basename(__FILE__)) {
+    http_response_code(403);
+    exit('Access denied.');
+}
+?>
+<link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+<link rel="icon" type="image/png" sizes="32x32" href="/assets/icon-32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/assets/icon-16.png">
+<link rel="apple-touch-icon" sizes="180x180" href="/assets/apple-touch-icon.png">

--- a/appWeb/public_html/manage/index.php
+++ b/appWeb/public_html/manage/index.php
@@ -83,6 +83,7 @@ $csrf = csrfToken();
     <!-- Shared iHymns palette + admin styles -->
     <link rel="stylesheet" href="/css/app.css?v=<?= filemtime(dirname(__DIR__) . "/css/app.css") ?>">
     <link rel="stylesheet" href="/css/admin.css?v=<?= filemtime(dirname(__DIR__) . "/css/admin.css") ?>">
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-favicon.php'; ?>
 </head>
 <body>
     <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-nav.php'; ?>

--- a/appWeb/public_html/manage/login.php
+++ b/appWeb/public_html/manage/login.php
@@ -66,6 +66,7 @@ $csrf = csrfToken();
     <!-- Shared iHymns palette + admin styles -->
     <link rel="stylesheet" href="/css/app.css?v=<?= filemtime(dirname(__DIR__) . "/css/app.css") ?>">
     <link rel="stylesheet" href="/css/admin.css?v=<?= filemtime(dirname(__DIR__) . "/css/admin.css") ?>">
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-favicon.php'; ?>
 </head>
 <body class="auth-center-page">
     <div class="login-card">

--- a/appWeb/public_html/manage/organisations.php
+++ b/appWeb/public_html/manage/organisations.php
@@ -248,6 +248,7 @@ $csrf = csrfToken();
           integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">
     <link rel="stylesheet" href="/css/app.css?v=<?= filemtime(dirname(__DIR__) . '/css/app.css') ?>">
     <link rel="stylesheet" href="/css/admin.css?v=<?= filemtime(dirname(__DIR__) . '/css/admin.css') ?>">
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-favicon.php'; ?>
 </head>
 <body>
 

--- a/appWeb/public_html/manage/requests.php
+++ b/appWeb/public_html/manage/requests.php
@@ -116,6 +116,7 @@ try {
           integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">
     <link rel="stylesheet" href="/css/app.css?v=<?= filemtime(dirname(__DIR__) . '/css/app.css') ?>">
     <link rel="stylesheet" href="/css/admin.css?v=<?= filemtime(dirname(__DIR__) . '/css/admin.css') ?>">
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-favicon.php'; ?>
 </head>
 <body>
 

--- a/appWeb/public_html/manage/revisions.php
+++ b/appWeb/public_html/manage/revisions.php
@@ -80,6 +80,7 @@ try {
           integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">
     <link rel="stylesheet" href="/css/app.css?v=<?= filemtime(dirname(__DIR__) . '/css/app.css') ?>">
     <link rel="stylesheet" href="/css/admin.css?v=<?= filemtime(dirname(__DIR__) . '/css/admin.css') ?>">
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-favicon.php'; ?>
 </head>
 <body>
 

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -278,6 +278,7 @@ if ($hasCredentials && defined('DB_HOST')) {
     <!-- Shared iHymns palette + admin styles -->
     <link rel="stylesheet" href="/css/app.css?v=<?= filemtime(dirname(__DIR__) . "/css/app.css") ?>">
     <link rel="stylesheet" href="/css/admin.css?v=<?= filemtime(dirname(__DIR__) . "/css/admin.css") ?>">
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-favicon.php'; ?>
 </head>
 <body>
 

--- a/appWeb/public_html/manage/setup.php
+++ b/appWeb/public_html/manage/setup.php
@@ -67,6 +67,7 @@ $csrf = csrfToken();
     <!-- Shared iHymns palette + admin styles -->
     <link rel="stylesheet" href="/css/app.css?v=<?= filemtime(dirname(__DIR__) . "/css/app.css") ?>">
     <link rel="stylesheet" href="/css/admin.css?v=<?= filemtime(dirname(__DIR__) . "/css/admin.css") ?>">
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-favicon.php'; ?>
 </head>
 <body class="auth-center-page">
     <div class="setup-card">

--- a/appWeb/public_html/manage/songbooks.php
+++ b/appWeb/public_html/manage/songbooks.php
@@ -217,6 +217,7 @@ $csrf = csrfToken();
           integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">
     <link rel="stylesheet" href="/css/app.css?v=<?= filemtime(dirname(__DIR__) . '/css/app.css') ?>">
     <link rel="stylesheet" href="/css/admin.css?v=<?= filemtime(dirname(__DIR__) . '/css/admin.css') ?>">
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-favicon.php'; ?>
 </head>
 <body>
 

--- a/appWeb/public_html/manage/users.php
+++ b/appWeb/public_html/manage/users.php
@@ -204,6 +204,7 @@ function canManage(array $target, array $actor): bool {
     <!-- Shared iHymns palette + admin styles -->
     <link rel="stylesheet" href="/css/app.css?v=<?= filemtime(dirname(__DIR__) . "/css/app.css") ?>">
     <link rel="stylesheet" href="/css/admin.css?v=<?= filemtime(dirname(__DIR__) . "/css/admin.css") ?>">
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-favicon.php'; ?>
 </head>
 <body>
     <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-nav.php'; ?>


### PR DESCRIPTION
## Favicon wiring
The favicon commit from the previous branch didn't make it into PR #433's merge (timing — #433 merged before the follow-up commit landed on its branch). `/manage/*` pages were still serving browser tabs with a generic globe icon.

Re-introduces the `head-favicon.php` partial mirroring the four `<link>` tags from the main site's `index.php` and wires it into every admin page's `<head>`:
- `/manage/` (dashboard), users, entitlements, analytics, requests, revisions, setup, setup-database, login, editor, songbooks, groups, organisations, data-health.

`logout.php` deliberately skipped (no HTML body). PWA manifest also kept out — admin pages aren't part of the installable bundle.

## Fixed-position admin footer
The copyright / version strip was rendering statically at document end, so on short admin pages (e.g. `/manage/users` with a single row) the screenshot shows a big dark gap below it.

Updated `.admin-footer-static` in `admin.css` to match the main site's treatment:
- `position: fixed; bottom: 0;`
- Shared `--footer-bg` / `--footer-shadow` tokens + `backdrop-filter: blur(16px) saturate(180%)`.
- Body gets `padding-bottom: calc(var(--footer-info-height) + 1rem)` (28 px normal / 40 px small viewports) so the last row of content never sits behind the bar.

Scoped correctly: `admin.css` is only loaded under `/manage/*`, so the new `body` rule doesn't conflict with the main app's existing `footer-total-height`-based padding.

## Test plan
- [ ] Any `/manage/*` page shows the iHymns favicon in the browser tab.
- [ ] The copyright / version / Terms / Privacy strip now sits on every admin page at the bottom of the viewport (not mid-page).
- [ ] Scrolling a long admin list (e.g. `/manage/users` with many rows) shows the footer staying put at the bottom.
- [ ] A short admin page (dashboard on a fresh install) shows the footer at the viewport bottom with no dark gap below it.
- [ ] Content at the bottom of the page scroll area isn't hidden behind the footer (padding-bottom reserve is working).
- [ ] Main site's footer unchanged — same spacing / positioning as before.

https://claude.ai/code/session_01LVu9oYy2LbeYjXfys5EhoF

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVu9oYy2LbeYjXfys5EhoF)_