### PR TITLE
fix(sw): skip non-GET requests in fetch handler — Cache API rejects them

### DIFF
--- a/appWeb/public_html/service-worker.js.php
+++ b/appWeb/public_html/service-worker.js.php
@@ -364,6 +364,19 @@ self.addEventListener('activate', (event) => {
  * ========================================================================= */
 
 self.addEventListener('fetch', (event) => {
+    /* The Cache API only supports GET responses — `cache.put()` on a
+     * HEAD / POST / PUT / DELETE / PATCH response throws
+     *   TypeError: Failed to execute 'put' on 'Cache':
+     *               Request method 'HEAD' is unsupported.
+     * Every branch below assumes GET (network-first-with-cache, etc.),
+     * so pass non-GET requests straight through to the network without
+     * SW interception. The offline-indicator's HEAD probe to
+     * /manifest.json (#354 B24, commit 6cfd3c6) is the specific
+     * request that surfaced this; any future non-GET probe is now
+     * also covered. Background Sync queueing for write requests is
+     * handled by the separate 'sync' event handler below, not here. */
+    if (event.request.method !== 'GET') return;
+
     const url = new URL(event.request.url);
 
     /* --- CDN / Third-party resources --- */


### PR DESCRIPTION
## Summary

Fix the `Uncaught (in promise) TypeError: Failed to execute 'put' on 'Cache': Request method 'HEAD' is unsupported` error that surfaces in the browser console on every page load of the main app.

**Root cause** — the Cache API forbids storing non-GET responses. Our SW fetch handler in [service-worker.js.php](appWeb/public_html/service-worker.js.php) — and every helper it dispatches to (`networkFirstWithCache`, the API/songs_json/navigation branches) — uniformly assumes GET semantics. When `offline-indicator.js`'s captive-portal probe (added in PR #354 / commit `6cfd3c6`) makes a `HEAD /manifest.json` request, the SW routes it through `networkFirstWithCache`, which calls `cache.put()` on the HEAD response → throws.

The error is recoverable (the fetch itself succeeds, only the cache write fails) but spams the console on every load and would mask any other genuine SW errors.

**Fix** — single early-return at the top of the fetch handler:

```js
self.addEventListener('fetch', (event) => {
+   if (event.request.method !== 'GET') return;
    const url = new URL(event.request.url);
    ...
});
```

Non-GET requests now bypass the SW entirely; the browser handles them normally. Universal — covers HEAD, POST, PUT, DELETE, PATCH, and any future non-GET probe. Background Sync queueing for write requests (setlist saves, favourites sync) is handled by the separate `'sync'` event handler, not `'fetch'`, so this bypass doesn't affect any offline-write logic.

Closes #543.

## Test plan

### Pre-merge (verified locally)
- [x] `php -l appWeb/public_html/service-worker.js.php` → No syntax errors
- [x] PHP renders cleanly; `node --check` on the rendered JS → OK
- [x] The fix appears at line 323 of the rendered SW output (verified with `grep`)
- [x] PR #540 audit grep (`<?` in backticks/HTML comments) → still clean across the tree
- [x] Diff is +13 lines, single file, trivially revertable per CLAUDE.md atomicity rule

### Post-merge (alpha verification once deployed)
- [ ] Open https://dev.ihymns.app/ in a fresh browser tab with DevTools console open from before the load
- [ ] Hard-reload (Cmd-Shift-R / Ctrl-Shift-R) — the `TypeError: Failed to execute 'put' on 'Cache': Request method 'HEAD' is unsupported` error should NOT appear in the console
- [ ] DevTools → Network tab → look for `manifest.json` HEAD request — confirm it succeeds (200) but no longer shows `(ServiceWorker)` in the "Fulfilled by" column (now bypasses SW)
- [ ] App still boots: `[iHymns] v0.25.0 initialised successfully` log line still appears
- [ ] Existing offline-mode behaviour still works: clear cache, load page, go offline, reload — songs/setlists still render from IndexedDB

## ⚠️ Deploy reminder

**This PR will auto-merge once CI passes** (via the `Auto-Merge Alpha PRs` workflow shipped in PR #538). However, that workflow uses `GITHUB_TOKEN`, which **does not trigger downstream workflows like Deploy via SFTP** — same issue that bit PR #542. Once this PR is merged you'll need to manually trigger the deploy via:

**https://github.com/MWBMPartners/iHymns/actions/workflows/deploy.yml** → Run workflow → branch: `alpha`

The PAT-based fix for the auto-merge workflow itself is a separate pending follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)