### PR TITLE
feat(licences): inheritance + multi-licence effective set (#462)

### DIFF
--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -4563,6 +4563,55 @@ if ($action !== null) {
             break;
 
         /* -----------------------------------------------------------------
+         * #462 — Effective licence set for a given user (admin-only).
+         * Returns the resolved inheritance-aware list for debugging +
+         * future admin UI. Shape matches licences.php::getUserEffectiveLicences.
+         *   GET /api?action=user_effective_licences&user_id=<int>
+         * ----------------------------------------------------------------- */
+        case 'user_effective_licences':
+            $authUser = getAuthenticatedUser();
+            if (!$authUser || !userHasEntitlement('view_licence_audit', $authUser['Role'] ?? null)) {
+                sendJson(['error' => 'Not authorised.'], 403);
+                break;
+            }
+            $targetId = (int)($_GET['user_id'] ?? 0);
+            if ($targetId <= 0) {
+                sendJson(['error' => 'user_id required.'], 400);
+                break;
+            }
+            require_once __DIR__ . '/includes/licences.php';
+            sendJson([
+                'user_id'  => $targetId,
+                'licences' => getUserEffectiveLicences($targetId),
+            ]);
+            break;
+
+        /* -----------------------------------------------------------------
+         * #462 — Current user's licence check. Returns { has: bool } for
+         * a given licence type, walking the org hierarchy. Any
+         * authenticated caller may ask about their own set so the
+         * frontend can show/hide features.
+         *   GET /api?action=licence_check&type=ccli
+         * ----------------------------------------------------------------- */
+        case 'licence_check':
+            $authUser = getAuthenticatedUser();
+            if (!$authUser) {
+                sendJson(['error' => 'Authentication required.'], 401);
+                break;
+            }
+            $type = trim((string)($_GET['type'] ?? ''));
+            if ($type === '') {
+                sendJson(['error' => 'type required.'], 400);
+                break;
+            }
+            require_once __DIR__ . '/includes/licences.php';
+            sendJson([
+                'type' => $type,
+                'has'  => userHasEffectiveLicence((int)$authUser['Id'], $type),
+            ]);
+            break;
+
+        /* -----------------------------------------------------------------
          * Unknown action
          * ----------------------------------------------------------------- */
         default:

--- a/appWeb/public_html/includes/content_access.php
+++ b/appWeb/public_html/includes/content_access.php
@@ -25,6 +25,12 @@ if (basename($_SERVER['SCRIPT_FILENAME'] ?? '') === basename(__FILE__)) {
     exit('Access denied.');
 }
 
+/* Inheritance-aware licence resolver (#462). The `require_licence` branch
+   below calls getUserEffectiveLicenceTypes() so a rule saying
+   `require_licence: ihymns_pro` passes when the user holds that licence
+   directly OR inherits it from any ancestor organisation. */
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'licences.php';
+
 /**
  * Check if a user has access to a specific entity (song, songbook, or feature).
  *
@@ -52,7 +58,9 @@ function checkContentAccess(string $entityType, string $entityId, ?int $userId, 
         return ['allowed' => true, 'reason' => ''];
     }
 
-    /* Get user's organisation memberships and licences */
+    /* Org memberships — still needed for block_org / require_org rules
+       which match on direct membership, not inheritance. The licence
+       set below handles its own ancestor walk. */
     $userOrgIds = [];
     $userLicenceTypes = [];
 
@@ -61,14 +69,10 @@ function checkContentAccess(string $entityType, string $entityId, ?int $userId, 
         $stmt->execute([$userId]);
         $userOrgIds = $stmt->fetchAll(PDO::FETCH_COLUMN);
 
-        /* Get licences from user directly + from orgs */
-        $stmt = $db->prepare(
-            'SELECT DISTINCT LicenceType FROM tblContentLicences
-             WHERE IsActive = 1 AND (ExpiresAt IS NULL OR ExpiresAt > NOW())
-             AND (UserId = ? OR OrgId IN (SELECT OrgId FROM tblOrganisationMembers WHERE UserId = ?))'
-        );
-        $stmt->execute([$userId, $userId]);
-        $userLicenceTypes = $stmt->fetchAll(PDO::FETCH_COLUMN);
+        /* Effective licence types: direct + via every org the user belongs
+           to + every ancestor org (#462). Replaces the old single-level
+           query that only looked at direct memberships. */
+        $userLicenceTypes = getUserEffectiveLicenceTypes($userId);
     }
 
     /* Evaluate rules in priority order */

--- a/appWeb/public_html/includes/entitlements.php
+++ b/appWeb/public_html/includes/entitlements.php
@@ -82,6 +82,13 @@ const ENTITLEMENTS = [
     'access_alpha'         => ['user', 'editor', 'admin', 'global_admin'],
     'access_beta'          => ['user', 'editor', 'admin', 'global_admin'],
 
+    /* Licences — multi-licence + inheritance (#462). Separate from the
+       generic `manage_organisations` entitlement so licence edits can
+       be delegated without granting full org admin. */
+    'manage_org_licences'   => ['admin', 'global_admin'],
+    'manage_user_licences'  => ['admin', 'global_admin'],
+    'view_licence_audit'    => ['admin', 'global_admin'],
+
     /* Meta */
     'manage_entitlements'  => ['global_admin'],
 ];

--- a/appWeb/public_html/includes/licences.php
+++ b/appWeb/public_html/includes/licences.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Licence Evaluator with Inheritance (#462)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * Resolves a user's effective licence set by unioning:
+ *
+ *   (a) Direct user-level rows in tblContentLicences
+ *       (UserId = $userId, IsActive, within validity).
+ *   (b) Legacy tblUsers.CcliNumber — if the user has a personal CCLI
+ *       number recorded on their profile, it counts as a 'ccli' licence.
+ *   (c) Licences on every organisation the user belongs to
+ *       (tblOrganisationMembers).
+ *   (d) Licences on every ancestor organisation, walking up
+ *       tblOrganisations.ParentOrgId recursively (bounded at
+ *       LICENCE_INHERITANCE_MAX_DEPTH to defend against cycles even
+ *       though the FK should prevent them).
+ *   (e) Legacy tblOrganisations.LicenceType column — if an org hasn't
+ *       yet been migrated to tblContentLicences rows, its single-column
+ *       licence still contributes.
+ *
+ * Results are cached per-request in a static map so repeated calls from
+ * checkContentAccess() + API handlers hit the DB once per user.
+ *
+ * Require order: this file relies on getDb() being available, so pages
+ * should require `manage/includes/db.php` first. The main app's
+ * `api.php` already does this near the top.
+ */
+
+if (basename($_SERVER['SCRIPT_FILENAME'] ?? '') === basename(__FILE__)) {
+    http_response_code(403);
+    exit('Access denied.');
+}
+
+/* Cap org hierarchy traversal depth. A real church → diocese → conference
+   chain is typically 2–3 deep; 10 is generous headroom and stops any
+   accidental cycle from looping forever. */
+const LICENCE_INHERITANCE_MAX_DEPTH = 10;
+
+/**
+ * Resolve the effective licence set for a user.
+ *
+ * @param int|null $userId The authenticated user. Null → empty set
+ *                         (anonymous callers have no licences).
+ * @return array<int, array{
+ *     type: string,
+ *     key: string,
+ *     expires_at: ?string,
+ *     source: string,           // 'user' | 'org'
+ *     source_id: ?int,          // user id or org id this row came from
+ *     inherited: bool           // true if reached via ancestor org
+ * }>
+ */
+function getUserEffectiveLicences(?int $userId): array
+{
+    static $cache = [];
+    if ($userId === null) {
+        return [];
+    }
+    if (isset($cache[$userId])) {
+        return $cache[$userId];
+    }
+
+    $db = getDb();
+
+    /* Collect every org the user transitively belongs to: direct
+       memberships first, then walk up the ParentOrgId chain. Uses a
+       frontier queue rather than recursion so the depth bound is
+       explicit and easy to audit. */
+    $stmt = $db->prepare('SELECT OrgId FROM tblOrganisationMembers WHERE UserId = ?');
+    $stmt->execute([$userId]);
+    $directOrgIds = array_map('intval', $stmt->fetchAll(PDO::FETCH_COLUMN));
+
+    $allOrgIds   = array_fill_keys($directOrgIds, false); /* false = direct, true = inherited */
+    $frontier    = $directOrgIds;
+
+    for ($depth = 0; $depth < LICENCE_INHERITANCE_MAX_DEPTH && !empty($frontier); $depth++) {
+        $placeholders = implode(',', array_fill(0, count($frontier), '?'));
+        $stmt = $db->prepare(
+            "SELECT DISTINCT ParentOrgId
+               FROM tblOrganisations
+              WHERE Id IN ($placeholders)
+                AND ParentOrgId IS NOT NULL"
+        );
+        $stmt->execute($frontier);
+        $parents = array_map('intval', $stmt->fetchAll(PDO::FETCH_COLUMN));
+
+        $newParents = array_values(array_filter(
+            $parents,
+            static fn(int $id): bool => !array_key_exists($id, $allOrgIds)
+        ));
+        foreach ($newParents as $id) {
+            $allOrgIds[$id] = true; /* marked inherited */
+        }
+        $frontier = $newParents;
+    }
+
+    $licences = [];
+
+    /* (a) direct user-level rows */
+    $stmt = $db->prepare(
+        'SELECT LicenceType AS type, LicenceKey AS `key`, ExpiresAt AS expires_at
+           FROM tblContentLicences
+          WHERE UserId = ?
+            AND IsActive = 1
+            AND (ExpiresAt IS NULL OR ExpiresAt > NOW())'
+    );
+    $stmt->execute([$userId]);
+    foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $r) {
+        $licences[] = [
+            'type'       => (string)$r['type'],
+            'key'        => (string)$r['key'],
+            'expires_at' => $r['expires_at'],
+            'source'     => 'user',
+            'source_id'  => $userId,
+            'inherited'  => false,
+        ];
+    }
+
+    /* (b) legacy tblUsers.CcliNumber */
+    $stmt = $db->prepare('SELECT CcliNumber FROM tblUsers WHERE Id = ? AND IsActive = 1');
+    $stmt->execute([$userId]);
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+    if ($row && !empty(trim((string)$row['CcliNumber']))) {
+        $licences[] = [
+            'type'       => 'ccli',
+            'key'        => (string)$row['CcliNumber'],
+            'expires_at' => null,
+            'source'     => 'user',
+            'source_id'  => $userId,
+            'inherited'  => false,
+        ];
+    }
+
+    if (!empty($allOrgIds)) {
+        $orgIds       = array_keys($allOrgIds);
+        $placeholders = implode(',', array_fill(0, count($orgIds), '?'));
+
+        /* (c + d) tblContentLicences rows for any org in the chain */
+        $stmt = $db->prepare(
+            "SELECT LicenceType AS type, LicenceKey AS `key`, ExpiresAt AS expires_at, OrgId
+               FROM tblContentLicences
+              WHERE OrgId IN ($placeholders)
+                AND IsActive = 1
+                AND (ExpiresAt IS NULL OR ExpiresAt > NOW())"
+        );
+        $stmt->execute($orgIds);
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $r) {
+            $orgId = (int)$r['OrgId'];
+            $licences[] = [
+                'type'       => (string)$r['type'],
+                'key'        => (string)$r['key'],
+                'expires_at' => $r['expires_at'],
+                'source'     => 'org',
+                'source_id'  => $orgId,
+                'inherited'  => $allOrgIds[$orgId] ?? false,
+            ];
+        }
+
+        /* (e) legacy tblOrganisations.LicenceType / LicenceNumber /
+               LicenceExpiresAt — skipped once the org has real rows in
+               tblContentLicences above, but harmless to include (dedup
+               happens via getUserEffectiveLicenceTypes). */
+        $stmt = $db->prepare(
+            "SELECT Id, LicenceType, LicenceNumber, LicenceExpiresAt
+               FROM tblOrganisations
+              WHERE Id IN ($placeholders)
+                AND IsActive = 1
+                AND LicenceType <> ''
+                AND LicenceType <> 'none'
+                AND (LicenceExpiresAt IS NULL OR LicenceExpiresAt > NOW())"
+        );
+        $stmt->execute($orgIds);
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $r) {
+            $orgId = (int)$r['Id'];
+            $licences[] = [
+                'type'       => (string)$r['LicenceType'],
+                'key'        => (string)$r['LicenceNumber'],
+                'expires_at' => $r['LicenceExpiresAt'],
+                'source'     => 'org',
+                'source_id'  => $orgId,
+                'inherited'  => $allOrgIds[$orgId] ?? false,
+            ];
+        }
+    }
+
+    return $cache[$userId] = $licences;
+}
+
+/**
+ * True if the user's effective licence set contains a licence of the
+ * given type (e.g. 'ccli', 'ihymns_pro'). Convenience wrapper around
+ * getUserEffectiveLicences() for the common access-check case.
+ */
+function userHasEffectiveLicence(?int $userId, string $type): bool
+{
+    if ($userId === null) {
+        return false;
+    }
+    foreach (getUserEffectiveLicences($userId) as $l) {
+        if ($l['type'] === $type) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Flat, de-duplicated list of licence type strings in the effective
+ * set — drop-in replacement for the ad-hoc query in checkContentAccess().
+ *
+ * @return string[]
+ */
+function getUserEffectiveLicenceTypes(?int $userId): array
+{
+    return array_values(array_unique(array_map(
+        static fn(array $l): string => $l['type'],
+        getUserEffectiveLicences($userId)
+    )));
+}


### PR DESCRIPTION
Closes #462.

Previously `checkContentAccess()` only saw licences held directly by the user or by orgs they were a *direct* member of. A user in a church that belonged to a diocese with the diocesan CCLI licence didn't inherit it — the resolver stopped at one hop. Legacy single-licence columns weren't read either.

## Summary
- **New** `includes/licences.php` resolver unions five sources per user: direct user rows, legacy `tblUsers.CcliNumber`, org-membership rows, every ancestor org (via a bounded `ParentOrgId` walk, max 10 levels), and legacy `tblOrganisations.LicenceType`. Request-cached.
- **Wired** `content_access.php::checkContentAccess()` to call `getUserEffectiveLicenceTypes()`, so `require_licence` rules match across the inheritance chain automatically.
- **New entitlements** registered for follow-up UI: `manage_org_licences`, `manage_user_licences`, `view_licence_audit`.
- **New API endpoints**:
  - `GET /api?action=user_effective_licences&user_id=<int>` (requires `view_licence_audit`) — admin-debug the resolved set.
  - `GET /api?action=licence_check&type=<key>` — any authenticated user, returns `{has: bool}` for their own effective set.

**Non-breaking**: no schema changes; legacy columns still read alongside the modern table.

## Test plan
- [ ] User in a church that belongs to a diocese with `ihymns_pro` sees `ihymns_pro` in their effective set (inheritance works).
- [ ] `/api?action=user_effective_licences&user_id=N` as an admin returns the resolved set.
- [ ] `/api?action=licence_check&type=ccli` returns `{has:true/false}` correctly for the current user.
- [ ] Expired licences (ValidUntil in the past) excluded.
- [ ] Removing a user from an org removes their inherited licences on the next evaluation.
- [ ] Existing single-licence users retain access — no regressions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CjQB5rJGmbPU9KAYiVNfX4)_