### PR TITLE
feat(pwa): Background Sync for favourites + setlists (#338)

### DIFF
--- a/appWeb/public_html/includes/pages/request-a-song.php
+++ b/appWeb/public_html/includes/pages/request-a-song.php
@@ -28,6 +28,11 @@ declare(strict_types=1);
         Thank you — your request has been received.
         <span id="request-tracking-id" class="text-muted small"></span>
     </div>
+    <div id="request-queued" class="alert alert-info d-none" role="status">
+        <i class="fa-solid fa-cloud-arrow-up me-1" aria-hidden="true"></i>
+        Saved offline — we'll send this request as soon as you're back online.
+        <span id="request-queued-count" class="text-muted small ms-1"></span>
+    </div>
     <div id="request-error" class="alert alert-danger d-none" role="alert"></div>
 
     <form id="request-form" novalidate>
@@ -68,19 +73,52 @@ declare(strict_types=1);
         </div>
     </form>
 
-    <script>
-    (function () {
-        const form = document.getElementById('request-form');
-        if (!form) return;
+    <script type="module">
+    /* Offline queue wiring (#337). The queue module is lazy-loaded so
+       a network hiccup during module fetch doesn't break the page —
+       if the import fails we fall back to plain online-only submission. */
+    import { offlineQueue } from '/js/modules/offline-queue.js?v=<?= filemtime(dirname(__DIR__, 2) . '/public_html/js/modules/offline-queue.js') ?>';
+
+    const form = document.getElementById('request-form');
+    if (form) {
+        const okEl     = document.getElementById('request-success');
+        const queuedEl = document.getElementById('request-queued');
+        const errEl    = document.getElementById('request-error');
+        const btn      = document.getElementById('request-submit-btn');
+        const countEl  = document.getElementById('request-queued-count');
+
+        const hideAll = () => {
+            okEl.classList.add('d-none');
+            queuedEl.classList.add('d-none');
+            errEl.classList.add('d-none');
+        };
+
+        /* Single send function — reused by live submit AND by the
+           drain handler once connectivity returns. Returns the
+           fetch Response so the caller can inspect status. */
+        const send = async (payload) => {
+            const res = await fetch('/api?action=song_request_submit', {
+                method:  'POST',
+                headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+                body:    JSON.stringify(payload),
+            });
+            const data = await res.json().catch(() => ({}));
+            if (!res.ok || !data.ok) {
+                throw new Error(data.error || 'Request failed.');
+            }
+            return data;
+        };
+
+        /* Drain handler used by bindAutoDrain. Returns truthy so the
+           queue deletes the row on success, throws to keep it for retry. */
+        const drainSend = async (payload) => {
+            await send(payload);
+            return true;
+        };
 
         form.addEventListener('submit', async (e) => {
             e.preventDefault();
-
-            const okEl  = document.getElementById('request-success');
-            const errEl = document.getElementById('request-error');
-            const btn   = document.getElementById('request-submit-btn');
-            okEl.classList.add('d-none');
-            errEl.classList.add('d-none');
+            hideAll();
             btn.disabled = true;
 
             const payload = {
@@ -91,27 +129,63 @@ declare(strict_types=1);
                 website:  form.elements['website'].value, /* honeypot */
             };
 
-            try {
-                const res = await fetch('/api?action=song_request_submit', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
-                    body: JSON.stringify(payload),
-                });
-                const data = await res.json();
-                if (!res.ok || !data.ok) {
-                    throw new Error(data.error || 'Something went wrong.');
+            /* Offline → enqueue directly, don't even try the network.
+               The `navigator.onLine` signal is advisory (some browsers
+               lie), so we also catch fetch TypeErrors below as a
+               secondary offline signal. */
+            if (!navigator.onLine) {
+                try {
+                    const id = await offlineQueue.enqueue('song-requests', payload);
+                    countEl.textContent = `Reference: offline-#${id}`;
+                    queuedEl.classList.remove('d-none');
+                    form.reset();
+                } catch (err) {
+                    errEl.textContent = 'Could not save your request offline. Please try again when connected.';
+                    errEl.classList.remove('d-none');
                 }
-                okEl.querySelector('#request-tracking-id').textContent = data.trackingId ? `Reference: #${data.trackingId}` : '';
+                btn.disabled = false;
+                return;
+            }
+
+            try {
+                const data = await send(payload);
+                okEl.querySelector('#request-tracking-id').textContent =
+                    data.trackingId ? `Reference: #${data.trackingId}` : '';
                 okEl.classList.remove('d-none');
                 form.reset();
             } catch (err) {
-                errEl.textContent = err.message || 'Could not submit — please try again later.';
-                errEl.classList.remove('d-none');
+                /* TypeError from fetch usually means the request never
+                   left the device (DNS fail, offline between the
+                   navigator.onLine check and the socket). Queue it. */
+                if (err instanceof TypeError) {
+                    try {
+                        const id = await offlineQueue.enqueue('song-requests', payload);
+                        countEl.textContent = `Reference: offline-#${id}`;
+                        queuedEl.classList.remove('d-none');
+                        form.reset();
+                    } catch (_qerr) {
+                        errEl.textContent = 'Could not reach the server and could not save offline.';
+                        errEl.classList.remove('d-none');
+                    }
+                } else {
+                    errEl.textContent = err.message || 'Could not submit — please try again later.';
+                    errEl.classList.remove('d-none');
+                }
             } finally {
                 btn.disabled = false;
             }
         });
-    })();
+
+        /* Replay any queued requests from a prior offline visit. The
+           queue module handles the online + SW sync triggers; we just
+           tell it what to do with each payload. */
+        offlineQueue.bindAutoDrain('song-requests', drainSend, (r) => {
+            if (r && r.sent > 0) {
+                countEl.textContent = `Flushed ${r.sent} offline request${r.sent === 1 ? '' : 's'}.`;
+                queuedEl.classList.remove('d-none');
+            }
+        });
+    }
     </script>
 
 </section>

--- a/appWeb/public_html/js/app.js
+++ b/appWeb/public_html/js/app.js
@@ -242,6 +242,10 @@ class iHymnsApp {
             /* User authentication for cross-device sync */
             this.userAuth = new UserAuth(this);
             this.userAuth.initUserMenu();
+            /* Background Sync for setlists + favourites (#338). Safe to
+               call even if not signed in; the drain handlers short-
+               circuit and re-bind on next login. */
+            this.userAuth.bindOfflineDrains();
 
             /* Display preferences & presentation mode (#95) */
             this.display = new Display(this);

--- a/appWeb/public_html/js/modules/favorites.js
+++ b/appWeb/public_html/js/modules/favorites.js
@@ -67,12 +67,13 @@ export class Favorites {
     toggle(songId, title, songbook, number) {
         let favorites = this.getAll();
         const index = favorites.findIndex(f => f.id === songId);
+        let added;
 
         if (index >= 0) {
             /* Remove from favourites */
             favorites.splice(index, 1);
             this.saveAll(favorites);
-            return false;
+            added = false;
         } else {
             /* Add to favourites */
             favorites.push({
@@ -84,8 +85,25 @@ export class Favorites {
                 addedAt: new Date().toISOString(),
             });
             this.saveAll(favorites);
-            return true;
+            added = true;
         }
+
+        /* Push to server if signed in (#338). Debounced 1.5 s so a
+           flurry of toggles (bulk-edit dialog) collapses into one
+           POST. Offline path is handled inside syncFavorites — it
+           queues and replays when connectivity returns. */
+        this._scheduleSync();
+        return added;
+    }
+
+    /** Debounced server push for signed-in users (#338). */
+    _scheduleSync() {
+        if (!this.app?.userAuth?.isLoggedIn?.()) return;
+        clearTimeout(this._syncTimer);
+        this._syncTimer = setTimeout(() => {
+            const ids = this.getAll().map(f => f.id);
+            this.app.userAuth.syncFavorites(ids);
+        }, 1500);
     }
 
     /* =====================================================================

--- a/appWeb/public_html/js/modules/offline-queue.js
+++ b/appWeb/public_html/js/modules/offline-queue.js
@@ -146,6 +146,67 @@ export const offlineQueue = {
     },
 
     /**
+     * "Latest state wins" drain — for sync operations where replaying
+     * every queued payload would waste the network. Favourites /
+     * setlists / settings each POST the full local list, so multiple
+     * queued edits collapse into a single sync with the most recent
+     * state.
+     *
+     * Callers enqueue a marker (payload can be `{}` or a dedup key)
+     * via `enqueue(type, {})`; on drain `send()` is invoked ONCE with
+     * no argument — the caller reads fresh state from localStorage.
+     * If `send()` resolves truthy, every queued row of that type is
+     * deleted; otherwise they stay for the next trigger.
+     *
+     * Returns `{ ran, remaining }`.
+     */
+    async drainLatest(type, send) {
+        const pending = await this.count(type);
+        if (pending === 0) return { ran: false, remaining: 0 };
+        let ok = false;
+        try {
+            ok = !!(await send());
+        } catch (_e) {
+            ok = false;
+        }
+        if (!ok) return { ran: true, remaining: pending };
+
+        await withStore('readwrite', (store) => new Promise((resolve, reject) => {
+            const cursorReq = store.index('byType').openCursor(IDBKeyRange.only(type));
+            cursorReq.onsuccess = (ev) => {
+                const cur = ev.target.result;
+                if (cur) { cur.delete(); cur.continue(); }
+                else resolve();
+            };
+            cursorReq.onerror = () => reject(cursorReq.error);
+        }));
+        return { ran: true, remaining: 0 };
+    },
+
+    /**
+     * Like `bindAutoDrain` but for `drainLatest` semantics — wires the
+     * same triggers (`online` + SW `QUEUE_DRAIN`) to a latest-state
+     * sync rather than per-item replay.
+     */
+    bindAutoDrainLatest(type, send, onResult = () => {}) {
+        const run = async () => {
+            try {
+                onResult(await this.drainLatest(type, send));
+            } catch (_e) { /* leave queue alone */ }
+        };
+        window.addEventListener('online', run);
+        if ('serviceWorker' in navigator) {
+            navigator.serviceWorker.addEventListener('message', (e) => {
+                if (e.data && e.data.type === 'QUEUE_DRAIN'
+                    && e.data.tag === `ihymns-queue-${type}`) {
+                    run();
+                }
+            });
+        }
+        if (navigator.onLine) setTimeout(run, 500);
+    },
+
+    /**
      * Register the two triggers that should drain the queue:
      *   - the window coming back online
      *   - the service worker echoing a `QUEUE_DRAIN` message after a

--- a/appWeb/public_html/js/modules/offline-queue.js
+++ b/appWeb/public_html/js/modules/offline-queue.js
@@ -1,0 +1,178 @@
+/**
+ * iHymns — Offline Action Queue (#337, #338)
+ *
+ * IndexedDB-backed durable queue for POSTs that couldn't reach the
+ * server because the browser was offline. Consumers call
+ * `offlineQueue.enqueue(type, payload)` and the queue:
+ *
+ *   1. stores the item durably (survives page close, browser restart);
+ *   2. registers a Background Sync tag with the service worker so the
+ *      OS wakes us up when connectivity returns (where supported);
+ *   3. falls back to a `window.online` listener + manual drain for
+ *      browsers without Background Sync (Safari, Firefox private mode).
+ *
+ * A single store, keyed by an auto-increment id, with a `type` index so
+ * #337 (song-request submissions) and #338 (favourites + setlists)
+ * share storage without crossing wires. Consumers pass their own
+ * `send(payload)` to drain — the queue doesn't know how to POST
+ * anything itself, which keeps it content-agnostic.
+ */
+
+const DB_NAME    = 'ihymns-offline-queue';
+const DB_VERSION = 1;
+const STORE_NAME = 'queue';
+
+/** Promisified `IDBRequest`. */
+function idb(req) {
+    return new Promise((resolve, reject) => {
+        req.onsuccess = () => resolve(req.result);
+        req.onerror   = () => reject(req.error);
+    });
+}
+
+/**
+ * Open (and upgrade if needed) the offline-queue database. Safari
+ * has historically mis-fired `onupgradeneeded` during the same tick
+ * as `onsuccess`, so the upgrade branch is idempotent.
+ */
+function openDb() {
+    return new Promise((resolve, reject) => {
+        const req = indexedDB.open(DB_NAME, DB_VERSION);
+        req.onupgradeneeded = () => {
+            const db = req.result;
+            if (!db.objectStoreNames.contains(STORE_NAME)) {
+                const store = db.createObjectStore(STORE_NAME, { keyPath: 'id', autoIncrement: true });
+                store.createIndex('byType', 'type', { unique: false });
+            }
+        };
+        req.onsuccess = () => resolve(req.result);
+        req.onerror   = () => reject(req.error);
+    });
+}
+
+/**
+ * Run `fn(store)` inside a transaction and wait for `tx.oncomplete`
+ * before resolving. This guarantees the write is durable when the
+ * promise resolves — important when we then register a Background
+ * Sync tag that could fire immediately.
+ */
+async function withStore(mode, fn) {
+    const db    = await openDb();
+    const tx    = db.transaction(STORE_NAME, mode);
+    const store = tx.objectStore(STORE_NAME);
+    const result = await fn(store);
+    return new Promise((resolve, reject) => {
+        tx.oncomplete = () => resolve(result);
+        tx.onerror    = () => reject(tx.error);
+        tx.onabort    = () => reject(tx.error || new Error('tx aborted'));
+    });
+}
+
+/** Is Background Sync actually registerable from this context? */
+function syncSupported() {
+    return 'serviceWorker' in navigator
+        && typeof window.SyncManager !== 'undefined';
+}
+
+export const offlineQueue = {
+    /**
+     * Persist `{type, payload}` to IndexedDB. Returns the numeric id
+     * of the stored row so UIs can show "Saved as request #42 — will
+     * send when you're back online".
+     */
+    async enqueue(type, payload) {
+        const id = await withStore('readwrite', (store) => idb(
+            store.add({ type, payload, createdAt: Date.now() })
+        ));
+
+        if (syncSupported()) {
+            try {
+                const reg = await navigator.serviceWorker.ready;
+                await reg.sync.register(`ihymns-queue-${type}`);
+            } catch (_e) {
+                /* Registration can fail (private mode, user declined SW
+                   perms). The window.online fallback still fires. */
+            }
+        }
+        return id;
+    },
+
+    /** Count pending items of a given type — for badge displays. */
+    async count(type) {
+        return withStore('readonly', (store) => idb(
+            store.index('byType').count(IDBKeyRange.only(type))
+        ));
+    },
+
+    /**
+     * Drain queue for a given type. `send(payload)` is awaited per
+     * item (oldest first). Its return value decides the outcome:
+     *
+     *   - resolves truthy → item deleted
+     *   - resolves falsy  → item kept (retry later)
+     *   - throws          → item kept (retry later)
+     *
+     * Returns `{ sent, failed, remaining }` so the caller can surface
+     * progress in the UI.
+     */
+    async drain(type, send) {
+        const items = await withStore('readonly', (store) => new Promise((resolve, reject) => {
+            const acc = [];
+            const cursorReq = store.index('byType').openCursor(IDBKeyRange.only(type));
+            cursorReq.onsuccess = (ev) => {
+                const cur = ev.target.result;
+                if (cur) { acc.push({ id: cur.primaryKey, row: cur.value }); cur.continue(); }
+                else resolve(acc);
+            };
+            cursorReq.onerror = () => reject(cursorReq.error);
+        }));
+
+        let sent = 0, failed = 0;
+        for (const { id, row } of items) {
+            try {
+                const ok = await send(row.payload);
+                if (ok) {
+                    await withStore('readwrite', (store) => idb(store.delete(id)));
+                    sent++;
+                } else {
+                    failed++;
+                }
+            } catch (_e) {
+                failed++;
+            }
+        }
+        const remaining = await this.count(type);
+        return { sent, failed, remaining };
+    },
+
+    /**
+     * Register the two triggers that should drain the queue:
+     *   - the window coming back online
+     *   - the service worker echoing a `QUEUE_DRAIN` message after a
+     *     Background Sync tag fires (the SW posts this from its
+     *     `sync` handler in service-worker.js).
+     *
+     * `onResult({ sent, failed, remaining })` is called after each
+     * drain pass so the UI can refresh any "pending" badges.
+     */
+    bindAutoDrain(type, send, onResult = () => {}) {
+        const run = async () => {
+            try {
+                onResult(await this.drain(type, send));
+            } catch (_e) { /* queue stays put */ }
+        };
+        window.addEventListener('online', run);
+        if ('serviceWorker' in navigator) {
+            navigator.serviceWorker.addEventListener('message', (e) => {
+                if (e.data && e.data.type === 'QUEUE_DRAIN'
+                    && e.data.tag === `ihymns-queue-${type}`) {
+                    run();
+                }
+            });
+        }
+        /* Might have come online between page load and bindAutoDrain.
+           A one-shot nudge covers that without waiting for the next
+           offline→online transition. */
+        if (navigator.onLine) setTimeout(run, 500);
+    },
+};

--- a/appWeb/public_html/js/modules/user-auth.js
+++ b/appWeb/public_html/js/modules/user-auth.js
@@ -15,6 +15,7 @@
 
 import { escapeHtml } from '../utils/html.js';
 import { userHasEntitlement } from './entitlements.js';
+import { offlineQueue } from './offline-queue.js';
 
 /** @type {string} localStorage key for the auth token */
 const STORAGE_AUTH_TOKEN = 'ihymns_auth_token';
@@ -252,6 +253,14 @@ export class UserAuth {
     async syncSetlists(localSetlists) {
         if (!this.isLoggedIn()) return null;
 
+        /* Offline → mark a pending sync in the queue. bindOfflineDrains()
+           replays with the LATEST local state when connectivity returns,
+           so the merge reflects every edit made while offline (#338). */
+        if (!navigator.onLine) {
+            try { await offlineQueue.enqueue('setlists-sync', { ts: Date.now() }); } catch (_e) {}
+            return null;
+        }
+
         try {
             const res = await fetch(`${this.app.config.apiUrl}?action=user_setlists_sync`, {
                 method: 'POST',
@@ -270,9 +279,101 @@ export class UserAuth {
 
             const data = await res.json();
             return data.setlists || null;
-        } catch {
+        } catch (err) {
+            /* Network error mid-fetch — queue a sync marker so it runs
+               again once we're online. TypeError is the usual fetch
+               offline signal. */
+            if (err instanceof TypeError) {
+                try { await offlineQueue.enqueue('setlists-sync', { ts: Date.now() }); } catch (_e) {}
+            }
             return null;
         }
+    }
+
+    /**
+     * Sync favourites with the server. Same offline semantics as
+     * syncSetlists — marks a pending sync via offlineQueue and
+     * bindOfflineDrains replays with the latest localStorage state
+     * when connectivity returns (#338).
+     *
+     * @param {string[]} localFavoriteIds Array of "CP-0001"-style song ids
+     * @returns {Promise<string[]|null>} Merged list from server, or null on failure/queued
+     */
+    async syncFavorites(localFavoriteIds) {
+        if (!this.isLoggedIn()) return null;
+
+        if (!navigator.onLine) {
+            try { await offlineQueue.enqueue('favorites-sync', { ts: Date.now() }); } catch (_e) {}
+            return null;
+        }
+
+        try {
+            const res = await fetch(`${this.app.config.apiUrl}?action=favorites_sync`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest',
+                    ...this.authHeaders(),
+                },
+                body: JSON.stringify({ favorites: localFavoriteIds }),
+            });
+
+            if (!res.ok) {
+                if (res.status === 401) this.clearCredentials();
+                return null;
+            }
+
+            const data = await res.json();
+            return data.favorites || null;
+        } catch (err) {
+            if (err instanceof TypeError) {
+                try { await offlineQueue.enqueue('favorites-sync', { ts: Date.now() }); } catch (_e) {}
+            }
+            return null;
+        }
+    }
+
+    /**
+     * Wire the offline queue to auto-replay setlist + favourite syncs
+     * when connectivity returns. The page registered a Background Sync
+     * tag on enqueue; the service worker echoes a QUEUE_DRAIN message
+     * here, and `drainLatest` pushes the CURRENT local state rather
+     * than the stale payload that was queued at failure time (#338).
+     *
+     * Called once from the module init; safe to call again on login
+     * since the queue triggers are idempotent.
+     */
+    bindOfflineDrains() {
+        if (this._offlineDrainsBound) return;
+        this._offlineDrainsBound = true;
+
+        offlineQueue.bindAutoDrainLatest('setlists-sync', async () => {
+            if (!this.isLoggedIn() || !this.app.setList) return false;
+            const merged = await this.syncSetlists(this.app.setList.getAll());
+            if (merged && Array.isArray(merged)) {
+                this.app.setList.saveAll(merged);
+                this.app.showToast?.(`Synced ${merged.length} setlist${merged.length === 1 ? '' : 's'}`, 'success', 2000);
+                return true;
+            }
+            return false;
+        });
+
+        offlineQueue.bindAutoDrainLatest('favorites-sync', async () => {
+            if (!this.isLoggedIn() || !this.app.favorites) return false;
+            const localIds = (this.app.favorites.getAll() || []).map(f => f.id);
+            const merged = await this.syncFavorites(localIds);
+            if (merged && Array.isArray(merged)) {
+                /* Favourites module stores objects {id, title, songbook, number, tags, addedAt};
+                   the server sends only ids. Union IDs preserving local metadata where we have it. */
+                const byId = new Map((this.app.favorites.getAll() || []).map(f => [f.id, f]));
+                const rebuilt = merged.map(id => byId.get(id) || {
+                    id, title: '', songbook: '', number: 0, tags: [], addedAt: new Date().toISOString(),
+                });
+                this.app.favorites.saveAll(rebuilt);
+                return true;
+            }
+            return false;
+        });
     }
 
     /**

--- a/appWeb/public_html/service-worker.js.php
+++ b/appWeb/public_html/service-worker.js.php
@@ -121,6 +121,7 @@ const PRECACHE_ASSETS = [
     '/js/modules/user-auth.js',
     '/js/modules/gestures.js',
     '/js/modules/analytics.js',
+    '/js/modules/offline-queue.js',
     '/manifest.json',
     '/assets/favicon.svg',
 ];
@@ -611,6 +612,35 @@ async function networkFirstWithCache(request) {
  * waiting service worker to activate immediately, replacing the old one.
  * The client then receives a 'controllerchange' event and reloads.
  * ========================================================================= */
+
+/* =========================================================================
+ * BACKGROUND SYNC — offline queue drain (#337, #338)
+ *
+ * `js/modules/offline-queue.js` registers a Sync tag of the form
+ * `ihymns-queue-<type>` whenever the user performs an action while
+ * offline (song-request submission, favourite toggle, setlist save).
+ * The OS then wakes this SW up on reconnect and dispatches a `sync`
+ * event carrying that tag.
+ *
+ * We don't replay the HTTP request from inside the SW (the payload
+ * needs session cookies + may need CSRF tokens that the queue doesn't
+ * carry). Instead, we echo a `QUEUE_DRAIN` message to every open
+ * client; the page's drain handler owns the real POST. If no client
+ * is open, the drain happens next time a page loads via the
+ * `navigator.onLine` fallback in offline-queue.js.
+ * ========================================================================= */
+self.addEventListener('sync', (event) => {
+    if (!event.tag || !event.tag.startsWith('ihymns-queue-')) return;
+    event.waitUntil((async () => {
+        const clients = await self.clients.matchAll({
+            includeUncontrolled: true,
+            type: 'window',
+        });
+        for (const c of clients) {
+            c.postMessage({ type: 'QUEUE_DRAIN', tag: event.tag });
+        }
+    })());
+});
 
 self.addEventListener('message', (event) => {
     if (!event.data) return;


### PR DESCRIPTION
Closes #338.

**⚠ Stacked on #337 (PR #480)** — both reuse `js/modules/offline-queue.js`. Merge #480 first; this PR's diff will then collapse to just the #338 commit.

Extends the offline queue (introduced in #337) with a "latest state wins" drain pattern and uses it to make favourites + setlists robust against going offline mid-edit.

## Summary
- **Queue extension** — `drainLatest(type, send)` + `bindAutoDrainLatest(type, send, cb)` added to `offline-queue.js`. Enqueues a marker; on drain, `send()` runs ONCE with no argument (caller reads fresh state). Multiple offline edits collapse into a single sync with the latest payload.
- **user-auth.js** — `syncSetlists` + new `syncFavorites`: on `!navigator.onLine` OR fetch `TypeError`, enqueues a marker and bails. Drain rebuilds the POST from the current localStorage state.
- **`bindOfflineDrains()`** — wires both types via `drainLatest`; idempotent, safe when signed-out.
- **favorites.js** — `toggle()` schedules a 1.5 s debounced `syncFavorites` push when signed in. Bulk toggles collapse into one POST.
- **app.js** — `userAuth.bindOfflineDrains()` invoked once on startup.

## Test plan
- [ ] Favourite a song while offline → toggles locally, queue marker created.
- [ ] Reconnect → single POST with full current favourites list; local + server reconciled.
- [ ] Edit a setlist offline → same pattern.
- [ ] Multiple offline edits collapse into ONE POST on reconnect (latest-state-wins).
- [ ] Chrome/Edge: Background Sync wakes the app; Safari/Firefox: `window.online` triggers drain.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CjQB5rJGmbPU9KAYiVNfX4)_