### PR TITLE
feat(schema): credit-people registry tables for #545 (data layer only)

### DIFF
--- a/appWeb/.sql/migrate-credit-people.php
+++ b/appWeb/.sql/migrate-credit-people.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Credit People Registry Migration (#545)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Brings an existing deployment up to the #545 schema by creating the
+ * three tables that back the new /manage/credit-people area:
+ *
+ *   1. tblCreditPeople — registry row per person credited on songs.
+ *      Holds the canonical Name plus optional biographical metadata
+ *      (Notes, BirthPlace, BirthDate, DeathPlace, DeathDate). Names
+ *      already in use across tblSongWriters / tblSongComposers /
+ *      tblSongArrangers / tblSongAdaptors / tblSongTranslators continue
+ *      to live there as free-text strings — no FK refactor of those
+ *      five tables. The registry is additive: drop these three new
+ *      tables and the rest of the system still works exactly as it
+ *      does today.
+ *
+ *   2. tblCreditPersonLinks — child of tblCreditPeople. Multiple
+ *      external reference links per person (Wikipedia / official site
+ *      / MusicBrainz / Discogs / IMSLP / Hymnary / other), with a
+ *      sort-order column for admin-controlled display order.
+ *      ON DELETE CASCADE so removing a registry row drops its links.
+ *
+ *   3. tblCreditPersonIPI — child of tblCreditPeople. Multiple IPI
+ *      Name Numbers per person (a single individual can be registered
+ *      under more than one IPI when they use multiple performing
+ *      names). UNIQUE on (CreditPersonId, IPINumber) prevents
+ *      accidental duplicates per person while still allowing the same
+ *      IPI number to legitimately attach to two different people if
+ *      the data demands it. ON DELETE CASCADE matches the links table.
+ *
+ * Idempotent — re-running is safe. Tables that already exist are
+ * skipped with a "skipped" note.
+ *
+ * The CREATE TABLE statements use literal table names (no PHP
+ * variable interpolation), so the schema-audit scanner picks up
+ * every column directly from this file. No @migration-adds doctags
+ * needed (cf. migrate-credit-fields.php where the loop-built
+ * statements DO require them).
+ *
+ * USAGE:
+ *   CLI:  php appWeb/.sql/migrate-credit-people.php
+ *   Web:  /manage/setup-database → "Credit People Registry Migration"
+ *         (entry point requires global_admin)
+ *
+ * @requires PHP 8.1+ with mysqli extension
+ */
+
+$isCli = (php_sapi_name() === 'cli');
+
+if (!$isCli && !defined('IHYMNS_SETUP_DASHBOARD')) {
+    header('Content-Type: text/plain; charset=UTF-8');
+    header('X-Content-Type-Options: nosniff');
+    header('Cache-Control: no-store');
+}
+
+function _migPeople_out(string $msg): void {
+    global $isCli;
+    echo $msg . ($isCli ? "\n" : "<br>\n");
+    if (!$isCli) flush();
+}
+
+/* Load DB credentials — same path as every other migration script. */
+$credPath = dirname(__DIR__) . DIRECTORY_SEPARATOR . '.auth' . DIRECTORY_SEPARATOR . 'db_credentials.php';
+if (!file_exists($credPath)) {
+    _migPeople_out('ERROR: db_credentials.php not found — run install.php first.');
+    exit(1);
+}
+if (!defined('DB_HOST')) {
+    require_once $credPath;
+}
+
+/* Strict reporting (#525) — exceptions on every failed query so a
+   broken CREATE TABLE doesn't silently no-op. Matches the rest of
+   the migration scripts. */
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+$mysqli = @new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME, defined('DB_PORT') ? (int)DB_PORT : 3306);
+if ($mysqli->connect_errno) {
+    _migPeople_out('ERROR: MySQL connect failed: ' . $mysqli->connect_error);
+    exit(1);
+}
+$mysqli->set_charset('utf8mb4');
+
+_migPeople_out('=== iHymns Credit People Registry Migration (#545) ===');
+_migPeople_out('Database: ' . DB_NAME . ' @ ' . DB_HOST);
+_migPeople_out('');
+
+/* Helper: does a table exist? Mysqli prepared statement against
+   INFORMATION_SCHEMA — same shape as migrate-credit-fields.php. */
+function _migPeople_tableExists(mysqli $db, string $table): bool {
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?
+          LIMIT 1'
+    );
+    $stmt->bind_param('s', $table);
+    $stmt->execute();
+    $exists = (bool)$stmt->get_result()->fetch_row();
+    $stmt->close();
+    return $exists;
+}
+
+/* Sanity: require tblSongs to exist. The new tables don't FK to
+   tblSongs, but their whole reason to exist is to curate names that
+   appear in the song-credit junction tables — without tblSongs (and
+   therefore without those junction tables) running this migration
+   would be premature. The caller should run install.php first, then
+   migrate-credit-fields.php (#497), then this one. */
+if (!_migPeople_tableExists($mysqli, 'tblSongs')) {
+    _migPeople_out('ERROR: tblSongs is missing — run install.php before this migration.');
+    exit(1);
+}
+
+/* ----------------------------------------------------------------------
+ * Step 1: create tblCreditPeople (parent registry)
+ *
+ * Must come before the two child tables — they FK to its Id.
+ * ---------------------------------------------------------------------- */
+if (_migPeople_tableExists($mysqli, 'tblCreditPeople')) {
+    _migPeople_out('[skip] tblCreditPeople already present.');
+} else {
+    $sql = "CREATE TABLE tblCreditPeople (
+        Id          INT UNSIGNED    AUTO_INCREMENT PRIMARY KEY,
+        Name        VARCHAR(255)    NOT NULL,
+        Notes       TEXT            NULL,
+        BirthPlace  VARCHAR(255)    NULL,
+        BirthDate   DATE            NULL,
+        DeathPlace  VARCHAR(255)    NULL,
+        DeathDate   DATE            NULL,
+        CreatedAt   DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        UpdatedAt   DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP
+                                    ON UPDATE CURRENT_TIMESTAMP,
+        UNIQUE KEY uk_Name (Name),
+        INDEX idx_Name (Name)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
+
+    if (!$mysqli->query($sql)) {
+        _migPeople_out('ERROR: creating tblCreditPeople failed: ' . $mysqli->error);
+        exit(1);
+    }
+    _migPeople_out('[add ] tblCreditPeople.');
+}
+
+/* ----------------------------------------------------------------------
+ * Step 2: create tblCreditPersonLinks (multi external links per person)
+ * ---------------------------------------------------------------------- */
+if (_migPeople_tableExists($mysqli, 'tblCreditPersonLinks')) {
+    _migPeople_out('[skip] tblCreditPersonLinks already present.');
+} else {
+    $sql = "CREATE TABLE tblCreditPersonLinks (
+        Id              INT UNSIGNED    AUTO_INCREMENT PRIMARY KEY,
+        CreditPersonId  INT UNSIGNED    NOT NULL,
+        LinkType        VARCHAR(64)     NOT NULL,
+        Url             VARCHAR(2048)   NOT NULL,
+        Label           VARCHAR(255)    NULL,
+        SortOrder       SMALLINT        NOT NULL DEFAULT 0,
+        CreatedAt       DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        UpdatedAt       DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP
+                                        ON UPDATE CURRENT_TIMESTAMP,
+        INDEX idx_CreditPersonId (CreditPersonId),
+        CONSTRAINT fk_CreditPersonLinks_Person
+            FOREIGN KEY (CreditPersonId) REFERENCES tblCreditPeople(Id)
+            ON DELETE CASCADE ON UPDATE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
+
+    if (!$mysqli->query($sql)) {
+        _migPeople_out('ERROR: creating tblCreditPersonLinks failed: ' . $mysqli->error);
+        exit(1);
+    }
+    _migPeople_out('[add ] tblCreditPersonLinks.');
+}
+
+/* ----------------------------------------------------------------------
+ * Step 3: create tblCreditPersonIPI (multi IPI Name Numbers per person)
+ * ---------------------------------------------------------------------- */
+if (_migPeople_tableExists($mysqli, 'tblCreditPersonIPI')) {
+    _migPeople_out('[skip] tblCreditPersonIPI already present.');
+} else {
+    $sql = "CREATE TABLE tblCreditPersonIPI (
+        Id              INT UNSIGNED    AUTO_INCREMENT PRIMARY KEY,
+        CreditPersonId  INT UNSIGNED    NOT NULL,
+        IPINumber       VARCHAR(32)     NOT NULL,
+        NameUsed        VARCHAR(255)    NULL,
+        Notes           VARCHAR(255)    NULL,
+        CreatedAt       DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        UpdatedAt       DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP
+                                        ON UPDATE CURRENT_TIMESTAMP,
+        UNIQUE KEY uk_PersonIPI (CreditPersonId, IPINumber),
+        INDEX idx_IPINumber (IPINumber),
+        CONSTRAINT fk_CreditPersonIPI_Person
+            FOREIGN KEY (CreditPersonId) REFERENCES tblCreditPeople(Id)
+            ON DELETE CASCADE ON UPDATE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
+
+    if (!$mysqli->query($sql)) {
+        _migPeople_out('ERROR: creating tblCreditPersonIPI failed: ' . $mysqli->error);
+        exit(1);
+    }
+    _migPeople_out('[add ] tblCreditPersonIPI.');
+}
+
+_migPeople_out('');
+_migPeople_out('Migration complete.');
+$mysqli->close();

--- a/appWeb/.sql/schema.sql
+++ b/appWeb/.sql/schema.sql
@@ -183,6 +183,92 @@ CREATE TABLE IF NOT EXISTS tblSongTranslators (
 
 
 -- ----------------------------------------------------------------------------
+-- tblCreditPeople (#545)
+-- Registry of people credited on songs. Holds the canonical Name plus
+-- optional biographical metadata. The five song-credit tables above
+-- (tblSongWriters / tblSongComposers / tblSongArrangers / tblSongAdaptors
+-- / tblSongTranslators) continue to store free-text Name strings — this
+-- registry is additive, not a foreign-key on those five. Rename / merge
+-- operations bulk-UPDATE the Name column across all five tables (and the
+-- registry row) inside a single transaction, leaving the existing schema
+-- intact.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS tblCreditPeople (
+    Id          INT UNSIGNED    AUTO_INCREMENT PRIMARY KEY,
+    Name        VARCHAR(255)    NOT NULL,
+    Notes       TEXT            NULL,
+    BirthPlace  VARCHAR(255)    NULL,
+    BirthDate   DATE            NULL,
+    DeathPlace  VARCHAR(255)    NULL,
+    DeathDate   DATE            NULL,
+    CreatedAt   DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UpdatedAt   DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP
+                                ON UPDATE CURRENT_TIMESTAMP,
+
+    UNIQUE KEY uk_Name (Name),
+    INDEX idx_Name (Name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+-- ----------------------------------------------------------------------------
+-- tblCreditPersonLinks (#545)
+-- Multiple external reference links per person (Wikipedia, official
+-- website, MusicBrainz, Discogs, IMSLP, Hymnary, other). LinkType is a
+-- short string key the UI maps to a friendly label and icon; storing as
+-- VARCHAR rather than ENUM keeps new categories cheap to add. SortOrder
+-- preserves admin-controlled display order. ON DELETE CASCADE removes
+-- the links automatically when the parent registry row is deleted.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS tblCreditPersonLinks (
+    Id              INT UNSIGNED    AUTO_INCREMENT PRIMARY KEY,
+    CreditPersonId  INT UNSIGNED    NOT NULL,
+    LinkType        VARCHAR(64)     NOT NULL,
+    Url             VARCHAR(2048)   NOT NULL,
+    Label           VARCHAR(255)    NULL,
+    SortOrder       SMALLINT        NOT NULL DEFAULT 0,
+    CreatedAt       DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UpdatedAt       DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP
+                                    ON UPDATE CURRENT_TIMESTAMP,
+
+    INDEX idx_CreditPersonId (CreditPersonId),
+
+    CONSTRAINT fk_CreditPersonLinks_Person
+        FOREIGN KEY (CreditPersonId) REFERENCES tblCreditPeople(Id)
+        ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+-- ----------------------------------------------------------------------------
+-- tblCreditPersonIPI (#545)
+-- IPI (Interested Parties Information) Name Numbers per person. A single
+-- individual can be registered under more than one IPI Name Number when
+-- they use multiple performing names — hence one-to-many on the registry
+-- row. UNIQUE on (CreditPersonId, IPINumber) prevents duplicate IPIs per
+-- person while still allowing the same number to legitimately attach to
+-- two different registry rows if the data demands it. NameUsed is the
+-- spelling that IPI is registered under (often differs from the canonical
+-- registry Name). ON DELETE CASCADE matches the links table.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS tblCreditPersonIPI (
+    Id              INT UNSIGNED    AUTO_INCREMENT PRIMARY KEY,
+    CreditPersonId  INT UNSIGNED    NOT NULL,
+    IPINumber       VARCHAR(32)     NOT NULL,
+    NameUsed        VARCHAR(255)    NULL,
+    Notes           VARCHAR(255)    NULL,
+    CreatedAt       DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UpdatedAt       DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP
+                                    ON UPDATE CURRENT_TIMESTAMP,
+
+    UNIQUE KEY uk_PersonIPI (CreditPersonId, IPINumber),
+    INDEX idx_IPINumber (IPINumber),
+
+    CONSTRAINT fk_CreditPersonIPI_Person
+        FOREIGN KEY (CreditPersonId) REFERENCES tblCreditPeople(Id)
+        ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+-- ----------------------------------------------------------------------------
 -- tblSongComponents
 -- Each component stores its lyrics lines as a JSON array.
 -- `SortOrder` preserves the display sequence from the original data.

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -199,6 +199,7 @@ if ($action !== '') {
         'songbook-meta' => 'migrate-songbook-meta.php',
         'user-features-catchup' => 'migrate-user-features-catchup.php',
         'activity-log-expand' => 'migrate-activity-log-expand.php',
+        'credit-people' => 'migrate-credit-people.php',
         'cleanup'     => 'cleanup.php',
         'backup'      => 'backup.php',
         'restore'     => 'restore.php',
@@ -543,6 +544,28 @@ if ($hasCredentials && defined('DB_HOST')) {
                         </p>
                         <a href="?action=activity-log-expand" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
                             Run Activity Log Expansion Migration
+                        </a>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="card bg-dark border-secondary h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">3f. Credit People Registry (#545)</h5>
+                        <p class="card-text text-secondary small">
+                            Creates the registry tables that back the new
+                            <code>/manage/credit-people</code> area:
+                            <code>tblCreditPeople</code> (canonical name plus
+                            optional birth/death + notes),
+                            <code>tblCreditPersonLinks</code> (multiple external
+                            reference URLs per person), and
+                            <code>tblCreditPersonIPI</code> (multiple IPI Name
+                            Numbers per person). The five song-credit tables
+                            are not modified — this is additive.
+                            Idempotent — safe to re-run.
+                        </p>
+                        <a href="?action=credit-people" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
+                            Run Credit People Registry Migration
                         </a>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary

Schema-only slice of [#545](https://github.com/MWBMPartners/iHymns/issues/545) — **data layer only**, no UI / API / entitlement / activity-log work in this PR. Lands the three tables that will back the new `/manage/credit-people` area so the migration can be exercised on alpha and the schema can settle before any UI commits to a particular shape.

- **`tblCreditPeople`** — registry row per person credited on songs. `Name UNIQUE` plus optional `Notes`, `BirthPlace`, `BirthDate`, `DeathPlace`, `DeathDate`, `CreatedAt`, `UpdatedAt`.
- **`tblCreditPersonLinks`** — multi external reference URLs per person (Wikipedia / official site / MusicBrainz / Discogs / IMSLP / Hymnary / other), with `SortOrder`. FK → `tblCreditPeople(Id)`, `ON DELETE CASCADE`.
- **`tblCreditPersonIPI`** — multi IPI Name Numbers per person. `UNIQUE (CreditPersonId, IPINumber)`. FK + cascade.

The five existing song-credit tables (`tblSongWriters` / `tblSongComposers` / `tblSongArrangers` / `tblSongAdaptors` / `tblSongTranslators`) are **not modified**. The registry is additive — drop the three new tables and the rest of the system still works exactly as it does today.

## What's in scope

| File | Change |
|---|---|
| `appWeb/.sql/schema.sql` | Three `CREATE TABLE IF NOT EXISTS` statements for fresh installs, slotted in immediately after `tblSongTranslators`. |
| `appWeb/.sql/migrate-credit-people.php` (new) | Idempotent migration for existing deployments. Mysqli prepared statements throughout (no PDO), `INFORMATION_SCHEMA` table-existence guard before each `CREATE TABLE`, parent table created before its two FK children. Skeleton mirrors `migrate-credit-fields.php` (#497). |
| `appWeb/public_html/manage/setup-database.php` | Adds `'credit-people' => 'migrate-credit-people.php'` to `\$scriptMap` and a new **3f. Credit People Registry (#545)** dashboard card between cards 3e and 4. |

## What's deferred to follow-up PRs against #545

- `/manage/credit-people.php` admin page (CRUD list, person detail drawer, rename / merge / view-songs modals).
- Editor integration: extending `manage/editor/api.php :: credit_search` to surface registry-only entries; silent `INSERT IGNORE` into `tblCreditPeople` when a new chip is added.
- New `manage_credit_people` entitlement (registration in `includes/entitlements.php`, `js/modules/entitlements.js`, `manage/entitlements.php`, `manage/includes/admin-links.php`).
- Activity log payloads for `credit_person.add` / `update_person` / `rename` / `merge` / `delete_from_registry`.

Each of those will land as a separate commit (or PR) once the schema is verified on alpha.

## Design notes

- **mysqli only.** The migration uses `mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT)` and a single `_migPeople_tableExists()` helper that issues a prepared `INFORMATION_SCHEMA.TABLES` lookup. No PDO anywhere in the new code.
- **Literal `CREATE TABLE` statements** (no PHP variable interpolation), so the schema-audit scanner's regex picks up every column directly from the migration file. No `@migration-adds` doctags needed (cf. `migrate-credit-fields.php`, which loop-builds its `CREATE TABLE`s and therefore does require them).
- **Dependency-ordered creates.** `tblCreditPeople` is created before the two child tables that FK to its `Id`.
- **Idempotency contract** matches every other migration in `.sql/`: re-running prints `[skip]` for every existing table and exits cleanly. Safe to wire into `setup-database` without a guard against double-clicks.
- **`IPINumber` stored as `VARCHAR(32)`** rather than INT — IPI Name Numbers are numeric in practice but representing them as strings preserves any leading zeros a registrar emits and avoids arithmetic-context surprises downstream. `UNIQUE (CreditPersonId, IPINumber)` blocks per-person duplicates while still allowing the same IPI to legitimately attach to two different registry rows if the data demands it.
- **`Url VARCHAR(2048)`** matches what the spec'd link types (Wikipedia / MusicBrainz / Discogs / IMSLP) can produce in the wild, with margin.

## Test plan

- [ ] Push to alpha → wait for deploy → on staging admin, sign in as a `global_admin`.
- [ ] Open `/manage/setup-database` → confirm the new **3f. Credit People Registry (#545)** card renders alongside cards 3a–3e with the standard styling (no broken Bootstrap, no duplicated nav / footer).
- [ ] Click **Run Credit People Registry Migration** → output should show `[add ] tblCreditPeople.` / `[add ] tblCreditPersonLinks.` / `[add ] tblCreditPersonIPI.` then `Migration complete.`
- [ ] Click it a second time → output should now show `[skip] tblCreditPeople already present.` / two more `[skip]` lines / `Migration complete.` (idempotency check).
- [ ] In `phpMyAdmin` (or `DESCRIBE tblCreditPeople;` etc. via `/manage/sql-runner` if available), verify the three tables and their column types / FKs / indexes match the schema in [#545](https://github.com/MWBMPartners/iHymns/issues/545).
- [ ] `INSERT INTO tblCreditPeople (Name) VALUES ('Smoke Test');` → `INSERT INTO tblCreditPersonLinks (CreditPersonId, LinkType, Url) VALUES (LAST_INSERT_ID(), 'wikipedia', 'https://en.wikipedia.org/wiki/Smoke_Test');` → `DELETE FROM tblCreditPeople WHERE Name='Smoke Test';` → confirm the link row is also gone (FK cascade).
- [ ] CLI alternative path: `php appWeb/.sql/migrate-credit-people.php` on a local dev DB → same `[add]` / `[skip]` output, no exceptions.
- [ ] Run the schema-audit page (if applicable) → all three new tables should report as covered, no orphan-column warnings.
- [ ] Confirm none of the five existing song-credit tables are touched in any way (no schema diff on `tblSongWriters` / `tblSongComposers` / `tblSongArrangers` / `tblSongAdaptors` / `tblSongTranslators`).

Refs #545 — does **not** close the issue (UI / entitlement / API work to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)