### PR TITLE
fix(db): defensive AFTER-clause helper in songbook-meta migration

### DIFF
--- a/appWeb/.sql/migrate-songbook-meta.php
+++ b/appWeb/.sql/migrate-songbook-meta.php
@@ -3,30 +3,31 @@
 declare(strict_types=1);
 
 /**
- * iHymns — Songbook Schema Catch-Up Migration (#502 + Colour catch-up)
+ * iHymns — Songbook Metadata Migration (#502)
  *
  * Copyright (c) 2026 iHymns. All rights reserved.
  *
  * PURPOSE:
- * Brings an existing deployment's tblSongbooks up to the current
- * schema:
- *   1. Adds the `Colour` column if it's missing. The column was
- *      introduced in the "Admin surface phases 1-4" change but no
- *      forward-migration was shipped at the time, so older databases
- *      (notably alpha/dev) still don't have it. SongData::getSongbooks()
- *      now SELECTs `Colour`, so its absence kills the home page.
- *      Added `AFTER DisplayOrder` to match schema.sql.
- *   2. Adds five nullable metadata columns (#502):
+ * Brings an existing deployment's tblSongbooks up to the #502 schema:
+ *   1. Adds five nullable metadata columns:
  *        - IsOfficial      (TINYINT(1) NOT NULL DEFAULT 0)
  *        - Publisher       (VARCHAR(255))
  *        - PublicationYear (VARCHAR(50))
  *        - Copyright       (VARCHAR(500))
  *        - Affiliation     (VARCHAR(120))
- *   3. Marks every existing seed songbook whose Abbreviation is NOT
+ *   2. Marks every existing seed songbook whose Abbreviation is NOT
  *      "Misc" as IsOfficial = 1, matching the real-world state
  *      (the project shipped with five published hymnals + one
  *      unstructured Misc collection). Admins can untick any row
  *      via the edit modal on /manage/songbooks afterwards.
+ *
+ * PREREQUISITES:
+ * Earlier tblSongbooks columns (DisplayOrder, Colour) live in
+ * `migrate-account-sync.php` Step 1b — that's the canonical owner.
+ * Run "Account Sync Migration" first if your DB pre-dates the admin
+ * surface refactor; otherwise the AFTER-clause helper below silently
+ * appends the #502 columns at end of the table rather than at their
+ * canonical position, which is cosmetic-only but worth knowing.
  *
  * Idempotent — re-running is safe. Columns that already exist are
  * skipped with a "skipped" note; the IsOfficial backfill step
@@ -108,11 +109,24 @@ if (!_migSongbookMeta_tableExists($mysqli, 'tblSongbooks')) {
 }
 
 /* Each step: column name → ALTER statement. Keeping them in a list
-   means adding a new column in the future is a one-line edit. */
+   means adding a new column in the future is a one-line edit.
+
+   The `AFTER X` positions match schema.sql for new installs, but the
+   loop below strips any `AFTER X` clause whose anchor column doesn't
+   actually exist on the target DB — so a deployment that hasn't yet
+   run the prerequisite Account Sync Migration (which owns Colour /
+   DisplayOrder) still gets the #502 columns added at end of the table
+   rather than failing. Column position is cosmetic; what matters is
+   the column existing for SongData's SELECT to find. The user is
+   nudged to run Account Sync Migration first; this is just a safety
+   net for the order-dependence. */
 $steps = [
     /* Colour was added to schema.sql in the "Admin surface phases 1-4"
-       change without a forward-migration. Catching it up here, first,
-       so the AFTER Colour clauses on the #502 columns below resolve. */
+       change. Its forward-migration lives in migrate-account-sync.php
+       Step 1b — that's the canonical owner. The catch-up here is left
+       in place from #508 as a defence-in-depth backstop; the helper
+       below makes the AFTER clause safe even if Colour doesn't yet
+       exist on the target DB. */
     ['col' => 'Colour', 'sql' => "ALTER TABLE tblSongbooks
         ADD COLUMN Colour VARCHAR(7) NOT NULL DEFAULT ''
         COMMENT 'Badge colour hex #RRGGBB (empty = theme default)'
@@ -139,12 +153,29 @@ $steps = [
         AFTER Copyright"],
 ];
 
+/**
+ * Strip an `AFTER X` positional clause from an ALTER … ADD COLUMN
+ * statement when the anchor column doesn't yet exist on the target
+ * database. Lets old schemas missing intermediate columns still
+ * migrate one column at a time.
+ */
+function _migSongbookMeta_resolveAfterClause(mysqli $db, string $tbl, string $sql): string
+{
+    if (preg_match('/\sAFTER\s+([A-Za-z_][A-Za-z0-9_]*)\b/i', $sql, $m)) {
+        if (!_migSongbookMeta_colExists($db, $tbl, $m[1])) {
+            return preg_replace('/\sAFTER\s+[A-Za-z_][A-Za-z0-9_]*\b/i', '', $sql);
+        }
+    }
+    return $sql;
+}
+
 foreach ($steps as $s) {
     if (_migSongbookMeta_colExists($mysqli, 'tblSongbooks', $s['col'])) {
         _migSongbookMeta_out("[skip] tblSongbooks.{$s['col']} already present.");
         continue;
     }
-    if (!$mysqli->query($s['sql'])) {
+    $sql = _migSongbookMeta_resolveAfterClause($mysqli, 'tblSongbooks', $s['sql']);
+    if (!$mysqli->query($sql)) {
         _migSongbookMeta_out("ERROR: adding {$s['col']} failed: " . $mysqli->error);
         exit(1);
     }


### PR DESCRIPTION
**Walk-back + scope reduction.** The original v1 of this PR added a `DisplayOrder` catch-up step. That was wrong — `DisplayOrder` (and `Colour`) already have a canonical forward-migration in `migrate-account-sync.php` Step 1b (per issue #429). The user just needed to run **"Account Sync Migration"** first, then **"Songbook Metadata Migration"**.

This PR is rewritten to keep only the genuinely useful piece from that work: a **defensive `AFTER`-clause helper**.

## What the helper does

Each step in `$steps` writes its column with `AFTER X` to match `schema.sql` for new installs. On a deployment that hasn't yet run the prerequisite migration, the anchor column may be missing — and before this change, that produced a hard fatal mid-migration. The helper intercepts each ALTER just before execution, checks whether the `AFTER` anchor exists on the target DB, and **strips the clause if not** (the column gets appended at end of the table instead).

Column position is cosmetic — what matters for `SongData`'s SELECTs is the column existing. So the safety net buys *"the migration doesn't fail"* with no functional cost.

This is a **backstop, not a substitute**. The PREREQUISITES note in the migration docblock still nudges users to run "Account Sync Migration" first; the helper just means "what if you didn't" doesn't blow up the whole flow.

## What I removed from v1

- The `DisplayOrder` `ADD COLUMN` step. Owned by `migrate-account-sync.php` Step 1b; duplicating it here would have violated DRY for no gain.
- Docblock + comment text claiming this migration is a "tblSongbooks schema catch-up". It's not — it's the #502 metadata migration. The helper keeps it robust against being run out of order, but the canonical owner of pre-#502 columns is `migrate-account-sync.php`.

## What I left alone

- The `Colour` `ADD COLUMN` step that #508 added. That PR is already merged; reverting it is out of scope for this PR. The helper makes its `AFTER` clause safe whether or not `Colour` exists, and on a correctly-ordered run it `[skip]`s anyway. If we want to remove the duplication with `migrate-account-sync.php`'s Colour step, that's a separate cleanup PR.

## Deployment

No special steps. Run-order on alpha:

1. **Account Sync Migration** (adds `DisplayOrder` + `Colour` + #135 columns + tblSharedSetlists)
2. **Songbook Metadata Migration** (adds the #502 columns + `IsOfficial` backfill)

Either order is now non-fatal thanks to the helper, but `1 → 2` produces canonical column positions and the cleanest migration log.

## Test plan

- [x] `php -l` clean
- [x] Trace by hand: when `AFTER Colour` is requested on a DB without `Colour`, helper strips the `AFTER`, ALTER succeeds appending at end. Subsequent steps see new column positions but their own AFTER clauses against still-missing anchors get stripped likewise.
- [ ] After deploy: confirm running "Songbook Metadata Migration" out-of-order on a test DB does not fatal — it should add the #502 columns at end of table with `[add ]` lines, and a re-run after Account Sync is then `[skip]`s.
- [ ] After deploy: on an in-order run (Account Sync → Songbook Metadata), confirm the migration log is identical to before this PR (no behavioural change for the canonical path).

## Related

- #429 (closed) — established `migrate-account-sync.php` Step 1b as the canonical owner of `DisplayOrder` + `Colour`.
- #508 (merged) — added the `Colour` step to *this* migration; left in place by this PR but acknowledged as redundant in the docblock.
- #509 (open) — alpha PWA hang tracking issue. The actual fix turned out to be "run Account Sync Migration first"; #508 was a mis-diagnosis. Will update #509 separately.
- A schema-vs-migration audit issue (to be opened) — the broader pattern this surfaced.

https://claude.ai/code/session_01JZ67hkdcqifZu7yWjiFywL