### PR TITLE
Offline download fixes (Edge stall) + cloud buttons + toolbar harmonisation + perf wins

### DIFF
--- a/appWeb/.sql/schema.sql
+++ b/appWeb/.sql/schema.sql
@@ -160,6 +160,7 @@ CREATE TABLE IF NOT EXISTS tblUserGroups (
     AccessBeta      TINYINT(1)      NOT NULL DEFAULT 0 COMMENT 'Can access Beta builds',
     AccessRc        TINYINT(1)      NOT NULL DEFAULT 0 COMMENT 'Can access RC (Release Candidate) builds',
     AccessRtw       TINYINT(1)      NOT NULL DEFAULT 1 COMMENT 'Can access RTW (Release to Web / production)',
+    AllowCardReorder TINYINT(1)     NOT NULL DEFAULT 1 COMMENT 'Group members may customise dashboard / home card layout (#448)',
     CreatedAt       TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UpdatedAt       TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -83,6 +83,24 @@ if ($page !== null) {
     /* Set content type for HTML fragments */
     header('Content-Type: text/html; charset=UTF-8');
 
+    /* Cache SPA fragments so bouncing between pages doesn't re-hit the
+       server for content that hasn't changed. Uses ETag + 304 so the
+       body isn't re-sent when the content is unchanged — the service
+       worker can treat fragment responses as cacheable. Logged-in
+       content would need a per-user ETag; this currently covers the
+       same-for-everyone pages (home, songbooks, song, songbook,
+       writer, help, terms, privacy) which make up most navigation.
+       Content-sensitive pages (favorites, setlist, settings, stats)
+       still skip this path because they include user-specific data. */
+    $_cacheablePages = [
+        'home', 'songbooks', 'songbook', 'song', 'search',
+        'writer', 'help', 'terms', 'privacy', 'request-a-song',
+    ];
+    $_shouldCachePage = in_array($page, $_cacheablePages, true);
+    if ($_shouldCachePage) {
+        ob_start();
+    }
+
     /* Route to the appropriate page template */
     switch ($page) {
         case 'home':
@@ -170,6 +188,21 @@ if ($page !== null) {
             http_response_code(404);
             require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'pages' . DIRECTORY_SEPARATOR . 'not-found.php';
             break;
+    }
+
+    if ($_shouldCachePage) {
+        $body = (string)ob_get_clean();
+        /* Include the query string so /api?page=song&id=CP-0001 and
+           /api?page=song&id=CP-0002 hash to different ETags. */
+        $etag = '"' . hash('xxh64', $page . '|' . ($_SERVER['QUERY_STRING'] ?? '') . '|' . $body) . '"';
+        header('ETag: ' . $etag);
+        header('Cache-Control: private, max-age=300, must-revalidate');
+        header('Vary: Cookie, Authorization');
+        if (($_SERVER['HTTP_IF_NONE_MATCH'] ?? '') === $etag) {
+            http_response_code(304);
+            exit;
+        }
+        echo $body;
     }
 
     exit;
@@ -351,11 +384,18 @@ if ($action !== null) {
             }
 
             $rendered = [];
+            /* getSongs() already returns every field song.php reads from
+               $song at bulk-cache time (id, title, number, songbook,
+               songbookName, copyright, ccli, verified, has*, writers,
+               composers, components). The only fields it leaves off —
+               arrangement / capo / key — are optional and rendered with
+               `!empty($song[...])`, so a missing value degrades
+               gracefully. Skipping getSongById() inside this loop drops
+               the per-songbook work from O(2N) to O(N) and eliminates
+               the 800+ extra queries per Church Hymnal bulk fetch. */
             foreach ($bulkSongs as $bulkSong) {
                 $songId = $bulkSong['id'];
-                /* Render the song page HTML into a buffer */
-                $song = $songData->getSongById($songId);
-                if ($song === null) continue;
+                $song = $bulkSong;
 
                 ob_start();
                 require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'pages' . DIRECTORY_SEPARATOR . 'song.php';

--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -46,6 +46,8 @@ require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'SongData.php';
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'content_access.php';
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'entitlements.php';
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'card_layout.php';
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'manage' . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db.php';
 
 /* =========================================================================
@@ -2386,6 +2388,111 @@ if ($action !== null) {
 
             sendJson(['ok' => true]);
             break;
+
+        /* =================================================================
+         * CARD LAYOUT PERSONALISATION (#448)
+         *
+         * Surfaces covered: "dashboard" (= /manage/) and "home" (= /).
+         * Read is public; save endpoints require auth + the appropriate
+         * entitlement. Group-level veto (tblUserGroups.AllowCardReorder)
+         * is enforced inside cardLayoutUserCanCustomise().
+         * ================================================================= */
+
+        case 'card_layout_get': {
+            $surface = (string)($_GET['surface'] ?? '');
+            if (!in_array($surface, CARD_LAYOUT_SURFACES, true)) {
+                sendJson(['error' => 'Invalid surface.'], 400);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            $user = $authUser ? [
+                'id'       => $authUser['Id'] ?? null,
+                'role'     => $authUser['Role'] ?? null,
+                'group_id' => $authUser['GroupId'] ?? null,
+            ] : null;
+            $default = cardLayoutDefault($surface);
+            $override = $user ? cardLayoutUserOverride((int)($user['id'] ?? 0), $surface) : ['order' => [], 'hidden' => []];
+            sendJson([
+                'surface'   => $surface,
+                'default'   => $default,
+                'override'  => $override,
+                'canCustomiseOwn' => cardLayoutUserCanCustomise($user),
+                'canSetDefault'   => $user && userHasEntitlement('manage_default_card_layout', $user['role'] ?? null),
+            ]);
+            break;
+        }
+
+        case 'card_layout_save_user': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST required.'], 405);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser) { sendJson(['error' => 'Auth required.'], 401); break; }
+            $user = [
+                'id'       => $authUser['Id'] ?? null,
+                'role'     => $authUser['Role'] ?? null,
+                'group_id' => $authUser['GroupId'] ?? null,
+            ];
+            if (!cardLayoutUserCanCustomise($user)) {
+                sendJson(['error' => 'Customisation not permitted for this account.'], 403);
+                break;
+            }
+            $body    = json_decode((string)file_get_contents('php://input'), true) ?: [];
+            $surface = (string)($body['surface'] ?? '');
+            if (!in_array($surface, CARD_LAYOUT_SURFACES, true)) {
+                sendJson(['error' => 'Invalid surface.'], 400);
+                break;
+            }
+            $ok = cardLayoutSaveUserOverride((int)$user['id'], $surface, [
+                'order'  => $body['order']  ?? [],
+                'hidden' => $body['hidden'] ?? [],
+            ]);
+            sendJson(['ok' => $ok]);
+            break;
+        }
+
+        case 'card_layout_reset_user': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST required.'], 405);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser) { sendJson(['error' => 'Auth required.'], 401); break; }
+            $body    = json_decode((string)file_get_contents('php://input'), true) ?: [];
+            $surface = (string)($body['surface'] ?? '');
+            if (!in_array($surface, CARD_LAYOUT_SURFACES, true)) {
+                sendJson(['error' => 'Invalid surface.'], 400);
+                break;
+            }
+            $ok = cardLayoutClearUserOverride((int)$authUser['Id'], $surface);
+            sendJson(['ok' => $ok]);
+            break;
+        }
+
+        case 'card_layout_save_default': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST required.'], 405);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser || !userHasEntitlement('manage_default_card_layout', $authUser['Role'] ?? null)) {
+                sendJson(['error' => 'Admin access required.'], 403);
+                break;
+            }
+            $body    = json_decode((string)file_get_contents('php://input'), true) ?: [];
+            $surface = (string)($body['surface'] ?? '');
+            if (!in_array($surface, CARD_LAYOUT_SURFACES, true)) {
+                sendJson(['error' => 'Invalid surface.'], 400);
+                break;
+            }
+            $ok = cardLayoutSaveDefault($surface, [
+                'order'  => $body['order']  ?? [],
+                'hidden' => $body['hidden'] ?? [],
+            ]);
+            sendJson(['ok' => $ok]);
+            break;
+        }
 
         /* =================================================================
          * SONG KEY & TRANSPOSITION (#298)

--- a/appWeb/public_html/css/admin.css
+++ b/appWeb/public_html/css/admin.css
@@ -67,14 +67,21 @@ a:not(.btn):not(.nav-link):not(.dropdown-item):hover {
     right: 0;
     z-index: 1030;
     min-height: var(--admin-navbar-height);
-    backdrop-filter: blur(16px) saturate(180%);
-    -webkit-backdrop-filter: blur(16px) saturate(180%);
-    background: var(--header-bg);
+    /* Keep the solid --surface-card background from the shared rule
+       above. The main app's .app-header uses a translucent glass token
+       because the content scrolling under it provides visual context,
+       but the admin navbar sits above tightly-packed dashboard cards
+       at the same slate-900 tone and disappears when translucent. */
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.35);
 }
 
-/* Admin footer — fixed to the bottom of the viewport, mirroring the
-   main app's .app-footer treatment minus the tab-nav. Shares the same
-   blur / shadow / border tokens so both surfaces feel identical. */
+/* Admin footer — fixed to the bottom of the viewport. Uses the card
+   surface colour (not the translucent --footer-bg glass token) because
+   the admin footer is a thin info strip with no tab-nav beneath it —
+   at 88% opacity over slate-900 body it's indistinguishable from the
+   background. --surface-card (#1e293b dark / #fff light) gives it the
+   same visual weight as the navbar it mirrors, and a stronger top
+   border pulls it away from the content above. */
 .admin-footer-static {
     position: fixed;
     bottom: 0;
@@ -83,12 +90,10 @@ a:not(.btn):not(.nav-link):not(.dropdown-item):hover {
     z-index: 1030;
     padding-top: 0.4rem;
     padding-bottom: 0.4rem;
-    background: var(--footer-bg);
-    backdrop-filter: blur(16px) saturate(180%);
-    -webkit-backdrop-filter: blur(16px) saturate(180%);
-    box-shadow: var(--footer-shadow);
+    background-color: var(--surface-card);
     border-top: 1px solid var(--card-border);
-    min-height: auto;
+    box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.35);
+    min-height: calc(var(--footer-info-height) + 0.2rem);
 }
 
 /* Reserve space above and below the scroll area on admin-dashboard

--- a/appWeb/public_html/css/admin.css
+++ b/appWeb/public_html/css/admin.css
@@ -35,6 +35,20 @@ a:not(.btn):not(.nav-link):not(.dropdown-item):hover {
     color: var(--accent-end);
 }
 
+/* Shared admin page container. Replaces the inline per-page
+   `style="max-width: NNNNpx"` pattern — the hard caps meant every
+   admin dashboard left 300–700 px of dead space on 1440–1920 desktops.
+   Uses the available viewport width with a generous gutter, capped
+   only at ultra-wide widths so long lists don't become unreadable. */
+.container-admin {
+    width: 100%;
+    max-width: min(100%, 1800px);
+    margin-left: auto;
+    margin-right: auto;
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+}
+
 /* ==========================================================================
    SHARED NAVBAR — admin dashboard header & editor top bar
    The dashboard pages pin .navbar-admin to the viewport top, matching the
@@ -125,6 +139,51 @@ body:has(.navbar-admin) {
 .navbar-admin .nav-link:hover,
 .navbar-admin .nav-link.active {
     color: var(--accent-solid);
+}
+
+/* Username + role button next to the avatar dropdown. Compact, low
+   visual weight, and only visible from sm up — xs screens get the
+   avatar alone to keep the bar uncluttered. */
+.admin-identity-btn {
+    background-color: transparent;
+    border: 1px solid transparent;
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    padding: 0.25rem 0.6rem;
+}
+.admin-identity-btn:hover,
+.admin-identity-btn:focus {
+    color: var(--text-primary);
+    border-color: var(--card-border);
+    background-color: rgba(255, 255, 255, 0.03);
+}
+
+/* Offcanvas surface nav — slide-out list launched by the hamburger.
+   Styled to match the dark admin palette rather than Bootstrap's
+   default card-on-white look. */
+#admin-nav-offcanvas {
+    background-color: var(--surface-card);
+    color: var(--text-primary);
+    border-left: 1px solid var(--card-border);
+}
+#admin-nav-offcanvas .list-group-item {
+    background-color: transparent;
+    color: var(--text-secondary);
+    border-color: var(--card-border);
+}
+#admin-nav-offcanvas .list-group-item:hover,
+#admin-nav-offcanvas .list-group-item:focus {
+    color: var(--text-primary);
+    background-color: rgba(255, 255, 255, 0.03);
+}
+#admin-nav-offcanvas .list-group-item.active {
+    background-color: rgba(99, 102, 241, 0.12);
+    color: var(--accent-solid);
+    border-color: transparent;
+}
+#admin-nav-offcanvas .offcanvas-header,
+#admin-nav-offcanvas .offcanvas-footer {
+    border-color: var(--card-border);
 }
 
 /* ==========================================================================

--- a/appWeb/public_html/css/admin.css
+++ b/appWeb/public_html/css/admin.css
@@ -37,7 +37,20 @@ a:not(.btn):not(.nav-link):not(.dropdown-item):hover {
 
 /* ==========================================================================
    SHARED NAVBAR — admin dashboard header & editor top bar
+   The dashboard pages pin .navbar-admin to the viewport top, matching the
+   main app's .app-header behaviour so admins don't lose navigation context
+   on long pages. The Song Editor uses .navbar-editor instead (full-height
+   flex layout with its own toolbar), so the body-padding rule is :has()-
+   scoped to .navbar-admin and doesn't affect it.
    ========================================================================== */
+
+:root {
+    /* Single source of truth for admin chrome sizes. Used by the pinned
+       navbar, the body padding that keeps content clear of it, and the
+       modal-offset tweak below. Keep in sync with the .navbar-admin
+       padding (0.5rem × 2 + content ≈ 56 px on desktop, 64 px below). */
+    --admin-navbar-height: 56px;
+}
 
 .navbar-admin,
 .navbar-editor {
@@ -45,6 +58,18 @@ a:not(.btn):not(.nav-link):not(.dropdown-item):hover {
     border-bottom: 1px solid var(--card-border);
     padding: 0.5rem 1rem;
     box-shadow: var(--card-shadow);
+}
+
+.navbar-admin {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 1030;
+    min-height: var(--admin-navbar-height);
+    backdrop-filter: blur(16px) saturate(180%);
+    -webkit-backdrop-filter: blur(16px) saturate(180%);
+    background: var(--header-bg);
 }
 
 /* Admin footer — fixed to the bottom of the viewport, mirroring the
@@ -66,11 +91,14 @@ a:not(.btn):not(.nav-link):not(.dropdown-item):hover {
     min-height: auto;
 }
 
-/* Every admin page loads admin.css, so reserve space under the final
-   row of content so it's never obscured by the fixed footer. Uses the
-   shared --footer-info-height token (28 px normal / 40 px small
-   viewports per app.css media queries). */
-body {
+/* Reserve space above and below the scroll area on admin-dashboard
+   pages so content isn't hidden under the pinned navbar or footer.
+   Scoped with :has() so the Song Editor (which uses .navbar-editor and
+   its own full-height flex layout) is unaffected. Uses the shared
+   --footer-info-height token (28 px normal / 40 px small viewports per
+   the media queries in app.css). */
+body:has(.navbar-admin) {
+    padding-top: calc(var(--admin-navbar-height) + 0.5rem);
     padding-bottom: calc(var(--footer-info-height) + 1rem);
 }
 

--- a/appWeb/public_html/css/admin.css
+++ b/appWeb/public_html/css/admin.css
@@ -187,6 +187,30 @@ body:has(.navbar-admin) {
 }
 
 /* ==========================================================================
+   CARD LAYOUT — edit-mode visuals (#448)
+   ========================================================================== */
+
+.card-layout-editing .card-layout-item .card-admin {
+    cursor: grab;
+    outline: 1px dashed var(--card-border);
+    outline-offset: -2px;
+}
+.card-layout-editing .card-layout-item .card-admin:active {
+    cursor: grabbing;
+}
+.card-layout-ghost {
+    opacity: 0.4;
+}
+.card-layout-hide-btn {
+    position: absolute;
+    top: 0.35rem;
+    right: 0.35rem;
+    padding: 0 0.4rem;
+    line-height: 1.4;
+    z-index: 2;
+}
+
+/* ==========================================================================
    BUTTONS — legacy .btn-amber kept for back-compat, re-coloured to accent
    ========================================================================== */
 

--- a/appWeb/public_html/css/app.css
+++ b/appWeb/public_html/css/app.css
@@ -2742,3 +2742,64 @@ body.reduce-motion .related-songs-chevron {
 .song-lyrics[data-practice-level="2"] .lyric-line:hover::before {
     display: none;
 }
+
+/* ==========================================================================
+   10. HARMONISED TOOLBAR BUTTONS (#456) + OFFLINE DOWNLOAD (#453, #454)
+   ========================================================================== */
+
+/* Song-view toolbar — every button below the song title shares this
+   class so sizing, hover, and disabled treatment are identical across
+   the row. Colour distinctions communicate STATE (active/cached/
+   favourited), not importance. */
+.song-toolbar-btn {
+    min-width: 2.5rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+.song-toolbar-btn:disabled,
+.song-toolbar-btn[aria-disabled="true"] {
+    opacity: 0.45;
+    cursor: not-allowed;
+}
+/* Active-state accents — applied via aria-pressed / data-state so the
+   base colour stays neutral. */
+.song-toolbar-btn.btn-favourite[aria-pressed="true"] {
+    color: var(--accent-solid);
+    border-color: var(--accent-solid);
+}
+.song-toolbar-btn[data-song-download][data-state="cached"] {
+    color: var(--accent-solid);
+    border-color: var(--accent-solid);
+}
+
+/* Songbook-card download button (#453) — sits in the top-right corner
+   of each card. Raised stacking context keeps it clickable above the
+   stretched link that covers the rest of the card. */
+.songbook-download-btn {
+    position: absolute;
+    top: 0.35rem;
+    right: 0.35rem;
+    z-index: 2;
+    padding: 0.2rem 0.45rem;
+    line-height: 1.3;
+}
+.songbook-download-btn:disabled,
+.songbook-download-btn[aria-disabled="true"] {
+    opacity: 0.55;
+    cursor: not-allowed;
+}
+.songbook-download-btn[data-state="cached"] {
+    color: var(--accent-solid);
+    border-color: var(--accent-solid);
+}
+
+/* Feature-detect class driven by js/modules/offline-ui.js. When
+   .offline-unsupported is on the body, every download control hides
+   (rather than showing a permanently-disabled UI that can't recover). */
+body.offline-unsupported [data-songbook-download],
+body.offline-unsupported [data-song-download],
+body.offline-unsupported .btn-save-offline,
+body.offline-unsupported .offline-only {
+    display: none !important;
+}

--- a/appWeb/public_html/css/app.css
+++ b/appWeb/public_html/css/app.css
@@ -1459,18 +1459,18 @@ body.reduce-transparency .pwa-install-banner {
     }
 }
 
-/* Medium screens and up */
+/* Medium screens and up — use the available viewport width with a
+   generous gutter and a soft cap only at ultra-wide widths so text
+   doesn't span an uncomfortably long line on 2560 px+ displays. The
+   cap is intentionally high (1800 px) so 1440/1920 desktops get the
+   full width and reading-specific pages (song lyrics) apply their
+   own tighter cap where needed. */
 @media (min-width: 768px) {
     .page-content {
-        max-width: 960px;
+        max-width: min(100%, 1800px);
         margin: 0 auto;
-    }
-}
-
-/* Large screens */
-@media (min-width: 1200px) {
-    .page-content {
-        max-width: 1140px;
+        padding-left: 1.5rem;
+        padding-right: 1.5rem;
     }
 }
 

--- a/appWeb/public_html/includes/card_layout.php
+++ b/appWeb/public_html/includes/card_layout.php
@@ -1,0 +1,283 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Card Layout Helper (#448)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Single place to compute the effective card order / hidden set for a
+ * given viewer on a given surface ("dashboard" or "home"). The resolver
+ * layers:
+ *   1. baseline  — every known card ID on this surface, in the
+ *                  template-author's preferred default order
+ *   2. system    — admin override in tblAppSettings
+ *   3. user      — per-user override in tblUsers.Settings JSON
+ *
+ * Missing IDs are appended (so shipping a new card never breaks anyone
+ * who saved their layout yesterday); removed IDs drop (so a card pulled
+ * from the codebase doesn't leave a ghost entry in saved layouts).
+ */
+
+if (basename($_SERVER['SCRIPT_FILENAME'] ?? '') === basename(__FILE__)) {
+    http_response_code(403);
+    exit('Access denied.');
+}
+
+const CARD_LAYOUT_SURFACES = ['dashboard', 'home'];
+
+/**
+ * Read the system-wide default layout for a surface.
+ *
+ * @return array{order: string[], hidden: string[]}
+ */
+function cardLayoutDefault(string $surface): array
+{
+    if (!in_array($surface, CARD_LAYOUT_SURFACES, true)) {
+        return ['order' => [], 'hidden' => []];
+    }
+
+    $key = $surface === 'dashboard'
+        ? 'dashboard_card_order_default'
+        : 'home_card_order_default';
+
+    try {
+        $db = getDb();
+        $stmt = $db->prepare('SELECT SettingValue FROM tblAppSettings WHERE SettingKey = ?');
+        $stmt->execute([$key]);
+        $raw = (string)($stmt->fetchColumn() ?: '');
+        if ($raw === '') return ['order' => [], 'hidden' => []];
+        $decoded = json_decode($raw, true);
+        if (!is_array($decoded)) return ['order' => [], 'hidden' => []];
+        return [
+            'order'  => cardLayoutSanitiseIds($decoded['order']  ?? []),
+            'hidden' => cardLayoutSanitiseIds($decoded['hidden'] ?? []),
+        ];
+    } catch (\Throwable $_e) {
+        return ['order' => [], 'hidden' => []];
+    }
+}
+
+/**
+ * Write the system-wide default layout. Caller must have confirmed the
+ * `manage_default_card_layout` entitlement first.
+ */
+function cardLayoutSaveDefault(string $surface, array $layout): bool
+{
+    if (!in_array($surface, CARD_LAYOUT_SURFACES, true)) return false;
+
+    $payload = json_encode([
+        'order'  => cardLayoutSanitiseIds($layout['order']  ?? []),
+        'hidden' => cardLayoutSanitiseIds($layout['hidden'] ?? []),
+    ], JSON_UNESCAPED_SLASHES);
+
+    $key = $surface === 'dashboard'
+        ? 'dashboard_card_order_default'
+        : 'home_card_order_default';
+
+    try {
+        $db = getDb();
+        $stmt = $db->prepare(
+            'INSERT INTO tblAppSettings (SettingKey, SettingValue) VALUES (?, ?)
+             ON DUPLICATE KEY UPDATE SettingValue = VALUES(SettingValue)'
+        );
+        $stmt->execute([$key, (string)$payload]);
+        return true;
+    } catch (\Throwable $_e) {
+        return false;
+    }
+}
+
+/**
+ * Read a user's layout override for a surface from tblUsers.Settings.
+ *
+ * @return array{order: string[], hidden: string[]}
+ */
+function cardLayoutUserOverride(int $userId, string $surface): array
+{
+    if ($userId <= 0 || !in_array($surface, CARD_LAYOUT_SURFACES, true)) {
+        return ['order' => [], 'hidden' => []];
+    }
+    try {
+        $db = getDb();
+        $stmt = $db->prepare('SELECT Settings FROM tblUsers WHERE Id = ?');
+        $stmt->execute([$userId]);
+        $raw = (string)($stmt->fetchColumn() ?: '');
+        if ($raw === '') return ['order' => [], 'hidden' => []];
+        $decoded = json_decode($raw, true);
+        if (!is_array($decoded)) return ['order' => [], 'hidden' => []];
+        $section = $decoded['cardLayouts'][$surface] ?? null;
+        if (!is_array($section)) return ['order' => [], 'hidden' => []];
+        return [
+            'order'  => cardLayoutSanitiseIds($section['order']  ?? []),
+            'hidden' => cardLayoutSanitiseIds($section['hidden'] ?? []),
+        ];
+    } catch (\Throwable $_e) {
+        return ['order' => [], 'hidden' => []];
+    }
+}
+
+/**
+ * Write a user's layout override to tblUsers.Settings, merging with any
+ * existing settings JSON (theme etc.) rather than replacing it.
+ */
+function cardLayoutSaveUserOverride(int $userId, string $surface, array $layout): bool
+{
+    if ($userId <= 0 || !in_array($surface, CARD_LAYOUT_SURFACES, true)) return false;
+
+    try {
+        $db = getDb();
+        $stmt = $db->prepare('SELECT Settings FROM tblUsers WHERE Id = ?');
+        $stmt->execute([$userId]);
+        $raw = (string)($stmt->fetchColumn() ?: '');
+        $settings = $raw === '' ? [] : (json_decode($raw, true) ?: []);
+        if (!isset($settings['cardLayouts']) || !is_array($settings['cardLayouts'])) {
+            $settings['cardLayouts'] = [];
+        }
+        $settings['cardLayouts'][$surface] = [
+            'order'  => cardLayoutSanitiseIds($layout['order']  ?? []),
+            'hidden' => cardLayoutSanitiseIds($layout['hidden'] ?? []),
+        ];
+        $json = json_encode($settings, JSON_UNESCAPED_SLASHES);
+        $stmt = $db->prepare('UPDATE tblUsers SET Settings = ?, UpdatedAt = CURRENT_TIMESTAMP WHERE Id = ?');
+        $stmt->execute([$json, $userId]);
+        return true;
+    } catch (\Throwable $_e) {
+        return false;
+    }
+}
+
+/**
+ * Clear a user's override for a surface, reverting them to the system default.
+ */
+function cardLayoutClearUserOverride(int $userId, string $surface): bool
+{
+    if ($userId <= 0 || !in_array($surface, CARD_LAYOUT_SURFACES, true)) return false;
+    try {
+        $db = getDb();
+        $stmt = $db->prepare('SELECT Settings FROM tblUsers WHERE Id = ?');
+        $stmt->execute([$userId]);
+        $raw = (string)($stmt->fetchColumn() ?: '');
+        if ($raw === '') return true;
+        $settings = json_decode($raw, true) ?: [];
+        if (isset($settings['cardLayouts'][$surface])) {
+            unset($settings['cardLayouts'][$surface]);
+        }
+        $json = json_encode($settings, JSON_UNESCAPED_SLASHES);
+        $stmt = $db->prepare('UPDATE tblUsers SET Settings = ?, UpdatedAt = CURRENT_TIMESTAMP WHERE Id = ?');
+        $stmt->execute([$json, $userId]);
+        return true;
+    } catch (\Throwable $_e) {
+        return false;
+    }
+}
+
+/**
+ * Is the given user allowed to customise their own layout? Requires BOTH
+ * the role-level entitlement AND (if they belong to a group) the group's
+ * AllowCardReorder flag to be set. Groupless users get the role-level
+ * answer alone.
+ */
+function cardLayoutUserCanCustomise(?array $user): bool
+{
+    if (!$user) return false;
+    $role = $user['role'] ?? null;
+    if (!userHasEntitlement('customise_own_card_layout', $role)) return false;
+
+    $groupId = (int)($user['group_id'] ?? $user['GroupId'] ?? 0);
+    if ($groupId <= 0) return true;
+
+    try {
+        $db = getDb();
+        $stmt = $db->prepare('SELECT AllowCardReorder FROM tblUserGroups WHERE Id = ?');
+        $stmt->execute([$groupId]);
+        $val = $stmt->fetchColumn();
+        /* Groups predating this column return null — treat as allowed
+           (i.e. default on) so the feature rolls out non-destructively. */
+        if ($val === null || $val === false) return true;
+        return (int)$val === 1;
+    } catch (\Throwable $_e) {
+        return true;
+    }
+}
+
+/**
+ * Merge baseline card IDs with a saved order / hidden set.
+ *
+ * - IDs in the baseline but missing from `order` append at the end
+ *   (new cards become visible for existing users).
+ * - IDs in `order` but missing from the baseline drop (removed cards
+ *   don't stick around as ghosts).
+ * - `hidden` IDs that aren't in the baseline drop for the same reason.
+ *
+ * @param string[] $baseline          The template's canonical list of IDs
+ * @param array{order: string[], hidden: string[]} $saved
+ * @return array{order: string[], hidden: string[]}
+ */
+function cardLayoutMerge(array $baseline, array $saved): array
+{
+    $baselineSet = array_flip($baseline);
+    $order = [];
+    $seen  = [];
+
+    foreach (($saved['order'] ?? []) as $id) {
+        if (isset($baselineSet[$id]) && !isset($seen[$id])) {
+            $order[] = $id;
+            $seen[$id] = true;
+        }
+    }
+    foreach ($baseline as $id) {
+        if (!isset($seen[$id])) {
+            $order[] = $id;
+            $seen[$id] = true;
+        }
+    }
+    $hidden = [];
+    foreach (($saved['hidden'] ?? []) as $id) {
+        if (isset($baselineSet[$id])) $hidden[] = $id;
+    }
+    return ['order' => $order, 'hidden' => $hidden];
+}
+
+/**
+ * Resolve the effective layout for a viewer on a surface. Pure function —
+ * just reads state, no side effects.
+ *
+ * @param string[] $baseline
+ */
+function cardLayoutResolve(array $baseline, string $surface, ?array $user): array
+{
+    $default = cardLayoutDefault($surface);
+    $effective = cardLayoutMerge($baseline, $default);
+
+    if ($user && cardLayoutUserCanCustomise($user)) {
+        $override = cardLayoutUserOverride((int)($user['id'] ?? $user['Id'] ?? 0), $surface);
+        if (!empty($override['order']) || !empty($override['hidden'])) {
+            $effective = cardLayoutMerge($baseline, $override);
+        }
+    }
+    return $effective;
+}
+
+/**
+ * Reject anything that doesn't look like a card ID. IDs are short,
+ * lowercase, alnum-plus-dash tokens (matches the template-author-chosen
+ * data-card-id values throughout the PHP templates).
+ *
+ * @return string[]
+ */
+function cardLayoutSanitiseIds($value): array
+{
+    if (!is_array($value)) return [];
+    $out = [];
+    foreach ($value as $v) {
+        if (!is_string($v)) continue;
+        $v = trim($v);
+        if ($v === '') continue;
+        if (!preg_match('/^[a-z0-9][a-z0-9_-]{0,63}$/', $v)) continue;
+        $out[] = $v;
+    }
+    return array_values(array_unique($out));
+}

--- a/appWeb/public_html/includes/entitlements.php
+++ b/appWeb/public_html/includes/entitlements.php
@@ -67,6 +67,14 @@ const ENTITLEMENTS = [
     'manage_access_tiers'         => ['admin', 'global_admin'],
     'assign_user_tier'            => ['admin', 'global_admin'],
 
+    /* Card-layout personalisation (#448). Default site layout is set by
+       admins; every role is allowed to customise their own by default,
+       but an admin can revoke `customise_own_card_layout` to lock a site
+       down. Group-level veto via tblUserGroups.AllowCardReorder layers
+       on top. */
+    'manage_default_card_layout' => ['admin', 'global_admin'],
+    'customise_own_card_layout'  => ['user', 'editor', 'admin', 'global_admin'],
+
     /* Channel access gating (#407) — controls who can reach alpha/beta
        subdomains. Applied BEFORE the page renders so pre-release builds
        are invisible to the public even when indexed. Defaults intentionally

--- a/appWeb/public_html/includes/infoAppVer.php
+++ b/appWeb/public_html/includes/infoAppVer.php
@@ -79,7 +79,7 @@ $app["Application"]["Description"]["Keywords"] = "hymns, worship, lyrics, songbo
 /* Semantic version number (MAJOR.MINOR.PATCH) */
 /* Auto-bumped by the version-bump GitHub Action on push to beta */
 /* v1.x.x = Phase 1 (local JSON data), v2.x.x = Phase 2 (iLyrics dB) */
-$app["Application"]["Version"]["Number"] = "0.10.0";
+$app["Application"]["Version"]["Number"] = "0.25.0";
 
 /* Version name: human-readable release name (e.g., "Hymnal", NULL if unused) */
 $app["Application"]["Version"]["Name"] = NULL;

--- a/appWeb/public_html/includes/pages/home.php
+++ b/appWeb/public_html/includes/pages/home.php
@@ -140,13 +140,18 @@ $songbooks = $songData->getSongbooks();
             <?php foreach ($songbooks as $index => $book): ?>
                 <?php if (($book['songCount'] ?? 0) > 0): ?>
                     <div class="col-6 col-md-4 col-lg-3" id="songbook-<?= htmlspecialchars($book['id']) ?>">
-                        <a href="/songbook/<?= htmlspecialchars($book['id']) ?>"
-                           class="card card-songbook h-100 text-decoration-none"
-                           data-navigate="songbook"
-                           data-songbook-id="<?= htmlspecialchars($book['id']) ?>"
-                           aria-label="<?= htmlspecialchars($book['name']) ?> — <?= $book['songCount'] ?> songs">
+                        <div class="card card-songbook h-100 position-relative"
+                             data-songbook-id="<?= htmlspecialchars($book['id']) ?>"
+                             data-songbook-songs="<?= (int)$book['songCount'] ?>">
+                            <!-- Stretched link covers the whole card body,
+                                 keeping the download button clickable because
+                                 the button's stacking context is raised by
+                                 position: relative + z-index on the button. -->
+                            <a href="/songbook/<?= htmlspecialchars($book['id']) ?>"
+                               class="stretched-link text-decoration-none text-reset"
+                               data-navigate="songbook"
+                               aria-label="<?= htmlspecialchars($book['name']) ?> — <?= $book['songCount'] ?> songs"></a>
                             <div class="card-body text-center">
-                                <!-- Songbook icon with colour variation -->
                                 <div class="songbook-icon songbook-icon-<?= htmlspecialchars($book['id']) ?> mb-2">
                                     <i class="fa-solid fa-book" aria-hidden="true"></i>
                                 </div>
@@ -160,7 +165,20 @@ $songbooks = $songData->getSongbooks();
                                     <?= number_format($book['songCount']) ?> songs
                                 </p>
                             </div>
-                        </a>
+                            <!-- Offline-download button (#453). Hidden by
+                                 default; the offline-support check in
+                                 js/modules/offline.js reveals it on capable
+                                 browsers. Always rendered so server-HTML
+                                 stays stable; never rendered enabled if
+                                 the browser can't act on it. -->
+                            <button type="button"
+                                    class="btn btn-sm btn-outline-secondary songbook-download-btn d-none"
+                                    data-songbook-download="<?= htmlspecialchars($book['id']) ?>"
+                                    aria-label="Download <?= htmlspecialchars($book['name']) ?> for offline use"
+                                    title="Download this songbook for offline use">
+                                <i class="fa-solid fa-cloud-arrow-down" aria-hidden="true"></i>
+                            </button>
+                        </div>
                     </div>
                 <?php endif; ?>
             <?php endforeach; ?>

--- a/appWeb/public_html/includes/pages/song.php
+++ b/appWeb/public_html/includes/pages/song.php
@@ -155,7 +155,7 @@ $components  = $song['components'] ?? [];
             <div class="d-flex flex-wrap gap-2">
                 <!-- Favourite toggle -->
                 <button type="button"
-                        class="btn btn-outline-danger btn-sm btn-favourite"
+                        class="btn btn-outline-secondary btn-sm song-toolbar-btn btn-favourite"
                         data-song-id="<?= htmlspecialchars($song['id']) ?>"
                         data-song-title="<?= htmlspecialchars($songTitle) ?>"
                         aria-label="Add to favourites"
@@ -166,7 +166,7 @@ $components  = $song['components'] ?? [];
 
                 <!-- Share button -->
                 <button type="button"
-                        class="btn btn-outline-primary btn-sm btn-share"
+                        class="btn btn-outline-secondary btn-sm song-toolbar-btn btn-share"
                         data-song-id="<?= htmlspecialchars($song['id']) ?>"
                         data-song-title="<?= htmlspecialchars($songTitle) ?>"
                         aria-label="Share this song">
@@ -177,7 +177,7 @@ $components  = $song['components'] ?? [];
                 <!-- Audio button (if available) -->
                 <?php if ($hasAudio): ?>
                     <button type="button"
-                            class="btn btn-outline-secondary btn-sm btn-audio"
+                            class="btn btn-outline-secondary btn-sm song-toolbar-btn btn-audio"
                             data-song-id="<?= htmlspecialchars($song['id']) ?>"
                             aria-label="Play audio">
                         <i class="fa-solid fa-headphones me-1" aria-hidden="true"></i>
@@ -188,7 +188,7 @@ $components  = $song['components'] ?? [];
                 <!-- Sheet music button (if available) -->
                 <?php if ($hasSheet): ?>
                     <button type="button"
-                            class="btn btn-outline-secondary btn-sm btn-sheet-music"
+                            class="btn btn-outline-secondary btn-sm song-toolbar-btn btn-sheet-music"
                             data-song-id="<?= htmlspecialchars($song['id']) ?>"
                             aria-label="View sheet music">
                         <i class="fa-solid fa-file-pdf me-1" aria-hidden="true"></i>
@@ -198,7 +198,7 @@ $components  = $song['components'] ?? [];
 
                 <!-- Add to set list (#94) -->
                 <button type="button"
-                        class="btn btn-outline-secondary btn-sm btn-add-to-setlist"
+                        class="btn btn-outline-secondary btn-sm song-toolbar-btn btn-add-to-setlist"
                         aria-label="Add to set list">
                     <i class="fa-solid fa-list-ol me-1" aria-hidden="true"></i>
                     Set List
@@ -206,24 +206,30 @@ $components  = $song['components'] ?? [];
 
                 <!-- Compare with another song (#102) -->
                 <button type="button"
-                        class="btn btn-outline-secondary btn-sm btn-compare"
+                        class="btn btn-outline-secondary btn-sm song-toolbar-btn btn-compare"
                         aria-label="Compare with another song">
                     <i class="fa-solid fa-columns me-1" aria-hidden="true"></i>
                     Compare
                 </button>
 
-                <!-- Save offline button -->
+                <!-- Save offline — consolidated into the harmonised cloud
+                     button (#453, #454, #456). The offline-ui module
+                     handles feature detection, cached-state, disabled
+                     tooltip, and click; the legacy .btn-save-offline
+                     handler still runs too, so either wire path works. -->
                 <button type="button"
-                        class="btn btn-outline-secondary btn-sm btn-save-offline"
+                        class="btn btn-outline-secondary btn-sm song-toolbar-btn btn-save-offline song-toolbar-btn d-none"
                         data-song-id="<?= htmlspecialchars($song['id']) ?>"
-                        aria-label="Save this song for offline use">
-                    <i class="fa-solid fa-download me-1" aria-hidden="true"></i>
+                        data-song-download="<?= htmlspecialchars($song['id']) ?>"
+                        aria-label="Save this song for offline use"
+                        title="Save this song for offline use">
+                    <i class="fa-solid fa-cloud-arrow-down me-1" aria-hidden="true"></i>
                     <span>Save Offline</span>
                 </button>
 
                 <!-- Presentation mode (#297) -->
                 <button type="button"
-                        class="btn btn-outline-secondary btn-sm"
+                        class="btn btn-outline-secondary btn-sm song-toolbar-btn"
                         id="btn-present"
                         title="Presentation mode"
                         aria-label="Enter presentation mode">
@@ -233,7 +239,7 @@ $components  = $song['components'] ?? [];
 
                 <!-- Print button -->
                 <button type="button"
-                        class="btn btn-outline-secondary btn-sm btn-print"
+                        class="btn btn-outline-secondary btn-sm song-toolbar-btn btn-print"
                         aria-label="Print this song"
                         data-action="print">
                     <i class="fa-solid fa-print me-1" aria-hidden="true"></i>
@@ -248,7 +254,7 @@ $components  = $song['components'] ?? [];
                 <!-- Edit in Song Editor (#407). Hidden by default; revealed
                      by JS when the signed-in user has the `edit_songs`
                      entitlement (editor / admin / global_admin). -->
-                <a class="btn btn-sm btn-outline-primary d-none"
+                <a class="btn btn-sm btn-outline-secondary song-toolbar-btn d-none"
                    id="btn-edit-song"
                    href="/manage/editor/?song=<?= urlencode($song['id'] ?? '') ?>"
                    title="Edit this song in the Song Editor">
@@ -389,7 +395,7 @@ $components  = $song['components'] ?? [];
         <div class="d-flex justify-content-between">
             <?php if ($prevSong): ?>
                 <a href="/song/<?= htmlspecialchars($prevSong['id']) ?>"
-                   class="btn btn-outline-secondary btn-sm"
+                   class="btn btn-outline-secondary btn-sm song-toolbar-btn"
                    data-navigate="song"
                    data-song-id="<?= htmlspecialchars($prevSong['id']) ?>"
                    aria-label="Previous song: <?= htmlspecialchars(toTitleCase($prevSong['title'])) ?>">
@@ -402,7 +408,7 @@ $components  = $song['components'] ?? [];
 
             <?php if ($nextSong): ?>
                 <a href="/song/<?= htmlspecialchars($nextSong['id']) ?>"
-                   class="btn btn-outline-secondary btn-sm"
+                   class="btn btn-outline-secondary btn-sm song-toolbar-btn"
                    data-navigate="song"
                    data-song-id="<?= htmlspecialchars($nextSong['id']) ?>"
                    aria-label="Next song: <?= htmlspecialchars(toTitleCase($nextSong['title'])) ?>">

--- a/appWeb/public_html/js/app.js
+++ b/appWeb/public_html/js/app.js
@@ -38,6 +38,7 @@ import { Transpose } from './modules/transpose.js';
 import { ReadingProgress } from './modules/reading-progress.js';
 import { SongbookIndex } from './modules/songbook-index.js';
 import { SearchHistory } from './modules/search-history.js';
+import { bootOfflineUi } from './modules/offline-ui.js';
 import { SongOfTheDay } from './modules/song-of-the-day.js';
 import { OfflineIndicator } from './modules/offline-indicator.js';
 import { StorageBridge } from './modules/storage-bridge.js';
@@ -304,6 +305,11 @@ class iHymnsApp {
 
             /* --- Load initial page based on current URL --- */
             await this.router.handleCurrentRoute();
+
+            /* Wire offline-download buttons in whatever page just
+               rendered. Safe to call every route change because the
+               helper only binds fresh nodes. */
+            bootOfflineUi();
 
             /* --- Hide the loading spinner --- */
             this.hideLoader();

--- a/appWeb/public_html/js/modules/card-layout.js
+++ b/appWeb/public_html/js/modules/card-layout.js
@@ -1,0 +1,195 @@
+/**
+ * iHymns — Card Layout Module (#448)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Client-side drag-and-drop + hide behaviour for any "card grid" that
+ * the server rendered with:
+ *
+ *   <div class="row" id="..." data-layout-surface="dashboard|home"
+ *        data-can-customise="0|1" data-can-set-default="0|1">
+ *     <div class="card-layout-item" data-card-id="editor"> … </div>
+ *     ...
+ *   </div>
+ *
+ * Attach with `initCardLayout(rootEl)` — the element's data-* attrs
+ * tell the module which API surface to save against and whether the
+ * current viewer is permitted to edit at all.
+ *
+ * Uses SortableJS (CDN-loaded once, on first edit toggle) for the
+ * reorder interaction. Keyboard fallback: while in edit mode, each
+ * card shows up / down buttons that move it by one slot.
+ *
+ * On save the order + hidden set is POSTed to /api?action=card_layout_
+ * save_user. Admins with manage_default_card_layout can also save the
+ * current arrangement as the system default via the "Save as site
+ * default" button.
+ */
+
+const SORTABLE_CDN = 'https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js';
+const SORTABLE_INTEGRITY = 'sha384-aq8eSnxHJKZ/IzVz/6lq59+H3dCblmnJ2opgw7gvpRQa8lVQ+bKvY+z0sn3h47AO';
+
+let _sortablePromise = null;
+function loadSortable() {
+    if (window.Sortable) return Promise.resolve(window.Sortable);
+    if (_sortablePromise) return _sortablePromise;
+    _sortablePromise = new Promise((resolve, reject) => {
+        const s = document.createElement('script');
+        s.src = SORTABLE_CDN;
+        s.integrity = SORTABLE_INTEGRITY;
+        s.crossOrigin = 'anonymous';
+        s.onload  = () => resolve(window.Sortable);
+        s.onerror = () => reject(new Error('Failed to load SortableJS'));
+        document.head.appendChild(s);
+    });
+    return _sortablePromise;
+}
+
+function qs(root, sel)   { return root.querySelector(sel); }
+function qsa(root, sel)  { return Array.from(root.querySelectorAll(sel)); }
+
+function serialiseLayout(root) {
+    const order = [];
+    const hidden = [];
+    for (const item of qsa(root, '.card-layout-item')) {
+        const id = item.dataset.cardId;
+        if (!id) continue;
+        order.push(id);
+        if (item.dataset.hidden === '1') hidden.push(id);
+    }
+    return { order, hidden };
+}
+
+async function postLayout(action, surface, payload) {
+    const body = JSON.stringify({ surface, ...payload });
+    const res = await fetch(`/api?action=${action}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+        body,
+        credentials: 'same-origin',
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return res.json();
+}
+
+/** Debounce a function — collapses bursts of drops into one save. */
+function debounce(fn, wait) {
+    let t;
+    return (...args) => {
+        clearTimeout(t);
+        t = setTimeout(() => fn(...args), wait);
+    };
+}
+
+/**
+ * Initialise a card grid. Idempotent — safe to call multiple times.
+ * @param {HTMLElement} root The `.row` container with data-layout-surface
+ */
+export function initCardLayout(root) {
+    if (!root || root.dataset.layoutInitialised === '1') return;
+    root.dataset.layoutInitialised = '1';
+
+    const surface      = root.dataset.layoutSurface || '';
+    const canCustomise = root.dataset.canCustomise === '1';
+    const canDefault   = root.dataset.canSetDefault === '1';
+    if (!surface || (!canCustomise && !canDefault)) return;
+
+    const toolbar    = document.getElementById('card-layout-toolbar');
+    const btnEdit    = document.getElementById('btn-card-layout-edit');
+    const btnDone    = document.getElementById('btn-card-layout-done');
+    const btnReset   = document.getElementById('btn-card-layout-reset');
+    const btnDefault = document.getElementById('btn-card-layout-save-default');
+    const help       = document.getElementById('card-layout-help');
+    if (!toolbar || !btnEdit || !btnDone) return;
+
+    let sortable = null;
+
+    const save = debounce(async () => {
+        if (!canCustomise) return;
+        const payload = serialiseLayout(root);
+        try { await postLayout('card_layout_save_user', surface, payload); }
+        catch (e) { console.error('[card-layout] save failed', e); }
+    }, 400);
+
+    function enterEditMode() {
+        root.classList.add('card-layout-editing');
+        btnEdit.classList.add('d-none');
+        btnDone.classList.remove('d-none');
+        if (canCustomise) btnReset?.classList.remove('d-none');
+        if (canDefault) btnDefault?.classList.remove('d-none');
+        help?.classList.remove('d-none');
+
+        for (const item of qsa(root, '.card-layout-item')) {
+            if (!qs(item, '.card-layout-hide-btn')) {
+                const hideBtn = document.createElement('button');
+                hideBtn.type = 'button';
+                hideBtn.className = 'btn btn-sm btn-outline-danger card-layout-hide-btn';
+                hideBtn.setAttribute('aria-label', 'Hide this card');
+                hideBtn.title = 'Hide this card';
+                hideBtn.innerHTML = '<i class="bi bi-x" aria-hidden="true"></i>';
+                hideBtn.addEventListener('click', () => {
+                    item.dataset.hidden = '1';
+                    item.classList.add('d-none');
+                    save();
+                });
+                qs(item, '.card-admin')?.appendChild(hideBtn);
+            }
+        }
+
+        loadSortable().then(S => {
+            if (sortable) return;
+            sortable = new S(root, {
+                animation: 160,
+                ghostClass: 'card-layout-ghost',
+                handle: '.card-admin',
+                onEnd: () => save(),
+            });
+        }).catch(err => console.error('[card-layout] sortable load failed', err));
+    }
+
+    function exitEditMode() {
+        root.classList.remove('card-layout-editing');
+        btnEdit.classList.remove('d-none');
+        btnDone.classList.add('d-none');
+        btnReset?.classList.add('d-none');
+        btnDefault?.classList.add('d-none');
+        help?.classList.add('d-none');
+        for (const btn of qsa(root, '.card-layout-hide-btn')) btn.remove();
+        if (sortable) { sortable.destroy(); sortable = null; }
+    }
+
+    btnEdit.addEventListener('click', enterEditMode);
+    btnDone.addEventListener('click', exitEditMode);
+
+    btnReset?.addEventListener('click', async () => {
+        if (!confirm('Reset your personalised layout back to the site default?')) return;
+        try {
+            await postLayout('card_layout_reset_user', surface, {});
+            window.location.reload();
+        } catch (e) { console.error('[card-layout] reset failed', e); }
+    });
+
+    btnDefault?.addEventListener('click', async () => {
+        if (!confirm('Save the current order as the site-wide default for every user?')) return;
+        const payload = serialiseLayout(root);
+        try {
+            await postLayout('card_layout_save_default', surface, payload);
+            alert('Site default saved.');
+        } catch (e) { console.error('[card-layout] save-default failed', e); }
+    });
+}
+
+/** Auto-init on DOMContentLoaded if the page already has a grid. */
+export function bootCardLayout() {
+    const go = () => {
+        for (const grid of document.querySelectorAll('[data-layout-surface]')) {
+            initCardLayout(grid);
+        }
+    };
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', go, { once: true });
+    } else {
+        go();
+    }
+}

--- a/appWeb/public_html/js/modules/entitlements.js
+++ b/appWeb/public_html/js/modules/entitlements.js
@@ -47,6 +47,10 @@ export const ENTITLEMENTS = {
     manage_access_tiers:         ['admin', 'global_admin'],
     assign_user_tier:            ['admin', 'global_admin'],
 
+    /* Card-layout personalisation (#448) */
+    manage_default_card_layout: ['admin', 'global_admin'],
+    customise_own_card_layout:  ['user', 'editor', 'admin', 'global_admin'],
+
     /* Channel access (#407) */
     access_alpha:         ['user', 'editor', 'admin', 'global_admin'],
     access_beta:          ['user', 'editor', 'admin', 'global_admin'],

--- a/appWeb/public_html/js/modules/offline-ui.js
+++ b/appWeb/public_html/js/modules/offline-ui.js
@@ -1,0 +1,196 @@
+/**
+ * iHymns — Offline Download UI Bindings (#453, #454, #455)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Runtime wiring for every "download for offline" button that lives
+ * inside templated HTML (songbook cards on the home page, per-song
+ * button in the song-view toolbar). Feature-detects Cache API +
+ * Service Worker + IndexedDB; only shows the controls on browsers
+ * that can actually act on them.
+ *
+ * Does NOT own the actual caching — that runs inside the service
+ * worker (public_html/service-worker.js.php). This module posts
+ * messages to the SW and listens for progress events back.
+ */
+
+/** Is this browser capable of offline caching? */
+export function isOfflineSupported() {
+    return (typeof navigator !== 'undefined')
+        && ('serviceWorker' in navigator)
+        && (typeof window !== 'undefined')
+        && ('caches' in window)
+        && ('indexedDB' in window);
+}
+
+/** One-time feature-detection toggle — adds body class, unhides controls. */
+export function markOfflineCapability() {
+    if (!isOfflineSupported()) {
+        document.body.classList.add('offline-unsupported');
+        return false;
+    }
+    document.body.classList.add('offline-supported');
+    for (const btn of document.querySelectorAll('[data-songbook-download], [data-song-download]')) {
+        btn.classList.remove('d-none');
+    }
+    return true;
+}
+
+/** Post a CACHE_ALL_SONGS message targeting a single songbook. */
+async function cacheSongbook(songbookId, totalSongs) {
+    const reg = await navigator.serviceWorker.ready;
+    if (!reg.active) throw new Error('Service worker not active');
+    reg.active.postMessage({
+        type: 'CACHE_ALL_SONGS',
+        songbooks: [songbookId],
+        totalSongs,
+    });
+}
+
+/** Post a CACHE_SONG message for a single song. */
+async function cacheSong(songId) {
+    const reg = await navigator.serviceWorker.ready;
+    if (!reg.active) throw new Error('Service worker not active');
+    const url = `/api?page=song&id=${encodeURIComponent(songId)}`;
+    reg.active.postMessage({ type: 'CACHE_SONG', url });
+}
+
+/** Read the user's "include audio" preference from Settings. */
+function includeAudioPref() {
+    try {
+        return localStorage.getItem('ihymns_offline_include_audio') === '1';
+    } catch { return false; }
+}
+
+function setButtonState(btn, state, labelOverride) {
+    const label = {
+        idle:        'Download for offline use',
+        downloading: 'Downloading…',
+        cached:      'Already saved offline',
+        error:       'Download failed — tap to retry',
+    }[state] || 'Download';
+    btn.dataset.state = state;
+    btn.title = labelOverride || label;
+    btn.setAttribute('aria-label', labelOverride || label);
+    btn.disabled = state === 'downloading' || state === 'cached';
+
+    const icon = btn.querySelector('i');
+    if (icon) {
+        icon.className = {
+            idle:        'fa-solid fa-cloud-arrow-down',
+            downloading: 'fa-solid fa-spinner fa-spin',
+            cached:      'fa-solid fa-cloud-check',
+            error:       'fa-solid fa-triangle-exclamation',
+        }[state] || 'fa-solid fa-cloud';
+    }
+}
+
+/** Has the given URL been cached? */
+async function urlIsCached(url) {
+    try {
+        for (const cacheName of await caches.keys()) {
+            const cache = await caches.open(cacheName);
+            const match = await cache.match(url);
+            if (match) return true;
+        }
+    } catch { /* ignore */ }
+    return false;
+}
+
+export function bootOfflineUi() {
+    if (!markOfflineCapability()) return;
+
+    /* Songbook cards (#453) — skip buttons we've already wired so that
+       calling bootOfflineUi on every SPA page change doesn't double-bind. */
+    for (const btn of document.querySelectorAll('[data-songbook-download]')) {
+        if (btn.dataset.wired === '1') continue;
+        btn.dataset.wired = '1';
+        const songbookId = btn.dataset.songbookDownload;
+        const card = btn.closest('.card-songbook');
+        const totalSongs = parseInt(card?.dataset?.songbookSongs || '0', 10);
+        setButtonState(btn, 'idle');
+
+        btn.addEventListener('click', async (ev) => {
+            ev.preventDefault();
+            ev.stopPropagation();
+            setButtonState(btn, 'downloading');
+            try {
+                await cacheSongbook(songbookId, totalSongs);
+            } catch (e) {
+                console.error('[offline-ui] cache songbook failed', e);
+                setButtonState(btn, 'error');
+            }
+        });
+    }
+
+    /* Per-song button (#454) — idempotent as above. */
+    for (const btn of document.querySelectorAll('[data-song-download]')) {
+        if (btn.dataset.wired === '1') continue;
+        btn.dataset.wired = '1';
+        const songId = btn.dataset.songDownload;
+        (async () => {
+            if (await urlIsCached(`/api?page=song&id=${encodeURIComponent(songId)}`)) {
+                setButtonState(btn, 'cached');
+            } else {
+                setButtonState(btn, 'idle');
+            }
+        })();
+
+        btn.addEventListener('click', async (ev) => {
+            ev.preventDefault();
+            ev.stopPropagation();
+            setButtonState(btn, 'downloading');
+            try {
+                await cacheSong(songId);
+                /* Give the SW a moment to land the cache entry, then
+                   verify. `cache.match` is cheap so we don't worry
+                   about the tight poll. */
+                setTimeout(async () => {
+                    const ok = await urlIsCached(`/api?page=song&id=${encodeURIComponent(songId)}`);
+                    setButtonState(btn, ok ? 'cached' : 'error');
+                }, 500);
+            } catch (e) {
+                console.error('[offline-ui] cache song failed', e);
+                setButtonState(btn, 'error');
+            }
+        });
+    }
+
+    /* Listen to SW progress to flip songbook buttons to `cached` when
+       their download finishes. */
+    if (navigator.serviceWorker) {
+        navigator.serviceWorker.addEventListener('message', (ev) => {
+            const msg = ev.data || {};
+            if (msg.type !== 'CACHE_ALL_SONGS_PROGRESS') return;
+            if (!msg.done) return;
+            /* Mark every songbook-download button that's in-flight as
+               cached; we don't get back the exact songbook ID in the
+               current SW message shape, so flip any that are currently
+               `downloading`. */
+            for (const btn of document.querySelectorAll('[data-songbook-download]')) {
+                if (btn.dataset.state === 'downloading') {
+                    setButtonState(btn, msg.failed > 0 ? 'error' : 'cached');
+                }
+            }
+        });
+    }
+
+    /* Respect the Include Audio pref implicitly — future work once the
+       SW actually consumes a flag. Exposed via global event for JS
+       listeners on the Settings page. */
+    window.addEventListener('ihymns:offline-settings-changed', () => {
+        /* No-op placeholder so Settings can trigger re-evaluation; the
+           decision lives on the server / SW when we hook audio caching
+           through the bulk_songs response. */
+    });
+}
+
+/** Attach on first DOMContentLoaded + also expose manually. */
+if (typeof document !== 'undefined') {
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', bootOfflineUi, { once: true });
+    } else {
+        bootOfflineUi();
+    }
+}

--- a/appWeb/public_html/js/modules/router.js
+++ b/appWeb/public_html/js/modules/router.js
@@ -388,6 +388,11 @@ export class Router {
      * @param {object} params Route parameters
      */
     afterPageLoad(page, params) {
+        /* Re-bind any offline-download buttons in the freshly injected
+           HTML (#453 / #454). The helper idempotently ignores nodes
+           that already have handlers. */
+        import('./offline-ui.js').then(m => m.bootOfflineUi()).catch(() => {});
+
         /* Initialise favourites state on song pages */
         if (page === 'song') {
             this.app.favorites.initSongPage();

--- a/appWeb/public_html/js/modules/router.js
+++ b/appWeb/public_html/js/modules/router.js
@@ -281,6 +281,15 @@ export class Router {
             /* Inject the new content */
             content.innerHTML = html;
 
+            /* Browsers intentionally do NOT run <script> tags inserted via
+               innerHTML, so any inline JS in the injected page template
+               (e.g. home.php's Popular Songs / Browse by Theme / Recently
+               Viewed fetches) silently no-ops. Replace each script node
+               with a freshly-created one so the browser parses and runs
+               it as if it had been in the original document. Preserves
+               type, src, async/defer and other attributes. */
+            this._executeInlineScripts(content);
+
             /* Complete loading bar and start enter transition */
             this.app.transitions.completeLoading();
             await this.app.transitions.pageIn(content);
@@ -299,6 +308,33 @@ export class Router {
                     Failed to load page. Please check your connection and try again.
                 </div>`;
             this.app.transitions.pageIn(content);
+        }
+    }
+
+    /**
+     * Re-create every <script> descendant of `root` so the browser actually
+     * executes it. `innerHTML` parses script tags but skips their execution
+     * by design — any JS in an injected page template would otherwise no-op
+     * silently. Re-created nodes preserve the original attributes (src,
+     * type, async, defer, nomodule, integrity, crossorigin) and replace
+     * the original in-place so document order is kept for side-effectful
+     * scripts that depend on it.
+     *
+     * @param {HTMLElement} root Container whose script descendants to run
+     * @private
+     */
+    _executeInlineScripts(root) {
+        if (!root) return;
+        const scripts = root.querySelectorAll('script');
+        for (const oldScript of scripts) {
+            const newScript = document.createElement('script');
+            for (const attr of oldScript.attributes) {
+                newScript.setAttribute(attr.name, attr.value);
+            }
+            if (!oldScript.src) {
+                newScript.textContent = oldScript.textContent;
+            }
+            oldScript.replaceWith(newScript);
         }
     }
 

--- a/appWeb/public_html/manage/analytics.php
+++ b/appWeb/public_html/manage/analytics.php
@@ -173,7 +173,7 @@ try {
     </div>
 </nav>
 
-<div class="container py-4" style="max-width: 1100px;">
+<div class="container-admin py-4">
 
     <div class="d-flex flex-wrap align-items-end justify-content-between mb-3 gap-2">
         <h1 class="h4 mb-0">Analytics — last <?= (int)$range ?> days</h1>

--- a/appWeb/public_html/manage/data-health.php
+++ b/appWeb/public_html/manage/data-health.php
@@ -165,7 +165,7 @@ $csrf = csrfToken();
 
     <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-nav.php'; ?>
 
-    <div class="container py-4" style="max-width: 1100px;">
+    <div class="container-admin py-4">
 
         <h1 class="h4 mb-3"><i class="bi bi-activity me-2"></i>Data Health Check</h1>
         <p class="text-secondary small mb-4">

--- a/appWeb/public_html/manage/entitlements.php
+++ b/appWeb/public_html/manage/entitlements.php
@@ -126,7 +126,7 @@ foreach (ENTITLEMENTS as $n => $_) {
     </div>
 </nav>
 
-<div class="container py-4" style="max-width: 1100px;">
+<div class="container-admin py-4">
 
     <h1 class="h4 mb-3">Role → Entitlement map</h1>
     <p class="text-secondary small mb-4">

--- a/appWeb/public_html/manage/groups.php
+++ b/appWeb/public_html/manage/groups.php
@@ -210,7 +210,7 @@ $csrf = csrfToken();
 
     <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-nav.php'; ?>
 
-    <div class="container py-4" style="max-width: 1100px;">
+    <div class="container-admin py-4">
 
         <h1 class="h4 mb-3"><i class="bi bi-people-fill me-2"></i>User Groups</h1>
         <p class="text-secondary small mb-4">

--- a/appWeb/public_html/manage/includes/admin-nav.php
+++ b/appWeb/public_html/manage/includes/admin-nav.php
@@ -8,13 +8,20 @@ declare(strict_types=1);
  * Copyright (c) 2026 iHymns. All rights reserved.
  *
  * PURPOSE:
- * Shared navigation bar for all /manage/ pages. Shows links
- * appropriate to the current user's role.
+ * Shared navigation bar for all /manage/ pages. Structure matches the
+ * main-site header (appWeb/public_html/index.php ≈ line 563) so admins
+ * don't context-switch visually when crossing from `/` to `/manage/`:
+ *   - Left: "iHymns Admin" brand with dropdown (parity with main site)
+ *   - Right: [search (hidden)] [theme] [username+role] [avatar] [hamburger]
+ *   - Hamburger opens an offcanvas panel listing every admin surface,
+ *     each gated by the same entitlement that controls its page.
  *
- * USAGE:
+ * Expected caller state:
+ *   require_once __DIR__ . '/includes/auth.php';
+ *   require_once dirname(__DIR__) . '/includes/entitlements.php';
  *   $currentUser = getCurrentUser();
- *   $activePage  = 'dashboard'; // 'dashboard', 'editor', 'users'
- *   require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-nav.php';
+ *   $activePage  = 'dashboard'; // or 'users', 'groups', ...
+ *   require __DIR__ . '/includes/admin-nav.php';
  */
 
 /* Prevent direct access */
@@ -22,46 +29,222 @@ if (basename($_SERVER['SCRIPT_FILENAME'] ?? '') === basename(__FILE__)) {
     http_response_code(403);
     exit('Access denied.');
 }
+
+$_activePage = $activePage ?? '';
+$_role       = $currentUser['role'] ?? null;
+$_displayName = $currentUser['display_name'] ?? $currentUser['username'] ?? 'admin';
+$_username    = $currentUser['username'] ?? '';
+$_roleBadge   = match($_role) {
+    'global_admin' => ['bg-danger',             'Global Admin'],
+    'admin'        => ['bg-warning text-dark',  'Admin'],
+    'editor'       => ['bg-primary',            'Curator / Editor'],
+    default        => ['bg-secondary',          'User'],
+};
+
+/* Admin-surface links. Each entry:
+ *   id          — matches $activePage set by the page, for highlight
+ *   href        — destination
+ *   icon        — bi-* class
+ *   label       — menu text
+ *   entitlement — required entitlement name (null → always visible)
+ * Kept in one place so the offcanvas, the brand dropdown, and future
+ * command-palette can all iterate the same list. */
+$_adminLinks = [
+    ['dashboard',    '/manage/',                'bi-speedometer2',   'Dashboard',          null],
+    ['editor',       '/manage/editor/',         'bi-pencil-square',  'Song Editor',        'edit_songs'],
+    ['requests',     '/manage/requests',        'bi-lightbulb',      'Song Requests',      'review_song_requests'],
+    ['revisions',    '/manage/revisions',       'bi-clock-history',  'Revisions Audit',    'verify_songs'],
+    ['users',        '/manage/users',           'bi-people',         'Users',              'view_users'],
+    ['groups',       '/manage/groups',          'bi-people-fill',    'User Groups',        'manage_user_groups'],
+    ['organisations','/manage/organisations',   'bi-building',       'Organisations',      'manage_organisations'],
+    ['songbooks',    '/manage/songbooks',       'bi-book',           'Songbooks',          'manage_songbooks'],
+    ['restrictions', '/manage/restrictions',    'bi-shield-lock',    'Content Restrictions','manage_content_restrictions'],
+    ['tiers',        '/manage/tiers',           'bi-stars',          'Access Tiers',       'manage_access_tiers'],
+    ['entitlements', '/manage/entitlements',    'bi-key',            'Entitlements',       'manage_entitlements'],
+    ['analytics',    '/manage/analytics',       'bi-graph-up',       'Analytics',          'view_analytics'],
+    ['data-health',  '/manage/data-health',     'bi-activity',       'Data Health',        'drop_legacy_tables'],
+    ['setup-database','/manage/setup-database', 'bi-database-gear',  'Database Setup',     'run_db_install'],
+];
+
+$_visibleAdminLinks = array_values(array_filter(
+    $_adminLinks,
+    static fn(array $l): bool => $l[4] === null || userHasEntitlement($l[4], $_role)
+));
+
 ?>
-<nav class="navbar-admin d-flex align-items-center flex-wrap gap-2">
-    <a href="/manage/" class="text-decoration-none me-auto d-flex align-items-center gap-2" style="color: var(--ih-amber);">
-        <i class="bi bi-music-note-beamed"></i>
-        <strong>iHymns Admin</strong>
-    </a>
+<header class="app-header navbar-admin" role="banner">
+    <nav class="navbar navbar-expand" aria-label="Admin navigation">
+        <div class="container-fluid px-3">
 
-    <a href="/manage/" class="nav-link d-inline <?= ($activePage ?? '') === 'dashboard' ? 'active' : '' ?>">
-        <i class="bi bi-speedometer2 me-1"></i>Dashboard
-    </a>
+            <!-- ============================================================
+                 LEFT — Brand with dropdown (mirrors main site header)
+                 ============================================================ -->
+            <div class="dropdown">
+                <button type="button"
+                        class="navbar-brand d-flex align-items-center gap-2 dropdown-toggle"
+                        data-bs-toggle="dropdown"
+                        aria-expanded="false"
+                        aria-label="iHymns Admin navigation menu"
+                        id="admin-brand-btn">
+                    <i class="bi bi-music-note-beamed fs-5" aria-hidden="true"></i>
+                    <span class="fw-bold">iHymns</span>
+                    <span class="badge bg-warning text-dark ms-1 small">Admin</span>
+                </button>
+                <ul class="dropdown-menu" aria-labelledby="admin-brand-btn">
+                    <li><a class="dropdown-item" href="/manage/">
+                        <i class="bi bi-speedometer2 me-2" aria-hidden="true"></i>Dashboard
+                    </a></li>
+                    <li><a class="dropdown-item" href="/">
+                        <i class="bi bi-house me-2" aria-hidden="true"></i>Home (Main site)
+                    </a></li>
+                    <li><a class="dropdown-item" href="/help" target="_blank" rel="noopener">
+                        <i class="bi bi-question-circle me-2" aria-hidden="true"></i>Help
+                    </a></li>
+                </ul>
+            </div>
 
-    <?php if (hasRole($currentUser['role'], 'editor')): ?>
-    <a href="/manage/editor/" class="nav-link d-inline <?= ($activePage ?? '') === 'editor' ? 'active' : '' ?>">
-        <i class="bi bi-pencil-square me-1"></i>Editor
-    </a>
-    <?php endif; ?>
+            <!-- ============================================================
+                 RIGHT — Search (hidden) · Theme · Name+role · Avatar · Burger
+                 ============================================================ -->
+            <div class="d-flex align-items-center gap-2 ms-auto">
 
-    <?php if (hasRole($currentUser['role'], 'admin')): ?>
-    <a href="/manage/users" class="nav-link d-inline <?= ($activePage ?? '') === 'users' ? 'active' : '' ?>">
-        <i class="bi bi-people me-1"></i>Users
-    </a>
-    <?php endif; ?>
+                <!-- Search — layout slot reserved, hidden until admin
+                     search is wired up. Keeping the button in the DOM
+                     means enabling it later doesn't reflow the bar. -->
+                <button type="button"
+                        class="btn btn-header-icon invisible"
+                        id="admin-search-btn"
+                        aria-hidden="true"
+                        tabindex="-1"
+                        title="Admin search (coming soon)">
+                    <i class="bi bi-search" aria-hidden="true"></i>
+                </button>
 
-    <span class="text-muted mx-1 d-none d-sm-inline">|</span>
-    <span class="text-muted small d-none d-sm-inline">
-        <?= htmlspecialchars($currentUser['display_name'] ?? $currentUser['username']) ?>
-        <span class="badge ms-1 <?= match($currentUser['role']) {
-            'global_admin' => 'bg-danger',
-            'admin'        => 'bg-warning text-dark',
-            'editor'       => 'bg-primary',
-            default        => 'bg-secondary',
-        } ?>" style="font-size: 0.65rem;">
-            <?= htmlspecialchars(roleLabel($currentUser['role'])) ?>
-        </span>
-    </span>
-    <a href="/" class="btn btn-sm btn-outline-secondary ms-1"
-       title="Back to the iHymns app home">
-        <i class="bi bi-house me-1"></i>Home
-    </a>
-    <a href="/manage/logout" class="btn btn-sm btn-outline-secondary ms-1">
-        <i class="bi bi-box-arrow-right me-1"></i>Logout
-    </a>
-</nav>
+                <!-- Theme toggle — same shape as main site but admin is
+                     currently always dark. Offered anyway so admins can
+                     temporarily switch for screenshots / demos. -->
+                <div class="dropdown">
+                    <button type="button"
+                            class="btn btn-header-icon dropdown-toggle"
+                            data-bs-toggle="dropdown"
+                            aria-expanded="false"
+                            aria-label="Theme"
+                            id="admin-theme-btn">
+                        <i class="bi bi-circle-half" aria-hidden="true"></i>
+                    </button>
+                    <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="admin-theme-btn">
+                        <li><button type="button" class="dropdown-item" data-bs-theme-value="light">
+                            <i class="bi bi-sun me-2" aria-hidden="true"></i>Light
+                        </button></li>
+                        <li><button type="button" class="dropdown-item" data-bs-theme-value="dark">
+                            <i class="bi bi-moon me-2" aria-hidden="true"></i>Dark
+                        </button></li>
+                        <li><hr class="dropdown-divider"></li>
+                        <li><button type="button" class="dropdown-item" data-bs-theme-value="auto">
+                            <i class="bi bi-laptop me-2" aria-hidden="true"></i>System
+                        </button></li>
+                    </ul>
+                </div>
+
+                <!-- Username + role badge — hidden on xs; shown from sm up.
+                     Clicking opens the avatar dropdown (same target), so
+                     this is a discoverable but optional affordance. -->
+                <button type="button"
+                        class="btn btn-sm d-none d-sm-inline-flex align-items-center gap-2 admin-identity-btn"
+                        data-bs-toggle="dropdown"
+                        data-bs-target="#admin-user-dropdown-menu"
+                        aria-expanded="false"
+                        aria-label="Account menu">
+                    <span><?= htmlspecialchars($_displayName) ?></span>
+                    <span class="badge <?= $_roleBadge[0] ?>" style="font-size: 0.65rem;">
+                        <?= htmlspecialchars($_roleBadge[1]) ?>
+                    </span>
+                </button>
+
+                <!-- Avatar dropdown — profile / logout, matches main site -->
+                <div class="dropdown" id="admin-user-dropdown">
+                    <button type="button"
+                            class="btn btn-header-icon dropdown-toggle"
+                            data-bs-toggle="dropdown"
+                            aria-expanded="false"
+                            aria-label="Account"
+                            title="Account"
+                            id="admin-user-btn">
+                        <i class="bi bi-person-circle" aria-hidden="true"></i>
+                    </button>
+                    <ul class="dropdown-menu dropdown-menu-end"
+                        aria-labelledby="admin-user-btn"
+                        id="admin-user-dropdown-menu">
+                        <li class="dropdown-item-text small">
+                            <div class="fw-semibold"><?= htmlspecialchars($_displayName) ?></div>
+                            <?php if ($_username && $_username !== $_displayName): ?>
+                                <div class="text-muted small">@<?= htmlspecialchars($_username) ?></div>
+                            <?php endif; ?>
+                            <span class="badge <?= $_roleBadge[0] ?> mt-1" style="font-size: 0.65rem;">
+                                <?= htmlspecialchars($_roleBadge[1]) ?>
+                            </span>
+                        </li>
+                        <li><hr class="dropdown-divider"></li>
+                        <li><a class="dropdown-item" href="/settings#tab-profile" target="_blank" rel="noopener">
+                            <i class="bi bi-person me-2" aria-hidden="true"></i>Profile &amp; settings
+                        </a></li>
+                        <li><a class="dropdown-item" href="/">
+                            <i class="bi bi-house me-2" aria-hidden="true"></i>Back to main site
+                        </a></li>
+                        <li><hr class="dropdown-divider"></li>
+                        <li><a class="dropdown-item text-danger" href="/manage/logout">
+                            <i class="bi bi-box-arrow-right me-2" aria-hidden="true"></i>Log out
+                        </a></li>
+                    </ul>
+                </div>
+
+                <!-- Hamburger — opens the offcanvas surface nav -->
+                <button type="button"
+                        class="btn btn-header-icon"
+                        data-bs-toggle="offcanvas"
+                        data-bs-target="#admin-nav-offcanvas"
+                        aria-controls="admin-nav-offcanvas"
+                        aria-label="Admin surfaces menu"
+                        title="All admin surfaces">
+                    <i class="bi bi-list fs-5" aria-hidden="true"></i>
+                </button>
+            </div>
+        </div>
+    </nav>
+</header>
+
+<!-- ================================================================
+     OFFCANVAS — Every admin surface, each entitlement-gated.
+     Rendered once per page so the hamburger has a consistent list
+     regardless of which page the user is on.
+     ================================================================ -->
+<div class="offcanvas offcanvas-end"
+     tabindex="-1"
+     id="admin-nav-offcanvas"
+     aria-labelledby="admin-nav-offcanvas-label">
+    <div class="offcanvas-header border-bottom">
+        <h5 class="offcanvas-title" id="admin-nav-offcanvas-label">
+            <i class="bi bi-grid-3x3-gap me-2" aria-hidden="true"></i>Admin surfaces
+        </h5>
+        <button type="button"
+                class="btn-close btn-close-white"
+                data-bs-dismiss="offcanvas"
+                aria-label="Close"></button>
+    </div>
+    <div class="offcanvas-body p-0">
+        <nav class="list-group list-group-flush" aria-label="Admin sections">
+            <?php foreach ($_visibleAdminLinks as $l): ?>
+                <?php [$id, $href, $icon, $label] = $l; ?>
+                <a href="<?= htmlspecialchars($href) ?>"
+                   class="list-group-item list-group-item-action d-flex align-items-center gap-2<?= $_activePage === $id ? ' active' : '' ?>"
+                   <?= $_activePage === $id ? 'aria-current="page"' : '' ?>>
+                    <i class="bi <?= htmlspecialchars($icon) ?>" aria-hidden="true"></i>
+                    <span><?= htmlspecialchars($label) ?></span>
+                </a>
+            <?php endforeach; ?>
+        </nav>
+    </div>
+    <div class="offcanvas-footer border-top small text-muted p-3">
+        Each item is shown only when your role holds the entitlement that controls it.
+    </div>
+</div>

--- a/appWeb/public_html/manage/includes/auth.php
+++ b/appWeb/public_html/manage/includes/auth.php
@@ -316,7 +316,10 @@ function needsSetup(): bool
 function createUser(string $username, string $password, string $displayName, string $role = 'editor', string $email = ''): int
 {
     $db = getDb();
-    $username = strtolower(trim($username));
+    /* Preserve the case the user chose — the `Username` column is
+       utf8mb4_unicode_ci, so uniqueness + login lookups remain
+       case-insensitive without us lowercasing. */
+    $username = trim($username);
 
     /* Validate role */
     if (!isset(ROLE_LEVELS[$role])) {
@@ -569,10 +572,13 @@ function updateUserProfile(int $userId, string $displayName, string $email): boo
  */
 function renameUser(int $userId, string $newUsername, ?string &$error = null): bool
 {
-    $newUsername = mb_strtolower(trim($newUsername));
+    /* Preserve case the user picked. Validation allows upper + lower
+       letters; the `ci` collation on Username still enforces unique-
+       across-case, so nobody can create "Alice" if "alice" exists. */
+    $newUsername = trim($newUsername);
     if (strlen($newUsername) < 3
         || strlen($newUsername) > 100
-        || !preg_match('/^[a-z0-9_.\-]+$/', $newUsername)) {
+        || !preg_match('/^[A-Za-z0-9_.\-]+$/', $newUsername)) {
         $error = 'Username must be 3–100 characters (letters, numbers, _, -, . only).';
         return false;
     }

--- a/appWeb/public_html/manage/index.php
+++ b/appWeb/public_html/manage/index.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'entitlements.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'card_layout.php';
 
 /* Dashboard is now the single landing page for every management
    surface, so admit any signed-in user who holds at least one
@@ -200,165 +201,107 @@ $csrf = csrfToken();
         </div>
         <?php endif; ?>
 
-        <!-- Quick Links — every card is gated by the same entitlement
-             that controls visibility of the corresponding menu item, so
-             the dashboard surfaces exactly the areas the user can act
-             on. Gate helper: userHasEntitlement($ent, $role). -->
-        <div class="row g-3 mb-4">
-            <?php if (userHasEntitlement('edit_songs', $_role)): ?>
-            <div class="col-md-4">
-                <div class="card-admin">
-                    <a href="/manage/editor/" class="quick-link">
-                        <i class="bi bi-pencil-square d-block mb-2"></i>
-                        <strong>Song Editor</strong>
-                        <div class="small text-muted">Edit songs, metadata, and arrangements</div>
-                    </a>
-                </div>
-            </div>
+        <?php
+        /* Every card is gated by the same entitlement that controls
+           visibility of the corresponding menu item, so the dashboard
+           surfaces exactly the areas the user can act on. A single
+           $cards array drives rendering so reorder / hide (#448) is a
+           matter of sorting + filtering this list. */
+        $pendingReqsLabel = $pendingReqs . ' pending · triage &amp; resolve';
+        $dashboardCards = [
+            ['editor',       'edit_songs',                  '/manage/editor/',       'bi-pencil-square', 'Song Editor',          'Edit songs, metadata, and arrangements',                                  true],
+            ['requests',     'review_song_requests',        '/manage/requests',      'bi-lightbulb',     'Song Requests',        $pendingReqsLabel,                                                         false],
+            ['revisions',    'verify_songs',                '/manage/revisions',     'bi-clock-history', 'Revisions Audit',      'Audit song edits; open any row in the editor to diff / restore',           true],
+            ['users',        'view_users',                  '/manage/users',         'bi-people',        'User Management',      'Manage accounts, roles, and permissions',                                 true],
+            ['groups',       'manage_user_groups',          '/manage/groups',        'bi-people-fill',   'User Groups',          'Group users for shared access settings',                                  true],
+            ['organisations','manage_organisations',        '/manage/organisations', 'bi-building',      'Organisations',        'Manage organisations &amp; their members',                                 true],
+            ['songbooks',    'manage_songbooks',            '/manage/songbooks',     'bi-book',          'Songbook Management',  'Create, rename, reorder the songbook catalogue',                          true],
+            ['restrictions', 'manage_content_restrictions', '/manage/restrictions',  'bi-shield-lock',   'Content Restrictions', 'Gate songs, songbooks &amp; features per user, org, platform or licence', true],
+            ['tiers',        'manage_access_tiers',         '/manage/tiers',         'bi-stars',         'Access Tiers',         'Define tiers controlling lyrics, audio, MIDI, sheet music &amp; offline', true],
+            ['entitlements', 'manage_entitlements',         '/manage/entitlements',  'bi-key',           'Entitlements &amp; Gating','Assign capabilities to roles',                                          true],
+            ['analytics',    'view_analytics',              '/manage/analytics',     'bi-graph-up',      'Analytics',            'Top songs, searches, and user activity',                                  true],
+            ['data-health',  'drop_legacy_tables',          '/manage/data-health',   'bi-activity',      'Data Health',          'Confirm MySQL is authoritative; disconnect legacy fallbacks',             true],
+            ['setup-db',     'run_db_install',              '/manage/setup-database','bi-database-gear', 'Database Setup',       'Install, migrate, backup, restore, cleanup',                              true],
+            ['view-site',    null,                          '/',                     'bi-globe',         'View Website',         'Open iHymns in a new tab',                                                true],
+        ];
+
+        /* Filter out cards the viewer can't see, then apply the layout
+           resolver (system default merged with per-user override). */
+        $dashboardCards = array_values(array_filter(
+            $dashboardCards,
+            static fn(array $c): bool => $c[1] === null || userHasEntitlement($c[1], $_role)
+        ));
+        $dashboardBaseline = array_map(static fn(array $c) => $c[0], $dashboardCards);
+        $dashboardLayout   = cardLayoutResolve($dashboardBaseline, 'dashboard', [
+            'id'       => $currentUser['id'] ?? null,
+            'role'     => $_role,
+            'group_id' => $currentUser['group_id'] ?? null,
+        ]);
+        $dashboardById = [];
+        foreach ($dashboardCards as $c) { $dashboardById[$c[0]] = $c; }
+
+        $canCustomiseOwn = cardLayoutUserCanCustomise([
+            'id'       => $currentUser['id'] ?? null,
+            'role'     => $_role,
+            'group_id' => $currentUser['group_id'] ?? null,
+        ]);
+        $canSetDefault = userHasEntitlement('manage_default_card_layout', $_role);
+        $hiddenSet = array_flip($dashboardLayout['hidden']);
+        ?>
+
+        <!-- Customise toolbar — only rendered if the viewer has at
+             least one relevant entitlement. -->
+        <?php if ($canCustomiseOwn || $canSetDefault): ?>
+        <div class="d-flex align-items-center gap-2 mb-3" id="card-layout-toolbar">
+            <button type="button" class="btn btn-sm btn-outline-info" id="btn-card-layout-edit">
+                <i class="bi bi-grid-3x3-gap me-1" aria-hidden="true"></i>Customise layout
+            </button>
+            <button type="button" class="btn btn-sm btn-outline-secondary d-none" id="btn-card-layout-done">
+                <i class="bi bi-check2 me-1" aria-hidden="true"></i>Done
+            </button>
+            <button type="button" class="btn btn-sm btn-outline-warning d-none" id="btn-card-layout-reset">
+                <i class="bi bi-arrow-counterclockwise me-1" aria-hidden="true"></i>Reset to default
+            </button>
+            <?php if ($canSetDefault): ?>
+            <button type="button" class="btn btn-sm btn-outline-danger d-none" id="btn-card-layout-save-default"
+                    title="Save the current order as the system-wide default for all users">
+                <i class="bi bi-save me-1" aria-hidden="true"></i>Save as site default
+            </button>
             <?php endif; ?>
-            <?php if (userHasEntitlement('review_song_requests', $_role)): ?>
-            <div class="col-md-4">
-                <div class="card-admin">
-                    <a href="/manage/requests" class="quick-link">
-                        <i class="bi bi-lightbulb d-block mb-2"></i>
-                        <strong>Song Requests</strong>
-                        <div class="small text-muted">
-                            <?= $pendingReqs ?> pending · triage &amp; resolve
-                        </div>
-                    </a>
+            <span class="small text-muted d-none" id="card-layout-help">
+                Drag the handle to reorder; click × to hide a card. Hidden cards reappear from
+                <a href="/settings#tab-profile" class="text-info">Settings → Profile</a>.
+            </span>
+        </div>
+        <?php endif; ?>
+
+        <!-- Quick Links — rendered from $dashboardLayout. data-card-id
+             keys each card so the client-side reorder module can move
+             them around without touching the DOM beyond the grid. -->
+        <div class="row g-3 mb-4"
+             id="dashboard-card-grid"
+             data-layout-surface="dashboard"
+             data-can-customise="<?= $canCustomiseOwn ? '1' : '0' ?>"
+             data-can-set-default="<?= $canSetDefault ? '1' : '0' ?>">
+            <?php foreach ($dashboardLayout['order'] as $cardId): ?>
+                <?php
+                if (!isset($dashboardById[$cardId])) continue;
+                [$id, , $href, $icon, $title, $sub, $sameTab] = $dashboardById[$cardId];
+                $isHidden = isset($hiddenSet[$id]);
+                $target = $sameTab ? '' : 'target="_blank" rel="noopener"';
+                ?>
+                <div class="col-md-4 card-layout-item<?= $isHidden ? ' d-none' : '' ?>"
+                     data-card-id="<?= htmlspecialchars($id) ?>"
+                     data-hidden="<?= $isHidden ? '1' : '0' ?>">
+                    <div class="card-admin position-relative">
+                        <a href="<?= htmlspecialchars($href) ?>" class="quick-link" <?= $target ?>>
+                            <i class="bi <?= htmlspecialchars($icon) ?> d-block mb-2" aria-hidden="true"></i>
+                            <strong><?= $title /* some titles contain &amp; entity */ ?></strong>
+                            <div class="small text-muted"><?= $sub /* same */ ?></div>
+                        </a>
+                    </div>
                 </div>
-            </div>
-            <?php endif; ?>
-            <?php if (userHasEntitlement('verify_songs', $_role)): ?>
-            <div class="col-md-4">
-                <div class="card-admin">
-                    <a href="/manage/revisions" class="quick-link">
-                        <i class="bi bi-clock-history d-block mb-2"></i>
-                        <strong>Revisions Audit</strong>
-                        <div class="small text-muted">Audit song edits; open any row in the editor to diff / restore</div>
-                    </a>
-                </div>
-            </div>
-            <?php endif; ?>
-            <?php if (userHasEntitlement('view_users', $_role)): ?>
-            <div class="col-md-4">
-                <div class="card-admin">
-                    <a href="/manage/users" class="quick-link">
-                        <i class="bi bi-people d-block mb-2"></i>
-                        <strong>User Management</strong>
-                        <div class="small text-muted">Manage accounts, roles, and permissions</div>
-                    </a>
-                </div>
-            </div>
-            <?php endif; ?>
-            <?php if (userHasEntitlement('manage_user_groups', $_role)): ?>
-            <div class="col-md-4">
-                <div class="card-admin">
-                    <a href="/manage/groups" class="quick-link">
-                        <i class="bi bi-people-fill d-block mb-2"></i>
-                        <strong>User Groups</strong>
-                        <div class="small text-muted">Group users for shared access settings</div>
-                    </a>
-                </div>
-            </div>
-            <?php endif; ?>
-            <?php if (userHasEntitlement('manage_organisations', $_role)): ?>
-            <div class="col-md-4">
-                <div class="card-admin">
-                    <a href="/manage/organisations" class="quick-link">
-                        <i class="bi bi-building d-block mb-2"></i>
-                        <strong>Organisations</strong>
-                        <div class="small text-muted">Manage organisations &amp; their members</div>
-                    </a>
-                </div>
-            </div>
-            <?php endif; ?>
-            <?php if (userHasEntitlement('manage_songbooks', $_role)): ?>
-            <div class="col-md-4">
-                <div class="card-admin">
-                    <a href="/manage/songbooks" class="quick-link">
-                        <i class="bi bi-book d-block mb-2"></i>
-                        <strong>Songbook Management</strong>
-                        <div class="small text-muted">Create, rename, reorder the songbook catalogue</div>
-                    </a>
-                </div>
-            </div>
-            <?php endif; ?>
-            <?php if (userHasEntitlement('manage_content_restrictions', $_role)): ?>
-            <div class="col-md-4">
-                <div class="card-admin">
-                    <a href="/manage/restrictions" class="quick-link">
-                        <i class="bi bi-shield-lock d-block mb-2"></i>
-                        <strong>Content Restrictions</strong>
-                        <div class="small text-muted">Gate songs, songbooks &amp; features per user, org, platform or licence</div>
-                    </a>
-                </div>
-            </div>
-            <?php endif; ?>
-            <?php if (userHasEntitlement('manage_access_tiers', $_role)): ?>
-            <div class="col-md-4">
-                <div class="card-admin">
-                    <a href="/manage/tiers" class="quick-link">
-                        <i class="bi bi-stars d-block mb-2"></i>
-                        <strong>Access Tiers</strong>
-                        <div class="small text-muted">Define tiers controlling lyrics, audio, MIDI, sheet music &amp; offline</div>
-                    </a>
-                </div>
-            </div>
-            <?php endif; ?>
-            <?php if (userHasEntitlement('manage_entitlements', $_role)): ?>
-            <div class="col-md-4">
-                <div class="card-admin">
-                    <a href="/manage/entitlements" class="quick-link">
-                        <i class="bi bi-key d-block mb-2"></i>
-                        <strong>Entitlements &amp; Gating</strong>
-                        <div class="small text-muted">Assign capabilities to roles</div>
-                    </a>
-                </div>
-            </div>
-            <?php endif; ?>
-            <?php if (userHasEntitlement('view_analytics', $_role)): ?>
-            <div class="col-md-4">
-                <div class="card-admin">
-                    <a href="/manage/analytics" class="quick-link">
-                        <i class="bi bi-graph-up d-block mb-2"></i>
-                        <strong>Analytics</strong>
-                        <div class="small text-muted">Top songs, searches, and user activity</div>
-                    </a>
-                </div>
-            </div>
-            <?php endif; ?>
-            <?php if (userHasEntitlement('drop_legacy_tables', $_role)): ?>
-            <div class="col-md-4">
-                <div class="card-admin">
-                    <a href="/manage/data-health" class="quick-link">
-                        <i class="bi bi-activity d-block mb-2"></i>
-                        <strong>Data Health</strong>
-                        <div class="small text-muted">Confirm MySQL is authoritative; disconnect legacy fallbacks</div>
-                    </a>
-                </div>
-            </div>
-            <?php endif; ?>
-            <?php if (userHasEntitlement('run_db_install', $_role)): ?>
-            <div class="col-md-4">
-                <div class="card-admin">
-                    <a href="/manage/setup-database" class="quick-link">
-                        <i class="bi bi-database-gear d-block mb-2"></i>
-                        <strong>Database Setup</strong>
-                        <div class="small text-muted">Install, migrate, backup, restore, cleanup</div>
-                    </a>
-                </div>
-            </div>
-            <?php endif; ?>
-            <div class="col-md-4">
-                <div class="card-admin">
-                    <a href="/" class="quick-link" target="_blank" rel="noopener">
-                        <i class="bi bi-globe d-block mb-2"></i>
-                        <strong>View Website</strong>
-                        <div class="small text-muted">Open iHymns in a new tab</div>
-                    </a>
-                </div>
-            </div>
+            <?php endforeach; ?>
         </div>
 
         <!-- Recent Users (admin+ only) -->
@@ -419,6 +362,15 @@ $csrf = csrfToken();
         </div>
 
     </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+            integrity="sha384-zKzgIZcXU99qF1nNW9g+x1znB5NhCPs9qZeGzUnnFOaHJF9jCCKySBjq3vIKabk/"
+            crossorigin="anonymous"></script>
+
+    <script type="module">
+        import { bootCardLayout } from '/js/modules/card-layout.js?v=<?= filemtime(dirname(__DIR__) . '/js/modules/card-layout.js') ?>';
+        bootCardLayout();
+    </script>
 
     <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>
 </body>

--- a/appWeb/public_html/manage/index.php
+++ b/appWeb/public_html/manage/index.php
@@ -112,7 +112,7 @@ $csrf = csrfToken();
 <body>
     <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-nav.php'; ?>
 
-    <div class="container py-4" style="max-width: 960px;">
+    <div class="container-admin py-4">
 
         <h1 class="h4 mb-1"><i class="bi bi-speedometer2 me-2"></i>Admin Portal</h1>
         <p class="text-secondary small mb-4">

--- a/appWeb/public_html/manage/organisations.php
+++ b/appWeb/public_html/manage/organisations.php
@@ -254,7 +254,7 @@ $csrf = csrfToken();
 
     <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-nav.php'; ?>
 
-    <div class="container py-4" style="max-width: 1100px;">
+    <div class="container-admin py-4">
 
         <h1 class="h4 mb-3"><i class="bi bi-building me-2"></i>Organisations</h1>
         <p class="text-secondary small mb-4">

--- a/appWeb/public_html/manage/requests.php
+++ b/appWeb/public_html/manage/requests.php
@@ -132,7 +132,7 @@ try {
     </div>
 </nav>
 
-<div class="container py-4" style="max-width: 1100px;">
+<div class="container-admin py-4">
 
     <?php if ($flash): ?>
         <div class="alert alert-success py-2"><?= htmlspecialchars($flash) ?></div>

--- a/appWeb/public_html/manage/restrictions.php
+++ b/appWeb/public_html/manage/restrictions.php
@@ -198,7 +198,7 @@ $csrf = csrfToken();
 
     <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-nav.php'; ?>
 
-    <div class="container py-4" style="max-width: 1100px;">
+    <div class="container-admin py-4">
 
         <h1 class="h4 mb-3"><i class="bi bi-shield-lock me-2"></i>Content Restrictions</h1>
         <p class="text-secondary small mb-3">

--- a/appWeb/public_html/manage/revisions.php
+++ b/appWeb/public_html/manage/revisions.php
@@ -102,7 +102,7 @@ try {
     </div>
 </nav>
 
-<div class="container py-4" style="max-width: 1200px;">
+<div class="container-admin py-4">
 
     <div class="d-flex flex-wrap align-items-end justify-content-between mb-3 gap-2">
         <h1 class="h4 mb-0">Song edit revisions</h1>

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -296,7 +296,7 @@ if ($hasCredentials && defined('DB_HOST')) {
 </nav>
 <?php endif; ?>
 
-<div class="container py-4" style="max-width: 900px;">
+<div class="container-admin py-4">
 
     <h1 class="mb-1">Database Setup</h1>
     <p class="text-secondary mb-4">iHymns Admin &mdash; Installation, migration, and maintenance</p>

--- a/appWeb/public_html/manage/songbooks.php
+++ b/appWeb/public_html/manage/songbooks.php
@@ -223,7 +223,7 @@ $csrf = csrfToken();
 
     <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-nav.php'; ?>
 
-    <div class="container py-4" style="max-width: 1100px;">
+    <div class="container-admin py-4">
 
         <h1 class="h4 mb-3"><i class="bi bi-book me-2"></i>Songbooks</h1>
         <p class="text-secondary small mb-4">

--- a/appWeb/public_html/manage/tiers.php
+++ b/appWeb/public_html/manage/tiers.php
@@ -199,7 +199,7 @@ $tierTableCols = 3 + count(TIER_CAPS) + 2;
 
     <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-nav.php'; ?>
 
-    <div class="container py-4" style="max-width: 1200px;">
+    <div class="container-admin py-4">
 
         <h1 class="h4 mb-3"><i class="bi bi-stars me-2"></i>Access Tiers</h1>
         <p class="text-secondary small mb-4">

--- a/appWeb/public_html/manage/users.php
+++ b/appWeb/public_html/manage/users.php
@@ -247,7 +247,7 @@ function canManage(array $target, array $actor): bool {
 <body>
     <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-nav.php'; ?>
 
-    <div class="container py-4" style="max-width: 960px;">
+    <div class="container-admin py-4">
 
         <h1 class="h4 mb-4"><i class="bi bi-people me-2"></i>User Management</h1>
 

--- a/appWeb/public_html/manage/users.php
+++ b/appWeb/public_html/manage/users.php
@@ -513,11 +513,11 @@ function canManage(array $target, array $actor): bool {
                         <div class="mb-3">
                             <label class="form-label">New username</label>
                             <input type="text" class="form-control" name="new_username" id="rename-new-username"
-                                   minlength="3" maxlength="100" pattern="[a-z0-9_.\-]+"
+                                   minlength="3" maxlength="100" pattern="[A-Za-z0-9_.\-]+"
                                    autocomplete="off" autocapitalize="none" spellcheck="false" required>
                             <div class="form-text" style="color: var(--ih-text-muted);">
-                                Lowercase letters, numbers, dots, dashes and underscores only. 3–100 characters.
-                                Usernames must be unique.
+                                Letters (any case), numbers, dots, dashes and underscores. 3–100 characters.
+                                Usernames are unique case-insensitively — "Alice" and "alice" cannot coexist.
                             </div>
                         </div>
                         <div class="alert alert-info py-2 small mb-0">

--- a/appWeb/public_html/service-worker.js.php
+++ b/appWeb/public_html/service-worker.js.php
@@ -646,64 +646,93 @@ self.addEventListener('message', (event) => {
 
         if (!Array.isArray(songbooks) || songbooks.length === 0) return;
 
-        caches.open(RECENT_CACHE).then(async (cache) => {
+        /* Self-invoking async wrapper so a rejection from caches.open(),
+           fetch() or cache.put() surfaces as a progress message with an
+           error string rather than silently stalling the UI at
+           "Downloading <book>…" indefinitely (#452). */
+        (async () => {
             let completed = 0;
             let failed = 0;
             const total = totalSongs;
 
-            for (const songbook of songbooks) {
-                try {
+            try {
+                const cache = await caches.open(RECENT_CACHE);
+
+                for (const songbook of songbooks) {
                     notifyClients({
                         type: 'CACHE_ALL_SONGS_PROGRESS',
                         completed, failed, total,
                         status: `Downloading ${songbook}...`,
                     });
 
-                    const resp = await fetch(`/api?action=bulk_songs&songbook=${encodeURIComponent(songbook)}`);
-                    if (!resp.ok) {
-                        failed++;
-                        continue;
-                    }
-
-                    const data = await resp.json();
-                    const songs = data.songs || {};
-                    const ids = Object.keys(songs);
-
-                    /* Store each song's HTML as an individual cache entry */
-                    for (const id of ids) {
-                        try {
-                            const url = `/api?page=song&id=${encodeURIComponent(id)}`;
-                            const html = songs[id];
-                            const fakeResponse = new Response(html, {
-                                status: 200,
-                                headers: {
-                                    'Content-Type': 'text/html; charset=UTF-8',
-                                    'X-Bulk-Cached': 'true',
-                                },
-                            });
-                            await cache.put(url, fakeResponse);
-                            completed++;
-                        } catch {
+                    try {
+                        const resp = await fetch(`/api?action=bulk_songs&songbook=${encodeURIComponent(songbook)}`);
+                        if (!resp.ok) {
                             failed++;
+                            notifyClients({
+                                type: 'CACHE_ALL_SONGS_PROGRESS',
+                                completed, failed, total,
+                                warning: `Skipped ${songbook}: HTTP ${resp.status}`,
+                            });
+                            continue;
                         }
-                    }
-                } catch {
-                    /* Network error for this songbook */
-                    failed++;
-                }
 
+                        const data = await resp.json();
+                        const songs = data.songs || {};
+                        const ids = Object.keys(songs);
+
+                        for (const id of ids) {
+                            try {
+                                const url = `/api?page=song&id=${encodeURIComponent(id)}`;
+                                const html = songs[id];
+                                const fakeResponse = new Response(html, {
+                                    status: 200,
+                                    headers: {
+                                        'Content-Type': 'text/html; charset=UTF-8',
+                                        'X-Bulk-Cached': 'true',
+                                    },
+                                });
+                                await cache.put(url, fakeResponse);
+                                completed++;
+                            } catch (e) {
+                                failed++;
+                            }
+                        }
+                    } catch (e) {
+                        /* Network error for this songbook — surface it so
+                           the UI moves on rather than hanging silently. */
+                        failed++;
+                        notifyClients({
+                            type: 'CACHE_ALL_SONGS_PROGRESS',
+                            completed, failed, total,
+                            warning: `Network error on ${songbook}: ${e && e.message ? e.message : 'unknown'}`,
+                        });
+                    }
+
+                    notifyClients({
+                        type: 'CACHE_ALL_SONGS_PROGRESS',
+                        completed, failed, total,
+                    });
+                }
+            } catch (e) {
+                /* caches.open() failed (storage quota, private-mode,
+                   Safari ITP etc.) — let the UI know instead of
+                   pretending to be mid-download forever. */
                 notifyClients({
                     type: 'CACHE_ALL_SONGS_PROGRESS',
                     completed, failed, total,
+                    error: (e && e.message) ? e.message : 'Cache unavailable',
                 });
+                return;
             }
 
             /* Final report */
             notifyClients({
                 type: 'CACHE_ALL_SONGS_PROGRESS',
                 completed, failed, total,
+                done: true,
             });
-        });
+        })();
     }
 
     /* Legacy per-song download (fallback if bulk not available) */


### PR DESCRIPTION
Stacked on #445 / #451 (diff will shrink once they merge).

Closes #452, #453, #454, #455, #456.

## Summary

- **Unblocks offline downloads on Edge/macOS (#452).** Root cause was an unhandled promise rejection in the service-worker `CACHE_ALL_SONGS` handler — any quota / network / opaque-response hiccup silently broke the chain and the UI hung at "Downloading CH…" forever. Wrapped the loop in a try/catch + self-invoking IIFE; every error path now surfaces a `CACHE_ALL_SONGS_PROGRESS` message with an `error` / `warning` field.
- **Cloud-download on songbook cards (#453).** Each songbook card on `/` now has a corner download button that caches the whole songbook without leaving the home page. Clicking the card still navigates; the button uses `stopPropagation`.
- **Cloud-download on song view (#454) + toolbar harmonisation (#456).** Replaced the text "Save Offline" with the matching cloud button. All song-view toolbar buttons now share `.song-toolbar-btn` (identical shape, identical neutral base colour); accent colour used only for state (favourited, cached). Disabled state has clear visual + `cursor: not-allowed`.
- **Feature detection (#455).** `isOfflineSupported()` checks serviceWorker + caches + indexedDB. Unsupported browsers get `body.offline-unsupported` which hides every download control via one CSS rule — no permanently-disabled controls.
- **Perf: N+1 in bulk_songs.** The loop called `getSongById()` for each song in a songbook that `getSongs()` had already fully loaded (~800 redundant queries per Church Hymnal fetch). Swapped to `$song = $bulkSong;`. Template fields missing from the bulk shape (arrangement / capo / key) are all rendered through `!empty()` so output degrades gracefully.
- **Perf: ETag + Cache-Control on SPA page fragments.** `/api?page=…` now ETag-ifies the rendered body; same-URL revisit short-circuits to 304. Covers home / songbooks / songbook / song / search / writer / help / terms / privacy. User-specific pages (favorites, setlist, settings, stats) stay out of the cache path.

## Test plan

- [ ] Edge/macOS: "Download CH" from Settings completes (or surfaces an actionable error); no permanent "Downloading CH…" stall.
- [ ] Home page: download button on each songbook card. Click downloads that songbook, icon flips to `cloud-check` on success, errors surface.
- [ ] Song view: cloud button, disabled with tooltip when song already cached (individually or via songbook).
- [ ] Open DevTools Network → navigate `/` → `/songbooks` → back to `/`: second load of `/api?page=home` returns 304.
- [ ] `/api?action=bulk_songs&songbook=CH` issues N+1-less queries (verify in slow query log or by manual EXPLAIN).
- [ ] Private-mode / non-PWA browser: offline controls hidden entirely, no broken UI.
- [ ] All song-toolbar buttons look like siblings (same size, same base colour); favourited heart + cached cloud use accent colour for state only.

https://claude.ai/code/session_01VK9zszCiViesutz7bj27MH

---
_Generated by [Claude Code](https://claude.ai/code/session_01VK9zszCiViesutz7bj27MH)_