### PR TITLE
fix(admin-nav): account button overflow hid theme + hamburger

### DIFF
--- a/appWeb/public_html/css/admin.css
+++ b/appWeb/public_html/css/admin.css
@@ -141,21 +141,24 @@ body:has(.navbar-admin) {
     color: var(--accent-solid);
 }
 
-/* Username + role button next to the avatar dropdown. Compact, low
-   visual weight, and only visible from sm up — xs screens get the
-   avatar alone to keep the bar uncluttered. */
-.admin-identity-btn {
-    background-color: transparent;
-    border: 1px solid transparent;
-    color: var(--text-secondary);
-    font-size: 0.85rem;
+/* Account dropdown trigger — avatar on xs, avatar + first name + role
+   badge on sm+. Shares `.btn-header-icon` for the hover/press feel,
+   but must relax that class's fixed 40×40 so the inline name + badge
+   don't overflow the box and paint over the hamburger to its right.
+   A 40px min keeps the xs icon-only state visually consistent with
+   the other header icon buttons. */
+.admin-account-btn {
+    width: auto;
+    height: auto;
+    min-width: 40px;
+    min-height: 40px;
     padding: 0.25rem 0.6rem;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
 }
-.admin-identity-btn:hover,
-.admin-identity-btn:focus {
+.admin-account-btn:hover,
+.admin-account-btn:focus {
     color: var(--text-primary);
-    border-color: var(--card-border);
-    background-color: rgba(255, 255, 255, 0.03);
 }
 
 /* Offcanvas surface nav — slide-out list launched by the hamburger.

--- a/appWeb/public_html/manage/includes/admin-nav.php
+++ b/appWeb/public_html/manage/includes/admin-nav.php
@@ -34,6 +34,10 @@ $_activePage = $activePage ?? '';
 $_role       = $currentUser['role'] ?? null;
 $_displayName = $currentUser['display_name'] ?? $currentUser['username'] ?? 'admin';
 $_username    = $currentUser['username'] ?? '';
+/* Header shows just the first word of the display name — keeps the bar
+   compact for users with long full names. The dropdown still renders
+   the full name so identity isn't lost. */
+$_headerName  = preg_split('/\s+/', trim($_displayName), 2)[0] ?: $_displayName;
 $_roleBadge   = match($_role) {
     'global_admin' => ['bg-danger',             'Global Admin'],
     'admin'        => ['bg-warning text-dark',  'Admin'],
@@ -161,7 +165,7 @@ $_visibleAdminLinks = array_values(array_filter(
                             aria-label="Account menu"
                             id="admin-user-btn">
                         <i class="bi bi-person-circle" aria-hidden="true"></i>
-                        <span class="d-none d-sm-inline text-nowrap"><?= htmlspecialchars($_displayName) ?></span>
+                        <span class="d-none d-sm-inline text-nowrap"><?= htmlspecialchars($_headerName) ?></span>
                         <span class="badge <?= $_roleBadge[0] ?> d-none d-sm-inline"
                               style="font-size: 0.65rem;">
                             <?= htmlspecialchars($_roleBadge[1]) ?>


### PR DESCRIPTION
Follow-up to #474. After that merged, the admin header still had two bugs visible with a long-ish display name:

1. The name overlapped the avatar icon.
2. The theme toggle and hamburger (offcanvas surfaces nav) appeared to be missing.

## Root cause

The account dropdown trigger button carries `.btn-header-icon`, which locks `width/height: 40×40` for icon-only buttons. Once the display name + role badge were rendered inside it, the flex content overflowed the 40px box and painted across the hamburger sitting to its right in the flex row — so the hamburger and theme toggle were still in the DOM, just obscured.

A stale CSS rule contributed: `.admin-identity-btn` was renamed to `.admin-account-btn` in the HTML long ago but never in the CSS, so no override existed.

## Changes

- **Header shows first word only** of the display name (e.g. "Lance" instead of "Lance Manasse"). The dropdown menu still renders the full name, so identity context isn't lost on click.
- **Rename `.admin-identity-btn` → `.admin-account-btn`** in `admin.css` so the rule actually applies to the button.
- **Relax the 40×40 lock** with `width: auto; height: auto; min-width: 40px; min-height: 40px`, so the button grows to fit name + badge on sm+ while keeping the xs icon-only footprint consistent with sibling header icons.

## Test plan
- [ ] Log in as a user with a two-word display name, visit `/manage/` — confirm first word only in header, no overlap, theme toggle + hamburger both visible.
- [ ] Open the account dropdown — confirm full name is shown in the menu.
- [ ] Open the hamburger — confirm the offcanvas surfaces list slides in.
- [ ] Resize to xs (< 576px) — confirm the account button collapses to icon-only at ~40×40, matching the other header icons.

https://claude.ai/code/session_01CjQB5rJGmbPU9KAYiVNfX4

---
_Generated by [Claude Code](https://claude.ai/code/session_01CjQB5rJGmbPU9KAYiVNfX4)_