### PR TITLE
docs(project-rules): never auto-open PRs, flag merged branches

### DIFF
--- a/.claude/project-rules.md
+++ b/.claude/project-rules.md
@@ -94,6 +94,7 @@ See `.claude/CLAUDE.md` for the full policy. Summary: don't duplicate — extrac
 - Issue BEFORE commit when possible: `feat(x): … (#NNN)`. Every PR lists the issues it closes.
 - Retrospective issues for work that shipped without one are OK — see #438-442 as precedent.
 - Every PR description explains WHY the change exists (not just WHAT) and carries a Test Plan checklist.
+- **Never open a PR unless the user explicitly asks for one.** Commit + push to the working branch and stop. If the previous PR from that branch has merged, further commits on the same branch do NOT land anywhere until a new PR opens — flag that to the user and wait for them to decide, don't auto-open a follow-up PR.
 
 ## 9. What NOT to do (recent anti-patterns to avoid)
 


### PR DESCRIPTION
Codifies a durable behaviour rule under §8 GitHub workflow in `.claude/project-rules.md`:

> Never open a PR unless the user explicitly asks for one. Commit + push to the working branch and stop. If the previous PR from that branch has merged, further commits on the same branch do NOT land anywhere until a new PR opens — flag that to the user and wait for them to decide, don't auto-open a follow-up PR.

## Why

During the session that produced PRs #474 and #475, I auto-opened #475 without being asked after #474 merged. A later commit on the same branch then ended up stranded once #475 also merged, because I kept pushing to a branch that no open PR was tracking. Writing the rule down so future sessions in this repo pick it up via the auto-loaded `.claude/project-rules.md`.

## Test plan
- [ ] Confirm `.claude/project-rules.md` §8 now lists the "never auto-open PRs" bullet.
- [ ] No code changes; docs-only.

https://claude.ai/code/session_01CjQB5rJGmbPU9KAYiVNfX4

---
_Generated by [Claude Code](https://claude.ai/code/session_01CjQB5rJGmbPU9KAYiVNfX4)_