### PR TITLE
fix(db): catch up missing tblSongbooks.Colour in songbook-meta migration

### DIFF
--- a/appWeb/.sql/migrate-songbook-meta.php
+++ b/appWeb/.sql/migrate-songbook-meta.php
@@ -3,19 +3,26 @@
 declare(strict_types=1);
 
 /**
- * iHymns — Songbook Metadata Migration (#502)
+ * iHymns — Songbook Schema Catch-Up Migration (#502 + Colour catch-up)
  *
  * Copyright (c) 2026 iHymns. All rights reserved.
  *
  * PURPOSE:
- * Brings an existing deployment up to the #502 schema:
- *   1. Adds five nullable metadata columns to tblSongbooks:
+ * Brings an existing deployment's tblSongbooks up to the current
+ * schema:
+ *   1. Adds the `Colour` column if it's missing. The column was
+ *      introduced in the "Admin surface phases 1-4" change but no
+ *      forward-migration was shipped at the time, so older databases
+ *      (notably alpha/dev) still don't have it. SongData::getSongbooks()
+ *      now SELECTs `Colour`, so its absence kills the home page.
+ *      Added `AFTER DisplayOrder` to match schema.sql.
+ *   2. Adds five nullable metadata columns (#502):
  *        - IsOfficial      (TINYINT(1) NOT NULL DEFAULT 0)
  *        - Publisher       (VARCHAR(255))
  *        - PublicationYear (VARCHAR(50))
  *        - Copyright       (VARCHAR(500))
  *        - Affiliation     (VARCHAR(120))
- *   2. Marks every existing seed songbook whose Abbreviation is NOT
+ *   3. Marks every existing seed songbook whose Abbreviation is NOT
  *      "Misc" as IsOfficial = 1, matching the real-world state
  *      (the project shipped with five published hymnals + one
  *      unstructured Misc collection). Admins can untick any row
@@ -103,6 +110,13 @@ if (!_migSongbookMeta_tableExists($mysqli, 'tblSongbooks')) {
 /* Each step: column name → ALTER statement. Keeping them in a list
    means adding a new column in the future is a one-line edit. */
 $steps = [
+    /* Colour was added to schema.sql in the "Admin surface phases 1-4"
+       change without a forward-migration. Catching it up here, first,
+       so the AFTER Colour clauses on the #502 columns below resolve. */
+    ['col' => 'Colour', 'sql' => "ALTER TABLE tblSongbooks
+        ADD COLUMN Colour VARCHAR(7) NOT NULL DEFAULT ''
+        COMMENT 'Badge colour hex #RRGGBB (empty = theme default)'
+        AFTER DisplayOrder"],
     ['col' => 'IsOfficial', 'sql' => "ALTER TABLE tblSongbooks
         ADD COLUMN IsOfficial TINYINT(1) NOT NULL DEFAULT 0
         COMMENT '1 = published hymnal; 0 = curated grouping / pseudo-songbook (#502)'

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -490,7 +490,9 @@ if ($hasCredentials && defined('DB_HOST')) {
                     <div class="card-body">
                         <h5 class="card-title">3c. Songbook Metadata (#502)</h5>
                         <p class="card-text text-secondary small">
-                            Adds <code>IsOfficial</code>, <code>Publisher</code>,
+                            Adds <code>Colour</code> (catch-up — missed
+                            forward-migration on older databases),
+                            <code>IsOfficial</code>, <code>Publisher</code>,
                             <code>PublicationYear</code>, <code>Copyright</code> and
                             <code>Affiliation</code> columns to <code>tblSongbooks</code>,
                             and flags existing non-Misc songbooks as official.


### PR DESCRIPTION
Closes #509.

## Summary

Follow-up to #507. The PHP debug mode shipped in #507 caught a real fatal on `dev.ihymns.app`:

```
Uncaught mysqli_sql_exception: Unknown column 'Colour' in 'field list'
  at SongData.php:246
  via index.php:1239 → SongData->getSongbooks()
```

That fatal was the actual cause of the *"Loading iHymns…"* hang on the alpha PWA. The HTML rendered up to the `iHymnsConfig` inline `<script>`, then PHP died mid-`json_encode`, which corrupted the `window.iHymnsConfig = { … }` literal into invalid JS. The browser threw a `SyntaxError` *before* reaching the `<script src="/js/app.js">` tag below — which is why `app.js` never even appeared in the Network tab.

See #509 for the full diagnostic write-up and history.

### History (how `Colour` ended up missing)

1. *"Admin surface phases 1–4"* added the `Colour VARCHAR(7)` column to `tblSongbooks` in `schema.sql` but **did not** ship a forward-migration. Fresh installs got the column; older databases (notably alpha/dev) did not.
2. PR #502 then started SELECTing `Colour` in `SongData::getSongbooks()` and used `AFTER Colour` for its own ALTERs in `migrate-songbook-meta.php`. Both silently failed on the alpha DB.

### Fix

Prepend a `Colour` step to `migrate-songbook-meta.php` (`AFTER DisplayOrder`, matching `schema.sql`). The migration was already idempotent and already wired into `/manage/setup-database`, so:

- **Fresh installs**: `[skip]` (column exists from `schema.sql`)
- **Older alpha/dev DB**: `[add ]` Colour, then proceeds with the #502 cols
- **Already-migrated DBs**: `[skip]` across the board, safe to re-run

The migration now serves as a generic `tblSongbooks` schema catch-up, not a #502-only step. Renamed the docblock title to reflect that. The setup-database card lists `Colour` in the column list with a brief *"missed forward-migration"* note so admins know why a long-deployed-and-working DB is suddenly being asked to migrate.

## Deployment

After this lands, an admin needs to visit:

> `/manage/setup-database` → **"Run Songbook Metadata Migration"**

on alpha (and any other channel whose DB pre-dates the *"Admin surface phases 1–4"* commit). Production almost certainly has `Colour` already and will `[skip]` everything — safe.

## Test plan

- [x] `php -l` clean on `migrate-songbook-meta.php` and `setup-database.php`
- [ ] After deploy: run the migration on alpha — expect `[add ] tblSongbooks.Colour.` then `[skip]` for the existing #502 columns
- [ ] After deploy: reload `https://dev.ihymns.app/` — expect the SPA to boot past the spinner (i.e., the PHP fatal is gone, `iHymnsConfig` is valid JSON, `app.js` actually loads)
- [ ] After deploy on production: run the migration; expect a clean sweep of `[skip]`s
- [ ] Sanity check `/manage/songbooks` after the migration — confirm the Colour column is editable and persisted as before

https://claude.ai/code/session_01JZ67hkdcqifZu7yWjiFywL