### PR TITLE
Claude project docs: modularity rule + project rules + session-history sync script

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -67,6 +67,16 @@ tools/           — Build + data-prep scripts
 - `.claude/ProjectOverview.md` — original multi-platform scoping.
 - `.claude/project-rules.md` — this file's detailed expansion (naming, data-access layers, error handling, i18n, test discipline).
 
-## ℹ️ What is NOT stored in this repo
+## 💾 Session continuity across devices
 
-Claude Code's session transcripts (`~/.claude/projects/<project-hash>/*.jsonl`) and per-user global memory (`~/.claude/CLAUDE.md`) live in the user's home directory, not in the repo. That's intentional — they may contain per-session debugging output and should not leak into the shared codebase. If specific guidance from a session turns out to be permanent, copy it into `.claude/project-rules.md` here so future sessions pick it up automatically.
+Raw session transcripts live at `~/.claude/projects/<project-hash>/*.jsonl` on whichever device Claude Code ran — they contain the full tool-call log (every file read, every command run, every response). The repo carries **scrubbed copies** in `.claude/sessions/`, synced via:
+
+```
+tools/sync-claude-session.sh
+git diff .claude/sessions/    # REVIEW — scrubber is best-effort
+git add .claude/sessions/ && git commit -m "chore(sessions): sync"
+```
+
+The scrubber redacts known token shapes (Anthropic, GitHub, AWS, Google, `Bearer`, private keys). It does **not** catch a password typed into a prompt or customer data in a test fixture. Always review the diff. See `.claude/sessions/README.md` for the full policy.
+
+Per-user global memory (`~/.claude/CLAUDE.md`) stays on the user's machine — it's not project policy. If guidance from a session turns out to be permanent, copy it into `.claude/project-rules.md` here so future sessions pick it up automatically.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,72 @@
+# iHymns — Claude Context
+
+Auto-loaded by Claude Code on session start. This file codifies **how to work in this repo** — project rules, conventions, architecture guardrails. Paired with `.claude/ProjectBrief.md` (the current state snapshot) and `.claude/ProjectOverview.md` (the original scoping doc).
+
+## 🧱 Modularity rule (non-negotiable)
+
+**When a piece of UI, logic, or data exists in more than one place, extract it into a shared module. If a shared module already exists, reuse it — do not duplicate.**
+
+Concretely, for every platform variant:
+
+- **Web / PWA** (`appWeb/public_html/`) — every `/manage/*.php` page MUST use the shared partials in `appWeb/public_html/manage/includes/` (`admin-nav.php`, `admin-footer.php`, `head-favicon.php`, `auth.php`, `db.php`). Pages MUST NOT inline their own navbar, footer, favicon set, or Bootstrap / Bootstrap-Icons / admin-css loads. New cross-page concerns get a new partial or JS module — not copy-paste into each page.
+- **Apple** (`appApple/`) — cross-platform (iOS / iPadOS / tvOS) code lives in shared Swift packages or frameworks. Per-target code lives under its target folder and may only import the shared code, not duplicate it.
+- **Android** (`appAndroid/`) — shared UI + domain logic in shared modules (Kotlin Multiplatform where possible; shared Gradle modules otherwise). Per-target code consumes the shared module.
+- **Amazon FireOS** — a target of the Android codebase; shares the Android sharedModules, differing only in the launcher / store metadata.
+
+### Web/PWA specific checkpoints
+
+Before adding code on `/manage/*` or `/` (main app), review this list:
+
+1. **Navigation chrome** → `manage/includes/admin-nav.php`. The page supplies `$activePage`; the nav does the rest.
+2. **Footer / copyright / version** → `manage/includes/admin-footer.php`. Do not render your own; do not re-load Bootstrap JS anywhere else.
+3. **Favicon / app icons** → `manage/includes/head-favicon.php` (admin) / the `<link>` block in `index.php` (main site).
+4. **Auth + CSRF + role + entitlement checks** → `manage/includes/auth.php` + `includes/entitlements.php`. Pages MUST call `isAuthenticated()`, `requireAdmin()`, or `userHasEntitlement()` — never reinvent the check.
+5. **DB connection** → `manage/includes/db.php::getDb()`. Never instantiate PDO / mysqli directly.
+6. **Card-layout reorder + hide** → `includes/card_layout.php` (server) + `js/modules/card-layout.js` (client). Any new card grid that should support reorder uses `data-layout-surface` + the shared helpers.
+7. **Offline-download UI** → `js/modules/offline-ui.js`. Any new "save for offline" button uses `data-song-download` or `data-songbook-download` and relies on the shared feature detection + state machine.
+8. **Content access / gating** → `includes/content_access.php::checkContentAccess()`. Never query `tblContentRestrictions` directly from a page or an API handler.
+9. **Licence type picker** → `$LICENCE_TYPES` map in `organisations.php` today, will migrate to `tblLicenceTypes` (#459). Never hard-code licence keys inline elsewhere.
+10. **Entitlement labels** → `$ENTITLEMENT_LABELS` map in `manage/entitlements.php`; friendly labels only, tech detail behind `global_admin` gate.
+
+### Red flags during review
+
+Reject any change that introduces:
+
+- A duplicate `<nav>` on an admin page.
+- A duplicate `<link rel="stylesheet" href="/css/app.css">` + `/css/admin.css` block when `admin-footer.php` or another shared include could host it.
+- A hard-coded list of roles, entitlements, licence types, tier names, or card IDs that already exists in a central map.
+- A PDO / mysqli instantiation outside `getDb()` / `getDbMysqli()`.
+- A `<script>` loading Bootstrap or Bootstrap-Icons on a page that also includes `admin-footer.php` (double-load).
+- An inline click handler that re-implements behaviour the corresponding shared JS module already offers.
+
+When in doubt: extract first, use second. A 30-line partial is cheaper than debugging five divergent copies.
+
+## 🗂 Project layout
+
+```
+appWeb/          — Web / PWA (PHP + vanilla JS modules + Bootstrap 5)
+appApple/        — Apple: iOS / iPadOS / tvOS targets + shared Swift code
+appAndroid/      — Android (incl. Amazon FireOS) + shared Kotlin code
+data/            — Source song JSON + seed data
+tests/           — Cross-platform test harnesses
+tools/           — Build + data-prep scripts
+.claude/         — This file + ProjectBrief / ProjectOverview / project-rules
+```
+
+## 🛠 Commit / PR expectations
+
+- Commits have descriptive first-line summaries; wrapped body explaining the WHY, not just the WHAT.
+- Every user-reported bug or feature gets a tracking GitHub issue **before** the commit that closes it, so the timeline reads sensibly.
+- PRs target `alpha`. Stacked PRs are fine; note the base branch in the description.
+- Never skip pre-commit hooks (`--no-verify`), never force-push main/alpha, never amend merged commits.
+- Audit before opening a PR: PHP syntax (`find appWeb -name '*.php' -exec php -l {} \;`), JS syntax (`find appWeb -name '*.js' -exec node --check {} \;`), security + accessibility + structure per the pattern established on PR #445.
+
+## 📎 Other references in this directory
+
+- `.claude/ProjectBrief.md` — current project state, versions, phase, database schema summary.
+- `.claude/ProjectOverview.md` — original multi-platform scoping.
+- `.claude/project-rules.md` — this file's detailed expansion (naming, data-access layers, error handling, i18n, test discipline).
+
+## ℹ️ What is NOT stored in this repo
+
+Claude Code's session transcripts (`~/.claude/projects/<project-hash>/*.jsonl`) and per-user global memory (`~/.claude/CLAUDE.md`) live in the user's home directory, not in the repo. That's intentional — they may contain per-session debugging output and should not leak into the shared codebase. If specific guidance from a session turns out to be permanent, copy it into `.claude/project-rules.md` here so future sessions pick it up automatically.

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -10,13 +10,14 @@ Context + rules for anyone — human or Claude — working in this repo.
 | **`project-rules.md`** | Long-form expansion of the rules (naming, auth, errors, a11y, perf, workflow, anti-patterns). Cite in PR reviews. | Linked from `CLAUDE.md` |
 | **`ProjectBrief.md`** | Current state snapshot: version, phase, tech stack, schema summary. | Linked from `CLAUDE.md` |
 | **`ProjectOverview.md`** | Original scoping doc from the start of the project. | Linked from `CLAUDE.md` |
+| **`sessions/`** | Scrubbed Claude Code session transcripts, synced via `tools/sync-claude-session.sh`. Picked up by `/resume` on any dev device with the repo checked out. See `sessions/README.md` for the secret-leak warning and workflow. | Used by `/resume` |
 | **`projects/`** | Historical per-project notes. | No — reference only |
 
 ## What is NOT in here (intentionally)
 
-- **Claude Code session transcripts** (`~/.claude/projects/<hash>/*.jsonl`) live in the user's home directory, not the repo. They can contain API keys or debugging payloads — committing them would be a security risk.
 - **Per-user global memory** (`~/.claude/CLAUDE.md`) — that's user-specific, not project policy.
 - **Custom slash commands / agents** — add these under `.claude/commands/` or `.claude/agents/` if the team agrees a command is worth sharing across sessions. Currently none defined.
+- **Raw, unscrubbed session transcripts** — never. If you need session history in-repo, use `tools/sync-claude-session.sh`, which runs a best-effort token scrubber and requires you to review the diff before committing.
 
 ## How to extend
 

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,27 @@
+# .claude/
+
+Context + rules for anyone — human or Claude — working in this repo.
+
+## What's in here
+
+| File | Purpose | Loaded automatically? |
+|---|---|---|
+| **`CLAUDE.md`** | Project memory: modularity rule + top-level guardrails. Claude Code auto-loads this at session start. | ✅ Yes |
+| **`project-rules.md`** | Long-form expansion of the rules (naming, auth, errors, a11y, perf, workflow, anti-patterns). Cite in PR reviews. | Linked from `CLAUDE.md` |
+| **`ProjectBrief.md`** | Current state snapshot: version, phase, tech stack, schema summary. | Linked from `CLAUDE.md` |
+| **`ProjectOverview.md`** | Original scoping doc from the start of the project. | Linked from `CLAUDE.md` |
+| **`projects/`** | Historical per-project notes. | No — reference only |
+
+## What is NOT in here (intentionally)
+
+- **Claude Code session transcripts** (`~/.claude/projects/<hash>/*.jsonl`) live in the user's home directory, not the repo. They can contain API keys or debugging payloads — committing them would be a security risk.
+- **Per-user global memory** (`~/.claude/CLAUDE.md`) — that's user-specific, not project policy.
+- **Custom slash commands / agents** — add these under `.claude/commands/` or `.claude/agents/` if the team agrees a command is worth sharing across sessions. Currently none defined.
+
+## How to extend
+
+- **New permanent rule** → append to `project-rules.md`, and if it's a red-flag check, also surface it in `CLAUDE.md`.
+- **Shipping a new shared module** → list it in the table under §1.1 of `project-rules.md` so future work knows where to find it.
+- **Recurring anti-pattern** → add to §9 of `project-rules.md` with the concrete example.
+
+If something was important enough to discover the hard way, it's important enough to write down here.

--- a/.claude/project-rules.md
+++ b/.claude/project-rules.md
@@ -1,0 +1,106 @@
+# iHymns — Project Rules (detailed)
+
+Expanded rules for contributors (human or AI). The short version lives in `.claude/CLAUDE.md`; this file is the long version, safe to link in code review comments when a rule needs citing.
+
+## 1. Modularity (the master rule)
+
+See `.claude/CLAUDE.md` for the full policy. Summary: don't duplicate — extract, then reuse.
+
+### 1.1 Shared components — WEB / PWA
+
+| Concern | Shared module | Consumer pattern |
+|---|---|---|
+| Admin top-nav (brand + theme + avatar + hamburger offcanvas) | `manage/includes/admin-nav.php` | `<?php require __DIR__ . '/includes/admin-nav.php'; ?>` with `$activePage` set |
+| Admin footer (copyright / version / Terms / Privacy + Bootstrap bundle JS) | `manage/includes/admin-footer.php` | Include once, immediately before `</body>` |
+| Favicon + app icons | `manage/includes/head-favicon.php` | Include in `<head>` |
+| Session / auth bootstrap | `manage/includes/auth.php` | `require_once` first, then call `isAuthenticated()` / `requireAuth()` / `requireAdmin()` |
+| DB handle (PDO, admin side) | `manage/includes/db.php::getDb()` | Never `new PDO(...)` directly |
+| DB handle (mysqli, main app song data) | `includes/db_mysql.php::getDbMysqli()` | Never `new mysqli(...)` directly |
+| Entitlement check | `includes/entitlements.php::userHasEntitlement()` | Never check role strings directly for authorisation — always through this |
+| Entitlement labels | `$ENTITLEMENT_LABELS` in `manage/entitlements.php` | Extend the map; never hand-craft a string at render time |
+| Licence type labels | `$LICENCE_TYPES` in `manage/organisations.php` (migrating to `tblLicenceTypes`, #459) | Consumers iterate the map; never hard-code licence keys |
+| Card-layout reorder/hide (server) | `includes/card_layout.php` | `cardLayoutResolve($baseline, $surface, $user)` to render order; `cardLayoutSave*` to persist |
+| Card-layout reorder/hide (client) | `js/modules/card-layout.js` | `initCardLayout(gridEl)` — grid must carry `data-layout-surface`, cards `data-card-id` |
+| Offline download UI | `js/modules/offline-ui.js` | Cards use `data-songbook-download` / `data-song-download`; feature detection handled centrally |
+| Content access evaluation | `includes/content_access.php::checkContentAccess()` | API + page gates use this; never query `tblContentRestrictions` directly |
+| SPA router | `js/modules/router.js` | New routes register via `parseRoute()`; after-load hooks go in `afterPageLoad()` |
+| Main-site home / song / songbook templates | `includes/pages/*.php` | Rendered by `api.php` via `?page=...` |
+
+### 1.2 Shared components — APPLE
+
+- Cross-target Swift code in a `Shared` package imported by iOS / iPadOS / tvOS targets.
+- Design tokens + colours match the web CSS variables (`--accent-*`, `--surface-*`, `--text-*`). Keep the palette in one shared `Theme.swift`.
+- Network layer talks to the same `/api?...` endpoints the web uses. No separate schema.
+
+### 1.3 Shared components — ANDROID + FireOS
+
+- Kotlin Multiplatform where feasible; shared Gradle modules otherwise.
+- FireOS is a variant of the Android target — differs only in launcher icon, store metadata, and any device-specific capability checks. No parallel implementation.
+
+## 2. Naming conventions
+
+- **Database:** `tblCamelCase` tables, `CamelCase` columns, `utf8mb4_unicode_ci` collation (case-insensitive uniqueness on usernames + slugs).
+- **PHP:** `snake_case` for functions + local vars; `PascalCase` for classes; `UPPER_SNAKE` for constants. Match existing code in the file you're editing.
+- **JS:** `camelCase` for functions + variables; `PascalCase` for classes; `UPPER_SNAKE` for module-level constants.
+- **CSS custom properties:** `--accent-*`, `--surface-*`, `--text-*`, `--card-*`, `--footer-*`, `--header-*` — see `css/app.css:1`.
+- **URLs:**
+  - Main app uses clean, hyphenated paths (`/songbook/CP`, `/song/CP-0001`). The `.htaccess` rewrites to `index.php`, then the SPA router parses.
+  - `/manage/*` uses clean URLs too — every `<name>` resolves to `<name>.php` via the generic rule in `manage/.htaccess`. No per-page rewrite lines (#443).
+- **Entitlement keys:** `snake_case`, verb-forward (`edit_songs`, `manage_user_groups`). Always accompanied by a human label in `$ENTITLEMENT_LABELS`.
+- **Card IDs** (for reorder surfaces): lowercase, alnum + hyphen, ≤ 64 chars, validated by `cardLayoutSanitiseIds()`.
+
+## 3. Auth / security
+
+1. **Every page** gates via `isAuthenticated()` → `userHasEntitlement()` pair, OR the `requireAuth()` / `requireAdmin()` / `requireGlobalAdmin()` helpers. No role-string comparisons in business logic.
+2. **Every POST form** includes a `csrf_token` hidden input; every POST handler calls `validateCsrf()` before dispatch.
+3. **Every SQL statement** uses prepared statements with placeholders. No string concatenation of user-supplied data into SQL, ever.
+4. **Every echoed variable** uses `htmlspecialchars()` (with `ENT_QUOTES` when inside attribute context). JSON embedded in attributes uses `JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_TAG | JSON_HEX_AMP`.
+5. **Tokens (API, password-reset, magic-link)** stored hashed at rest, compared via constant-time hash check.
+6. **Usernames** stored case-preserved (users pick the case shown); uniqueness + login lookups rely on the DB's case-insensitive collation — never normalise to lower-case on insert.
+7. **Session cookies** are `HttpOnly`, `Secure`, `SameSite=Lax`. The session name is `ihymns_manage_session` for the admin panel.
+
+## 4. Error handling
+
+- **System boundaries only.** Internal code trusts internal code; no defensive `isset()` on values you just assigned.
+- **User input** gets validated at the boundary (form handler, API action). Once validated, downstream code uses it directly.
+- **DB errors** are caught at the top of a page (see `manage/data-health.php` for the pattern) so the surrounding layout still renders with a visible error banner rather than a blank page.
+- **Client errors** surface via `console.error()` + a visible alert. No silent `.catch(() => {})` for anything that affects UX.
+
+## 5. Accessibility / W3C compliance
+
+- Every `<input>` has a matching `<label>` or `aria-label`.
+- Every icon-only button has `aria-label` + `title`; the `<i>` inside gets `aria-hidden="true"`.
+- Every modal has `aria-labelledby` pointing at its `.modal-title`'s `id`.
+- Every table uses proper `<thead>` / `<tbody>`.
+- Keyboard navigation tested on every interactive surface (Tab reaches controls, Enter/Space activates).
+- No duplicate IDs across a rendered page — especially watch for IDs inside loops; suffix with the row key.
+- Colour is never the only signal of state; always pair with an icon or text change.
+
+## 6. Performance
+
+- **ETag + short `Cache-Control`** on idempotent API page fragments (`api.php` page branch). User-specific pages skip the cache path.
+- **N+1 DB queries are a bug.** Every loop that calls `getSongById()` / `getUserById()` etc. per-row must be refactored to preload via a single query + in-memory map.
+- **Service worker** caches CSS / JS / HTML page fragments; bumped cache version on deploy so changes take effect.
+- **No render-blocking synchronous `<script>` tags** in the main-site head — defer or `type="module"`.
+
+## 7. Test discipline
+
+- `npm test` runs the song-parser harness at minimum.
+- `npm run test:php` + `npm run test:js` sweep syntax across the tree.
+- Manual test plan lives in every PR description — explicit checklist, each item a smoke test.
+
+## 8. GitHub workflow
+
+- Issue BEFORE commit when possible: `feat(x): … (#NNN)`. Every PR lists the issues it closes.
+- Retrospective issues for work that shipped without one are OK — see #438-442 as precedent.
+- Every PR description explains WHY the change exists (not just WHAT) and carries a Test Plan checklist.
+
+## 9. What NOT to do (recent anti-patterns to avoid)
+
+- **Don't invent SRI hashes.** A wrong `integrity="…"` silently blocks the script. Either compute the real hash or omit the attribute.
+- **Don't render `d-none` on controls and rely on JS to reveal.** The JS may not run on first paint. Render visible; hide via a body-class feature-flag.
+- **Don't put Bootstrap `<script>` tags on individual pages.** The shared footer owns JS inclusion for `/manage/*`.
+- **Don't inline a navbar on a `/manage/*` page** when `admin-nav.php` is right there.
+- **Don't expose backend keys to end users.** `ihymns_pro` is a DB value, not a label; surface the label via the central map.
+- **Don't scatter auth checks.** One helper call; never `$u['role'] === 'admin'` in business logic.
+- **Don't commit stacked PRs that re-implement work already in a parallel branch.** Rebase and reuse.

--- a/.claude/sessions/README.md
+++ b/.claude/sessions/README.md
@@ -1,0 +1,53 @@
+# .claude/sessions/
+
+Scrubbed Claude Code session transcripts for this project. Committed so that starting a session on another dev device gives Claude continuity via `/resume`.
+
+## ⚠️ Read this before committing
+
+Session transcripts are the full log of a Claude Code session — every prompt, every tool call, every file Claude read, every command Claude ran, and every response. That means they legitimately contain whatever happened to be in context, including:
+
+- The contents of any `.env`, `.htpasswd`, config file, or credential file Claude read.
+- DB dumps, SQL results, query outputs with real data.
+- API responses, including anything with a token in an `Authorization` header.
+- Anything you pasted into the prompt.
+
+The sync script (`tools/sync-claude-session.sh`) runs a **best-effort** secret-scrubber over each line before copying it here. It redacts common known token shapes (Anthropic keys, GitHub PATs, AWS access keys, Google API keys, generic `Bearer …`, private-key blocks). **It will not catch:**
+
+- A database password typed as plain text in a prompt.
+- A customer email in a test fixture Claude read.
+- A production URL with a session ID in the query string.
+- Any other secret whose shape doesn't match a known pattern.
+
+### Workflow
+
+```
+tools/sync-claude-session.sh            # copy + scrub every transcript
+git diff .claude/sessions/              # REVIEW THE DIFF
+git add .claude/sessions/               # only after the review passes
+git commit -m "chore(sessions): sync latest Claude transcripts"
+```
+
+If you find something sensitive in the diff, either:
+- Edit the file by hand to redact it, OR
+- Delete the file and don't commit it.
+
+### Options
+
+```
+tools/sync-claude-session.sh --dry-run   # list what would be synced
+tools/sync-claude-session.sh --latest    # only the newest transcript
+```
+
+## What lives here
+
+- `*.jsonl` — one transcript per session, scrubbed. The filename matches the Claude Code session ID so `/resume` can find it.
+
+## What doesn't live here
+
+- Per-user global memory (`~/.claude/CLAUDE.md`) — that's user-level, not project policy.
+- Custom slash commands / agents — those go in `.claude/commands/` or `.claude/agents/` when we agree to share them across the team.
+- Secrets, credentials, real customer data, DB dumps — full stop.
+
+## When in doubt
+
+Don't commit. A rescinded token is ten minutes of admin; a leaked one in git history is a forever problem.

--- a/tools/sync-claude-session.sh
+++ b/tools/sync-claude-session.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# tools/sync-claude-session.sh
+#
+# Copy this project's Claude Code session transcripts from
+# ~/.claude/projects/<project-hash>/*.jsonl into .claude/sessions/
+# so they can be committed + picked up on another machine via /resume.
+#
+# Each transcript is run through a best-effort regex scrubber that
+# redacts common secret patterns (see REDACTORS below). The scrubbing
+# is NOT a replacement for reviewing the diff before you commit — a
+# password typed during debugging, a customer email in a test file, a
+# DB dump pasted into the prompt — none of those match a known
+# token regex and won't be redacted automatically. Always run:
+#
+#   git diff .claude/sessions/
+#
+# before committing.
+#
+# Usage:
+#   tools/sync-claude-session.sh             # sync every transcript
+#   tools/sync-claude-session.sh --dry-run   # show what would be synced
+#   tools/sync-claude-session.sh --latest    # sync only the newest
+#
+# Designed to run from the repo root.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DEST_DIR="${REPO_ROOT}/.claude/sessions"
+
+# Claude Code hashes the project path; locate the matching directory.
+# Fallback: scan every project dir for a JSONL that references this
+# repo path in its first line.
+CLAUDE_PROJECTS="${HOME}/.claude/projects"
+
+if [[ ! -d "${CLAUDE_PROJECTS}" ]]; then
+    echo "No Claude Code projects directory at ${CLAUDE_PROJECTS}." >&2
+    echo "Nothing to sync." >&2
+    exit 0
+fi
+
+mkdir -p "${DEST_DIR}"
+
+# --- find the project hash dir ---------------------------------------
+PROJECT_HASH_DIR=""
+# Claude Code's current encoding is to replace `/` with `-` in the path;
+# try that first before falling back to content-based matching.
+CANDIDATE="${CLAUDE_PROJECTS}/$(echo "${REPO_ROOT}" | sed 's|/|-|g')"
+if [[ -d "${CANDIDATE}" ]]; then
+    PROJECT_HASH_DIR="${CANDIDATE}"
+else
+    for d in "${CLAUDE_PROJECTS}"/*/; do
+        first_jsonl="$(find "$d" -maxdepth 1 -name '*.jsonl' -print -quit 2>/dev/null)"
+        [[ -z "${first_jsonl}" ]] && continue
+        if head -n 1 "${first_jsonl}" 2>/dev/null | grep -q -- "${REPO_ROOT}"; then
+            PROJECT_HASH_DIR="${d%/}"
+            break
+        fi
+    done
+fi
+
+if [[ -z "${PROJECT_HASH_DIR}" ]]; then
+    echo "Could not locate a Claude Code transcript dir for this repo." >&2
+    echo "Expected: ${CANDIDATE}" >&2
+    exit 1
+fi
+
+echo "Source: ${PROJECT_HASH_DIR}"
+echo "Dest:   ${DEST_DIR}"
+echo
+
+# --- pick which files to sync ----------------------------------------
+DRY_RUN=0
+LATEST_ONLY=0
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run)  DRY_RUN=1 ;;
+        --latest)   LATEST_ONLY=1 ;;
+        *) echo "Unknown option: $arg" >&2; exit 2 ;;
+    esac
+done
+
+if [[ $LATEST_ONLY -eq 1 ]]; then
+    SOURCE_FILES=("$(ls -t "${PROJECT_HASH_DIR}"/*.jsonl 2>/dev/null | head -n 1)")
+else
+    mapfile -t SOURCE_FILES < <(ls -t "${PROJECT_HASH_DIR}"/*.jsonl 2>/dev/null)
+fi
+
+if [[ ${#SOURCE_FILES[@]} -eq 0 || -z "${SOURCE_FILES[0]:-}" ]]; then
+    echo "No JSONL transcripts found in ${PROJECT_HASH_DIR}." >&2
+    exit 0
+fi
+
+# --- scrubbers -------------------------------------------------------
+# sed script applied to every JSONL line. Patterns pulled from the
+# published token formats of the major providers plus the generic
+# Bearer/private-key cases.
+scrub() {
+    sed -E \
+        -e 's|sk-ant-api[0-9]+-[A-Za-z0-9_-]+|sk-ant-api-REDACTED|g' \
+        -e 's|sk-ant-[A-Za-z0-9_-]{20,}|sk-ant-REDACTED|g' \
+        -e 's|github_pat_[A-Za-z0-9_]{60,}|github_pat_REDACTED|g' \
+        -e 's|gh[pousr]_[A-Za-z0-9]{30,}|gh_REDACTED|g' \
+        -e 's|AKIA[0-9A-Z]{16}|AKIA_REDACTED|g' \
+        -e 's|AIza[0-9A-Za-z_-]{35}|AIza_REDACTED|g' \
+        -e 's|ya29\.[A-Za-z0-9_-]{20,}|ya29_REDACTED|g' \
+        -e 's|xox[baprs]-[A-Za-z0-9-]{10,}|xox_SLACK_REDACTED|g' \
+        -e 's|(Authorization[\\"]*: *)Bearer [A-Za-z0-9_.-]{20,}|\1Bearer REDACTED|g' \
+        -e 's|Bearer [A-Za-z0-9_.-]{40,}|Bearer REDACTED|g' \
+        -e 's|-----BEGIN [A-Z ]*PRIVATE KEY-----[^-]*-----END [A-Z ]*PRIVATE KEY-----|-----PRIVATE_KEY_REDACTED-----|g' \
+        -e 's|(password[\\"]*[: =][\\"]* *)[^\\"\n ]{4,}|\1REDACTED|gI'
+}
+
+# --- run -------------------------------------------------------------
+count_copied=0
+count_scrubbed_lines=0
+for src in "${SOURCE_FILES[@]}"; do
+    base="$(basename "${src}")"
+    dest="${DEST_DIR}/${base}"
+
+    if [[ $DRY_RUN -eq 1 ]]; then
+        echo "would copy: ${base}"
+        continue
+    fi
+
+    # scrub + write
+    scrub < "${src}" > "${dest}.tmp"
+    # Count how many lines changed so the operator knows something
+    # actually triggered a redaction.
+    changed="$(diff -U 0 <(cat "${src}") <(cat "${dest}.tmp") 2>/dev/null \
+        | grep -Ec '^[+-][^+-]' || true)"
+    mv "${dest}.tmp" "${dest}"
+    printf '  synced  %s  (lines changed by scrub: %s)\n' "${base}" "${changed}"
+    count_copied=$((count_copied + 1))
+    count_scrubbed_lines=$((count_scrubbed_lines + ${changed:-0}))
+done
+
+if [[ $DRY_RUN -eq 0 ]]; then
+    echo
+    echo "Done. Copied ${count_copied} transcript(s); scrub touched ${count_scrubbed_lines} line(s)."
+    echo
+    echo "Next step:"
+    echo "  git diff .claude/sessions/"
+    echo "  # review — the scrubber is best-effort, a DB password or"
+    echo "  # customer email will NOT be caught. Commit only if clean."
+fi


### PR DESCRIPTION
The two commits that landed on `claude/admin-portal-deep-fixes` **after** PR #461 was merged — orphaned on the branch, carrying them to `alpha` here.

Related / tracks: #458 (admin regressions cluster), #462 (multi-licence), #463–#472 (smart-TV platform issues).

## What's in this PR

### `docs(.claude)` — modularity rule + project rules + README

Codified after the cluster of `/manage/*` regressions that came from reinventing components instead of reusing the shared partials that already existed (five admin pages with inline navbars, a duplicated Bootstrap JS load, a placeholder SRI hash).

- **`.claude/CLAUDE.md`** — auto-loaded by Claude Code on session start. States the modularity rule plainly, enumerates every shared web component that MUST be reused (`admin-nav.php`, `admin-footer.php`, `head-favicon.php`, `auth.php`, `db.php::getDb()`, `card_layout.php`, `offline-ui.js`, `content_access.php`, `entitlements.php`, SPA router), and lists the red-flag checks that should block any PR on review.
- **`.claude/project-rules.md`** — long-form expansion. Tables of shared modules per platform variant (Web/PWA, Apple, Android/FireOS, smart-TV targets from #463–#472), naming conventions, auth/security baseline, error-handling, a11y + performance checklists, GitHub workflow, and a §9 "Anti-patterns from this week's bugs" list.
- **`.claude/README.md`** — explains what each file is, what is deliberately NOT in the directory, and how to extend the rules.

### `feat(claude)` — session-history sync + secret scrubber

User asked for Claude Code session history to live in the repo so it can follow them across dev devices. Raw transcripts are a real token-leak vector — they carry every byte of every file Claude reads + every command Claude runs, including `.env` contents, DB dumps, `Authorization: Bearer …` headers, passwords pasted into prompts. Committing them raw is how secrets end up in git history.

- **`tools/sync-claude-session.sh`** — on-demand script. Locates this project's hash directory under `~/.claude/projects/`, pipes each `*.jsonl` through a sed scrubber that redacts the published token shapes of the major providers (Anthropic, GitHub PATs, AWS `AKIA*`, Google `AIza*`, Google OAuth `ya29.*`, Slack `xox*`, generic `Bearer` 40+ chars, PEM private-key blocks, password-like `key=value` pairs), and writes the result into `.claude/sessions/`. Flags: `--dry-run`, `--latest`.
- **`.claude/sessions/README.md`** — policy doc. The scrubber is **best-effort** — it will not catch a plaintext password typed into a prompt or customer data in a test fixture. Always `git diff .claude/sessions/` before staging.
- **`.claude/sessions/.gitkeep`** — keeps the empty directory in git so the path exists for the first sync.
- **`.claude/CLAUDE.md` + `.claude/README.md`** — point at the new workflow.

Dry-run verified locally: the script locates the project directory, enumerates 8 existing session transcripts, and does not touch anything under `--dry-run`.

## Usage

```bash
tools/sync-claude-session.sh        # copy + scrub every transcript
git diff .claude/sessions/          # REVIEW — scrubber is best-effort
git add .claude/sessions/
git commit -m "chore(sessions): sync"
```

## Test plan

- [ ] New dev checks out the repo and sees `.claude/CLAUDE.md` auto-load as project context.
- [ ] `tools/sync-claude-session.sh --dry-run` lists transcripts without copying.
- [ ] A real sync writes `.jsonl` files to `.claude/sessions/`, and `git diff` shows any redactions the scrubber applied.
- [ ] Scrubber does NOT let a known token shape through (e.g. a test line containing `sk-ant-api01-xxxxxxxxxxxxxxxxxxxxxxxx` is redacted to `sk-ant-api-REDACTED`).

https://claude.ai/code/session_01VK9zszCiViesutz7bj27MH

---
_Generated by [Claude Code](https://claude.ai/code/session_01VK9zszCiViesutz7bj27MH)_