### PR TITLE
ci(auto-merge): dispatch deploy.yml after auto-merge completes (#551)

### DIFF
--- a/.github/workflows/auto-merge-alpha.yml
+++ b/.github/workflows/auto-merge-alpha.yml
@@ -39,6 +39,16 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # `gh workflow run` (used below to dispatch deploy.yml after merge)
+  # requires the actions:write scope.
+  actions: write
+
+# Coalesce repeated synchronize events on the same PR — otherwise a quick
+# series of pushes spawns parallel watchers that all race to dispatch the
+# same deploy when the PR finally merges.
+concurrency:
+  group: auto-merge-alpha-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   enable-auto-merge:
@@ -52,3 +62,44 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: gh pr merge --auto --squash "$PR_URL"
+
+      # ---------------------------------------------------------------------
+      # Bridge GitHub's GITHUB_TOKEN anti-recursion rule (#551).
+      #
+      # The push to `alpha` produced by GitHub's auto-merge is attributed to
+      # GITHUB_TOKEN, so deploy.yml's `on: push` trigger is suppressed and
+      # no SFTP deploy fires. workflow_dispatch IS one of the two events a
+      # workflow can trigger via GITHUB_TOKEN, so once the merge lands we
+      # explicitly dispatch the deploy.
+      #
+      # Polling tradeoff: this step keeps a runner busy for the duration of
+      # the merge gate (typically 1–5 min on alpha — only the lint job
+      # gates). Capped at 60 min so a stuck check never burns runner time
+      # indefinitely. A `CLOSED`-without-merge outcome exits cleanly with
+      # no deploy dispatch.
+      # ---------------------------------------------------------------------
+      - name: Wait for merge and dispatch deploy
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 120); do
+              STATE=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json state -q .state)
+              case "$STATE" in
+                  MERGED)
+                      echo "PR #$PR_NUMBER merged — dispatching deploy.yml on alpha."
+                      gh workflow run deploy.yml --repo "$REPO" --ref alpha
+                      exit 0
+                      ;;
+                  CLOSED)
+                      echo "PR #$PR_NUMBER closed without merging — skipping deploy."
+                      exit 0
+                      ;;
+              esac
+              echo "PR #$PR_NUMBER state=$STATE (poll $i/120) — sleeping 30 s"
+              sleep 30
+          done
+          echo "::error::Timed out waiting for PR #$PR_NUMBER to reach a terminal state."
+          exit 1


### PR DESCRIPTION
## Summary

Closes #551. Re-establishes the auto-merge → deploy chain that PR #538 inadvertently broke. Five PRs on alpha are currently un-deployed for this reason.

**Root cause** — `auto-merge-alpha.yml` calls `gh pr merge --auto` under `secrets.GITHUB_TOKEN`. When auto-merge eventually squashes the PR, the resulting push to `alpha` is attributed to `GITHUB_TOKEN`. [GitHub's anti-recursion rule](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow) suppresses workflows triggered by such pushes, so `deploy.yml`'s `on: push` trigger never fires.

**Fix (option A from the issue discussion)** — `workflow_dispatch` is one of the two events `GITHUB_TOKEN` *is* allowed to trigger. The auto-merge workflow now:

1. Enables auto-merge as before (`gh pr merge --auto --squash`).
2. Polls the PR's state every 30 s until it reaches `MERGED` or `CLOSED`, capped at 60 min. Alpha's only merge gate is the lint job, so the typical wait is 1–5 min.
3. On `MERGED`, fires `gh workflow run deploy.yml --ref alpha` so SFTP deploy runs against the freshly-merged tip.
4. On `CLOSED`-without-merge, exits cleanly with no dispatch.

Also adds:
- `actions: write` permission (required by `gh workflow run`).
- A `concurrency` group keyed on the PR number with `cancel-in-progress`, so a fast series of `synchronize` events on the same PR doesn't spawn parallel watchers racing to fire the same deploy.

No new secrets. A future migration to a PAT or GitHub App would obsolete the polling, but isn't required.

## Test plan

- [ ] **Smoke** — once merged, open a trivial follow-up PR against `alpha` (e.g. whitespace-only doc tweak) and watch:
  - [ ] `Auto-Merge Alpha PRs` workflow run starts.
  - [ ] Once the lint check passes and auto-merge fires the squash, the same workflow run reaches the "Wait for merge and dispatch deploy" step and exits 0 logging "PR #N merged — dispatching deploy.yml on alpha."
  - [ ] `Deploy via SFTP` workflow run appears in the Actions tab within ~30 s of the merge.
  - [ ] dev.ihymns.app reflects the change.
- [ ] **Closed-without-merge path** — open then close (without merging) a PR; confirm the auto-merge workflow exits 0 with the "skipping deploy" log line and no `Deploy via SFTP` run is dispatched.
- [ ] **Concurrency** — push twice in quick succession to a PR; confirm the older workflow run is cancelled by the newer one (cancel-in-progress) so only one dispatch fires.

## Backlog to flush manually after merge

Five un-deployed PRs need a one-shot manual `workflow_dispatch` of `Deploy via SFTP` (or wait for the next merge to flush them): #540, #542, #544, #548, #550.

https://claude.ai/code/session_01AnQFr8Jx3UsYHxHjmaEDdH

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnQFr8Jx3UsYHxHjmaEDdH)_