### PR TITLE
Collapse iHymns menu to a single "Manage" entry

### DIFF
--- a/appWeb/public_html/index.php
+++ b/appWeb/public_html/index.php
@@ -598,85 +598,16 @@ if (!empty($breadcrumbItems)) {
                             <i class="fa-solid fa-circle-question me-2" aria-hidden="true"></i> Help
                         </a></li>
 
-                        <!-- ============================================
-                             Curator + Administration sections — moved out
-                             of the user/avatar menu because these relate to
-                             the app itself, not the logged-in person.
-                             Each section (divider + header + items) is
-                             toggled together by user-auth.js so users who
-                             lack every entitlement in a section see none of
-                             its markup.
-                             ============================================ -->
-
-                        <!-- ── Curator ── -->
-                        <li id="nav-curator-divider" class="d-none"><hr class="dropdown-divider"></li>
-                        <li id="nav-curator-header" class="d-none">
-                            <h6 class="dropdown-header" id="nav-curator-heading">Curator</h6>
-                        </li>
-                        <li id="nav-curator-editor-li" class="d-none">
-                            <a class="dropdown-item" href="/manage/editor/">
-                                <i class="fa-solid fa-pen-to-square me-2" aria-hidden="true"></i> Song Editor
-                            </a>
-                        </li>
-                        <li id="nav-curator-requests-li" class="d-none">
-                            <a class="dropdown-item" href="/manage/requests">
-                                <i class="fa-solid fa-inbox me-2" aria-hidden="true"></i> Song Requests
-                            </a>
-                        </li>
-                        <li id="nav-curator-revisions-li" class="d-none">
-                            <a class="dropdown-item" href="/manage/revisions">
-                                <i class="fa-solid fa-clock-rotate-left me-2" aria-hidden="true"></i> Revisions Audit
-                            </a>
-                        </li>
-
-                        <!-- ── Administration ── -->
-                        <li id="nav-admin-divider" class="d-none"><hr class="dropdown-divider"></li>
-                        <li id="nav-admin-header" class="d-none">
-                            <h6 class="dropdown-header" id="nav-admin-heading">Administration</h6>
-                        </li>
-                        <li id="nav-admin-dashboard-li" class="d-none">
+                        <!-- Single "Manage" entry — opens /manage/ which
+                             shows per-entitlement cards for every
+                             curator and administration surface. Visible
+                             to any signed-in user with at least one
+                             management entitlement (toggled by
+                             user-auth.js). -->
+                        <li id="nav-manage-divider" class="d-none"><hr class="dropdown-divider"></li>
+                        <li id="nav-manage-li" class="d-none">
                             <a class="dropdown-item" href="/manage/">
-                                <i class="fa-solid fa-gauge-high me-2" aria-hidden="true"></i> Admin Dashboard
-                            </a>
-                        </li>
-                        <li id="nav-admin-users-li" class="d-none">
-                            <a class="dropdown-item" href="/manage/users">
-                                <i class="fa-solid fa-users me-2" aria-hidden="true"></i> User Management
-                            </a>
-                        </li>
-                        <li id="nav-admin-groups-li" class="d-none">
-                            <a class="dropdown-item" href="/manage/groups">
-                                <i class="fa-solid fa-user-group me-2" aria-hidden="true"></i> User Groups
-                            </a>
-                        </li>
-                        <li id="nav-admin-organisations-li" class="d-none">
-                            <a class="dropdown-item" href="/manage/organisations">
-                                <i class="fa-solid fa-building me-2" aria-hidden="true"></i> Organisations
-                            </a>
-                        </li>
-                        <li id="nav-admin-songbooks-li" class="d-none">
-                            <a class="dropdown-item" href="/manage/songbooks">
-                                <i class="fa-solid fa-book-open me-2" aria-hidden="true"></i> Songbook Management
-                            </a>
-                        </li>
-                        <li id="nav-admin-entitlements-li" class="d-none">
-                            <a class="dropdown-item" href="/manage/entitlements">
-                                <i class="fa-solid fa-key me-2" aria-hidden="true"></i> Entitlements &amp; Gating
-                            </a>
-                        </li>
-                        <li id="nav-admin-analytics-li" class="d-none">
-                            <a class="dropdown-item" href="/manage/analytics">
-                                <i class="fa-solid fa-chart-line me-2" aria-hidden="true"></i> Analytics
-                            </a>
-                        </li>
-                        <li id="nav-admin-health-li" class="d-none">
-                            <a class="dropdown-item" href="/manage/data-health">
-                                <i class="fa-solid fa-heart-pulse me-2" aria-hidden="true"></i> Data Health
-                            </a>
-                        </li>
-                        <li id="nav-admin-db-li" class="d-none">
-                            <a class="dropdown-item" href="/manage/setup-database">
-                                <i class="fa-solid fa-database me-2" aria-hidden="true"></i> Database Setup
+                                <i class="fa-solid fa-gears me-2" aria-hidden="true"></i> Manage
                             </a>
                         </li>
                     </ul>

--- a/appWeb/public_html/js/modules/user-auth.js
+++ b/appWeb/public_html/js/modules/user-auth.js
@@ -477,43 +477,24 @@ export class UserAuth {
             if (roleEl) roleEl.textContent = this._roleLabel(user.role || 'user');
         }
 
-        /* Per-entitlement items on the iHymns (logo) dropdown.
-           Each entry: [elementId, entitlement-name]. Signed-out hides all. */
-        const entItems = {
-            curator: [
-                ['nav-curator-editor-li',     'edit_songs'],
-                ['nav-curator-requests-li',   'review_song_requests'],
-                ['nav-curator-revisions-li',  'verify_songs'],
-            ],
-            admin: [
-                ['nav-admin-dashboard-li',      'view_admin_dashboard'],
-                ['nav-admin-users-li',          'view_users'],
-                ['nav-admin-groups-li',         'manage_user_groups'],
-                ['nav-admin-organisations-li',  'manage_organisations'],
-                ['nav-admin-songbooks-li',      'manage_songbooks'],
-                ['nav-admin-entitlements-li',   'manage_entitlements'],
-                ['nav-admin-analytics-li',      'view_analytics'],
-                ['nav-admin-db-li',             'run_db_install'],
-                ['nav-admin-health-li',         'drop_legacy_tables'],
-            ],
-        };
-
-        const applySection = (items, dividerId, headerId) => {
-            let anyVisible = false;
-            items.forEach(([id, ent]) => {
-                const visible = loggedIn && userHasEntitlement(ent, role);
-                const el = document.getElementById(id);
-                if (el) el.classList.toggle('d-none', !visible);
-                if (visible) anyVisible = true;
-            });
-            const dEl = document.getElementById(dividerId);
-            const hEl = document.getElementById(headerId);
-            if (dEl) dEl.classList.toggle('d-none', !anyVisible);
-            if (hEl) hEl.classList.toggle('d-none', !anyVisible);
-        };
-
-        applySection(entItems.curator, 'nav-curator-divider', 'nav-curator-header');
-        applySection(entItems.admin,   'nav-admin-divider',   'nav-admin-header');
+        /* Single "Manage" entry in the iHymns dropdown. Visible to any
+           signed-in user holding at least one curator or administration
+           entitlement; the landing page (/manage/) then reveals
+           per-card links based on the same entitlements. */
+        const manageEntitlements = [
+            'edit_songs', 'review_song_requests', 'verify_songs',
+            'view_admin_dashboard', 'view_users', 'manage_user_groups',
+            'manage_organisations', 'manage_songbooks',
+            'manage_entitlements', 'view_analytics',
+            'run_db_install', 'drop_legacy_tables',
+        ];
+        const canManage = loggedIn && manageEntitlements.some(
+            ent => userHasEntitlement(ent, role)
+        );
+        ['nav-manage-divider', 'nav-manage-li'].forEach(id => {
+            const el = document.getElementById(id);
+            if (el) el.classList.toggle('d-none', !canManage);
+        });
 
         /* Update icon style */
         const icon = document.getElementById('header-user-icon');

--- a/appWeb/public_html/manage/index.php
+++ b/appWeb/public_html/manage/index.php
@@ -13,9 +13,32 @@ declare(strict_types=1);
  */
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
-requireEditor();
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'entitlements.php';
 
+/* Dashboard is now the single landing page for every management
+   surface, so admit any signed-in user who holds at least one
+   curator/admin entitlement. Each card below is individually
+   gated, so unauthorised users see a subset — or, if they hold
+   none, are bounced to /. */
+requireAuth();
 $currentUser = getCurrentUser();
+$_role = $currentUser['role'] ?? null;
+$_manageEntitlements = [
+    'edit_songs', 'review_song_requests', 'verify_songs',
+    'view_admin_dashboard', 'view_users', 'manage_user_groups',
+    'manage_organisations', 'manage_songbooks',
+    'manage_entitlements', 'view_analytics',
+    'run_db_install', 'drop_legacy_tables',
+];
+$_canManage = false;
+foreach ($_manageEntitlements as $_e) {
+    if (userHasEntitlement($_e, $_role)) { $_canManage = true; break; }
+}
+if (!$_canManage) {
+    http_response_code(403);
+    exit('Access denied. A management entitlement is required.');
+}
+
 $activePage  = 'dashboard';
 
 /* Gather stats — all queries updated for the v0.10 PascalCase schema
@@ -176,8 +199,12 @@ $csrf = csrfToken();
         </div>
         <?php endif; ?>
 
-        <!-- Quick Links -->
+        <!-- Quick Links — every card is gated by the same entitlement
+             that controls visibility of the corresponding menu item, so
+             the dashboard surfaces exactly the areas the user can act
+             on. Gate helper: userHasEntitlement($ent, $role). -->
         <div class="row g-3 mb-4">
+            <?php if (userHasEntitlement('edit_songs', $_role)): ?>
             <div class="col-md-4">
                 <div class="card-admin">
                     <a href="/manage/editor/" class="quick-link">
@@ -187,107 +214,8 @@ $csrf = csrfToken();
                     </a>
                 </div>
             </div>
-            <?php if (hasRole($currentUser['role'], 'admin')): ?>
-            <div class="col-md-4">
-                <div class="card-admin">
-                    <a href="/manage/users" class="quick-link">
-                        <i class="bi bi-people d-block mb-2"></i>
-                        <strong>User Management</strong>
-                        <div class="small text-muted">Manage accounts, roles, and permissions</div>
-                    </a>
-                </div>
-            </div>
             <?php endif; ?>
-            <?php if (hasRole($currentUser['role'], 'admin')): ?>
-            <div class="col-md-4">
-                <div class="card-admin">
-                    <a href="/manage/analytics" class="quick-link">
-                        <i class="bi bi-graph-up d-block mb-2"></i>
-                        <strong>Analytics</strong>
-                        <div class="small text-muted">Top songs, searches, and user activity</div>
-                    </a>
-                </div>
-            </div>
-            <div class="col-md-4">
-                <div class="card-admin">
-                    <a href="/manage/revisions" class="quick-link">
-                        <i class="bi bi-clock-history d-block mb-2"></i>
-                        <strong>Revisions</strong>
-                        <div class="small text-muted">Audit song edits; open any row in the editor to diff / restore</div>
-                    </a>
-                </div>
-            </div>
-            <?php endif; ?>
-            <?php
-                require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'entitlements.php';
-            ?>
-            <?php if (userHasEntitlement('view_admin_dashboard', $currentUser['role'] ?? null)): ?>
-            <div class="col-md-4">
-                <div class="card-admin">
-                    <a href="/manage/setup-database" class="quick-link">
-                        <i class="bi bi-database-gear d-block mb-2"></i>
-                        <strong>Database Setup</strong>
-                        <div class="small text-muted">Install, migrate, backup, restore, cleanup</div>
-                    </a>
-                </div>
-            </div>
-            <?php endif; ?>
-            <?php if (($currentUser['role'] ?? '') === 'global_admin'): ?>
-            <div class="col-md-4">
-                <div class="card-admin">
-                    <a href="/manage/data-health" class="quick-link">
-                        <i class="bi bi-activity d-block mb-2"></i>
-                        <strong>Data Health</strong>
-                        <div class="small text-muted">Confirm MySQL is authoritative; disconnect legacy fallbacks</div>
-                    </a>
-                </div>
-            </div>
-            <?php endif; ?>
-            <?php if (userHasEntitlement('manage_entitlements', $currentUser['role'] ?? null)): ?>
-            <div class="col-md-4">
-                <div class="card-admin">
-                    <a href="/manage/entitlements" class="quick-link">
-                        <i class="bi bi-key d-block mb-2"></i>
-                        <strong>Entitlements</strong>
-                        <div class="small text-muted">Assign capabilities to roles</div>
-                    </a>
-                </div>
-            </div>
-            <?php endif; ?>
-            <?php if (userHasEntitlement('manage_songbooks', $currentUser['role'] ?? null)): ?>
-            <div class="col-md-4">
-                <div class="card-admin">
-                    <a href="/manage/songbooks" class="quick-link">
-                        <i class="bi bi-book d-block mb-2"></i>
-                        <strong>Songbooks</strong>
-                        <div class="small text-muted">Create, rename, reorder the songbook catalogue</div>
-                    </a>
-                </div>
-            </div>
-            <?php endif; ?>
-            <?php if (userHasEntitlement('manage_user_groups', $currentUser['role'] ?? null)): ?>
-            <div class="col-md-4">
-                <div class="card-admin">
-                    <a href="/manage/groups" class="quick-link">
-                        <i class="bi bi-people-fill d-block mb-2"></i>
-                        <strong>User Groups</strong>
-                        <div class="small text-muted">Group users for shared access settings</div>
-                    </a>
-                </div>
-            </div>
-            <?php endif; ?>
-            <?php if (userHasEntitlement('manage_organisations', $currentUser['role'] ?? null)): ?>
-            <div class="col-md-4">
-                <div class="card-admin">
-                    <a href="/manage/organisations" class="quick-link">
-                        <i class="bi bi-building d-block mb-2"></i>
-                        <strong>Organisations</strong>
-                        <div class="small text-muted">Manage organisations &amp; their members</div>
-                    </a>
-                </div>
-            </div>
-            <?php endif; ?>
-            <?php if (userHasEntitlement('review_song_requests', $currentUser['role'] ?? null)): ?>
+            <?php if (userHasEntitlement('review_song_requests', $_role)): ?>
             <div class="col-md-4">
                 <div class="card-admin">
                     <a href="/manage/requests" class="quick-link">
@@ -300,9 +228,108 @@ $csrf = csrfToken();
                 </div>
             </div>
             <?php endif; ?>
+            <?php if (userHasEntitlement('verify_songs', $_role)): ?>
             <div class="col-md-4">
                 <div class="card-admin">
-                    <a href="/" class="quick-link" target="_blank">
+                    <a href="/manage/revisions" class="quick-link">
+                        <i class="bi bi-clock-history d-block mb-2"></i>
+                        <strong>Revisions Audit</strong>
+                        <div class="small text-muted">Audit song edits; open any row in the editor to diff / restore</div>
+                    </a>
+                </div>
+            </div>
+            <?php endif; ?>
+            <?php if (userHasEntitlement('view_users', $_role)): ?>
+            <div class="col-md-4">
+                <div class="card-admin">
+                    <a href="/manage/users" class="quick-link">
+                        <i class="bi bi-people d-block mb-2"></i>
+                        <strong>User Management</strong>
+                        <div class="small text-muted">Manage accounts, roles, and permissions</div>
+                    </a>
+                </div>
+            </div>
+            <?php endif; ?>
+            <?php if (userHasEntitlement('manage_user_groups', $_role)): ?>
+            <div class="col-md-4">
+                <div class="card-admin">
+                    <a href="/manage/groups" class="quick-link">
+                        <i class="bi bi-people-fill d-block mb-2"></i>
+                        <strong>User Groups</strong>
+                        <div class="small text-muted">Group users for shared access settings</div>
+                    </a>
+                </div>
+            </div>
+            <?php endif; ?>
+            <?php if (userHasEntitlement('manage_organisations', $_role)): ?>
+            <div class="col-md-4">
+                <div class="card-admin">
+                    <a href="/manage/organisations" class="quick-link">
+                        <i class="bi bi-building d-block mb-2"></i>
+                        <strong>Organisations</strong>
+                        <div class="small text-muted">Manage organisations &amp; their members</div>
+                    </a>
+                </div>
+            </div>
+            <?php endif; ?>
+            <?php if (userHasEntitlement('manage_songbooks', $_role)): ?>
+            <div class="col-md-4">
+                <div class="card-admin">
+                    <a href="/manage/songbooks" class="quick-link">
+                        <i class="bi bi-book d-block mb-2"></i>
+                        <strong>Songbook Management</strong>
+                        <div class="small text-muted">Create, rename, reorder the songbook catalogue</div>
+                    </a>
+                </div>
+            </div>
+            <?php endif; ?>
+            <?php if (userHasEntitlement('manage_entitlements', $_role)): ?>
+            <div class="col-md-4">
+                <div class="card-admin">
+                    <a href="/manage/entitlements" class="quick-link">
+                        <i class="bi bi-key d-block mb-2"></i>
+                        <strong>Entitlements &amp; Gating</strong>
+                        <div class="small text-muted">Assign capabilities to roles</div>
+                    </a>
+                </div>
+            </div>
+            <?php endif; ?>
+            <?php if (userHasEntitlement('view_analytics', $_role)): ?>
+            <div class="col-md-4">
+                <div class="card-admin">
+                    <a href="/manage/analytics" class="quick-link">
+                        <i class="bi bi-graph-up d-block mb-2"></i>
+                        <strong>Analytics</strong>
+                        <div class="small text-muted">Top songs, searches, and user activity</div>
+                    </a>
+                </div>
+            </div>
+            <?php endif; ?>
+            <?php if (userHasEntitlement('drop_legacy_tables', $_role)): ?>
+            <div class="col-md-4">
+                <div class="card-admin">
+                    <a href="/manage/data-health" class="quick-link">
+                        <i class="bi bi-activity d-block mb-2"></i>
+                        <strong>Data Health</strong>
+                        <div class="small text-muted">Confirm MySQL is authoritative; disconnect legacy fallbacks</div>
+                    </a>
+                </div>
+            </div>
+            <?php endif; ?>
+            <?php if (userHasEntitlement('run_db_install', $_role)): ?>
+            <div class="col-md-4">
+                <div class="card-admin">
+                    <a href="/manage/setup-database" class="quick-link">
+                        <i class="bi bi-database-gear d-block mb-2"></i>
+                        <strong>Database Setup</strong>
+                        <div class="small text-muted">Install, migrate, backup, restore, cleanup</div>
+                    </a>
+                </div>
+            </div>
+            <?php endif; ?>
+            <div class="col-md-4">
+                <div class="card-admin">
+                    <a href="/" class="quick-link" target="_blank" rel="noopener">
                         <i class="bi bi-globe d-block mb-2"></i>
                         <strong>View Website</strong>
                         <div class="small text-muted">Open iHymns in a new tab</div>

--- a/appWeb/public_html/manage/revisions.php
+++ b/appWeb/public_html/manage/revisions.php
@@ -12,9 +12,14 @@ declare(strict_types=1);
  */
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
-requireAdmin();
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'entitlements.php';
 
+requireAuth();
 $currentUser = getCurrentUser();
+if (!$currentUser || !userHasEntitlement('verify_songs', $currentUser['role'] ?? null)) {
+    http_response_code(403);
+    exit('Access denied. The verify_songs entitlement is required.');
+}
 $db = getDb();
 
 $filterUser   = trim((string)($_GET['user']   ?? ''));


### PR DESCRIPTION
## Summary

Follow-up to #435. The iHymns (logo) dropdown still felt long once Curator + Administration sections were filled in for a signed-in admin. Collapse both into a single **"Manage"** entry that opens `/manage/`, where cards reveal each management area per-entitlement.

- **Menu** — replaces the 11-item Curator + Administration block with one "Manage" link, visible whenever the signed-in user holds any of the twelve management entitlements.
- **`/manage/` dashboard** — admits anyone with any management entitlement (was `requireEditor()`, which could lock out curators under non-default entitlement maps). Every card is now gated by the same `userHasEntitlement()` call the menu uses, and a duplicate card block lower in the template was removed.
- **Cards covered**: Song Editor, Song Requests, Revisions Audit, User Management, User Groups, Organisations, Songbook Management, Entitlements & Gating, Analytics, Data Health, Database Setup. Each sub-page still enforces its own entitlement check independently.
- **`revisions.php`** — gate changed from `requireAdmin()` to `userHasEntitlement('verify_songs', …)`. The card is gated on `verify_songs` (editor+), so editors would previously have seen the card and 403'd on click.

## Test plan

- [ ] Signed out: iHymns menu shows Home, Songbooks, Favourites, Set Lists, Statistics, Help — no "Manage" entry.
- [ ] Signed in as a pure editor: "Manage" appears in the iHymns menu; clicking opens `/manage/`; dashboard shows Song Editor, Song Requests, Revisions Audit cards only; all three links load without 403.
- [ ] Signed in as admin: dashboard shows everything except Data Health and Database Setup; all links load.
- [ ] Signed in as global_admin: every card appears, every link loads.
- [ ] A user whose role grants no management entitlement navigates directly to `/manage/` → 403.
- [ ] Keyboard: Tab reaches "Manage"; Enter opens the dashboard; each card is reachable via Tab and activatable via Enter.
- [ ] Screen reader (VoiceOver / NVDA): dashboard cards are announced as links with their label and description.

https://claude.ai/code/session_01CLSdCcDA6zoVDVVSHt2cV8

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLSdCcDA6zoVDVVSHt2cV8)_