### PR TITLE
Admin portal deep fixes: Bootstrap JS + drag-drop + offline buttons + friendly labels + Data Health

### DIFF
--- a/appWeb/public_html/includes/pages/home.php
+++ b/appWeb/public_html/includes/pages/home.php
@@ -171,8 +171,11 @@ $songbooks = $songData->getSongbooks();
                                  browsers. Always rendered so server-HTML
                                  stays stable; never rendered enabled if
                                  the browser can't act on it. -->
+                            <!-- Rendered visible; a capability-free browser
+                                 picks up `body.offline-unsupported` and the
+                                 shared CSS rule hides all download UI. -->
                             <button type="button"
-                                    class="btn btn-sm btn-outline-secondary songbook-download-btn d-none"
+                                    class="btn btn-sm btn-outline-secondary songbook-download-btn"
                                     data-songbook-download="<?= htmlspecialchars($book['id']) ?>"
                                     aria-label="Download <?= htmlspecialchars($book['name']) ?> for offline use"
                                     title="Download this songbook for offline use">

--- a/appWeb/public_html/includes/pages/song.php
+++ b/appWeb/public_html/includes/pages/song.php
@@ -218,7 +218,7 @@ $components  = $song['components'] ?? [];
                      tooltip, and click; the legacy .btn-save-offline
                      handler still runs too, so either wire path works. -->
                 <button type="button"
-                        class="btn btn-outline-secondary btn-sm song-toolbar-btn btn-save-offline song-toolbar-btn d-none"
+                        class="btn btn-outline-secondary btn-sm song-toolbar-btn btn-save-offline"
                         data-song-id="<?= htmlspecialchars($song['id']) ?>"
                         data-song-download="<?= htmlspecialchars($song['id']) ?>"
                         aria-label="Save this song for offline use"

--- a/appWeb/public_html/js/modules/card-layout.js
+++ b/appWeb/public_html/js/modules/card-layout.js
@@ -28,16 +28,19 @@
  */
 
 const SORTABLE_CDN = 'https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js';
-const SORTABLE_INTEGRITY = 'sha384-aq8eSnxHJKZ/IzVz/6lq59+H3dCblmnJ2opgw7gvpRQa8lVQ+bKvY+z0sn3h47AO';
 
 let _sortablePromise = null;
 function loadSortable() {
     if (window.Sortable) return Promise.resolve(window.Sortable);
     if (_sortablePromise) return _sortablePromise;
+    /* SRI is intentionally NOT set here — the previous placeholder hash
+       silently blocked the script from executing, so the whole reorder
+       feature was dead on arrival. When we pin the CDN version we can
+       add a real integrity attribute; until then, `crossorigin` alone
+       is acceptable for a client-side-only, non-auth-carrying library. */
     _sortablePromise = new Promise((resolve, reject) => {
         const s = document.createElement('script');
         s.src = SORTABLE_CDN;
-        s.integrity = SORTABLE_INTEGRITY;
         s.crossOrigin = 'anonymous';
         s.onload  = () => resolve(window.Sortable);
         s.onerror = () => reject(new Error('Failed to load SortableJS'));

--- a/appWeb/public_html/js/modules/offline-ui.js
+++ b/appWeb/public_html/js/modules/offline-ui.js
@@ -24,13 +24,19 @@ export function isOfflineSupported() {
         && ('indexedDB' in window);
 }
 
-/** One-time feature-detection toggle — adds body class, unhides controls. */
+/** One-time feature-detection toggle. Controls are rendered visible
+ *  server-side; we only ADD the body class so the shared CSS rule in
+ *  app.css / admin.css can hide them when the browser can't act. */
 export function markOfflineCapability() {
     if (!isOfflineSupported()) {
         document.body.classList.add('offline-unsupported');
         return false;
     }
     document.body.classList.add('offline-supported');
+    /* Legacy cleanup — older builds rendered these with `d-none` and
+       relied on the JS to reveal them. New builds render them visible,
+       but leave this unhide step in place so mid-version caches don't
+       hide buttons on users who just got the refresh. */
     for (const btn of document.querySelectorAll('[data-songbook-download], [data-song-download]')) {
         btn.classList.remove('d-none');
     }

--- a/appWeb/public_html/manage/analytics.php
+++ b/appWeb/public_html/manage/analytics.php
@@ -160,18 +160,7 @@ try {
 </head>
 <body>
 
-<nav class="navbar-admin d-flex align-items-center justify-content-between">
-    <a class="navbar-brand" href="/manage/"><i class="bi bi-chart-line me-2"></i>iHymns Analytics</a>
-    <div class="d-flex align-items-center gap-2">
-        <span class="text-muted small d-none d-md-inline"><?= htmlspecialchars($currentUser['username'] ?? '') ?></span>
-        <a href="/manage/" class="btn btn-sm btn-outline-secondary">
-            <i class="bi bi-speedometer2 me-1"></i>Dashboard
-        </a>
-        <a href="/" class="btn btn-sm btn-outline-secondary" title="Back to the iHymns app home">
-            <i class="bi bi-house me-1"></i>Home
-        </a>
-    </div>
-</nav>
+<?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-nav.php'; ?>
 
 <div class="container-admin py-4">
 

--- a/appWeb/public_html/manage/data-health.php
+++ b/appWeb/public_html/manage/data-health.php
@@ -29,9 +29,21 @@ if (!$currentUser || ($currentUser['role'] ?? '') !== 'global_admin') {
 }
 $activePage = 'data-health';
 
-$db      = getDb();
 $flash   = '';
 $error   = '';
+
+/* getDb() can throw if MySQL credentials are wrong or the server is
+   unreachable — previously that fatal killed the page output before a
+   single byte reached the browser, so admins saw a blank screen with
+   no clue what went wrong. Catch, record, and render the admin layout
+   anyway with the error surfaced. */
+try {
+    $db = getDb();
+} catch (\Throwable $e) {
+    error_log('[manage/data-health.php] getDb failed: ' . $e->getMessage());
+    $db = null;
+    $error = 'Database is currently unreachable. ' . $e->getMessage();
+}
 
 /* Legacy paths to inspect / optionally disable */
 $songsJsonPath    = defined('APP_DATA_FILE')          ? APP_DATA_FILE          : '';
@@ -83,6 +95,10 @@ $tableCounts = [];
 foreach (['tblSongs', 'tblSongbooks', 'tblUsers', 'tblUserSetlists',
           'tblSharedSetlists', 'tblSongRequests', 'tblSongRevisions',
           'tblUserGroups', 'tblOrganisations'] as $tbl) {
+    if ($db === null) {
+        $tableCounts[$tbl] = null;
+        continue;
+    }
     try {
         $tableCounts[$tbl] = (int)$db->query('SELECT COUNT(*) FROM ' . $tbl)->fetchColumn();
     } catch (\Throwable $_e) {

--- a/appWeb/public_html/manage/entitlements.php
+++ b/appWeb/public_html/manage/entitlements.php
@@ -92,6 +92,48 @@ foreach (ENTITLEMENTS as $n => $_) {
     if (empty($seen[$n])) { $grouped['Other'][] = $n; }
 }
 
+/* Human-readable labels per entitlement. Missing entries fall back to
+   a humanised version of the machine key so shipping a new entitlement
+   is non-fatal — but every existing one should have a label here. */
+$ENTITLEMENT_LABELS = [
+    'edit_songs'                => ['Edit songs',                    'Create + edit songs, metadata, arrangements'],
+    'delete_songs'              => ['Delete songs',                  'Permanently remove a song'],
+    'bulk_edit_songs'           => ['Bulk-edit songs',               'Multi-select → tag / move / verify / export'],
+    'verify_songs'              => ['Verify songs',                  'Mark a song as editorially reviewed'],
+    'view_users'                => ['View users',                    'Open the Users page'],
+    'edit_users'                => ['Edit users',                    'Change profile / display name / email'],
+    'change_user_roles'         => ['Change user roles',             'Promote or demote another user (below own level)'],
+    'assign_global_admin'       => ['Assign Global Admin',           'Grant the highest role — Global Admin only'],
+    'delete_users'              => ['Delete users',                  'Permanently remove a user account'],
+    'view_admin_dashboard'      => ['Reach the Admin dashboard',     'Land on /manage/ and see any admin card'],
+    'view_analytics'            => ['View analytics',                'Open the analytics dashboard'],
+    'run_db_install'            => ['Install / migrate database',    'Create or upgrade schema — Global Admin only'],
+    'run_db_migrate'            => ['Run database migrations',       'Apply schema migrations'],
+    'run_db_backup'             => ['Back up database',              'Download a SQL snapshot'],
+    'run_db_restore'            => ['Restore database from backup',  'Overwrite the live DB from a snapshot'],
+    'drop_legacy_tables'        => ['Drop legacy tables',            'Retire obsolete tables — Global Admin only'],
+    'review_song_requests'      => ['Review song requests',          'Triage submissions from the public queue'],
+    'manage_songbooks'          => ['Manage songbooks',              'CRUD over the songbook catalogue'],
+    'manage_user_groups'        => ['Manage user groups',            'CRUD over groups + channel-access toggles'],
+    'manage_organisations'      => ['Manage organisations',          'CRUD over orgs + licence metadata + members'],
+    'manage_content_restrictions' => ['Manage content restrictions', 'Per-song / per-songbook gating rules'],
+    'manage_access_tiers'       => ['Manage access tiers',           'Define tiers that gate audio / MIDI / PDF / offline'],
+    'assign_user_tier'          => ['Assign a user\'s access tier',  'Move users between tiers'],
+    'manage_default_card_layout'=> ['Manage default card layout',    'Set the site-wide dashboard / home layout'],
+    'customise_own_card_layout' => ['Customise own layout',          'Personalise your own dashboard / home order'],
+    'access_alpha'              => ['Reach the Alpha channel',       'Sign in on alpha.ihymns.app when gate is on'],
+    'access_beta'               => ['Reach the Beta channel',        'Sign in on beta.ihymns.app when gate is on'],
+    'manage_entitlements'       => ['Manage entitlements',           'Edit this map itself — Global Admin only'],
+];
+
+$entLabel = static function (string $key) use ($ENTITLEMENT_LABELS): array {
+    if (isset($ENTITLEMENT_LABELS[$key])) return $ENTITLEMENT_LABELS[$key];
+    /* Fallback: humanise the snake_case key. */
+    return [ucfirst(str_replace('_', ' ', $key)), ''];
+};
+
+$isGlobalAdmin = ($currentUser['role'] ?? '') === 'global_admin';
+
 ?>
 <!DOCTYPE html>
 <html lang="en" data-bs-theme="dark">
@@ -114,29 +156,32 @@ foreach (ENTITLEMENTS as $n => $_) {
 </head>
 <body>
 
-<nav class="navbar-admin d-flex align-items-center justify-content-between">
-    <a class="navbar-brand" href="/manage/"><i class="bi bi-key me-2"></i>Entitlements</a>
-    <div class="d-flex align-items-center gap-2">
-        <a href="/manage/" class="btn btn-sm btn-outline-secondary">
-            <i class="bi bi-speedometer2 me-1"></i>Dashboard
-        </a>
-        <a href="/" class="btn btn-sm btn-outline-secondary" title="Back to the iHymns app home">
-            <i class="bi bi-house me-1"></i>Home
-        </a>
-    </div>
-</nav>
+<?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-nav.php'; ?>
 
 <div class="container-admin py-4">
 
     <h1 class="h4 mb-3">Role → Entitlement map</h1>
     <p class="text-secondary small mb-4">
-        Toggle the checkbox where you want a role to hold a capability.
-        Server-side checks always re-evaluate this map, so changes take
-        effect on the next request. The client-side mirror in
-        <code>js/modules/entitlements.js</code> keeps the defaults for
-        UI affordance — it won't reflect admin overrides until the page
-        is next loaded by the user.
+        Decide which roles hold which capabilities. A tick in a cell
+        means users with that role can perform the named action; an
+        unticked cell revokes it. Changes take effect on the next
+        request — no sign-out required.
     </p>
+
+    <?php if ($isGlobalAdmin): ?>
+    <details class="mb-4">
+        <summary class="text-muted small" style="cursor:pointer;">
+            <i class="bi bi-wrench me-1" aria-hidden="true"></i>Technical notes (Global Admin)
+        </summary>
+        <div class="small text-muted mt-2 ps-3 border-start">
+            Server-side checks always re-evaluate this map, so every
+            request reads the current state. A client-side mirror lives
+            in <code>js/modules/entitlements.js</code> (defaults only;
+            admin overrides apply only after the user's next page
+            load). Full help lives in the developer documentation.
+        </div>
+    </details>
+    <?php endif; ?>
 
     <?php if ($saved): ?>
         <div class="alert alert-success py-2">Entitlement map saved.</div>
@@ -177,17 +222,28 @@ foreach (ENTITLEMENTS as $n => $_) {
                     <table class="table table-sm ent-grid mb-0">
                         <thead>
                             <tr class="text-muted small">
-                                <th>Entitlement</th>
+                                <th>Capability</th>
                                 <?php foreach ($ROLES as $r): ?>
-                                    <th class="role-col"><?= htmlspecialchars($r) ?></th>
+                                    <th class="role-col"><?= htmlspecialchars(roleLabel($r)) ?></th>
                                 <?php endforeach; ?>
                             </tr>
                         </thead>
                         <tbody>
                         <?php foreach ($ents as $ent): ?>
-                            <?php $current = $effective[$ent] ?? ENTITLEMENTS[$ent]; ?>
+                            <?php
+                                $current = $effective[$ent] ?? ENTITLEMENTS[$ent];
+                                [$entLbl, $entDesc] = $entLabel($ent);
+                            ?>
                             <tr>
-                                <td class="ent-name"><?= htmlspecialchars($ent) ?></td>
+                                <td>
+                                    <div class="fw-semibold"><?= htmlspecialchars($entLbl) ?></div>
+                                    <?php if ($entDesc !== ''): ?>
+                                        <div class="small text-muted"><?= htmlspecialchars($entDesc) ?></div>
+                                    <?php endif; ?>
+                                    <?php if ($isGlobalAdmin): ?>
+                                        <code class="small text-muted"><?= htmlspecialchars($ent) ?></code>
+                                    <?php endif; ?>
+                                </td>
                                 <?php foreach ($ROLES as $r): ?>
                                     <?php $checked = in_array($r, $current, true) ? 'checked' : ''; ?>
                                     <td class="role-col">
@@ -196,7 +252,7 @@ foreach (ENTITLEMENTS as $n => $_) {
                                                name="ent[<?= htmlspecialchars($ent) ?>][]"
                                                value="<?= htmlspecialchars($r) ?>"
                                                <?= $checked ?>
-                                               aria-label="<?= htmlspecialchars("$r can $ent") ?>">
+                                               aria-label="<?= htmlspecialchars(roleLabel($r) . ' — ' . $entLbl) ?>">
                                     </td>
                                 <?php endforeach; ?>
                             </tr>

--- a/appWeb/public_html/manage/includes/admin-footer.php
+++ b/appWeb/public_html/manage/includes/admin-footer.php
@@ -48,3 +48,12 @@ if (($app['Application']['Version']['Development']['Status'] ?? null) === 'Alpha
         <a href="/privacy" class="footer-link">Privacy</a>
     </small>
 </footer>
+
+<!-- Bootstrap bundle — needed by the shared admin nav (hamburger
+     offcanvas, brand dropdown, theme dropdown, user avatar dropdown)
+     and any per-page modals. Loaded here so every /manage/* page
+     picks it up regardless of whether the page template remembered. -->
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-zKzgIZcXU99qF1nNW9g+x1znB5NhCPs9qZeGzUnnFOaHJF9jCCKySBjq3vIKabk/"
+        crossorigin="anonymous"></script>
+

--- a/appWeb/public_html/manage/includes/admin-nav.php
+++ b/appWeb/public_html/manage/includes/admin-nav.php
@@ -146,31 +146,26 @@ $_visibleAdminLinks = array_values(array_filter(
                     </ul>
                 </div>
 
-                <!-- Username + role badge — hidden on xs; shown from sm up.
-                     Clicking opens the avatar dropdown (same target), so
-                     this is a discoverable but optional affordance. -->
-                <button type="button"
-                        class="btn btn-sm d-none d-sm-inline-flex align-items-center gap-2 admin-identity-btn"
-                        data-bs-toggle="dropdown"
-                        data-bs-target="#admin-user-dropdown-menu"
-                        aria-expanded="false"
-                        aria-label="Account menu">
-                    <span><?= htmlspecialchars($_displayName) ?></span>
-                    <span class="badge <?= $_roleBadge[0] ?>" style="font-size: 0.65rem;">
-                        <?= htmlspecialchars($_roleBadge[1]) ?>
-                    </span>
-                </button>
-
-                <!-- Avatar dropdown — profile / logout, matches main site -->
+                <!-- Account dropdown — avatar on xs, avatar + username +
+                     role badge on sm+. A single Bootstrap dropdown (so
+                     the toggle is the one element Bootstrap wires), the
+                     inline text is rendered as a visual affordance
+                     inside the same button; no separate toggle, no
+                     custom data-bs-target (which doesn't apply to
+                     dropdowns). -->
                 <div class="dropdown" id="admin-user-dropdown">
                     <button type="button"
-                            class="btn btn-header-icon dropdown-toggle"
+                            class="btn btn-sm btn-header-icon admin-account-btn d-flex align-items-center gap-2"
                             data-bs-toggle="dropdown"
                             aria-expanded="false"
-                            aria-label="Account"
-                            title="Account"
+                            aria-label="Account menu"
                             id="admin-user-btn">
                         <i class="bi bi-person-circle" aria-hidden="true"></i>
+                        <span class="d-none d-sm-inline"><?= htmlspecialchars($_displayName) ?></span>
+                        <span class="badge <?= $_roleBadge[0] ?> d-none d-sm-inline"
+                              style="font-size: 0.65rem;">
+                            <?= htmlspecialchars($_roleBadge[1]) ?>
+                        </span>
                     </button>
                     <ul class="dropdown-menu dropdown-menu-end"
                         aria-labelledby="admin-user-btn"

--- a/appWeb/public_html/manage/index.php
+++ b/appWeb/public_html/manage/index.php
@@ -347,7 +347,10 @@ $csrf = csrfToken();
         </div>
         <?php endif; ?>
 
-        <!-- System Info -->
+        <!-- System Info — infrastructure-level; only Global Admin sees
+             the PHP + DB-driver details. Regular admins / curators see a
+             lightweight "Your session" card instead. -->
+        <?php if (($currentUser['role'] ?? '') === 'global_admin'): ?>
         <div class="card-admin p-3">
             <h2 class="h6 mb-3"><i class="bi bi-info-circle me-2"></i>System Info</h2>
             <table class="table table-sm table-borderless mb-0 small">
@@ -360,6 +363,15 @@ $csrf = csrfToken();
                 <tr><td class="text-muted">Your Username</td><td><code><?= htmlspecialchars($currentUser['username']) ?></code></td></tr>
             </table>
         </div>
+        <?php else: ?>
+        <div class="card-admin p-3">
+            <h2 class="h6 mb-3"><i class="bi bi-person-badge me-2"></i>Your session</h2>
+            <table class="table table-sm table-borderless mb-0 small">
+                <tr><td class="text-muted" style="width:40%">Your Role</td><td><?= htmlspecialchars(roleLabel($currentUser['role'])) ?></td></tr>
+                <tr><td class="text-muted">Your Username</td><td><code><?= htmlspecialchars($currentUser['username']) ?></code></td></tr>
+            </table>
+        </div>
+        <?php endif; ?>
 
     </div>
 

--- a/appWeb/public_html/manage/organisations.php
+++ b/appWeb/public_html/manage/organisations.php
@@ -28,7 +28,17 @@ $error   = '';
 $success = '';
 $db      = getDb();
 
-$LICENCE_TYPES  = ['none', 'ihymns_basic', 'ihymns_pro', 'ccli'];
+/* Machine key → human label + short description. The key is what the
+   DB / evaluator reference; the label is what every UI surface renders
+   so admins never see raw tokens like `ihymns_pro`. An admin-managed
+   catalogue (new schema) is the follow-up, tracked on #459. */
+$LICENCE_TYPES  = [
+    'none'         => ['label' => 'None',          'description' => 'No licence on file'],
+    'ihymns_basic' => ['label' => 'iHymns Basic',  'description' => 'Free — public-domain songs only'],
+    'ihymns_pro'   => ['label' => 'iHymns Pro',    'description' => 'Paid — full catalogue access'],
+    'ccli'         => ['label' => 'CCLI',          'description' => 'Christian Copyright Licensing International licence'],
+];
+$LICENCE_TYPE_KEYS = array_keys($LICENCE_TYPES);
 $MEMBER_ROLES   = ['member', 'admin', 'owner'];
 
 $slugify = function (string $s): string {
@@ -60,7 +70,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 if ($name === '') { $error = 'Name is required.'; break; }
                 $slug = $slugInput !== '' ? $slugify($slugInput) : $slugify($name);
                 if ($slug === '') { $error = 'Slug could not be derived — supply one explicitly.'; break; }
-                if (!in_array($licenceType, $LICENCE_TYPES, true)) { $error = 'Unknown licence type.'; break; }
+                if (!in_array($licenceType, $LICENCE_TYPE_KEYS, true)) { $error = 'Unknown licence type.'; break; }
 
                 $stmt = $db->prepare('SELECT Id FROM tblOrganisations WHERE Slug = ?');
                 $stmt->execute([$slug]);
@@ -88,7 +98,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 if ($id <= 0) { $error = 'Organisation id missing.'; break; }
                 if ($name === '') { $error = 'Name is required.'; break; }
                 if ($slug === '') { $error = 'Slug is required.'; break; }
-                if (!in_array($licenceType, $LICENCE_TYPES, true)) { $error = 'Unknown licence type.'; break; }
+                if (!in_array($licenceType, $LICENCE_TYPE_KEYS, true)) { $error = 'Unknown licence type.'; break; }
                 if ($parent === $id) { $error = 'An organisation cannot be its own parent.'; break; }
 
                 $stmt = $db->prepare('SELECT Id FROM tblOrganisations WHERE Slug = ? AND Id <> ?');
@@ -292,7 +302,13 @@ $csrf = csrfToken();
                                 <td><code class="small"><?= htmlspecialchars($o['Slug']) ?></code></td>
                                 <td class="text-muted small"><?= htmlspecialchars($o['ParentName'] ?? '—') ?></td>
                                 <td>
-                                    <span class="badge bg-secondary" style="font-size: 0.7rem"><?= htmlspecialchars($o['LicenceType']) ?></span>
+                                    <?php
+                                    $_ltKey = (string)$o['LicenceType'];
+                                    $_ltLabel = $LICENCE_TYPES[$_ltKey]['label'] ?? $_ltKey;
+                                    $_ltDesc  = $LICENCE_TYPES[$_ltKey]['description'] ?? '';
+                                    ?>
+                                    <span class="badge bg-secondary" style="font-size: 0.7rem"
+                                          title="<?= htmlspecialchars($_ltDesc) ?>"><?= htmlspecialchars($_ltLabel) ?></span>
                                     <?php if ($o['LicenceNumber']): ?>
                                         <small class="text-muted ms-1"><?= htmlspecialchars($o['LicenceNumber']) ?></small>
                                     <?php endif; ?>
@@ -356,8 +372,11 @@ $csrf = csrfToken();
                     <div class="col-sm-4">
                         <label class="form-label small">Licence type</label>
                         <select name="licence_type" class="form-select form-select-sm">
-                            <?php foreach ($LICENCE_TYPES as $lt): ?>
-                                <option value="<?= $lt ?>"><?= $lt ?></option>
+                            <?php foreach ($LICENCE_TYPES as $key => $info): ?>
+                                <option value="<?= htmlspecialchars($key) ?>"
+                                        title="<?= htmlspecialchars($info['description']) ?>">
+                                    <?= htmlspecialchars($info['label']) ?>
+                                </option>
                             <?php endforeach; ?>
                         </select>
                     </div>
@@ -423,8 +442,12 @@ $csrf = csrfToken();
                     <div class="col-sm-4">
                         <label class="form-label small">Licence type</label>
                         <select name="licence_type" class="form-select form-select-sm">
-                            <?php foreach ($LICENCE_TYPES as $lt): ?>
-                                <option value="<?= $lt ?>" <?= $editOrg['LicenceType'] === $lt ? 'selected' : '' ?>><?= $lt ?></option>
+                            <?php foreach ($LICENCE_TYPES as $key => $info): ?>
+                                <option value="<?= htmlspecialchars($key) ?>"
+                                        title="<?= htmlspecialchars($info['description']) ?>"
+                                        <?= $editOrg['LicenceType'] === $key ? 'selected' : '' ?>>
+                                    <?= htmlspecialchars($info['label']) ?>
+                                </option>
                             <?php endforeach; ?>
                         </select>
                     </div>

--- a/appWeb/public_html/manage/requests.php
+++ b/appWeb/public_html/manage/requests.php
@@ -120,17 +120,7 @@ try {
 </head>
 <body>
 
-<nav class="navbar-admin d-flex align-items-center justify-content-between">
-    <a class="navbar-brand" href="/manage/"><i class="bi bi-lightbulb me-2"></i>Song Requests</a>
-    <div class="d-flex align-items-center gap-2">
-        <a href="/manage/" class="btn btn-sm btn-outline-secondary">
-            <i class="bi bi-speedometer2 me-1"></i>Dashboard
-        </a>
-        <a href="/" class="btn btn-sm btn-outline-secondary" title="Back to the iHymns app home">
-            <i class="bi bi-house me-1"></i>Home
-        </a>
-    </div>
-</nav>
+<?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-nav.php'; ?>
 
 <div class="container-admin py-4">
 

--- a/appWeb/public_html/manage/revisions.php
+++ b/appWeb/public_html/manage/revisions.php
@@ -89,18 +89,7 @@ try {
 </head>
 <body>
 
-<nav class="navbar-admin d-flex align-items-center justify-content-between">
-    <a class="navbar-brand" href="/manage/"><i class="bi bi-clock-history me-2"></i>iHymns Revisions</a>
-    <div class="d-flex align-items-center gap-2">
-        <span class="text-muted small d-none d-md-inline"><?= htmlspecialchars($currentUser['username'] ?? '') ?></span>
-        <a href="/manage/" class="btn btn-sm btn-outline-secondary">
-            <i class="bi bi-speedometer2 me-1"></i>Dashboard
-        </a>
-        <a href="/" class="btn btn-sm btn-outline-secondary" title="Back to the iHymns app home">
-            <i class="bi bi-house me-1"></i>Home
-        </a>
-    </div>
-</nav>
+<?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-nav.php'; ?>
 
 <div class="container-admin py-4">
 

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -283,17 +283,7 @@ if ($hasCredentials && defined('DB_HOST')) {
 <body>
 
 <?php if (!$isInitialSetup): ?>
-<nav class="navbar-admin d-flex align-items-center justify-content-between">
-    <a class="navbar-brand" href="/manage/"><i class="bi bi-database me-2"></i>Database Setup</a>
-    <div class="d-flex align-items-center gap-2">
-        <a href="/manage/" class="btn btn-sm btn-outline-secondary">
-            <i class="bi bi-speedometer2 me-1"></i>Dashboard
-        </a>
-        <a href="/" class="btn btn-sm btn-outline-secondary" title="Back to the iHymns app home">
-            <i class="bi bi-house me-1"></i>Home
-        </a>
-    </div>
-</nav>
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-nav.php'; ?>
 <?php endif; ?>
 
 <div class="container-admin py-4">


### PR DESCRIPTION
Closes #458. Follow-ups #459, #460 (see "Deferred" below).

## Root-cause deep-dive

The cluster of `/manage/*` regressions reported after #451 / #457 landed came from **four underlying bugs and one coverage gap**, not seven independent problems. Fix them and most of the reported symptoms clear up together:

| # | Root cause | Symptoms it explained |
|---|------------|-----------------------|
| 1 | Bootstrap bundle JS loaded only on 8 of 16 admin pages | Hamburger didn't open, dropdowns didn't open, modals didn't open on the other 8 |
| 2 | Identity button in admin-nav used `data-bs-target` which Bootstrap dropdowns ignore | Clicking "Lance Manasse Global Admin" did nothing |
| 3 | SortableJS loaded with a placeholder SRI hash — browsers silently block on mismatch | Card reorder drag-and-drop never worked, even after entering edit mode |
| 4 | Offline-download buttons rendered with `d-none`; JS was supposed to unhide them but didn't always run on first page load | No cloud buttons on songbook cards or song view |
| 5 | 5 pages (analytics, entitlements, requests, revisions, setup-database) still used inline navbars from before the #451 redesign | Hamburger / new identity dropdown missing on those pages |

## Fixes in this PR

- **Shared Bootstrap bundle.** Moved the `<script src="bootstrap.bundle…">` into `manage/includes/admin-footer.php` so every page gets it automatically. Pages that still inline it just double-load from cache — no regression.
- **Identity dropdown rewrite.** Merged the separate username / role / avatar widgets into a single `.dropdown` wrapper where Bootstrap sees exactly one toggle.
- **SortableJS SRI removed.** Can be re-added once we pin a real hash for the committed version.
- **Offline buttons render visible server-side.** CSS rule `body.offline-unsupported` hides them on browsers that can't cache; capable browsers show the button immediately with no flicker.
- **5 admin pages converted to the shared `admin-nav.php`.**
- **Data Health: defensive DB probe.** `getDb()` now try/catch — page renders the admin layout + a readable error banner on DB failure instead of a blank void.

## Content / UX fixes

- **System Info gated to `global_admin`.** Regular admins see a trimmed "Your session" card with only Role + Username.
- **Organisations licence picker shows friendly labels** ("None", "iHymns Basic", "iHymns Pro", "CCLI") with hover descriptions. Backend keys unchanged.
- **Entitlements page: human labels + descriptions** per capability; tech notes (including the `js/modules/entitlements.js` mirror reference) collapsed inside a `<details>` visible only to Global Admin.

## Deferred to follow-ups

- **#459 Admin-managed licence type catalogue.** Requires a schema migration (`tblLicenceTypes`) + a new CRUD page. The hard-coded list still works today; moving it to the DB is a clean, isolated follow-up.
- **#460 Sidebar nav on desktop + hamburger on smaller screens.** Significant layout restructure deserving its own PR and review pass. The hamburger now works (after this fix), so the sidebar is a progressive enhancement rather than a blocker.

## Test plan

- [ ] `/manage/data-health` renders the page chrome + a visible "DB unreachable" banner when MySQL is down; full health report when up.
- [ ] Hamburger offcanvas opens on every `/manage/*` page (dashboard, users, groups, orgs, songbooks, restrictions, tiers, entitlements, analytics, data-health, setup-database, revisions, requests, editor).
- [ ] Avatar dropdown opens (Profile / Back to site / Log out).
- [ ] "Customise layout" on `/manage/` enters edit mode; dragging a card actually moves it; the order persists across refresh.
- [ ] Home page: each Songbook card has a visible cloud-download button in the top-right corner.
- [ ] Song view: cloud-download button visible in the toolbar.
- [ ] `/manage/organisations`: licence picker shows "None / iHymns Basic / iHymns Pro / CCLI", not raw keys.
- [ ] `/manage/entitlements`: every capability has a human label + description; Global Admin additionally sees the raw key + a collapsible tech-notes block.
- [ ] Non-global admin on `/manage/`: System Info panel shows only Role + Username; no PHP / DB details.

https://claude.ai/code/session_01VK9zszCiViesutz7bj27MH

---
_Generated by [Claude Code](https://claude.ai/code/session_01VK9zszCiViesutz7bj27MH)_