### PR TITLE
Stop PWA from serving stale JS after a deploy

### DIFF
--- a/appWeb/public_html/.htaccess
+++ b/appWeb/public_html/.htaccess
@@ -203,9 +203,15 @@ RewriteRule ^ index.php [QSA,L]
         Header set Expires "0"
     </FilesMatch>
 
-    # CSS and JS — short cache in beta
+    # CSS and JS — always revalidate so deploys take effect immediately.
+    # ES module graphs make per-file cache-busting impractical (only the
+    # entry script tag carries ?v=...; its static imports do not), and
+    # the semver bumps only on release, not on every alpha/beta deploy.
+    # "no-cache, must-revalidate" still caches the response but forces a
+    # conditional GET — the server answers 304 when unchanged (cheap) and
+    # sends fresh bytes only when the file really changed.
     <FilesMatch "\.(css|js|mjs)$">
-        Header set Cache-Control "public, max-age=3600"
+        Header set Cache-Control "no-cache, must-revalidate"
     </FilesMatch>
 
     # Images and fonts — longer cache

--- a/appWeb/public_html/index.php
+++ b/appWeb/public_html/index.php
@@ -1199,8 +1199,20 @@ if (!empty($breadcrumbItems)) {
         };
     </script>
 
-    <!-- iHymns Application Scripts (ES Modules) -->
-    <script src="/js/app.js?v=<?= urlencode($app["Application"]["Version"]["Number"]) ?>" type="module"></script>
+    <!-- iHymns Application Scripts (ES Modules)
+
+         Cache-buster combines the semver with the deploy-time commit-date
+         stamp (injected by the GH Actions pipeline into infoAppVer.php)
+         so every deploy produces a new URL even when the semver hasn't
+         bumped. Without the commit stamp, .htaccess' max-age=3600 holds
+         onto user-auth.js and peers for up to an hour after a deploy. -->
+    <?php
+        $_appJsStamp = preg_replace('/[^0-9]/', '',
+            (string)($app['Application']['Version']['Repo']['Commit']['Date'] ?? ''));
+        $_appJsVersion = $app['Application']['Version']['Number']
+            . ($_appJsStamp !== '' ? '-' . $_appJsStamp : '');
+    ?>
+    <script src="/js/app.js?v=<?= urlencode($_appJsVersion) ?>" type="module"></script>
 
     <!-- Colour Vision Deficiency (CVD) SVG correction filters (#319) -->
     <?php readfile(__DIR__ . DIRECTORY_SEPARATOR . 'assets' . DIRECTORY_SEPARATOR . 'cvd-filters.svg'); ?>

--- a/appWeb/public_html/service-worker.js.php
+++ b/appWeb/public_html/service-worker.js.php
@@ -19,6 +19,17 @@ header('Service-Worker-Allowed: /');
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'infoAppVer.php';
 $swVersion = $app['Application']['Version']['Number'] ?? '0.0.0';
+/* Fold the commit date (deploy-injected by the GH Actions pipeline) into
+   the cache key. Without it every build inside a single semver shares the
+   same key and clients stay pinned to the first-installed bundle. Falls
+   back to NULL (stripped) during local dev where Commit.Date is unset. */
+$swCommitStamp = preg_replace(
+    '/[^0-9]/', '',
+    (string)($app['Application']['Version']['Repo']['Commit']['Date'] ?? '')
+);
+$swCacheKey = $swCommitStamp !== ''
+    ? $swVersion . '-' . $swCommitStamp
+    : $swVersion;
 ?>
 /**
  * iHymns — Service Worker
@@ -51,11 +62,13 @@ $swVersion = $app['Application']['Version']['Number'] ?? '0.0.0';
  * ========================================================================= */
 
 /**
- * Cache version — derived from the application version in infoAppVer.php.
- * When the version is bumped by CI/CD, the service worker automatically
- * gets a new cache key, triggering a full cache purge on next load.
+ * Cache version — derived from the application version AND the deploy-time
+ * commit date in infoAppVer.php. The commit date component means every
+ * deploy (not just every semver bump) produces a new cache key, so clients
+ * pick up fresh module scripts instead of being pinned to the bundle their
+ * SW first installed. Old caches are purged on activation (#81).
  */
-const CACHE_VERSION = 'ihymns-v<?= $swVersion ?>';
+const CACHE_VERSION = 'ihymns-v<?= $swCacheKey ?>';
 
 /**
  * Songs cache (#105).


### PR DESCRIPTION
## Summary

You reported that the "Manage" menu from #436 wasn't showing up even as a global admin about 1h20 after the merge. Two overlapping reasons — fixed here:

1. **`.htaccess` served CSS/JS with `public, max-age=3600`.** ES module import graphs mean only the entry `<script>` carries `?v=…`; its static imports (including `user-auth.js`) do not. And the semver only bumps on release, not on every alpha/beta deploy. So a browser that installed the app with the old `user-auth.js` would hold it for up to an hour after each deploy. Switched the rule to `no-cache, must-revalidate` — still cached, but the browser always sends a conditional GET; 304s when nothing changed (cheap) and fresh bytes when it did. The comment above the rule already said "aggressive no-cache to ensure fresh content during development" — the rule now matches that.

2. **Service worker `CACHE_VERSION` was pinned to the semver.** Fold the deploy-injected commit-date stamp in so every deploy produces a new cache key, which trips the existing activation-time cache purge.

3. **Belt-and-braces:** mix the same commit-date stamp into `?v=` on the entry script tag so `app.js` itself also gets fresh URLs per deploy.

### The "Manage" entry bug this fixes

It was a user-visible symptom of this caching issue: #436 added `<li id="nav-manage-li">` plus a matching toggle in `user-auth.js`. When the old cached `user-auth.js` ran against the new HTML, it looked for elements (`nav-curator-*` / `nav-admin-*`) that no longer existed — so nothing in the iHymns dropdown was toggled visible for signed-in curators or admins.

## Immediate workaround for testing

Force-refresh once (Cmd/Ctrl+Shift+R) or close/reopen the PWA. After this PR deploys, the next one after it will do it automatically.

## Test plan

- [ ] After this deploys and a normal soft-refresh: DevTools → Network shows `user-auth.js` returning 200 with the new bytes (not a `(disk cache)` hit from before the deploy).
- [ ] Sign in as global admin → iHymns (logo) menu now shows the "Manage" entry.
- [ ] DevTools → Application → Cache Storage: the active cache bucket is named `ihymns-v0.10.0-<commit-date-stamp>`, and older `ihymns-v0.10.0*` buckets have been deleted.
- [ ] DevTools → Service Workers: a new SW was installed, activated, and took control after the merge of this PR.
- [ ] Offline: pre-cached shell still loads from cache when the network is cut (no regression from the header change).
- [ ] Response headers on `/js/modules/user-auth.js`: `Cache-Control: no-cache, must-revalidate` (not `max-age=3600`).

https://claude.ai/code/session_01CLSdCcDA6zoVDVVSHt2cV8

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLSdCcDA6zoVDVVSHt2cV8)_