### PR TITLE
feat(admin): pinned sidebar at lg+, hamburger below — closes #460

### DIFF
--- a/appWeb/public_html/css/admin.css
+++ b/appWeb/public_html/css/admin.css
@@ -121,6 +121,70 @@ body:has(.navbar-admin) {
     padding-bottom: calc(var(--footer-info-height) + 1rem);
 }
 
+/* ==========================================================================
+   ADMIN LAYOUT — top bar + sidebar (#460)
+   The sidebar pins to the left at lg+; below lg it's hidden (d-none/d-lg-flex
+   in the markup) and the top bar's hamburger opens an offcanvas with the
+   same link registry (admin-links.php).
+   ========================================================================== */
+
+.admin-layout {
+    display: flex;
+    align-items: stretch;
+    gap: 0;
+}
+
+.admin-sidebar {
+    flex: 0 0 240px;
+    width: 240px;
+    background-color: var(--surface-card);
+    border-right: 1px solid var(--card-border);
+    padding-block: 0.75rem;
+    /* Sticky under the fixed top bar, bounded by the fixed footer, so
+       the sidebar stays visible while the main column scrolls. The
+       `top` offset matches the body's padding-top that clears
+       .navbar-admin (see body:has(.navbar-admin) above). */
+    position: sticky;
+    top: calc(var(--admin-navbar-height) + 0.5rem);
+    align-self: flex-start;
+    max-height: calc(100vh
+                     - var(--admin-navbar-height)
+                     - var(--footer-info-height)
+                     - 1.5rem);
+    overflow-y: auto;
+}
+
+.admin-sidebar-group-label {
+    letter-spacing: 0.04em;
+    font-weight: 600;
+}
+
+.admin-sidebar-link {
+    color: var(--text-secondary);
+    text-decoration: none;
+    border-left: 3px solid transparent;
+    font-size: 0.9rem;
+    transition: color var(--transition-fast),
+                background-color var(--transition-fast),
+                border-color var(--transition-fast);
+}
+.admin-sidebar-link:hover,
+.admin-sidebar-link:focus {
+    color: var(--text-primary);
+    background-color: rgba(255, 255, 255, 0.03);
+}
+.admin-sidebar-link.active {
+    color: var(--accent-solid);
+    border-left-color: var(--accent-solid);
+    background-color: rgba(129, 140, 248, 0.08);
+    font-weight: 600;
+}
+
+.admin-main {
+    flex: 1 1 auto;
+    min-width: 0;   /* allow flex shrink so inner `.container` can still center */
+}
+
 .navbar-admin .navbar-brand,
 .navbar-editor .navbar-brand {
     background: linear-gradient(135deg, var(--accent-start), var(--accent-end));

--- a/appWeb/public_html/manage/includes/admin-footer.php
+++ b/appWeb/public_html/manage/includes/admin-footer.php
@@ -37,6 +37,16 @@ if (($app['Application']['Version']['Development']['Status'] ?? null) === 'Alpha
     }
 }
 ?>
+<?php
+/* Close the admin-layout flex wrapper opened by admin-nav.php (#460).
+   Guarded: login.php / setup.php / editor/index.php call this footer
+   without going through admin-nav.php, so the flag prevents closing
+   containers that were never opened. */
+if (!empty($GLOBALS['_adminLayoutOpen'])):
+?>
+    </main>
+</div> <!-- /.admin-layout -->
+<?php endif; ?>
 <footer class="footer-info admin-footer-static" role="contentinfo">
     <small>
         <?= $app['Application']['Copyright']['Full'] ?? '' ?>

--- a/appWeb/public_html/manage/includes/admin-links.php
+++ b/appWeb/public_html/manage/includes/admin-links.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Shared Admin Link Registry (#460)
+ *
+ * Single source of truth for every /manage/* destination. Both the
+ * top-bar hamburger offcanvas (< lg) and the pinned sidebar (>= lg)
+ * iterate this registry, so adding a new admin page means editing
+ * one array.
+ *
+ * Entry shape (positional for tightness — array_map-style consumers
+ * can unpack with `[$id, $href, $icon, $label, $ent, $group] = $l;`):
+ *
+ *   0 id           matches $activePage on the page; drives highlight.
+ *   1 href         destination URL.
+ *   2 icon         bi-* class (Bootstrap Icons).
+ *   3 label        menu text.
+ *   4 entitlement  entitlement key required to see this link; null =
+ *                  visible to every authenticated admin surface user.
+ *   5 group        sidebar section heading; '' = top-level (shown
+ *                  above the first group). Groups are rendered in the
+ *                  order they first appear in the array.
+ */
+
+if (basename($_SERVER['SCRIPT_FILENAME'] ?? '') === basename(__FILE__)) {
+    http_response_code(403);
+    exit('Access denied.');
+}
+
+$_adminLinks = [
+    /* id               href                       icon                 label                   entitlement                    group         */
+    ['dashboard',       '/manage/',                'bi-speedometer2',   'Dashboard',            null,                          ''           ],
+    ['editor',          '/manage/editor/',         'bi-pencil-square',  'Song Editor',          'edit_songs',                  'Content'    ],
+    ['requests',        '/manage/requests',        'bi-lightbulb',      'Song Requests',        'review_song_requests',        'Content'    ],
+    ['revisions',       '/manage/revisions',       'bi-clock-history',  'Revisions Audit',      'verify_songs',                'Content'    ],
+    ['missing-numbers', '/manage/missing-numbers', 'bi-binoculars',     'Missing Numbers',      'edit_songs',                  'Content'    ],
+    ['songbooks',       '/manage/songbooks',       'bi-book',           'Songbooks',            'manage_songbooks',            'Content'    ],
+    ['restrictions',    '/manage/restrictions',    'bi-shield-lock',    'Content Restrictions', 'manage_content_restrictions', 'Content'    ],
+    ['tiers',           '/manage/tiers',           'bi-stars',          'Access Tiers',         'manage_access_tiers',         'Content'    ],
+    ['users',           '/manage/users',           'bi-people',         'Users',                'view_users',                  'People'     ],
+    ['groups',          '/manage/groups',          'bi-people-fill',    'User Groups',          'manage_user_groups',          'People'     ],
+    ['organisations',   '/manage/organisations',   'bi-building',       'Organisations',        'manage_organisations',        'People'     ],
+    ['entitlements',    '/manage/entitlements',    'bi-key',            'Entitlements',         'manage_entitlements',         'People'     ],
+    ['analytics',       '/manage/analytics',       'bi-graph-up',       'Analytics',            'view_analytics',              'Operations' ],
+    ['data-health',     '/manage/data-health',     'bi-activity',       'Data Health',          'drop_legacy_tables',          'Operations' ],
+    ['setup-database',  '/manage/setup-database',  'bi-database-gear',  'Database Setup',       'run_db_install',              'Operations' ],
+];
+
+/**
+ * Entitlement-gated view of the link registry for a given role.
+ *
+ * `userHasEntitlement()` lives in /includes/entitlements.php and is
+ * already required by admin pages via the auth bootstrap; the caller
+ * doesn't need to pull it in separately.
+ *
+ * @param string|null $role The user's role (e.g. 'global_admin').
+ * @return array            Links the role is entitled to see.
+ */
+function visibleAdminLinks(?string $role): array
+{
+    global $_adminLinks;
+    return array_values(array_filter(
+        $_adminLinks,
+        static fn(array $l): bool => $l[4] === null || userHasEntitlement($l[4], $role)
+    ));
+}

--- a/appWeb/public_html/manage/includes/admin-nav.php
+++ b/appWeb/public_html/manage/includes/admin-nav.php
@@ -45,36 +45,12 @@ $_roleBadge   = match($_role) {
     default        => ['bg-secondary',          'User'],
 };
 
-/* Admin-surface links. Each entry:
- *   id          — matches $activePage set by the page, for highlight
- *   href        — destination
- *   icon        — bi-* class
- *   label       — menu text
- *   entitlement — required entitlement name (null → always visible)
- * Kept in one place so the offcanvas, the brand dropdown, and future
- * command-palette can all iterate the same list. */
-$_adminLinks = [
-    ['dashboard',    '/manage/',                'bi-speedometer2',   'Dashboard',          null],
-    ['editor',       '/manage/editor/',         'bi-pencil-square',  'Song Editor',        'edit_songs'],
-    ['requests',     '/manage/requests',        'bi-lightbulb',      'Song Requests',      'review_song_requests'],
-    ['revisions',    '/manage/revisions',       'bi-clock-history',  'Revisions Audit',    'verify_songs'],
-    ['missing-numbers','/manage/missing-numbers', 'bi-binoculars',    'Missing Numbers',    'edit_songs'],
-    ['users',        '/manage/users',           'bi-people',         'Users',              'view_users'],
-    ['groups',       '/manage/groups',          'bi-people-fill',    'User Groups',        'manage_user_groups'],
-    ['organisations','/manage/organisations',   'bi-building',       'Organisations',      'manage_organisations'],
-    ['songbooks',    '/manage/songbooks',       'bi-book',           'Songbooks',          'manage_songbooks'],
-    ['restrictions', '/manage/restrictions',    'bi-shield-lock',    'Content Restrictions','manage_content_restrictions'],
-    ['tiers',        '/manage/tiers',           'bi-stars',          'Access Tiers',       'manage_access_tiers'],
-    ['entitlements', '/manage/entitlements',    'bi-key',            'Entitlements',       'manage_entitlements'],
-    ['analytics',    '/manage/analytics',       'bi-graph-up',       'Analytics',          'view_analytics'],
-    ['data-health',  '/manage/data-health',     'bi-activity',       'Data Health',        'drop_legacy_tables'],
-    ['setup-database','/manage/setup-database', 'bi-database-gear',  'Database Setup',     'run_db_install'],
-];
-
-$_visibleAdminLinks = array_values(array_filter(
-    $_adminLinks,
-    static fn(array $l): bool => $l[4] === null || userHasEntitlement($l[4], $_role)
-));
+/* Admin-surface link registry lives in admin-links.php so the sidebar
+   (#460, lg+) and the hamburger offcanvas (< lg) iterate the same
+   source and stay in lock-step. `visibleAdminLinks()` applies the
+   per-link entitlement gate for the current role. */
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'admin-links.php';
+$_visibleAdminLinks = visibleAdminLinks($_role);
 
 ?>
 <header class="app-header navbar-admin" role="banner">
@@ -198,9 +174,10 @@ $_visibleAdminLinks = array_values(array_filter(
                     </ul>
                 </div>
 
-                <!-- Hamburger — opens the offcanvas surface nav -->
+                <!-- Hamburger — opens the offcanvas surface nav. Hidden
+                     at lg+ where the pinned sidebar (#460) takes over. -->
                 <button type="button"
-                        class="btn btn-header-icon"
+                        class="btn btn-header-icon d-lg-none"
                         data-bs-toggle="offcanvas"
                         data-bs-target="#admin-nav-offcanvas"
                         aria-controls="admin-nav-offcanvas"
@@ -248,3 +225,15 @@ $_visibleAdminLinks = array_values(array_filter(
         Each item is shown only when your role holds the entitlement that controls it.
     </div>
 </div>
+
+<?php
+/* Open the sidebar + main flex wrapper for #460. `admin-footer.php`
+   closes it again. A GLOBALS flag lets the footer know the wrapper
+   was actually opened — login.php / setup.php / editor/index.php
+   include the footer without first including this nav, so the
+   footer must not close containers that were never opened. */
+$GLOBALS['_adminLayoutOpen'] = true;
+?>
+<div class="admin-layout">
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'admin-sidebar.php'; ?>
+    <main class="admin-main" role="main">

--- a/appWeb/public_html/manage/includes/admin-sidebar.php
+++ b/appWeb/public_html/manage/includes/admin-sidebar.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Shared Admin Sidebar (#460)
+ *
+ * Pinned-left navigation visible at lg+ viewports; hidden below lg
+ * by the `d-none d-lg-flex` utility classes, where the hamburger
+ * offcanvas rendered by admin-nav.php takes over instead.
+ *
+ * Iterates `visibleAdminLinks()` from admin-links.php so the
+ * destinations, entitlement gates and active-state highlighting stay
+ * in lock-step with the offcanvas.
+ *
+ * Expects the caller (admin-nav.php) to have already:
+ *   - required admin-links.php (so visibleAdminLinks() is defined)
+ *   - set $currentUser + $activePage in the surrounding scope
+ */
+
+if (basename($_SERVER['SCRIPT_FILENAME'] ?? '') === basename(__FILE__)) {
+    http_response_code(403);
+    exit('Access denied.');
+}
+
+$_sidebarActive = $activePage ?? '';
+$_sidebarRole   = $currentUser['role'] ?? null;
+$_sidebarLinks  = visibleAdminLinks($_sidebarRole);
+
+/* Collect into { groupHeading => [link, …] } while preserving the
+   registry's declaration order so groups surface in a stable sequence
+   (top-level → Content → People → Operations). */
+$_sidebarGrouped = [];
+foreach ($_sidebarLinks as $l) {
+    $_sidebarGrouped[$l[5] ?? ''][] = $l;
+}
+
+?>
+<aside class="admin-sidebar d-none d-lg-flex flex-column" aria-label="Admin sections">
+    <nav class="admin-sidebar-nav flex-grow-1" aria-label="Primary">
+        <?php foreach ($_sidebarGrouped as $group => $links): ?>
+            <?php if ($group !== ''): ?>
+                <div class="admin-sidebar-group-label text-uppercase small text-muted px-3 pt-3 pb-1">
+                    <?= htmlspecialchars((string)$group) ?>
+                </div>
+            <?php endif; ?>
+            <?php foreach ($links as $l): ?>
+                <?php [$id, $href, $icon, $label] = $l; ?>
+                <a href="<?= htmlspecialchars($href) ?>"
+                   class="admin-sidebar-link d-flex align-items-center gap-2 px-3 py-2<?= $_sidebarActive === $id ? ' active' : '' ?>"
+                   <?= $_sidebarActive === $id ? 'aria-current="page"' : '' ?>>
+                    <i class="bi <?= htmlspecialchars($icon) ?> fs-6" aria-hidden="true"></i>
+                    <span><?= htmlspecialchars($label) ?></span>
+                </a>
+            <?php endforeach; ?>
+        <?php endforeach; ?>
+    </nav>
+</aside>


### PR DESCRIPTION
Closes #460.

Admins on desktop now get a persistent left sidebar with every destination visible and the current section highlighted, instead of one extra click into the hamburger offcanvas every time. Below lg the sidebar hides and the existing hamburger offcanvas returns.

## Summary
- **New** `manage/includes/admin-links.php` — single registry of every admin destination (id, href, icon, label, entitlement, group). Exposes `visibleAdminLinks($role)` for the entitlement-gated view.
- **New** `manage/includes/admin-sidebar.php` — renders the lg+ sidebar with grouped sections (Content / People / Operations) and a top-level Dashboard. Current section highlighted with an accent-coloured left border and background tint.
- **Modified** `manage/includes/admin-nav.php` — drops the inline link array in favour of the shared registry; adds `d-lg-none` to the hamburger; opens `<div class="admin-layout">` + sidebar + `<main class="admin-main">` after the offcanvas.
- **Modified** `manage/includes/admin-footer.php` — closes the layout wrapper (flag-guarded so `login.php` / `setup.php` / `editor/index.php`, which include the footer without the nav, don't blow up).
- **Modified** `css/admin.css` — `.admin-layout` flex, 240 px sticky sidebar under the fixed top bar, accent-active link state, `.admin-main` takes the remaining width.

**Zero per-page edits needed** — every `/manage/*.php` that already used `admin-nav.php` + `admin-footer.php` picks up the new layout automatically.

## Test plan
- [ ] ≥ lg viewport: sidebar visible on every `/manage/*` page, current section highlighted, hamburger gone from top bar.
- [ ] < lg viewport: sidebar hidden, hamburger back, offcanvas lists the same entitled items.
- [ ] Curator / Editor role: sidebar only shows destinations they can use.
- [ ] `/manage/editor/`, `/manage/login`, `/manage/setup` still render correctly (they bypass `admin-nav.php`).
- [ ] PWA installed on desktop → sidebar works. PWA on mobile → hamburger only. Theme toggle + avatar dropdown unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CjQB5rJGmbPU9KAYiVNfX4)_