### PR TITLE
feat(editor+admin): missing-numbers detector in editor sidebar + /manage page (#285)

### DIFF
--- a/appWeb/public_html/manage/editor/index.php
+++ b/appWeb/public_html/manage/editor/index.php
@@ -300,6 +300,22 @@ $currentUser = getCurrentUser();
                     <option value="number">Sort by Number</option>
                     <option value="songbook">Sort by Songbook, then Number</option>
                 </select>
+
+                <!-- Find missing song numbers (#285). Only enabled when a
+                     specific songbook is selected — "All Songbooks" has
+                     no single numbering to gap-check. -->
+                <button
+                    type="button"
+                    class="btn btn-sm btn-outline-secondary w-100 mt-2"
+                    id="find-missing-numbers-btn"
+                    data-bs-toggle="modal"
+                    data-bs-target="#missing-numbers-modal"
+                    disabled
+                    title="Shows gaps in the numbering of the currently filtered songbook"
+                >
+                    <i class="bi bi-binoculars me-1" aria-hidden="true"></i>
+                    Find missing numbers
+                </button>
             </div>
 
             <!-- Song list — scrollable container; each song is a clickable row -->
@@ -1201,6 +1217,178 @@ $currentUser = getCurrentUser();
     <!-- Editor JavaScript — all interactive logic (loading, saving, editing, previewing)
          is handled in this separate file to keep concerns separated -->
     <script src="editor.js"></script>
+
+    <!-- ============================================================
+         Find Missing Numbers modal (#285)
+         Shows the gaps in a songbook's numbering plus an at-a-glance
+         count of present / expected / missing songs. A dedicated
+         "Log a request" link on each missing number jumps straight to
+         the public request form with the number prefilled.
+         ============================================================ -->
+    <div class="modal fade" id="missing-numbers-modal" tabindex="-1"
+         aria-labelledby="missing-numbers-modal-label" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-scrollable modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="missing-numbers-modal-label">
+                        <i class="bi bi-binoculars me-2" aria-hidden="true"></i>
+                        Missing Song Numbers
+                        <span class="text-muted small ms-2" id="missing-numbers-scope"></span>
+                    </h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div id="missing-numbers-loading" class="text-center text-muted py-4">
+                        <div class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></div>
+                        Scanning the songbook&hellip;
+                    </div>
+                    <div id="missing-numbers-error" class="alert alert-danger d-none" role="alert"></div>
+                    <div id="missing-numbers-summary" class="row g-3 mb-3 d-none">
+                        <div class="col-sm-4">
+                            <div class="card-admin text-center">
+                                <div class="text-muted text-uppercase small">Present</div>
+                                <div class="h5 mb-0" id="missing-numbers-present">0</div>
+                            </div>
+                        </div>
+                        <div class="col-sm-4">
+                            <div class="card-admin text-center">
+                                <div class="text-muted text-uppercase small">Expected</div>
+                                <div class="h5 mb-0" id="missing-numbers-expected">0</div>
+                            </div>
+                        </div>
+                        <div class="col-sm-4">
+                            <div class="card-admin text-center">
+                                <div class="text-muted text-uppercase small">Missing</div>
+                                <div class="h5 mb-0 text-warning" id="missing-numbers-count">0</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div id="missing-numbers-list" class="d-none"></div>
+                    <div id="missing-numbers-empty" class="alert alert-success d-none" role="status">
+                        <i class="bi bi-check-circle me-1" aria-hidden="true"></i>
+                        No gaps in this songbook — every number from 1 to the maximum is present.
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+    /* Wiring for #285 — Find Missing Numbers. Kept inline here to avoid
+       a second editor.js round-trip; the endpoint + modal are
+       self-contained. */
+    (function () {
+        const btn      = document.getElementById('find-missing-numbers-btn');
+        const filterEl = document.getElementById('songbook-filter');
+        const modalEl  = document.getElementById('missing-numbers-modal');
+        if (!btn || !filterEl || !modalEl) return;
+
+        /* Toggle the button's disabled state as the songbook filter
+           changes — "All Songbooks" has no single numbering to gap. */
+        const syncEnabled = () => { btn.disabled = !filterEl.value; };
+        filterEl.addEventListener('change', syncEnabled);
+        syncEnabled();
+
+        const scopeEl    = document.getElementById('missing-numbers-scope');
+        const loadingEl  = document.getElementById('missing-numbers-loading');
+        const errorEl    = document.getElementById('missing-numbers-error');
+        const summaryEl  = document.getElementById('missing-numbers-summary');
+        const listEl     = document.getElementById('missing-numbers-list');
+        const emptyEl    = document.getElementById('missing-numbers-empty');
+        const presentEl  = document.getElementById('missing-numbers-present');
+        const expectedEl = document.getElementById('missing-numbers-expected');
+        const countEl    = document.getElementById('missing-numbers-count');
+
+        const resetView = () => {
+            loadingEl.classList.remove('d-none');
+            errorEl.classList.add('d-none');
+            summaryEl.classList.add('d-none');
+            listEl.classList.add('d-none');
+            emptyEl.classList.add('d-none');
+            listEl.innerHTML = '';
+        };
+
+        /* Group consecutive missing numbers into ranges so a songbook
+           with a big trailing gap doesn't produce a wall of badges. */
+        const groupRuns = (nums) => {
+            const out = [];
+            let run = [];
+            for (const n of nums) {
+                if (run.length === 0 || n === run[run.length - 1] + 1) run.push(n);
+                else { out.push(run); run = [n]; }
+            }
+            if (run.length) out.push(run);
+            return out;
+        };
+
+        const authHeader = () => {
+            /* Editor page already has a session cookie, but if an admin
+               opens the editor from a native shell the bearer token is
+               in localStorage. Mirror both in case. */
+            const t = localStorage.getItem('ihymns_auth_token');
+            return t ? { 'Authorization': 'Bearer ' + t } : {};
+        };
+
+        modalEl.addEventListener('shown.bs.modal', async () => {
+            const bookId = filterEl.value;
+            scopeEl.textContent = bookId ? `— ${bookId}` : '';
+            resetView();
+            if (!bookId) {
+                errorEl.textContent = 'Select a specific songbook first.';
+                errorEl.classList.remove('d-none');
+                loadingEl.classList.add('d-none');
+                return;
+            }
+            try {
+                const res = await fetch(`/api?action=missing_songs&songbook=${encodeURIComponent(bookId)}`, {
+                    headers: { 'X-Requested-With': 'XMLHttpRequest', ...authHeader() },
+                    credentials: 'same-origin',
+                });
+                const data = await res.json();
+                if (!res.ok) throw new Error(data.error || 'Could not load missing numbers.');
+
+                /* API shape (#285): { missing: int[], maxNumber, totalExisting, songbook } */
+                const missing  = Array.isArray(data.missing)      ? data.missing         : [];
+                const present  = Number.isFinite(data.totalExisting) ? data.totalExisting : 0;
+                const expected = Number.isFinite(data.maxNumber)     ? data.maxNumber     : (present + missing.length);
+
+                presentEl.textContent  = present.toLocaleString();
+                expectedEl.textContent = expected.toLocaleString();
+                countEl.textContent    = missing.length.toLocaleString();
+                summaryEl.classList.remove('d-none');
+
+                if (missing.length === 0) {
+                    emptyEl.classList.remove('d-none');
+                } else {
+                    const runs = groupRuns(missing);
+                    const html = runs.map((run) => {
+                        const label = run.length === 1 ? `#${run[0]}` : `#${run[0]}–${run[run.length - 1]}`;
+                        const count = run.length === 1 ? '1 song' : `${run.length} songs`;
+                        return `
+                            <div class="d-flex align-items-center gap-2 border-bottom py-2 missing-range">
+                                <span class="badge bg-warning text-dark" style="min-width:7rem;">${label}</span>
+                                <span class="text-muted small flex-grow-1">${count} missing</span>
+                                <a class="btn btn-sm btn-outline-primary" target="_blank" rel="noopener"
+                                   href="/request-a-song?songbook=${encodeURIComponent(bookId)}&number=${run[0]}">
+                                    <i class="bi bi-lightbulb me-1" aria-hidden="true"></i>Log request
+                                </a>
+                            </div>`;
+                    }).join('');
+                    listEl.innerHTML = html;
+                    listEl.classList.remove('d-none');
+                }
+            } catch (err) {
+                errorEl.textContent = err.message || 'Could not load missing numbers.';
+                errorEl.classList.remove('d-none');
+            } finally {
+                loadingEl.classList.add('d-none');
+            }
+        });
+    })();
+    </script>
 
     <?php require dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>
 </body>

--- a/appWeb/public_html/manage/includes/admin-nav.php
+++ b/appWeb/public_html/manage/includes/admin-nav.php
@@ -58,6 +58,7 @@ $_adminLinks = [
     ['editor',       '/manage/editor/',         'bi-pencil-square',  'Song Editor',        'edit_songs'],
     ['requests',     '/manage/requests',        'bi-lightbulb',      'Song Requests',      'review_song_requests'],
     ['revisions',    '/manage/revisions',       'bi-clock-history',  'Revisions Audit',    'verify_songs'],
+    ['missing-numbers','/manage/missing-numbers', 'bi-binoculars',    'Missing Numbers',    'edit_songs'],
     ['users',        '/manage/users',           'bi-people',         'Users',              'view_users'],
     ['groups',       '/manage/groups',          'bi-people-fill',    'User Groups',        'manage_user_groups'],
     ['organisations','/manage/organisations',   'bi-building',       'Organisations',      'manage_organisations'],

--- a/appWeb/public_html/manage/missing-numbers.php
+++ b/appWeb/public_html/manage/missing-numbers.php
@@ -1,0 +1,262 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Missing Song Numbers Report (#285)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * Admin page that surfaces gaps in every songbook's numbering. Per
+ * songbook, shows:
+ *   - the highest number present
+ *   - the count of songs present
+ *   - the count of gaps
+ *   - the list of gaps, collapsed into ranges so a long trailing
+ *     gap doesn't flood the page
+ *
+ * Mirrors the in-editor "Find missing numbers" tool (#285 editor
+ * commit) but from a catalogue-wide angle so an admin can audit
+ * every book without clicking through each one in the editor.
+ *
+ * Entitlement: reuses `edit_songs` — the same role that can fix the
+ * gaps can see the report.
+ */
+
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'entitlements.php';
+
+requireAuth();
+$currentUser = getCurrentUser();
+if (!userHasEntitlement('edit_songs', $currentUser['role'] ?? null)) {
+    http_response_code(403);
+    exit('Access denied — missing-numbers report requires the edit_songs entitlement.');
+}
+
+$activePage = 'missing-numbers';
+
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'SongData.php';
+
+/* ========================================================================
+ * Build the report — one row per songbook with its gap list
+ * ======================================================================== */
+try {
+    $songData     = new SongData();
+    $allSongbooks = $songData->getSongbooks();
+    $reports      = [];
+
+    foreach ($allSongbooks as $book) {
+        $id   = (string)($book['id']   ?? '');
+        $name = (string)($book['name'] ?? $id);
+        if ($id === '') continue;
+
+        $result = $songData->getMissingSongNumbers($id);
+        $reports[] = [
+            'id'             => $id,
+            'name'           => $name,
+            'max_number'     => (int)($result['maxNumber']     ?? 0),
+            'total_existing' => (int)($result['totalExisting'] ?? 0),
+            'missing'        => array_map('intval', $result['missing'] ?? []),
+            'missing_count'  => count($result['missing'] ?? []),
+        ];
+    }
+} catch (\Throwable $e) {
+    error_log('[missing-numbers] ' . $e->getMessage());
+    $reports  = [];
+    $loadError = 'Could not load the missing-numbers report — see server logs.';
+}
+
+/* Group consecutive gaps into runs so a big trailing gap renders as
+   "#400–#500 · 101 songs missing" rather than 101 badges. */
+function groupGapRuns(array $nums): array
+{
+    if (empty($nums)) return [];
+    sort($nums);
+    $out = [];
+    $run = [$nums[0]];
+    for ($i = 1; $i < count($nums); $i++) {
+        if ($nums[$i] === end($run) + 1) {
+            $run[] = $nums[$i];
+        } else {
+            $out[] = $run;
+            $run   = [$nums[$i]];
+        }
+    }
+    $out[] = $run;
+    return $out;
+}
+
+$requestedBook = $_GET['songbook'] ?? '';
+$grandMissing  = 0;
+$grandPresent  = 0;
+foreach ($reports as $r) {
+    $grandMissing += $r['missing_count'];
+    $grandPresent += $r['total_existing'];
+}
+
+?>
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Missing Song Numbers — iHymns Admin</title>
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-favicon.php'; ?>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="/css/app.css?v=<?= filemtime(dirname(__DIR__) . '/css/app.css') ?>">
+    <link rel="stylesheet" href="/css/admin.css?v=<?= filemtime(dirname(__DIR__) . '/css/admin.css') ?>">
+</head>
+<body>
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-nav.php'; ?>
+
+    <div class="container-admin py-4">
+        <h1 class="h4 mb-1">
+            <i class="bi bi-binoculars me-2" aria-hidden="true"></i>
+            Missing Song Numbers
+        </h1>
+        <p class="text-secondary small mb-4">
+            Gaps in each songbook's numbering — useful for spotting songs
+            that haven't been added yet, or misnumbered rows. The editor
+            has a per-songbook view on the Song Editor sidebar; this page
+            shows every songbook at a glance.
+        </p>
+
+        <?php if (!empty($loadError)): ?>
+            <div class="alert alert-danger"><?= htmlspecialchars($loadError) ?></div>
+        <?php endif; ?>
+
+        <!-- Summary cards -->
+        <div class="row g-3 mb-4">
+            <div class="col-sm-4">
+                <div class="card-admin">
+                    <div class="text-muted text-uppercase small">Songbooks audited</div>
+                    <div class="h4 mb-0"><?= number_format(count($reports)) ?></div>
+                </div>
+            </div>
+            <div class="col-sm-4">
+                <div class="card-admin">
+                    <div class="text-muted text-uppercase small">Total songs present</div>
+                    <div class="h4 mb-0"><?= number_format($grandPresent) ?></div>
+                </div>
+            </div>
+            <div class="col-sm-4">
+                <div class="card-admin">
+                    <div class="text-muted text-uppercase small">Total gaps</div>
+                    <div class="h4 mb-0 <?= $grandMissing > 0 ? 'text-warning' : 'text-success' ?>">
+                        <?= number_format($grandMissing) ?>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <?php if (empty($reports)): ?>
+            <div class="alert alert-info small mb-0">No songbooks in the catalogue yet.</div>
+        <?php else: ?>
+            <!-- Per-songbook accordion: expanded for the book in ?songbook=,
+                 otherwise the first one with gaps. -->
+            <?php
+            $autoExpand = $requestedBook !== '' ? $requestedBook : '';
+            if ($autoExpand === '') {
+                foreach ($reports as $r) {
+                    if ($r['missing_count'] > 0) { $autoExpand = $r['id']; break; }
+                }
+            }
+            ?>
+            <div class="accordion" id="missing-numbers-acc">
+                <?php foreach ($reports as $r):
+                    $runs    = groupGapRuns($r['missing']);
+                    $accId   = 'acc-' . preg_replace('/[^A-Za-z0-9_-]/', '-', $r['id']);
+                    $expanded = $r['id'] === $autoExpand;
+                ?>
+                    <div class="accordion-item">
+                        <h2 class="accordion-header" id="h-<?= htmlspecialchars($accId) ?>">
+                            <button class="accordion-button<?= $expanded ? '' : ' collapsed' ?>"
+                                    type="button"
+                                    data-bs-toggle="collapse"
+                                    data-bs-target="#b-<?= htmlspecialchars($accId) ?>"
+                                    aria-expanded="<?= $expanded ? 'true' : 'false' ?>"
+                                    aria-controls="b-<?= htmlspecialchars($accId) ?>">
+                                <span class="badge bg-body-secondary me-2" style="min-width: 3.5rem;">
+                                    <?= htmlspecialchars($r['id']) ?>
+                                </span>
+                                <span class="me-auto"><?= htmlspecialchars($r['name']) ?></span>
+                                <span class="small text-muted me-3">
+                                    <?= number_format($r['total_existing']) ?> present ·
+                                    highest #<?= number_format($r['max_number']) ?>
+                                </span>
+                                <span class="badge <?= $r['missing_count'] > 0 ? 'bg-warning text-dark' : 'bg-success' ?>">
+                                    <?= $r['missing_count'] > 0
+                                        ? number_format($r['missing_count']) . ' missing'
+                                        : 'complete' ?>
+                                </span>
+                            </button>
+                        </h2>
+                        <div id="b-<?= htmlspecialchars($accId) ?>"
+                             class="accordion-collapse collapse<?= $expanded ? ' show' : '' ?>"
+                             aria-labelledby="h-<?= htmlspecialchars($accId) ?>"
+                             data-bs-parent="#missing-numbers-acc">
+                            <div class="accordion-body">
+                                <?php if (empty($runs)): ?>
+                                    <div class="alert alert-success small mb-0" role="status">
+                                        <i class="bi bi-check-circle me-1" aria-hidden="true"></i>
+                                        No gaps — every number from 1 to
+                                        <?= (int)$r['max_number'] ?> is present.
+                                    </div>
+                                <?php else: ?>
+                                    <div class="table-responsive">
+                                        <table class="table table-sm align-middle mb-0">
+                                            <thead>
+                                                <tr>
+                                                    <th scope="col">Range</th>
+                                                    <th scope="col" class="text-end">Missing</th>
+                                                    <th scope="col">Action</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <?php foreach ($runs as $run):
+                                                    $first = $run[0];
+                                                    $last  = $run[count($run) - 1];
+                                                    $label = ($first === $last)
+                                                        ? '#' . $first
+                                                        : '#' . $first . '–#' . $last;
+                                                ?>
+                                                    <tr>
+                                                        <td class="fw-semibold"><?= htmlspecialchars($label) ?></td>
+                                                        <td class="text-end">
+                                                            <?= count($run) ?>
+                                                            song<?= count($run) === 1 ? '' : 's' ?>
+                                                        </td>
+                                                        <td>
+                                                            <a class="btn btn-sm btn-outline-primary"
+                                                               href="/request-a-song?songbook=<?= htmlspecialchars(urlencode($r['id'])) ?>&number=<?= (int)$first ?>"
+                                                               target="_blank" rel="noopener">
+                                                                <i class="bi bi-lightbulb me-1" aria-hidden="true"></i>
+                                                                Log request
+                                                            </a>
+                                                            <a class="btn btn-sm btn-outline-secondary"
+                                                               href="/manage/editor/?songbook=<?= htmlspecialchars(urlencode($r['id'])) ?>#number=<?= (int)$first ?>"
+                                                               target="_blank" rel="noopener">
+                                                                <i class="bi bi-pencil-square me-1" aria-hidden="true"></i>
+                                                                Open in editor
+                                                            </a>
+                                                        </td>
+                                                    </tr>
+                                                <?php endforeach; ?>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                <?php endif; ?>
+                            </div>
+                        </div>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+        <?php endif; ?>
+    </div>
+
+    <!-- Bootstrap JS loaded by admin-footer.php -->
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>
+</body>
+</html>


### PR DESCRIPTION
Closes #285.

Two surfaces for the existing `missing_songs` API: an editor-sidebar modal for per-book work, and a catalogue-wide admin page for auditing every songbook at once.

## Summary

### Editor sidebar modal (commit 88c1c7b)
- **"Find missing numbers" button** in the editor sidebar, disabled until a specific songbook is selected.
- **Modal** on click — three summary cards (Present / Expected / Missing), consecutive gaps collapsed into ranges, "Log request" link per range that opens `/request-a-song` pre-filled.

### Catalogue-wide admin page (commit 8a1f8a2)
- **New** `/manage/missing-numbers.php` — three summary cards, accordion per songbook auto-expanding the first book with gaps (or the one in `?songbook=X`).
- Gap runs grouped so a trailing gap of 100 renders as one `#400–#500 · 100 missing` row.
- Per-range actions: "Log request" + "Open in editor".
- **Entitlement** — reuses `edit_songs`; linked from the shared admin nav.

## Test plan
- [ ] Editor sidebar: button disabled on "All Songbooks", enabled on specific book → modal shows gaps.
- [ ] Editor modal "Log request" → `/request-a-song?songbook=X&number=N` opens in new tab.
- [ ] `/manage/missing-numbers` lists every songbook with gap counts.
- [ ] Songbook with no gaps → "complete" green badge, collapsed by default.
- [ ] Songbook with gaps → expanded, table of ranges rendered.
- [ ] Deep link `/manage/missing-numbers?songbook=CP` auto-expands CP.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CjQB5rJGmbPU9KAYiVNfX4)_