### PR TITLE
feat(debug): wire ?_debug=1&_dev=1 into /manage/* admin pages

### DIFF
--- a/appWeb/public_html/manage/includes/auth.php
+++ b/appWeb/public_html/manage/includes/auth.php
@@ -26,6 +26,16 @@ if (basename($_SERVER['SCRIPT_FILENAME'] ?? '') === basename(__FILE__)) {
     exit('Access denied.');
 }
 
+/* On-demand debug mode (#507 / #509) — wire as early as possible so a
+   fatal in db.php, the auth bootstrap, or the page itself surfaces in
+   the response instead of producing a silent blank page. Every manage
+   page requires this file first, so this hook covers the whole admin
+   surface in one place. Honoured only on Alpha/Beta with both
+   `?_debug=1` and `?_dev=1` (or the cookie set by either). */
+require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'includes'
+          . DIRECTORY_SEPARATOR . 'debug_mode.php';
+enableDebugModeIfRequested();
+
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'db.php';
 
 /* =========================================================================


### PR DESCRIPTION
## Summary

Follow-up to #507 / #509. The on-demand PHP debug mode shipped in #507 is wired into `index.php` and `api.php` but I deliberately left `/manage/*` out of scope at the time. That decision came back to bite us right away:

- #509's fix (#508) instructs admins to recover by visiting `/manage/setup-database` → **Run Songbook Metadata Migration**.
- But `/manage/setup-database` itself is now serving a blank page on alpha (almost certainly the same fatal class as the home-page bug — possibly another `tblSongbooks` column read against an old schema).
- Without debug mode wired into `/manage/`, there's no way to see what's killing it, leaving a chicken-and-egg lock-out: the documented recovery path is itself broken and we can't introspect it.

This PR wires `debug_mode.php` into `manage/includes/auth.php`, the bootstrap that every `/manage/*.php` page requires first. Placed **before** the existing `db.php` require so a fatal during DB connect / schema introspection surfaces in the response instead of producing a silent blank page.

## Behaviour

Identical guards to the existing index/api wiring — channel-locked to Alpha/Beta, requires both `?_debug=1` and `?_dev=1`, audit-logged, 30-min cookie inheritance, `?_debug=off` clears. Production is untouched. The only change is the surface area.

## Diff

One file, 10 lines added:

```php
require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'includes'
          . DIRECTORY_SEPARATOR . 'debug_mode.php';
enableDebugModeIfRequested();
```

inserted right after the direct-access guard and before the `db.php` require.

## Why bootstrap-level is the right hook

Every `/manage/*.php` page in the repo includes `manage/includes/auth.php` first (verified: `analytics.php`, `ccli-report.php`, `data-health.php`, `entitlements.php`, `groups.php`, `index.php`, `login.php`, `logout.php`, `missing-numbers.php`, `organisations.php`, `requests.php`, `restrictions.php`, `revisions.php`, `setup-database.php`, `setup.php`, `songbooks.php`, `tiers.php`, `users.php`). One wire-up, every admin page covered. Adding the call to each page individually would violate the modularity rule in `.claude/CLAUDE.md`.

## Test plan

- [x] `php -l` clean on `manage/includes/auth.php`
- [ ] After deploy: visit `https://dev.ihymns.app/manage/setup-database?_debug=1&_dev=1`. Expect either:
  - The page renders (auth + DB intro succeeded) — in which case run the Songbook Metadata Migration to fix #509, OR
  - A red `ihymns-debug` block at the bottom of the response naming the actual fatal — paste it back and we fix it
- [ ] After deploy: confirm `/manage/*` on production with `?_debug=1&_dev=1` does NOT enable debug (channel guard holds at the bootstrap layer too)
- [ ] After deploy: confirm `?_debug=off` from any `/manage/*` page clears the cookie (no regression in the off-switch)

## Origin

User feedback 2026-04-25, mid-rollout of #508: *"manage/setup-database is loading a blank page as well now, so I cant do the migration of the DB changes!"*

## Related

- #507 — original debug mode (wired to index/api only)
- #508 — the migration fix that needs `/manage/setup-database` to be runnable
- #509 — the underlying tracking issue for the alpha PWA hang

https://claude.ai/code/session_01JZ67hkdcqifZu7yWjiFywL

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZ67hkdcqifZu7yWjiFywL)_