### PR TITLE
fix(db/audit): backfill @migration-adds doctags on credit-fields migration

### DIFF
--- a/appWeb/.sql/migrate-credit-fields.php
+++ b/appWeb/.sql/migrate-credit-fields.php
@@ -22,6 +22,24 @@ declare(strict_types=1);
  * Idempotent — re-running is safe. Columns/indexes/tables that already
  * exist are skipped with a "skipped" note.
  *
+ * The Step 3 CREATE TABLE statements iterate over a [tableName => fkName]
+ * array and build the SQL with `CREATE TABLE {$table} (...)`, where
+ * `$table` is a PHP variable interpolation. The schema-audit scanner's
+ * literal-CREATE-TABLE regex can't see those bindings, so we declare
+ * the columns explicitly via @migration-adds doctags below to keep the
+ * audit's coverage map accurate. Any future addition to $creditTables
+ * needs a corresponding doctag here.
+ *
+ * @migration-adds tblSongArrangers.Id
+ * @migration-adds tblSongArrangers.SongId
+ * @migration-adds tblSongArrangers.Name
+ * @migration-adds tblSongAdaptors.Id
+ * @migration-adds tblSongAdaptors.SongId
+ * @migration-adds tblSongAdaptors.Name
+ * @migration-adds tblSongTranslators.Id
+ * @migration-adds tblSongTranslators.SongId
+ * @migration-adds tblSongTranslators.Name
+ *
  * USAGE:
  *   CLI:  php appWeb/.sql/migrate-credit-fields.php
  *   Web:  /manage/setup-database → "Credit Fields Migration" button


### PR DESCRIPTION
Follow-up to #519 / #520. The first clean run of `/manage/schema-audit` on alpha (post #520) showed three credit-related tables as **Uncovered**:

- `tblSongArrangers` (3 cols)
- `tblSongAdaptors` (3 cols)
- `tblSongTranslators` (3 cols)

These ARE covered by `migrate-credit-fields.php` Step 3 — the audit scanner just can't see it.

## Why the scanner missed them

Step 3 iterates over a `[tableName => fkName]` array and builds the SQL like:

```php
$sql = "CREATE TABLE {$table} ( … )";
```

— a PHP variable interpolation that the scanner's literal `CREATE TABLE` regex doesn't match (the regex requires `tblXxx` literally). **Same shape that defeated `migrate-account-sync.php`'s Step 1b for `DisplayOrder` / `Colour`, which we papered over with `@migration-adds` doctags in #519.**

## Fix

Backfill nine `@migration-adds` doctags on the migration's docblock — one per column it creates dynamically. Per the convention the scanner already supports, doctags are picked up as a third coverage signal alongside literal ALTER strings and CREATE TABLE blocks.

Also added an explanatory note in the docblock pointing at the regex gap, so the next person who adds a `$creditTables` entry knows to tag it.

## Verified

After the change, the scanner reports each of the nine columns as **COVERED by `migrate-credit-fields.php`**. Total mappings count rises from 16 → 25 (exactly the 9 new doctags).

## Post-deploy

Re-running `/manage/schema-audit` on alpha drops the **uncovered count from 22 → 13** — exactly the 9 phantom rows the backfill removes. The remaining 13 are the **genuine drift items** that need new migrations written:

| Table | Columns | Note |
|---|---|---|
| `tblSearchQueries` | 5 (Id, Query, ResultCount, UserId, SearchedAt) | No migration anywhere; `manage/analytics.php` even has a hardcoded *"(or the tblSearchQueries table hasn't been created — re-run install)"* fallback |
| `tblUserSetlists` | 7 (Id, UserId, SetlistId, Name, SongsJson, CreatedAt, UpdatedAt) | `migrate-users.php` `INSERT`s into it but never `CREATE`s — likely accidental from an earlier refactor |
| `tblUserGroups.AllowCardReorder` | 1 column | Card-layout work |

Those are tracked under #517 Audit 1; placement (one new migration vs spread across existing) is the next decision.

## Test plan

- [x] `php -l` clean
- [x] Scanner picks up all nine columns as covered
- [ ] After deploy: re-run `/manage/schema-audit` on alpha — expect uncovered count to drop from 22 to 13

## Related

- #519 / #520 — schema-audit page + parser fix
- #517 — umbrella audit issue; this PR closes the "scanner gap" follow-up under Audit 1.1
- #497 — the PR that originally shipped `migrate-credit-fields.php`

https://claude.ai/code/session_01JZ67hkdcqifZu7yWjiFywL

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZ67hkdcqifZu7yWjiFywL)_