### PR TITLE
fix(home): dedupe Popular Songs and Recently Viewed lists (#549)

### DIFF
--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -3220,18 +3220,23 @@ if ($action !== null) {
                 /* INNER JOIN tblSongs so the recently-viewed list can show
                    the song title + songbook badge instead of the bare ID
                    (#546). A history row whose song has since been deleted
-                   drops out — preferable to rendering an unresolvable ID. */
+                   drops out — preferable to rendering an unresolvable ID.
+
+                   GROUP BY h.SongId collapses repeat views of the same
+                   song into a single row, anchored to its most recent
+                   view, so the list never displays duplicates (#549). */
                 $stmt = $db->prepare(
                     'SELECT h.SongId        AS songId,
                             s.Title         AS title,
                             s.Number        AS number,
                             s.SongbookAbbr  AS songbook,
                             s.SongbookName  AS songbookName,
-                            h.ViewedAt      AS viewedAt
+                            MAX(h.ViewedAt) AS viewedAt
                      FROM tblSongHistory h
                      JOIN tblSongs s ON s.SongId = h.SongId
                      WHERE h.UserId = ?
-                     ORDER BY h.ViewedAt DESC
+                     GROUP BY h.SongId, s.Title, s.Number, s.SongbookAbbr, s.SongbookName
+                     ORDER BY MAX(h.ViewedAt) DESC
                      LIMIT 50'
                 );
                 $stmt->execute([$authUser['Id']]);

--- a/appWeb/public_html/js/modules/history.js
+++ b/appWeb/public_html/js/modules/history.js
@@ -69,14 +69,41 @@ export class History {
     /**
      * Get all history entries, ordered by most recent first.
      *
-     * @returns {Array} History entries
+     * `recordView()` dedupes on write, but localStorage may carry legacy
+     * entries written before that logic existed (#549). Dedupe on read so
+     * the returned list is always unique-by-id, keeping the first
+     * occurrence (which is the most recent because the array is ordered
+     * newest-first).
+     *
+     * @returns {Array} History entries — unique by id
      */
     getAll() {
+        let raw;
         try {
-            return JSON.parse(localStorage.getItem(this.storageKey)) || [];
+            raw = JSON.parse(localStorage.getItem(this.storageKey)) || [];
         } catch {
             return [];
         }
+        if (!Array.isArray(raw)) return [];
+
+        const seen = new Set();
+        const deduped = [];
+        for (const h of raw) {
+            if (!h?.id || seen.has(h.id)) continue;
+            seen.add(h.id);
+            deduped.push(h);
+        }
+
+        /* Legacy localStorage from before the on-write dedupe carries
+           duplicates that recordView() only purges for the song currently
+           being recorded. If we've just stripped any out, persist the
+           clean version so subsequent reads stay cheap and other tabs
+           pick up the cleanup via the storage sync. */
+        if (deduped.length !== raw.length) {
+            try { this.saveAll(deduped); } catch { /* best-effort */ }
+        }
+
+        return deduped;
     }
 
     /**

--- a/appWeb/public_html/js/modules/home-page.js
+++ b/appWeb/public_html/js/modules/home-page.js
@@ -71,7 +71,29 @@ async function loadPopularSongs() {
         return;
     }
 
-    el.innerHTML = songs.map(renderPopularRow).join('');
+    el.innerHTML = uniqueBySongId(songs).map(s => renderPopularRow(s)).join('');
+}
+
+/**
+ * Defensive dedupe by songId/id. The server already groups Popular Songs
+ * by SongId, but a future regression there shouldn't surface duplicates
+ * in the UI (#549). Keeps the first occurrence — the server orders by
+ * relevance (views DESC for popular, recency DESC for history) so first-
+ * seen is the right one to retain.
+ *
+ * @param {Array<{songId?:string,id?:string}>} songs
+ * @returns {Array}
+ */
+function uniqueBySongId(songs) {
+    const seen = new Set();
+    const out = [];
+    for (const s of songs) {
+        const key = s?.songId || s?.id;
+        if (!key || seen.has(key)) continue;
+        seen.add(key);
+        out.push(s);
+    }
+    return out;
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up to PR #548 — addresses the duplicate-song bug in the Recently Viewed widget that surfaced on alpha after #546 landed (issue #549).

- **API (`song_history`)** — `GROUP BY h.SongId` with `MAX(h.ViewedAt)` so each song appears at most once, anchored to its most recent view.
- **`history.js::getAll()`** — defensive dedupe on read, keeping the first occurrence (newest-first ordering means the first occurrence is the most recent). When the deduped list differs from the raw payload the cleaned version is persisted back, so legacy duplicates are cleared once on first read rather than recomputed every time.
- **`home-page.js`** — belt-and-braces `uniqueBySongId()` filter on the Popular Songs render path. The server already groups by SongId, but this guards against any future regression on that endpoint reintroducing duplicates in the UI.

Popular Songs was already deduped server-side, so the substantive fix is on Recently Viewed; the Popular Songs change is purely defensive.

## Test plan

- [ ] **Recently Viewed (server-side, `loadRecentlyViewed`)** as an authenticated user who has viewed the same song multiple times:
  - [ ] The list shows that song exactly once, at the position of its most recent view.
  - [ ] No regression when the user has only ever viewed each song once.
- [ ] **Recently Viewed (client-side, `history.js`)** with a localStorage `ihymns_history` payload that contains synthetic duplicates (paste a JSON array with 3 copies of the same id):
  - [ ] On first home-page load the list shows that song once.
  - [ ] localStorage is rewritten in place so subsequent loads start from a clean array (`JSON.parse(localStorage.ihymns_history)` shows no duplicates).
- [ ] **Popular Songs** — list shows each song exactly once (was true pre-PR via server `GROUP BY`; this PR adds a frontend guard so the test should pass identically).
- [ ] **PHP + JS syntax** clean (verified locally with `php -l` / `node --check`).

## Related

- #546 (parent — title-vs-id bug, fixed in PR #548)
- #92 / #304 (the two original Recently Viewed widgets)

https://claude.ai/code/session_01AnQFr8Jx3UsYHxHjmaEDdH

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnQFr8Jx3UsYHxHjmaEDdH)_