### PR TITLE
fix(db): relax SQL strict mode in user-features-catchup migration

### DIFF
--- a/appWeb/.sql/migrate-user-features-catchup.php
+++ b/appWeb/.sql/migrate-user-features-catchup.php
@@ -75,6 +75,17 @@ if ($mysqli->connect_errno) {
 }
 $mysqli->set_charset('utf8mb4');
 
+/* Relax SQL strict mode for this session — schema.sql declares
+   `SongsJson MEDIUMTEXT NOT NULL DEFAULT '[]'` which MySQL refuses
+   under STRICT_TRANS_TABLES (the default since 5.7) with:
+       "BLOB, TEXT, GEOMETRY or JSON column 'X' can't have a default"
+   install.php gets away with it because the deployed server's mode
+   has historically been permissive; this migration may run on a
+   stricter server, so we explicitly drop strict mode for the
+   connection only. NO_ENGINE_SUBSTITUTION is the conservative
+   replacement (just guards against silently switching engines). */
+$mysqli->query("SET SESSION sql_mode = 'NO_ENGINE_SUBSTITUTION'");
+
 _migUserFeatures_out('=== iHymns User Features Catch-Up Migration (#517) ===');
 _migUserFeatures_out('Database: ' . DB_NAME . ' @ ' . DB_HOST);
 _migUserFeatures_out('');


### PR DESCRIPTION
Hot-fix for #522. Running "User Features Catch-Up Migration" on alpha failed at Step 2 with:

```
ERROR: BLOB, TEXT, GEOMETRY or JSON column 'SongsJson' can't have a default value
File: migrate-user-features-catchup.php:153
```

(Step 1 succeeded — `tblUserGroups.AllowCardReorder` was added cleanly. Steps 2 + 3 didn't run.)

## Root cause

The Step 2 `CREATE TABLE` was copied verbatim from `schema.sql`:

```sql
SongsJson  MEDIUMTEXT  NOT NULL DEFAULT '[]'  COMMENT '…'
```

MySQL refuses `MEDIUMTEXT` defaults under `STRICT_TRANS_TABLES` (the default `sql_mode` since 5.7 / 8.0). `install.php` gets away with the same line because the long-lived deployed server's mode has historically been permissive enough to accept it; the migration ran on a stricter session and tripped the check.

## Fix

One line right after `set_charset`:

```php
$mysqli->query("SET SESSION sql_mode = 'NO_ENGINE_SUBSTITUTION'");
```

- **SESSION-scoped** — doesn't affect other connections.
- **`NO_ENGINE_SUBSTITUTION`** is the conservative replacement (just guards against silently switching storage engines if the requested one is unavailable).
- Drops `STRICT_TRANS_TABLES`, which was triggering the error.

`schema.sql` is left unchanged — the canonical column shape stays `MEDIUMTEXT NOT NULL DEFAULT '[]'` so a fresh install (whose server config the project assumes is already permissive) and a re-run of this migration produce byte-identical structure.

## Deployment

After merge + redeploy, click **"Run User Features Catch-Up Migration"** again. Expected output:

```
--- Step 1: tblUserGroups.AllowCardReorder column ---
  [skip] tblUserGroups.AllowCardReorder already present.

--- Step 2: tblUserSetlists table ---
  [add ] tblUserSetlists.

--- Step 3: tblSearchQueries table ---
  [add ] tblSearchQueries.

Migration complete.
```

Then refresh `/manage/schema-audit` — expect **green banner**.

## Follow-up (separate, low priority)

The same risk theoretically applies to `install.php` and other `migrate-*.php` files that copy `schema.sql` literals containing `TEXT/BLOB` defaults. Worth a standardisation pass that adds the same one-liner across all of them as a defence-in-depth measure. Tracked as a follow-up under #517 Audit 1.

## Test plan

- [x] `php -l` clean
- [ ] After deploy: re-run on alpha — expect Step 1 `[skip]` + Step 2/3 `[add ]`
- [ ] Re-run `/manage/schema-audit` — expect 0 missing, 0 uncovered, green banner

## Related

- #522 — original migration that this hot-fix patches
- #517 — umbrella audit issue
- #519 / #520 / #521 — schema-audit page that surfaced the underlying drift

https://claude.ai/code/session_01JZ67hkdcqifZu7yWjiFywL

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZ67hkdcqifZu7yWjiFywL)_