### PR TITLE
fix(home,editor): show titles on home + tighten editor toolbar on mobile (#546, #547)

### DIFF
--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -3163,11 +3163,21 @@ if ($action !== null) {
 
             try {
                 $db = getDb();
+                /* INNER JOIN tblSongs so we return the human-readable
+                   title + songbook metadata the home-page renderer needs.
+                   Songs that have been deleted since they were viewed
+                   drop out of the list naturally (#546). */
                 $stmt = $db->prepare(
-                    'SELECT SongId AS songId, COUNT(*) AS views
-                     FROM tblSongHistory
-                     WHERE ViewedAt > DATE_SUB(NOW(), INTERVAL ? DAY)
-                     GROUP BY SongId
+                    'SELECT h.SongId        AS songId,
+                            s.Title         AS title,
+                            s.Number        AS number,
+                            s.SongbookAbbr  AS songbook,
+                            s.SongbookName  AS songbookName,
+                            COUNT(*)        AS views
+                     FROM tblSongHistory h
+                     JOIN tblSongs s ON s.SongId = h.SongId
+                     WHERE h.ViewedAt > DATE_SUB(NOW(), INTERVAL ? DAY)
+                     GROUP BY h.SongId, s.Title, s.Number, s.SongbookAbbr, s.SongbookName
                      ORDER BY views DESC
                      LIMIT ?'
                 );
@@ -3207,11 +3217,21 @@ if ($action !== null) {
 
             try {
                 $db = getDb();
+                /* INNER JOIN tblSongs so the recently-viewed list can show
+                   the song title + songbook badge instead of the bare ID
+                   (#546). A history row whose song has since been deleted
+                   drops out — preferable to rendering an unresolvable ID. */
                 $stmt = $db->prepare(
-                    'SELECT SongId AS songId, ViewedAt AS viewedAt
-                     FROM tblSongHistory
-                     WHERE UserId = ?
-                     ORDER BY ViewedAt DESC
+                    'SELECT h.SongId        AS songId,
+                            s.Title         AS title,
+                            s.Number        AS number,
+                            s.SongbookAbbr  AS songbook,
+                            s.SongbookName  AS songbookName,
+                            h.ViewedAt      AS viewedAt
+                     FROM tblSongHistory h
+                     JOIN tblSongs s ON s.SongId = h.SongId
+                     WHERE h.UserId = ?
+                     ORDER BY h.ViewedAt DESC
                      LIMIT 50'
                 );
                 $stmt->execute([$authUser['Id']]);

--- a/appWeb/public_html/css/admin.css
+++ b/appWeb/public_html/css/admin.css
@@ -793,3 +793,47 @@ body:has(.navbar-admin) {
         max-height: 40vh;
     }
 }
+
+/* --------------------------------------------------------------------------
+   Editor toolbar — phone widths (#547)
+
+   The desktop toolbar carries 10+ controls (brand, Dashboard, Home, Load
+   JSON, Load URL, Save, Validate, History, Export, Import, Users, Logout).
+   Even with btn-sm, that wraps onto two or three rows on a phone and
+   swallows most of the editing surface. Below 576 px we:
+
+     - Hide low-priority controls outright (Load URL, Users link, brand
+       wordmark, the visual `|` separator).
+     - Tighten button padding + font-size so the surviving controls pack
+       into a single row where possible.
+     - Allow controlled wrap so anything that doesn't fit drops cleanly
+       to the next row instead of overflowing horizontally.
+   -------------------------------------------------------------------------- */
+
+@media (max-width: 575.98px) {
+    .navbar-editor {
+        padding: 0.35rem 0.5rem;
+        flex-wrap: wrap;
+        row-gap: 0.35rem;
+    }
+    .navbar-editor .navbar-brand {
+        font-size: 1rem;
+    }
+    .navbar-editor .navbar-brand-text,
+    .navbar-editor .navbar-editor-separator,
+    .navbar-editor #btn-load-url,
+    .navbar-editor a[href="/manage/users"] {
+        display: none;
+    }
+    .navbar-editor .btn.btn-sm {
+        padding: 0.2rem 0.45rem;
+        font-size: 0.78rem;
+    }
+    .navbar-editor .btn.btn-sm .bi {
+        font-size: 0.85rem;
+    }
+    /* Both flex groups (left nav, right actions) — tighten internal gap. */
+    .navbar-editor > .d-flex {
+        gap: 0.35rem !important;
+    }
+}

--- a/appWeb/public_html/js/modules/home-page.js
+++ b/appWeb/public_html/js/modules/home-page.js
@@ -106,13 +106,21 @@ function popularFromLocalHistory() {
     }
 }
 
-function renderPopularRow(s) {
+function renderPopularRow(s, opts = {}) {
+    const showViews = opts.showViews !== false;
     const id       = s.songId || s.id || '';
-    const title    = toTitleCase(s.title || id);
+    /* No usable title means the API didn't join (#546) or the song
+       was deleted — drop the row rather than render a bare ID. */
+    if (!id || !s.title) return '';
+    const title    = toTitleCase(s.title);
     const book     = s.songbook || id.split('-')[0] || '';
-    const bookName = SONGBOOK_NAMES[book] || book;
+    const bookName = s.songbookName || SONGBOOK_NAMES[book] || book;
     const number   = s.number ?? '';
     const views    = s.views ?? 0;
+
+    const viewsBadge = showViews
+        ? `<span class="badge bg-secondary">${escapeHtml(String(views))}</span>`
+        : '';
 
     return `<a href="/song/${escapeHtml(id)}"
                data-navigate="song"
@@ -126,7 +134,7 @@ function renderPopularRow(s) {
                         <span class="songbook-name-abbr">${escapeHtml(book)}</span>
                     </small>
                 </div>
-                <span class="badge bg-secondary">${escapeHtml(String(views))}</span>
+                ${viewsBadge}
             </a>`;
 }
 
@@ -155,12 +163,16 @@ async function loadRecentlyViewed() {
         if (!hist.length) return;
 
         section.style.display = '';
-        el.innerHTML = hist.map(h => {
-            const id = escapeHtml(h.songId || '');
-            return `<a href="/song/${id}"
-                       data-navigate="song"
-                       class="list-group-item list-group-item-action">${id}</a>`;
-        }).join('');
+        /* Reuse renderPopularRow so the recently-viewed and popular lists
+           feel consistent (title + songbook badge + number). The 'views'
+           badge is meaningless for a per-row history entry, so suppress
+           it by passing showViews:false. (#546) */
+        el.innerHTML = hist.map(h => renderPopularRow({
+            songId:   h.songId,
+            title:    h.title,
+            songbook: h.songbook,
+            number:   h.number,
+        }, { showViews: false })).join('');
     } catch {
         /* Non-fatal — leave the section hidden. */
     }

--- a/appWeb/public_html/manage/editor/index.php
+++ b/appWeb/public_html/manage/editor/index.php
@@ -107,7 +107,7 @@ $currentUser = getCurrentUser();
         <a class="navbar-brand d-flex align-items-center gap-2" href="/manage/"
            title="Back to Admin Dashboard">
             <i class="bi bi-music-note-beamed"></i>
-            iHymns Song Editor
+            <span class="navbar-brand-text">iHymns Song Editor</span>
         </a>
 
         <!-- Quick navigation links. `/manage/` returns to the admin dashboard;
@@ -222,7 +222,7 @@ $currentUser = getCurrentUser();
             </button>
 
             <!-- Separator + Admin links / Logout -->
-            <span class="text-muted mx-1">|</span>
+            <span class="text-muted mx-1 navbar-editor-separator">|</span>
             <?php if (($currentUser['role'] ?? '') === 'admin'): ?>
             <a href="/manage/users"
                class="btn btn-sm btn-outline-secondary me-1"


### PR DESCRIPTION
## Summary

Two unrelated bugfixes batched onto one branch — both reported in the same iHymns mobile screenshot session.

- **#546 — Popular Songs and Recently Viewed showed song IDs instead of titles** (commit f9a6f11). The `popular_songs` and `song_history` API endpoints were selecting only from `tblSongHistory` and never joining `tblSongs`, so the home-page renderer never received a title to display. Both endpoints now `INNER JOIN tblSongs` on `SongId` and return `title` + `number` + `songbookAbbr` + `songbookName`. `loadRecentlyViewed()` in `home-page.js` reuses the existing `renderPopularRow()` for visual consistency (with a new `showViews:false` flag to suppress the per-row counter). `renderPopularRow()` itself now refuses to emit a row without a usable title — defence in depth.
- **#547 — Song Editor toolbar consumed too much vertical space on phone widths** (commit 8f1eaff). New `@media (max-width: 575.98px)` block in `admin.css` hides Load URL, the Users admin link, the visual `\|` separator, and the brand wordmark; tightens button padding (`0.2rem 0.45rem`) + font-size (`0.78rem`); allows controlled `flex-wrap` with a small row-gap. Two stable hook classes added to the editor template (`navbar-brand-text`, `navbar-editor-separator`). Tablet and desktop layouts are untouched.

## Test plan

- [ ] **Home page (`/`)** as an authenticated user with view history:
  - [ ] Popular Songs section shows `Title` followed by songbook + number, not the bare `MP-1051`-style ID.
  - [ ] Recently Viewed section shows the same row shape (title + songbook badge + number), with no per-row views badge.
  - [ ] Section is hidden when there's no history rather than showing an empty list.
  - [ ] Bare-ID display does not return when one of the API responses is missing `title` (deleted song): the row is silently skipped.
- [ ] **Song Editor (`/manage/editor/`)** on a 375 px wide phone (Chrome devtools mobile preset is fine):
  - [ ] Toolbar fits on at most one wrapped row; Load URL is gone; brand wordmark is gone (icon stays).
  - [ ] Save / Validate / History / Export / Import / Logout still tappable and labelled.
  - [ ] At ≥576 px the toolbar reverts to the desktop layout — no rules leak.
- [ ] **PHP + JS syntax** clean (already verified locally with `php -l` and `node --check`).

https://claude.ai/code/session_01AnQFr8Jx3UsYHxHjmaEDdH

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnQFr8Jx3UsYHxHjmaEDdH)_