### PR TITLE
fix(manage): load config.php in admin bootstrap so head-libs.php sees APP_CONFIG

### DIFF
--- a/appWeb/public_html/manage/includes/auth.php
+++ b/appWeb/public_html/manage/includes/auth.php
@@ -26,6 +26,18 @@ if (basename($_SERVER['SCRIPT_FILENAME'] ?? '') === basename(__FILE__)) {
     exit('Access denied.');
 }
 
+/* App configuration constants — defines APP_CONFIG used by head-libs.php
+   and other shared partials. Loaded FIRST in the admin bootstrap so
+   every /manage/* page has APP_CONFIG available transitively without
+   each page (or each shared partial) having to require it itself.
+   Without this, head-libs.php's `APP_CONFIG['libraries']['bootstrap']`
+   read fatals on PHP 8+ (undefined constant), halting output mid-stream
+   right after `<title>` and producing a near-blank /manage/login page —
+   the symptom that surfaced once #531's idle timeout started kicking
+   users back to the login form. */
+require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'includes'
+          . DIRECTORY_SEPARATOR . 'config.php';
+
 /* On-demand debug mode (#507 / #509) — wire as early as possible so a
    fatal in db.php, the auth bootstrap, or the page itself surfaces in
    the response instead of producing a silent blank page. Every manage


### PR DESCRIPTION
## Summary

Hotfix for the alpha admin-surface outage. `/manage/login` was returning a truncated 209-byte HTML response, rendering blank in the browser. Other `/manage/*` URLs 302 to `/manage/login` when unauthenticated, so the entire admin surface looked dead.

**Root cause** — `manage/includes/head-libs.php:36` reads `APP_CONFIG['libraries']['bootstrap'] ?? null`. The `??` operator handles undefined array offsets, NOT undefined constants. PHP 8+ throws an `Error` on undefined-constant access → fatal → output halts mid-stream right after the `<title>` tag.

`APP_CONFIG` is defined in `includes/config.php`, but the `/manage/login` require chain (`auth.php` → `debug_mode.php` / `db.php` / `entitlements.php` / `activity_log.php`) never loads `config.php`. Latent since PR #527 (which added the `head-libs.php` require to `login.php`); surfaced now because PR #531's idle timeout brings users back to `/manage/login` more often.

**Fix** — single 12-line addition to [manage/includes/auth.php](appWeb/public_html/manage/includes/auth.php): load `config.php` as the first step of the admin bootstrap. Since every `/manage/*` page already requires `auth.php`, `APP_CONFIG` becomes universally available — closes this bug AND any other latent `head-libs.php`/shared-partial bug that touches `APP_CONFIG` in code we haven't exercised yet. `config.php` is just constant definitions with a direct-access guard, no side effects, safe to require early.

Closes #541.

## Test plan

### Pre-merge (verified locally)
- [x] `php -l appWeb/public_html/manage/includes/auth.php` → No syntax errors
- [x] Local CLI repro: requiring `auth.php` from a fresh PHP process now leaves `APP_CONFIG` defined; `APP_CONFIG['libraries']['bootstrap']['css_cdn']` resolves to the expected jsDelivr URL
- [x] PR #540 audit grep (`<?` in backticks/HTML comments) → still clean across the tree
- [x] Diff is +12 lines, single file, trivially revertable per CLAUDE.md atomicity rule

### Post-merge (alpha verification)
- [ ] `curl -s -o /dev/null -w "%{size_download} %{http_code}\n" https://dev.ihymns.app/manage/login` should return ~10–20 KB and 200 (not 209/200)
- [ ] Browse to https://dev.ihymns.app/manage/login in a browser — login form renders fully (Bootstrap-styled card with username/password inputs)
- [ ] Sign in via the form — should successfully redirect to `/manage/editor/`
- [ ] Sign out, then log back in — second cycle works
- [ ] `curl -s https://dev.ihymns.app/manage/login | tail -c 100` should show closing `</body></html>` tags
- [ ] Open `/manage/setup-database` and `/manage/activity-log` once authenticated — both render fully (validates the fix isn't login-specific)

## Notable

- This is the **third runtime-fatal-truncates-response bug in a week** (see #509 schema gap, #539 PHP-tag-in-comment, this one). The class needs a render-test step in CI that actually `curl`s canonical URLs and verifies responses are non-truncated. Per user instruction, that fix is **out of scope for this PR** and will land as a separate follow-up. This PR stays focused on the immediate bleeding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)