### PR TITLE
fix(admin-nav): keep long display names on one line

### DIFF
--- a/appWeb/public_html/manage/includes/admin-nav.php
+++ b/appWeb/public_html/manage/includes/admin-nav.php
@@ -161,7 +161,7 @@ $_visibleAdminLinks = array_values(array_filter(
                             aria-label="Account menu"
                             id="admin-user-btn">
                         <i class="bi bi-person-circle" aria-hidden="true"></i>
-                        <span class="d-none d-sm-inline"><?= htmlspecialchars($_displayName) ?></span>
+                        <span class="d-none d-sm-inline text-nowrap"><?= htmlspecialchars($_displayName) ?></span>
                         <span class="badge <?= $_roleBadge[0] ?> d-none d-sm-inline"
                               style="font-size: 0.65rem;">
                             <?= htmlspecialchars($_roleBadge[1]) ?>


### PR DESCRIPTION
## Summary
- Adds `text-nowrap` to the display-name span in `manage/includes/admin-nav.php` so long-ish names like "Lance Manasse" no longer break mid-word in the admin header account button.
- The button lays its children out as flex items (`d-flex align-items-center gap-2`); the name span had no white-space rule, so the text wrapped onto a second line. Bootstrap's `.badge` already sets `white-space: nowrap`, so the role badge didn't need the same treatment.

## Test plan
- [ ] Log in as a user with a long-ish display name (e.g. "Lance Manasse") and visit `/manage/` — confirm the name stays on one line beside the role badge in the header.
- [ ] Resize to sm/md/lg widths — confirm the name still renders on one line and the layout doesn't overflow.
- [ ] Verify xs viewports still hide the name + badge (existing `d-none d-sm-inline` behaviour is unchanged).

https://claude.ai/code/session_01CjQB5rJGmbPU9KAYiVNfX4

---
_Generated by [Claude Code](https://claude.ai/code/session_01CjQB5rJGmbPU9KAYiVNfX4)_