### PR TITLE
Editor + admin overhaul: perf, save bugfix, drag-drop arrangement, name-first pickers, songbook metadata, security

### DIFF
--- a/appWeb/.sql/migrate-credit-fields.php
+++ b/appWeb/.sql/migrate-credit-fields.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Credit Fields Migration (#497)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Brings an existing deployment up to the #497 schema:
+ *   1. tblSongs gains two nullable columns:
+ *      - TuneName VARCHAR(120)  (e.g. HYFRYDOL, OLD HUNDREDTH)
+ *      - Iswc     VARCHAR(15)   (International Standard Musical Work Code)
+ *      Plus an idx_TuneName index for the cross-reference listing.
+ *   2. Three new credit tables are created if missing:
+ *      - tblSongArrangers
+ *      - tblSongAdaptors
+ *      - tblSongTranslators
+ *      Each mirrors the tblSongWriters / tblSongComposers shape.
+ *
+ * Idempotent — re-running is safe. Columns/indexes/tables that already
+ * exist are skipped with a "skipped" note.
+ *
+ * USAGE:
+ *   CLI:  php appWeb/.sql/migrate-credit-fields.php
+ *   Web:  /manage/setup-database → "Credit Fields Migration" button
+ *         (entry point requires global_admin)
+ *
+ * @requires PHP 8.1+ with mysqli extension
+ */
+
+$isCli = (php_sapi_name() === 'cli');
+
+if (!$isCli && !defined('IHYMNS_SETUP_DASHBOARD')) {
+    header('Content-Type: text/plain; charset=UTF-8');
+    header('X-Content-Type-Options: nosniff');
+    header('Cache-Control: no-store');
+}
+
+function _migCredits_out(string $msg): void {
+    global $isCli;
+    echo $msg . ($isCli ? "\n" : "<br>\n");
+    if (!$isCli) flush();
+}
+
+/* Load DB credentials — same path as every other migration script. */
+$credPath = dirname(__DIR__) . DIRECTORY_SEPARATOR . '.auth' . DIRECTORY_SEPARATOR . 'db_credentials.php';
+if (!file_exists($credPath)) {
+    _migCredits_out('ERROR: db_credentials.php not found — run install.php first.');
+    exit(1);
+}
+if (!defined('DB_HOST')) {
+    require_once $credPath;
+}
+
+$mysqli = @new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME, defined('DB_PORT') ? (int)DB_PORT : 3306);
+if ($mysqli->connect_errno) {
+    _migCredits_out('ERROR: MySQL connect failed: ' . $mysqli->connect_error);
+    exit(1);
+}
+$mysqli->set_charset('utf8mb4');
+
+_migCredits_out('=== iHymns Credit Fields Migration (#497) ===');
+_migCredits_out('Database: ' . DB_NAME . ' @ ' . DB_HOST);
+_migCredits_out('');
+
+/* Helper: does a column exist on a table? */
+function _migCredits_colExists(mysqli $db, string $table, string $col): bool {
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?
+          LIMIT 1'
+    );
+    $stmt->bind_param('ss', $table, $col);
+    $stmt->execute();
+    $exists = (bool)$stmt->get_result()->fetch_row();
+    $stmt->close();
+    return $exists;
+}
+
+/* Helper: does an index exist on a table? */
+function _migCredits_indexExists(mysqli $db, string $table, string $index): bool {
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.STATISTICS
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND INDEX_NAME = ?
+          LIMIT 1'
+    );
+    $stmt->bind_param('ss', $table, $index);
+    $stmt->execute();
+    $exists = (bool)$stmt->get_result()->fetch_row();
+    $stmt->close();
+    return $exists;
+}
+
+/* Helper: does a table exist? */
+function _migCredits_tableExists(mysqli $db, string $table): bool {
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?
+          LIMIT 1'
+    );
+    $stmt->bind_param('s', $table);
+    $stmt->execute();
+    $exists = (bool)$stmt->get_result()->fetch_row();
+    $stmt->close();
+    return $exists;
+}
+
+/* Sanity: require tblSongs to exist. Without it this migration is
+   premature — the caller needs to run install.php first. */
+if (!_migCredits_tableExists($mysqli, 'tblSongs')) {
+    _migCredits_out('ERROR: tblSongs is missing — run install.php before this migration.');
+    exit(1);
+}
+
+/* ----------------------------------------------------------------------
+ * Step 1: add TuneName to tblSongs
+ * ---------------------------------------------------------------------- */
+if (_migCredits_colExists($mysqli, 'tblSongs', 'TuneName')) {
+    _migCredits_out('[skip] tblSongs.TuneName already present.');
+} else {
+    $sql = "ALTER TABLE tblSongs
+              ADD COLUMN TuneName VARCHAR(120) NULL DEFAULT NULL
+              COMMENT 'Traditional tune name, e.g. HYFRYDOL, OLD HUNDREDTH (#497)'
+              AFTER Copyright";
+    if (!$mysqli->query($sql)) {
+        _migCredits_out('ERROR: adding TuneName failed: ' . $mysqli->error);
+        exit(1);
+    }
+    _migCredits_out('[add ] tblSongs.TuneName.');
+}
+
+if (_migCredits_indexExists($mysqli, 'tblSongs', 'idx_TuneName')) {
+    _migCredits_out('[skip] tblSongs idx_TuneName already present.');
+} else {
+    if (!$mysqli->query('CREATE INDEX idx_TuneName ON tblSongs (TuneName)')) {
+        _migCredits_out('WARN:  creating idx_TuneName failed: ' . $mysqli->error);
+    } else {
+        _migCredits_out('[add ] tblSongs idx_TuneName.');
+    }
+}
+
+/* ----------------------------------------------------------------------
+ * Step 2: add Iswc to tblSongs
+ * ---------------------------------------------------------------------- */
+if (_migCredits_colExists($mysqli, 'tblSongs', 'Iswc')) {
+    _migCredits_out('[skip] tblSongs.Iswc already present.');
+} else {
+    $sql = "ALTER TABLE tblSongs
+              ADD COLUMN Iswc VARCHAR(15) NULL DEFAULT NULL
+              COMMENT 'International Standard Musical Work Code, e.g. T-034.524.680-C (#497)'
+              AFTER Ccli";
+    if (!$mysqli->query($sql)) {
+        _migCredits_out('ERROR: adding Iswc failed: ' . $mysqli->error);
+        exit(1);
+    }
+    _migCredits_out('[add ] tblSongs.Iswc.');
+}
+
+/* ----------------------------------------------------------------------
+ * Step 3: create tblSongArrangers / tblSongAdaptors / tblSongTranslators
+ * ---------------------------------------------------------------------- */
+$creditTables = [
+    'tblSongArrangers'   => 'fk_Arrangers_Song',
+    'tblSongAdaptors'    => 'fk_Adaptors_Song',
+    'tblSongTranslators' => 'fk_Translators_Song',
+];
+
+foreach ($creditTables as $table => $fkName) {
+    if (_migCredits_tableExists($mysqli, $table)) {
+        _migCredits_out("[skip] {$table} already present.");
+        continue;
+    }
+    $sql = "CREATE TABLE {$table} (
+        Id          INT UNSIGNED    AUTO_INCREMENT PRIMARY KEY,
+        SongId      VARCHAR(20)     NOT NULL,
+        Name        VARCHAR(255)    NOT NULL,
+        INDEX idx_SongId    (SongId),
+        INDEX idx_Name      (Name),
+        CONSTRAINT {$fkName}
+            FOREIGN KEY (SongId) REFERENCES tblSongs(SongId)
+            ON DELETE CASCADE ON UPDATE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
+
+    if (!$mysqli->query($sql)) {
+        _migCredits_out("ERROR: creating {$table} failed: " . $mysqli->error);
+        exit(1);
+    }
+    _migCredits_out("[add ] {$table}.");
+}
+
+_migCredits_out('');
+_migCredits_out('Migration complete.');
+$mysqli->close();

--- a/appWeb/.sql/migrate-songbook-meta.php
+++ b/appWeb/.sql/migrate-songbook-meta.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Songbook Metadata Migration (#502)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Brings an existing deployment up to the #502 schema:
+ *   1. Adds five nullable metadata columns to tblSongbooks:
+ *        - IsOfficial      (TINYINT(1) NOT NULL DEFAULT 0)
+ *        - Publisher       (VARCHAR(255))
+ *        - PublicationYear (VARCHAR(50))
+ *        - Copyright       (VARCHAR(500))
+ *        - Affiliation     (VARCHAR(120))
+ *   2. Marks every existing seed songbook whose Abbreviation is NOT
+ *      "Misc" as IsOfficial = 1, matching the real-world state
+ *      (the project shipped with five published hymnals + one
+ *      unstructured Misc collection). Admins can untick any row
+ *      via the edit modal on /manage/songbooks afterwards.
+ *
+ * Idempotent — re-running is safe. Columns that already exist are
+ * skipped with a "skipped" note; the IsOfficial backfill step
+ * `WHERE IsOfficial = 0 AND Abbreviation <> 'Misc'` self-gates so
+ * admins who've deliberately unticked rows don't get overridden.
+ *
+ * USAGE:
+ *   CLI: php appWeb/.sql/migrate-songbook-meta.php
+ *   Web: /manage/setup-database → "Songbook Metadata Migration"
+ *        (entry point requires global_admin)
+ *
+ * @requires PHP 8.1+ with mysqli extension
+ */
+
+$isCli = (php_sapi_name() === 'cli');
+
+if (!$isCli && !defined('IHYMNS_SETUP_DASHBOARD')) {
+    header('Content-Type: text/plain; charset=UTF-8');
+    header('X-Content-Type-Options: nosniff');
+    header('Cache-Control: no-store');
+}
+
+function _migSongbookMeta_out(string $msg): void {
+    global $isCli;
+    echo $msg . ($isCli ? "\n" : "<br>\n");
+    if (!$isCli) flush();
+}
+
+/* Credentials — same path as every other migration script. */
+$credPath = dirname(__DIR__) . DIRECTORY_SEPARATOR . '.auth' . DIRECTORY_SEPARATOR . 'db_credentials.php';
+if (!file_exists($credPath)) {
+    _migSongbookMeta_out('ERROR: db_credentials.php not found — run install.php first.');
+    exit(1);
+}
+if (!defined('DB_HOST')) {
+    require_once $credPath;
+}
+
+$mysqli = @new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME, defined('DB_PORT') ? (int)DB_PORT : 3306);
+if ($mysqli->connect_errno) {
+    _migSongbookMeta_out('ERROR: MySQL connect failed: ' . $mysqli->connect_error);
+    exit(1);
+}
+$mysqli->set_charset('utf8mb4');
+
+_migSongbookMeta_out('=== iHymns Songbook Metadata Migration (#502) ===');
+_migSongbookMeta_out('Database: ' . DB_NAME . ' @ ' . DB_HOST);
+_migSongbookMeta_out('');
+
+function _migSongbookMeta_colExists(mysqli $db, string $table, string $col): bool {
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?
+          LIMIT 1'
+    );
+    $stmt->bind_param('ss', $table, $col);
+    $stmt->execute();
+    $exists = (bool)$stmt->get_result()->fetch_row();
+    $stmt->close();
+    return $exists;
+}
+
+function _migSongbookMeta_tableExists(mysqli $db, string $table): bool {
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?
+          LIMIT 1'
+    );
+    $stmt->bind_param('s', $table);
+    $stmt->execute();
+    $exists = (bool)$stmt->get_result()->fetch_row();
+    $stmt->close();
+    return $exists;
+}
+
+if (!_migSongbookMeta_tableExists($mysqli, 'tblSongbooks')) {
+    _migSongbookMeta_out('ERROR: tblSongbooks is missing — run install.php before this migration.');
+    exit(1);
+}
+
+/* Each step: column name → ALTER statement. Keeping them in a list
+   means adding a new column in the future is a one-line edit. */
+$steps = [
+    ['col' => 'IsOfficial', 'sql' => "ALTER TABLE tblSongbooks
+        ADD COLUMN IsOfficial TINYINT(1) NOT NULL DEFAULT 0
+        COMMENT '1 = published hymnal; 0 = curated grouping / pseudo-songbook (#502)'
+        AFTER Colour"],
+    ['col' => 'Publisher', 'sql' => "ALTER TABLE tblSongbooks
+        ADD COLUMN Publisher VARCHAR(255) NULL DEFAULT NULL
+        COMMENT 'Publisher or originator (e.g. Praise Trust, Hope Publishing) (#502)'
+        AFTER IsOfficial"],
+    ['col' => 'PublicationYear', 'sql' => "ALTER TABLE tblSongbooks
+        ADD COLUMN PublicationYear VARCHAR(50) NULL DEFAULT NULL
+        COMMENT 'Year / edition range — free-form, e.g. 1986, 1986-2003, 2nd edition 2011 (#502)'
+        AFTER Publisher"],
+    ['col' => 'Copyright', 'sql' => "ALTER TABLE tblSongbooks
+        ADD COLUMN Copyright VARCHAR(500) NULL DEFAULT NULL
+        COMMENT 'Copyright notice for the collection as a whole (#502)'
+        AFTER PublicationYear"],
+    ['col' => 'Affiliation', 'sql' => "ALTER TABLE tblSongbooks
+        ADD COLUMN Affiliation VARCHAR(120) NULL DEFAULT NULL
+        COMMENT 'Denominational / religious affiliation; free-text for now, lookup table later (#502)'
+        AFTER Copyright"],
+];
+
+foreach ($steps as $s) {
+    if (_migSongbookMeta_colExists($mysqli, 'tblSongbooks', $s['col'])) {
+        _migSongbookMeta_out("[skip] tblSongbooks.{$s['col']} already present.");
+        continue;
+    }
+    if (!$mysqli->query($s['sql'])) {
+        _migSongbookMeta_out("ERROR: adding {$s['col']} failed: " . $mysqli->error);
+        exit(1);
+    }
+    _migSongbookMeta_out("[add ] tblSongbooks.{$s['col']}.");
+}
+
+/* Backfill step: mark every existing non-Misc songbook as official.
+   Guarded by IsOfficial = 0 so admins who deliberately unticked a
+   row later won't have their edit reverted by a re-run. */
+$res = $mysqli->query(
+    "UPDATE tblSongbooks
+        SET IsOfficial = 1
+      WHERE IsOfficial = 0 AND Abbreviation <> 'Misc'"
+);
+if ($res) {
+    _migSongbookMeta_out('[mark] ' . $mysqli->affected_rows
+        . ' existing songbook(s) flagged as IsOfficial (non-Misc rows only).');
+} else {
+    _migSongbookMeta_out('WARN: backfill IsOfficial failed: ' . $mysqli->error);
+}
+
+_migSongbookMeta_out('');
+_migSongbookMeta_out('Migration complete.');
+$mysqli->close();

--- a/appWeb/.sql/schema.sql
+++ b/appWeb/.sql/schema.sql
@@ -36,6 +36,11 @@ CREATE TABLE IF NOT EXISTS tblSongbooks (
     SongCount       INT UNSIGNED    NOT NULL DEFAULT 0,
     DisplayOrder    INT UNSIGNED    NOT NULL DEFAULT 0 COMMENT 'Explicit sort order for listings / filter dropdowns',
     Colour          VARCHAR(7)      NOT NULL DEFAULT '' COMMENT 'Badge colour hex #RRGGBB (empty = theme default)',
+    IsOfficial      TINYINT(1)      NOT NULL DEFAULT 0 COMMENT '1 = published hymnal; 0 = curated grouping / pseudo-songbook (#502)',
+    Publisher       VARCHAR(255)    NULL DEFAULT NULL COMMENT 'Publisher or originator (e.g. Praise Trust, Hope Publishing) (#502)',
+    PublicationYear VARCHAR(50)     NULL DEFAULT NULL COMMENT 'Year / edition range (free-form: 1986, 1986-2003, 2nd edition 2011) (#502)',
+    Copyright       VARCHAR(500)    NULL DEFAULT NULL COMMENT 'Copyright notice for the collection as a whole (#502)',
+    Affiliation     VARCHAR(120)    NULL DEFAULT NULL COMMENT 'Denominational / religious affiliation; free-text for now, lookup table later (#502)',
     CreatedAt       TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UpdatedAt       TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 

--- a/appWeb/.sql/schema.sql
+++ b/appWeb/.sql/schema.sql
@@ -59,7 +59,9 @@ CREATE TABLE IF NOT EXISTS tblSongs (
     SongbookName        VARCHAR(255)    NOT NULL COMMENT 'Denormalised songbook name for convenience',
     Language            VARCHAR(10)     NOT NULL DEFAULT 'en',
     Copyright           VARCHAR(500)    NOT NULL DEFAULT '',
-    Ccli                VARCHAR(50)     NOT NULL DEFAULT '',
+    TuneName            VARCHAR(120)    NULL DEFAULT NULL COMMENT 'Traditional tune name, e.g. HYFRYDOL, OLD HUNDREDTH (#497)',
+    Ccli                VARCHAR(50)     NOT NULL DEFAULT '' COMMENT 'CCLI Song Number',
+    Iswc                VARCHAR(15)     NULL DEFAULT NULL COMMENT 'International Standard Musical Work Code, e.g. T-034.524.680-C (#497)',
     Verified            TINYINT(1)      NOT NULL DEFAULT 0,
     LyricsPublicDomain  TINYINT(1)      NOT NULL DEFAULT 0,
     MusicPublicDomain   TINYINT(1)      NOT NULL DEFAULT 0,
@@ -71,6 +73,7 @@ CREATE TABLE IF NOT EXISTS tblSongs (
 
     INDEX idx_Songbook          (SongbookAbbr),
     INDEX idx_SongbookNumber    (SongbookAbbr, Number),
+    INDEX idx_TuneName          (TuneName),
     FULLTEXT idx_TitleFt        (Title),
     FULLTEXT idx_LyricsFt       (LyricsText),
     FULLTEXT idx_TitleLyricsFt  (Title, LyricsText),
@@ -112,6 +115,63 @@ CREATE TABLE IF NOT EXISTS tblSongComposers (
     INDEX idx_Name      (Name),
 
     CONSTRAINT fk_Composers_Song
+        FOREIGN KEY (SongId) REFERENCES tblSongs(SongId)
+        ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+-- ----------------------------------------------------------------------------
+-- tblSongArrangers (#497)
+-- Many-to-one: a song can have multiple arrangers.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS tblSongArrangers (
+    Id          INT UNSIGNED    AUTO_INCREMENT PRIMARY KEY,
+    SongId      VARCHAR(20)     NOT NULL,
+    Name        VARCHAR(255)    NOT NULL,
+
+    INDEX idx_SongId    (SongId),
+    INDEX idx_Name      (Name),
+
+    CONSTRAINT fk_Arrangers_Song
+        FOREIGN KEY (SongId) REFERENCES tblSongs(SongId)
+        ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+-- ----------------------------------------------------------------------------
+-- tblSongAdaptors (#497)
+-- Many-to-one: a song can have multiple adaptors.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS tblSongAdaptors (
+    Id          INT UNSIGNED    AUTO_INCREMENT PRIMARY KEY,
+    SongId      VARCHAR(20)     NOT NULL,
+    Name        VARCHAR(255)    NOT NULL,
+
+    INDEX idx_SongId    (SongId),
+    INDEX idx_Name      (Name),
+
+    CONSTRAINT fk_Adaptors_Song
+        FOREIGN KEY (SongId) REFERENCES tblSongs(SongId)
+        ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+-- ----------------------------------------------------------------------------
+-- tblSongTranslators (#497)
+-- Many-to-one: a song can have multiple translators. Distinct from the
+-- tblSongTranslations link table (#352) which joins a source song to its
+-- equivalent in another language — the Translators table credits the
+-- people who produced those translations for *this* song.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS tblSongTranslators (
+    Id          INT UNSIGNED    AUTO_INCREMENT PRIMARY KEY,
+    SongId      VARCHAR(20)     NOT NULL,
+    Name        VARCHAR(255)    NOT NULL,
+
+    INDEX idx_SongId    (SongId),
+    INDEX idx_Name      (Name),
+
+    CONSTRAINT fk_Translators_Song
         FOREIGN KEY (SongId) REFERENCES tblSongs(SongId)
         ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/appWeb/public_html/css/admin.css
+++ b/appWeb/public_html/css/admin.css
@@ -132,6 +132,16 @@ body:has(.navbar-admin) {
     display: flex;
     align-items: stretch;
     gap: 0;
+    /* Peg the layout column to fill the viewport between the fixed
+       header and fixed footer, so both the sidebar and the main
+       pane can stretch to a visible edge on short pages instead of
+       leaving body-background whitespace below them (#499). Tall
+       pages scroll naturally because .admin-main's content grows
+       the layout. */
+    min-height: calc(100vh
+                     - var(--admin-navbar-height)
+                     - var(--footer-info-height)
+                     - 1rem);
 }
 
 .admin-sidebar {
@@ -146,11 +156,16 @@ body:has(.navbar-admin) {
        .navbar-admin (see body:has(.navbar-admin) above). */
     position: sticky;
     top: calc(var(--admin-navbar-height) + 0.5rem);
-    align-self: flex-start;
+    /* Before #499 the sidebar aligned flex-start with a max-height,
+       which left visible body background below it on tall viewports.
+       Drop align-self so the flex parent stretches us to the layout
+       column height (.admin-layout min-height above), giving a
+       WordPress-style full-height side column. max-height becomes
+       the scroll cap for long link lists. */
     max-height: calc(100vh
                      - var(--admin-navbar-height)
                      - var(--footer-info-height)
-                     - 1.5rem);
+                     - 1rem);
     overflow-y: auto;
 }
 

--- a/appWeb/public_html/css/admin.css
+++ b/appWeb/public_html/css/admin.css
@@ -633,6 +633,30 @@ body:has(.navbar-admin) {
 .status-indicator.unsaved { background-color: var(--accent-solid); }
 
 /* ==========================================================================
+   ARRANGEMENT BUILDER (#492) — pool + strip drag-and-drop chips
+   ========================================================================== */
+
+.arr-chip {
+    transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+.arr-chip:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+}
+#arrangement-strip .arr-chip {
+    cursor: grab;
+}
+#arrangement-strip .arr-chip:active {
+    cursor: grabbing;
+}
+/* SortableJS drop placeholder */
+.arr-chip-ghost {
+    opacity: 0.35;
+    outline: 2px dashed var(--accent-solid);
+    outline-offset: 2px;
+}
+
+/* ==========================================================================
    DYNAMIC LIST INPUTS — credits rows (writer/composer)
    ========================================================================== */
 

--- a/appWeb/public_html/css/admin.css
+++ b/appWeb/public_html/css/admin.css
@@ -409,8 +409,16 @@ body:has(.navbar-admin) {
 
 .editor-wrapper {
     display: flex;
-    /* 56px navbar + 36px status bar = 92px */
-    height: calc(100vh - 56px - 36px);
+    /* Navbar (56 px) + internal status bar (36 px) + shared admin
+       footer (var(--footer-info-height), 28 px normally / 40 px
+       on narrow viewports) are all fixed-position siblings. This
+       wrapper owns the scroll region between them, so its height
+       must subtract all three or the bottom row of any tab paints
+       behind the pinned footer (#487). */
+    height: calc(100vh
+                 - var(--admin-navbar-height)
+                 - var(--footer-info-height)
+                 - 36px);
     overflow: hidden;
 }
 
@@ -733,7 +741,12 @@ body:has(.navbar-admin) {
 @media (max-width: 768px) {
     .editor-wrapper {
         flex-direction: column;
-        height: calc(100vh - 56px - 36px);
+        /* Match the desktop height formula so the stacked layout
+           still clears the shared admin footer (#487). */
+        height: calc(100vh
+                     - var(--admin-navbar-height)
+                     - var(--footer-info-height)
+                     - 36px);
     }
     .editor-sidebar {
         width: 100%;

--- a/appWeb/public_html/includes/SongData.php
+++ b/appWeb/public_html/includes/SongData.php
@@ -387,6 +387,12 @@ class SongData
             $adaptorsMap    = $this->_getAdaptorsMap($songIds);
             $translatorsMap = $this->_getTranslatorsMap($songIds);
             $componentsMap  = $this->_getComponentsMap($songIds);
+            /* Tags included in the bulk load (#496 follow-up) so the
+               Song Editor's full-catalogue load + any client that
+               calls getSongs() has tag assignments available without
+               a second per-song round-trip. Same bulk-loader pattern
+               as writers / composers / etc. */
+            $tagsMap = $this->_getTagsMap($songIds);
             foreach ($songs as &$song) {
                 $sid = $song['id'];
                 $song['writers']     = $writersMap[$sid]     ?? [];
@@ -395,6 +401,7 @@ class SongData
                 $song['adaptors']    = $adaptorsMap[$sid]    ?? [];
                 $song['translators'] = $translatorsMap[$sid] ?? [];
                 $song['components']  = $componentsMap[$sid]  ?? [];
+                $song['tags']        = $tagsMap[$sid]        ?? [];
             }
             unset($song);
         }
@@ -969,6 +976,11 @@ class SongData
         $row['adaptors']     = $this->_getAdaptors($songId);
         $row['translators']  = $this->_getTranslators($songId);
         $row['components']   = $this->_getComponents($songId);
+        /* Tags attached here too so the single-song read path matches
+           the bulk getSongs() shape (#496 follow-up). Uses the same
+           SongId-keyed helper — collapsed to the one-song slice. */
+        $tagsMap = $this->_getTagsMap([$songId]);
+        $row['tags'] = $tagsMap[$songId] ?? [];
         $translations = $this->_getTranslations($songId);
         if (!empty($translations)) {
             $row['translations'] = $translations;
@@ -1279,6 +1291,42 @@ class SongData
         $map = [];
         while ($row = $result->fetch_assoc()) {
             $map[$row['SongId']][] = $row['Name'];
+        }
+        $stmt->close();
+        return $map;
+    }
+
+    /**
+     * Bulk-load tag assignments keyed by SongId (#496 follow-up).
+     * Joins tblSongTagMap → tblSongTags so the returned rows carry
+     * both the tag name and slug — callers that render chips can use
+     * the name, callers that build /tag/<slug> links can use the slug.
+     *
+     * @param string[] $songIds
+     * @return array<string,array<int,array{id:int,name:string,slug:string}>>
+     */
+    private function _getTagsMap(array $songIds): array
+    {
+        if (empty($songIds)) return [];
+        $placeholders = implode(',', array_fill(0, count($songIds), '?'));
+        $types = str_repeat('s', count($songIds));
+        $stmt = $this->db->prepare(
+            "SELECT m.SongId, t.Id AS id, t.Name AS name, t.Slug AS slug
+             FROM tblSongTagMap m
+             JOIN tblSongTags t ON t.Id = m.TagId
+             WHERE m.SongId IN ($placeholders)
+             ORDER BY m.SongId, t.Name ASC"
+        );
+        $stmt->bind_param($types, ...$songIds);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        $map = [];
+        while ($row = $result->fetch_assoc()) {
+            $map[$row['SongId']][] = [
+                'id'   => (int)$row['id'],
+                'name' => $row['name'],
+                'slug' => $row['slug'],
+            ];
         }
         $stmt->close();
         return $map;

--- a/appWeb/public_html/includes/SongData.php
+++ b/appWeb/public_html/includes/SongData.php
@@ -244,7 +244,13 @@ class SongData
         }
 
         $stmt = $this->db->prepare(
-            "SELECT Abbreviation AS id, Name AS name, SongCount AS songCount
+            "SELECT Abbreviation AS id, Name AS name, SongCount AS songCount,
+                    Colour AS colour,
+                    IsOfficial      AS isOfficial,
+                    Publisher       AS publisher,
+                    PublicationYear AS publicationYear,
+                    Copyright       AS copyright,
+                    Affiliation     AS affiliation
              FROM tblSongbooks
              ORDER BY Name ASC"
         );
@@ -252,7 +258,10 @@ class SongData
         $result = $stmt->get_result();
         $books = [];
         while ($row = $result->fetch_assoc()) {
-            $row['songCount'] = (int)$row['songCount'];
+            $row['songCount']  = (int)$row['songCount'];
+            /* Cast to a strict bool so JSON consumers don't have to
+               deal with 0/1 vs true/false ambiguity (#502). */
+            $row['isOfficial'] = (bool)$row['isOfficial'];
             $books[] = $row;
         }
         $stmt->close();
@@ -275,7 +284,13 @@ class SongData
             return null;
         }
         $stmt = $this->db->prepare(
-            "SELECT Abbreviation AS id, Name AS name, SongCount AS songCount
+            "SELECT Abbreviation AS id, Name AS name, SongCount AS songCount,
+                    Colour AS colour,
+                    IsOfficial      AS isOfficial,
+                    Publisher       AS publisher,
+                    PublicationYear AS publicationYear,
+                    Copyright       AS copyright,
+                    Affiliation     AS affiliation
              FROM tblSongbooks
              WHERE Abbreviation = ?"
         );
@@ -288,7 +303,8 @@ class SongData
         if ($row === null) {
             return null;
         }
-        $row['songCount'] = (int)$row['songCount'];
+        $row['songCount']  = (int)$row['songCount'];
+        $row['isOfficial'] = (bool)$row['isOfficial'];
         return $row;
     }
 

--- a/appWeb/public_html/includes/SongData.php
+++ b/appWeb/public_html/includes/SongData.php
@@ -361,13 +361,27 @@ class SongData
         }
         $stmt->close();
 
-        /* Attach writers, composers, and components for each song */
-        foreach ($songs as &$song) {
-            $song['writers']    = $this->_getWriters($song['id']);
-            $song['composers'] = $this->_getComposers($song['id']);
-            $song['components'] = $this->_getComponents($song['id']);
+        /* Bulk-load writers, composers and components for every song in
+           one query per table instead of three per song (#EditorLoad).
+           For the full catalogue (≈3,600 songs) this cuts 10,800
+           round-trips down to 3 and is the single biggest win for
+           `exportAsJson()` (Song Editor load) and any page that calls
+           `getSongs()` without a songbook filter. The per-song private
+           helpers are still used by `_fetchSongRow()` for single-song
+           fetches where one-round-trip beats three table scans. */
+        $songIds = array_column($songs, 'id');
+        if (!empty($songIds)) {
+            $writersMap    = $this->_getWritersMap($songIds);
+            $composersMap  = $this->_getComposersMap($songIds);
+            $componentsMap = $this->_getComponentsMap($songIds);
+            foreach ($songs as &$song) {
+                $sid = $song['id'];
+                $song['writers']    = $writersMap[$sid]    ?? [];
+                $song['composers']  = $composersMap[$sid]  ?? [];
+                $song['components'] = $componentsMap[$sid] ?? [];
+            }
+            unset($song);
         }
-        unset($song);
 
         return $songs;
     }
@@ -1012,6 +1026,97 @@ class SongData
         }
         $stmt->close();
         return $components;
+    }
+
+    /**
+     * Bulk-load writers for every song in $songIds and return them as a
+     * map keyed by SongId. One query instead of N. Preserves per-song
+     * ordering by the `Id` surrogate so the listing order matches what
+     * `_getWriters()` would have returned. Used by `getSongs()`.
+     *
+     * @param string[] $songIds List of song IDs to fetch writers for
+     * @return array<string,string[]> SongId → array of writer names
+     */
+    private function _getWritersMap(array $songIds): array
+    {
+        if (empty($songIds)) return [];
+        $placeholders = implode(',', array_fill(0, count($songIds), '?'));
+        $types = str_repeat('s', count($songIds));
+        $stmt = $this->db->prepare(
+            "SELECT SongId, Name FROM tblSongWriters
+             WHERE SongId IN ($placeholders)
+             ORDER BY SongId, Id"
+        );
+        $stmt->bind_param($types, ...$songIds);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        $map = [];
+        while ($row = $result->fetch_assoc()) {
+            $map[$row['SongId']][] = $row['Name'];
+        }
+        $stmt->close();
+        return $map;
+    }
+
+    /**
+     * Bulk-load composers keyed by SongId. See `_getWritersMap()`.
+     *
+     * @param string[] $songIds
+     * @return array<string,string[]>
+     */
+    private function _getComposersMap(array $songIds): array
+    {
+        if (empty($songIds)) return [];
+        $placeholders = implode(',', array_fill(0, count($songIds), '?'));
+        $types = str_repeat('s', count($songIds));
+        $stmt = $this->db->prepare(
+            "SELECT SongId, Name FROM tblSongComposers
+             WHERE SongId IN ($placeholders)
+             ORDER BY SongId, Id"
+        );
+        $stmt->bind_param($types, ...$songIds);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        $map = [];
+        while ($row = $result->fetch_assoc()) {
+            $map[$row['SongId']][] = $row['Name'];
+        }
+        $stmt->close();
+        return $map;
+    }
+
+    /**
+     * Bulk-load components (verses, choruses) keyed by SongId. Same
+     * structure as `_getComponents()` but amortised across every
+     * requested song in a single query.
+     *
+     * @param string[] $songIds
+     * @return array<string,array<int,array{type:string,number:int,lines:array}>>
+     */
+    private function _getComponentsMap(array $songIds): array
+    {
+        if (empty($songIds)) return [];
+        $placeholders = implode(',', array_fill(0, count($songIds), '?'));
+        $types = str_repeat('s', count($songIds));
+        $stmt = $this->db->prepare(
+            "SELECT SongId, Type AS type, Number AS number, LinesJson AS lines_json
+             FROM tblSongComponents
+             WHERE SongId IN ($placeholders)
+             ORDER BY SongId, SortOrder"
+        );
+        $stmt->bind_param($types, ...$songIds);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        $map = [];
+        while ($row = $result->fetch_assoc()) {
+            $map[$row['SongId']][] = [
+                'type'   => $row['type'],
+                'number' => (int)$row['number'],
+                'lines'  => json_decode($row['lines_json'], true) ?? [],
+            ];
+        }
+        $stmt->close();
+        return $map;
     }
 
     /**

--- a/appWeb/public_html/includes/SongData.php
+++ b/appWeb/public_html/includes/SongData.php
@@ -334,7 +334,8 @@ class SongData
         $whereClause = !empty($where) ? 'WHERE ' . implode(' AND ', $where) : '';
 
         $sql = "SELECT s.SongId AS id, s.Number AS number, s.Title AS title, s.SongbookAbbr AS songbook,
-                       s.SongbookName AS songbookName, s.Language AS language, s.Copyright AS copyright, s.Ccli AS ccli,
+                       s.SongbookName AS songbookName, s.Language AS language, s.Copyright AS copyright,
+                       s.TuneName AS tuneName, s.Ccli AS ccli, s.Iswc AS iswc,
                        s.Verified AS verified, s.LyricsPublicDomain AS lyricsPublicDomain,
                        s.MusicPublicDomain AS musicPublicDomain,
                        s.HasAudio AS hasAudio, s.HasSheetMusic AS hasSheetMusic
@@ -357,28 +358,43 @@ class SongData
             $row['musicPublicDomain'] = (bool)$row['musicPublicDomain'];
             $row['hasAudio'] = (bool)$row['hasAudio'];
             $row['hasSheetMusic'] = (bool)$row['hasSheetMusic'];
+            /* tuneName / iswc are nullable; normalise to empty string
+               in the public JSON so the editor can treat them as plain
+               text inputs without null-checking every reader. */
+            $row['tuneName'] = $row['tuneName'] ?? '';
+            $row['iswc']     = $row['iswc']     ?? '';
             $songs[] = $row;
         }
         $stmt->close();
 
-        /* Bulk-load writers, composers and components for every song in
-           one query per table instead of three per song (#EditorLoad).
-           For the full catalogue (≈3,600 songs) this cuts 10,800
-           round-trips down to 3 and is the single biggest win for
-           `exportAsJson()` (Song Editor load) and any page that calls
-           `getSongs()` without a songbook filter. The per-song private
-           helpers are still used by `_fetchSongRow()` for single-song
-           fetches where one-round-trip beats three table scans. */
+        /* Bulk-load every many-to-one collection in one query per table
+           instead of N per song (#EditorLoad). For the full catalogue
+           (≈3,600 songs) this cuts thousands of round-trips down to six
+           and is the single biggest win for `exportAsJson()` (Song
+           Editor load) and any page that calls `getSongs()` without a
+           songbook filter. The per-song private helpers are still used
+           by `_fetchSongRow()` for single-song fetches where one
+           round-trip beats three table scans.
+
+           Credit collections attached here: writers, composers,
+           arrangers (#497), adaptors (#497), translators (#497),
+           components. */
         $songIds = array_column($songs, 'id');
         if (!empty($songIds)) {
-            $writersMap    = $this->_getWritersMap($songIds);
-            $composersMap  = $this->_getComposersMap($songIds);
-            $componentsMap = $this->_getComponentsMap($songIds);
+            $writersMap     = $this->_getWritersMap($songIds);
+            $composersMap   = $this->_getComposersMap($songIds);
+            $arrangersMap   = $this->_getArrangersMap($songIds);
+            $adaptorsMap    = $this->_getAdaptorsMap($songIds);
+            $translatorsMap = $this->_getTranslatorsMap($songIds);
+            $componentsMap  = $this->_getComponentsMap($songIds);
             foreach ($songs as &$song) {
                 $sid = $song['id'];
-                $song['writers']    = $writersMap[$sid]    ?? [];
-                $song['composers']  = $composersMap[$sid]  ?? [];
-                $song['components'] = $componentsMap[$sid] ?? [];
+                $song['writers']     = $writersMap[$sid]     ?? [];
+                $song['composers']   = $composersMap[$sid]   ?? [];
+                $song['arrangers']   = $arrangersMap[$sid]   ?? [];
+                $song['adaptors']    = $adaptorsMap[$sid]    ?? [];
+                $song['translators'] = $translatorsMap[$sid] ?? [];
+                $song['components']  = $componentsMap[$sid]  ?? [];
             }
             unset($song);
         }
@@ -920,7 +936,8 @@ class SongData
     {
         $stmt = $this->db->prepare(
             "SELECT SongId AS id, Number AS number, Title AS title, SongbookAbbr AS songbook,
-                    SongbookName AS songbookName, Language AS language, Copyright AS copyright, Ccli AS ccli,
+                    SongbookName AS songbookName, Language AS language, Copyright AS copyright,
+                    TuneName AS tuneName, Ccli AS ccli, Iswc AS iswc,
                     Verified AS verified, LyricsPublicDomain AS lyricsPublicDomain,
                     MusicPublicDomain AS musicPublicDomain,
                     HasAudio AS hasAudio, HasSheetMusic AS hasSheetMusic
@@ -944,9 +961,14 @@ class SongData
         $row['musicPublicDomain'] = (bool)$row['musicPublicDomain'];
         $row['hasAudio'] = (bool)$row['hasAudio'];
         $row['hasSheetMusic'] = (bool)$row['hasSheetMusic'];
+        $row['tuneName'] = $row['tuneName'] ?? '';
+        $row['iswc']     = $row['iswc']     ?? '';
         $row['writers']      = $this->_getWriters($songId);
-        $row['composers']   = $this->_getComposers($songId);
-        $row['components']  = $this->_getComponents($songId);
+        $row['composers']    = $this->_getComposers($songId);
+        $row['arrangers']    = $this->_getArrangers($songId);
+        $row['adaptors']     = $this->_getAdaptors($songId);
+        $row['translators']  = $this->_getTranslators($songId);
+        $row['components']   = $this->_getComponents($songId);
         $translations = $this->_getTranslations($songId);
         if (!empty($translations)) {
             $row['translations'] = $translations;
@@ -1114,6 +1136,149 @@ class SongData
                 'number' => (int)$row['number'],
                 'lines'  => json_decode($row['lines_json'], true) ?? [],
             ];
+        }
+        $stmt->close();
+        return $map;
+    }
+
+    /* --------------------------------------------------------------
+     * Arrangers / Adaptors / Translators (#497)
+     *
+     * Three sibling credit collections to writers/composers, each
+     * backed by a dedicated many-to-one table (tblSongArrangers,
+     * tblSongAdaptors, tblSongTranslators). Same idioms as the
+     * writers/composers helpers above: a per-song variant for single
+     * song lookups (`_fetchSongRow`) and a bulk `*Map` variant for
+     * `getSongs()` full-catalogue loads.
+     *
+     * Note the naming gotcha: `_getTranslators` credits the *people*
+     * who produced translations for this specific song, while
+     * `_getTranslations` (below) lists the cross-song link records in
+     * tblSongTranslations (#352) that map this song to its equivalent
+     * in another language. Different tables, different concepts.
+     * -------------------------------------------------------------- */
+
+    /** @return string[] */
+    private function _getArrangers(string $songId): array
+    {
+        $stmt = $this->db->prepare(
+            "SELECT Name FROM tblSongArrangers WHERE SongId = ? ORDER BY Id"
+        );
+        $stmt->bind_param('s', $songId);
+        $stmt->execute();
+        $res = $stmt->get_result();
+        $out = [];
+        while ($row = $res->fetch_assoc()) { $out[] = $row['Name']; }
+        $stmt->close();
+        return $out;
+    }
+
+    /** @return string[] */
+    private function _getAdaptors(string $songId): array
+    {
+        $stmt = $this->db->prepare(
+            "SELECT Name FROM tblSongAdaptors WHERE SongId = ? ORDER BY Id"
+        );
+        $stmt->bind_param('s', $songId);
+        $stmt->execute();
+        $res = $stmt->get_result();
+        $out = [];
+        while ($row = $res->fetch_assoc()) { $out[] = $row['Name']; }
+        $stmt->close();
+        return $out;
+    }
+
+    /** @return string[] */
+    private function _getTranslators(string $songId): array
+    {
+        $stmt = $this->db->prepare(
+            "SELECT Name FROM tblSongTranslators WHERE SongId = ? ORDER BY Id"
+        );
+        $stmt->bind_param('s', $songId);
+        $stmt->execute();
+        $res = $stmt->get_result();
+        $out = [];
+        while ($row = $res->fetch_assoc()) { $out[] = $row['Name']; }
+        $stmt->close();
+        return $out;
+    }
+
+    /**
+     * Bulk-load arrangers keyed by SongId. See `_getWritersMap()`.
+     *
+     * @param string[] $songIds
+     * @return array<string,string[]>
+     */
+    private function _getArrangersMap(array $songIds): array
+    {
+        if (empty($songIds)) return [];
+        $placeholders = implode(',', array_fill(0, count($songIds), '?'));
+        $types = str_repeat('s', count($songIds));
+        $stmt = $this->db->prepare(
+            "SELECT SongId, Name FROM tblSongArrangers
+             WHERE SongId IN ($placeholders)
+             ORDER BY SongId, Id"
+        );
+        $stmt->bind_param($types, ...$songIds);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        $map = [];
+        while ($row = $result->fetch_assoc()) {
+            $map[$row['SongId']][] = $row['Name'];
+        }
+        $stmt->close();
+        return $map;
+    }
+
+    /**
+     * Bulk-load adaptors keyed by SongId. See `_getWritersMap()`.
+     *
+     * @param string[] $songIds
+     * @return array<string,string[]>
+     */
+    private function _getAdaptorsMap(array $songIds): array
+    {
+        if (empty($songIds)) return [];
+        $placeholders = implode(',', array_fill(0, count($songIds), '?'));
+        $types = str_repeat('s', count($songIds));
+        $stmt = $this->db->prepare(
+            "SELECT SongId, Name FROM tblSongAdaptors
+             WHERE SongId IN ($placeholders)
+             ORDER BY SongId, Id"
+        );
+        $stmt->bind_param($types, ...$songIds);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        $map = [];
+        while ($row = $result->fetch_assoc()) {
+            $map[$row['SongId']][] = $row['Name'];
+        }
+        $stmt->close();
+        return $map;
+    }
+
+    /**
+     * Bulk-load translators keyed by SongId. See `_getWritersMap()`.
+     *
+     * @param string[] $songIds
+     * @return array<string,string[]>
+     */
+    private function _getTranslatorsMap(array $songIds): array
+    {
+        if (empty($songIds)) return [];
+        $placeholders = implode(',', array_fill(0, count($songIds), '?'));
+        $types = str_repeat('s', count($songIds));
+        $stmt = $this->db->prepare(
+            "SELECT SongId, Name FROM tblSongTranslators
+             WHERE SongId IN ($placeholders)
+             ORDER BY SongId, Id"
+        );
+        $stmt->bind_param($types, ...$songIds);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        $map = [];
+        while ($row = $result->fetch_assoc()) {
+            $map[$row['SongId']][] = $row['Name'];
         }
         $stmt->close();
         return $map;

--- a/appWeb/public_html/includes/pages/home.php
+++ b/appWeb/public_html/includes/pages/home.php
@@ -191,95 +191,14 @@ $songbooks = $songData->getSongbooks();
         </div>
     </section>
 
-    <!-- Inline JS for dynamic home page sections (#303, #304, #305) -->
-    <script>
-    (function() {
-        var esc = function(s) { return (s||'').replace(/[&<>"']/g, function(c){return{'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]}); };
-        var SONGBOOK_NAMES = {CP:'Carol Praise',JP:'Junior Praise',MP:'Mission Praise',SDAH:'Seventh-day Adventist Hymnal',CH:'The Church Hymnal',Misc:'Miscellaneous'};
-        /* Minimal title-case for this inline script — mirrors utils/text.js toTitleCase. */
-        var MINOR = {a:1,an:1,and:1,as:1,at:1,but:1,by:1,for:1,in:1,nor:1,of:1,on:1,or:1,so:1,the:1,to:1,up:1,yet:1};
-        var titleCase = function(s) {
-            if (!s) return s || '';
-            var w = String(s).toLowerCase().split(/\s+/), last = w.length - 1;
-            return w.map(function(word, i) {
-                var prev = i > 0 ? w[i - 1] : '';
-                var newClause = i > 0 && /[.!?:\u2014\u2013]$/.test(prev);
-                var bare = word.replace(/[^\p{L}\p{N}']/gu, '');
-                if (i === 0 || i === last || newClause || !MINOR[bare]) {
-                    word = word.replace(/^([^\p{L}]*)(\p{L})/u, function(_, p, c){ return p + c.toUpperCase(); });
-                }
-                return word.replace(/-\w/g, function(m){ return m.toUpperCase(); });
-            }).join(' ');
-        };
-
-        // #303 — Popular Songs (server or client-side fallback)
-        fetch('/api?action=popular_songs&period=month&limit=10')
-            .then(function(r){return r.json()})
-            .then(function(data) {
-                var el = document.getElementById('popular-songs-list');
-                if (!el) return;
-
-                var songs = data.songs || [];
-
-                /* If server returned empty (JSON fallback mode), build from localStorage history */
-                if (!songs.length) {
-                    try {
-                        var hist = JSON.parse(localStorage.getItem('ihymns_history') || '[]');
-                        /* Count song occurrences to estimate popularity */
-                        var counts = {};
-                        hist.forEach(function(h) {
-                            if (!counts[h.id]) counts[h.id] = { songId: h.id, title: h.title, songbook: h.songbook, number: h.number, views: 0 };
-                            counts[h.id].views++;
-                        });
-                        songs = Object.values(counts).sort(function(a,b){return b.views-a.views}).slice(0, 10);
-                    } catch(e) { songs = []; }
-                }
-
-                if (!songs.length) { el.closest('#popular-songs-section')?.remove(); return; }
-
-                el.innerHTML = songs.map(function(s) {
-                    var id = s.songId || s.id || '';
-                    var title = titleCase(s.title || id);
-                    var book = s.songbook || id.split('-')[0] || '';
-                    var bookName = SONGBOOK_NAMES[book] || book;
-                    return '<a href="/song/' + esc(id) + '" data-navigate="song" data-song-id="' + esc(id) + '" class="list-group-item list-group-item-action song-list-item">' +
-                        '<span class="song-number-badge" data-songbook="' + esc(book) + '">' + (s.number ?? '') + '</span>' +
-                        '<div class="song-info flex-grow-1">' +
-                            '<span class="song-title">' + esc(title) + '</span>' +
-                            '<small class="text-muted d-block"><span class="songbook-name-full">' + esc(bookName) + '</span><span class="songbook-name-abbr">' + esc(book) + '</span></small>' +
-                        '</div>' +
-                        '<span class="badge bg-secondary">' + s.views + '</span>' +
-                    '</a>';
-                }).join('');
-            }).catch(function() { document.getElementById('popular-songs-section')?.remove(); });
-
-        // #304 — Recently Viewed (authenticated users only)
-        var token = localStorage.getItem('ihymns_auth_token');
-        if (token) {
-            fetch('/api?action=song_history&limit=8', {
-                headers: { 'Authorization': 'Bearer ' + token }
-            }).then(function(r){return r.json()}).then(function(data) {
-                var section = document.getElementById('recent-songs-section');
-                var el = document.getElementById('recent-songs-list');
-                if (!data.history?.length) return;
-                section.style.display = '';
-                el.innerHTML = data.history.map(function(h) {
-                    return '<a href="/song/' + esc(h.songId) + '" data-navigate="song" class="list-group-item list-group-item-action">' + esc(h.songId) + '</a>';
-                }).join('');
-            }).catch(function(){});
-        }
-
-        // #305 — Browse by Theme
-        fetch('/api?action=tags')
-            .then(function(r){return r.json()})
-            .then(function(data) {
-                var el = document.getElementById('tags-list');
-                if (!data.tags?.length) { el?.closest('#tags-section')?.remove(); return; }
-                el.innerHTML = data.tags.map(function(t) {
-                    return '<a href="/tag/' + esc(t.slug) + '" data-navigate="tag" class="btn btn-sm btn-outline-secondary">' + esc(t.name) + '</a>';
-                }).join('');
-            }).catch(function() { document.getElementById('tags-section')?.remove(); });
-    })();
-    </script>
+    <!-- The dynamic sections above (Popular Songs, Recently Viewed,
+         Browse by Theme) are populated client-side by
+         js/modules/home-page.js, which the SPA router imports and
+         invokes after loading this template. Keeping the logic in a
+         proper module instead of an inline <script> means it runs
+         reliably through the normal import graph — inline <script>
+         tags in AJAX-injected HTML do not execute natively, and the
+         previous re-parse shim was an extra transport dependency this
+         feature does not need. -->
 
 </section>

--- a/appWeb/public_html/includes/pages/song.php
+++ b/appWeb/public_html/includes/pages/song.php
@@ -37,10 +37,15 @@ $songNumber    = ($rawSongNumber === null || $rawSongNumber === '') ? null : (in
 $songTitle   = toTitleCase($song['title'] ?? 'Untitled');
 $songbook    = $song['songbook'] ?? '';
 $bookName    = $song['songbookName'] ?? '';
-$writers     = $song['writers'] ?? [];
-$composers   = $song['composers'] ?? [];
-$copyright   = $song['copyright'] ?? '';
-$ccli        = $song['ccli'] ?? '';
+$writers     = $song['writers']     ?? [];
+$composers   = $song['composers']   ?? [];
+$arrangers   = $song['arrangers']   ?? [];   /* #497 */
+$adaptors    = $song['adaptors']    ?? [];   /* #497 */
+$translators = $song['translators'] ?? [];   /* #497 */
+$tuneName    = $song['tuneName']    ?? '';   /* #497 */
+$iswc        = $song['iswc']        ?? '';   /* #497 */
+$copyright   = $song['copyright']   ?? '';
+$ccli        = $song['ccli']        ?? '';
 $hasAudio    = !empty($song['hasAudio']);
 $hasSheet    = !empty($song['hasSheetMusic']);
 $components  = $song['components'] ?? [];
@@ -178,28 +183,50 @@ unset($_t);
                 </div>
             </div>
 
-            <!-- Writers and composers -->
-            <?php if (!empty($writers) || !empty($composers)): ?>
+            <!-- Credits block (#497).
+                 Five collections now: Writers · Composers · Arrangers ·
+                 Adaptors · Translators. Each is a many-to-one list from
+                 its own MySQL table; we render a row per non-empty
+                 collection and join names with "; " (per #495) since
+                 surname-first hymnal citations can legitimately contain
+                 commas inside a single name. -->
+            <?php
+            $_creditRows = [
+                ['words',       'Words',       'fa-solid fa-pen-fancy',   $writers],
+                ['music',       'Music',       'fa-solid fa-music',       $composers],
+                ['arranged',    'Arranged by', 'fa-solid fa-sliders',     $arrangers],
+                ['adapted',     'Adapted by',  'fa-solid fa-compact-disc',$adaptors],
+                ['translated',  'Translated by','fa-solid fa-language',   $translators],
+            ];
+            $_hasAnyCredit = false;
+            foreach ($_creditRows as $row) { if (!empty($row[3])) { $_hasAnyCredit = true; break; } }
+            ?>
+            <?php if ($_hasAnyCredit): ?>
                 <div class="song-meta mb-3">
-                    <?php if (!empty($writers)): ?>
-                        <p class="mb-1">
-                            <i class="fa-solid fa-pen-fancy me-2 text-muted" aria-hidden="true"></i>
-                            <strong>Words:</strong>
-                            <?php foreach ($writers as $i => $w): ?><a href="/writer/<?= htmlspecialchars(urlencode(strtolower(str_replace(' ', '-', $w)))) ?>"
+                    <?php foreach ($_creditRows as $rowIdx => $row): ?>
+                        <?php [$rowId, $rowLabel, $rowIcon, $rowNames] = $row; ?>
+                        <?php if (empty($rowNames)) continue; ?>
+                        <p class="mb-<?= $rowIdx === count($_creditRows) - 1 || empty(array_slice($_creditRows, $rowIdx + 1, null, true)) ? '0' : '1' ?> song-credit-row" data-credit-kind="<?= htmlspecialchars($rowId) ?>">
+                            <i class="<?= htmlspecialchars($rowIcon) ?> me-2 text-muted" aria-hidden="true"></i>
+                            <strong><?= htmlspecialchars($rowLabel) ?>:</strong>
+                            <?php foreach ($rowNames as $i => $name): ?><a href="/writer/<?= htmlspecialchars(urlencode(strtolower(str_replace(' ', '-', $name)))) ?>"
                                    class="writer-link"
-                                   data-navigate="writer"><?= htmlspecialchars($w) ?></a><?php if ($i < count($writers) - 1): ?>, <?php endif; ?><?php endforeach; ?>
+                                   data-navigate="writer"><?= htmlspecialchars($name) ?></a><?php if ($i < count($rowNames) - 1): ?>;&nbsp;<?php endif; ?><?php endforeach; ?>
                         </p>
-                    <?php endif; ?>
-                    <?php if (!empty($composers)): ?>
-                        <p class="mb-0">
-                            <i class="fa-solid fa-music me-2 text-muted" aria-hidden="true"></i>
-                            <strong>Music:</strong>
-                            <?php foreach ($composers as $i => $c): ?><a href="/writer/<?= htmlspecialchars(urlencode(strtolower(str_replace(' ', '-', $c)))) ?>"
-                                   class="writer-link"
-                                   data-navigate="writer"><?= htmlspecialchars($c) ?></a><?php if ($i < count($composers) - 1): ?>, <?php endif; ?><?php endforeach; ?>
-                        </p>
-                    <?php endif; ?>
+                    <?php endforeach; ?>
                 </div>
+            <?php endif; ?>
+
+            <!-- Tune name (#497). Rendered when set so the viewer sees
+                 "Tune: HYFRYDOL" — a meaningful pointer for hymnbook
+                 users. The link target `/tune/<slug>` is reserved for
+                 a future cross-reference listing (#494); until that
+                 ships we still render the label as plain text. -->
+            <?php if ($tuneName !== ''): ?>
+                <p class="song-meta-tune small text-muted mb-2">
+                    <i class="fa-solid fa-music-note-list me-2" aria-hidden="true"></i>
+                    <strong>Tune:</strong> <?= htmlspecialchars($tuneName) ?>
+                </p>
             <?php endif; ?>
 
             <!-- ============================================================
@@ -249,8 +276,8 @@ unset($_t);
                 </div>
             <?php endif; ?>
 
-            <!-- Copyright and CCLI in song header -->
-            <?php if (!empty($copyright) || !empty($ccli)): ?>
+            <!-- Copyright, CCLI Song Number, ISWC in song header (#497). -->
+            <?php if (!empty($copyright) || !empty($ccli) || $iswc !== ''): ?>
                 <div class="song-meta-copyright mb-3">
                     <?php if (!empty($copyright)): ?>
                         <p class="mb-1 small text-muted">
@@ -259,9 +286,15 @@ unset($_t);
                         </p>
                     <?php endif; ?>
                     <?php if (!empty($ccli)): ?>
-                        <p class="mb-0 small text-muted">
+                        <p class="mb-<?= $iswc !== '' ? '1' : '0' ?> small text-muted">
                             <i class="fa-solid fa-hashtag me-2" aria-hidden="true"></i>
                             CCLI Song #<?= htmlspecialchars($ccli) ?>
+                        </p>
+                    <?php endif; ?>
+                    <?php if ($iswc !== ''): ?>
+                        <p class="mb-0 small text-muted" title="International Standard Musical Work Code">
+                            <i class="fa-solid fa-barcode me-2" aria-hidden="true"></i>
+                            ISWC <?= htmlspecialchars($iswc) ?>
                         </p>
                     <?php endif; ?>
                 </div>

--- a/appWeb/public_html/js/modules/favorites.js
+++ b/appWeb/public_html/js/modules/favorites.js
@@ -254,7 +254,17 @@ export class Favorites {
                 const container = modal.querySelector('.d-flex.flex-wrap');
                 const newBtn = document.createElement('label');
                 newBtn.className = 'btn btn-sm btn-primary rounded-pill tag-toggle-btn';
-                newBtn.innerHTML = `<input type="checkbox" class="d-none tag-checkbox" value="${escapeHtml(tag)}" checked> ${escapeHtml(tag)}`;
+                /* DOM-API construction rather than innerHTML-with-
+                   escape, so CodeQL has nothing to trace and a future
+                   edit can't accidentally drop the escapeHtml call
+                   (#504). */
+                const tagCheckbox = document.createElement('input');
+                tagCheckbox.type = 'checkbox';
+                tagCheckbox.className = 'd-none tag-checkbox';
+                tagCheckbox.value = tag;
+                tagCheckbox.checked = true;
+                newBtn.appendChild(tagCheckbox);
+                newBtn.appendChild(document.createTextNode(' ' + tag));
                 newBtn.addEventListener('click', (e) => {
                     e.preventDefault();
                     const cb = newBtn.querySelector('.tag-checkbox');
@@ -499,9 +509,21 @@ export class Favorites {
 
         if (toggle) {
             toggle.setAttribute('aria-pressed', String(this.selectMode));
-            toggle.innerHTML = this.selectMode
-                ? '<i class="fa-solid fa-xmark me-1" aria-hidden="true"></i> Cancel'
-                : '<i class="fa-solid fa-check-double me-1" aria-hidden="true"></i> Select';
+            /* Construct the button contents via DOM APIs rather than
+               innerHTML so CodeQL's "DOM text reinterpreted as HTML"
+               rule is happy, and we're immune to any future edit
+               that accidentally introduces a dynamic string into the
+               ternary (#504). */
+            toggle.replaceChildren();
+            const icon = document.createElement('i');
+            icon.className = this.selectMode
+                ? 'fa-solid fa-xmark me-1'
+                : 'fa-solid fa-check-double me-1';
+            icon.setAttribute('aria-hidden', 'true');
+            toggle.appendChild(icon);
+            toggle.appendChild(document.createTextNode(
+                ' ' + (this.selectMode ? 'Cancel' : 'Select')
+            ));
         }
 
         checkboxes.forEach(cb => {

--- a/appWeb/public_html/js/modules/home-page.js
+++ b/appWeb/public_html/js/modules/home-page.js
@@ -1,0 +1,203 @@
+/**
+ * iHymns — Home Page Dynamic Sections (#303, #304, #305)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Wires up the three data-driven sections on the SPA home page —
+ *   - Popular Songs (#303)            server-ranked last-30-day views
+ *   - Recently Viewed (#304)          authenticated users only
+ *   - Browse by Theme (#305)          tag list → /tag/<slug>
+ *
+ * History:
+ * This code originally lived as an inline <script> at the bottom of
+ * includes/pages/home.php. The SPA router loads each page via AJAX and
+ * injects the returned HTML via innerHTML, and browsers intentionally
+ * do not execute <script> descendants inserted that way. A replaceWith-
+ * based shim in router.js was added to re-run injected inline scripts,
+ * but that still left a single-point-of-failure transport path for
+ * three separate page features. Moving the logic into a proper ES
+ * module removes the transport dependency entirely — the router
+ * imports and invokes this module directly after loading the home
+ * page, so the sections work whether the shim fires or not.
+ */
+
+import { toTitleCase } from '../utils/text.js';
+import { escapeHtml } from '../utils/html.js';
+import { SONGBOOK_NAMES, STORAGE_HISTORY } from '../constants.js';
+
+const STORAGE_AUTH_TOKEN = 'ihymns_auth_token';
+
+/**
+ * Entry point — call after the home page HTML has been injected into
+ * the DOM. Idempotent: if a section's target element is missing (e.g.
+ * the server already removed it, or we navigated away mid-fetch) the
+ * corresponding block no-ops.
+ */
+export function initHomePage() {
+    loadPopularSongs();
+    loadRecentlyViewed();
+    loadTags();
+}
+
+/* ==================================================================
+ * POPULAR SONGS (#303)
+ *
+ * Server returns the last-30-day top-10 by view count. On DB-less
+ * (JSON fallback) deployments or empty installs the server returns
+ * an empty list; we then build a local approximation from the
+ * viewing history in localStorage. If neither source yields songs,
+ * the section is removed entirely so the page doesn't carry an
+ * empty heading.
+ * ================================================================== */
+async function loadPopularSongs() {
+    const el = document.getElementById('popular-songs-list');
+    if (!el) return;
+
+    let songs = [];
+    try {
+        const res  = await fetch('/api?action=popular_songs&period=month&limit=10');
+        const data = await res.json();
+        songs = Array.isArray(data.songs) ? data.songs : [];
+    } catch {
+        /* Network failure → fall through to the localStorage fallback;
+           if that's also empty the section gets removed below. */
+    }
+
+    if (!songs.length) {
+        songs = popularFromLocalHistory();
+    }
+
+    if (!songs.length) {
+        document.getElementById('popular-songs-section')?.remove();
+        return;
+    }
+
+    el.innerHTML = songs.map(renderPopularRow).join('');
+}
+
+/**
+ * Build a rough local popularity list from localStorage viewing history.
+ * Used when the server returns nothing (JSON fallback mode) so the
+ * section still shows something on a fresh install.
+ *
+ * @returns {Array<{songId:string,title:string,songbook:string,number:(string|number),views:number}>}
+ */
+function popularFromLocalHistory() {
+    try {
+        const hist = JSON.parse(localStorage.getItem(STORAGE_HISTORY) || '[]');
+        const counts = {};
+        for (const h of hist) {
+            if (!h?.id) continue;
+            if (!counts[h.id]) {
+                counts[h.id] = {
+                    songId:   h.id,
+                    title:    h.title,
+                    songbook: h.songbook,
+                    number:   h.number,
+                    views:    0,
+                };
+            }
+            counts[h.id].views++;
+        }
+        return Object.values(counts)
+            .sort((a, b) => b.views - a.views)
+            .slice(0, 10);
+    } catch {
+        return [];
+    }
+}
+
+function renderPopularRow(s) {
+    const id       = s.songId || s.id || '';
+    const title    = toTitleCase(s.title || id);
+    const book     = s.songbook || id.split('-')[0] || '';
+    const bookName = SONGBOOK_NAMES[book] || book;
+    const number   = s.number ?? '';
+    const views    = s.views ?? 0;
+
+    return `<a href="/song/${escapeHtml(id)}"
+               data-navigate="song"
+               data-song-id="${escapeHtml(id)}"
+               class="list-group-item list-group-item-action song-list-item">
+                <span class="song-number-badge" data-songbook="${escapeHtml(book)}">${escapeHtml(String(number))}</span>
+                <div class="song-info flex-grow-1">
+                    <span class="song-title">${escapeHtml(title)}</span>
+                    <small class="text-muted d-block">
+                        <span class="songbook-name-full">${escapeHtml(bookName)}</span>
+                        <span class="songbook-name-abbr">${escapeHtml(book)}</span>
+                    </small>
+                </div>
+                <span class="badge bg-secondary">${escapeHtml(String(views))}</span>
+            </a>`;
+}
+
+/* ==================================================================
+ * RECENTLY VIEWED (#304)
+ *
+ * Authenticated users only. Returns the latest 8 song views recorded
+ * against the current user. If there's no auth token or the API
+ * returns an empty list, leave the section hidden (it starts as
+ * display:none in the server template).
+ * ================================================================== */
+async function loadRecentlyViewed() {
+    const token = localStorage.getItem(STORAGE_AUTH_TOKEN);
+    if (!token) return;
+
+    const section = document.getElementById('recent-songs-section');
+    const el      = document.getElementById('recent-songs-list');
+    if (!section || !el) return;
+
+    try {
+        const res  = await fetch('/api?action=song_history&limit=8', {
+            headers: { 'Authorization': 'Bearer ' + token },
+        });
+        const data = await res.json();
+        const hist = Array.isArray(data.history) ? data.history : [];
+        if (!hist.length) return;
+
+        section.style.display = '';
+        el.innerHTML = hist.map(h => {
+            const id = escapeHtml(h.songId || '');
+            return `<a href="/song/${id}"
+                       data-navigate="song"
+                       class="list-group-item list-group-item-action">${id}</a>`;
+        }).join('');
+    } catch {
+        /* Non-fatal — leave the section hidden. */
+    }
+}
+
+/* ==================================================================
+ * BROWSE BY THEME (#305)
+ *
+ * Lists every song-tag as a pill linking to /tag/<slug>. If the tag
+ * registry is empty (fresh install / JSON fallback) the section is
+ * removed so the empty heading doesn't linger.
+ * ================================================================== */
+async function loadTags() {
+    const el = document.getElementById('tags-list');
+    if (!el) return;
+
+    let tags = [];
+    try {
+        const res  = await fetch('/api?action=tags');
+        const data = await res.json();
+        tags = Array.isArray(data.tags) ? data.tags : [];
+    } catch {
+        /* Fall through — no tags will remove the section. */
+    }
+
+    if (!tags.length) {
+        el.closest('#tags-section')?.remove();
+        return;
+    }
+
+    el.innerHTML = tags.map(t => {
+        const slug = escapeHtml(t.slug || '');
+        const name = escapeHtml(t.name || '');
+        return `<a href="/tag/${slug}"
+                   data-navigate="tag"
+                   class="btn btn-sm btn-outline-secondary">${name}</a>`;
+    }).join('');
+}

--- a/appWeb/public_html/js/modules/router.js
+++ b/appWeb/public_html/js/modules/router.js
@@ -468,6 +468,17 @@ export class Router {
             this.app.history.renderHomeSection();
             this.app.songOfTheDay.renderHomeSection();
             this.renderRecentSongbooks();
+
+            /* Popular Songs / Recently Viewed / Browse by Theme (#303,
+               #304, #305). Previously lived as an inline <script> at the
+               bottom of home.php, which relied on a re-parse shim in
+               loadPage() to execute after innerHTML injection. Pulling
+               it into a proper module and invoking it here removes that
+               transport dependency — the sections now run reliably
+               whenever the home page is shown. */
+            import('./home-page.js')
+                .then(m => m.initHomePage())
+                .catch(err => console.error('[Router] home-page init failed:', err));
         }
 
         /* Initialise favourites list on favorites page */

--- a/appWeb/public_html/js/modules/search.js
+++ b/appWeb/public_html/js/modules/search.js
@@ -509,7 +509,10 @@ export class Search {
         html += '<div class="list-group">';
 
         results.forEach(song => {
-            const writers = (song.writers || []).join(', ');
+            /* Canonical separator is "; " (#495). Surname-first hymnal
+               citations legitimately contain commas inside a single
+               name ("Smith, John"), so comma is ambiguous. */
+            const writers = (song.writers || []).join('; ');
             const snippet = song.lyricsSnippet
                 ? `<small class="text-muted d-block fst-italic"><i class="fa-solid fa-music me-1" aria-hidden="true"></i>&ldquo;${escapeHtml(song.lyricsSnippet)}&rdquo;</small>`
                 : '';

--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -128,10 +128,17 @@ switch ($action) {
             $db->query("SET FOREIGN_KEY_CHECKS = 0");
             $db->begin_transaction();
 
-            /* Clear existing data */
+            /* Clear existing data. New credit tables (#497) are TRUNCATEd
+               alongside the originals so a bulk import yields a clean
+               slate; the migration must have been run first or the query
+               will fail with a clear "Table … doesn't exist" error that
+               points the admin at /manage/setup-database. */
             $db->query("TRUNCATE TABLE tblSongComponents");
             $db->query("TRUNCATE TABLE tblSongComposers");
             $db->query("TRUNCATE TABLE tblSongWriters");
+            $db->query("TRUNCATE TABLE tblSongArrangers");
+            $db->query("TRUNCATE TABLE tblSongAdaptors");
+            $db->query("TRUNCATE TABLE tblSongTranslators");
             $db->query("TRUNCATE TABLE tblSongs");
             $db->query("TRUNCATE TABLE tblSongbooks");
 
@@ -150,20 +157,22 @@ switch ($action) {
             }
             $stmtSongbook->close();
 
-            /* Prepare song statements */
+            /* Prepare song statements. tblSongs INSERT now carries the
+               #497 TuneName + Iswc columns; both are nullable and bind
+               as the string types below (mysqli emits NULL when the
+               bound PHP value is null). */
             $stmtSong = $db->prepare(
                 "INSERT INTO tblSongs (SongId, Number, Title, SongbookAbbr, SongbookName,
-                 Language, Copyright, Ccli, Verified, LyricsPublicDomain,
+                 Language, Copyright, TuneName, Ccli, Iswc, Verified, LyricsPublicDomain,
                  MusicPublicDomain, HasAudio, HasSheetMusic, LyricsText)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
             );
-            $stmtWriter = $db->prepare(
-                "INSERT INTO tblSongWriters (SongId, Name) VALUES (?, ?)"
-            );
-            $stmtComposer = $db->prepare(
-                "INSERT INTO tblSongComposers (SongId, Name) VALUES (?, ?)"
-            );
-            $stmtComponent = $db->prepare(
+            $stmtWriter     = $db->prepare("INSERT INTO tblSongWriters     (SongId, Name) VALUES (?, ?)");
+            $stmtComposer   = $db->prepare("INSERT INTO tblSongComposers   (SongId, Name) VALUES (?, ?)");
+            $stmtArranger   = $db->prepare("INSERT INTO tblSongArrangers   (SongId, Name) VALUES (?, ?)");
+            $stmtAdaptor    = $db->prepare("INSERT INTO tblSongAdaptors    (SongId, Name) VALUES (?, ?)");
+            $stmtTranslator = $db->prepare("INSERT INTO tblSongTranslators (SongId, Name) VALUES (?, ?)");
+            $stmtComponent  = $db->prepare(
                 "INSERT INTO tblSongComponents (SongId, Type, Number, SortOrder, LinesJson)
                  VALUES (?, ?, ?, ?, ?)"
             );
@@ -184,7 +193,14 @@ switch ($action) {
                 $songbookName = $song['songbookName'] ?? '';
                 $language     = $song['language'] ?? 'en';
                 $copyright    = $song['copyright'] ?? '';
+                /* TuneName / Iswc: empty strings normalise to NULL so
+                   the indexed TuneName column groups "unknown" rows
+                   together and doesn't fragment on empty values. */
+                $tuneRaw      = trim((string)($song['tuneName'] ?? ''));
+                $tuneName     = $tuneRaw === '' ? null : $tuneRaw;
                 $ccli         = $song['ccli'] ?? '';
+                $iswcRaw      = trim((string)($song['iswc'] ?? ''));
+                $iswc         = $iswcRaw === '' ? null : $iswcRaw;
                 $verified     = (int)($song['verified'] ?? false);
                 $lyricsPD     = (int)($song['lyricsPublicDomain'] ?? false);
                 $musicPD      = (int)($song['musicPublicDomain'] ?? false);
@@ -201,24 +217,19 @@ switch ($action) {
                 $lyricsText = implode("\n", $lyricsLines);
 
                 $stmtSong->bind_param(
-                    'sissssssiiiiis',
+                    'sissssssssiiiiis',
                     $songId, $number, $title, $songbookAbbr, $songbookName,
-                    $language, $copyright, $ccli, $verified, $lyricsPD,
-                    $musicPD, $hasAudio, $hasSheet, $lyricsText
+                    $language, $copyright, $tuneName, $ccli, $iswc,
+                    $verified, $lyricsPD, $musicPD, $hasAudio, $hasSheet, $lyricsText
                 );
                 $stmtSong->execute();
 
-                /* Writers */
-                foreach ($song['writers'] ?? [] as $writer) {
-                    $stmtWriter->bind_param('ss', $songId, $writer);
-                    $stmtWriter->execute();
-                }
-
-                /* Composers */
-                foreach ($song['composers'] ?? [] as $composer) {
-                    $stmtComposer->bind_param('ss', $songId, $composer);
-                    $stmtComposer->execute();
-                }
+                /* Credit collections — one table each. */
+                foreach ($song['writers']     ?? [] as $v) { if (is_string($v) && $v !== '') { $stmtWriter->bind_param('ss', $songId, $v);     $stmtWriter->execute(); } }
+                foreach ($song['composers']   ?? [] as $v) { if (is_string($v) && $v !== '') { $stmtComposer->bind_param('ss', $songId, $v);   $stmtComposer->execute(); } }
+                foreach ($song['arrangers']   ?? [] as $v) { if (is_string($v) && $v !== '') { $stmtArranger->bind_param('ss', $songId, $v);   $stmtArranger->execute(); } }
+                foreach ($song['adaptors']    ?? [] as $v) { if (is_string($v) && $v !== '') { $stmtAdaptor->bind_param('ss', $songId, $v);    $stmtAdaptor->execute(); } }
+                foreach ($song['translators'] ?? [] as $v) { if (is_string($v) && $v !== '') { $stmtTranslator->bind_param('ss', $songId, $v); $stmtTranslator->execute(); } }
 
                 /* Components */
                 $sortOrder = 0;
@@ -235,6 +246,9 @@ switch ($action) {
             $stmtSong->close();
             $stmtWriter->close();
             $stmtComposer->close();
+            $stmtArranger->close();
+            $stmtAdaptor->close();
+            $stmtTranslator->close();
             $stmtComponent->close();
 
             /*
@@ -422,7 +436,14 @@ switch ($action) {
         $songbookName = (string)($song['songbookName'] ?? '');
         $language     = (string)($song['language']    ?? 'en');
         $copyright    = (string)($song['copyright']   ?? '');
+        /* TuneName + Iswc are nullable (#497). Empty/whitespace-only
+           input normalises to NULL so the indexed TuneName column
+           groups "unknown" rows together. */
+        $tuneRaw      = trim((string)($song['tuneName'] ?? ''));
+        $tuneName     = $tuneRaw === '' ? null : $tuneRaw;
         $ccli         = (string)($song['ccli']        ?? '');
+        $iswcRaw      = trim((string)($song['iswc']   ?? ''));
+        $iswc         = $iswcRaw === '' ? null : $iswcRaw;
         $verified     = (int)($song['verified']           ?? 0);
         $lyricsPD     = (int)($song['lyricsPublicDomain'] ?? 0);
         $musicPD      = (int)($song['musicPublicDomain']  ?? 0);
@@ -454,53 +475,66 @@ switch ($action) {
             }
             $action = $prevRow === null ? 'create' : 'edit';
 
-            /* UPSERT tblSongs */
+            /* UPSERT tblSongs — now carries TuneName + Iswc (#497). */
             $upsert = $db->prepare(
                 'INSERT INTO tblSongs
                     (SongId, Number, Title, SongbookAbbr, SongbookName, Language,
-                     Copyright, Ccli, Verified, LyricsPublicDomain, MusicPublicDomain,
-                     HasAudio, HasSheetMusic, LyricsText)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                     Copyright, TuneName, Ccli, Iswc, Verified, LyricsPublicDomain,
+                     MusicPublicDomain, HasAudio, HasSheetMusic, LyricsText)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                  ON DUPLICATE KEY UPDATE
                     Number = VALUES(Number), Title = VALUES(Title),
                     SongbookAbbr = VALUES(SongbookAbbr), SongbookName = VALUES(SongbookName),
                     Language = VALUES(Language), Copyright = VALUES(Copyright),
-                    Ccli = VALUES(Ccli), Verified = VALUES(Verified),
+                    TuneName = VALUES(TuneName),
+                    Ccli = VALUES(Ccli), Iswc = VALUES(Iswc),
+                    Verified = VALUES(Verified),
                     LyricsPublicDomain = VALUES(LyricsPublicDomain),
                     MusicPublicDomain = VALUES(MusicPublicDomain),
                     HasAudio = VALUES(HasAudio), HasSheetMusic = VALUES(HasSheetMusic),
                     LyricsText = VALUES(LyricsText)'
             );
             $upsert->bind_param(
-                'sissssssiiiiis',
+                'sissssssssiiiiis',
                 $songId, $number, $title, $songbookAbbr, $songbookName,
-                $language, $copyright, $ccli, $verified, $lyricsPD,
-                $musicPD, $hasAudio, $hasSheet, $lyricsText
+                $language, $copyright, $tuneName, $ccli, $iswc,
+                $verified, $lyricsPD, $musicPD, $hasAudio, $hasSheet, $lyricsText
             );
             $upsert->execute();
             $upsert->close();
 
             /* Child rows: DELETE then INSERT — simpler than diffing and
-               the row counts per song are small (≈1–20 each). */
-            $del = $db->prepare('DELETE FROM tblSongWriters    WHERE SongId = ?'); $del->bind_param('s', $songId); $del->execute(); $del->close();
-            $del = $db->prepare('DELETE FROM tblSongComposers  WHERE SongId = ?'); $del->bind_param('s', $songId); $del->execute(); $del->close();
-            $del = $db->prepare('DELETE FROM tblSongComponents WHERE SongId = ?'); $del->bind_param('s', $songId); $del->execute(); $del->close();
-
-            $insWriter = $db->prepare('INSERT INTO tblSongWriters (SongId, Name) VALUES (?, ?)');
-            foreach ($song['writers'] ?? [] as $w) {
-                if (!is_string($w) || $w === '') continue;
-                $insWriter->bind_param('ss', $songId, $w);
-                $insWriter->execute();
+               the row counts per song are small (≈1–20 each). New credit
+               tables from #497 are cleaned up here too. */
+            foreach ([
+                'tblSongWriters', 'tblSongComposers', 'tblSongArrangers',
+                'tblSongAdaptors', 'tblSongTranslators', 'tblSongComponents',
+            ] as $childTable) {
+                $del = $db->prepare("DELETE FROM {$childTable} WHERE SongId = ?");
+                $del->bind_param('s', $songId);
+                $del->execute();
+                $del->close();
             }
-            $insWriter->close();
 
-            $insComposer = $db->prepare('INSERT INTO tblSongComposers (SongId, Name) VALUES (?, ?)');
-            foreach ($song['composers'] ?? [] as $c) {
-                if (!is_string($c) || $c === '') continue;
-                $insComposer->bind_param('ss', $songId, $c);
-                $insComposer->execute();
+            /* Insert credit collections. Each collection is a separate
+               prepared statement to keep the field name explicit at each
+               call site. */
+            $creditInserts = [
+                'writers'     => 'INSERT INTO tblSongWriters     (SongId, Name) VALUES (?, ?)',
+                'composers'   => 'INSERT INTO tblSongComposers   (SongId, Name) VALUES (?, ?)',
+                'arrangers'   => 'INSERT INTO tblSongArrangers   (SongId, Name) VALUES (?, ?)',
+                'adaptors'    => 'INSERT INTO tblSongAdaptors    (SongId, Name) VALUES (?, ?)',
+                'translators' => 'INSERT INTO tblSongTranslators (SongId, Name) VALUES (?, ?)',
+            ];
+            foreach ($creditInserts as $key => $sql) {
+                $stmt = $db->prepare($sql);
+                foreach ($song[$key] ?? [] as $name) {
+                    if (!is_string($name) || $name === '') continue;
+                    $stmt->bind_param('ss', $songId, $name);
+                    $stmt->execute();
+                }
+                $stmt->close();
             }
-            $insComposer->close();
 
             $insComp = $db->prepare(
                 'INSERT INTO tblSongComponents

--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -1084,6 +1084,100 @@ switch ($action) {
         break;
 
     /* -----------------------------------------------------------------
+     * USER_SEARCH (#498) — live-search users by display name / username
+     *
+     * Used by the /manage/restrictions name-first picker to resolve a
+     * human-friendly user label ("Lance Manasse · @admin") to the
+     * canonical tblUsers.Id on save. Admin-gated like every endpoint
+     * in this file.
+     *
+     * GET parameters:
+     *   q     — partial match against DisplayName OR Username (LIKE %q%)
+     *   limit — max 20 suggestions (default 10)
+     *
+     * Response: { suggestions: [{id, label, hint}, ...] }
+     * ----------------------------------------------------------------- */
+    case 'user_search':
+        $q     = trim((string)($_GET['q'] ?? ''));
+        $limit = max(1, min(20, (int)($_GET['limit'] ?? 10)));
+        if ($q === '') {
+            echo json_encode(['suggestions' => []]);
+            break;
+        }
+        try {
+            $db = getDbMysqli();
+            $like = '%' . $q . '%';
+            $stmt = $db->prepare(
+                'SELECT Id, DisplayName, Username, Role
+                 FROM tblUsers
+                 WHERE DisplayName LIKE ? OR Username LIKE ?
+                 ORDER BY DisplayName ASC
+                 LIMIT ?'
+            );
+            $stmt->bind_param('ssi', $like, $like, $limit);
+            $stmt->execute();
+            $res = $stmt->get_result();
+            $suggestions = [];
+            while ($row = $res->fetch_assoc()) {
+                $suggestions[] = [
+                    'id'    => (int)$row['Id'],
+                    'label' => $row['DisplayName'] ?: $row['Username'],
+                    'hint'  => '@' . $row['Username'] . ' · ' . $row['Role'],
+                ];
+            }
+            $stmt->close();
+            echo json_encode(['suggestions' => $suggestions]);
+        } catch (\Throwable $e) {
+            error_log('[editor user_search] ' . $e->getMessage());
+            echo json_encode(['suggestions' => []]);
+        }
+        break;
+
+    /* -----------------------------------------------------------------
+     * ORG_SEARCH (#498) — live-search organisations by name
+     * ----------------------------------------------------------------- */
+    case 'org_search':
+        $q     = trim((string)($_GET['q'] ?? ''));
+        $limit = max(1, min(50, (int)($_GET['limit'] ?? 20)));
+        try {
+            $db = getDbMysqli();
+            if ($q === '') {
+                $stmt = $db->prepare(
+                    'SELECT Id, Name, Slug, LicenceType FROM tblOrganisations
+                     WHERE IsActive = 1
+                     ORDER BY Name ASC
+                     LIMIT ?'
+                );
+                $stmt->bind_param('i', $limit);
+            } else {
+                $like = '%' . $q . '%';
+                $stmt = $db->prepare(
+                    'SELECT Id, Name, Slug, LicenceType FROM tblOrganisations
+                     WHERE IsActive = 1 AND (Name LIKE ? OR Slug LIKE ?)
+                     ORDER BY Name ASC
+                     LIMIT ?'
+                );
+                $stmt->bind_param('ssi', $like, $like, $limit);
+            }
+            $stmt->execute();
+            $res = $stmt->get_result();
+            $suggestions = [];
+            while ($row = $res->fetch_assoc()) {
+                $suggestions[] = [
+                    'id'    => (int)$row['Id'],
+                    'label' => $row['Name'],
+                    'hint'  => 'licence: ' . ($row['LicenceType'] ?: 'none') . ' · slug: ' . $row['Slug'],
+                ];
+            }
+            $stmt->close();
+            echo json_encode(['suggestions' => $suggestions]);
+        } catch (\Throwable $e) {
+            error_log('[editor org_search] ' . $e->getMessage());
+            echo json_encode(['suggestions' => []]);
+        }
+        break;
+
+    /* -----------------------------------------------------------------
      * Unknown action
      * ----------------------------------------------------------------- */
     default:

--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -77,7 +77,11 @@ switch ($action) {
 
             header('Content-Type: application/json; charset=UTF-8');
             header('X-Content-Type-Options: nosniff');
-            echo json_encode($fullData, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+            /* No JSON_PRETTY_PRINT — the editor parses the response
+               with JSON.parse, nothing reads it by eye, and the extra
+               whitespace inflates the 3,600-song payload by ~25% on
+               the wire. */
+            echo json_encode($fullData, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
         } catch (\Exception $e) {
             http_response_code(500);
             error_log('[iHymns Editor] Failed to load song data: ' . $e->getMessage());

--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -586,6 +586,111 @@ switch ($action) {
         break;
 
     /* -----------------------------------------------------------------
+     * SONG_TAGS (#496) — return the tags currently assigned to a song
+     *
+     * GET parameters:
+     *   id — song id (e.g. CP-0001)
+     *
+     * Response: { tags: [{id, name, slug, description}, ...] }
+     *
+     * Used by the editor's Tags tab to render the per-song chip list
+     * when a song is selected.
+     * ----------------------------------------------------------------- */
+    case 'song_tags':
+        $songId = trim((string)($_GET['id'] ?? ''));
+        if ($songId === '') {
+            http_response_code(400);
+            echo json_encode(['error' => 'Song id is required.']);
+            break;
+        }
+        try {
+            $db = getDbMysqli();
+            $stmt = $db->prepare(
+                'SELECT t.Id AS id, t.Name AS name, t.Slug AS slug,
+                        t.Description AS description
+                 FROM tblSongTagMap m
+                 JOIN tblSongTags t ON t.Id = m.TagId
+                 WHERE m.SongId = ?
+                 ORDER BY t.Name ASC'
+            );
+            $stmt->bind_param('s', $songId);
+            $stmt->execute();
+            $result = $stmt->get_result();
+            $tags = [];
+            while ($row = $result->fetch_assoc()) {
+                $row['id'] = (int)$row['id'];
+                $tags[] = $row;
+            }
+            $stmt->close();
+            echo json_encode(['tags' => $tags]);
+        } catch (\Throwable $e) {
+            error_log('[editor song_tags] ' . $e->getMessage());
+            echo json_encode(['tags' => []]);
+        }
+        break;
+
+    /* -----------------------------------------------------------------
+     * TAG_SEARCH (#496) — autocomplete for existing tag names
+     *
+     * GET parameters:
+     *   q — partial name, case-insensitive substring match (optional;
+     *       if empty, returns the most-used tags — useful for the
+     *       "start typing" empty-state list)
+     *   limit — max 20 suggestions (default 10)
+     *
+     * Response: { suggestions: [{id, name, slug, usage}, ...] }
+     *   usage — number of songs currently carrying this tag, so popular
+     *           tags sort first and admins don't accidentally coin a
+     *           near-duplicate of an existing one.
+     * ----------------------------------------------------------------- */
+    case 'tag_search':
+        $q     = trim((string)($_GET['q'] ?? ''));
+        $limit = max(1, min(20, (int)($_GET['limit'] ?? 10)));
+        try {
+            $db = getDbMysqli();
+            if ($q === '') {
+                $sql = 'SELECT t.Id AS id, t.Name AS name, t.Slug AS slug,
+                               COUNT(m.TagId) AS usage
+                        FROM tblSongTags t
+                        LEFT JOIN tblSongTagMap m ON m.TagId = t.Id
+                        GROUP BY t.Id
+                        ORDER BY usage DESC, t.Name ASC
+                        LIMIT ?';
+                $stmt = $db->prepare($sql);
+                $stmt->bind_param('i', $limit);
+            } else {
+                $like = '%' . $q . '%';
+                $sql = 'SELECT t.Id AS id, t.Name AS name, t.Slug AS slug,
+                               COUNT(m.TagId) AS usage
+                        FROM tblSongTags t
+                        LEFT JOIN tblSongTagMap m ON m.TagId = t.Id
+                        WHERE t.Name LIKE ?
+                        GROUP BY t.Id
+                        ORDER BY usage DESC, t.Name ASC
+                        LIMIT ?';
+                $stmt = $db->prepare($sql);
+                $stmt->bind_param('si', $like, $limit);
+            }
+            $stmt->execute();
+            $result = $stmt->get_result();
+            $suggestions = [];
+            while ($row = $result->fetch_assoc()) {
+                $suggestions[] = [
+                    'id'    => (int)$row['id'],
+                    'name'  => $row['name'],
+                    'slug'  => $row['slug'],
+                    'usage' => (int)$row['usage'],
+                ];
+            }
+            $stmt->close();
+            echo json_encode(['suggestions' => $suggestions]);
+        } catch (\Throwable $e) {
+            error_log('[editor tag_search] ' . $e->getMessage());
+            echo json_encode(['suggestions' => []]);
+        }
+        break;
+
+    /* -----------------------------------------------------------------
      * POST api.php?action=bulk_tag   (#399)
      * Add and/or remove a set of tag names across a list of songs.
      * Body: { songIds: [...], add: [tagNames], remove: [tagNames] }

--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -886,10 +886,103 @@ switch ($action) {
         break;
 
     /* -----------------------------------------------------------------
+     * CREDIT_SEARCH (#495) — live-search distinct credit names
+     *
+     * GET parameters:
+     *   q    — partial name, case-insensitive substring match
+     *   kind — writer | composer | arranger | adaptor | translator | any
+     *          (default: any; "any" unions all five tables so the same
+     *          canonical spelling is surfaced regardless of which role
+     *          the user is typing into)
+     *   limit — max 50 suggestions (default 20)
+     *
+     * Returns: { suggestions: [{name, usage, kinds:["writer",...]}, ...] }
+     *   * usage — total song-count across the chosen kind(s), so popular
+     *             spellings sort first.
+     *   * kinds — which tables the name appears in; useful for the UI
+     *             to signal "this name is already used as an arranger".
+     * ----------------------------------------------------------------- */
+    case 'credit_search':
+        $q     = trim((string)($_GET['q'] ?? ''));
+        $kind  = strtolower(trim((string)($_GET['kind'] ?? 'any')));
+        $limit = max(1, min(50, (int)($_GET['limit'] ?? 20)));
+
+        if ($q === '' || strlen($q) < 1) {
+            echo json_encode(['suggestions' => []]);
+            break;
+        }
+
+        $kindToTable = [
+            'writer'     => 'tblSongWriters',
+            'composer'   => 'tblSongComposers',
+            'arranger'   => 'tblSongArrangers',
+            'adaptor'    => 'tblSongAdaptors',
+            'translator' => 'tblSongTranslators',
+        ];
+
+        $tablesToSearch = $kind === 'any'
+            ? $kindToTable
+            : (isset($kindToTable[$kind]) ? [$kind => $kindToTable[$kind]] : []);
+
+        if (empty($tablesToSearch)) {
+            http_response_code(400);
+            echo json_encode(['error' => 'Unknown kind. Use writer|composer|arranger|adaptor|translator|any.']);
+            break;
+        }
+
+        try {
+            $db   = getDbMysqli();
+            $like = '%' . $q . '%';
+
+            /* Build a UNION ALL across the selected tables, grouping by
+               name so the same "Fanny Crosby" from three different
+               tables collapses to a single suggestion with a combined
+               song count and the list of kinds it appears in. */
+            $unionParts = [];
+            $params     = [];
+            $types      = '';
+            foreach ($tablesToSearch as $kindLabel => $table) {
+                $unionParts[] = "SELECT Name, '{$kindLabel}' AS kindLabel, COUNT(*) AS cnt
+                                 FROM {$table}
+                                 WHERE Name LIKE ?
+                                 GROUP BY Name";
+                $params[] = $like;
+                $types   .= 's';
+            }
+            $sql = "SELECT Name, GROUP_CONCAT(DISTINCT kindLabel) AS kinds, SUM(cnt) AS usage
+                    FROM (" . implode(' UNION ALL ', $unionParts) . ") u
+                    GROUP BY Name
+                    ORDER BY usage DESC, Name ASC
+                    LIMIT ?";
+            $types   .= 'i';
+            $params[] = $limit;
+
+            $stmt = $db->prepare($sql);
+            $stmt->bind_param($types, ...$params);
+            $stmt->execute();
+            $res = $stmt->get_result();
+            $suggestions = [];
+            while ($row = $res->fetch_assoc()) {
+                $suggestions[] = [
+                    'name'  => $row['Name'],
+                    'usage' => (int)$row['usage'],
+                    'kinds' => $row['kinds'] !== null ? explode(',', $row['kinds']) : [],
+                ];
+            }
+            $stmt->close();
+            echo json_encode(['suggestions' => $suggestions]);
+        } catch (\Throwable $e) {
+            http_response_code(500);
+            error_log('[editor credit_search] ' . $e->getMessage());
+            echo json_encode(['error' => 'Credit search failed.']);
+        }
+        break;
+
+    /* -----------------------------------------------------------------
      * Unknown action
      * ----------------------------------------------------------------- */
     default:
         http_response_code(400);
-        echo json_encode(['error' => 'Unknown action. Use: load, save, save_song, bulk_tag, list_revisions, restore_revision, get_translations, add_translation, remove_translation']);
+        echo json_encode(['error' => 'Unknown action. Use: load, save, save_song, save_song_tags, tag_search, credit_search, bulk_tag, list_revisions, restore_revision, get_translations, add_translation, remove_translation']);
         break;
 }

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -1746,19 +1746,29 @@ function renderTranslators(song) {
  * ---------------------------------------------------------------------- */
 
 /**
- * Fetch + render tags for the given song. Idempotent.
+ * Fetch + render tags for the given song. Idempotent. Prefers the
+ * song.tags array already attached by the bulk ?action=load (#496
+ * follow-up); only round-trips when the bulk load didn't include
+ * them (e.g. older servers, or after a tag mutation that invalidated
+ * the local copy).
  */
 function loadSongTags(song) {
     var container = document.getElementById('song-tags-container');
     if (!container || !song || !song.id) return;
-    container.innerHTML = '<span class="text-muted small">Loading…</span>';
 
+    /* Fast path — the bulk load already attached tags. */
+    if (Array.isArray(song.tags)) {
+        song._tags = song.tags;
+        renderSongTagsChips(song, song.tags);
+        return;
+    }
+
+    container.innerHTML = '<span class="text-muted small">Loading…</span>';
     fetch(EDITOR_API_URL + '?action=song_tags&id=' + encodeURIComponent(song.id))
         .then(function (r) { return r.json(); })
         .then(function (data) {
             var tags = Array.isArray(data.tags) ? data.tags : [];
-            /* Cache on the song object so other UI (e.g. preview) can
-               read without a second fetch. */
+            song.tags = tags;
             song._tags = tags;
             renderSongTagsChips(song, tags);
         })
@@ -1831,6 +1841,9 @@ function addSongTag(song, tagName) {
     .then(function (r) { return r.json(); })
     .then(function (data) {
         if (data && data.added != null) {
+            /* Invalidate the bulk-load cache so loadSongTags re-fetches
+               with the authoritative row set (#496 follow-up). */
+            delete song.tags;
             loadSongTags(song);
             showToast('Added tag "' + tagName + '".', 'success');
         } else {
@@ -1852,6 +1865,8 @@ function removeSongTag(song, tagName) {
     })
     .then(function (r) { return r.json(); })
     .then(function () {
+        /* Invalidate the cached bulk-load copy — see addSongTag. */
+        delete song.tags;
         loadSongTags(song);
         showToast('Removed tag "' + tagName + '".', 'info');
     })

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -2597,7 +2597,8 @@ function renderPreview(song) {
     if (song.writers && song.writers.length > 0) {
         var writersEl = document.createElement('p');
         writersEl.className = 'text-muted small mt-3';
-        writersEl.textContent = 'Writers: ' + song.writers.join(', ');
+        /* "; " separator (#495). */
+        writersEl.textContent = 'Writers: ' + song.writers.join('; ');
         container.appendChild(writersEl);
     }
     if (song.copyright) {

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -196,70 +196,66 @@ function _fetchAndParseSongs(target) {
 /**
  * saveSongs()
  * -----------
- * Primary save action for the editor. Writes the current `songData` to the
- * MySQL database via the editor PHP API (POST api.php?action=save).
+ * Primary save action for the editor. Persists every song the admin has
+ * edited in this session, via POST api.php?action=save_song (one request
+ * per modified song, sequentially).
  *
- * If the server is unreachable or the DB is not configured, the editor falls
- * back to a browser download of songs.json so the admin never loses changes.
+ * Why per-song and not a single bulk write:
+ *   - `action=save` rewrites the whole corpus — TRUNCATE + re-INSERT of
+ *     every songbook, song, writer, composer and component row. That
+ *     blocks the save on validation of songs the user never touched
+ *     (a missing component on SDAH-1653 refuses to let you save a fix
+ *     on SDAH-93) and risks wiping good data if the POST body is
+ *     malformed mid-way.
+ *   - `action=save_song` UPSERTs a single song's rows inside a txn and
+ *     writes a revision to tblSongRevisions (#400). Exactly the unit
+ *     the user worked on.
  *
- * Invoked by the toolbar "Save" button (#btn-save) and by saveToJSON()
- * (legacy alias used by the validation flow).
+ * Validation is scoped to the modified set — issues on other songs are
+ * surfaced by the standalone "Validate" button (toolbar), not by Save.
+ *
+ * Invoked by the toolbar "Save" button (#btn-save).
  */
 function saveSongs() {
-    /* Run validation first; abort if the data is not valid. */
-    var errors = validateSongData();
-    if (errors.length > 0) {
-        /* Show each validation error as a toast notification. */
-        errors.forEach(function (msg) {
-            showToast(msg, 'danger');
-        });
-        return; // do not proceed with save
+    /* Nothing edited -> no-op with a friendly toast. */
+    if (modifiedSongIds.size === 0) {
+        showToast('No unsaved changes.', 'info');
+        return;
     }
 
-    /* Update the generatedAt timestamp so consumers know when data was last built. */
+    var ids = Array.from(modifiedSongIds);
+
+    /* Validate only the songs we're about to save. The user should
+       never be blocked from saving a fix on song X because song Y (that
+       they never opened) is missing a field. */
+    var errors = validateSongsByIds(ids);
+    if (errors.length > 0) {
+        errors.forEach(function (msg) { showToast(msg, 'danger'); });
+        return;
+    }
+
+    /* Refresh the generatedAt timestamp so any subsequent export
+       reflects the save time. */
     songData.meta.generatedAt = new Date().toISOString();
 
-    /* Serialise with 2-space indentation for human readability. */
-    var jsonString = JSON.stringify(songData, null, 2);
-
-    /* Primary path: save to MySQL via the editor API. */
-    fetch(EDITOR_API_URL + '?action=save', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: jsonString,
-    })
-    .then(function (response) {
-        return response.json().then(function (data) {
-            if (response.ok && data.success) {
-                /* DB save succeeded */
-                lastSaveTime = new Date();
-                modifiedSongIds.clear();
-                renderSongList();
-                updateStatusBar();
-                showToast(
-                    'Saved ' + data.songs + ' songs to the database.',
-                    'success'
-                );
-            } else {
-                /* Server reachable but the DB save failed — fall back to a
-                   JSON download so the admin can recover the work manually. */
-                showToast(
-                    'Database save failed: ' + (data.error || 'Unknown error') +
-                    '. Downloading a JSON backup so you don\u2019t lose changes.',
-                    'warning'
-                );
-                downloadSongsJson(jsonString);
-            }
-        });
-    })
-    .catch(function (err) {
-        /* Network error / server unavailable — fall back to browser download. */
-        showToast(
-            'Server unavailable: ' + err.message +
-            '. Downloading a JSON backup so you don\u2019t lose changes.',
-            'warning'
-        );
-        downloadSongsJson(jsonString);
+    /* Stream each song to the per-song endpoint. */
+    autoSaveSongsPerSong(ids).then(function (summary) {
+        if (summary.saved.length > 0) {
+            lastSaveTime = new Date();
+            summary.saved.forEach(function (id) { modifiedSongIds.delete(id); });
+            renderSongList();
+            updateStatusBar();
+            showToast(
+                'Saved ' + summary.saved.length + ' song' +
+                (summary.saved.length === 1 ? '' : 's') + ' to the database.',
+                'success'
+            );
+        }
+        if (summary.failed.length > 0) {
+            summary.failed.forEach(function (f) {
+                showToast('Failed to save ' + f.id + ': ' + f.error, 'danger');
+            });
+        }
     });
 }
 
@@ -1630,6 +1626,43 @@ function validateSongData() {
     });
 
     /* Return the collected errors (empty array means everything is valid). */
+    return errors;
+}
+
+/**
+ * validateSongsByIds(ids)
+ * -----------------------
+ * Same validation rules as validateSongData(), but scoped to a specific
+ * list of song IDs. Used by the manual Save button so that missing
+ * fields on a song the admin never touched don't block a save of the
+ * song they actually edited.
+ *
+ * @param {string[]} ids Song IDs to validate
+ * @returns {string[]} Human-readable error messages; empty if all valid
+ */
+function validateSongsByIds(ids) {
+    var wanted = new Set(ids);
+    var errors = [];
+    (songData.songs || []).forEach(function (song, i) {
+        if (!wanted.has(song.id)) return;
+        var label = 'Song ' + (song.id || '[' + i + ']') +
+                    ' (' + (song.title || 'no title') + ')';
+        if (!song.id || typeof song.id !== 'string' || song.id.trim() === '') {
+            errors.push(label + ': missing or empty "id".');
+        }
+        if (!song.title || typeof song.title !== 'string' || song.title.trim() === '') {
+            errors.push(label + ': missing or empty "title".');
+        }
+        if (song.number == null || String(song.number).trim() === '') {
+            errors.push(label + ': missing "number".');
+        }
+        if (!song.songbook || typeof song.songbook !== 'string' || song.songbook.trim() === '') {
+            errors.push(label + ': missing or empty "songbook".');
+        }
+        if (!Array.isArray(song.components) || song.components.length === 0) {
+            errors.push(label + ': must have at least one component.');
+        }
+    });
     return errors;
 }
 

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -730,25 +730,36 @@ function renderComponents(song) {
             renderPreview(song); // refresh preview
         });
 
-        /* Number input (e.g. verse 1, verse 2). */
+        /* Number input — optional (#491). Empty / 0 stores as null so
+           a single-instance component reads as "Chorus" (no number). */
         var numInput = document.createElement('input');
         numInput.type = 'number';
         numInput.className = 'form-control form-control-sm';
-        numInput.style.width = '80px';
-        numInput.placeholder = '#';
-        numInput.value = comp.number != null ? comp.number : '';
+        numInput.style.width = '110px';
+        numInput.placeholder = '(optional)';
+        numInput.min = '0';
+        numInput.value = (comp.number != null && comp.number > 0) ? comp.number : '';
         /* Live-bind number changes. */
         numInput.addEventListener('input', function () {
             comp.number = numInput.value ? parseInt(numInput.value, 10) : null;
             markModified(song.id);
+            /* Update the header label in place so the user sees the
+               effect of their edit without re-rendering every card. */
+            typeLabel.textContent = componentHeaderLabel(comp);
             renderArrangement(song); // refresh arrangement chips (#161)
             renderPreview(song);
         });
 
-        /* Label for clarity. */
+        /* Header label — type + optional number, not the generic
+           "Component N" position we used to show (#491). */
         var typeLabel = document.createElement('span');
         typeLabel.className = 'fw-semibold me-auto';
-        typeLabel.textContent = 'Component ' + (index + 1);
+        typeLabel.textContent = componentHeaderLabel(comp);
+
+        /* Keep label in sync when the user changes the type dropdown. */
+        typeSelect.addEventListener('change', function () {
+            typeLabel.textContent = componentHeaderLabel(comp);
+        });
 
         /* ---- Action buttons (move up, move down, remove) ---- */
         var btnGroup = document.createElement('div');
@@ -803,12 +814,10 @@ function renderComponents(song) {
 
         var textarea = document.createElement('textarea');
         textarea.className = 'form-control component-lyrics';
-        textarea.rows = 4;
+        textarea.rows = 1;  /* Seed at minimum; autoResizeTextarea grows it to content (#490). */
         textarea.placeholder = 'Enter lyrics here...';
         /* Convert lines array to newline-separated string for editing (#244). */
         textarea.value = Array.isArray(comp.lines) ? comp.lines.join('\n') : '';
-        /* Auto-resize: adjust height to content. */
-        autoResizeTextarea(textarea);
         /* Live-bind lyrics changes — split back into lines array on every edit. */
         textarea.addEventListener('input', function () {
             comp.lines = textarea.value.split('\n');
@@ -825,6 +834,55 @@ function renderComponents(song) {
 
         /* Add the card to the container. */
         container.appendChild(card);
+    });
+
+    /* Auto-size every textarea we just inserted (#490).
+       Must be called AFTER the cards are in the DOM — `scrollHeight`
+       on a detached or `display:none` textarea returns 0, which left
+       the boxes stuck at one line on initial load even when they held
+       several lines of lyrics. The tab-shown hook installed once at
+       boot (see below) re-fits them when the Structure tab is opened
+       from a hidden state. */
+    fitAllComponentTextareas(container);
+}
+
+/**
+ * componentHeaderLabel(comp)
+ * --------------------------
+ * Render the human-friendly heading for a component card (#491):
+ *   { type: "chorus", number: 0|null }   → "Chorus"
+ *   { type: "verse",  number: 2 }        → "Verse 2"
+ *   { type: "bridge", number: 1 }        → "Bridge 1"   (kept — author explicitly set it)
+ *
+ * A null / empty / non-positive number is treated as "no number" and
+ * suppressed. We no longer prefix every card with "Component N"
+ * where N was just the row position — the type already names the
+ * row, and the row's vertical order already encodes the position.
+ *
+ * @param {{type:string, number:(number|null|string)}} comp
+ * @returns {string}
+ */
+function componentHeaderLabel(comp) {
+    var type = (comp && comp.type) ? String(comp.type) : 'verse';
+    var cap = type.charAt(0).toUpperCase() + type.slice(1);
+    var n = comp && comp.number;
+    var num = (n != null && n !== '' && !isNaN(n) && parseInt(n, 10) > 0)
+        ? parseInt(n, 10)
+        : null;
+    return num != null ? (cap + ' ' + num) : cap;
+}
+
+/**
+ * fitAllComponentTextareas(scope)
+ * -------------------------------
+ * Run autoResizeTextarea() on every `.component-lyrics` textarea
+ * inside `scope` (defaults to the document). Safe to call at any
+ * time — no-op on nodes whose computed size reports 0 (still hidden).
+ */
+function fitAllComponentTextareas(scope) {
+    var root = scope || document;
+    root.querySelectorAll('.component-lyrics').forEach(function (ta) {
+        autoResizeTextarea(ta);
     });
 }
 
@@ -974,13 +1032,13 @@ function autoResizeTextarea(el) {
  * @returns {string} Human-readable label.
  */
 function getComponentLabel(comp) {
-    /* Refrain is an alias for Chorus in the UI */
-    var type = comp.type === 'refrain' ? 'chorus' : comp.type;
-    var label = type.charAt(0).toUpperCase() + type.slice(1);
-    if (comp.number != null) {
-        label += ' ' + comp.number;
-    }
-    return label;
+    /* Refrain is an alias for Chorus in the UI; otherwise delegate
+       to the shared componentHeaderLabel helper so every chip /
+       card / preview heading says the same thing (#491). */
+    var normalised = Object.assign({}, comp, {
+        type: comp.type === 'refrain' ? 'chorus' : comp.type,
+    });
+    return componentHeaderLabel(normalised);
 }
 
 /**
@@ -1930,11 +1988,14 @@ function renderPreview(song) {
         /* Component label, e.g. "Verse 1" or "Chorus". Refrain → Chorus alias. */
         var heading = document.createElement('h6');
         heading.className = 'mt-3 mb-1 fw-bold text-uppercase small';
-        var displayType = comp.type === 'refrain' ? 'chorus' : (comp.type || 'Section');
-        var headingText = displayType;
-        if (comp.number != null) {
-            headingText += ' ' + comp.number;
-        }
+        /* Use the shared labelling helper so the Preview heading
+           matches the Structure-tab card heading exactly (#491):
+           no generic "Component N"; number is suppressed when
+           unset or zero. */
+        var previewComp = Object.assign({}, comp, {
+            type: comp.type === 'refrain' ? 'chorus' : comp.type,
+        });
+        var headingText = componentHeaderLabel(previewComp);
         heading.textContent = headingText;
 
         /* Lyrics block. */
@@ -2173,57 +2234,154 @@ function setChecked(elementId, checked) {
     }
 }
 
+/* ----------------------------------------------------------------------
+ * Language / Script / Region lookup tables (#489)
+ *
+ * The editor's three language inputs now display **full names** by
+ * default — the average admin doesn't know that "Latn" is Latin or
+ * that "cy" is Welsh. Each table is keyed by ISO code (which is what
+ * MySQL actually stores, as part of the composed IETF BCP 47 tag) and
+ * maps to the human-friendly name shown in the input.
+ *
+ * Keep in lock-step with the <datalist> options in index.php — an
+ * option in the markup but absent from this table would resolve back
+ * to its code on save (harmless but uglier).
+ * ---------------------------------------------------------------------- */
+var LANG_CODE_TO_NAME = {
+    en:'English', fr:'French', de:'German', es:'Spanish', it:'Italian',
+    pt:'Portuguese', la:'Latin', cy:'Welsh', gd:'Scottish Gaelic',
+    ga:'Irish', nl:'Dutch', sv:'Swedish', no:'Norwegian', da:'Danish',
+    fi:'Finnish', pl:'Polish', cs:'Czech', hu:'Hungarian', ro:'Romanian',
+    ko:'Korean', ja:'Japanese', zh:'Chinese', ar:'Arabic', he:'Hebrew',
+    hi:'Hindi', sw:'Swahili', zu:'Zulu', xh:'Xhosa', af:'Afrikaans',
+    tl:'Tagalog',
+};
+var SCRIPT_CODE_TO_NAME = {
+    Latn:'Latin', Cyrl:'Cyrillic', Arab:'Arabic', Hebr:'Hebrew',
+    Deva:'Devanagari', Hans:'Simplified Chinese', Hant:'Traditional Chinese',
+    Hang:'Hangul', Kana:'Katakana', Grek:'Greek', Geor:'Georgian',
+    Armn:'Armenian', Thai:'Thai', Ethi:'Ethiopic',
+};
+var REGION_CODE_TO_NAME = {
+    GB:'United Kingdom', US:'United States', AU:'Australia', NZ:'New Zealand',
+    CA:'Canada', IE:'Ireland', ZA:'South Africa', FR:'France', DE:'Germany',
+    AT:'Austria', CH:'Switzerland', ES:'Spain', MX:'Mexico', IT:'Italy',
+    PT:'Portugal', BR:'Brazil', NL:'Netherlands', SE:'Sweden', NO:'Norway',
+    DK:'Denmark', FI:'Finland', PL:'Poland', CZ:'Czechia', HU:'Hungary',
+    RO:'Romania', KR:'South Korea', JP:'Japan', CN:'China', TW:'Taiwan',
+    IN:'India', PH:'Philippines', KE:'Kenya', NG:'Nigeria', GH:'Ghana',
+};
+
+/* Pre-compute reverse maps (lowercased name → code) for lookup. */
+var _LANG_NAME_TO_CODE = _flipLangMap(LANG_CODE_TO_NAME);
+var _SCRIPT_NAME_TO_CODE = _flipLangMap(SCRIPT_CODE_TO_NAME);
+var _REGION_NAME_TO_CODE = _flipLangMap(REGION_CODE_TO_NAME);
+
+function _flipLangMap(src) {
+    var out = {};
+    Object.keys(src).forEach(function (code) {
+        out[src[code].toLowerCase()] = code;
+    });
+    return out;
+}
+
+/**
+ * Resolve a free-text input value to its canonical ISO code.
+ * Accepts either the full name ("English", case-insensitive) or the
+ * bare code ("en"). Returns the input unchanged if it can't be
+ * resolved — we don't want to silently discard a value the admin
+ * deliberately typed for a language we don't yet list.
+ *
+ * @param {string} value   Raw value from a language/script/region input
+ * @param {"language"|"script"|"region"} dim
+ * @returns {string} ISO code (or original value if not recognised)
+ */
+function resolveLangCode(value, dim) {
+    var v = (value || '').trim();
+    if (!v) return '';
+    var lower = v.toLowerCase();
+    var nameMap = dim === 'language' ? _LANG_NAME_TO_CODE
+                : dim === 'script'   ? _SCRIPT_NAME_TO_CODE
+                : dim === 'region'   ? _REGION_NAME_TO_CODE
+                : {};
+    if (nameMap[lower] != null) return nameMap[lower];
+
+    /* Fall through to code-normalisation. The datalist no longer
+       offers raw codes, but power users may still type them. */
+    if (dim === 'language') return lower.toLowerCase();
+    if (dim === 'region')   return v.toUpperCase();
+    if (dim === 'script') {
+        return v.length > 0
+            ? v.charAt(0).toUpperCase() + v.slice(1).toLowerCase()
+            : '';
+    }
+    return v;
+}
+
+/**
+ * Convert an ISO code back to its full display name, falling back to
+ * the code itself (useful for inputs populated from existing songs
+ * with codes the lookup table doesn't yet know).
+ */
+function resolveLangName(code, dim) {
+    var map = dim === 'language' ? LANG_CODE_TO_NAME
+            : dim === 'script'   ? SCRIPT_CODE_TO_NAME
+            : dim === 'region'   ? REGION_CODE_TO_NAME
+            : {};
+    return map[code] != null ? map[code] : (code || '');
+}
+
 /**
  * parseIetfTag(tag)
  * -----------------
- * Splits an IETF BCP 47 language tag into its constituent parts.
- * Format: language[-Script][-REGION]
- *   - language: 2-3 lowercase letters (ISO 639)
- *   - Script:   4 letters, title-case (ISO 15924) — optional
- *   - REGION:   2 uppercase letters (ISO 3166-1) — optional
+ * Splits an IETF BCP 47 language tag into its constituent parts,
+ * mapping each code to its human-friendly display name (#489). The
+ * returned values are what the three editor inputs should show.
  *
  * @param {string} tag - e.g. "en", "en-GB", "zh-Hant-TW"
  * @returns {{ language: string, script: string, region: string }}
+ *          display names (e.g. "English", "Latin", "United Kingdom")
  */
 function parseIetfTag(tag) {
     var parts = (tag || 'en').split('-');
-    var result = { language: parts[0] || 'en', script: '', region: '' };
+    var langCode = parts[0] || 'en';
+    var scriptCode = '';
+    var regionCode = '';
 
     for (var i = 1; i < parts.length; i++) {
         var p = parts[i];
-        /* Script: exactly 4 chars, first uppercase (e.g. Latn, Cyrl) */
         if (p.length === 4 && /^[A-Z][a-z]{3}$/.test(p)) {
-            result.script = p;
-        /* Region: exactly 2 uppercase chars (e.g. GB, US) */
+            scriptCode = p;
         } else if (p.length === 2 && /^[A-Z]{2}$/.test(p)) {
-            result.region = p;
+            regionCode = p;
         }
     }
-    return result;
+
+    return {
+        language: resolveLangName(langCode,  'language'),
+        script:   resolveLangName(scriptCode,'script'),
+        region:   resolveLangName(regionCode,'region'),
+    };
 }
 
 /**
  * composeIetfTag()
  * ----------------
- * Reads the three language sub-fields from the DOM and composes
- * the IETF BCP 47 tag. Updates the hidden edit-language field
- * and the preview element.
+ * Reads the three language sub-fields from the DOM (which carry full
+ * names after #489), resolves each back to an ISO code, and composes
+ * the IETF BCP 47 tag. Updates the hidden edit-language field and
+ * the preview element.
  *
  * @returns {string} The composed IETF tag (e.g. "en-Latn-GB")
  */
 function composeIetfTag() {
-    var lang   = (getVal('edit-lang-language') || 'en').trim().toLowerCase();
-    var script = (getVal('edit-lang-script') || '').trim();
-    var region = (getVal('edit-lang-region') || '').trim().toUpperCase();
+    var langCode   = resolveLangCode(getVal('edit-lang-language'), 'language') || 'en';
+    var scriptCode = resolveLangCode(getVal('edit-lang-script'),   'script');
+    var regionCode = resolveLangCode(getVal('edit-lang-region'),   'region');
 
-    /* Normalise script to title case (e.g. "latn" → "Latn") */
-    if (script.length > 0) {
-        script = script.charAt(0).toUpperCase() + script.slice(1).toLowerCase();
-    }
-
-    var tag = lang;
-    if (script) tag += '-' + script;
-    if (region) tag += '-' + region;
+    var tag = langCode;
+    if (scriptCode) tag += '-' + scriptCode;
+    if (regionCode) tag += '-' + regionCode;
 
     /* Update the hidden field and preview. */
     setVal('edit-language', tag);
@@ -2286,7 +2444,8 @@ function clearEditForm() {
     setVal('edit-ccli', '');
     setVal('edit-iswc', '');           /* #497 */
     setVal('edit-tune-name', '');      /* #497 */
-    setVal('edit-lang-language', 'en');
+    /* Default to the display name not the raw code (#489). */
+    setVal('edit-lang-language', resolveLangName('en', 'language'));
     setVal('edit-lang-script', '');
     setVal('edit-lang-region', '');
     composeIetfTag();
@@ -2683,6 +2842,17 @@ function init() {
 
     /* Bind translation controls (#352). */
     initTranslationControls();
+
+    /* Structure tab is display:none until its Bootstrap tab is opened,
+       so scrollHeight reads 0 on any component textarea fitted while
+       the tab is hidden. Listen for shown.bs.tab and re-fit once the
+       browser actually lays the panel out (#490). */
+    var structureTab = document.getElementById('tab-structure');
+    if (structureTab) {
+        structureTab.addEventListener('shown.bs.tab', function () {
+            fitAllComponentTextareas();
+        });
+    }
 
     /* Register the beforeunload handler for unsaved-changes protection. */
     window.addEventListener('beforeunload', warnBeforeUnload);

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -513,6 +513,8 @@ function selectSong(songId) {
     setVal('edit-number', song.number || '');
     setVal('edit-songbook', song.songbook || '');
     setVal('edit-ccli', song.ccli || '');
+    setVal('edit-iswc', song.iswc || '');            /* #497 */
+    setVal('edit-tune-name', song.tuneName || '');   /* #497 */
     /* Parse IETF BCP 47 tag into sub-fields (#240). */
     var ietf = parseIetfTag(song.language || 'en');
     setVal('edit-lang-language', ietf.language);
@@ -531,13 +533,16 @@ function selectSong(songId) {
     /* Render the arrangement editor (#161). */
     renderArrangement(song);
 
-    /* Render the writers list. */
+    /* Render all five credit chip lists — writers + composers are
+       long-standing; arrangers / adaptors / translators are the new
+       #497 collections. */
     renderWriters(song);
-
-    /* Render the composers list. */
     renderComposers(song);
+    renderArrangers(song);    /* #497 */
+    renderAdaptors(song);     /* #497 */
+    renderTranslators(song);  /* #497 */
 
-    /* Render the translations panel (#352). */
+    /* Render the translations (cross-song link) panel (#352). */
     renderTranslations(song);
 
     /* Render the copyright textarea. */
@@ -566,10 +571,12 @@ function selectSong(songId) {
 function bindMetadataListeners() {
     /* List of text/select field IDs mapped to their corresponding song-object keys. */
     var fields = [
-        { elId: 'edit-title',    key: 'title' },
-        { elId: 'edit-number',   key: 'number' },
-        { elId: 'edit-songbook', key: 'songbook' },
-        { elId: 'edit-ccli',     key: 'ccli' },
+        { elId: 'edit-title',     key: 'title' },
+        { elId: 'edit-number',    key: 'number' },
+        { elId: 'edit-songbook',  key: 'songbook' },
+        { elId: 'edit-ccli',      key: 'ccli' },
+        { elId: 'edit-iswc',      key: 'iswc' },        /* #497 */
+        { elId: 'edit-tune-name', key: 'tuneName' },    /* #497 */
         { elId: 'edit-copyright', key: 'copyright' }
     ];
 
@@ -1399,6 +1406,59 @@ function renderComposers(song) {
     container.appendChild(addBtn);
 }
 
+/* ----------------------------------------------------------------------
+ * Arrangers / Adaptors / Translators (#497)
+ *
+ * Three sibling credit collections that follow the same rendering
+ * pattern as writers/composers. We factor the per-collection logic
+ * through a tiny helper so adding future credit types (e.g. producers)
+ * is a one-line change.
+ *
+ * Note on naming: `renderTranslators` (here) drives the chip list of
+ * the *people* who translated this song's lyrics. `renderTranslations`
+ * (below) drives the #352 cross-song link list — different feature.
+ * ---------------------------------------------------------------------- */
+
+function renderCreditChipList(song, key, containerId, addLabel) {
+    var container = document.getElementById(containerId);
+    if (!container) return;
+    if (!Array.isArray(song[key])) song[key] = [];
+    container.innerHTML = '';
+
+    song[key].forEach(function (name, i) {
+        var row = createDynamicInputRow(
+            name,
+            function (newVal) { song[key][i] = newVal; markModified(song.id); },
+            function ()       { song[key].splice(i, 1); markModified(song.id);
+                                renderCreditChipList(song, key, containerId, addLabel); }
+        );
+        container.appendChild(row);
+    });
+
+    var addBtn = document.createElement('button');
+    addBtn.type = 'button';
+    addBtn.className = 'btn btn-sm btn-outline-primary mt-2';
+    addBtn.textContent = '+ ' + addLabel;
+    addBtn.addEventListener('click', function () {
+        song[key].push('');
+        markModified(song.id);
+        renderCreditChipList(song, key, containerId, addLabel);
+    });
+    container.appendChild(addBtn);
+}
+
+function renderArrangers(song) {
+    renderCreditChipList(song, 'arrangers',   'arrangers-container',   'Add Arranger');
+}
+
+function renderAdaptors(song) {
+    renderCreditChipList(song, 'adaptors',    'adaptors-container',    'Add Adaptor');
+}
+
+function renderTranslators(song) {
+    renderCreditChipList(song, 'translators', 'translators-container', 'Add Translator');
+}
+
 /**
  * renderTranslations(song)
  * ------------------------
@@ -2224,6 +2284,8 @@ function clearEditForm() {
     setVal('edit-number', '');
     setVal('edit-songbook', '');
     setVal('edit-ccli', '');
+    setVal('edit-iswc', '');           /* #497 */
+    setVal('edit-tune-name', '');      /* #497 */
     setVal('edit-lang-language', 'en');
     setVal('edit-lang-script', '');
     setVal('edit-lang-region', '');
@@ -2366,6 +2428,8 @@ function addNewSong() {
         songbookName: '',
         language: 'en',
         ccli: '',
+        iswc: '',           /* #497 */
+        tuneName: '',       /* #497 */
         copyright: '',
         verified: false,
         lyricsPublicDomain: false,
@@ -2374,6 +2438,9 @@ function addNewSong() {
         hasSheetMusic: false,
         writers: [],
         composers: [],
+        arrangers: [],      /* #497 */
+        adaptors: [],       /* #497 */
+        translators: [],    /* #497 */
         components: [
             {
                 type: 'verse',

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -545,6 +545,11 @@ function selectSong(songId) {
     /* Render the translations (cross-song link) panel (#352). */
     renderTranslations(song);
 
+    /* Fetch + render this song's tags (#496). Async — the chip list
+       shows "Loading…" until the fetch resolves; failures keep the
+       list empty rather than blocking the whole editor. */
+    loadSongTags(song);
+
     /* Render the copyright textarea. */
     setVal('edit-copyright', song.copyright || '');
 
@@ -1785,6 +1790,255 @@ function renderAdaptors(song) {
 
 function renderTranslators(song) {
     renderCreditChipList(song, 'translators', 'translators-container', 'Add Translator');
+}
+
+/* ----------------------------------------------------------------------
+ * Tags tab (#496)
+ *
+ * Fetches the current song's assigned tags from /api?action=song_tags,
+ * renders them as a chip list with × remove buttons, and wires up a
+ * live-search / create input via /api?action=tag_search. Adds/removes
+ * hit /api?action=bulk_tag with a single-songId payload — the same
+ * endpoint used by the bulk tagging tool elsewhere.
+ *
+ * Tag writes are immediate (no "Save" needed) because the editor save
+ * contract is per-song for tblSongs + its direct children; tag maps
+ * live in tblSongTagMap, outside the save_song flow, and should
+ * persist the moment the admin clicks.
+ * ---------------------------------------------------------------------- */
+
+/**
+ * Fetch + render tags for the given song. Idempotent.
+ */
+function loadSongTags(song) {
+    var container = document.getElementById('song-tags-container');
+    if (!container || !song || !song.id) return;
+    container.innerHTML = '<span class="text-muted small">Loading…</span>';
+
+    fetch(EDITOR_API_URL + '?action=song_tags&id=' + encodeURIComponent(song.id))
+        .then(function (r) { return r.json(); })
+        .then(function (data) {
+            var tags = Array.isArray(data.tags) ? data.tags : [];
+            /* Cache on the song object so other UI (e.g. preview) can
+               read without a second fetch. */
+            song._tags = tags;
+            renderSongTagsChips(song, tags);
+        })
+        .catch(function (err) {
+            console.error('[tags] load failed', err);
+            container.innerHTML = '<span class="text-danger small">Failed to load tags.</span>';
+        });
+}
+
+function renderSongTagsChips(song, tags) {
+    var container = document.getElementById('song-tags-container');
+    if (!container) return;
+    container.innerHTML = '';
+
+    if (!tags.length) {
+        container.innerHTML = '<span class="text-muted small">No tags yet — add one below.</span>';
+        return;
+    }
+
+    tags.forEach(function (tag) {
+        var chip = document.createElement('span');
+        chip.className = 'badge rounded-pill d-inline-flex align-items-center gap-1';
+        chip.style.backgroundColor = '#6366f1';  /* accent-solid */
+        chip.style.color = '#ffffff';
+        chip.style.padding = '0.35rem 0.6rem';
+        chip.title = tag.description || tag.name;
+
+        var label = document.createElement('span');
+        label.textContent = tag.name;
+        chip.appendChild(label);
+
+        var x = document.createElement('button');
+        x.type = 'button';
+        x.className = 'btn-close btn-close-white';
+        x.setAttribute('aria-label', 'Remove tag');
+        x.style.fontSize = '0.55rem';
+        x.style.marginLeft = '0.25rem';
+        x.addEventListener('click', function (e) {
+            e.stopPropagation();
+            removeSongTag(song, tag.name);
+        });
+        chip.appendChild(x);
+
+        container.appendChild(chip);
+    });
+}
+
+/**
+ * POST bulk_tag to add a single tag to the current song.
+ */
+function addSongTag(song, tagName) {
+    if (!song || !song.id || !tagName || !tagName.trim()) return;
+    tagName = tagName.trim();
+
+    /* Optimistic update: append the chip locally so the UI feels
+       snappy, then re-fetch on completion to pick up the real row
+       (so the ×-remove later uses the canonical spelling the DB
+       ended up with, not the user's input casing). */
+    var existing = song._tags || [];
+    if (existing.some(function (t) { return t.name.toLowerCase() === tagName.toLowerCase(); })) {
+        showToast('Already tagged with "' + tagName + '".', 'info');
+        return;
+    }
+
+    fetch(EDITOR_API_URL + '?action=bulk_tag', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ songIds: [song.id], add: [tagName], remove: [] }),
+    })
+    .then(function (r) { return r.json(); })
+    .then(function (data) {
+        if (data && data.added != null) {
+            loadSongTags(song);
+            showToast('Added tag "' + tagName + '".', 'success');
+        } else {
+            showToast((data && data.error) || 'Failed to add tag.', 'danger');
+        }
+    })
+    .catch(function (err) {
+        console.error('[tags] add failed', err);
+        showToast('Failed to add tag.', 'danger');
+    });
+}
+
+function removeSongTag(song, tagName) {
+    if (!song || !song.id || !tagName) return;
+    fetch(EDITOR_API_URL + '?action=bulk_tag', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ songIds: [song.id], add: [], remove: [tagName] }),
+    })
+    .then(function (r) { return r.json(); })
+    .then(function () {
+        loadSongTags(song);
+        showToast('Removed tag "' + tagName + '".', 'info');
+    })
+    .catch(function (err) {
+        console.error('[tags] remove failed', err);
+        showToast('Failed to remove tag.', 'danger');
+    });
+}
+
+/**
+ * Wire the tag-search autocomplete input. Idempotent — safe to call
+ * multiple times; a `_tagsWired` flag on the input prevents duplicate
+ * listeners.
+ */
+function bindTagSearchInput() {
+    var input = document.getElementById('song-tag-input');
+    var panel = document.getElementById('song-tag-suggestions');
+    if (!input || !panel || input._tagsWired) return;
+    input._tagsWired = true;
+
+    var debounceTimer = null;
+    var activeIdx = -1;
+    var currentSuggestions = [];
+
+    function closePanel() {
+        panel.classList.add('d-none');
+        panel.innerHTML = '';
+        activeIdx = -1;
+        currentSuggestions = [];
+    }
+
+    function renderSuggestions(suggestions, q) {
+        panel.innerHTML = '';
+        currentSuggestions = suggestions;
+        activeIdx = -1;
+
+        /* "Create new tag" affordance when the query doesn't exactly
+           match an existing name. */
+        var exact = suggestions.some(function (s) {
+            return s.name.toLowerCase() === q.toLowerCase();
+        });
+        if (q && !exact) {
+            var createItem = document.createElement('button');
+            createItem.type = 'button';
+            createItem.className = 'list-group-item list-group-item-action d-flex align-items-center gap-2';
+            createItem.innerHTML = '<i class="bi bi-plus-circle"></i> Create new tag: <strong>' +
+                escapeHtmlSafe(q) + '</strong>';
+            createItem.addEventListener('click', function () {
+                var song = findSongById(currentSongId);
+                if (song) addSongTag(song, q);
+                input.value = '';
+                closePanel();
+            });
+            panel.appendChild(createItem);
+        }
+
+        suggestions.forEach(function (s) {
+            var item = document.createElement('button');
+            item.type = 'button';
+            item.className = 'list-group-item list-group-item-action d-flex justify-content-between align-items-center';
+            item.innerHTML =
+                '<span>' + escapeHtmlSafe(s.name) + '</span>' +
+                '<span class="badge bg-secondary">' + s.usage + '</span>';
+            item.addEventListener('click', function () {
+                var song = findSongById(currentSongId);
+                if (song) addSongTag(song, s.name);
+                input.value = '';
+                closePanel();
+            });
+            panel.appendChild(item);
+        });
+
+        panel.classList.toggle('d-none', panel.children.length === 0);
+    }
+
+    function fetchSuggestions(q) {
+        fetch(EDITOR_API_URL + '?action=tag_search&q=' + encodeURIComponent(q || ''))
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                renderSuggestions(Array.isArray(data.suggestions) ? data.suggestions : [], q);
+            })
+            .catch(function (err) {
+                console.error('[tags] search failed', err);
+                closePanel();
+            });
+    }
+
+    input.addEventListener('input', function () {
+        clearTimeout(debounceTimer);
+        var q = input.value.trim();
+        debounceTimer = setTimeout(function () { fetchSuggestions(q); }, 180);
+    });
+
+    input.addEventListener('focus', function () {
+        if (!input.value) fetchSuggestions('');
+    });
+
+    input.addEventListener('keydown', function (e) {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            /* Plain Enter on a non-empty input creates/adds the tag. */
+            var q = input.value.trim();
+            if (!q) return;
+            var song = findSongById(currentSongId);
+            if (song) addSongTag(song, q);
+            input.value = '';
+            closePanel();
+        } else if (e.key === 'Escape') {
+            closePanel();
+        }
+    });
+
+    /* Click outside to dismiss. */
+    document.addEventListener('click', function (e) {
+        if (!panel.contains(e.target) && e.target !== input) {
+            closePanel();
+        }
+    });
+}
+
+/** Tiny HTML-escape helper for inline suggestion markup. */
+function escapeHtmlSafe(s) {
+    return String(s || '').replace(/[&<>"']/g, function (c) {
+        return { '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' }[c];
+    });
 }
 
 /**
@@ -3123,6 +3377,9 @@ function init() {
             fitAllComponentTextareas();
         });
     }
+
+    /* Wire the Tags tab autocomplete input (#496). Idempotent. */
+    bindTagSearchInput();
 
     /* Register the beforeunload handler for unsaved-changes protection. */
     window.addEventListener('beforeunload', warnBeforeUnload);

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -1650,93 +1650,16 @@ function refreshArrangementPresetAvailability(song) {
  *
  * @param {Object} song - The song object.
  */
+/* Writers + Composers collapsed onto the shared chip-list helper
+   that also drives Arrangers/Adaptors/Translators (#497). All five
+   credit collections now get the #495 cross-collection autocomplete
+   for free — createDynamicInputRow() attaches a live-search popover
+   whenever a `creditKind` is passed through. */
 function renderWriters(song) {
-    /* Grab the container. */
-    var container = document.getElementById('writers-container');
-    if (!container) return;
-
-    /* Clear previous content. */
-    container.innerHTML = '';
-
-    /* Ensure the song has a writers array. */
-    if (!song.writers) song.writers = [];
-
-    /* Render one input per writer. */
-    song.writers.forEach(function (writer, i) {
-        var row = createDynamicInputRow(
-            writer,                              // current value
-            function (newVal) {                   // on change callback
-                song.writers[i] = newVal;
-                markModified(song.id);
-            },
-            function () {                         // on remove callback
-                song.writers.splice(i, 1);
-                markModified(song.id);
-                renderWriters(song);              // re-render the list
-            }
-        );
-        container.appendChild(row);
-    });
-
-    /* "Add Writer" button. */
-    var addBtn = document.createElement('button');
-    addBtn.type = 'button';
-    addBtn.className = 'btn btn-sm btn-outline-primary mt-2';
-    addBtn.textContent = '+ Add Writer';
-    addBtn.addEventListener('click', function () {
-        song.writers.push('');       // add an empty entry
-        markModified(song.id);
-        renderWriters(song);         // re-render
-    });
-    container.appendChild(addBtn);
+    renderCreditChipList(song, 'writers',   'writers-container',   'Add Writer');
 }
-
-/**
- * renderComposers(song)
- * ---------------------
- * Same pattern as renderWriters but for the composers array.
- *
- * @param {Object} song - The song object.
- */
 function renderComposers(song) {
-    /* Grab the container. */
-    var container = document.getElementById('composers-container');
-    if (!container) return;
-
-    /* Clear previous content. */
-    container.innerHTML = '';
-
-    /* Ensure the song has a composers array. */
-    if (!song.composers) song.composers = [];
-
-    /* Render one input per composer. */
-    song.composers.forEach(function (composer, i) {
-        var row = createDynamicInputRow(
-            composer,                             // current value
-            function (newVal) {                   // on change callback
-                song.composers[i] = newVal;
-                markModified(song.id);
-            },
-            function () {                         // on remove callback
-                song.composers.splice(i, 1);
-                markModified(song.id);
-                renderComposers(song);            // re-render
-            }
-        );
-        container.appendChild(row);
-    });
-
-    /* "Add Composer" button. */
-    var addBtn = document.createElement('button');
-    addBtn.type = 'button';
-    addBtn.className = 'btn btn-sm btn-outline-primary mt-2';
-    addBtn.textContent = '+ Add Composer';
-    addBtn.addEventListener('click', function () {
-        song.composers.push('');     // add an empty entry
-        markModified(song.id);
-        renderComposers(song);       // re-render
-    });
-    container.appendChild(addBtn);
+    renderCreditChipList(song, 'composers', 'composers-container', 'Add Composer');
 }
 
 /* ----------------------------------------------------------------------
@@ -1752,18 +1675,33 @@ function renderComposers(song) {
  * (below) drives the #352 cross-song link list — different feature.
  * ---------------------------------------------------------------------- */
 
+/* Map the song-object key to the credit_search `kind` (#495). Used
+   by renderCreditChipList to decorate chip inputs with the right
+   live-search popover — the endpoint unions across all five tables
+   and uses the kind only as the primary sort bias. */
+var CREDIT_KIND_FOR_KEY = {
+    writers:     'writer',
+    composers:   'composer',
+    arrangers:   'arranger',
+    adaptors:    'adaptor',
+    translators: 'translator',
+};
+
 function renderCreditChipList(song, key, containerId, addLabel) {
     var container = document.getElementById(containerId);
     if (!container) return;
     if (!Array.isArray(song[key])) song[key] = [];
     container.innerHTML = '';
 
+    var kind = CREDIT_KIND_FOR_KEY[key] || null;
+
     song[key].forEach(function (name, i) {
         var row = createDynamicInputRow(
             name,
             function (newVal) { song[key][i] = newVal; markModified(song.id); },
             function ()       { song[key].splice(i, 1); markModified(song.id);
-                                renderCreditChipList(song, key, containerId, addLabel); }
+                                renderCreditChipList(song, key, containerId, addLabel); },
+            kind
         );
         container.appendChild(row);
     });
@@ -2184,16 +2122,17 @@ function initTranslationControls() {
  * @param {Function} onRemove - Called when the remove button is clicked.
  * @returns {HTMLElement} The assembled input-group div.
  */
-function createDynamicInputRow(value, onChange, onRemove) {
+function createDynamicInputRow(value, onChange, onRemove, creditKind) {
     /* Wrapper div styled as a Bootstrap input group. */
     var row = document.createElement('div');
-    row.className = 'input-group input-group-sm mb-1';
+    row.className = 'input-group input-group-sm mb-1 position-relative credit-chip-row';
 
     /* Text input. */
     var input = document.createElement('input');
     input.type = 'text';
     input.className = 'form-control';
     input.value = value;
+    input.autocomplete = 'off';
     /* Live-bind every keystroke back to the data. */
     input.addEventListener('input', function () {
         onChange(input.value);
@@ -2213,7 +2152,104 @@ function createDynamicInputRow(value, onChange, onRemove) {
     row.appendChild(input);
     row.appendChild(removeBtn);
 
+    /* Attach the live-search popover (#495) when a credit kind is
+       passed. The popover queries /api?action=credit_search which
+       unions across all five credit tables so a "Fanny Crosby"
+       already used as a Writer surfaces when typing in Composers,
+       avoiding the dedupe drift problem described in the issue.
+
+       No-op when called without a kind (e.g. for non-credit dynamic
+       list uses), so the helper stays general. */
+    if (creditKind) {
+        attachCreditAutocomplete(input, row, creditKind, onChange);
+    }
+
     return row;
+}
+
+/**
+ * attachCreditAutocomplete(input, row, kind, onChange)
+ * ----------------------------------------------------
+ * Wire a chip input to the /api?action=credit_search endpoint so
+ * typing surfaces a popover of matching stored-canonical spellings.
+ * Clicking one rewrites the input to the exact stored form and fires
+ * onChange so the song object picks it up. Escape / click-outside
+ * dismiss; popover is constrained within the input-group row via
+ * absolute positioning so long credit lists stay readable.
+ */
+function attachCreditAutocomplete(input, row, kind, onChange) {
+    var popover = document.createElement('div');
+    popover.className = 'list-group position-absolute w-100 shadow d-none credit-suggestions-popover';
+    popover.style.zIndex = '1050';
+    popover.style.top = '100%';
+    popover.style.left = '0';
+    popover.style.maxHeight = '220px';
+    popover.style.overflowY = 'auto';
+    row.appendChild(popover);
+
+    var debounceTimer = null;
+
+    function close() {
+        popover.classList.add('d-none');
+        popover.innerHTML = '';
+    }
+
+    function render(suggestions) {
+        popover.innerHTML = '';
+        if (!suggestions.length) { close(); return; }
+        suggestions.forEach(function (s) {
+            var item = document.createElement('button');
+            item.type = 'button';
+            item.className = 'list-group-item list-group-item-action d-flex justify-content-between align-items-center py-1';
+            var kindsBadge = (s.kinds && s.kinds.length)
+                ? '<small class="text-muted">' + escapeHtmlSafe(s.kinds.join(' · ')) + '</small>'
+                : '';
+            item.innerHTML =
+                '<span><strong>' + escapeHtmlSafe(s.name) + '</strong> ' + kindsBadge + '</span>' +
+                '<span class="badge bg-secondary">' + (s.usage || 0) + '</span>';
+            item.addEventListener('click', function (e) {
+                e.preventDefault();
+                input.value = s.name;
+                onChange(s.name);
+                close();
+                input.focus();
+            });
+            popover.appendChild(item);
+        });
+        popover.classList.remove('d-none');
+    }
+
+    function fetchSuggestions(q) {
+        /* `kind=any` unions all five tables so the same spelling
+           surfaces no matter which chip list the admin is editing. */
+        var url = EDITOR_API_URL + '?action=credit_search' +
+                  '&q='    + encodeURIComponent(q) +
+                  '&kind=any&limit=12';
+        fetch(url, { credentials: 'same-origin' })
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                render(Array.isArray(data.suggestions) ? data.suggestions : []);
+            })
+            .catch(function () { close(); });
+    }
+
+    input.addEventListener('input', function () {
+        clearTimeout(debounceTimer);
+        var q = input.value.trim();
+        if (q.length < 1) { close(); return; }
+        debounceTimer = setTimeout(function () { fetchSuggestions(q); }, 180);
+    });
+
+    input.addEventListener('keydown', function (e) {
+        if (e.key === 'Escape') close();
+    });
+
+    /* Dismiss on click outside this specific row. We register a
+       delegated handler only once per row — listener is cleaned up
+       implicitly when the row is removed from the DOM. */
+    document.addEventListener('click', function (e) {
+        if (!row.contains(e.target)) close();
+    });
 }
 
 /* ========================================================================

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -1198,13 +1198,17 @@ function autoGenerateArrangement(song) {
  */
 function renderArrangement(song) {
     var chipsContainer = document.getElementById('arrangement-chips');
-    var input = document.getElementById('arrangement-input');
-    var feedback = document.getElementById('arrangement-feedback');
+    var input          = document.getElementById('arrangement-input');
+    var feedback       = document.getElementById('arrangement-feedback');
+    var pool           = document.getElementById('arrangement-pool');
+    var strip          = document.getElementById('arrangement-strip');
 
     if (!chipsContainer || !input || !feedback) return;
 
     /* Clear previous state. */
     chipsContainer.innerHTML = '';
+    if (pool)  pool.innerHTML  = '';
+    if (strip) strip.innerHTML = '';
     feedback.style.display = 'none';
     feedback.textContent = '';
 
@@ -1213,33 +1217,203 @@ function renderArrangement(song) {
         return;
     }
 
-    /* Convert arrangement to labels and show in input. */
-    var labelsStr = arrangementToLabels(song);
-    input.value = labelsStr;
+    /* Advanced text-mode mirror (kept for paste-in / power users). */
+    input.value = arrangementToLabels(song);
 
-    if (!song.arrangement || !Array.isArray(song.arrangement) || song.arrangement.length === 0) {
-        /* Show sequential order as muted chips. */
-        chipsContainer.innerHTML = '<span class="text-muted small">Sequential order (no custom arrangement)</span>';
-        return;
+    /* Legacy summary chips row — kept for at-a-glance reading, even
+       though the builder below is the interactive surface now (#492). */
+    renderArrangementSummaryChips(song, chipsContainer);
+
+    /* Drag-drop builder (#492). */
+    if (pool && strip) {
+        renderArrangementPool(song, pool, strip);
+        renderArrangementStrip(song, strip);
     }
 
-    /* Render coloured chips for each arrangement entry. */
+    /* Re-evaluate quick-action buttons for the song's component set (#493). */
+    refreshArrangementPresetAvailability(song);
+}
+
+/**
+ * Render the read-only chip summary at the top of the Arrangement
+ * block. Matches the pre-#492 look of a coloured pill row, but is now
+ * a display surface only — the interactive builder lives below.
+ */
+function renderArrangementSummaryChips(song, chipsContainer) {
+    if (!song.arrangement || !Array.isArray(song.arrangement) || song.arrangement.length === 0) {
+        chipsContainer.classList.add('d-none');
+        return;
+    }
+    chipsContainer.classList.remove('d-none');
     song.arrangement.forEach(function (idx, pos) {
         var comp = song.components[idx];
         if (!comp) return;
-
         var chip = document.createElement('span');
         chip.className = 'badge rounded-pill';
         chip.textContent = getComponentLabel(comp);
         chip.title = getComponentLabel(comp) + ' — position ' + (pos + 1);
-
-        /* Colour chips by type with WCAG-safe text contrast. */
         var colors = COMP_COLORS[comp.type] || { bg: '#6b7280', text: '#ffffff' };
         chip.style.backgroundColor = colors.bg;
         chip.style.color = colors.text;
-
         chipsContainer.appendChild(chip);
     });
+}
+
+/**
+ * Render the component pool (source chips). Clicking a pool chip
+ * appends that component to the arrangement strip.
+ */
+function renderArrangementPool(song, pool, strip) {
+    if (!Array.isArray(song.components) || song.components.length === 0) {
+        pool.innerHTML = '<span class="text-muted small">No components defined.</span>';
+        return;
+    }
+
+    song.components.forEach(function (comp, idx) {
+        var chip = makeArrangementChip(comp, /* includeRemove */ false);
+        chip.style.cursor = 'pointer';
+        chip.title = getComponentLabel(comp) + ' — click to add';
+        chip.addEventListener('click', function () {
+            appendToArrangement(song, idx);
+        });
+        pool.appendChild(chip);
+    });
+}
+
+/**
+ * Render the sequence strip. Each chip has a remove × and the whole
+ * strip is SortableJS-reorderable. Lazy-loads SortableJS on first use.
+ */
+function renderArrangementStrip(song, strip) {
+    /* Resolve the effective arrangement: explicit or sequential fallback. */
+    var indices = effectiveArrangement(song);
+
+    if (indices.length === 0) {
+        strip.innerHTML = '<span class="text-muted small">Sequence is empty — click a component above to add.</span>';
+        return;
+    }
+
+    indices.forEach(function (idx, posIdx) {
+        var comp = song.components[idx];
+        if (!comp) return;
+        var chip = makeArrangementChip(comp, /* includeRemove */ true);
+        chip.dataset.position = String(posIdx);
+        chip.dataset.compIdx  = String(idx);
+        /* Remove handler — takes the chip's live DOM position, not the
+           closed-over posIdx, so it stays accurate after a drag. */
+        chip.querySelector('.arr-chip-remove')?.addEventListener('click', function (e) {
+            e.stopPropagation();
+            var pos = Array.prototype.indexOf.call(strip.children, chip);
+            removeFromArrangement(song, pos);
+        });
+        strip.appendChild(chip);
+    });
+
+    /* SortableJS for drag-reorder. Lazy-loaded on first use. */
+    ensureSortable().then(function (Sortable) {
+        if (strip._sortable) return;
+        strip._sortable = Sortable.create(strip, {
+            animation: 160,
+            ghostClass: 'arr-chip-ghost',
+            onEnd: function () {
+                /* Rebuild song.arrangement from the strip's new order. */
+                var newOrder = [];
+                Array.prototype.forEach.call(strip.children, function (el) {
+                    if (el.dataset && el.dataset.compIdx != null) {
+                        newOrder.push(parseInt(el.dataset.compIdx, 10));
+                    }
+                });
+                var curSong = findSongById(currentSongId);
+                if (!curSong) return;
+                curSong.arrangement = newOrder;
+                markModified(curSong.id);
+                renderArrangement(curSong);
+                renderPreview(curSong);
+            },
+        });
+    }).catch(function (err) {
+        console.error('[arrangement] failed to load SortableJS:', err);
+    });
+}
+
+/**
+ * Build a coloured chip DOM node for a component. Optionally includes
+ * a ×-remove button in the right corner.
+ */
+function makeArrangementChip(comp, includeRemove) {
+    var chip = document.createElement('span');
+    chip.className = 'badge rounded-pill d-inline-flex align-items-center gap-1 arr-chip';
+    var colors = COMP_COLORS[comp.type] || { bg: '#6b7280', text: '#ffffff' };
+    chip.style.backgroundColor = colors.bg;
+    chip.style.color = colors.text;
+    chip.style.padding = '0.35rem 0.6rem';
+
+    var label = document.createElement('span');
+    label.textContent = getComponentLabel(comp);
+    chip.appendChild(label);
+
+    if (includeRemove) {
+        var x = document.createElement('button');
+        x.type = 'button';
+        x.className = 'btn-close btn-close-white arr-chip-remove';
+        x.setAttribute('aria-label', 'Remove from arrangement');
+        x.style.fontSize = '0.55rem';
+        x.style.marginLeft = '0.25rem';
+        chip.appendChild(x);
+    }
+
+    return chip;
+}
+
+function effectiveArrangement(song) {
+    if (Array.isArray(song.arrangement) && song.arrangement.length > 0) {
+        return song.arrangement.slice();
+    }
+    if (Array.isArray(song.components)) {
+        return song.components.map(function (_, i) { return i; });
+    }
+    return [];
+}
+
+function appendToArrangement(song, compIdx) {
+    var current = effectiveArrangement(song);
+    current.push(compIdx);
+    song.arrangement = current;
+    markModified(song.id);
+    renderArrangement(song);
+    renderPreview(song);
+}
+
+function removeFromArrangement(song, pos) {
+    var current = effectiveArrangement(song);
+    if (pos < 0 || pos >= current.length) return;
+    current.splice(pos, 1);
+    /* Empty list means "fall back to component order" — represent it
+       as `null` so the existing downstream logic keeps working. */
+    song.arrangement = current.length === 0 ? null : current;
+    markModified(song.id);
+    renderArrangement(song);
+    renderPreview(song);
+}
+
+/* ------------------------------------------------------------------
+ * SortableJS lazy loader — same pattern as /js/modules/card-layout.js,
+ * duplicated here because editor.js is a classic script and can't
+ * import the ES-module version.
+ * ------------------------------------------------------------------ */
+var _arrSortablePromise = null;
+function ensureSortable() {
+    if (window.Sortable) return Promise.resolve(window.Sortable);
+    if (_arrSortablePromise) return _arrSortablePromise;
+    _arrSortablePromise = new Promise(function (resolve, reject) {
+        var s = document.createElement('script');
+        s.src = 'https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js';
+        s.crossOrigin = 'anonymous';
+        s.onload  = function () { resolve(window.Sortable); };
+        s.onerror = function () { reject(new Error('SortableJS load failed')); };
+        document.head.appendChild(s);
+    });
+    return _arrSortablePromise;
 }
 
 /**
@@ -1324,27 +1498,17 @@ function bindArrangementListeners() {
         });
     }
 
-    /* Auto-generate button (chorus after each verse). */
-    var btnAuto = document.getElementById('btnArrangementAuto');
-    if (btnAuto) {
-        btnAuto.addEventListener('click', function () {
+    /* Preset quick-action buttons (#493). Delegated click handler on
+       any `.arrangement-preset` so adding new presets is a markup-only
+       change — each button carries its preset name in data-preset. */
+    document.querySelectorAll('.arrangement-preset').forEach(function (btn) {
+        btn.addEventListener('click', function () {
             if (!currentSongId) return;
             var song = findSongById(currentSongId);
             if (!song) return;
-
-            var arrangement = autoGenerateArrangement(song);
-            if (arrangement === null) {
-                showToast('No chorus found to auto-arrange.', 'warning');
-                return;
-            }
-
-            song.arrangement = arrangement;
-            markModified(song.id);
-            renderArrangement(song);
-            renderPreview(song);
-            showToast('Arrangement auto-generated.', 'success');
+            applyArrangementPreset(song, btn.dataset.preset);
         });
-    }
+    });
 
     /* Sequential / clear button. */
     var btnSeq = document.getElementById('btnArrangementSequential');
@@ -1358,9 +1522,115 @@ function bindArrangementListeners() {
             markModified(song.id);
             renderArrangement(song);
             renderPreview(song);
-            showToast('Arrangement cleared — sequential order.', 'info');
+            showToast('Arrangement cleared — using component order.', 'info');
         });
     }
+}
+
+/* ========================================================================
+ *  Arrangement presets (#493)
+ *  --------------------------------------------------------------------
+ *  Each preset consumes the song's components array and returns an
+ *  index array. Presets must NEVER throw — they're responsible for
+ *  checking their own prerequisites (which also feed the UI's
+ *  enable/disable logic via the data-requires attribute). Returning
+ *  null means "can't apply — show a toast explaining why".
+ * ======================================================================== */
+function applyArrangementPreset(song, presetName) {
+    var fn = ARRANGEMENT_PRESETS[presetName];
+    if (!fn) {
+        showToast('Unknown arrangement preset: ' + presetName, 'warning');
+        return;
+    }
+    var arrangement = fn(song);
+    if (!arrangement) {
+        showToast('This song is missing a component type needed for that pattern.', 'warning');
+        return;
+    }
+    song.arrangement = arrangement;
+    markModified(song.id);
+    renderArrangement(song);
+    renderPreview(song);
+    showToast('Arrangement set: ' + presetName.replace(/-/g, ' ') + '.', 'success');
+}
+
+var ARRANGEMENT_PRESETS = {
+    'chorus-after-each-verse': function (song) {
+        return autoGenerateArrangement(song);
+    },
+
+    'verses-only': function (song) {
+        var verses = componentIdxByType(song, 'verse');
+        return verses.length > 0 ? verses : null;
+    },
+
+    'verse-prechorus-chorus': function (song) {
+        var verses  = componentIdxByType(song, 'verse');
+        var preIdx  = firstIndexOfType(song, 'pre-chorus');
+        var choIdx  = firstIndexOfType(song, 'chorus', /* alias */ 'refrain');
+        if (!verses.length || preIdx < 0 || choIdx < 0) return null;
+        var arr = [];
+        verses.forEach(function (v) { arr.push(v); arr.push(preIdx); arr.push(choIdx); });
+        return arr;
+    },
+
+    'verse-bridge-verse': function (song) {
+        var verses = componentIdxByType(song, 'verse');
+        var brIdx  = firstIndexOfType(song, 'bridge');
+        if (verses.length < 2 || brIdx < 0) return null;
+        /* Common shape: all-but-last verse · bridge · final verse. */
+        var arr = verses.slice(0, -1);
+        arr.push(brIdx);
+        arr.push(verses[verses.length - 1]);
+        return arr;
+    },
+
+    'intro-verses-outro': function (song) {
+        var intro  = firstIndexOfType(song, 'intro');
+        var outro  = firstIndexOfType(song, 'outro');
+        var verses = componentIdxByType(song, 'verse');
+        if (intro < 0 || outro < 0 || !verses.length) return null;
+        return [intro].concat(verses).concat([outro]);
+    },
+};
+
+function componentIdxByType(song, type) {
+    var out = [];
+    (song.components || []).forEach(function (c, i) { if (c.type === type) out.push(i); });
+    return out;
+}
+function firstIndexOfType(song, type, aliasType) {
+    var comps = song.components || [];
+    for (var i = 0; i < comps.length; i++) {
+        if (comps[i].type === type || (aliasType && comps[i].type === aliasType)) return i;
+    }
+    return -1;
+}
+
+/**
+ * Enable / disable each preset button based on whether its data-requires
+ * component types are all present in the current song (#493). Disabled
+ * buttons get a tooltip explaining which type is missing, so the UI
+ * never silently no-ops.
+ */
+function refreshArrangementPresetAvailability(song) {
+    var types = new Set((song.components || []).map(function (c) {
+        /* Refrain is an alias for chorus everywhere else. */
+        return c.type === 'refrain' ? 'chorus' : c.type;
+    }));
+    document.querySelectorAll('.arrangement-preset').forEach(function (btn) {
+        var req = (btn.dataset.requires || '').split(',').map(function (s) { return s.trim(); }).filter(Boolean);
+        var missing = req.filter(function (t) { return !types.has(t); });
+        if (missing.length === 0) {
+            btn.disabled = false;
+            btn.title = btn.dataset.origTitle || btn.title;
+            if (!btn.dataset.origTitle) btn.dataset.origTitle = btn.title;
+        } else {
+            if (!btn.dataset.origTitle) btn.dataset.origTitle = btn.title;
+            btn.disabled = true;
+            btn.title = 'Needs: ' + missing.join(', ') + ' (not in this song).';
+        }
+    });
 }
 
 /* ========================================================================

--- a/appWeb/public_html/manage/editor/index.php
+++ b/appWeb/public_html/manage/editor/index.php
@@ -463,6 +463,22 @@ $currentUser = getCurrentUser();
                         </button>
                     </li>
 
+                    <!-- Tags tab trigger (#496) -->
+                    <li class="nav-item" role="presentation">
+                        <button
+                            class="nav-link"
+                            id="tab-tags"
+                            data-bs-toggle="tab"
+                            data-bs-target="#panel-tags"
+                            type="button"
+                            role="tab"
+                            aria-controls="panel-tags"
+                            aria-selected="false"
+                        >
+                            <i class="bi bi-tags me-1"></i>Tags
+                        </button>
+                    </li>
+
                     <!-- Preview tab trigger -->
                     <li class="nav-item" role="presentation">
                         <button
@@ -1089,6 +1105,63 @@ $currentUser = getCurrentUser();
                         </div>
                     </div>
                     <!-- END Credits Tab Panel -->
+
+
+                    <!-- -------------------------------------------------
+                         TAGS TAB PANEL (#496)
+                         Per-song tag assignment. Chips show current tags
+                         (× to remove). Autocomplete input searches
+                         tblSongTags; typing a brand-new name + Enter
+                         creates the tag. Writes go straight to MySQL
+                         via /api?action=bulk_tag (single-songId call).
+                         ------------------------------------------------- -->
+                    <div
+                        class="tab-pane fade"
+                        id="panel-tags"
+                        role="tabpanel"
+                        aria-labelledby="tab-tags"
+                    >
+                        <div class="form-section">
+                            <h6 class="section-title">
+                                <i class="bi bi-tags me-1"></i>Tags &amp; Themes
+                            </h6>
+                            <div class="text-muted small mb-3">
+                                Tags power the <strong>Browse by Theme</strong> section on the
+                                home page and the <code>/tag/&lt;slug&gt;</code> listing pages.
+                                Changes save immediately.
+                            </div>
+
+                            <!-- Current assignments — chip list, one per tag.
+                                 Rendered by editor.js renderSongTags(). -->
+                            <label class="form-label">Assigned tags</label>
+                            <div id="song-tags-container"
+                                 class="d-flex flex-wrap gap-1 p-2 rounded mb-3"
+                                 style="min-height: 44px; background-color: var(--ih-bg-card); border: 1px solid var(--ih-border);">
+                                <span class="text-muted small">Loading…</span>
+                            </div>
+
+                            <!-- Add-tag picker with live autocomplete. -->
+                            <label for="song-tag-input" class="form-label">Add a tag</label>
+                            <div class="position-relative">
+                                <input
+                                    type="text"
+                                    class="form-control"
+                                    id="song-tag-input"
+                                    placeholder="Type to search or create — e.g. Easter, Communion"
+                                    autocomplete="off"
+                                >
+                                <div id="song-tag-suggestions"
+                                     class="list-group position-absolute w-100 shadow d-none"
+                                     style="z-index: 1050; max-height: 240px; overflow-y: auto;">
+                                </div>
+                            </div>
+                            <div class="form-text" style="color: var(--ih-text-muted); font-size: 0.75rem;">
+                                Select an existing tag from the dropdown, or type a new name
+                                and press Enter to create it.
+                            </div>
+                        </div>
+                    </div>
+                    <!-- END Tags Tab Panel -->
 
 
                     <!-- -------------------------------------------------

--- a/appWeb/public_html/manage/editor/index.php
+++ b/appWeb/public_html/manage/editor/index.php
@@ -511,10 +511,12 @@ $currentUser = getCurrentUser();
                             >
                         </div>
 
-                        <!-- Song Number and Songbook — displayed side by side -->
-                        <div class="row mb-3">
-                            <!-- Song Number — the numeric identifier within a songbook -->
-                            <div class="col-md-4">
+                        <!-- Song Number · Songbook · CCLI Song Number — one row (#488).
+                             Song numbers never exceed 4 digits; the compact col-2
+                             frees room for the CCLI field that used to sit on its
+                             own full-width line. -->
+                        <div class="row g-2 mb-3">
+                            <div class="col-md-2">
                                 <label for="edit-number" class="form-label">Song Number</label>
                                 <input
                                     type="number"
@@ -522,64 +524,58 @@ $currentUser = getCurrentUser();
                                     id="edit-number"
                                     placeholder="e.g. 42"
                                     min="1"
+                                    max="9999"
                                 >
                             </div>
-
-                            <!-- Songbook — the collection this song belongs to -->
-                            <div class="col-md-8">
+                            <div class="col-md-5">
                                 <label for="edit-songbook" class="form-label">Songbook</label>
                                 <select class="form-select" id="edit-songbook">
                                     <option value="">Select songbook...</option>
-                                    <!--
-                                         Songbook options are populated dynamically
-                                         by editor.js from the loaded dataset.
-                                         Users can also type a new songbook name.
-                                    -->
+                                    <!-- Options are populated dynamically by editor.js. -->
                                 </select>
                             </div>
-                        </div>
-
-                        <!-- Identifiers — CCLI Song Number + ISWC (#497) -->
-                        <div class="mb-3">
-                            <label class="form-label"><i class="bi bi-upc me-1"></i>Identifiers</label>
-                            <div class="row g-2">
-                                <div class="col-md-6">
-                                    <label for="edit-ccli" class="form-label" style="font-size:0.75rem;">CCLI Song Number</label>
-                                    <input
-                                        type="text"
-                                        class="form-control form-control-sm"
-                                        id="edit-ccli"
-                                        placeholder="e.g. 1234567"
-                                    >
-                                </div>
-                                <div class="col-md-6">
-                                    <label for="edit-iswc" class="form-label" style="font-size:0.75rem;">ISWC</label>
-                                    <input
-                                        type="text"
-                                        class="form-control form-control-sm"
-                                        id="edit-iswc"
-                                        placeholder="e.g. T-034.524.680-C"
-                                    >
-                                </div>
-                            </div>
-                            <div class="form-text" style="color: var(--ih-text-muted); font-size: 0.75rem;">
-                                CCLI Song Number (for licensing reports) and ISWC (International Standard Musical Work Code).
+                            <div class="col-md-5">
+                                <label for="edit-ccli" class="form-label">CCLI Song Number</label>
+                                <input
+                                    type="text"
+                                    class="form-control"
+                                    id="edit-ccli"
+                                    placeholder="e.g. 1234567"
+                                >
                             </div>
                         </div>
 
-                        <!-- Tune Name (#497) — traditional hymn tune identifier -->
-                        <div class="mb-3">
-                            <label for="edit-tune-name" class="form-label">
-                                <i class="bi bi-music-note-list me-1"></i>Tune Name
-                            </label>
-                            <input
-                                type="text"
-                                class="form-control"
-                                id="edit-tune-name"
-                                placeholder="e.g. HYFRYDOL, OLD HUNDREDTH"
-                            >
-                            <div class="form-text" style="color: var(--ih-text-muted); font-size: 0.75rem;">
-                                The traditional tune name, if known. Uppercase is conventional. Leave blank for songs with no named tune.
+                        <!-- Tune Name + ISWC pair (#497, #488). Two identifiers that
+                             are typically set together for traditionally-tuned hymns
+                             (HYFRYDOL + T-xxx). -->
+                        <div class="row g-2 mb-3">
+                            <div class="col-md-6">
+                                <label for="edit-tune-name" class="form-label">
+                                    <i class="bi bi-music-note-list me-1"></i>Tune Name
+                                </label>
+                                <input
+                                    type="text"
+                                    class="form-control"
+                                    id="edit-tune-name"
+                                    placeholder="e.g. HYFRYDOL, OLD HUNDREDTH"
+                                >
+                                <div class="form-text" style="color: var(--ih-text-muted); font-size: 0.75rem;">
+                                    Traditional tune name, if known. Uppercase by convention.
+                                </div>
+                            </div>
+                            <div class="col-md-6">
+                                <label for="edit-iswc" class="form-label">
+                                    <i class="bi bi-upc me-1"></i>ISWC
+                                </label>
+                                <input
+                                    type="text"
+                                    class="form-control"
+                                    id="edit-iswc"
+                                    placeholder="e.g. T-034.524.680-C"
+                                >
+                                <div class="form-text" style="color: var(--ih-text-muted); font-size: 0.75rem;">
+                                    International Standard Musical Work Code.
+                                </div>
                             </div>
                         </div>
 
@@ -587,106 +583,108 @@ $currentUser = getCurrentUser();
                         <div class="mb-3">
                             <label class="form-label"><i class="bi bi-translate me-1"></i>Language (IETF BCP 47)</label>
                             <div class="row g-2">
-                                <!-- Language (required) — ISO 639 -->
+                                <!-- Language (required) — shows full names (#489).
+                                     Datalist values are full names; editor.js resolves
+                                     them to ISO 639 codes when composing the IETF tag. -->
                                 <div class="col-4">
                                     <label for="edit-lang-language" class="form-label" style="font-size:0.75rem;">Language</label>
                                     <input type="text" class="form-control form-control-sm" id="edit-lang-language"
-                                        placeholder="e.g. en" list="lang-language-list" required>
+                                        placeholder="e.g. English" list="lang-language-list" required>
                                     <datalist id="lang-language-list">
-                                        <option value="en">English</option>
-                                        <option value="fr">French</option>
-                                        <option value="de">German</option>
-                                        <option value="es">Spanish</option>
-                                        <option value="it">Italian</option>
-                                        <option value="pt">Portuguese</option>
-                                        <option value="la">Latin</option>
-                                        <option value="cy">Welsh</option>
-                                        <option value="gd">Scottish Gaelic</option>
-                                        <option value="ga">Irish</option>
-                                        <option value="nl">Dutch</option>
-                                        <option value="sv">Swedish</option>
-                                        <option value="no">Norwegian</option>
-                                        <option value="da">Danish</option>
-                                        <option value="fi">Finnish</option>
-                                        <option value="pl">Polish</option>
-                                        <option value="cs">Czech</option>
-                                        <option value="hu">Hungarian</option>
-                                        <option value="ro">Romanian</option>
-                                        <option value="ko">Korean</option>
-                                        <option value="ja">Japanese</option>
-                                        <option value="zh">Chinese</option>
-                                        <option value="ar">Arabic</option>
-                                        <option value="he">Hebrew</option>
-                                        <option value="hi">Hindi</option>
-                                        <option value="sw">Swahili</option>
-                                        <option value="zu">Zulu</option>
-                                        <option value="xh">Xhosa</option>
-                                        <option value="af">Afrikaans</option>
-                                        <option value="tl">Tagalog</option>
+                                        <option value="English">en</option>
+                                        <option value="French">fr</option>
+                                        <option value="German">de</option>
+                                        <option value="Spanish">es</option>
+                                        <option value="Italian">it</option>
+                                        <option value="Portuguese">pt</option>
+                                        <option value="Latin">la</option>
+                                        <option value="Welsh">cy</option>
+                                        <option value="Scottish Gaelic">gd</option>
+                                        <option value="Irish">ga</option>
+                                        <option value="Dutch">nl</option>
+                                        <option value="Swedish">sv</option>
+                                        <option value="Norwegian">no</option>
+                                        <option value="Danish">da</option>
+                                        <option value="Finnish">fi</option>
+                                        <option value="Polish">pl</option>
+                                        <option value="Czech">cs</option>
+                                        <option value="Hungarian">hu</option>
+                                        <option value="Romanian">ro</option>
+                                        <option value="Korean">ko</option>
+                                        <option value="Japanese">ja</option>
+                                        <option value="Chinese">zh</option>
+                                        <option value="Arabic">ar</option>
+                                        <option value="Hebrew">he</option>
+                                        <option value="Hindi">hi</option>
+                                        <option value="Swahili">sw</option>
+                                        <option value="Zulu">zu</option>
+                                        <option value="Xhosa">xh</option>
+                                        <option value="Afrikaans">af</option>
+                                        <option value="Tagalog">tl</option>
                                     </datalist>
                                 </div>
-                                <!-- Script (optional) — ISO 15924 -->
+                                <!-- Script (optional) — full names (#489) -->
                                 <div class="col-4">
                                     <label for="edit-lang-script" class="form-label" style="font-size:0.75rem;">Script</label>
                                     <input type="text" class="form-control form-control-sm" id="edit-lang-script"
-                                        placeholder="e.g. Latn" list="lang-script-list">
+                                        placeholder="e.g. Latin" list="lang-script-list">
                                     <datalist id="lang-script-list">
-                                        <option value="Latn">Latin</option>
-                                        <option value="Cyrl">Cyrillic</option>
-                                        <option value="Arab">Arabic</option>
-                                        <option value="Hebr">Hebrew</option>
-                                        <option value="Deva">Devanagari</option>
-                                        <option value="Hans">Simplified Chinese</option>
-                                        <option value="Hant">Traditional Chinese</option>
-                                        <option value="Hang">Hangul</option>
-                                        <option value="Kana">Katakana</option>
-                                        <option value="Grek">Greek</option>
-                                        <option value="Geor">Georgian</option>
-                                        <option value="Armn">Armenian</option>
+                                        <option value="Latin">Latn</option>
+                                        <option value="Cyrillic">Cyrl</option>
+                                        <option value="Arabic">Arab</option>
+                                        <option value="Hebrew">Hebr</option>
+                                        <option value="Devanagari">Deva</option>
+                                        <option value="Simplified Chinese">Hans</option>
+                                        <option value="Traditional Chinese">Hant</option>
+                                        <option value="Hangul">Hang</option>
+                                        <option value="Katakana">Kana</option>
+                                        <option value="Greek">Grek</option>
+                                        <option value="Georgian">Geor</option>
+                                        <option value="Armenian">Armn</option>
                                         <option value="Thai">Thai</option>
-                                        <option value="Ethi">Ethiopic</option>
+                                        <option value="Ethiopic">Ethi</option>
                                     </datalist>
                                 </div>
-                                <!-- Region (optional) — ISO 3166-1 alpha-2 -->
+                                <!-- Region (optional) — full names (#489) -->
                                 <div class="col-4">
                                     <label for="edit-lang-region" class="form-label" style="font-size:0.75rem;">Region</label>
                                     <input type="text" class="form-control form-control-sm" id="edit-lang-region"
-                                        placeholder="e.g. GB" list="lang-region-list">
+                                        placeholder="e.g. United Kingdom" list="lang-region-list">
                                     <datalist id="lang-region-list">
-                                        <option value="GB">United Kingdom</option>
-                                        <option value="US">United States</option>
-                                        <option value="AU">Australia</option>
-                                        <option value="NZ">New Zealand</option>
-                                        <option value="CA">Canada</option>
-                                        <option value="IE">Ireland</option>
-                                        <option value="ZA">South Africa</option>
-                                        <option value="FR">France</option>
-                                        <option value="DE">Germany</option>
-                                        <option value="AT">Austria</option>
-                                        <option value="CH">Switzerland</option>
-                                        <option value="ES">Spain</option>
-                                        <option value="MX">Mexico</option>
-                                        <option value="IT">Italy</option>
-                                        <option value="PT">Portugal</option>
-                                        <option value="BR">Brazil</option>
-                                        <option value="NL">Netherlands</option>
-                                        <option value="SE">Sweden</option>
-                                        <option value="NO">Norway</option>
-                                        <option value="DK">Denmark</option>
-                                        <option value="FI">Finland</option>
-                                        <option value="PL">Poland</option>
-                                        <option value="CZ">Czechia</option>
-                                        <option value="HU">Hungary</option>
-                                        <option value="RO">Romania</option>
-                                        <option value="KR">South Korea</option>
-                                        <option value="JP">Japan</option>
-                                        <option value="CN">China</option>
-                                        <option value="TW">Taiwan</option>
-                                        <option value="IN">India</option>
-                                        <option value="PH">Philippines</option>
-                                        <option value="KE">Kenya</option>
-                                        <option value="NG">Nigeria</option>
-                                        <option value="GH">Ghana</option>
+                                        <option value="United Kingdom">GB</option>
+                                        <option value="United States">US</option>
+                                        <option value="Australia">AU</option>
+                                        <option value="New Zealand">NZ</option>
+                                        <option value="Canada">CA</option>
+                                        <option value="Ireland">IE</option>
+                                        <option value="South Africa">ZA</option>
+                                        <option value="France">FR</option>
+                                        <option value="Germany">DE</option>
+                                        <option value="Austria">AT</option>
+                                        <option value="Switzerland">CH</option>
+                                        <option value="Spain">ES</option>
+                                        <option value="Mexico">MX</option>
+                                        <option value="Italy">IT</option>
+                                        <option value="Portugal">PT</option>
+                                        <option value="Brazil">BR</option>
+                                        <option value="Netherlands">NL</option>
+                                        <option value="Sweden">SE</option>
+                                        <option value="Norway">NO</option>
+                                        <option value="Denmark">DK</option>
+                                        <option value="Finland">FI</option>
+                                        <option value="Poland">PL</option>
+                                        <option value="Czechia">CZ</option>
+                                        <option value="Hungary">HU</option>
+                                        <option value="Romania">RO</option>
+                                        <option value="South Korea">KR</option>
+                                        <option value="Japan">JP</option>
+                                        <option value="China">CN</option>
+                                        <option value="Taiwan">TW</option>
+                                        <option value="India">IN</option>
+                                        <option value="Philippines">PH</option>
+                                        <option value="Kenya">KE</option>
+                                        <option value="Nigeria">NG</option>
+                                        <option value="Ghana">GH</option>
                                     </datalist>
                                 </div>
                             </div>

--- a/appWeb/public_html/manage/editor/index.php
+++ b/appWeb/public_html/manage/editor/index.php
@@ -539,17 +539,47 @@ $currentUser = getCurrentUser();
                             </div>
                         </div>
 
-                        <!-- CCLI Number — Christian Copyright Licensing International identifier -->
+                        <!-- Identifiers — CCLI Song Number + ISWC (#497) -->
                         <div class="mb-3">
-                            <label for="edit-ccli" class="form-label">CCLI Number</label>
+                            <label class="form-label"><i class="bi bi-upc me-1"></i>Identifiers</label>
+                            <div class="row g-2">
+                                <div class="col-md-6">
+                                    <label for="edit-ccli" class="form-label" style="font-size:0.75rem;">CCLI Song Number</label>
+                                    <input
+                                        type="text"
+                                        class="form-control form-control-sm"
+                                        id="edit-ccli"
+                                        placeholder="e.g. 1234567"
+                                    >
+                                </div>
+                                <div class="col-md-6">
+                                    <label for="edit-iswc" class="form-label" style="font-size:0.75rem;">ISWC</label>
+                                    <input
+                                        type="text"
+                                        class="form-control form-control-sm"
+                                        id="edit-iswc"
+                                        placeholder="e.g. T-034.524.680-C"
+                                    >
+                                </div>
+                            </div>
+                            <div class="form-text" style="color: var(--ih-text-muted); font-size: 0.75rem;">
+                                CCLI Song Number (for licensing reports) and ISWC (International Standard Musical Work Code).
+                            </div>
+                        </div>
+
+                        <!-- Tune Name (#497) — traditional hymn tune identifier -->
+                        <div class="mb-3">
+                            <label for="edit-tune-name" class="form-label">
+                                <i class="bi bi-music-note-list me-1"></i>Tune Name
+                            </label>
                             <input
                                 type="text"
                                 class="form-control"
-                                id="edit-ccli"
-                                placeholder="e.g. 1234567"
+                                id="edit-tune-name"
+                                placeholder="e.g. HYFRYDOL, OLD HUNDREDTH"
                             >
                             <div class="form-text" style="color: var(--ih-text-muted); font-size: 0.75rem;">
-                                The CCLI song number for licensing and reporting purposes.
+                                The traditional tune name, if known. Uppercase is conventional. Leave blank for songs with no named tune.
                             </div>
                         </div>
 
@@ -914,6 +944,30 @@ $currentUser = getCurrentUser();
                                 -->
                             </div>
                             <!-- Add Composer button is dynamically rendered by editor.js inside composers-container -->
+                        </div>
+
+                        <!-- Arrangers Section (#497) — who re-arranged the music for this setting -->
+                        <div class="mb-4">
+                            <label class="form-label">
+                                <i class="bi bi-sliders me-1"></i>Arrangers
+                            </label>
+                            <div id="arrangers-container"></div>
+                        </div>
+
+                        <!-- Adaptors Section (#497) — who adapted the lyrics or melody -->
+                        <div class="mb-4">
+                            <label class="form-label">
+                                <i class="bi bi-vinyl me-1"></i>Adaptors
+                            </label>
+                            <div id="adaptors-container"></div>
+                        </div>
+
+                        <!-- Translators Section (#497) — who translated the lyrics (distinct from the #352 translation-link list below) -->
+                        <div class="mb-4">
+                            <label class="form-label">
+                                <i class="bi bi-translate me-1"></i>Translators
+                            </label>
+                            <div id="translators-container"></div>
                         </div>
 
                         <!-- Translations Section — linked translations in other languages (#352) -->

--- a/appWeb/public_html/manage/editor/index.php
+++ b/appWeb/public_html/manage/editor/index.php
@@ -832,50 +832,129 @@ $currentUser = getCurrentUser();
                             <small class="text-muted fw-normal ms-2">(display order)</small>
                         </h6>
 
-                        <!-- Arrangement chip display — rendered dynamically -->
-                        <div id="arrangement-chips" class="d-flex flex-wrap gap-1 mb-2" style="min-height: 32px;"></div>
-
-                        <!-- Arrangement text input for manual editing -->
-                        <div class="input-group input-group-sm mb-2">
-                            <input
-                                type="text"
-                                class="form-control"
-                                id="arrangement-input"
-                                placeholder="e.g. Verse 1, Chorus, Verse 2, Chorus, Verse 3, Chorus"
-                                aria-label="Arrangement order (comma-separated component labels)"
-                            >
-                            <button
-                                type="button"
-                                class="btn btn-outline-secondary"
-                                id="btnApplyArrangement"
-                                title="Apply arrangement"
-                            >
-                                <i class="bi bi-check-lg"></i> Apply
-                            </button>
+                        <!-- Drag-and-drop arrangement builder (#492).
+                             POOL = source chips, one per defined component; click
+                             to append to the strip.
+                             STRIP = the ordered sequence; drag to reorder, click
+                             × on a chip to remove. -->
+                        <div class="mb-2">
+                            <label class="form-label small text-muted mb-1">
+                                Components <small class="text-muted">(click to add)</small>
+                            </label>
+                            <div id="arrangement-pool"
+                                 class="d-flex flex-wrap gap-1 p-2 rounded"
+                                 style="min-height: 44px; background-color: var(--ih-bg-card); border: 1px solid var(--ih-border);"
+                                 aria-label="Component pool">
+                            </div>
                         </div>
 
-                        <!-- Validation feedback -->
+                        <div class="mb-2">
+                            <label class="form-label small text-muted mb-1">
+                                Sequence <small class="text-muted">(drag to reorder, × to remove)</small>
+                            </label>
+                            <div id="arrangement-strip"
+                                 class="d-flex flex-wrap gap-1 p-2 rounded"
+                                 style="min-height: 44px; background-color: var(--ih-bg-card); border: 1px solid var(--ih-border);"
+                                 aria-label="Arrangement sequence">
+                            </div>
+                        </div>
+
+                        <!-- Legacy chips readout — preserved as a visual summary
+                             so the whole tab keeps the pill-row look from before
+                             #492. Updated by renderArrangement() whenever the
+                             strip changes. -->
+                        <div id="arrangement-chips" class="d-flex flex-wrap gap-1 mb-2 d-none"></div>
+
+                        <!-- Validation feedback (used by the advanced text input
+                             below and for preset application errors from #493). -->
                         <div id="arrangement-feedback" class="small mb-2" style="display: none;"></div>
 
-                        <!-- Quick action buttons -->
+                        <!-- Quick action buttons (#493).
+                             Each button carries data-requires with a comma-
+                             separated list of component types that must be
+                             present before it can fire. editor.js disables any
+                             button whose requirements aren't met by the current
+                             song and swaps the title to an explanation. -->
                         <div class="d-flex flex-wrap gap-2 mb-2">
                             <button
                                 type="button"
-                                class="btn btn-sm btn-outline-secondary"
-                                id="btnArrangementAuto"
+                                class="btn btn-sm btn-outline-secondary arrangement-preset"
+                                data-preset="chorus-after-each-verse"
+                                data-requires="verse,chorus"
                                 title="Insert chorus after each verse"
                             >
-                                <i class="bi bi-magic me-1"></i>Auto: Chorus after each verse
+                                <i class="bi bi-magic me-1"></i>Chorus after each verse
                             </button>
                             <button
                                 type="button"
-                                class="btn btn-sm btn-outline-secondary"
-                                id="btnArrangementSequential"
-                                title="Use sequential order (clear arrangement)"
+                                class="btn btn-sm btn-outline-secondary arrangement-preset"
+                                data-preset="verse-prechorus-chorus"
+                                data-requires="verse,pre-chorus,chorus"
+                                title="Verse → Pre-Chorus → Chorus (for each verse)"
                             >
-                                <i class="bi bi-arrow-down me-1"></i>Sequential (clear)
+                                <i class="bi bi-magic me-1"></i>Verse · Pre-Chorus · Chorus
+                            </button>
+                            <button
+                                type="button"
+                                class="btn btn-sm btn-outline-secondary arrangement-preset"
+                                data-preset="verse-bridge-verse"
+                                data-requires="verse,bridge"
+                                title="Verses with a Bridge near the end"
+                            >
+                                <i class="bi bi-magic me-1"></i>Verses · Bridge · Final Verse
+                            </button>
+                            <button
+                                type="button"
+                                class="btn btn-sm btn-outline-secondary arrangement-preset"
+                                data-preset="intro-verses-outro"
+                                data-requires="intro,verse,outro"
+                                title="Intro → all Verses → Outro"
+                            >
+                                <i class="bi bi-magic me-1"></i>Intro · Verses · Outro
+                            </button>
+                            <button
+                                type="button"
+                                class="btn btn-sm btn-outline-secondary arrangement-preset"
+                                data-preset="verses-only"
+                                data-requires="verse"
+                                title="All verses in sequence (no chorus)"
+                            >
+                                <i class="bi bi-magic me-1"></i>Verses only
+                            </button>
+                            <button
+                                type="button"
+                                class="btn btn-sm btn-outline-warning"
+                                id="btnArrangementSequential"
+                                title="Clear the arrangement — falls back to the order defined above"
+                            >
+                                <i class="bi bi-arrow-counterclockwise me-1"></i>Reset to component order
                             </button>
                         </div>
+
+                        <!-- Advanced text input — collapsed by default, kept for
+                             power-users and clipboard paste-in. -->
+                        <details class="mb-2">
+                            <summary class="small text-muted" style="cursor: pointer;">
+                                Advanced · type arrangement as text
+                            </summary>
+                            <div class="input-group input-group-sm mt-2">
+                                <input
+                                    type="text"
+                                    class="form-control"
+                                    id="arrangement-input"
+                                    placeholder="e.g. Verse 1, Chorus, Verse 2, Chorus, Verse 3, Chorus"
+                                    aria-label="Arrangement order (comma-separated component labels)"
+                                >
+                                <button
+                                    type="button"
+                                    class="btn btn-outline-secondary"
+                                    id="btnApplyArrangement"
+                                    title="Apply arrangement"
+                                >
+                                    <i class="bi bi-check-lg"></i> Apply
+                                </button>
+                            </div>
+                        </details>
 
                         <div class="p-2 rounded" style="background-color: var(--ih-bg-card); border: 1px solid var(--ih-border);">
                             <small class="text-muted">

--- a/appWeb/public_html/manage/includes/renderEntityPicker.js
+++ b/appWeb/public_html/manage/includes/renderEntityPicker.js
@@ -1,0 +1,256 @@
+/**
+ * iHymns — Shared Entity/Target Picker (#498)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * A reusable "name-first picker" for admin forms where the canonical
+ * stored value is an internal id but the admin wants to see a human
+ * label. Extracted from /manage/restrictions (#498) so Entitlements /
+ * Organisations / any future surface can reuse the same UX without
+ * copy-pasting 150 lines of inline JavaScript.
+ *
+ * Not an ES module — loaded via `<script src="…">` from admin pages
+ * and exposes `window.initEntityPickers(formEl)` on the global. That
+ * keeps the file usable from PHP-rendered forms that don't run
+ * through the main SPA module graph.
+ *
+ * DOM CONTRACT:
+ * Each "group" is a self-contained picker that has:
+ *   <select data-picker-canonical="#my-hidden-id">        ← type select
+ *     <option value="song">…</option>
+ *     <option value="songbook">…</option>
+ *   </select>
+ *
+ *   <input type="hidden" id="my-hidden-id" name="…">      ← canonical
+ *
+ *   <div data-picker-group-for="#my-hidden-id">           ← panel wrapper
+ *     <div class="rx-picker" data-picker-for="song">…</div>
+ *     <div class="rx-picker d-none" data-picker-for="songbook">…</div>
+ *     …
+ *   </div>
+ *
+ * Each `.rx-picker` panel either:
+ *   * contains a `.rx-picker-select` whose `value` is the canonical
+ *     id (for small-cardinality dropdowns), OR
+ *   * contains a `.rx-picker-input` plus a sibling `.rx-picker-popover`
+ *     (for live-search comboboxes). The input carries
+ *     `data-picker-source="song|user|…"` selecting which backend
+ *     endpoint to hit.
+ *
+ * The helper takes care of the rest: swapping panels when the type
+ * select changes, syncing the visible picker's value into the hidden
+ * canonical input, wiring debounced live-search, and a last-chance
+ * sync on form submit so keyboard-only users can't POST an empty
+ * canonical id.
+ */
+
+(function (global) {
+    'use strict';
+
+    /* Source name → endpoint URL. Keep this table in one place so new
+       pickers just add an entry. The "user" source goes through the
+       editor's admin-gated api.php because tblUsers isn't exposed on
+       the public api.php; "song" uses the public search endpoint
+       since songs aren't gated. */
+    var PICKER_SOURCES = {
+        song: {
+            url: function (q) { return '/api?action=search&q=' + encodeURIComponent(q) + '&limit=15'; },
+            extract: function (data) {
+                return (data.results || []).map(function (s) {
+                    return {
+                        id:    s.id,
+                        label: (s.title || s.id) + (s.songbook ? ' · ' + s.songbook : ''),
+                        hint:  s.id,
+                    };
+                });
+            },
+        },
+        user: {
+            url: function (q) { return '/manage/editor/api?action=user_search&q=' + encodeURIComponent(q); },
+            extract: function (data) { return data.suggestions || []; },
+        },
+        organisation: {
+            url: function (q) { return '/manage/editor/api?action=org_search&q=' + encodeURIComponent(q); },
+            extract: function (data) { return data.suggestions || []; },
+        },
+    };
+
+    function escapeHtml(s) {
+        return String(s == null ? '' : s).replace(/[&<>"']/g, function (c) {
+            return { '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' }[c];
+        });
+    }
+
+    /**
+     * Auto-discover every picker group inside `form` and wire it up.
+     *
+     * @param {HTMLFormElement} form The form containing picker groups
+     * @returns {function} Teardown (no-op today, reserved for SPA use)
+     */
+    function initEntityPickers(form) {
+        if (!form) return function () {};
+
+        var groups = [];
+
+        form.querySelectorAll('select[data-picker-canonical]').forEach(function (typeSelect) {
+            var canonicalSel = typeSelect.dataset.pickerCanonical;
+            var hiddenInput  = form.querySelector(canonicalSel);
+            if (!hiddenInput) return;
+            var panel = form.querySelector('[data-picker-group-for="' + canonicalSel + '"]');
+            if (!panel) return;
+            groups.push({ typeSelect: typeSelect, hiddenInput: hiddenInput, panel: panel });
+        });
+
+        if (groups.length === 0) return function () {};
+
+        groups.forEach(wireGroup);
+
+        /* Click outside any popover dismisses them — one document
+           listener covers every group in this form. */
+        var onDocClick = function (e) {
+            form.querySelectorAll('.rx-picker-popover:not(.d-none)').forEach(function (p) {
+                if (!p.contains(e.target) && e.target !== p.previousElementSibling) {
+                    p.classList.add('d-none');
+                }
+            });
+        };
+        document.addEventListener('click', onDocClick);
+
+        /* Last-chance sync on submit. */
+        var onSubmit = function () {
+            groups.forEach(function (g) { syncHiddenFromPanel(g.panel, g.hiddenInput); });
+        };
+        form.addEventListener('submit', onSubmit);
+
+        /* Teardown — useful if this ever gets called from an SPA
+           router that reuses DOM fragments. Present-day admin pages
+           are full-page loads and will GC the listeners naturally. */
+        return function () {
+            document.removeEventListener('click', onDocClick);
+            form.removeEventListener('submit', onSubmit);
+        };
+    }
+
+    /**
+     * Show the panel matching `key`, hide siblings. The type select's
+     * `value` drives this.
+     */
+    function swapPanel(panel, key) {
+        panel.querySelectorAll('.rx-picker').forEach(function (p) {
+            p.classList.toggle('d-none', p.dataset.pickerFor !== key);
+        });
+    }
+
+    /**
+     * Sync the visible panel's chosen value into `hiddenInput`.
+     * Priority: dedicated canonical on the input > select.value >
+     * input.value > empty.
+     */
+    function syncHiddenFromPanel(panel, hiddenInput) {
+        var visible = panel.querySelector('.rx-picker:not(.d-none)');
+        if (!visible) { hiddenInput.value = ''; return; }
+        var sel = visible.querySelector('.rx-picker-select');
+        var inp = visible.querySelector('.rx-picker-input');
+        if (sel) { hiddenInput.value = sel.value || ''; return; }
+        if (inp) {
+            hiddenInput.value = inp.dataset.canonical || inp.value || '';
+            return;
+        }
+        hiddenInput.value = '';
+    }
+
+    function wireGroup(group) {
+        var typeSelect  = group.typeSelect;
+        var hiddenInput = group.hiddenInput;
+        var panel       = group.panel;
+
+        typeSelect.addEventListener('change', function () {
+            swapPanel(panel, typeSelect.value);
+            syncHiddenFromPanel(panel, hiddenInput);
+        });
+
+        /* Select-based sub-pickers sync their value on change. */
+        panel.querySelectorAll('.rx-picker-select').forEach(function (sel) {
+            sel.addEventListener('change', function () {
+                syncHiddenFromPanel(panel, hiddenInput);
+            });
+        });
+
+        /* Live-search combobox sub-pickers. */
+        panel.querySelectorAll('.rx-picker-input').forEach(function (input) {
+            wireComboboxInput(input, panel, hiddenInput);
+        });
+
+        /* Initialise visible panel + hidden value on load. */
+        swapPanel(panel, typeSelect.value);
+        syncHiddenFromPanel(panel, hiddenInput);
+    }
+
+    function wireComboboxInput(input, panel, hiddenInput) {
+        var popover = input.nextElementSibling;
+        var source  = input.dataset.pickerSource;
+        var debounce = null;
+
+        if (!popover || !popover.classList.contains('rx-picker-popover')) return;
+
+        function close() { popover.classList.add('d-none'); popover.innerHTML = ''; }
+
+        function renderItems(items) {
+            popover.innerHTML = '';
+            if (!items.length) { close(); return; }
+            items.forEach(function (it) {
+                var row = document.createElement('button');
+                row.type = 'button';
+                row.className = 'list-group-item list-group-item-action d-flex justify-content-between align-items-center';
+                row.innerHTML = '<span>' + escapeHtml(it.label) + '</span>' +
+                    (it.hint ? '<small class="text-muted">' + escapeHtml(it.hint) + '</small>' : '');
+                row.addEventListener('click', function () {
+                    input.value = it.label;
+                    input.dataset.canonical = String(it.id);
+                    hiddenInput.value = String(it.id);
+                    close();
+                });
+                popover.appendChild(row);
+            });
+            popover.classList.remove('d-none');
+        }
+
+        function fetchSuggestions(q) {
+            var cfg = PICKER_SOURCES[source];
+            if (!cfg) return;
+            fetch(cfg.url(q), { credentials: 'same-origin' })
+                .then(function (r) { return r.json(); })
+                .then(function (data) { renderItems(cfg.extract(data)); })
+                .catch(close);
+        }
+
+        input.addEventListener('input', function () {
+            clearTimeout(debounce);
+            var q = input.value.trim();
+            /* '*' is the canonical match-all sentinel — accepted in
+               the song combobox (see restrictions.php). Skip the
+               suggestion fetch and stage the id directly. */
+            if (q === '*') {
+                input.dataset.canonical = '*';
+                hiddenInput.value = '*';
+                close();
+                return;
+            }
+            /* Editing the text drops any staged canonical id so the
+               admin can't accidentally submit "Amazing Grace" mapped
+               to a different canonical id. */
+            delete input.dataset.canonical;
+            hiddenInput.value = '';
+            if (q.length < 1) { close(); return; }
+            debounce = setTimeout(function () { fetchSuggestions(q); }, 200);
+        });
+
+        input.addEventListener('keydown', function (e) {
+            if (e.key === 'Escape') close();
+        });
+    }
+
+    /* Expose on the global for PHP-rendered admin pages to call. */
+    global.initEntityPickers = initEntityPickers;
+})(window);

--- a/appWeb/public_html/manage/index.php
+++ b/appWeb/public_html/manage/index.php
@@ -355,9 +355,9 @@ $csrf = csrfToken();
             <h2 class="h6 mb-3"><i class="bi bi-info-circle me-2"></i>System Info</h2>
             <table class="table table-sm table-borderless mb-0 small">
                 <tr><td class="text-muted" style="width:40%">PHP Version</td><td><?= phpversion() ?></td></tr>
-                <tr><td class="text-muted">Database Driver</td><td><?= ucfirst(DB_CONFIG['driver']) ?></td></tr>
-                <?php if (DB_CONFIG['driver'] === 'sqlite'): ?>
-                <tr><td class="text-muted">Database File</td><td><code class="small"><?= htmlspecialchars(basename(DB_CONFIG['sqlite']['path'])) ?></code></td></tr>
+                <tr><td class="text-muted">Database Driver</td><td>MySQL</td></tr>
+                <?php if (defined('DB_HOST') && defined('DB_NAME')): ?>
+                <tr><td class="text-muted">Database</td><td><code class="small"><?= htmlspecialchars(DB_NAME . '@' . DB_HOST) ?></code></td></tr>
                 <?php endif; ?>
                 <tr><td class="text-muted">Your Role</td><td><?= htmlspecialchars(roleLabel($currentUser['role'])) ?></td></tr>
                 <tr><td class="text-muted">Your Username</td><td><code><?= htmlspecialchars($currentUser['username']) ?></code></td></tr>

--- a/appWeb/public_html/manage/index.php
+++ b/appWeb/public_html/manage/index.php
@@ -375,10 +375,12 @@ $csrf = csrfToken();
 
     </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
-            integrity="sha384-zKzgIZcXU99qF1nNW9g+x1znB5NhCPs9qZeGzUnnFOaHJF9jCCKySBjq3vIKabk/"
-            crossorigin="anonymous"></script>
-
+    <?php /* Bootstrap bundle is loaded once, centrally, by admin-footer.php
+             (CLAUDE.md modularity rule: "A <script> loading Bootstrap ...
+             on a page that also includes admin-footer.php (double-load)"
+             is an explicit red flag). The `type="module"` block below uses
+             native ES-module semantics, not Bootstrap, so it does not need
+             the bundle to be loaded first. */ ?>
     <script type="module">
         import { bootCardLayout } from '/js/modules/card-layout.js?v=<?= filemtime(dirname(__DIR__) . '/js/modules/card-layout.js') ?>';
         bootCardLayout();

--- a/appWeb/public_html/manage/restrictions.php
+++ b/appWeb/public_html/manage/restrictions.php
@@ -406,13 +406,17 @@ $csrf = csrfToken();
             <div class="row g-2 mb-2">
                 <div class="col-sm-3">
                     <label class="form-label small">Entity type</label>
-                    <select name="entity_type" id="rx-entity-type" class="form-select form-select-sm" required>
+                    <!-- data-picker-canonical points the shared helper at
+                         the hidden canonical input this type-select feeds. -->
+                    <select name="entity_type" id="rx-entity-type"
+                            class="form-select form-select-sm"
+                            data-picker-canonical="#rx-entity-id" required>
                         <?php foreach (RESTRICTIONS_ENTITY_TYPES as $et): ?>
                             <option value="<?= htmlspecialchars($et) ?>"><?= htmlspecialchars(ucfirst($et)) ?></option>
                         <?php endforeach; ?>
                     </select>
                 </div>
-                <div class="col-sm-5">
+                <div class="col-sm-5" data-picker-group-for="#rx-entity-id">
                     <label class="form-label small">Entity</label>
 
                     <!-- song picker: live-search combobox -->
@@ -470,7 +474,9 @@ $csrf = csrfToken();
             <div class="row g-2 mb-2">
                 <div class="col-sm-3">
                     <label class="form-label small">Target type</label>
-                    <select name="target_type" id="rx-target-type" class="form-select form-select-sm">
+                    <select name="target_type" id="rx-target-type"
+                            class="form-select form-select-sm"
+                            data-picker-canonical="#rx-target-id">
                         <option value="">— (none)</option>
                         <option value="platform">Platform</option>
                         <option value="user">User</option>
@@ -478,7 +484,7 @@ $csrf = csrfToken();
                         <option value="licence_type">Licence type</option>
                     </select>
                 </div>
-                <div class="col-sm-5">
+                <div class="col-sm-5" data-picker-group-for="#rx-target-id">
                     <label class="form-label small">Target</label>
 
                     <!-- platform picker: hard-coded select -->
@@ -552,176 +558,27 @@ $csrf = csrfToken();
             </p>
         </form>
 
-        <!-- Picker behaviour (#498).
-             One tiny inline script keeps the two visible pickers in sync
-             with their type dropdowns and wires the live-search comboboxes. -->
+        <!-- Picker behaviour (#498). Previously a 150-line inline script;
+             now a shared helper at /manage/includes/renderEntityPicker.js
+             that auto-discovers every picker group inside the form via the
+             data-picker-canonical / data-picker-group-for attributes set
+             on the markup above. Other admin pages can reuse the same
+             module by loading this script and calling initEntityPickers. -->
+        <?php
+            /* Cache-bust using the helper file's mtime, so admins get
+               the latest version immediately after a deploy. */
+            $pickerPath = __DIR__ . DIRECTORY_SEPARATOR . 'includes' .
+                          DIRECTORY_SEPARATOR . 'renderEntityPicker.js';
+            $pickerVer  = @filemtime($pickerPath) ?: 0;
+        ?>
+        <script src="/manage/includes/renderEntityPicker.js?v=<?= (int)$pickerVer ?>"></script>
         <script>
-        (function () {
-            var form = document.getElementById('restriction-form');
-            if (!form) return;
-
-            var entityType  = document.getElementById('rx-entity-type');
-            var targetType  = document.getElementById('rx-target-type');
-            var entityId    = document.getElementById('rx-entity-id');
-            var targetId    = document.getElementById('rx-target-id');
-
-            /* Show the picker matching `key`, hide the rest, within `group`
-               (the element holding the sibling pickers). */
-            function swapPicker(group, key) {
-                group.querySelectorAll('.rx-picker').forEach(function (p) {
-                    var want = p.dataset.pickerFor;
-                    p.classList.toggle('d-none', want !== key);
-                });
-            }
-
-            /* Sync the visible picker's chosen value into the hidden
-               canonical field. Called on change + on submit. */
-            function syncHiddenFromPicker(group, hiddenInput) {
-                var visible = group.querySelector('.rx-picker:not(.d-none)');
-                if (!visible) { hiddenInput.value = ''; return; }
-                var sel = visible.querySelector('.rx-picker-select');
-                var inp = visible.querySelector('.rx-picker-input');
-                if (sel) { hiddenInput.value = sel.value || ''; return; }
-                if (inp) { hiddenInput.value = inp.dataset.canonical || inp.value || ''; return; }
-                hiddenInput.value = '';
-            }
-
-            var entityGroup = entityType.closest('.row').querySelector('[data-picker-for="song"]').parentElement;
-            var targetGroup = targetType.closest('.row').querySelector('[data-picker-for="platform"]').parentElement;
-
-            entityType.addEventListener('change', function () {
-                swapPicker(entityGroup, entityType.value);
-                syncHiddenFromPicker(entityGroup, entityId);
-            });
-            targetType.addEventListener('change', function () {
-                swapPicker(targetGroup, targetType.value);
-                syncHiddenFromPicker(targetGroup, targetId);
-            });
-
-            /* Select-based pickers: sync on change. */
-            form.querySelectorAll('.rx-picker-select').forEach(function (sel) {
-                sel.addEventListener('change', function () {
-                    var group = sel.closest('.col-sm-5');
-                    var hidden = group === entityGroup ? entityId : targetId;
-                    syncHiddenFromPicker(group, hidden);
-                });
-            });
-
-            /* Live-search combobox pickers. One handler covers both song
-               and user; the data-picker-source attribute selects the API
-               action (song → /api?action=search, user → /manage/editor/api?action=user_search). */
-            form.querySelectorAll('.rx-picker-input').forEach(function (input) {
-                var popover = input.nextElementSibling;
-                var source  = input.dataset.pickerSource;
-                var debounce = null;
-
-                function close() { popover.classList.add('d-none'); popover.innerHTML = ''; }
-
-                function renderItems(items) {
-                    popover.innerHTML = '';
-                    if (!items.length) { close(); return; }
-                    items.forEach(function (it) {
-                        var row = document.createElement('button');
-                        row.type = 'button';
-                        row.className = 'list-group-item list-group-item-action d-flex justify-content-between align-items-center';
-                        row.innerHTML = '<span>' + escapeHtml(it.label) + '</span>' +
-                            (it.hint ? '<small class="text-muted">' + escapeHtml(it.hint) + '</small>' : '');
-                        row.addEventListener('click', function () {
-                            input.value = it.label;
-                            input.dataset.canonical = String(it.id);
-                            var group = input.closest('.col-sm-5');
-                            var hidden = group === entityGroup ? entityId : targetId;
-                            hidden.value = String(it.id);
-                            close();
-                        });
-                        popover.appendChild(row);
-                    });
-                    popover.classList.remove('d-none');
+            (function () {
+                var form = document.getElementById('restriction-form');
+                if (form && typeof window.initEntityPickers === 'function') {
+                    window.initEntityPickers(form);
                 }
-
-                function fetchSuggestions(q) {
-                    var url;
-                    if (source === 'song') {
-                        /* Reuse the public song-search endpoint. */
-                        url = '/api?action=search&q=' + encodeURIComponent(q) + '&limit=15';
-                    } else if (source === 'user') {
-                        url = '/manage/editor/api?action=user_search&q=' + encodeURIComponent(q);
-                    } else {
-                        return;
-                    }
-                    fetch(url, { credentials: 'same-origin' })
-                        .then(function (r) { return r.json(); })
-                        .then(function (data) {
-                            var items = [];
-                            if (source === 'song' && Array.isArray(data.results)) {
-                                items = data.results.map(function (s) {
-                                    return {
-                                        id: s.id,
-                                        label: (s.title || s.id) + ' · ' + (s.songbook || ''),
-                                        hint: s.id,
-                                    };
-                                });
-                            } else if (Array.isArray(data.suggestions)) {
-                                items = data.suggestions;
-                            }
-                            renderItems(items);
-                        }).catch(function () { close(); });
-                }
-
-                input.addEventListener('input', function () {
-                    clearTimeout(debounce);
-                    var q = input.value.trim();
-                    /* '*' is a legal canonical match-all value for songs; treat it specially. */
-                    if (q === '*') {
-                        input.dataset.canonical = '*';
-                        var group = input.closest('.col-sm-5');
-                        var hidden = group === entityGroup ? entityId : targetId;
-                        hidden.value = '*';
-                        close();
-                        return;
-                    }
-                    /* Drop the staged canonical id if the user edits the text. */
-                    delete input.dataset.canonical;
-                    var group = input.closest('.col-sm-5');
-                    var hidden = group === entityGroup ? entityId : targetId;
-                    hidden.value = '';
-                    if (q.length < 1) { close(); return; }
-                    debounce = setTimeout(function () { fetchSuggestions(q); }, 200);
-                });
-                input.addEventListener('keydown', function (e) {
-                    if (e.key === 'Escape') close();
-                });
-            });
-
-            /* Click outside any popover dismisses them. */
-            document.addEventListener('click', function (e) {
-                form.querySelectorAll('.rx-picker-popover:not(.d-none)').forEach(function (p) {
-                    if (!p.contains(e.target) && e.target !== p.previousElementSibling) {
-                        p.classList.add('d-none');
-                    }
-                });
-            });
-
-            function escapeHtml(s) {
-                return String(s || '').replace(/[&<>"']/g, function (c) {
-                    return { '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' }[c];
-                });
-            }
-
-            /* Initialise visible pickers at load. */
-            swapPicker(entityGroup, entityType.value);
-            swapPicker(targetGroup, targetType.value);
-            syncHiddenFromPicker(entityGroup, entityId);
-            syncHiddenFromPicker(targetGroup, targetId);
-
-            /* Last-chance sync on submit so keyboard-only users who
-               typed-and-picked from the dropdown can't accidentally
-               POST an empty canonical id. */
-            form.addEventListener('submit', function () {
-                syncHiddenFromPicker(entityGroup, entityId);
-                syncHiddenFromPicker(targetGroup, targetId);
-            });
-        })();
+            })();
         </script>
 
     </div>

--- a/appWeb/public_html/manage/restrictions.php
+++ b/appWeb/public_html/manage/restrictions.php
@@ -55,6 +55,37 @@ const RESTRICTIONS_TYPES = [
 ];
 const RESTRICTIONS_EFFECTS = ['deny', 'allow'];
 
+/* Picker vocabularies for the #498 name-first form. Hard-coded where
+   the list is small and closed (platforms, features), loaded from
+   the DB where it's admin-managed (songbooks, organisations).
+
+   * PLATFORMS — matches the set recognised by
+     includes/content_access.php::checkContentAccess().
+   * FEATURES  — mirrors APP_CONFIG['features'] in includes/config.php;
+     this is the full set a restriction rule can reference.
+   * LICENCE_TYPES — duplicated from organisations.php for now (same
+     4-row map); #459 migrates this to tblLicenceTypes, at which
+     point restrictions.php should source from there too. */
+const RESTRICTIONS_PLATFORMS = [
+    'PWA'    => 'PWA · Web app',
+    'Apple'  => 'Apple · iOS / iPadOS / tvOS',
+    'Android'=> 'Android · phone / tablet / TV',
+    'Amazon' => 'Amazon · Fire OS',
+    'Web'    => 'Web · generic browser (non-PWA)',
+];
+const RESTRICTIONS_FEATURES = [
+    'audio_playback' => 'Audio playback (MIDI)',
+    'sheet_music'    => 'Sheet music (PDF)',
+    'shuffle'        => 'Shuffle / random song',
+    'favorites'      => 'Favourites',
+];
+const RESTRICTIONS_LICENCE_TYPES = [
+    'none'         => 'None — no licence on file',
+    'ihymns_basic' => 'iHymns Basic — public-domain only',
+    'ihymns_pro'   => 'iHymns Pro — full catalogue',
+    'ccli'         => 'CCLI — licence number required',
+];
+
 /* ----- POST actions ----- */
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!validateCsrf((string)($_POST['csrf_token'] ?? ''))) {
@@ -177,6 +208,27 @@ try {
     $stmt->execute();
     $gatingEnabled = ((string)($stmt->fetchColumn() ?: '0')) === '1';
 } catch (\Throwable $e) { /* ignore */ }
+
+/* Preload songbooks + organisations for the #498 pickers. Both lists
+   are small (≈6 songbooks, tens of orgs), so server-rendering the full
+   dropdown avoids an API round-trip on page load. Song + user pickers
+   stay AJAX-driven because their cardinalities are large. */
+$picker_songbooks = [];
+try {
+    $rs = $db->query(
+        'SELECT Abbreviation, Name, SongCount FROM tblSongbooks ORDER BY Name ASC'
+    );
+    $picker_songbooks = $rs->fetchAll(PDO::FETCH_ASSOC);
+} catch (\Throwable $_e) { /* empty list is a safe default */ }
+
+$picker_organisations = [];
+try {
+    $rs = $db->query(
+        'SELECT Id, Name, Slug, LicenceType FROM tblOrganisations
+         WHERE IsActive = 1 ORDER BY Name ASC'
+    );
+    $picker_organisations = $rs->fetchAll(PDO::FETCH_ASSOC);
+} catch (\Throwable $_e) { /* empty; the picker will fall back to live-search */ }
 
 $csrf = csrfToken();
 ?>
@@ -334,34 +386,79 @@ $csrf = csrfToken();
             </div>
         </div>
 
-        <!-- Create -->
-        <form method="POST" class="card-admin p-3 mb-4">
+        <!-- Create — name-first picker form (#498). Each ID field is a
+             type-aware picker instead of raw text: selects for small-
+             cardinality (songbook / feature / platform / licence / org)
+             and live-search comboboxes for large-cardinality (song /
+             user). A hidden canonical input (`entity_id`, `target_id`)
+             mirrors the chosen value so the POST handler is unchanged. -->
+        <form method="POST" class="card-admin p-3 mb-4" id="restriction-form">
             <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
             <input type="hidden" name="action" value="create">
             <h2 class="h6 mb-3"><i class="bi bi-plus-circle me-2"></i>Add a restriction</h2>
+
+            <!-- Hidden canonical fields — populated by JS from whichever
+                 picker is visible. The server sees the same names as
+                 before, so the POST handler at line ~70 is unchanged. -->
+            <input type="hidden" name="entity_id"  id="rx-entity-id">
+            <input type="hidden" name="target_id"  id="rx-target-id">
+
             <div class="row g-2 mb-2">
                 <div class="col-sm-3">
                     <label class="form-label small">Entity type</label>
-                    <select name="entity_type" class="form-select form-select-sm" required>
+                    <select name="entity_type" id="rx-entity-type" class="form-select form-select-sm" required>
                         <?php foreach (RESTRICTIONS_ENTITY_TYPES as $et): ?>
                             <option value="<?= htmlspecialchars($et) ?>"><?= htmlspecialchars(ucfirst($et)) ?></option>
                         <?php endforeach; ?>
                     </select>
                 </div>
-                <div class="col-sm-3">
-                    <label class="form-label small">Entity ID</label>
-                    <input type="text" name="entity_id" class="form-control form-control-sm" maxlength="50" required
-                           placeholder="e.g. CP-0001, MP, audio_playback, *">
+                <div class="col-sm-5">
+                    <label class="form-label small">Entity</label>
+
+                    <!-- song picker: live-search combobox -->
+                    <div class="rx-picker" data-picker-for="song">
+                        <div class="position-relative">
+                            <input type="text" class="form-control form-control-sm rx-picker-input"
+                                   data-picker-source="song" autocomplete="off"
+                                   placeholder="Type a song title or number — e.g. Amazing Grace">
+                            <div class="rx-picker-popover list-group position-absolute w-100 shadow d-none"
+                                 style="z-index: 1050; max-height: 240px; overflow-y: auto;"></div>
+                        </div>
+                        <small class="text-muted">Type <code>*</code> to target every song.</small>
+                    </div>
+
+                    <!-- songbook picker: server-rendered select -->
+                    <div class="rx-picker d-none" data-picker-for="songbook">
+                        <select class="form-select form-select-sm rx-picker-select">
+                            <option value="*">* — every songbook</option>
+                            <?php foreach ($picker_songbooks as $sb): ?>
+                                <option value="<?= htmlspecialchars($sb['Abbreviation']) ?>">
+                                    <?= htmlspecialchars($sb['Name']) ?>
+                                    (<?= htmlspecialchars($sb['Abbreviation']) ?>) — <?= (int)$sb['SongCount'] ?> songs
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+
+                    <!-- feature picker: hard-coded select -->
+                    <div class="rx-picker d-none" data-picker-for="feature">
+                        <select class="form-select form-select-sm rx-picker-select">
+                            <option value="*">* — every feature</option>
+                            <?php foreach (RESTRICTIONS_FEATURES as $k => $lbl): ?>
+                                <option value="<?= htmlspecialchars($k) ?>"><?= htmlspecialchars($lbl) ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
                 </div>
-                <div class="col-sm-3">
+                <div class="col-sm-2">
                     <label class="form-label small">Restriction type</label>
-                    <select name="restriction_type" class="form-select form-select-sm" required>
+                    <select name="restriction_type" id="rx-restriction-type" class="form-select form-select-sm" required>
                         <?php foreach (RESTRICTIONS_TYPES as $k => $lbl): ?>
                             <option value="<?= htmlspecialchars($k) ?>"><?= htmlspecialchars($lbl) ?></option>
                         <?php endforeach; ?>
                     </select>
                 </div>
-                <div class="col-sm-3">
+                <div class="col-sm-2">
                     <label class="form-label small">Effect</label>
                     <select name="effect" class="form-select form-select-sm">
                         <option value="deny" selected>deny</option>
@@ -369,38 +466,263 @@ $csrf = csrfToken();
                     </select>
                 </div>
             </div>
+
             <div class="row g-2 mb-2">
                 <div class="col-sm-3">
                     <label class="form-label small">Target type</label>
-                    <input type="text" name="target_type" class="form-control form-control-sm" maxlength="20"
-                           placeholder="platform / user / org / licence_type">
+                    <select name="target_type" id="rx-target-type" class="form-select form-select-sm">
+                        <option value="">— (none)</option>
+                        <option value="platform">Platform</option>
+                        <option value="user">User</option>
+                        <option value="organisation">Organisation</option>
+                        <option value="licence_type">Licence type</option>
+                    </select>
                 </div>
-                <div class="col-sm-3">
-                    <label class="form-label small">Target ID</label>
-                    <input type="text" name="target_id" class="form-control form-control-sm" maxlength="50"
-                           placeholder="PWA / Apple / Android / user-ID / org-ID / ccli">
+                <div class="col-sm-5">
+                    <label class="form-label small">Target</label>
+
+                    <!-- platform picker: hard-coded select -->
+                    <div class="rx-picker" data-picker-for="platform">
+                        <select class="form-select form-select-sm rx-picker-select">
+                            <option value="">— (any platform)</option>
+                            <?php foreach (RESTRICTIONS_PLATFORMS as $k => $lbl): ?>
+                                <option value="<?= htmlspecialchars($k) ?>"><?= htmlspecialchars($lbl) ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+
+                    <!-- user picker: live-search combobox -->
+                    <div class="rx-picker d-none" data-picker-for="user">
+                        <div class="position-relative">
+                            <input type="text" class="form-control form-control-sm rx-picker-input"
+                                   data-picker-source="user" autocomplete="off"
+                                   placeholder="Type a display name or @username">
+                            <div class="rx-picker-popover list-group position-absolute w-100 shadow d-none"
+                                 style="z-index: 1050; max-height: 240px; overflow-y: auto;"></div>
+                        </div>
+                    </div>
+
+                    <!-- organisation picker: server-rendered select + live-search fallback -->
+                    <div class="rx-picker d-none" data-picker-for="organisation">
+                        <select class="form-select form-select-sm rx-picker-select">
+                            <option value="">— (any organisation)</option>
+                            <?php foreach ($picker_organisations as $org): ?>
+                                <option value="<?= (int)$org['Id'] ?>">
+                                    <?= htmlspecialchars($org['Name']) ?>
+                                    — licence: <?= htmlspecialchars($org['LicenceType'] ?: 'none') ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+
+                    <!-- licence type picker -->
+                    <div class="rx-picker d-none" data-picker-for="licence_type">
+                        <select class="form-select form-select-sm rx-picker-select">
+                            <?php foreach (RESTRICTIONS_LICENCE_TYPES as $k => $lbl): ?>
+                                <option value="<?= htmlspecialchars($k) ?>"><?= htmlspecialchars($lbl) ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+
+                    <!-- none picker (shown when target_type = "") -->
+                    <div class="rx-picker d-none" data-picker-for="">
+                        <div class="form-text mb-0">No target — rule applies to all users / platforms / orgs.</div>
+                    </div>
                 </div>
                 <div class="col-sm-2">
                     <label class="form-label small">Priority</label>
                     <input type="number" name="priority" class="form-control form-control-sm"
                            min="0" max="1000" value="100">
                 </div>
-                <div class="col-sm-4">
+                <div class="col-sm-2">
                     <label class="form-label small">Reason (shown to user)</label>
                     <input type="text" name="reason" class="form-control form-control-sm" maxlength="255"
-                           placeholder="e.g. Subscription required for this songbook">
+                           placeholder="e.g. Subscription required">
                 </div>
             </div>
+
             <button type="submit" class="btn btn-amber-solid btn-sm mt-2">
                 <i class="bi bi-plus me-1"></i>Add rule
             </button>
             <p class="text-muted small mt-3 mb-0">
                 <strong>Tips.</strong>
-                Entity ID <code>*</code> matches every entity of the selected type.
-                For <em>Require licence</em> set Target ID to the licence type (e.g. <code>ccli</code>).
-                For <em>Require organisation</em> leave Target ID blank to require any org, or set an org ID to require a specific one.
+                Most fields now offer pickers — the canonical IDs are saved for you automatically.
+                Use <code>*</code> in the song picker (or the "every" option elsewhere) to match everything of that type.
+                For <em>Require organisation</em>, leave the target blank to require any org.
             </p>
         </form>
+
+        <!-- Picker behaviour (#498).
+             One tiny inline script keeps the two visible pickers in sync
+             with their type dropdowns and wires the live-search comboboxes. -->
+        <script>
+        (function () {
+            var form = document.getElementById('restriction-form');
+            if (!form) return;
+
+            var entityType  = document.getElementById('rx-entity-type');
+            var targetType  = document.getElementById('rx-target-type');
+            var entityId    = document.getElementById('rx-entity-id');
+            var targetId    = document.getElementById('rx-target-id');
+
+            /* Show the picker matching `key`, hide the rest, within `group`
+               (the element holding the sibling pickers). */
+            function swapPicker(group, key) {
+                group.querySelectorAll('.rx-picker').forEach(function (p) {
+                    var want = p.dataset.pickerFor;
+                    p.classList.toggle('d-none', want !== key);
+                });
+            }
+
+            /* Sync the visible picker's chosen value into the hidden
+               canonical field. Called on change + on submit. */
+            function syncHiddenFromPicker(group, hiddenInput) {
+                var visible = group.querySelector('.rx-picker:not(.d-none)');
+                if (!visible) { hiddenInput.value = ''; return; }
+                var sel = visible.querySelector('.rx-picker-select');
+                var inp = visible.querySelector('.rx-picker-input');
+                if (sel) { hiddenInput.value = sel.value || ''; return; }
+                if (inp) { hiddenInput.value = inp.dataset.canonical || inp.value || ''; return; }
+                hiddenInput.value = '';
+            }
+
+            var entityGroup = entityType.closest('.row').querySelector('[data-picker-for="song"]').parentElement;
+            var targetGroup = targetType.closest('.row').querySelector('[data-picker-for="platform"]').parentElement;
+
+            entityType.addEventListener('change', function () {
+                swapPicker(entityGroup, entityType.value);
+                syncHiddenFromPicker(entityGroup, entityId);
+            });
+            targetType.addEventListener('change', function () {
+                swapPicker(targetGroup, targetType.value);
+                syncHiddenFromPicker(targetGroup, targetId);
+            });
+
+            /* Select-based pickers: sync on change. */
+            form.querySelectorAll('.rx-picker-select').forEach(function (sel) {
+                sel.addEventListener('change', function () {
+                    var group = sel.closest('.col-sm-5');
+                    var hidden = group === entityGroup ? entityId : targetId;
+                    syncHiddenFromPicker(group, hidden);
+                });
+            });
+
+            /* Live-search combobox pickers. One handler covers both song
+               and user; the data-picker-source attribute selects the API
+               action (song → /api?action=search, user → /manage/editor/api?action=user_search). */
+            form.querySelectorAll('.rx-picker-input').forEach(function (input) {
+                var popover = input.nextElementSibling;
+                var source  = input.dataset.pickerSource;
+                var debounce = null;
+
+                function close() { popover.classList.add('d-none'); popover.innerHTML = ''; }
+
+                function renderItems(items) {
+                    popover.innerHTML = '';
+                    if (!items.length) { close(); return; }
+                    items.forEach(function (it) {
+                        var row = document.createElement('button');
+                        row.type = 'button';
+                        row.className = 'list-group-item list-group-item-action d-flex justify-content-between align-items-center';
+                        row.innerHTML = '<span>' + escapeHtml(it.label) + '</span>' +
+                            (it.hint ? '<small class="text-muted">' + escapeHtml(it.hint) + '</small>' : '');
+                        row.addEventListener('click', function () {
+                            input.value = it.label;
+                            input.dataset.canonical = String(it.id);
+                            var group = input.closest('.col-sm-5');
+                            var hidden = group === entityGroup ? entityId : targetId;
+                            hidden.value = String(it.id);
+                            close();
+                        });
+                        popover.appendChild(row);
+                    });
+                    popover.classList.remove('d-none');
+                }
+
+                function fetchSuggestions(q) {
+                    var url;
+                    if (source === 'song') {
+                        /* Reuse the public song-search endpoint. */
+                        url = '/api?action=search&q=' + encodeURIComponent(q) + '&limit=15';
+                    } else if (source === 'user') {
+                        url = '/manage/editor/api?action=user_search&q=' + encodeURIComponent(q);
+                    } else {
+                        return;
+                    }
+                    fetch(url, { credentials: 'same-origin' })
+                        .then(function (r) { return r.json(); })
+                        .then(function (data) {
+                            var items = [];
+                            if (source === 'song' && Array.isArray(data.results)) {
+                                items = data.results.map(function (s) {
+                                    return {
+                                        id: s.id,
+                                        label: (s.title || s.id) + ' · ' + (s.songbook || ''),
+                                        hint: s.id,
+                                    };
+                                });
+                            } else if (Array.isArray(data.suggestions)) {
+                                items = data.suggestions;
+                            }
+                            renderItems(items);
+                        }).catch(function () { close(); });
+                }
+
+                input.addEventListener('input', function () {
+                    clearTimeout(debounce);
+                    var q = input.value.trim();
+                    /* '*' is a legal canonical match-all value for songs; treat it specially. */
+                    if (q === '*') {
+                        input.dataset.canonical = '*';
+                        var group = input.closest('.col-sm-5');
+                        var hidden = group === entityGroup ? entityId : targetId;
+                        hidden.value = '*';
+                        close();
+                        return;
+                    }
+                    /* Drop the staged canonical id if the user edits the text. */
+                    delete input.dataset.canonical;
+                    var group = input.closest('.col-sm-5');
+                    var hidden = group === entityGroup ? entityId : targetId;
+                    hidden.value = '';
+                    if (q.length < 1) { close(); return; }
+                    debounce = setTimeout(function () { fetchSuggestions(q); }, 200);
+                });
+                input.addEventListener('keydown', function (e) {
+                    if (e.key === 'Escape') close();
+                });
+            });
+
+            /* Click outside any popover dismisses them. */
+            document.addEventListener('click', function (e) {
+                form.querySelectorAll('.rx-picker-popover:not(.d-none)').forEach(function (p) {
+                    if (!p.contains(e.target) && e.target !== p.previousElementSibling) {
+                        p.classList.add('d-none');
+                    }
+                });
+            });
+
+            function escapeHtml(s) {
+                return String(s || '').replace(/[&<>"']/g, function (c) {
+                    return { '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' }[c];
+                });
+            }
+
+            /* Initialise visible pickers at load. */
+            swapPicker(entityGroup, entityType.value);
+            swapPicker(targetGroup, targetType.value);
+            syncHiddenFromPicker(entityGroup, entityId);
+            syncHiddenFromPicker(targetGroup, targetId);
+
+            /* Last-chance sync on submit so keyboard-only users who
+               typed-and-picked from the dropdown can't accidentally
+               POST an empty canonical id. */
+            form.addEventListener('submit', function () {
+                syncHiddenFromPicker(entityGroup, entityId);
+                syncHiddenFromPicker(targetGroup, targetId);
+            });
+        })();
+        </script>
 
     </div>
 

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -194,6 +194,7 @@ if ($action !== '') {
         'users'       => 'migrate-users.php',
         'account-sync'=> 'migrate-account-sync.php',
         'credits'     => 'migrate-credit-fields.php',
+        'songbook-meta' => 'migrate-songbook-meta.php',
         'cleanup'     => 'cleanup.php',
         'backup'      => 'backup.php',
         'restore'     => 'restore.php',
@@ -480,6 +481,23 @@ if ($hasCredentials && defined('DB_HOST')) {
                         </p>
                         <a href="?action=credits" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
                             Run Credit Fields Migration
+                        </a>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="card bg-dark border-secondary h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">3c. Songbook Metadata (#502)</h5>
+                        <p class="card-text text-secondary small">
+                            Adds <code>IsOfficial</code>, <code>Publisher</code>,
+                            <code>PublicationYear</code>, <code>Copyright</code> and
+                            <code>Affiliation</code> columns to <code>tblSongbooks</code>,
+                            and flags existing non-Misc songbooks as official.
+                            Idempotent — safe to re-run.
+                        </p>
+                        <a href="?action=songbook-meta" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
+                            Run Songbook Metadata Migration
                         </a>
                     </div>
                 </div>

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -193,6 +193,7 @@ if ($action !== '') {
         'migrate'     => 'migrate-json.php',
         'users'       => 'migrate-users.php',
         'account-sync'=> 'migrate-account-sync.php',
+        'credits'     => 'migrate-credit-fields.php',
         'cleanup'     => 'cleanup.php',
         'backup'      => 'backup.php',
         'restore'     => 'restore.php',
@@ -463,6 +464,22 @@ if ($hasCredentials && defined('DB_HOST')) {
                         </p>
                         <a href="?action=account-sync" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
                             Run Account Sync Migration
+                        </a>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="card bg-dark border-secondary h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">3b. Credit Fields (#497)</h5>
+                        <p class="card-text text-secondary small">
+                            Adds <code>TuneName</code> and <code>Iswc</code> columns to
+                            <code>tblSongs</code>, and creates
+                            <code>tblSongArrangers</code>, <code>tblSongAdaptors</code>
+                            and <code>tblSongTranslators</code>. Idempotent — safe to re-run.
+                        </p>
+                        <a href="?action=credits" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
+                            Run Credit Fields Migration
                         </a>
                     </div>
                 </div>

--- a/appWeb/public_html/manage/songbooks.php
+++ b/appWeb/public_html/manage/songbooks.php
@@ -60,10 +60,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     try {
         switch ($action) {
             case 'create': {
-                $abbr   = trim((string)($_POST['abbreviation'] ?? ''));
-                $name   = trim((string)($_POST['name']         ?? ''));
-                $colour = trim((string)($_POST['colour']       ?? ''));
-                $order  = (int)($_POST['display_order']        ?? 0);
+                $abbr    = trim((string)($_POST['abbreviation']    ?? ''));
+                $name    = trim((string)($_POST['name']            ?? ''));
+                $colour  = trim((string)($_POST['colour']          ?? ''));
+                $order   = (int)($_POST['display_order']           ?? 0);
+                /* #502 — new metadata columns. All nullable; empty
+                   input normalises to null so the UNIQUE/null-group
+                   semantics work as expected. */
+                $isOfficial = !empty($_POST['is_official']) ? 1 : 0;
+                $publisher  = trim((string)($_POST['publisher']        ?? '')) ?: null;
+                $pubYear    = trim((string)($_POST['publication_year'] ?? '')) ?: null;
+                $copyright  = trim((string)($_POST['copyright']        ?? '')) ?: null;
+                $affiliation= trim((string)($_POST['affiliation']      ?? '')) ?: null;
 
                 if ($e = $validateAbbr($abbr))   { $error = $e; break; }
                 if ($name === '')                { $error = 'Name is required.'; break; }
@@ -74,10 +82,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 if ($stmt->fetch()) { $error = 'Abbreviation already exists.'; break; }
 
                 $stmt = $db->prepare(
-                    'INSERT INTO tblSongbooks (Abbreviation, Name, DisplayOrder, Colour)
-                     VALUES (?, ?, ?, ?)'
+                    'INSERT INTO tblSongbooks
+                        (Abbreviation, Name, DisplayOrder, Colour,
+                         IsOfficial, Publisher, PublicationYear, Copyright, Affiliation)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)'
                 );
-                $stmt->execute([$abbr, $name, $order ?: 0, $colour]);
+                $stmt->execute([
+                    $abbr, $name, $order ?: 0, $colour,
+                    $isOfficial, $publisher, $pubYear, $copyright, $affiliation,
+                ]);
                 $success = "Songbook '{$abbr}' created.";
                 break;
             }
@@ -89,6 +102,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $order       = (int)($_POST['display_order']        ?? 0);
                 $newAbbr     = trim((string)($_POST['new_abbreviation'] ?? ''));
                 $alsoRename  = !empty($_POST['rename_song_refs']);
+                /* #502 — new metadata columns. */
+                $isOfficial  = !empty($_POST['is_official']) ? 1 : 0;
+                $publisher   = trim((string)($_POST['publisher']        ?? '')) ?: null;
+                $pubYear     = trim((string)($_POST['publication_year'] ?? '')) ?: null;
+                $copyright   = trim((string)($_POST['copyright']        ?? '')) ?: null;
+                $affiliation = trim((string)($_POST['affiliation']      ?? '')) ?: null;
 
                 $existing = $db->prepare('SELECT Abbreviation FROM tblSongbooks WHERE Id = ?');
                 $existing->execute([$id]);
@@ -111,10 +130,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 try {
                     $stmt = $db->prepare(
                         'UPDATE tblSongbooks
-                            SET Name = ?, Colour = ?, DisplayOrder = ?
+                            SET Name = ?, Colour = ?, DisplayOrder = ?,
+                                IsOfficial = ?, Publisher = ?,
+                                PublicationYear = ?, Copyright = ?, Affiliation = ?
                           WHERE Id = ?'
                     );
-                    $stmt->execute([$name, $colour, $order ?: 0, $id]);
+                    $stmt->execute([
+                        $name, $colour, $order ?: 0,
+                        $isOfficial, $publisher, $pubYear, $copyright, $affiliation,
+                        $id,
+                    ]);
 
                     if ($abbrChanged) {
                         $stmt = $db->prepare('UPDATE tblSongbooks SET Abbreviation = ? WHERE Id = ?');
@@ -191,6 +216,8 @@ $rows = [];
 try {
     $rs = $db->query(
         'SELECT b.Id, b.Abbreviation, b.Name, b.SongCount, b.DisplayOrder, b.Colour,
+                b.IsOfficial, b.Publisher, b.PublicationYear,
+                b.Copyright, b.Affiliation,
                 COUNT(s.Id) AS ActualSongCount
            FROM tblSongbooks b
            LEFT JOIN tblSongs s ON s.SongbookAbbr = b.Abbreviation
@@ -249,6 +276,7 @@ $csrf = csrfToken();
                         <th style="width:6rem">Order</th>
                         <th>Abbr</th>
                         <th>Name</th>
+                        <th class="text-center" title="Official published hymnal (#502)">Official</th>
                         <th class="text-center">Songs</th>
                         <th>Colour</th>
                         <th class="text-end">Actions</th>
@@ -265,6 +293,15 @@ $csrf = csrfToken();
                             </td>
                             <td><code><?= htmlspecialchars($r['Abbreviation']) ?></code></td>
                             <td><?= htmlspecialchars($r['Name']) ?></td>
+                            <td class="text-center">
+                                <?php if ((int)$r['IsOfficial'] === 1): ?>
+                                    <span class="badge bg-info" title="Official published hymnal">
+                                        <i class="bi bi-patch-check-fill" aria-hidden="true"></i> Yes
+                                    </span>
+                                <?php else: ?>
+                                    <small class="text-muted" title="Curated grouping / pseudo-songbook">—</small>
+                                <?php endif; ?>
+                            </td>
                             <td class="text-center"><?= number_format((int)$r['ActualSongCount']) ?></td>
                             <td>
                                 <?php if ($r['Colour']): ?>
@@ -277,12 +314,17 @@ $csrf = csrfToken();
                             <td class="text-end">
                                 <button type="button" class="btn btn-sm btn-outline-info"
                                         onclick='openEditModal(<?= json_encode([
-                                            'id'           => (int)$r['Id'],
-                                            'abbreviation' => $r['Abbreviation'],
-                                            'name'         => $r['Name'],
-                                            'colour'       => $r['Colour'],
-                                            'display_order'=> (int)$r['DisplayOrder'],
-                                            'song_count'   => (int)$r['ActualSongCount'],
+                                            'id'               => (int)$r['Id'],
+                                            'abbreviation'     => $r['Abbreviation'],
+                                            'name'             => $r['Name'],
+                                            'colour'           => $r['Colour'],
+                                            'display_order'    => (int)$r['DisplayOrder'],
+                                            'song_count'       => (int)$r['ActualSongCount'],
+                                            'is_official'      => (int)$r['IsOfficial'] === 1,
+                                            'publisher'        => $r['Publisher']       ?? '',
+                                            'publication_year' => $r['PublicationYear'] ?? '',
+                                            'copyright'        => $r['Copyright']       ?? '',
+                                            'affiliation'      => $r['Affiliation']     ?? '',
                                         ]) ?>)'
                                         title="Edit songbook">
                                     <i class="bi bi-pencil"></i>
@@ -303,7 +345,7 @@ $csrf = csrfToken();
                         </tr>
                     <?php endforeach; ?>
                     <?php if (!$rows): ?>
-                        <tr><td colspan="6" class="text-muted text-center py-4">No songbooks yet. Add one below.</td></tr>
+                        <tr><td colspan="7" class="text-muted text-center py-4">No songbooks yet. Add one below.</td></tr>
                     <?php endif; ?>
                 </tbody>
             </table>
@@ -320,6 +362,7 @@ $csrf = csrfToken();
             <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
             <input type="hidden" name="action" value="create">
             <h2 class="h6 mb-3"><i class="bi bi-plus-circle me-2"></i>Add a songbook</h2>
+
             <div class="row g-2">
                 <div class="col-sm-3">
                     <label class="form-label small">Abbreviation</label>
@@ -343,6 +386,44 @@ $csrf = csrfToken();
                            min="0" step="10" value="0">
                 </div>
             </div>
+
+            <!-- #502 metadata -->
+            <div class="row g-2 mt-2">
+                <div class="col-sm-3 d-flex align-items-end">
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" name="is_official" id="create-is-official" value="1">
+                        <label class="form-check-label small" for="create-is-official">
+                            Official published hymnal
+                        </label>
+                        <div class="form-text small">
+                            Unticked by default — tick for a published hymnal; leave unticked for a curated grouping.
+                        </div>
+                    </div>
+                </div>
+                <div class="col-sm-5">
+                    <label class="form-label small">Publisher</label>
+                    <input type="text" name="publisher" class="form-control form-control-sm"
+                           maxlength="255" placeholder="e.g. Praise Trust">
+                </div>
+                <div class="col-sm-4">
+                    <label class="form-label small">Publication year / edition</label>
+                    <input type="text" name="publication_year" class="form-control form-control-sm"
+                           maxlength="50" placeholder="e.g. 1986, 1986–2003, 2nd edition 2011">
+                </div>
+            </div>
+            <div class="row g-2 mt-2">
+                <div class="col-sm-8">
+                    <label class="form-label small">Copyright</label>
+                    <input type="text" name="copyright" class="form-control form-control-sm"
+                           maxlength="500" placeholder="e.g. © 2012 Praise Trust, All Rights Reserved">
+                </div>
+                <div class="col-sm-4">
+                    <label class="form-label small">Affiliation</label>
+                    <input type="text" name="affiliation" class="form-control form-control-sm"
+                           maxlength="120" placeholder="e.g. Seventh-day Adventist, Non-denominational">
+                </div>
+            </div>
+
             <button type="submit" class="btn btn-amber-solid btn-sm mt-3">
                 <i class="bi bi-plus me-1"></i>Create songbook
             </button>
@@ -379,6 +460,42 @@ $csrf = csrfToken();
                                        min="0" step="10">
                             </div>
                         </div>
+
+                        <!-- #502 metadata block -->
+                        <div class="form-check mb-3">
+                            <input class="form-check-input" type="checkbox"
+                                   name="is_official" id="edit-is-official" value="1">
+                            <label class="form-check-label" for="edit-is-official">
+                                Official published hymnal
+                            </label>
+                            <div class="form-text small">
+                                Unticked means this is a curated grouping / pseudo-songbook.
+                            </div>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Publisher</label>
+                            <input type="text" class="form-control" name="publisher" id="edit-publisher"
+                                   maxlength="255" placeholder="e.g. Praise Trust">
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Publication year / edition</label>
+                            <input type="text" class="form-control" name="publication_year" id="edit-publication-year"
+                                   maxlength="50" placeholder="e.g. 1986, 1986–2003, 2nd edition 2011">
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Copyright</label>
+                            <input type="text" class="form-control" name="copyright" id="edit-copyright"
+                                   maxlength="500" placeholder="e.g. © 2012 Praise Trust, All Rights Reserved">
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Affiliation</label>
+                            <input type="text" class="form-control" name="affiliation" id="edit-affiliation"
+                                   maxlength="120" placeholder="e.g. Seventh-day Adventist, Non-denominational">
+                            <div class="form-text small">
+                                Free-text for now; a controlled lookup table is planned (#502).
+                            </div>
+                        </div>
+
                         <hr>
                         <div class="mb-3">
                             <label class="form-label">New abbreviation (optional)</label>
@@ -434,14 +551,22 @@ $csrf = csrfToken();
             crossorigin="anonymous"></script>
     <script>
         function openEditModal(row) {
-            document.getElementById('edit-id').value            = row.id;
-            document.getElementById('edit-abbr-label').textContent = row.abbreviation;
-            document.getElementById('edit-name').value          = row.name;
-            document.getElementById('edit-colour').value        = row.colour || '';
-            document.getElementById('edit-order').value         = row.display_order || 0;
-            document.getElementById('edit-new-abbr').value      = '';
-            document.getElementById('edit-rename-refs').checked = false;
-            document.getElementById('edit-song-count').textContent = row.song_count;
+            document.getElementById('edit-id').value                = row.id;
+            document.getElementById('edit-abbr-label').textContent  = row.abbreviation;
+            document.getElementById('edit-name').value              = row.name;
+            document.getElementById('edit-colour').value            = row.colour || '';
+            document.getElementById('edit-order').value             = row.display_order || 0;
+
+            /* #502 metadata fields */
+            document.getElementById('edit-is-official').checked     = !!row.is_official;
+            document.getElementById('edit-publisher').value         = row.publisher        || '';
+            document.getElementById('edit-publication-year').value  = row.publication_year || '';
+            document.getElementById('edit-copyright').value         = row.copyright        || '';
+            document.getElementById('edit-affiliation').value       = row.affiliation      || '';
+
+            document.getElementById('edit-new-abbr').value          = '';
+            document.getElementById('edit-rename-refs').checked     = false;
+            document.getElementById('edit-song-count').textContent  = row.song_count;
             document.getElementById('edit-rename-refs-wrap').style.display = row.song_count > 0 ? '' : 'none';
             new bootstrap.Modal(document.getElementById('editModal')).show();
         }

--- a/appWeb/public_html/service-worker.js.php
+++ b/appWeb/public_html/service-worker.js.php
@@ -123,6 +123,7 @@ const PRECACHE_ASSETS = [
     '/js/modules/analytics.js',
     '/js/modules/offline-queue.js',
     '/js/modules/notifications.js',
+    '/js/modules/home-page.js',
     '/manifest.json',
     '/assets/favicon.svg',
 ];


### PR DESCRIPTION
## Summary

Branch covers two emergencies, a perf fix, three new features, fifteen UX issues, and a CodeQL high-severity finding — all on the editor + admin surfaces.

## Critical fixes
- **`96d3d6d`** — Home page Popular Songs / Browse by Theme stuck loading, plus admin footer missing on dashboard. Extracted home dynamic logic into `js/modules/home-page.js` invoked by the SPA router; removed Bootstrap double-load on `/manage/`.
- **`3a0bc05`** — `manage/index.php` referenced an undefined `DB_CONFIG` constant for global-admin viewers, raising a PHP fatal that killed the render mid-row and explains why the footer "disappeared".
- **`16fa145`** — `Save` button on the Song Editor was POSTing the entire 3,612-song corpus to `?action=save` (TRUNCATE + reinsert) and validating the whole catalogue, blocking saves on a fix to one song. Now per-song via `save_song`; validation scoped to modified set.

## Performance
- **`dcf3ace`** — `SongData::getSongs()` N+1 fix: per-song writers/composers/components attach loop replaced with three bulk loaders (`_getWritersMap` / `_getComposersMap` / `_getComponentsMap`). 10,800 → 3 queries on full editor load. Knock-on wins for sitemap, audio manifest, songbook page.

## Features

### Songs
- **`82df378` (#497)** — Schema + editor for Tune Name, ISWC, Arrangers, Adaptors, Translators. Three new credit tables, two new `tblSongs` columns, idempotent `migrate-credit-fields.php` wired into `/manage/setup-database`.
- **`d945068`** — Surface those new fields on the public song page.
- **`ed19f39` (#496 follow-up)** — Tags attached to the bulk `?action=load` payload via `_getTagsMap`; editor's Tags tab now renders instantly without a per-selection round-trip.

### Editor UX (#487–#493, #495, #496)
- **`599aa28`** — Footer clearance (#487), compact Song Number row + CCLI Song Number relocation (#488), full-name language/script/region pickers (#489), textarea auto-size on initial render (#490), drop "Component N" + optional component number (#491).
- **`693d031`** — ProPresenter-style drag-and-drop arrangement builder (#492); requirement-aware quick-action presets with five new patterns (#493).
- **`c050bec` + `c410cf6` (#495)** — `credit_search` backend endpoint + UI wiring; live-search across all five credit collections to surface canonical spellings as the admin types.
- **`72d9ee6` (#496)** — New Tags tab in the Song Editor; chip list + autocomplete + create-on-Enter.
- **`120f5cf`** — Standardised `; ` separator for multi-credit display strings.

### Admin
- **`653ddff` (#498)** — `/manage/restrictions` Entity/Target inputs replaced with name-first pickers (live-search comboboxes for songs/users/orgs; dropdowns for platforms/features/licence types/songbooks).
- **`9a3484f` (#498)** — Picker extracted to a shared `manage/includes/renderEntityPicker.js` helper; auto-discovers groups via `data-picker-canonical` / `data-picker-group-for` attributes for any future admin page.
- **`b87f749` (#499)** — Admin sidebar now spans full viewport height (WordPress-style column).
- **`882fe70` (#502)** — `tblSongbooks` gains `IsOfficial`, `Publisher`, `PublicationYear`, `Copyright`, `Affiliation` columns; `migrate-songbook-meta.php` (idempotent, with non-Misc backfill) wired into `/manage/setup-database`; admin UI extended.

## Security
- **`cbfd621` (#504)** — Two CodeQL High "DOM text reinterpreted as HTML" alerts on `favorites.js:504`. Rewrote both flagged sites to use `replaceChildren()` + `createElement` + `createTextNode` instead of `innerHTML` strings.

## Issues addressed
Closes #487, #488, #489, #490, #491, #492, #493, #495, #496, #498, #499, #502, #504.
Closed as dup: #494.

## Deploy notes
After merge, a global admin should visit `/manage/setup-database` and run **3b. Credit Fields (#497)** then **3c. Songbook Metadata (#502)** once. Both migrations are idempotent and safe to re-run; running them is required before the editor's `save_song` UPSERTs against the new columns.

## Test plan
- [ ] `/` loads with Popular Songs + Browse by Theme populated.
- [ ] `/manage/` dashboard shows the footer.
- [ ] Edit and save a single song; only that row changes in `tblSongs` / its child rows.
- [ ] Editor Tags tab adds/removes tags; chips persist across page reload.
- [ ] Editor Credits tab autocomplete suggests cross-collection spellings.
- [ ] `/manage/restrictions`: typing a song title narrows the picker; selecting persists the canonical id.
- [ ] `/manage/songbooks`: create a new pseudo-songbook with `IsOfficial=0`, then edit one of the seeded songbooks; round-trip works.
- [ ] CodeQL re-scan closes alerts #1 and #2 on `favorites.js:504`.

🤖 Generated with [Claude Code](<https://claude.ai/code>) on session 01KFktr5AbuxqovbiyRiEM2j
