### PR TITLE
Fix broken /manage URLs + add regular-user gating admin (restrictions, tiers)

### DIFF
--- a/appWeb/public_html/includes/entitlements.php
+++ b/appWeb/public_html/includes/entitlements.php
@@ -60,6 +60,13 @@ const ENTITLEMENTS = [
     'manage_user_groups'   => ['admin', 'global_admin'],
     'manage_organisations' => ['admin', 'global_admin'],
 
+    /* Content gating for regular users — per-song / per-songbook / per-user
+       restrictions (tblContentRestrictions) and access-tier definitions
+       (tblAccessTiers) that control lyrics / audio / MIDI / PDF / offline. */
+    'manage_content_restrictions' => ['admin', 'global_admin'],
+    'manage_access_tiers'         => ['admin', 'global_admin'],
+    'assign_user_tier'            => ['admin', 'global_admin'],
+
     /* Channel access gating (#407) — controls who can reach alpha/beta
        subdomains. Applied BEFORE the page renders so pre-release builds
        are invisible to the public even when indexed. Defaults intentionally

--- a/appWeb/public_html/js/modules/entitlements.js
+++ b/appWeb/public_html/js/modules/entitlements.js
@@ -42,6 +42,11 @@ export const ENTITLEMENTS = {
     manage_user_groups:   ['admin', 'global_admin'],
     manage_organisations: ['admin', 'global_admin'],
 
+    /* Content gating for regular users */
+    manage_content_restrictions: ['admin', 'global_admin'],
+    manage_access_tiers:         ['admin', 'global_admin'],
+    assign_user_tier:            ['admin', 'global_admin'],
+
     /* Channel access (#407) */
     access_alpha:         ['user', 'editor', 'admin', 'global_admin'],
     access_beta:          ['user', 'editor', 'admin', 'global_admin'],

--- a/appWeb/public_html/manage/.htaccess
+++ b/appWeb/public_html/manage/.htaccess
@@ -7,54 +7,50 @@
 # Handles routing for the /manage/ admin area. This directory is
 # excluded from the main SPA rewrite rules and has its own auth system.
 #
-# ROUTING:
-#   /manage/              → /manage/index.php (admin dashboard)
-#   /manage/login         → /manage/login.php
-#   /manage/logout        → /manage/logout.php
-#   /manage/setup         → /manage/setup.php
-#   /manage/users         → /manage/users.php
-#   /manage/editor/       → /manage/editor/index.php (DirectoryIndex)
+# ROUTING STRATEGY:
+#   Every /manage/<name> URL is resolved by checking whether a matching
+#   <name>.php (or <name>/index.php) exists on disk. This is deliberately
+#   generic — adding a new admin page is now a single-file change: drop
+#   /manage/foo.php and /manage/foo works immediately. Previously each
+#   new page also needed a per-URL rewrite rule here, and forgetting one
+#   silently broke the page (it fell through to the SPA's 404 shell,
+#   which surfaces as "Failed to load page").
 # ==========================================================================
 
-# Enable the rewrite engine
 RewriteEngine On
+RewriteBase /manage/
 
-# ---- Clean URL rewrites (hide .php extensions) ----
+# ---- DirectoryIndex for /manage/ and /manage/editor/ ----
+DirectoryIndex index.php
 
-# /manage/login → login.php
-RewriteRule ^login$ login.php [L]
+# ==========================================================================
+# Explicit rewrites that need special flags
+# ==========================================================================
 
-# /manage/logout → logout.php
-RewriteRule ^logout$ logout.php [L]
-
-# /manage/setup → setup.php
-RewriteRule ^setup$ setup.php [L]
-
-# /manage/users → users.php (admin-only user management)
-RewriteRule ^users$ users.php [L]
-
-# /manage/setup-database → setup-database.php (DB setup dashboard)
-RewriteRule ^setup-database$ setup-database.php [L]
-
-# /manage/analytics → analytics.php (admin analytics dashboard, #404)
-RewriteRule ^analytics$ analytics.php [L]
-
-# /manage/entitlements → entitlements.php (entitlements editor, #407)
-RewriteRule ^entitlements$ entitlements.php [L]
-
-# /manage/requests → requests.php (song-request triage, #403)
-RewriteRule ^requests$ requests.php [L]
-
-# /manage/editor/api → /manage/editor/api.php (editor API)
+# /manage/editor/api → /manage/editor/api.php (preserve query string)
 RewriteRule ^editor/api$ editor/api.php [QSA,L]
 
-# Block direct .php access in /manage/ (hide PHP from URLs)
+# ==========================================================================
+# Generic clean-URL rewrite:
+#   /manage/<name>       → /manage/<name>.php   (if <name>.php exists)
+#   /manage/<path>/<name> → same, at any depth
+#
+# Only fires when the request doesn't point to an existing file or
+# directory but a matching .php sibling does exist. QSA preserves query
+# strings for pages like /manage/groups?edit=3.
+# ==========================================================================
+
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_FILENAME}.php -f
+RewriteRule ^(.+?)/?$ $1.php [QSA,L]
+
+# ==========================================================================
+# Hide .php extensions — redirect direct /manage/foo.php to /manage/foo.
+# Uses THE_REQUEST so the check sees the original browser request, not
+# the internal rewrite produced by the rule above.
+# ==========================================================================
+
 RewriteCond %{THE_REQUEST} \.php[\s?/] [NC]
 RewriteCond %{REQUEST_URI} !^/manage/includes/ [NC]
 RewriteRule ^(.+)\.php$ /manage/$1 [R=301,L]
-
-# /manage/ root → serve dashboard (index.php via DirectoryIndex)
-# No rewrite needed — DirectoryIndex handles it
-
-# ---- Ensure DirectoryIndex works for /manage/editor/ ----
-DirectoryIndex index.php

--- a/appWeb/public_html/manage/index.php
+++ b/appWeb/public_html/manage/index.php
@@ -28,6 +28,7 @@ $_manageEntitlements = [
     'view_admin_dashboard', 'view_users', 'manage_user_groups',
     'manage_organisations', 'manage_songbooks',
     'manage_entitlements', 'view_analytics',
+    'manage_content_restrictions', 'manage_access_tiers',
     'run_db_install', 'drop_legacy_tables',
 ];
 $_canManage = false;
@@ -279,6 +280,28 @@ $csrf = csrfToken();
                         <i class="bi bi-book d-block mb-2"></i>
                         <strong>Songbook Management</strong>
                         <div class="small text-muted">Create, rename, reorder the songbook catalogue</div>
+                    </a>
+                </div>
+            </div>
+            <?php endif; ?>
+            <?php if (userHasEntitlement('manage_content_restrictions', $_role)): ?>
+            <div class="col-md-4">
+                <div class="card-admin">
+                    <a href="/manage/restrictions" class="quick-link">
+                        <i class="bi bi-shield-lock d-block mb-2"></i>
+                        <strong>Content Restrictions</strong>
+                        <div class="small text-muted">Gate songs, songbooks &amp; features per user, org, platform or licence</div>
+                    </a>
+                </div>
+            </div>
+            <?php endif; ?>
+            <?php if (userHasEntitlement('manage_access_tiers', $_role)): ?>
+            <div class="col-md-4">
+                <div class="card-admin">
+                    <a href="/manage/tiers" class="quick-link">
+                        <i class="bi bi-stars d-block mb-2"></i>
+                        <strong>Access Tiers</strong>
+                        <div class="small text-muted">Define tiers controlling lyrics, audio, MIDI, sheet music &amp; offline</div>
                     </a>
                 </div>
             </div>

--- a/appWeb/public_html/manage/restrictions.php
+++ b/appWeb/public_html/manage/restrictions.php
@@ -1,0 +1,411 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Admin: Content Restrictions
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * CRUD over `tblContentRestrictions` — the rule-based lockout system that
+ * decides, per song / songbook / feature, whether a given user on a given
+ * platform can access the entity. Pairs with the evaluator in
+ * appWeb/public_html/includes/content_access.php.
+ *
+ * Rule model (see schema.sql:438):
+ *   EntityType      — song | songbook | feature
+ *   EntityId        — concrete ID, or '*' to apply to every entity of the type
+ *   RestrictionType — block_platform | block_user | block_org
+ *                     | require_licence | require_org
+ *   TargetType/Id   — what the rule applies against
+ *   Effect          — allow | deny
+ *   Priority        — higher wins; deny beats allow at equal priority
+ *
+ * Gated by the `manage_content_restrictions` entitlement.
+ */
+
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'entitlements.php';
+
+if (!isAuthenticated()) {
+    header('Location: /manage/login');
+    exit;
+}
+$currentUser = getCurrentUser();
+if (!$currentUser || !userHasEntitlement('manage_content_restrictions', $currentUser['role'] ?? null)) {
+    http_response_code(403);
+    echo '<!DOCTYPE html><html><body><h1>403 — manage_content_restrictions required</h1></body></html>';
+    exit;
+}
+$activePage = 'restrictions';
+
+$error   = '';
+$success = '';
+$db      = getDb();
+
+/* Allowed vocabularies — kept tight so the UI can't POST rubbish the
+   evaluator will silently ignore. Keep in sync with content_access.php. */
+const RESTRICTIONS_ENTITY_TYPES = ['song', 'songbook', 'feature'];
+const RESTRICTIONS_TYPES = [
+    'block_platform' => 'Block platform',
+    'block_user'     => 'Block user',
+    'block_org'      => 'Block organisation',
+    'require_licence'=> 'Require licence',
+    'require_org'    => 'Require organisation',
+];
+const RESTRICTIONS_EFFECTS = ['deny', 'allow'];
+
+/* ----- POST actions ----- */
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!validateCsrf((string)($_POST['csrf_token'] ?? ''))) {
+        http_response_code(403);
+        echo 'Invalid CSRF token';
+        exit;
+    }
+
+    $action = (string)($_POST['action'] ?? '');
+    try {
+        switch ($action) {
+            case 'create': {
+                $entityType      = trim((string)($_POST['entity_type']      ?? ''));
+                $entityId        = trim((string)($_POST['entity_id']        ?? ''));
+                $restrictionType = trim((string)($_POST['restriction_type'] ?? ''));
+                $targetType      = trim((string)($_POST['target_type']      ?? ''));
+                $targetId        = trim((string)($_POST['target_id']        ?? ''));
+                $effect          = trim((string)($_POST['effect']           ?? 'deny'));
+                $priority        = (int)  ($_POST['priority']               ?? 0);
+                $reason          = trim((string)($_POST['reason']           ?? ''));
+
+                if (!in_array($entityType, RESTRICTIONS_ENTITY_TYPES, true)) {
+                    $error = 'Invalid entity type.'; break;
+                }
+                if ($entityId === '') {
+                    $error = 'Entity ID is required (use "*" to target every entity of the type).'; break;
+                }
+                if (!array_key_exists($restrictionType, RESTRICTIONS_TYPES)) {
+                    $error = 'Invalid restriction type.'; break;
+                }
+                if (!in_array($effect, RESTRICTIONS_EFFECTS, true)) {
+                    $error = 'Effect must be allow or deny.'; break;
+                }
+                if ($priority < 0 || $priority > 1000) {
+                    $error = 'Priority must be between 0 and 1000.'; break;
+                }
+
+                $stmt = $db->prepare(
+                    'INSERT INTO tblContentRestrictions
+                        (EntityType, EntityId, RestrictionType, TargetType, TargetId, Effect, Priority, Reason)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
+                );
+                $stmt->execute([
+                    $entityType, $entityId, $restrictionType,
+                    $targetType, $targetId, $effect, $priority, $reason,
+                ]);
+                $success = 'Restriction created.';
+                break;
+            }
+
+            case 'delete': {
+                $id = (int)($_POST['id'] ?? 0);
+                if ($id <= 0) { $error = 'Invalid request.'; break; }
+                $stmt = $db->prepare('DELETE FROM tblContentRestrictions WHERE Id = ?');
+                $stmt->execute([$id]);
+                $success = 'Restriction removed.';
+                break;
+            }
+
+            default:
+                $error = 'Unknown action.';
+        }
+    } catch (\Throwable $e) {
+        error_log('[manage/restrictions.php] ' . $e->getMessage());
+        $error = $error ?: 'Database error — check server logs for details.';
+    }
+}
+
+/* ----- GET: filters + rows ----- */
+$filterEntity = (string)($_GET['entity_type'] ?? '');
+$filterType   = (string)($_GET['restriction_type'] ?? '');
+
+$rows = [];
+try {
+    $sql = 'SELECT Id, EntityType, EntityId, RestrictionType, TargetType, TargetId,
+                   Effect, Priority, Reason, CreatedAt
+              FROM tblContentRestrictions';
+    $where = [];
+    $args  = [];
+    if ($filterEntity !== '' && in_array($filterEntity, RESTRICTIONS_ENTITY_TYPES, true)) {
+        $where[] = 'EntityType = ?';
+        $args[]  = $filterEntity;
+    }
+    if ($filterType !== '' && array_key_exists($filterType, RESTRICTIONS_TYPES)) {
+        $where[] = 'RestrictionType = ?';
+        $args[]  = $filterType;
+    }
+    if ($where) {
+        $sql .= ' WHERE ' . implode(' AND ', $where);
+    }
+    $sql .= ' ORDER BY Priority DESC, CreatedAt DESC LIMIT 500';
+    $stmt = $db->prepare($sql);
+    $stmt->execute($args);
+    $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+} catch (\Throwable $e) {
+    error_log('[manage/restrictions.php] ' . $e->getMessage());
+    $error = $error ?: 'Could not load restrictions.';
+}
+
+/* Summary counts per entity type for the header pills */
+$counts = ['song' => 0, 'songbook' => 0, 'feature' => 0, 'total' => 0];
+try {
+    $rs = $db->query(
+        'SELECT EntityType, COUNT(*) AS n
+           FROM tblContentRestrictions
+          GROUP BY EntityType'
+    );
+    foreach ($rs->fetchAll(PDO::FETCH_ASSOC) as $r) {
+        $t = (string)$r['EntityType'];
+        if (isset($counts[$t])) $counts[$t] = (int)$r['n'];
+        $counts['total'] += (int)$r['n'];
+    }
+} catch (\Throwable $e) { /* ignore */ }
+
+/* Is the master gating switch enabled? Surface it prominently so admins
+   don't wonder why their restrictions have no effect. */
+$gatingEnabled = false;
+try {
+    $stmt = $db->prepare("SELECT SettingValue FROM tblAppSettings WHERE SettingKey = 'content_gating_enabled'");
+    $stmt->execute();
+    $gatingEnabled = ((string)($stmt->fetchColumn() ?: '0')) === '1';
+} catch (\Throwable $e) { /* ignore */ }
+
+$csrf = csrfToken();
+?>
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Content Restrictions — iHymns Admin</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
+          integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
+          integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">
+    <link rel="stylesheet" href="/css/app.css?v=<?= filemtime(dirname(__DIR__) . '/css/app.css') ?>">
+    <link rel="stylesheet" href="/css/admin.css?v=<?= filemtime(dirname(__DIR__) . '/css/admin.css') ?>">
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-favicon.php'; ?>
+</head>
+<body>
+
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-nav.php'; ?>
+
+    <div class="container py-4" style="max-width: 1100px;">
+
+        <h1 class="h4 mb-3"><i class="bi bi-shield-lock me-2"></i>Content Restrictions</h1>
+        <p class="text-secondary small mb-3">
+            Rule-based lockout for regular users: hide specific songs, whole songbooks, or app features
+            based on platform, user, organisation, or licence. Rules evaluate by <code>Priority</code>
+            (highest first); at equal priority, <em>deny</em> beats <em>allow</em>.
+        </p>
+
+        <?php if (!$gatingEnabled): ?>
+            <div class="alert alert-warning py-2 mb-3">
+                <i class="bi bi-exclamation-triangle me-1"></i>
+                The master switch <code>content_gating_enabled</code> is <strong>OFF</strong>.
+                Rules here are saved but currently have no runtime effect.
+                Flip it in <a href="/manage/entitlements" class="alert-link">Entitlements &amp; Gating</a>
+                (or directly in <code>tblAppSettings</code>).
+            </div>
+        <?php endif; ?>
+
+        <?php if ($success): ?>
+            <div class="alert alert-success py-2"><?= htmlspecialchars($success) ?></div>
+        <?php endif; ?>
+        <?php if ($error): ?>
+            <div class="alert alert-danger py-2"><?= htmlspecialchars($error) ?></div>
+        <?php endif; ?>
+
+        <!-- Summary pills -->
+        <div class="d-flex flex-wrap gap-2 small mb-3">
+            <span class="badge bg-secondary">Total <strong class="ms-1"><?= (int)$counts['total'] ?></strong></span>
+            <span class="badge bg-info text-dark">Songs <strong class="ms-1"><?= (int)$counts['song'] ?></strong></span>
+            <span class="badge bg-primary">Songbooks <strong class="ms-1"><?= (int)$counts['songbook'] ?></strong></span>
+            <span class="badge bg-warning text-dark">Features <strong class="ms-1"><?= (int)$counts['feature'] ?></strong></span>
+        </div>
+
+        <!-- Filters -->
+        <form method="GET" class="card-admin p-3 mb-3">
+            <div class="row g-2 align-items-end">
+                <div class="col-sm-4">
+                    <label class="form-label small mb-1">Entity type</label>
+                    <select name="entity_type" class="form-select form-select-sm">
+                        <option value="">All</option>
+                        <?php foreach (RESTRICTIONS_ENTITY_TYPES as $et): ?>
+                            <option value="<?= htmlspecialchars($et) ?>" <?= $filterEntity === $et ? 'selected' : '' ?>>
+                                <?= htmlspecialchars(ucfirst($et)) ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="col-sm-5">
+                    <label class="form-label small mb-1">Restriction type</label>
+                    <select name="restriction_type" class="form-select form-select-sm">
+                        <option value="">All</option>
+                        <?php foreach (RESTRICTIONS_TYPES as $k => $lbl): ?>
+                            <option value="<?= htmlspecialchars($k) ?>" <?= $filterType === $k ? 'selected' : '' ?>>
+                                <?= htmlspecialchars($lbl) ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="col-sm-3 d-grid">
+                    <button type="submit" class="btn btn-sm btn-outline-info">
+                        <i class="bi bi-funnel me-1"></i>Apply filter
+                    </button>
+                </div>
+            </div>
+        </form>
+
+        <!-- Rules list -->
+        <div class="card-admin p-3 mb-4">
+            <h2 class="h6 mb-3">Rules <span class="text-muted small">(<?= count($rows) ?> shown, newest first within priority)</span></h2>
+            <div class="table-responsive">
+                <table class="table table-sm align-middle mb-0">
+                    <thead>
+                        <tr class="text-muted small">
+                            <th>Entity</th>
+                            <th>Restriction</th>
+                            <th>Target</th>
+                            <th class="text-center">Effect</th>
+                            <th class="text-center">Priority</th>
+                            <th>Reason</th>
+                            <th class="text-end">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($rows as $r): ?>
+                            <tr>
+                                <td>
+                                    <span class="badge bg-secondary"><?= htmlspecialchars($r['EntityType']) ?></span>
+                                    <code class="ms-1"><?= htmlspecialchars($r['EntityId']) ?></code>
+                                </td>
+                                <td>
+                                    <?= htmlspecialchars(RESTRICTIONS_TYPES[$r['RestrictionType']] ?? $r['RestrictionType']) ?>
+                                </td>
+                                <td class="small text-muted">
+                                    <?php if ($r['TargetType'] !== '' || $r['TargetId'] !== ''): ?>
+                                        <?= htmlspecialchars($r['TargetType']) ?>
+                                        <?php if ($r['TargetId'] !== ''): ?>
+                                            = <code><?= htmlspecialchars($r['TargetId']) ?></code>
+                                        <?php endif; ?>
+                                    <?php else: ?>
+                                        <span class="text-muted">—</span>
+                                    <?php endif; ?>
+                                </td>
+                                <td class="text-center">
+                                    <?php if ($r['Effect'] === 'deny'): ?>
+                                        <span class="badge bg-danger">deny</span>
+                                    <?php else: ?>
+                                        <span class="badge bg-success">allow</span>
+                                    <?php endif; ?>
+                                </td>
+                                <td class="text-center"><?= (int)$r['Priority'] ?></td>
+                                <td class="small"><?= htmlspecialchars(mb_substr((string)$r['Reason'], 0, 140)) ?></td>
+                                <td class="text-end">
+                                    <form method="POST" class="d-inline" onsubmit="return confirm('Delete this restriction?')">
+                                        <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                                        <input type="hidden" name="action" value="delete">
+                                        <input type="hidden" name="id" value="<?= (int)$r['Id'] ?>">
+                                        <button type="submit" class="btn btn-sm btn-outline-danger" title="Remove rule">
+                                            <i class="bi bi-trash"></i>
+                                        </button>
+                                    </form>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                        <?php if (!$rows): ?>
+                            <tr><td colspan="7" class="text-muted text-center py-4">
+                                No restrictions match. Add one below to start gating content.
+                            </td></tr>
+                        <?php endif; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <!-- Create -->
+        <form method="POST" class="card-admin p-3 mb-4">
+            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+            <input type="hidden" name="action" value="create">
+            <h2 class="h6 mb-3"><i class="bi bi-plus-circle me-2"></i>Add a restriction</h2>
+            <div class="row g-2 mb-2">
+                <div class="col-sm-3">
+                    <label class="form-label small">Entity type</label>
+                    <select name="entity_type" class="form-select form-select-sm" required>
+                        <?php foreach (RESTRICTIONS_ENTITY_TYPES as $et): ?>
+                            <option value="<?= htmlspecialchars($et) ?>"><?= htmlspecialchars(ucfirst($et)) ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="col-sm-3">
+                    <label class="form-label small">Entity ID</label>
+                    <input type="text" name="entity_id" class="form-control form-control-sm" maxlength="50" required
+                           placeholder="e.g. CP-0001, MP, audio_playback, *">
+                </div>
+                <div class="col-sm-3">
+                    <label class="form-label small">Restriction type</label>
+                    <select name="restriction_type" class="form-select form-select-sm" required>
+                        <?php foreach (RESTRICTIONS_TYPES as $k => $lbl): ?>
+                            <option value="<?= htmlspecialchars($k) ?>"><?= htmlspecialchars($lbl) ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="col-sm-3">
+                    <label class="form-label small">Effect</label>
+                    <select name="effect" class="form-select form-select-sm">
+                        <option value="deny" selected>deny</option>
+                        <option value="allow">allow</option>
+                    </select>
+                </div>
+            </div>
+            <div class="row g-2 mb-2">
+                <div class="col-sm-3">
+                    <label class="form-label small">Target type</label>
+                    <input type="text" name="target_type" class="form-control form-control-sm" maxlength="20"
+                           placeholder="platform / user / org / licence_type">
+                </div>
+                <div class="col-sm-3">
+                    <label class="form-label small">Target ID</label>
+                    <input type="text" name="target_id" class="form-control form-control-sm" maxlength="50"
+                           placeholder="PWA / Apple / Android / user-ID / org-ID / ccli">
+                </div>
+                <div class="col-sm-2">
+                    <label class="form-label small">Priority</label>
+                    <input type="number" name="priority" class="form-control form-control-sm"
+                           min="0" max="1000" value="100">
+                </div>
+                <div class="col-sm-4">
+                    <label class="form-label small">Reason (shown to user)</label>
+                    <input type="text" name="reason" class="form-control form-control-sm" maxlength="255"
+                           placeholder="e.g. Subscription required for this songbook">
+                </div>
+            </div>
+            <button type="submit" class="btn btn-amber-solid btn-sm mt-2">
+                <i class="bi bi-plus me-1"></i>Add rule
+            </button>
+            <p class="text-muted small mt-3 mb-0">
+                <strong>Tips.</strong>
+                Entity ID <code>*</code> matches every entity of the selected type.
+                For <em>Require licence</em> set Target ID to the licence type (e.g. <code>ccli</code>).
+                For <em>Require organisation</em> leave Target ID blank to require any org, or set an org ID to require a specific one.
+            </p>
+        </form>
+
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+            integrity="sha384-zKzgIZcXU99qF1nNW9g+x1znB5NhCPs9qZeGzUnnFOaHJF9jCCKySBjq3vIKabk/"
+            crossorigin="anonymous"></script>
+
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>
+</body>
+</html>

--- a/appWeb/public_html/manage/restrictions.php
+++ b/appWeb/public_html/manage/restrictions.php
@@ -315,8 +315,10 @@ $csrf = csrfToken();
                                         <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
                                         <input type="hidden" name="action" value="delete">
                                         <input type="hidden" name="id" value="<?= (int)$r['Id'] ?>">
-                                        <button type="submit" class="btn btn-sm btn-outline-danger" title="Remove rule">
-                                            <i class="bi bi-trash"></i>
+                                        <button type="submit" class="btn btn-sm btn-outline-danger"
+                                                title="Remove rule"
+                                                aria-label="Remove restriction rule">
+                                            <i class="bi bi-trash" aria-hidden="true"></i>
                                         </button>
                                     </form>
                                 </td>

--- a/appWeb/public_html/manage/tiers.php
+++ b/appWeb/public_html/manage/tiers.php
@@ -1,0 +1,398 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Admin: Access Tiers
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * Manage the `tblAccessTiers` catalogue — the tier catalogue controls which
+ * regular users can view copyrighted lyrics, play audio, download MIDI,
+ * download sheet-music PDFs, and save songs offline. Each user carries an
+ * `AccessTier` name on `tblUsers`; the client-side checks use
+ * ?action=tier_check in api.php.
+ *
+ * Defaults seeded in schema.sql: public / free / ccli / premium / pro.
+ *
+ * Gated by the `manage_access_tiers` entitlement.
+ */
+
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'entitlements.php';
+
+if (!isAuthenticated()) {
+    header('Location: /manage/login');
+    exit;
+}
+$currentUser = getCurrentUser();
+if (!$currentUser || !userHasEntitlement('manage_access_tiers', $currentUser['role'] ?? null)) {
+    http_response_code(403);
+    echo '<!DOCTYPE html><html><body><h1>403 — manage_access_tiers required</h1></body></html>';
+    exit;
+}
+$activePage = 'tiers';
+
+$error   = '';
+$success = '';
+$db      = getDb();
+
+/* Ordered list of capability columns — used for both the table header
+   and as the authoritative input/update list, so adding a new capability
+   on the schema is a one-line change here. */
+const TIER_CAPS = [
+    'CanViewLyrics'      => ['Lyrics',       'View song lyrics'],
+    'CanViewCopyrighted' => ['Copyrighted',  'View copyrighted songs'],
+    'CanPlayAudio'       => ['Audio',        'Play MIDI / audio in-app'],
+    'CanDownloadMidi'    => ['MIDI',         'Download MIDI files'],
+    'CanDownloadPdf'     => ['PDF',          'Download sheet-music PDFs'],
+    'CanOfflineSave'     => ['Offline',      'Save songs for offline use'],
+    'RequiresCcli'       => ['Needs CCLI',   'Tier requires a valid CCLI licence number'],
+];
+
+$validName = function (string $n): ?string {
+    $n = trim($n);
+    if ($n === '')                         return 'Name is required.';
+    if (strlen($n) > 30)                   return 'Name must be 30 characters or fewer.';
+    if (!preg_match('/^[a-z0-9_]+$/', $n)) return 'Name must be lowercase letters, digits, or underscore.';
+    return null;
+};
+
+/* ----- POST actions ----- */
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!validateCsrf((string)($_POST['csrf_token'] ?? ''))) {
+        http_response_code(403);
+        echo 'Invalid CSRF token';
+        exit;
+    }
+
+    $action = (string)($_POST['action'] ?? '');
+    try {
+        switch ($action) {
+            case 'create': {
+                $name        = strtolower(trim((string)($_POST['name']         ?? '')));
+                $displayName = trim((string)($_POST['display_name']            ?? ''));
+                $level       = (int)($_POST['level']                           ?? 0);
+                $description = trim((string)($_POST['description']             ?? ''));
+
+                if ($e = $validName($name))       { $error = $e; break; }
+                if ($displayName === '')          { $error = 'Display name is required.'; break; }
+                if ($level < 0 || $level > 1000)  { $error = 'Level must be between 0 and 1000.'; break; }
+
+                $stmt = $db->prepare('SELECT Id FROM tblAccessTiers WHERE Name = ?');
+                $stmt->execute([$name]);
+                if ($stmt->fetch()) { $error = 'A tier with that name already exists.'; break; }
+
+                $caps = [];
+                foreach (array_keys(TIER_CAPS) as $col) {
+                    $caps[$col] = !empty($_POST['cap_' . $col]) ? 1 : 0;
+                }
+
+                $cols = array_merge(['Name','DisplayName','Level','Description'], array_keys(TIER_CAPS));
+                $placeholders = implode(', ', array_fill(0, count($cols), '?'));
+                $sql = 'INSERT INTO tblAccessTiers (' . implode(',', $cols) . ') VALUES (' . $placeholders . ')';
+                $stmt = $db->prepare($sql);
+                $stmt->execute(array_merge([$name, $displayName, $level, $description], array_values($caps)));
+                $success = "Tier '{$name}' created.";
+                break;
+            }
+
+            case 'update': {
+                $id          = (int)($_POST['id']                              ?? 0);
+                $displayName = trim((string)($_POST['display_name']            ?? ''));
+                $level       = (int)($_POST['level']                           ?? 0);
+                $description = trim((string)($_POST['description']             ?? ''));
+
+                if ($id <= 0)                    { $error = 'Tier id missing.'; break; }
+                if ($displayName === '')         { $error = 'Display name is required.'; break; }
+                if ($level < 0 || $level > 1000) { $error = 'Level must be between 0 and 1000.'; break; }
+
+                $caps = [];
+                foreach (array_keys(TIER_CAPS) as $col) {
+                    $caps[$col] = !empty($_POST['cap_' . $col]) ? 1 : 0;
+                }
+
+                $sets = ['DisplayName = ?', 'Level = ?', 'Description = ?'];
+                $args = [$displayName, $level, $description];
+                foreach ($caps as $col => $val) {
+                    $sets[] = "$col = ?";
+                    $args[] = $val;
+                }
+                $args[] = $id;
+
+                $stmt = $db->prepare(
+                    'UPDATE tblAccessTiers SET ' . implode(', ', $sets) . ' WHERE Id = ?'
+                );
+                $stmt->execute($args);
+                $success = 'Tier updated.';
+                break;
+            }
+
+            case 'delete': {
+                $id = (int)($_POST['id'] ?? 0);
+                $stmt = $db->prepare('SELECT Name FROM tblAccessTiers WHERE Id = ?');
+                $stmt->execute([$id]);
+                $name = (string)($stmt->fetchColumn() ?: '');
+                if ($name === '') { $error = 'Tier not found.'; break; }
+
+                $stmt = $db->prepare('SELECT COUNT(*) FROM tblUsers WHERE AccessTier = ?');
+                $stmt->execute([$name]);
+                $inUse = (int)$stmt->fetchColumn();
+                if ($inUse > 0) {
+                    $error = "Cannot delete '{$name}': {$inUse} user(s) are currently on this tier. Reassign them first.";
+                    break;
+                }
+
+                $stmt = $db->prepare('DELETE FROM tblAccessTiers WHERE Id = ?');
+                $stmt->execute([$id]);
+                $success = "Tier '{$name}' deleted.";
+                break;
+            }
+
+            default:
+                $error = 'Unknown action.';
+        }
+    } catch (\Throwable $e) {
+        error_log('[manage/tiers.php] ' . $e->getMessage());
+        $error = $error ?: 'Database error — check server logs for details.';
+    }
+}
+
+/* ----- GET: tiers + per-tier user counts ----- */
+$tiers = [];
+try {
+    $capsCols = implode(', ', array_keys(TIER_CAPS));
+    $rs = $db->query(
+        "SELECT t.Id, t.Name, t.DisplayName, t.Level, t.Description, $capsCols,
+                (SELECT COUNT(*) FROM tblUsers u WHERE u.AccessTier = t.Name) AS UserCount
+           FROM tblAccessTiers t
+          ORDER BY t.Level ASC, t.Name ASC"
+    );
+    $tiers = $rs->fetchAll(PDO::FETCH_ASSOC);
+} catch (\Throwable $e) {
+    error_log('[manage/tiers.php] ' . $e->getMessage());
+    $error = $error ?: 'Could not load tiers.';
+}
+
+$csrf = csrfToken();
+?>
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Access Tiers — iHymns Admin</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
+          integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
+          integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">
+    <link rel="stylesheet" href="/css/app.css?v=<?= filemtime(dirname(__DIR__) . '/css/app.css') ?>">
+    <link rel="stylesheet" href="/css/admin.css?v=<?= filemtime(dirname(__DIR__) . '/css/admin.css') ?>">
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-favicon.php'; ?>
+</head>
+<body>
+
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-nav.php'; ?>
+
+    <div class="container py-4" style="max-width: 1200px;">
+
+        <h1 class="h4 mb-3"><i class="bi bi-stars me-2"></i>Access Tiers</h1>
+        <p class="text-secondary small mb-4">
+            Each regular user carries an access tier (<code>tblUsers.AccessTier</code>) that controls
+            whether they see copyrighted lyrics, play audio, or download MIDI / sheet music / offline
+            content. Higher <em>Level</em> values are treated as more privileged.
+            Assign tiers per user from <a href="/manage/users" class="text-info">User Management</a>.
+        </p>
+
+        <?php if ($success): ?>
+            <div class="alert alert-success py-2"><?= htmlspecialchars($success) ?></div>
+        <?php endif; ?>
+        <?php if ($error): ?>
+            <div class="alert alert-danger py-2"><?= htmlspecialchars($error) ?></div>
+        <?php endif; ?>
+
+        <!-- Tier matrix -->
+        <div class="card-admin p-3 mb-4">
+            <h2 class="h6 mb-3">All tiers</h2>
+            <div class="table-responsive">
+                <table class="table table-sm align-middle mb-0">
+                    <thead>
+                        <tr class="text-muted small">
+                            <th>Name</th>
+                            <th>Display</th>
+                            <th class="text-center">Level</th>
+                            <?php foreach (TIER_CAPS as $col => [$lbl, $hint]): ?>
+                                <th class="text-center" title="<?= htmlspecialchars($hint) ?>"><?= htmlspecialchars($lbl) ?></th>
+                            <?php endforeach; ?>
+                            <th class="text-center">Users</th>
+                            <th class="text-end">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($tiers as $t): ?>
+                            <tr>
+                                <td><code><?= htmlspecialchars($t['Name']) ?></code></td>
+                                <td><?= htmlspecialchars($t['DisplayName']) ?></td>
+                                <td class="text-center"><?= (int)$t['Level'] ?></td>
+                                <?php foreach (array_keys(TIER_CAPS) as $col): ?>
+                                    <td class="text-center">
+                                        <?= (int)$t[$col]
+                                            ? '<i class="bi bi-check-circle text-success"></i>'
+                                            : '<i class="bi bi-dash text-muted"></i>' ?>
+                                    </td>
+                                <?php endforeach; ?>
+                                <td class="text-center"><?= (int)$t['UserCount'] ?></td>
+                                <td class="text-end">
+                                    <button type="button" class="btn btn-sm btn-outline-info" title="Edit"
+                                            onclick='openEditTier(<?= json_encode($t, JSON_HEX_APOS | JSON_HEX_QUOT) ?>)'>
+                                        <i class="bi bi-pencil"></i>
+                                    </button>
+                                    <?php if ((int)$t['UserCount'] === 0): ?>
+                                        <form method="POST" class="d-inline"
+                                              onsubmit="return confirm('Delete tier <?= htmlspecialchars($t['Name'], ENT_QUOTES) ?>?')">
+                                            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                                            <input type="hidden" name="action" value="delete">
+                                            <input type="hidden" name="id" value="<?= (int)$t['Id'] ?>">
+                                            <button type="submit" class="btn btn-sm btn-outline-danger" title="Delete (no users)">
+                                                <i class="bi bi-trash"></i>
+                                            </button>
+                                        </form>
+                                    <?php else: ?>
+                                        <button type="button" class="btn btn-sm btn-outline-secondary" disabled
+                                                title="In use — reassign users first">
+                                            <i class="bi bi-trash"></i>
+                                        </button>
+                                    <?php endif; ?>
+                                </td>
+                            </tr>
+                            <?php if (!empty($t['Description'])): ?>
+                                <tr><td colspan="<?= 4 + count(TIER_CAPS) + 2 ?>" class="small text-muted pt-0">
+                                    <?= htmlspecialchars($t['Description']) ?>
+                                </td></tr>
+                            <?php endif; ?>
+                        <?php endforeach; ?>
+                        <?php if (!$tiers): ?>
+                            <tr><td colspan="<?= 4 + count(TIER_CAPS) + 2 ?>" class="text-muted text-center py-4">
+                                No tiers defined. Run the DB installer or add one below.
+                            </td></tr>
+                        <?php endif; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <!-- Create -->
+        <form method="POST" class="card-admin p-3 mb-4">
+            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+            <input type="hidden" name="action" value="create">
+            <h2 class="h6 mb-3"><i class="bi bi-plus-circle me-2"></i>Add a tier</h2>
+            <div class="row g-2 mb-2">
+                <div class="col-sm-3">
+                    <label class="form-label small">Name (machine)</label>
+                    <input type="text" name="name" class="form-control form-control-sm" maxlength="30" required
+                           placeholder="e.g. premium_plus" pattern="[a-z0-9_]+">
+                </div>
+                <div class="col-sm-3">
+                    <label class="form-label small">Display name</label>
+                    <input type="text" name="display_name" class="form-control form-control-sm" maxlength="50" required
+                           placeholder="e.g. Premium Plus">
+                </div>
+                <div class="col-sm-2">
+                    <label class="form-label small">Level</label>
+                    <input type="number" name="level" class="form-control form-control-sm" min="0" max="1000" value="50">
+                </div>
+                <div class="col-sm-4">
+                    <label class="form-label small">Description</label>
+                    <input type="text" name="description" class="form-control form-control-sm"
+                           placeholder="What does this tier unlock?">
+                </div>
+            </div>
+            <div class="d-flex flex-wrap gap-3 mt-2">
+                <?php foreach (TIER_CAPS as $col => [$lbl, $hint]): ?>
+                    <div class="form-check" title="<?= htmlspecialchars($hint) ?>">
+                        <input class="form-check-input" type="checkbox" name="cap_<?= $col ?>" id="new-cap-<?= $col ?>" value="1">
+                        <label class="form-check-label" for="new-cap-<?= $col ?>"><?= htmlspecialchars($lbl) ?></label>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+            <button type="submit" class="btn btn-amber-solid btn-sm mt-3">
+                <i class="bi bi-plus me-1"></i>Create tier
+            </button>
+        </form>
+
+    </div>
+
+    <!-- Edit Tier Modal -->
+    <div class="modal fade" id="editTierModal" tabindex="-1">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content" style="background: var(--ih-surface); color: var(--ih-text); border-color: var(--ih-border);">
+                <form method="POST">
+                    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                    <input type="hidden" name="action" value="update">
+                    <input type="hidden" name="id" id="edit-tier-id">
+                    <div class="modal-header" style="border-color: var(--ih-border);">
+                        <h5 class="modal-title">
+                            <i class="bi bi-pencil me-2"></i>Edit tier — <code id="edit-tier-name"></code>
+                        </h5>
+                        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+                    </div>
+                    <div class="modal-body">
+                        <div class="row g-2 mb-3">
+                            <div class="col-sm-6">
+                                <label class="form-label small">Display name</label>
+                                <input type="text" name="display_name" id="edit-tier-display" class="form-control form-control-sm" required>
+                            </div>
+                            <div class="col-sm-3">
+                                <label class="form-label small">Level</label>
+                                <input type="number" name="level" id="edit-tier-level" class="form-control form-control-sm" min="0" max="1000">
+                            </div>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label small">Description</label>
+                            <input type="text" name="description" id="edit-tier-description" class="form-control form-control-sm">
+                        </div>
+                        <div class="d-flex flex-wrap gap-3">
+                            <?php foreach (TIER_CAPS as $col => [$lbl, $hint]): ?>
+                                <div class="form-check" title="<?= htmlspecialchars($hint) ?>">
+                                    <input class="form-check-input edit-cap" type="checkbox"
+                                           name="cap_<?= $col ?>" id="edit-cap-<?= $col ?>"
+                                           data-cap="<?= htmlspecialchars($col) ?>" value="1">
+                                    <label class="form-check-label" for="edit-cap-<?= $col ?>"><?= htmlspecialchars($lbl) ?></label>
+                                </div>
+                            <?php endforeach; ?>
+                        </div>
+                        <p class="form-text mt-3 mb-0">
+                            Tier name (machine key) cannot be changed — it's referenced by
+                            <code>tblUsers.AccessTier</code> and the <code>tier_check</code> API.
+                        </p>
+                    </div>
+                    <div class="modal-footer" style="border-color: var(--ih-border);">
+                        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                        <button type="submit" class="btn btn-amber-solid">Save changes</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+            integrity="sha384-zKzgIZcXU99qF1nNW9g+x1znB5NhCPs9qZeGzUnnFOaHJF9jCCKySBjq3vIKabk/"
+            crossorigin="anonymous"></script>
+    <script>
+        function openEditTier(t) {
+            document.getElementById('edit-tier-id').value          = t.Id;
+            document.getElementById('edit-tier-name').textContent  = t.Name;
+            document.getElementById('edit-tier-display').value     = t.DisplayName ?? '';
+            document.getElementById('edit-tier-level').value       = t.Level ?? 0;
+            document.getElementById('edit-tier-description').value = t.Description ?? '';
+            document.querySelectorAll('.edit-cap').forEach(cb => {
+                const col = cb.dataset.cap;
+                cb.checked = Number(t[col]) === 1;
+            });
+            new bootstrap.Modal(document.getElementById('editTierModal')).show();
+        }
+    </script>
+
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>
+</body>
+</html>

--- a/appWeb/public_html/manage/tiers.php
+++ b/appWeb/public_html/manage/tiers.php
@@ -175,6 +175,11 @@ try {
 }
 
 $csrf = csrfToken();
+
+/* Total column count for the tier matrix table — used for colspans on
+   the description row and empty-state row. Static columns:
+     Name, Display, Level, ...TIER_CAPS..., Users, Actions */
+$tierTableCols = 3 + count(TIER_CAPS) + 2;
 ?>
 <!DOCTYPE html>
 <html lang="en" data-bs-theme="dark">
@@ -243,9 +248,11 @@ $csrf = csrfToken();
                                 <?php endforeach; ?>
                                 <td class="text-center"><?= (int)$t['UserCount'] ?></td>
                                 <td class="text-end">
-                                    <button type="button" class="btn btn-sm btn-outline-info" title="Edit"
-                                            onclick='openEditTier(<?= json_encode($t, JSON_HEX_APOS | JSON_HEX_QUOT) ?>)'>
-                                        <i class="bi bi-pencil"></i>
+                                    <button type="button" class="btn btn-sm btn-outline-info"
+                                            title="Edit tier"
+                                            aria-label="Edit tier <?= htmlspecialchars($t['Name'], ENT_QUOTES) ?>"
+                                            onclick='openEditTier(<?= json_encode($t, JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_TAG | JSON_HEX_AMP) ?>)'>
+                                        <i class="bi bi-pencil" aria-hidden="true"></i>
                                     </button>
                                     <?php if ((int)$t['UserCount'] === 0): ?>
                                         <form method="POST" class="d-inline"
@@ -253,26 +260,29 @@ $csrf = csrfToken();
                                             <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
                                             <input type="hidden" name="action" value="delete">
                                             <input type="hidden" name="id" value="<?= (int)$t['Id'] ?>">
-                                            <button type="submit" class="btn btn-sm btn-outline-danger" title="Delete (no users)">
-                                                <i class="bi bi-trash"></i>
+                                            <button type="submit" class="btn btn-sm btn-outline-danger"
+                                                    title="Delete tier"
+                                                    aria-label="Delete tier <?= htmlspecialchars($t['Name'], ENT_QUOTES) ?>">
+                                                <i class="bi bi-trash" aria-hidden="true"></i>
                                             </button>
                                         </form>
                                     <?php else: ?>
                                         <button type="button" class="btn btn-sm btn-outline-secondary" disabled
-                                                title="In use — reassign users first">
-                                            <i class="bi bi-trash"></i>
+                                                title="In use — reassign users first"
+                                                aria-label="Delete tier <?= htmlspecialchars($t['Name'], ENT_QUOTES) ?> (disabled: users still on this tier)">
+                                            <i class="bi bi-trash" aria-hidden="true"></i>
                                         </button>
                                     <?php endif; ?>
                                 </td>
                             </tr>
                             <?php if (!empty($t['Description'])): ?>
-                                <tr><td colspan="<?= 4 + count(TIER_CAPS) + 2 ?>" class="small text-muted pt-0">
+                                <tr><td colspan="<?= $tierTableCols ?>" class="small text-muted pt-0">
                                     <?= htmlspecialchars($t['Description']) ?>
                                 </td></tr>
                             <?php endif; ?>
                         <?php endforeach; ?>
                         <?php if (!$tiers): ?>
-                            <tr><td colspan="<?= 4 + count(TIER_CAPS) + 2 ?>" class="text-muted text-center py-4">
+                            <tr><td colspan="<?= $tierTableCols ?>" class="text-muted text-center py-4">
                                 No tiers defined. Run the DB installer or add one below.
                             </td></tr>
                         <?php endif; ?>
@@ -323,7 +333,7 @@ $csrf = csrfToken();
     </div>
 
     <!-- Edit Tier Modal -->
-    <div class="modal fade" id="editTierModal" tabindex="-1">
+    <div class="modal fade" id="editTierModal" tabindex="-1" aria-labelledby="editTierModalLabel" aria-hidden="true">
         <div class="modal-dialog modal-lg">
             <div class="modal-content" style="background: var(--ih-surface); color: var(--ih-text); border-color: var(--ih-border);">
                 <form method="POST">
@@ -331,8 +341,8 @@ $csrf = csrfToken();
                     <input type="hidden" name="action" value="update">
                     <input type="hidden" name="id" id="edit-tier-id">
                     <div class="modal-header" style="border-color: var(--ih-border);">
-                        <h5 class="modal-title">
-                            <i class="bi bi-pencil me-2"></i>Edit tier — <code id="edit-tier-name"></code>
+                        <h5 class="modal-title" id="editTierModalLabel">
+                            <i class="bi bi-pencil me-2" aria-hidden="true"></i>Edit tier — <code id="edit-tier-name"></code>
                         </h5>
                         <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
                     </div>

--- a/appWeb/public_html/manage/users.php
+++ b/appWeb/public_html/manage/users.php
@@ -59,7 +59,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 } else {
                     try {
                         createUser($username, $password, $displayName ?: $username, $role);
-                        $success = 'User "' . htmlspecialchars($username) . '" created successfully.';
+                        $success = 'User "' . $username . '" created successfully.';
                     } catch (\RuntimeException $e) {
                         $error = $e->getMessage();
                     }
@@ -108,7 +108,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     $error = 'Cannot reset password for a user at or above your role level.';
                 } else {
                     changeUserPassword($targetId, $newPassword);
-                    $success = 'Password reset successfully for "' . htmlspecialchars($target['username']) . '".';
+                    $success = 'Password reset successfully for "' . $target['username'] . '".';
                 }
                 break;
 
@@ -126,7 +126,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     $error = 'Display name cannot be empty.';
                 } else {
                     updateUserProfile($targetId, $displayName, $email);
-                    $success = 'Profile updated for "' . htmlspecialchars($target['username']) . '".';
+                    $success = 'Profile updated for "' . $target['username'] . '".';
                 }
                 break;
 
@@ -142,8 +142,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 } else {
                     $renameError = null;
                     if (renameUser($targetId, $newUsername, $renameError)) {
-                        $success = 'User "' . htmlspecialchars($target['username'])
-                                 . '" renamed to "' . htmlspecialchars(mb_strtolower(trim($newUsername))) . '".';
+                        $success = 'User "' . $target['username']
+                                 . '" renamed to "' . mb_strtolower(trim($newUsername)) . '".';
                     } else {
                         $error = $renameError ?? 'Could not rename user.';
                     }
@@ -170,7 +170,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     } else {
                         $stmt = $db->prepare('UPDATE tblUsers SET AccessTier = ?, UpdatedAt = CURRENT_TIMESTAMP WHERE Id = ?');
                         $stmt->execute([$newTier, $targetId]);
-                        $success = 'Access tier updated for "' . htmlspecialchars($target['username']) . '".';
+                        $success = 'Access tier updated for "' . $target['username'] . '".';
                     }
                 }
                 break;
@@ -187,7 +187,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     $error = 'Cannot delete a user at or above your role level.';
                 } else {
                     deleteUser($targetId);
-                    $success = 'User "' . htmlspecialchars($target['username']) . '" deleted permanently.';
+                    $success = 'User "' . $target['username'] . '" deleted permanently.';
                 }
                 break;
         }
@@ -253,7 +253,7 @@ function canManage(array $target, array $actor): bool {
 
         <?php if ($success): ?>
             <div class="alert alert-success py-2 alert-dismissible fade show">
-                <i class="bi bi-check-circle me-1"></i><?= $success ?>
+                <i class="bi bi-check-circle me-1"></i><?= htmlspecialchars($success) ?>
                 <button type="button" class="btn-close btn-close-white" data-bs-dismiss="alert"></button>
             </div>
         <?php endif; ?>
@@ -327,15 +327,17 @@ function canManage(array $target, array $actor): bool {
                                     <!-- Change Role (not for self) -->
                                     <?php if (!$isSelf): ?>
                                     <button class="btn btn-outline-warning" title="Change role"
-                                            onclick="openRoleModal(<?= (int)$u['id'] ?>, '<?= htmlspecialchars($u['username'], ENT_QUOTES) ?>', '<?= $u['role'] ?>')">
+                                            onclick="openRoleModal(<?= (int)$u['id'] ?>, '<?= htmlspecialchars($u['username'], ENT_QUOTES) ?>', '<?= htmlspecialchars((string)$u['role'], ENT_QUOTES) ?>')">
                                         <i class="bi bi-shield"></i>
                                     </button>
                                     <?php endif; ?>
                                     <!-- Change Access Tier -->
                                     <?php if ($canAssignTier): ?>
-                                    <button class="btn btn-outline-info" title="Change access tier"
+                                    <button type="button" class="btn btn-outline-info"
+                                            title="Change access tier"
+                                            aria-label="Change access tier for <?= htmlspecialchars($u['username'], ENT_QUOTES) ?>"
                                             onclick="openTierModal(<?= (int)$u['id'] ?>, '<?= htmlspecialchars($u['username'], ENT_QUOTES) ?>', '<?= htmlspecialchars((string)($u['access_tier'] ?? ''), ENT_QUOTES) ?>')">
-                                        <i class="bi bi-stars"></i>
+                                        <i class="bi bi-stars" aria-hidden="true"></i>
                                     </button>
                                     <?php endif; ?>
                                     <!-- Reset Password -->
@@ -536,7 +538,7 @@ function canManage(array $target, array $actor): bool {
 
     <!-- Change Access Tier Modal -->
     <?php if ($canAssignTier): ?>
-    <div class="modal fade" id="tierModal" tabindex="-1">
+    <div class="modal fade" id="tierModal" tabindex="-1" aria-labelledby="tierModalLabel" aria-hidden="true">
         <div class="modal-dialog">
             <div class="modal-content" style="background: var(--ih-surface); color: var(--ih-text); border-color: var(--ih-border);">
                 <form method="POST">
@@ -544,7 +546,7 @@ function canManage(array $target, array $actor): bool {
                     <input type="hidden" name="action" value="change_tier">
                     <input type="hidden" name="user_id" id="tier-user-id">
                     <div class="modal-header" style="border-color: var(--ih-border);">
-                        <h5 class="modal-title"><i class="bi bi-stars me-2"></i>Change Access Tier — <span id="tier-username"></span></h5>
+                        <h5 class="modal-title" id="tierModalLabel"><i class="bi bi-stars me-2" aria-hidden="true"></i>Change Access Tier — <span id="tier-username"></span></h5>
                         <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
                     </div>
                     <div class="modal-body">

--- a/appWeb/public_html/manage/users.php
+++ b/appWeb/public_html/manage/users.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
  */
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'entitlements.php';
 requireAdmin();
 
 $currentUser = getCurrentUser();
@@ -149,6 +150,31 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 }
                 break;
 
+            /* ----- Change access tier ----- */
+            case 'change_tier':
+                $targetId = (int)($_POST['user_id']    ?? 0);
+                $newTier  = trim((string)($_POST['new_tier'] ?? ''));
+                $target   = getUserById($targetId);
+                if (!userHasEntitlement('assign_user_tier', $currentUser['role'] ?? null)) {
+                    $error = 'You do not have permission to change access tiers.';
+                } elseif (!$target) {
+                    $error = 'User not found.';
+                } elseif ($newTier === '') {
+                    $error = 'Pick a tier.';
+                } else {
+                    $db = getDb();
+                    $stmt = $db->prepare('SELECT 1 FROM tblAccessTiers WHERE Name = ?');
+                    $stmt->execute([$newTier]);
+                    if (!$stmt->fetch()) {
+                        $error = 'Unknown access tier.';
+                    } else {
+                        $stmt = $db->prepare('UPDATE tblUsers SET AccessTier = ?, UpdatedAt = CURRENT_TIMESTAMP WHERE Id = ?');
+                        $stmt->execute([$newTier, $targetId]);
+                        $success = 'Access tier updated for "' . htmlspecialchars($target['username']) . '".';
+                    }
+                }
+                break;
+
             /* ----- Delete user ----- */
             case 'delete':
                 $targetId = (int)($_POST['user_id'] ?? 0);
@@ -176,7 +202,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
  * ========================================================================= */
 
 $db = getDb();
-$users = $db->query('SELECT Id AS id, Username AS username, DisplayName AS display_name, Email AS email, Role AS role, IsActive AS is_active, CreatedAt AS created_at FROM tblUsers ORDER BY CreatedAt ASC')->fetchAll(PDO::FETCH_ASSOC);
+$users = $db->query('SELECT Id AS id, Username AS username, DisplayName AS display_name, Email AS email, Role AS role, IsActive AS is_active, AccessTier AS access_tier, CreatedAt AS created_at FROM tblUsers ORDER BY CreatedAt ASC')->fetchAll(PDO::FETCH_ASSOC);
+
+/* Available access tiers for the Change-tier modal. Falls back to an empty
+   list if the table is missing (e.g. pre-migration DB) — in that case the
+   Tier button is hidden rather than breaking the page. */
+$accessTiers = [];
+try {
+    $accessTiers = $db->query(
+        'SELECT Name, DisplayName, Level FROM tblAccessTiers ORDER BY Level ASC, Name ASC'
+    )->fetchAll(PDO::FETCH_ASSOC);
+} catch (\Throwable $_e) { /* tier table not installed yet — hide control */ }
+
+$canAssignTier = !empty($accessTiers) && userHasEntitlement('assign_user_tier', $currentUser['role'] ?? null);
 
 $csrf = csrfToken();
 
@@ -237,6 +275,7 @@ function canManage(array $target, array $actor): bool {
                             <th>Display Name</th>
                             <th>Email</th>
                             <th>Role</th>
+                            <th title="Access tier — controls lyrics / audio / MIDI / PDF / offline access for regular users">Tier</th>
                             <th>Status</th>
                             <th class="text-end">Actions</th>
                         </tr>
@@ -259,6 +298,11 @@ function canManage(array $target, array $actor): bool {
                                     default        => 'bg-secondary',
                                 } ?>" style="font-size: 0.7rem;">
                                     <?= htmlspecialchars(roleLabel($u['role'])) ?>
+                                </span>
+                            </td>
+                            <td>
+                                <span class="badge bg-dark border border-secondary text-light" style="font-size: 0.7rem;">
+                                    <?= htmlspecialchars((string)($u['access_tier'] ?? 'free')) ?>
                                 </span>
                             </td>
                             <td>
@@ -285,6 +329,13 @@ function canManage(array $target, array $actor): bool {
                                     <button class="btn btn-outline-warning" title="Change role"
                                             onclick="openRoleModal(<?= (int)$u['id'] ?>, '<?= htmlspecialchars($u['username'], ENT_QUOTES) ?>', '<?= $u['role'] ?>')">
                                         <i class="bi bi-shield"></i>
+                                    </button>
+                                    <?php endif; ?>
+                                    <!-- Change Access Tier -->
+                                    <?php if ($canAssignTier): ?>
+                                    <button class="btn btn-outline-info" title="Change access tier"
+                                            onclick="openTierModal(<?= (int)$u['id'] ?>, '<?= htmlspecialchars($u['username'], ENT_QUOTES) ?>', '<?= htmlspecialchars((string)($u['access_tier'] ?? ''), ENT_QUOTES) ?>')">
+                                        <i class="bi bi-stars"></i>
                                     </button>
                                     <?php endif; ?>
                                     <!-- Reset Password -->
@@ -483,6 +534,46 @@ function canManage(array $target, array $actor): bool {
         </div>
     </div>
 
+    <!-- Change Access Tier Modal -->
+    <?php if ($canAssignTier): ?>
+    <div class="modal fade" id="tierModal" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content" style="background: var(--ih-surface); color: var(--ih-text); border-color: var(--ih-border);">
+                <form method="POST">
+                    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                    <input type="hidden" name="action" value="change_tier">
+                    <input type="hidden" name="user_id" id="tier-user-id">
+                    <div class="modal-header" style="border-color: var(--ih-border);">
+                        <h5 class="modal-title"><i class="bi bi-stars me-2"></i>Change Access Tier — <span id="tier-username"></span></h5>
+                        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+                    </div>
+                    <div class="modal-body">
+                        <label class="form-label small">Access tier</label>
+                        <select class="form-select" name="new_tier" id="tier-select">
+                            <?php foreach ($accessTiers as $at): ?>
+                                <option value="<?= htmlspecialchars($at['Name']) ?>">
+                                    <?= htmlspecialchars($at['DisplayName']) ?>
+                                    — <code><?= htmlspecialchars($at['Name']) ?></code>
+                                    (level <?= (int)$at['Level'] ?>)
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                        <div class="form-text" style="color: var(--ih-text-muted);">
+                            Controls whether the user can view copyrighted lyrics, play audio,
+                            download MIDI / sheet music, and save songs offline. Tiers are defined in
+                            <a href="/manage/tiers" class="text-info">Access Tiers</a>.
+                        </div>
+                    </div>
+                    <div class="modal-footer" style="border-color: var(--ih-border);">
+                        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                        <button type="submit" class="btn btn-amber-solid">Update tier</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+    <?php endif; ?>
+
     <!-- Reset Password Modal -->
     <div class="modal fade" id="passwordModal" tabindex="-1">
         <div class="modal-dialog">
@@ -540,6 +631,18 @@ function canManage(array $target, array $actor): bool {
             document.getElementById('pw-user-id').value = userId;
             document.getElementById('pw-username').textContent = username;
             new bootstrap.Modal(document.getElementById('passwordModal')).show();
+        }
+
+        /* Open Change-tier modal */
+        function openTierModal(userId, username, currentTier) {
+            document.getElementById('tier-user-id').value = userId;
+            document.getElementById('tier-username').textContent = username;
+            const sel = document.getElementById('tier-select');
+            if (sel && currentTier) {
+                const match = Array.from(sel.options).find(o => o.value === currentTier);
+                if (match) sel.value = currentTier;
+            }
+            new bootstrap.Modal(document.getElementById('tierModal')).show();
         }
 
         /* Open Rename modal */


### PR DESCRIPTION
Closes #443, #444.

## Summary

Reported: `/manage/groups`, `/manage/organisations`, `/manage/songbooks`, `/manage/data-health` all showed "Failed to load page. Please check your connection and try again." This has recurred across multiple releases. Also: the stipulated gating for regular users (song visibility, sheet music, MIDI/audio) had backend plumbing but no admin UI — it was effectively unreachable for non-technical admins.

Three logical commits on this branch:

### 1. `fix(admin): generic clean-URL rewrite so every /manage/<name>.php works` (#443)

**Root cause:** `/manage/.htaccess` had one `RewriteRule` per page. Whoever added `groups.php`, `organisations.php`, `songbooks.php`, `data-health.php`, and `revisions.php` didn't add the matching rules, so Apache 404'd → top-level `ErrorDocument 404 /index.php` → SPA shell → SPA router has no `manage` case → "Failed to load page".

**Fix:** Replaced the per-page rules with one generic rewrite that maps `/manage/<name>` → `/manage/<name>.php` whenever the `.php` file exists. New admin pages are now zero-config — drop the file in and the clean URL works.

### 2. `feat(admin): regular-user content gating — restrictions, tiers, per-user AccessTier` (#444)

Surfaces the long-requested gating controls:

- **`/manage/restrictions` (new)** — CRUD over `tblContentRestrictions`: per-song / per-songbook / per-feature rules that block by platform, user, org or licence (or require a licence / org). Filters by entity + restriction type, shows the master-switch state (`content_gating_enabled`) so admins understand when rules are inert.
- **`/manage/tiers` (new)** — CRUD over `tblAccessTiers`: the catalogue that determines whether a regular user can view copyrighted lyrics, play audio, download MIDI, download sheet music, or save for offline. Refuses to delete a tier that any user still belongs to.
- **`/manage/users`** — New `AccessTier` column + "Change access tier" action (stars icon → modal populated from the live `tblAccessTiers` list). Hides cleanly pre-migration.
- **Dashboard** — Content Restrictions + Access Tiers cards, slotted next to the content-structure group.
- **Entitlements** — new `manage_content_restrictions`, `manage_access_tiers`, `assign_user_tier` entitlements in PHP + JS mirror, admin + global_admin by default.

### 3. `chore(admin): audit fixes — XSS, a11y, colspan`

Findings from a post-build security + accessibility audit:

- **Security (XSS):** `users.php` success banner rendered the `$success` string unescaped at the output, while individual handlers pre-escaped usernames inline. Fixed by escaping at the output boundary and removing the now-redundant pre-escaping. Also escaped `$u['role']` in an `onclick` attribute (whitelist-constrained in practice, but the pattern shouldn't exist).
- **A11y:** Added `type="button"` + `aria-label` to icon-only modal-opener buttons; added `aria-labelledby` to the new Bootstrap modals (`tierModal`, `editTierModal`) with matching label IDs; marked decorative Bootstrap icons `aria-hidden="true"`; gave destructive icon-only buttons explicit aria-labels.
- **Code structure:** Fixed an off-by-one colspan in `tiers.php` (was `4 + count(caps) + 2`, should have been `3 + count(caps) + 2`) and hoisted it into `$tierTableCols`. Hardened the inline `onclick` JSON payload with `JSON_HEX_TAG | JSON_HEX_AMP` in addition to `JSON_HEX_APOS | JSON_HEX_QUOT`.

## Audit results — all categories passed

| Category | Result |
|---|---|
| PHP syntax (all files in `appWeb/`) | ✅ No errors |
| JS syntax (all files in `appWeb/`) | ✅ No errors |
| CSRF | ✅ Every POST form + handler validates `csrf_token` |
| SQL injection | ✅ All queries use PDO prepared statements |
| Access control | ✅ Every page auth + entitlement-gated; `change_tier` double-gated |
| XSS | ✅ All DB-sourced / user-sourced output escaped after fixes |
| Open redirect | ✅ None |
| File inclusion / traversal | ✅ None; `.htaccess` path-normalisation keeps rewrites inside `/manage/` |
| Backdoors / debug toggles | ✅ None |
| A11y: form labels, modal aria, icon-button labels | ✅ After fixes |
| W3C: duplicate IDs, button type, table semantics | ✅ After fixes |

## GitHub issues created as part of this work

Retrospective tracking issues for recent merged PRs that were missing tickets — #437, #436, #435, #434, #433:

- #438 PWA cache staleness → #437
- #439 Collapse header menu to "Manage" → #436
- #440 Back-to-top theme + split header menus → #435
- #441 Favicon + admin footer pinning → #434
- #442 Admin surface phases 1–4 → #433

And for this branch:

- #443 Generic `/manage` rewrite
- #444 Regular-user content gating admin

## Test plan

- [ ] `/manage/groups`, `/manage/organisations`, `/manage/songbooks`, `/manage/data-health`, `/manage/revisions` all load without the "Failed to load page" error.
- [ ] Add a new admin page by dropping a `.php` file into `/manage/` — the clean URL works immediately with no `.htaccess` edit.
- [ ] `/manage/restrictions` — create a `block_platform` rule for a song; verify it appears in the list; delete it.
- [ ] `/manage/restrictions` — banner warns when `content_gating_enabled` is off.
- [ ] `/manage/tiers` — create, edit, and delete a tier with zero users; confirm delete is blocked when users still belong.
- [ ] `/manage/users` — open the "Change access tier" modal for a user; dropdown lists the tiers from `tblAccessTiers`; change and verify persistence.
- [ ] Dashboard shows the two new cards only when the viewer holds the corresponding entitlement.
- [ ] `/manage/foo.php` redirects 301 to `/manage/foo`; `/manage/editor/api?foo=bar` still works with QSA.

https://claude.ai/code/session_01VK9zszCiViesutz7bj27MH

---
_Generated by [Claude Code](https://claude.ai/code/session_01VK9zszCiViesutz7bj27MH)_