### PR TITLE
fix(php): drop literal <?=…?> from HTML comment to stop runtime fatal

### DIFF
--- a/.claude/project-rules.md
+++ b/.claude/project-rules.md
@@ -105,6 +105,7 @@ See `.claude/CLAUDE.md` for the full policy. Summary: don't duplicate — extrac
 - **Don't expose backend keys to end users.** `ihymns_pro` is a DB value, not a label; surface the label via the central map.
 - **Don't scatter auth checks.** One helper call; never `$u['role'] === 'admin'` in business logic.
 - **Don't commit stacked PRs that re-implement work already in a parallel branch.** Rebase and reuse.
+- **Don't write literal `<?=` / `<?php` / `<?` inside HTML comments or backticks in `.php` files.** PHP doesn't respect HTML-comment boundaries — it parses every `<?` open-tag it finds, regardless of surrounding `<!-- ... -->`. On PHP 8.1+, `func(...)` is first-class callable syntax, so a comment that says `<?= json_encode(...) ?>` evaluates `json_encode(...)` (returns a Closure), then `<?=` tries to echo it → runtime fatal `Object of class Closure could not be converted to string` → output halts mid-stream → browser receives a truncated HTML response → the SPA shell renders but `app.js` is never reached and the loading spinner hangs forever. This took down alpha in PR #536 (commit `96cd14a`). If you need to reference PHP code in a comment, omit the open tag (`echo json_encode() call` not `<?= json_encode() ?>`). CI now greps for this pattern in `.github/workflows/test.yml`.
 
 ## 10. Activity logging — what NEVER goes in `tblActivityLog.Details` (#535)
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,6 +132,34 @@ jobs:
           fi
 
       # -----------------------------------------------------------------------
+      # Step 5a: Detect literal PHP open tags inside HTML comments / backticks
+      #
+      # PHP doesn't respect HTML-comment boundaries — it parses every `<?`
+      # open-tag it finds. A documentation comment like `<?= json_encode(...) ?>`
+      # is therefore evaluated as live PHP at request time. On PHP 8.1+ the
+      # `(...)` is first-class callable syntax, so `json_encode(...)` returns
+      # a Closure and the `<?=` then fatals trying to echo it, halting output
+      # mid-stream and leaving the browser with a truncated HTML response.
+      # This took down alpha in PR #536 (commit 96cd14a) — see
+      # `.claude/project-rules.md` §9 for the full incident note.
+      # -----------------------------------------------------------------------
+      - name: Detect embedded PHP open tags in HTML comments / backticks
+        run: |
+          echo "Scanning .php files for literal '<?' inside backticks or HTML comments..."
+          MATCHES=$(grep -rnP '`[^`]*<\?|<!--[^>]*<\?' appWeb --include='*.php' || true)
+          if [ -n "$MATCHES" ]; then
+            echo "::error::Found literal PHP open tags inside HTML comments or backticks. PHP will parse and execute these at runtime — see .claude/project-rules.md §9."
+            echo "$MATCHES" | while IFS= read -r line; do
+              # Re-emit each match as a GitHub annotation pinned to the file:line
+              FILE=$(echo "$line" | cut -d: -f1)
+              LINE=$(echo "$line" | cut -d: -f2)
+              echo "::error file=$FILE,line=$LINE::Literal PHP open tag in comment/backtick — will be parsed at runtime"
+            done
+            exit 1
+          fi
+          echo "OK: no embedded PHP tags inside HTML comments or backticks."
+
+      # -----------------------------------------------------------------------
       # Step 5: Run PHP syntax check on all PHP files
       # Uses `php -l` (lint mode) to check for parse errors
       # -----------------------------------------------------------------------

--- a/appWeb/public_html/index.php
+++ b/appWeb/public_html/index.php
@@ -1204,7 +1204,7 @@ if (!empty($breadcrumbItems)) {
          iHymns Application Configuration — PHP to JavaScript bridge
 
          Hardened (#526) — previously every field was its own inline
-         `<?= json_encode(...) ?>`, which meant any throw inside one
+         echo json_encode() call, which meant any throw inside one
          corrupted the JS literal mid-output and killed SPA boot (the
          exact root cause of #509). Now the entire config is built
          server-side as a single PHP array, the only DB-touching call


### PR DESCRIPTION
## Summary

Hotfix for the alpha outage introduced by PR #536 / commit `96cd14a`. The HTML-comment block at `appWeb/public_html/index.php:1207` contained a literal `<?= json_encode(...) ?>` as documentation. PHP doesn't respect HTML-comment boundaries — it parses every `<?` open-tag it finds. On PHP 8.1+ that comment evaluated `json_encode(...)` (returns a Closure via first-class callable syntax), then `<?=` fataled trying to echo the Closure, halting output mid-stream. The browser received a truncated HTML response that rendered the chrome but never reached the `<script src="/js/app.js" type="module">` tag — so app.js never loaded, no JS ran, the loading spinner hung forever, and no errors appeared in the console because no JS executed at all.

Three changes in one commit (`f6d4668`):

- **[appWeb/public_html/index.php:1207](appWeb/public_html/index.php#L1207)** — rephrase the comment to drop the literal `<?=`/`?>` tags. The `(...)` outside a PHP block is just literal HTML text.
- **[.claude/project-rules.md](.claude/project-rules.md) §9** — new "What NOT to do" entry documenting the trap, the runtime mechanism, and the symptom shape (loader hangs forever + no JS errors + no `/api.php` calls) so it's recognisable next time.
- **[.github/workflows/test.yml](.github/workflows/test.yml)** — new "Step 5a" runs before `php -l`, greps every `.php` file for `<?` inside backticks or HTML comments, fails the build with line-pinned annotations if any are found. `php -l` cannot catch this on its own — first-class callable syntax IS valid, the failure is at runtime.

Closes #539.

## Test plan

### Pre-merge (already verified locally)
- [x] `php -l appWeb/public_html/index.php` → No syntax errors
- [x] Local repro of the bug: `php -r 'echo "before "; echo json_encode(...); echo " after";'` → fatals between `before` and ` after`, exactly matching the alpha truncation pattern
- [x] New CI grep `grep -rnP '\`[^\`]*<\?|<!--[^>]*<\?' appWeb --include='*.php'` returns no matches on the patched tree
- [x] Same grep against the original `96cd14a` snippet → matches as expected, proving the guard would have blocked the regression
- [x] `.github/workflows/test.yml` parses cleanly via `ruby -ryaml`

### Post-merge (alpha verification once deploy completes)
- [ ] Browse to https://dev.ihymns.app/ — the "Loading iHymns…" spinner should disappear within ~1s and the home page content should render
- [ ] Open DevTools → Console — should see `[iHymns] v0.25.0 initialised successfully` (or similar) log line
- [ ] DevTools → Network → filter `api.php` — should see the page-content fetch (`?action=page&page=home`) and any other init API calls firing
- [ ] `curl -s https://dev.ihymns.app/ | tail -5` — should now show the closing `</body></html>` tags, not truncate mid-comment
- [ ] CI for this PR shows the new "Detect embedded PHP open tags in HTML comments / backticks" step passing green

## Notable

- The deploy story for the SW is unaffected by this PR. The new SW from PR #536 is in "waiting" state by design (so app.js can show a "Refresh to update" toast). After this hotfix lands, that design assumption holds — app.js can actually load.
- Audit before opening a future PR: the new CI step now runs automatically on every PR, so this specific antipattern is guarded going forward without relying on memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)