### PR TITLE
fix(manage): load entitlements.php in auth bootstrap

### DIFF
--- a/appWeb/public_html/manage/includes/auth.php
+++ b/appWeb/public_html/manage/includes/auth.php
@@ -38,6 +38,18 @@ enableDebugModeIfRequested();
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'db.php';
 
+/* Entitlement helpers — paired with this file as the canonical /manage/
+   bootstrap per the modularity rule in .claude/CLAUDE.md ("Auth + CSRF
+   + role + entitlement checks → manage/includes/auth.php + includes/
+   entitlements.php"). Loading it here means shared partials such as
+   admin-nav.php / admin-links.php — which call userHasEntitlement()
+   transitively — work everywhere this bootstrap runs, instead of each
+   admin page having to remember its own entitlements.php require. The
+   helper file is just const definitions + pure functions, so it's
+   side-effect-free apart from a direct-access guard. */
+require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'includes'
+          . DIRECTORY_SEPARATOR . 'entitlements.php';
+
 /* =========================================================================
  * SESSION CONFIGURATION
  * ========================================================================= */


### PR DESCRIPTION
## Summary

The on-demand debug mode wired into `/manage/` in #510 caught the next fatal on `dev.ihymns.app/manage/setup-database?_debug=1&_dev=1`:

```
Call to undefined function userHasEntitlement()
  at admin-links.php:67
  via admin-nav.php:53 → setup-database.php:288
```

## Root cause

`manage/includes/admin-nav.php` is the shared chrome partial every `/manage/*.php` page is supposed to include for its navbar. It in turn requires `admin-links.php`, whose `visibleAdminLinks()` closure calls `userHasEntitlement()`. That helper lives in `/includes/entitlements.php`.

The convention until now has been *"every individual `/manage/*.php` page `require_once` `entitlements.php` for itself"* — eleven pages do exactly that. `setup-database.php` (and possibly others) does NOT, so the moment `admin-nav.php` pulls in `admin-links.php` the closure fires and explodes.

`admin-links.php`'s own docblock optimistically declares: *"userHasEntitlement() lives in /includes/entitlements.php and is already required by admin pages via the auth bootstrap."* But the auth bootstrap (`manage/includes/auth.php`) didn't actually require it. **Documentation-vs-reality gap.**

## Fix

Add one `require_once` to `manage/includes/auth.php`, right after the existing `db.php` require. Matches the modularity rule in `.claude/CLAUDE.md`:

> Auth + CSRF + role + entitlement checks → `manage/includes/auth.php` + `includes/entitlements.php`

— which already pairs the two files conceptually. This makes `admin-links.php`'s docblock claim actually true.

`entitlements.php` is just const definitions + pure functions with a direct-access guard, so loading it eagerly in the auth bootstrap has no side effects beyond making `userHasEntitlement()` globally available for every `/manage/*` request.

The eleven existing per-page `require_once …/entitlements.php` lines are now redundant but harmless (`require_once` is idempotent). Leaving them in place rather than touching eleven unrelated files in this fix; a follow-up cleanup PR can remove them if the duplication is worth the diff churn.

## Deployment

After this lands and deploys:

1. Sign in as global admin → `https://dev.ihymns.app/manage/setup-database`
2. Click **"Run Songbook Metadata Migration"** under "3c. Songbook Metadata"
3. Output should be `[add ] tblSongbooks.Colour.` then a sweep of `[skip]`s
4. Reload `https://dev.ihymns.app/` — the SPA should finally boot past the spinner

## Test plan

- [x] `php -l` clean on `manage/includes/auth.php`
- [ ] After deploy: `/manage/setup-database` renders without fatal
- [ ] After deploy: the migration runs to completion and the home page loads
- [ ] Sanity check: any other `/manage/*` page that was relying on its own `require_once entitlements.php` still works (it should — `require_once` makes the duplicate require a no-op)

## Why this and #508 didn't surface earlier

PR #508's deployment instructions said *"sign into /manage/setup-database and click Run Songbook Metadata Migration"* — but that path was already broken before this fix because `setup-database.php` lacked the `entitlements.php` require. The two bugs together (missing column + missing require) created a chicken-and-egg lockout that #510's debug-mode extension finally cracked.

## Origin

User-driven debug session 2026-04-25, mid-rollout of #508. Surfaced by #510.

## Related

- #507 — original PHP debug mode
- #508 — the migration fix that needs `/manage/setup-database` runnable
- #509 — alpha PWA stuck on "Loading iHymns…" tracking issue
- #510 — extended debug mode into `/manage/*`, caught this one
- `.claude/CLAUDE.md` modularity rule on auth + entitlements pairing

https://claude.ai/code/session_01JZ67hkdcqifZu7yWjiFywL

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZ67hkdcqifZu7yWjiFywL)_