### PR TITLE
feat(db): user-features catch-up migration for the 3 audit-discovered drift items

### DIFF
--- a/appWeb/.sql/migrate-user-features-catchup.php
+++ b/appWeb/.sql/migrate-user-features-catchup.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — User Features Catch-Up Migration (#517)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Catches up three pieces of user-feature schema that landed in
+ * `appWeb/.sql/schema.sql` without an accompanying forward-migration.
+ * Fresh installs got them via `install.php`; existing alpha/dev/beta
+ * databases didn't, and the gap was only surfaced by the first run of
+ * `/manage/schema-audit` (#519). Specifically:
+ *
+ *   1. tblUserGroups.AllowCardReorder
+ *      — TINYINT(1) NOT NULL DEFAULT 1
+ *      — Group members may customise dashboard / home card layout (#448).
+ *      — Default 1 keeps existing groups permissive (matches install.php).
+ *
+ *   2. tblUserSetlists
+ *      — Per-user set-list storage (Id, UserId, SetlistId, Name,
+ *        SongsJson, CreatedAt, UpdatedAt) plus FK to tblUsers.
+ *      — `migrate-users.php` already INSERTs into this table, but no
+ *        migration ever CREATEd it on existing DBs — accidental gap
+ *        from an earlier refactor.
+ *
+ *   3. tblSearchQueries
+ *      — Search analytics table (Id, Query, ResultCount, UserId,
+ *        SearchedAt) plus FK to tblUsers.
+ *      — `manage/analytics.php` SELECTs from it and even has a
+ *        hardcoded "(or the tblSearchQueries table hasn't been created
+ *        — re-run install)" fallback message — known-but-untracked.
+ *
+ * Idempotent — re-running is safe. Each step probes for existence
+ * (column or table) before attempting the ALTER / CREATE.
+ *
+ * USAGE:
+ *   CLI: php appWeb/.sql/migrate-user-features-catchup.php
+ *   Web: /manage/setup-database → "User Features Catch-Up Migration"
+ *        (entry point requires global_admin)
+ *
+ * @requires PHP 8.1+ with mysqli extension
+ */
+
+$isCli = (php_sapi_name() === 'cli');
+
+if (!$isCli && !defined('IHYMNS_SETUP_DASHBOARD')) {
+    header('Content-Type: text/plain; charset=UTF-8');
+    header('X-Content-Type-Options: nosniff');
+    header('Cache-Control: no-store');
+}
+
+function _migUserFeatures_out(string $msg): void {
+    global $isCli;
+    echo $msg . ($isCli ? "\n" : "<br>\n");
+    if (!$isCli) flush();
+}
+
+/* Credentials — same path as every other migration script. */
+$credPath = dirname(__DIR__) . DIRECTORY_SEPARATOR . '.auth' . DIRECTORY_SEPARATOR . 'db_credentials.php';
+if (!file_exists($credPath)) {
+    _migUserFeatures_out('ERROR: db_credentials.php not found — run install.php first.');
+    exit(1);
+}
+if (!defined('DB_HOST')) {
+    require_once $credPath;
+}
+
+$mysqli = @new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME, defined('DB_PORT') ? (int)DB_PORT : 3306);
+if ($mysqli->connect_errno) {
+    _migUserFeatures_out('ERROR: MySQL connect failed: ' . $mysqli->connect_error);
+    exit(1);
+}
+$mysqli->set_charset('utf8mb4');
+
+_migUserFeatures_out('=== iHymns User Features Catch-Up Migration (#517) ===');
+_migUserFeatures_out('Database: ' . DB_NAME . ' @ ' . DB_HOST);
+_migUserFeatures_out('');
+
+function _migUserFeatures_colExists(mysqli $db, string $table, string $col): bool {
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?
+          LIMIT 1'
+    );
+    $stmt->bind_param('ss', $table, $col);
+    $stmt->execute();
+    $exists = (bool)$stmt->get_result()->fetch_row();
+    $stmt->close();
+    return $exists;
+}
+
+function _migUserFeatures_tableExists(mysqli $db, string $table): bool {
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?
+          LIMIT 1'
+    );
+    $stmt->bind_param('s', $table);
+    $stmt->execute();
+    $exists = (bool)$stmt->get_result()->fetch_row();
+    $stmt->close();
+    return $exists;
+}
+
+/* ----------------------------------------------------------------------
+ * Step 1: tblUserGroups.AllowCardReorder column
+ * ---------------------------------------------------------------------- */
+_migUserFeatures_out('--- Step 1: tblUserGroups.AllowCardReorder column ---');
+if (!_migUserFeatures_tableExists($mysqli, 'tblUserGroups')) {
+    _migUserFeatures_out('  [WARN] tblUserGroups missing — run install.php first; skipping.');
+} elseif (_migUserFeatures_colExists($mysqli, 'tblUserGroups', 'AllowCardReorder')) {
+    _migUserFeatures_out('  [skip] tblUserGroups.AllowCardReorder already present.');
+} else {
+    $sql = "ALTER TABLE tblUserGroups
+            ADD COLUMN AllowCardReorder TINYINT(1) NOT NULL DEFAULT 1
+            COMMENT 'Group members may customise dashboard / home card layout (#448)'
+            AFTER AccessRtw";
+    if (!$mysqli->query($sql)) {
+        _migUserFeatures_out('  [ERROR] Could not add AllowCardReorder: ' . $mysqli->error);
+    } else {
+        _migUserFeatures_out('  [add ] tblUserGroups.AllowCardReorder.');
+    }
+}
+_migUserFeatures_out('');
+
+/* ----------------------------------------------------------------------
+ * Step 2: tblUserSetlists table
+ * ---------------------------------------------------------------------- */
+_migUserFeatures_out('--- Step 2: tblUserSetlists table ---');
+if (_migUserFeatures_tableExists($mysqli, 'tblUserSetlists')) {
+    _migUserFeatures_out('  [skip] tblUserSetlists already present.');
+} else {
+    $sql = "CREATE TABLE IF NOT EXISTS tblUserSetlists (
+        Id              INT UNSIGNED    AUTO_INCREMENT PRIMARY KEY,
+        UserId          INT UNSIGNED    NOT NULL,
+        SetlistId       VARCHAR(100)    NOT NULL COMMENT 'Client-generated unique ID',
+        Name            VARCHAR(200)    NOT NULL,
+        SongsJson       MEDIUMTEXT      NOT NULL DEFAULT '[]' COMMENT 'JSON array of song objects',
+        CreatedAt       TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        UpdatedAt       TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+        UNIQUE KEY uq_UserSetlist (UserId, SetlistId),
+        INDEX idx_User (UserId),
+
+        CONSTRAINT fk_Setlists_User
+            FOREIGN KEY (UserId) REFERENCES tblUsers(Id)
+            ON DELETE CASCADE ON UPDATE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
+
+    if (!$mysqli->query($sql)) {
+        _migUserFeatures_out('  [ERROR] Could not create tblUserSetlists: ' . $mysqli->error);
+    } else {
+        _migUserFeatures_out('  [add ] tblUserSetlists.');
+    }
+}
+_migUserFeatures_out('');
+
+/* ----------------------------------------------------------------------
+ * Step 3: tblSearchQueries table
+ * ---------------------------------------------------------------------- */
+_migUserFeatures_out('--- Step 3: tblSearchQueries table ---');
+if (_migUserFeatures_tableExists($mysqli, 'tblSearchQueries')) {
+    _migUserFeatures_out('  [skip] tblSearchQueries already present.');
+} else {
+    $sql = "CREATE TABLE IF NOT EXISTS tblSearchQueries (
+        Id              BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+        Query           VARCHAR(500)    NOT NULL,
+        ResultCount     INT UNSIGNED    NOT NULL DEFAULT 0,
+        UserId          INT UNSIGNED    NULL,
+        SearchedAt      TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        INDEX idx_SearchedAt (SearchedAt),
+        INDEX idx_Query      (Query(191)),
+        CONSTRAINT fk_Search_User FOREIGN KEY (UserId) REFERENCES tblUsers(Id)
+            ON DELETE SET NULL ON UPDATE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
+
+    if (!$mysqli->query($sql)) {
+        _migUserFeatures_out('  [ERROR] Could not create tblSearchQueries: ' . $mysqli->error);
+    } else {
+        _migUserFeatures_out('  [add ] tblSearchQueries.');
+    }
+}
+_migUserFeatures_out('');
+
+_migUserFeatures_out('Migration complete.');
+$mysqli->close();

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -195,6 +195,7 @@ if ($action !== '') {
         'account-sync'=> 'migrate-account-sync.php',
         'credits'     => 'migrate-credit-fields.php',
         'songbook-meta' => 'migrate-songbook-meta.php',
+        'user-features-catchup' => 'migrate-user-features-catchup.php',
         'cleanup'     => 'cleanup.php',
         'backup'      => 'backup.php',
         'restore'     => 'restore.php',
@@ -500,6 +501,25 @@ if ($hasCredentials && defined('DB_HOST')) {
                         </p>
                         <a href="?action=songbook-meta" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
                             Run Songbook Metadata Migration
+                        </a>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="card bg-dark border-secondary h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">3d. User Features Catch-Up (#517)</h5>
+                        <p class="card-text text-secondary small">
+                            Catches up three pieces of user-feature schema that
+                            landed in <code>schema.sql</code> without forward-
+                            migrations and were surfaced by the Schema Audit page:
+                            <code>tblUserGroups.AllowCardReorder</code>,
+                            <code>tblUserSetlists</code> table, and
+                            <code>tblSearchQueries</code> table.
+                            Idempotent — safe to re-run.
+                        </p>
+                        <a href="?action=user-features-catchup" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
+                            Run User Features Catch-Up Migration
                         </a>
                     </div>
                 </div>


### PR DESCRIPTION
Closes the **"genuinely uncovered"** findings from the first clean run of `/manage/schema-audit` on alpha (#519 page, post #520 + #521):

| Item | What it is |
|---|---|
| `tblUserGroups.AllowCardReorder` | Single column, card-layout (#448) |
| `tblUserSetlists` | 7 cols, per-user set-list storage (already INSERTed into by `migrate-users.php`, never CREATEd) |
| `tblSearchQueries` | 5 cols, search analytics (`manage/analytics.php` even has a hardcoded "(or the tblSearchQueries table hasn't been created — re-run install)" fallback) |

All three landed in `schema.sql` at various points without an accompanying forward-migration. Fresh installs got them via `install.php`; existing alpha/dev/beta DBs didn't, and the gap was only surfaced once the audit page existed to look. Per #517 Audit 1's process: ship the audit, fix what it surfaces.

## Design

Per Option A (your call): **single new migration file** `migrate-user-features-catchup.php` rather than spreading the three steps across topical existing migrations. Reasons:

- One button on `/manage/setup-database`; one audit-driven cleanup; one place to look in git history if this batch ever needs revisiting.
- The three items don't have semantic reasons to live with their topical neighbours — they're connected by *"audit found these together"*, which is what the file name reflects.

Each step is idempotent (probes for column / table existence first via `INFORMATION_SCHEMA`), matches the shape of every other migration in this directory. Column / table definitions copied verbatim from `schema.sql` so a fresh install on `schema.sql` and an existing install on this migration produce byte-identical structure.

## Wiring

- New entry in `setup-database.php`'s `$scriptMap`: `'user-features-catchup' => 'migrate-user-features-catchup.php'`.
- New **"3d. User Features Catch-Up (#517)"** card on the dashboard, placed right after 3c (Songbook Metadata) so all the catch-up migrations cluster together.

## Verification

Schema-audit scanner exercised against the new migration before push:

- All **13 audit-flagged columns** (1 ALTER + 7 + 5 from the two `CREATE TABLE`s) show as COVERED by `migrate-user-features-catchup.php`.
- Total scanner mappings rose 25 → **38** (+13 exactly).

Once this lands and an admin runs the migration, `/manage/schema-audit` should show:

- **Uncovered count: 13 → 0**
- **Banner: red → green** ✅

## Deployment

After merge + deploy, sign in as global admin → `/manage/setup-database` → click **"Run User Features Catch-Up Migration"**. Expected output on alpha:

```
--- Step 1: tblUserGroups.AllowCardReorder column ---
  [add ] tblUserGroups.AllowCardReorder.

--- Step 2: tblUserSetlists table ---
  [add ] tblUserSetlists.

--- Step 3: tblSearchQueries table ---
  [add ] tblSearchQueries.

Migration complete.
```

On production / fresh installs (assuming they have these from `install.php`), expect 3× `[skip]` across all steps.

## Test plan

- [x] `php -l` clean on both files
- [x] Scanner picks up all 13 columns as covered by the new migration
- [ ] After deploy: run on alpha, expect 3× `[add ]`
- [ ] After deploy: re-run `/manage/schema-audit` on alpha — expect 0 uncovered, green banner
- [ ] After deploy on production: run, expect 3× `[skip]`
- [ ] Sanity check `/manage/data-health` after the migration — `tblUserSetlists` should appear in the row counts; `tblSearchQueries` likewise (the data-health page already references both)

## Related

- #517 — umbrella audit, this PR closes the substantive findings
- #519 / #520 / #521 — schema-audit page + parser fix + scanner doctags backfill
- #448 — origin of the `AllowCardReorder` column

https://claude.ai/code/session_01JZ67hkdcqifZu7yWjiFywL

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZ67hkdcqifZu7yWjiFywL)_