### PR TITLE
Theme back-to-top button + split overloaded header menus

### DIFF
--- a/appWeb/public_html/css/app.css
+++ b/appWeb/public_html/css/app.css
@@ -1530,7 +1530,7 @@ body.reduce-motion .song-list-item {
     height: 48px;
     border: none;
     border-radius: 50%;
-    background: var(--bs-primary, #6366f1);
+    background: var(--accent-solid, #6366f1);
     color: #fff;
     font-size: 1.2rem;
     display: flex;
@@ -1541,7 +1541,7 @@ body.reduce-motion .song-list-item {
     opacity: 0;
     visibility: hidden;
     transform: translateY(10px);
-    transition: opacity 0.3s ease, visibility 0.3s ease, transform 0.3s ease, background-color 0.2s ease;
+    transition: opacity 0.3s ease, visibility 0.3s ease, transform 0.3s ease, background 0.2s ease, box-shadow 0.2s ease;
 }
 
 .scroll-to-top-btn.visible {
@@ -1552,18 +1552,24 @@ body.reduce-motion .song-list-item {
 
 .scroll-to-top-btn:hover,
 .scroll-to-top-btn:focus-visible {
-    background: var(--bs-primary-dark, #4f46e5);
+    background: var(--accent-end, var(--accent-solid, #4f46e5));
     box-shadow: 0 6px 16px rgba(0, 0, 0, 0.35);
 }
 
 .scroll-to-top-btn:focus-visible {
-    outline: 3px solid var(--bs-primary, #6366f1);
+    outline: 3px solid var(--accent-solid, #6366f1);
     outline-offset: 3px;
 }
 
 /* High contrast theme */
-[data-bs-theme="high-contrast"] .scroll-to-top-btn {
-    border: 2px solid #fff;
+[data-ihymns-theme="high-contrast"] .scroll-to-top-btn {
+    border: 2px solid #000;
+    box-shadow: 0 2px 0 #000;
+}
+
+[data-ihymns-theme="high-contrast"] .scroll-to-top-btn:hover,
+[data-ihymns-theme="high-contrast"] .scroll-to-top-btn:focus-visible {
+    box-shadow: 0 3px 0 #000;
 }
 
 /* Reduced motion */

--- a/appWeb/public_html/index.php
+++ b/appWeb/public_html/index.php
@@ -590,13 +590,6 @@ if (!empty($breadcrumbItems)) {
                         <li><a class="dropdown-item" href="/setlist" data-navigate="setlist">
                             <i class="fa-solid fa-list-ol me-2" aria-hidden="true"></i> Set Lists
                         </a></li>
-                        <!-- Song Editor — visible to users with the edit_songs
-                             entitlement (toggled by user-auth.js). -->
-                        <li id="nav-app-editor-li" class="d-none">
-                            <a class="dropdown-item" href="/manage/editor/">
-                                <i class="fa-solid fa-pen-to-square me-2" aria-hidden="true"></i> Song Editor
-                            </a>
-                        </li>
                         <li><hr class="dropdown-divider"></li>
                         <li><a class="dropdown-item" href="/stats" data-navigate="stats">
                             <i class="fa-solid fa-chart-simple me-2" aria-hidden="true"></i> Statistics
@@ -604,6 +597,88 @@ if (!empty($breadcrumbItems)) {
                         <li><a class="dropdown-item" href="/help" data-navigate="help">
                             <i class="fa-solid fa-circle-question me-2" aria-hidden="true"></i> Help
                         </a></li>
+
+                        <!-- ============================================
+                             Curator + Administration sections — moved out
+                             of the user/avatar menu because these relate to
+                             the app itself, not the logged-in person.
+                             Each section (divider + header + items) is
+                             toggled together by user-auth.js so users who
+                             lack every entitlement in a section see none of
+                             its markup.
+                             ============================================ -->
+
+                        <!-- ── Curator ── -->
+                        <li id="nav-curator-divider" class="d-none"><hr class="dropdown-divider"></li>
+                        <li id="nav-curator-header" class="d-none">
+                            <h6 class="dropdown-header" id="nav-curator-heading">Curator</h6>
+                        </li>
+                        <li id="nav-curator-editor-li" class="d-none">
+                            <a class="dropdown-item" href="/manage/editor/">
+                                <i class="fa-solid fa-pen-to-square me-2" aria-hidden="true"></i> Song Editor
+                            </a>
+                        </li>
+                        <li id="nav-curator-requests-li" class="d-none">
+                            <a class="dropdown-item" href="/manage/requests">
+                                <i class="fa-solid fa-inbox me-2" aria-hidden="true"></i> Song Requests
+                            </a>
+                        </li>
+                        <li id="nav-curator-revisions-li" class="d-none">
+                            <a class="dropdown-item" href="/manage/revisions">
+                                <i class="fa-solid fa-clock-rotate-left me-2" aria-hidden="true"></i> Revisions Audit
+                            </a>
+                        </li>
+
+                        <!-- ── Administration ── -->
+                        <li id="nav-admin-divider" class="d-none"><hr class="dropdown-divider"></li>
+                        <li id="nav-admin-header" class="d-none">
+                            <h6 class="dropdown-header" id="nav-admin-heading">Administration</h6>
+                        </li>
+                        <li id="nav-admin-dashboard-li" class="d-none">
+                            <a class="dropdown-item" href="/manage/">
+                                <i class="fa-solid fa-gauge-high me-2" aria-hidden="true"></i> Admin Dashboard
+                            </a>
+                        </li>
+                        <li id="nav-admin-users-li" class="d-none">
+                            <a class="dropdown-item" href="/manage/users">
+                                <i class="fa-solid fa-users me-2" aria-hidden="true"></i> User Management
+                            </a>
+                        </li>
+                        <li id="nav-admin-groups-li" class="d-none">
+                            <a class="dropdown-item" href="/manage/groups">
+                                <i class="fa-solid fa-user-group me-2" aria-hidden="true"></i> User Groups
+                            </a>
+                        </li>
+                        <li id="nav-admin-organisations-li" class="d-none">
+                            <a class="dropdown-item" href="/manage/organisations">
+                                <i class="fa-solid fa-building me-2" aria-hidden="true"></i> Organisations
+                            </a>
+                        </li>
+                        <li id="nav-admin-songbooks-li" class="d-none">
+                            <a class="dropdown-item" href="/manage/songbooks">
+                                <i class="fa-solid fa-book-open me-2" aria-hidden="true"></i> Songbook Management
+                            </a>
+                        </li>
+                        <li id="nav-admin-entitlements-li" class="d-none">
+                            <a class="dropdown-item" href="/manage/entitlements">
+                                <i class="fa-solid fa-key me-2" aria-hidden="true"></i> Entitlements &amp; Gating
+                            </a>
+                        </li>
+                        <li id="nav-admin-analytics-li" class="d-none">
+                            <a class="dropdown-item" href="/manage/analytics">
+                                <i class="fa-solid fa-chart-line me-2" aria-hidden="true"></i> Analytics
+                            </a>
+                        </li>
+                        <li id="nav-admin-health-li" class="d-none">
+                            <a class="dropdown-item" href="/manage/data-health">
+                                <i class="fa-solid fa-heart-pulse me-2" aria-hidden="true"></i> Data Health
+                            </a>
+                        </li>
+                        <li id="nav-admin-db-li" class="d-none">
+                            <a class="dropdown-item" href="/manage/setup-database">
+                                <i class="fa-solid fa-database me-2" aria-hidden="true"></i> Database Setup
+                            </a>
+                        </li>
                     </ul>
                 </div>
 
@@ -688,18 +763,10 @@ if (!empty($breadcrumbItems)) {
                             </li>
                             <!-- ============================================
                                  Logged-in state (hidden by default; visibility
-                                 toggled by user-auth.js based on signed-in
-                                 state and per-entitlement checks).
-
-                                 Sections:
-                                   • Account   — always visible to signed-in users
-                                   • Curator   — visible if user holds any of
-                                                 edit_songs / review_song_requests
-                                                 / verify_songs
-                                   • Admin     — visible if user holds any of
-                                                 view_admin_dashboard / view_users /
-                                                 manage_entitlements / view_analytics /
-                                                 run_db_install / run_db_migrate
+                                 toggled by user-auth.js). This menu now holds
+                                 only items that relate to the signed-in
+                                 person; app-wide Curator + Administration
+                                 sections live in the iHymns (logo) dropdown.
                                  ============================================ -->
                             <!-- Display name + role are clickable shortcuts that
                                  deep-link to the Account & Profile tab on /settings. -->
@@ -728,78 +795,6 @@ if (!empty($breadcrumbItems)) {
                                 <button class="dropdown-item" type="button" id="header-sync-btn">
                                     <i class="fa-solid fa-arrows-rotate me-2" aria-hidden="true"></i> Sync Set Lists
                                 </button>
-                            </li>
-
-                            <!-- ── Curator ── -->
-                            <li id="header-curator-divider" class="d-none"><hr class="dropdown-divider"></li>
-                            <li id="header-curator-header" class="d-none">
-                                <h6 class="dropdown-header">Curator</h6>
-                            </li>
-                            <li id="header-user-editor-li" class="d-none">
-                                <a class="dropdown-item" href="/manage/editor/">
-                                    <i class="fa-solid fa-pen-to-square me-2" aria-hidden="true"></i> Song Editor
-                                </a>
-                            </li>
-                            <li id="header-curator-requests-li" class="d-none">
-                                <a class="dropdown-item" href="/manage/requests">
-                                    <i class="fa-solid fa-inbox me-2" aria-hidden="true"></i> Song Requests
-                                </a>
-                            </li>
-                            <li id="header-curator-revisions-li" class="d-none">
-                                <a class="dropdown-item" href="/manage/revisions">
-                                    <i class="fa-solid fa-clock-rotate-left me-2" aria-hidden="true"></i> Revisions Audit
-                                </a>
-                            </li>
-
-                            <!-- ── Administration ── -->
-                            <li id="header-admin-divider" class="d-none"><hr class="dropdown-divider"></li>
-                            <li id="header-admin-header" class="d-none">
-                                <h6 class="dropdown-header">Administration</h6>
-                            </li>
-                            <li id="header-user-dashboard-li" class="d-none">
-                                <a class="dropdown-item" href="/manage/">
-                                    <i class="fa-solid fa-gauge-high me-2" aria-hidden="true"></i> Admin Dashboard
-                                </a>
-                            </li>
-                            <li id="header-admin-users-li" class="d-none">
-                                <a class="dropdown-item" href="/manage/users">
-                                    <i class="fa-solid fa-users me-2" aria-hidden="true"></i> User Management
-                                </a>
-                            </li>
-                            <li id="header-admin-groups-li" class="d-none">
-                                <a class="dropdown-item" href="/manage/groups">
-                                    <i class="fa-solid fa-user-group me-2" aria-hidden="true"></i> User Groups
-                                </a>
-                            </li>
-                            <li id="header-admin-organisations-li" class="d-none">
-                                <a class="dropdown-item" href="/manage/organisations">
-                                    <i class="fa-solid fa-building me-2" aria-hidden="true"></i> Organisations
-                                </a>
-                            </li>
-                            <li id="header-admin-songbooks-li" class="d-none">
-                                <a class="dropdown-item" href="/manage/songbooks">
-                                    <i class="fa-solid fa-book-open me-2" aria-hidden="true"></i> Songbooks
-                                </a>
-                            </li>
-                            <li id="header-admin-entitlements-li" class="d-none">
-                                <a class="dropdown-item" href="/manage/entitlements">
-                                    <i class="fa-solid fa-key me-2" aria-hidden="true"></i> Entitlements &amp; Gating
-                                </a>
-                            </li>
-                            <li id="header-admin-analytics-li" class="d-none">
-                                <a class="dropdown-item" href="/manage/analytics">
-                                    <i class="fa-solid fa-chart-line me-2" aria-hidden="true"></i> Analytics
-                                </a>
-                            </li>
-                            <li id="header-admin-health-li" class="d-none">
-                                <a class="dropdown-item" href="/manage/data-health">
-                                    <i class="fa-solid fa-heart-pulse me-2" aria-hidden="true"></i> Data Health
-                                </a>
-                            </li>
-                            <li id="header-admin-db-li" class="d-none">
-                                <a class="dropdown-item" href="/manage/setup-database">
-                                    <i class="fa-solid fa-database me-2" aria-hidden="true"></i> Database Setup
-                                </a>
                             </li>
 
                             <!-- ── Sign out ── -->

--- a/appWeb/public_html/js/modules/user-auth.js
+++ b/appWeb/public_html/js/modules/user-auth.js
@@ -441,13 +441,12 @@ export class UserAuth {
     }
 
     /**
-     * Update the header dropdown to reflect current auth state.
+     * Update the header dropdowns to reflect current auth state.
      *
-     * Account section is visible to any signed-in user. Curator and
-     * Administration sections (each with a label header + divider)
-     * are toggled per-entitlement via userHasEntitlement(); the section
-     * label collapses with the items so a user with no curator/admin
-     * privileges sees a clean menu.
+     * The avatar menu holds only account items (always on when signed in).
+     * Curator and Administration live on the iHymns (logo) dropdown and
+     * are toggled per-entitlement; each section's label + divider collapse
+     * with its items so users without the relevant rights see nothing.
      */
     _updateHeaderState() {
         const loggedIn = this.isLoggedIn();
@@ -478,24 +477,24 @@ export class UserAuth {
             if (roleEl) roleEl.textContent = this._roleLabel(user.role || 'user');
         }
 
-        /* Per-entitlement items. Each entry: [elementId, entitlement-name].
-           When the user is signed out, every gated item is hidden. */
+        /* Per-entitlement items on the iHymns (logo) dropdown.
+           Each entry: [elementId, entitlement-name]. Signed-out hides all. */
         const entItems = {
             curator: [
-                ['header-user-editor-li',         'edit_songs'],
-                ['header-curator-requests-li',    'review_song_requests'],
-                ['header-curator-revisions-li',   'verify_songs'],
+                ['nav-curator-editor-li',     'edit_songs'],
+                ['nav-curator-requests-li',   'review_song_requests'],
+                ['nav-curator-revisions-li',  'verify_songs'],
             ],
             admin: [
-                ['header-user-dashboard-li',      'view_admin_dashboard'],
-                ['header-admin-users-li',         'view_users'],
-                ['header-admin-groups-li',        'manage_user_groups'],
-                ['header-admin-organisations-li', 'manage_organisations'],
-                ['header-admin-songbooks-li',     'manage_songbooks'],
-                ['header-admin-entitlements-li',  'manage_entitlements'],
-                ['header-admin-analytics-li',     'view_analytics'],
-                ['header-admin-db-li',            'run_db_install'],
-                ['header-admin-health-li',        'drop_legacy_tables'],
+                ['nav-admin-dashboard-li',      'view_admin_dashboard'],
+                ['nav-admin-users-li',          'view_users'],
+                ['nav-admin-groups-li',         'manage_user_groups'],
+                ['nav-admin-organisations-li',  'manage_organisations'],
+                ['nav-admin-songbooks-li',      'manage_songbooks'],
+                ['nav-admin-entitlements-li',   'manage_entitlements'],
+                ['nav-admin-analytics-li',      'view_analytics'],
+                ['nav-admin-db-li',             'run_db_install'],
+                ['nav-admin-health-li',         'drop_legacy_tables'],
             ],
         };
 
@@ -513,16 +512,8 @@ export class UserAuth {
             if (hEl) hEl.classList.toggle('d-none', !anyVisible);
         };
 
-        applySection(entItems.curator, 'header-curator-divider', 'header-curator-header');
-        applySection(entItems.admin,   'header-admin-divider',   'header-admin-header');
-
-        /* Left "app name" dropdown also surfaces Song Editor for users
-           who hold edit_songs. Same entitlement check, separate element. */
-        const navEditor = document.getElementById('nav-app-editor-li');
-        if (navEditor) {
-            const canEdit = loggedIn && userHasEntitlement('edit_songs', role);
-            navEditor.classList.toggle('d-none', !canEdit);
-        }
+        applySection(entItems.curator, 'nav-curator-divider', 'nav-curator-header');
+        applySection(entItems.admin,   'nav-admin-divider',   'nav-admin-header');
 
         /* Update icon style */
         const icon = document.getElementById('header-user-icon');


### PR DESCRIPTION
## Summary

- **Back-to-top button** now uses the app's `--accent-solid` / `--accent-end` tokens instead of Bootstrap's `--bs-primary` fallback royal blue, so it harmonises with light, dark, and high-contrast themes, and transforms correctly under the colour-blind SVG filters applied to `<html>`. Also fixed a dead high-contrast override (selector was `data-bs-theme` but the app uses `data-ihymns-theme`) and swapped the invisible white border for a black one that matches the rest of the high-contrast surface styling.
- **Header menu restructure.** The user/avatar dropdown had grown to ~15 items, mixing personal actions with Curator and Administration tools. Redistributed along that seam:
  - Avatar menu (user-specific): name/role, Settings, My Set Lists, Sync Set Lists, Sign Out.
  - iHymns logo menu (app + management): existing nav + Curator section (Song Editor, Song Requests, Revisions Audit) + Administration section (Dashboard, Users, Groups, Orgs, Songbook Management, Entitlements & Gating, Analytics, Data Health, Database Setup).
- Role-gating migrated to the new `nav-*` ids in `user-auth.js`; section headers + dividers collapse when no child is visible, so users without entitlements see no trace of the section.
- Renamed admin "Songbooks" → "Songbook Management" to distinguish from the public browse entry sitting in the same menu.
- A11y: flat grouped lists with `h6.dropdown-header` labels rather than nested submenus (WCAG 2.5.5 + APG menu-flyout friction). Native `<a>` / `<button>` elements preserve Tab, Enter, Escape, and arrow-key handling that Bootstrap wires.

## Test plan

- [ ] Light mode: back-to-top button is indigo (`#6366f1`), matches the Home tab accent.
- [ ] Dark mode: back-to-top button is brighter indigo (`#818cf8`), no longer royal blue.
- [ ] High-contrast: back-to-top is `#0000cc` with a **black** 2px border, hover/focus bumps shadow.
- [ ] Colour-blind modes (protanopia, deuteranopia, tritanopia, achromatopsia): button colour shifts in step with the rest of the UI.
- [ ] Avatar menu while signed out: Sign In + Create Account only.
- [ ] Avatar menu while signed in as a regular user: name, role, Settings, My Set Lists, Sync Set Lists, Sign Out — nothing more.
- [ ] iHymns menu while signed out: Home, Songbooks, Favourites, Set Lists, Statistics, Help — no Curator or Admin section rendered.
- [ ] iHymns menu as a curator: Curator section appears with a header and divider; Admin section stays hidden.
- [ ] iHymns menu as a global admin: both Curator and Administration sections appear, Songbook Management label is clear against the public Songbooks entry.
- [ ] Keyboard: Tab traverses all items, arrow keys cycle within each menu, Escape closes and returns focus to the toggle.
- [ ] Screen reader (VoiceOver / NVDA): dropdown triggers announce "menu, collapsed/expanded"; section headings are announced before their items.
- [ ] Reduced-motion system setting: no transition on open/close or on the scroll button.

https://claude.ai/code/session_01CLSdCcDA6zoVDVVSHt2cV8

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLSdCcDA6zoVDVVSHt2cV8)_