### PR TITLE
feat(home): responsive songbook grid — scale columns with viewport

### DIFF
--- a/appWeb/public_html/includes/pages/home.php
+++ b/appWeb/public_html/includes/pages/home.php
@@ -136,10 +136,13 @@ $songbooks = $songData->getSongbooks();
             Songbooks
         </h2>
 
-        <div class="row g-3 mb-4">
+        <!-- `row-cols-*` ladders the column count with the viewport so
+             cards stop stretching on xl/xxl monitors: 2 → 3 → 4 → 5 → 6
+             as the breakpoints unlock. Each child is just `.col`. -->
+        <div class="row row-cols-2 row-cols-md-3 row-cols-lg-4 row-cols-xl-5 row-cols-xxl-6 g-3 mb-4">
             <?php foreach ($songbooks as $index => $book): ?>
                 <?php if (($book['songCount'] ?? 0) > 0): ?>
-                    <div class="col-6 col-md-4 col-lg-3" id="songbook-<?= htmlspecialchars($book['id']) ?>">
+                    <div class="col" id="songbook-<?= htmlspecialchars($book['id']) ?>">
                         <div class="card card-songbook h-100 position-relative"
                              data-songbook-id="<?= htmlspecialchars($book['id']) ?>"
                              data-songbook-songs="<?= (int)$book['songCount'] ?>">


### PR DESCRIPTION
Scales the songbook card grid with viewport width so cards stop stretching on xl/xxl monitors.

## Summary
- On lg the grid topped out at `col-lg-3` (4 per row); xl/xxl just stretched those same 4 cards wider.
- Swapped the per-column classes for Bootstrap's `row-cols-*` idiom with added xl/xxl breakpoints.
- Each child is now just `.col`, taking its width from the row's breakpoint-driven column count.

Ladder: `row-cols-2 row-cols-md-3 row-cols-lg-4 row-cols-xl-5 row-cols-xxl-6` → 2 cards (xs/sm) → 3 (md) → 4 (lg) → 5 (xl) → 6 (xxl).

`/songbooks` listing left alone — its horizontal-banner cards don't have the stretch problem.

## Test plan
- [ ] Home page at xs / sm / md / lg / xl / xxl viewports renders 2/2/3/4/5/6 cards per row.
- [ ] Cards maintain consistent sizing; "The Church Hymnal" no longer isolated on a row.
- [ ] Card content (icon, name, badge, song count) stays legible at each breakpoint.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CjQB5rJGmbPU9KAYiVNfX4)_