### PR TITLE
fix(admin/schema-audit): skip ON DELETE/UPDATE + FULLTEXT lines in parser

### DIFF
--- a/appWeb/public_html/manage/schema-audit.php
+++ b/appWeb/public_html/manage/schema-audit.php
@@ -85,8 +85,21 @@ function _schemaAudit_parseSchema(string $schemaSql): array
             if ($line === '' || str_starts_with($line, '--') || str_starts_with($line, '/*')) {
                 continue;
             }
-            /* Skip table-level constraints. */
-            if (preg_match('/^(PRIMARY\s+KEY|INDEX|UNIQUE|KEY|CONSTRAINT|FOREIGN\s+KEY)\b/i', $line)) {
+            /* Skip table-level constraints AND constraint-continuation lines.
+               Catches:
+                 - PRIMARY KEY / KEY / UNIQUE / INDEX / FULLTEXT / SPATIAL
+                 - CONSTRAINT … FOREIGN KEY … REFERENCES …
+                 - The continuation line of a multi-line FOREIGN KEY:
+                       …REFERENCES tblX(Id)
+                           ON DELETE SET NULL ON UPDATE CASCADE
+                   — the second line starts with `ON`, which a naïve column
+                   parser would otherwise read as a column literally named
+                   "ON". Same for the FULLTEXT / SPATIAL index forms which
+                   start with their own keyword (not INDEX). */
+            if (preg_match(
+                '/^(PRIMARY\s+KEY|INDEX|UNIQUE|KEY|CONSTRAINT|FOREIGN\s+KEY|FULLTEXT|SPATIAL|ON\s+(DELETE|UPDATE))\b/i',
+                $line
+            )) {
                 continue;
             }
             /* Column line: starts with `Name` or `\`Name\`` followed by a type. */


### PR DESCRIPTION
Follow-up to #519. The first real-world run of `/manage/schema-audit` on alpha surfaced 73 "uncovered" columns — but ~50 were a column literally named **`ON`** and 3 were named **`FULLTEXT`**, both **parser artifacts, not real drift**.

## Root cause — two gaps in the schema-line skip-list

`_schemaAudit_parseSchema()` walks each line inside a `CREATE TABLE (…)` block and skips lines that look like table-level constraints rather than column definitions. The previous skip-list caught:

> `PRIMARY KEY` · `INDEX` · `UNIQUE` · `KEY` · `CONSTRAINT` · `FOREIGN KEY`

Two patterns slipped past it:

1. **Multi-line FOREIGN KEY definitions:**
   ```sql
   CONSTRAINT fk_X FOREIGN KEY (Y) REFERENCES tblZ(W)
       ON DELETE SET NULL ON UPDATE CASCADE
   ```
   Line 1 was caught by `CONSTRAINT`, but line 2 starts with `ON` — which the column-name regex matches happily, so every multi-line FK contributed a phantom `ON` column to the containing table. With ~30 FK relationships in `schema.sql`, that produced ~50 phantom rows.

2. **`FULLTEXT idx_X (Title, ...)` index definitions** — three on `tblSongs`. `FULLTEXT` wasn't in the skip-list (only `INDEX` was), so each contributed a phantom `FULLTEXT` column.

## Fix

Extend the skip-list regex to match `FULLTEXT` / `SPATIAL` (future-proofing) / `ON\s+(DELETE|UPDATE)` in addition to the existing list. The migration scanner reuses `parseSchema()` against migration source files for its `CREATE TABLE` detection, so the same fix also benefits scanned coverage (which previously over-credited migrations with phantom `ON` / `FULLTEXT` entries).

## Verified — 14-check regression test

Subprocess harness against the real `schema.sql`:

- Zero `ON` pseudo-columns parsed
- Zero `FULLTEXT` pseudo-columns parsed
- `tblSongs` has its real columns (Id, Title, TuneName, LyricsText, …) and **no** `ON` / `FULLTEXT`
- `tblOrganisations` has its real columns and **no** `ON`
- Migration scanner attributes `tblSharedSetlists.ShareId` / `.ViewCount` to `migrate-account-sync.php` and does **not** attribute `.ON` to it
- Zero migration entries ending in `.ON` or `.FULLTEXT`

Total real-column count drops from **366 → 314** — exactly the ~52 phantom-row drop the alpha audit predicted.

## Post-deploy

Re-running `/manage/schema-audit` on alpha after this lands should show the genuine drift list, no longer drowned in noise. From the pre-fix output we already know what to expect:

- **Missing in DB (amber)** — `tblSongs.TuneName` + `tblSongs.Iswc` → run `migrate-credit-fields.php` via Setup Database
- **Uncovered (red)** — `tblUserGroups.AllowCardReorder` (one column with no migration)
- **Uncovered (red)** — five entire tables that look uncovered: `tblSearchQueries`, `tblSongAdaptors`, `tblSongArrangers`, `tblSongTranslators`, `tblUserSetlists`. These need migrations written if they're meant to exist on older DBs.

I'll triage that list properly once this fix lands and we have clean output.

## Test plan

- [x] `php -l` clean
- [x] 14-check regression smoke test passes against real `schema.sql`
- [ ] After deploy: `/manage/schema-audit` on alpha — expect ~50-row drop in "uncovered" count, leaving only the genuine drift list above

## Related

- #519 — initial audit page; this is the first iteration of "ship audit, run it, fix what it surfaces"
- #518 — tracking issue for the audit page
- #517 — umbrella audit issue; this PR keeps Audit 1.1 useful

https://claude.ai/code/session_01JZ67hkdcqifZu7yWjiFywL

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZ67hkdcqifZu7yWjiFywL)_