### PR TITLE
fix(db): use MySQL 8.0+ expression-default syntax for SongsJson

### DIFF
--- a/appWeb/.sql/migrate-user-features-catchup.php
+++ b/appWeb/.sql/migrate-user-features-catchup.php
@@ -75,15 +75,22 @@ if ($mysqli->connect_errno) {
 }
 $mysqli->set_charset('utf8mb4');
 
-/* Relax SQL strict mode for this session — schema.sql declares
-   `SongsJson MEDIUMTEXT NOT NULL DEFAULT '[]'` which MySQL refuses
-   under STRICT_TRANS_TABLES (the default since 5.7) with:
-       "BLOB, TEXT, GEOMETRY or JSON column 'X' can't have a default"
-   install.php gets away with it because the deployed server's mode
-   has historically been permissive; this migration may run on a
-   stricter server, so we explicitly drop strict mode for the
-   connection only. NO_ENGINE_SUBSTITUTION is the conservative
-   replacement (just guards against silently switching engines). */
+/* MySQL 8.0+ enforces — independent of sql_mode — that BLOB / TEXT /
+   JSON / GEOMETRY columns cannot carry a literal default value. The
+   parenthesised "expression default" form has been valid since 8.0.13
+   and is what we use below for SongsJson:
+
+       SongsJson MEDIUMTEXT NOT NULL DEFAULT ('[]')
+
+   schema.sql still uses the literal form, which is on a list of
+   schema cleanups for a separate PR — for now this migration uses
+   the expression form so the CREATE succeeds on 8.0+ servers. The
+   resulting column behaves identically: NOT NULL with default '[]'
+   inserted on rows that don't supply the value.
+
+   The SET SESSION sql_mode line below is kept as defence-in-depth
+   for any other strictness issues we might trip on later (cheap
+   insurance — session-scoped, doesn't affect other connections). */
 $mysqli->query("SET SESSION sql_mode = 'NO_ENGINE_SUBSTITUTION'");
 
 _migUserFeatures_out('=== iHymns User Features Catch-Up Migration (#517) ===');
@@ -149,7 +156,7 @@ if (_migUserFeatures_tableExists($mysqli, 'tblUserSetlists')) {
         UserId          INT UNSIGNED    NOT NULL,
         SetlistId       VARCHAR(100)    NOT NULL COMMENT 'Client-generated unique ID',
         Name            VARCHAR(200)    NOT NULL,
-        SongsJson       MEDIUMTEXT      NOT NULL DEFAULT '[]' COMMENT 'JSON array of song objects',
+        SongsJson       MEDIUMTEXT      NOT NULL DEFAULT ('[]') COMMENT 'JSON array of song objects',
         CreatedAt       TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
         UpdatedAt       TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 


### PR DESCRIPTION
Hot-fix follow-up to #523. **My #523 fix was a misdiagnosis** — the migration still failed after #523 deployed:

```
ERROR: BLOB, TEXT, GEOMETRY or JSON column 'SongsJson' can't have a default value
File: migrate-user-features-catchup.php:164
```

(Line number jumped 153 → 164 because of #523's added 11 lines, confirming #523 is live; the fix just didn't help.)

## Root cause — corrected

In **MySQL 8.0+**, the rule *"BLOB/TEXT/JSON/GEOMETRY columns cannot carry a literal default value"* is **independent of `sql_mode`** — it's a hard rule baked into the parser. `SET SESSION sql_mode` does nothing for this case. #523 was solving a 5.7-era problem that doesn't apply to the actually-deployed 8.0 server.

The supported workaround on 8.0.13+ is the parenthesised **"expression default"** form:

```sql
DEFAULT ('[]')    -- expression: works on 8.0+
DEFAULT '[]'      -- literal:    rejected on 8.0+
```

Both produce identical column behaviour at `INSERT` time; only the parser distinguishes them.

## Fix

A one-character pair of changes inside the `tblUserSetlists` `CREATE TABLE`:

```diff
-SongsJson MEDIUMTEXT NOT NULL DEFAULT '[]' COMMENT '…'
+SongsJson MEDIUMTEXT NOT NULL DEFAULT ('[]') COMMENT '…'
```

Plus a docblock-comment update where I previously misdiagnosed. The `SET SESSION sql_mode` line from #523 is **left in place** — harmless, session-scoped, cheap defence-in-depth for unrelated strictness issues that might come up later.

## Out of scope — `schema.sql` cleanup

`schema.sql` line 574 still has the literal-default form:

```sql
SongsJson MEDIUMTEXT NOT NULL DEFAULT '[]'
```

…which means a fresh `install.php` run on a stock MySQL 8.0+ server would also fail at this line. Nobody's noticed because no one's done a fresh install recently — the long-lived deployed servers came up under older MySQL where the literal worked.

Fixing `schema.sql` is a separate PR (probably wants a sweep of all `TEXT/BLOB`-with-default columns to switch them to the expression form). **Tracked as a follow-up under #517 Audit 1.**

## Deployment

After merge + redeploy, run **"User Features Catch-Up Migration"** again. Expected:

```
[skip] tblUserGroups.AllowCardReorder already present.
[add ] tblUserSetlists.
[add ] tblSearchQueries.
Migration complete.
```

Then refresh `/manage/schema-audit` → expect green banner.

## Test plan

- [x] `php -l` clean
- [ ] After deploy: re-run on alpha — expect Step 1 `[skip]` + Steps 2/3 `[add ]`
- [ ] Refresh `/manage/schema-audit` — expect 0 missing, 0 uncovered, green banner

## Related

- #523 — earlier sql_mode hot-fix (kept; harmless even though it didn't address this specific cause)
- #522 — original migration
- #517 — umbrella audit; the schema.sql cleanup will be a follow-up here

https://claude.ai/code/session_01JZ67hkdcqifZu7yWjiFywL

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZ67hkdcqifZu7yWjiFywL)_