### PR TITLE
fix: PHP/MySQL safety audit Tier 1 + 2 fixes (closes #556, #557, #558)

### DIFF
--- a/appWeb/.sql/cleanup.php
+++ b/appWeb/.sql/cleanup.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
  *   CLI:  php appWeb/.sql/cleanup.php
  *   Cron: 0 3 * * * /usr/bin/php /path/to/appWeb/.sql/cleanup.php >> /var/log/ihymns-cleanup.log 2>&1
  *
- * @requires PHP 8.1+ with pdo_mysql extension
+ * @requires PHP 8.1+ with mysqli extension
  */
 
 /* =========================================================================
@@ -61,18 +61,19 @@ if (!defined('DB_HOST') || !defined('DB_USER') || !defined('DB_PASS') || !define
 $port    = defined('DB_PORT') ? (int)DB_PORT : 3306;
 $charset = defined('DB_CHARSET') ? DB_CHARSET : 'utf8mb4';
 
-$dsn = sprintf(
-    'mysql:host=%s;port=%d;dbname=%s;charset=%s',
-    DB_HOST, $port, DB_NAME, $charset
-);
+/* Strict reporting (#525) — exceptions on every failed query so a
+   broken DELETE doesn't silently no-op. Matches the migrate-*.php
+   scripts in this directory. */
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 
 try {
-    $db = new PDO($dsn, DB_USER, DB_PASS, [
-        PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
-        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-        PDO::ATTR_EMULATE_PREPARES   => false,
-    ]);
-} catch (PDOException $e) {
+    $db = @new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME, $port);
+    if ($db->connect_errno) {
+        echo "ERROR: Database connection failed: " . $db->connect_error . "\n";
+        return;
+    }
+    $db->set_charset($charset);
+} catch (\mysqli_sql_exception $e) {
     echo "ERROR: Database connection failed: " . $e->getMessage() . "\n";
     return;
 }
@@ -90,33 +91,39 @@ $totalDeleted = 0;
 /* 1. Expired API tokens */
 try {
     $stmt = $db->prepare('DELETE FROM tblApiTokens WHERE ExpiresAt < ?');
-    $stmt->execute([$now]);
-    $count = $stmt->rowCount();
+    $stmt->bind_param('s', $now);
+    $stmt->execute();
+    $count = $stmt->affected_rows;
     echo "tblApiTokens:          $count expired token(s) deleted\n";
     $totalDeleted += $count;
-} catch (PDOException $e) {
+    $stmt->close();
+} catch (\mysqli_sql_exception $e) {
     echo "tblApiTokens:          ERROR — " . $e->getMessage() . "\n";
 }
 
 /* 2. Expired or used email login tokens */
 try {
     $stmt = $db->prepare('DELETE FROM tblEmailLoginTokens WHERE ExpiresAt < ? OR Used = 1');
-    $stmt->execute([$now]);
-    $count = $stmt->rowCount();
+    $stmt->bind_param('s', $now);
+    $stmt->execute();
+    $count = $stmt->affected_rows;
     echo "tblEmailLoginTokens:   $count expired/used token(s) deleted\n";
     $totalDeleted += $count;
-} catch (PDOException $e) {
+    $stmt->close();
+} catch (\mysqli_sql_exception $e) {
     echo "tblEmailLoginTokens:   ERROR — " . $e->getMessage() . "\n";
 }
 
 /* 3. Expired or used password reset tokens */
 try {
     $stmt = $db->prepare('DELETE FROM tblPasswordResetTokens WHERE ExpiresAt < ? OR Used = 1');
-    $stmt->execute([$now]);
-    $count = $stmt->rowCount();
+    $stmt->bind_param('s', $now);
+    $stmt->execute();
+    $count = $stmt->affected_rows;
     echo "tblPasswordResetTokens: $count expired/used token(s) deleted\n";
     $totalDeleted += $count;
-} catch (PDOException $e) {
+    $stmt->close();
+} catch (\mysqli_sql_exception $e) {
     echo "tblPasswordResetTokens: ERROR — " . $e->getMessage() . "\n";
 }
 
@@ -124,10 +131,11 @@ try {
 try {
     $stmt = $db->prepare('DELETE FROM tblLoginAttempts WHERE AttemptedAt < DATE_SUB(NOW(), INTERVAL 30 DAY)');
     $stmt->execute();
-    $count = $stmt->rowCount();
+    $count = $stmt->affected_rows;
     echo "tblLoginAttempts:      $count old attempt(s) deleted\n";
     $totalDeleted += $count;
-} catch (PDOException $e) {
+    $stmt->close();
+} catch (\mysqli_sql_exception $e) {
     echo "tblLoginAttempts:      ERROR — " . $e->getMessage() . "\n";
 }
 
@@ -140,22 +148,28 @@ try {
 try {
     $stmt = $db->prepare("SELECT SettingValue FROM tblAppSettings WHERE SettingKey = 'activity_log_retention_days'");
     $stmt->execute();
-    $raw = (string)($stmt->fetchColumn() ?: '');
+    $row = $stmt->get_result()->fetch_row();
+    $stmt->close();
+    $raw = (string)($row[0] ?? '');
     $retentionDays = $raw !== '' ? (int)$raw : 90;
     if ($retentionDays === 0) {
         echo "tblActivityLog:        skipped (retention = 0, pruning disabled)\n";
     } else {
         $retentionDays = max(1, min(3650, $retentionDays));
         $stmt = $db->prepare('DELETE FROM tblActivityLog WHERE CreatedAt < DATE_SUB(NOW(), INTERVAL ? DAY)');
-        $stmt->execute([$retentionDays]);
-        $count = $stmt->rowCount();
+        $stmt->bind_param('i', $retentionDays);
+        $stmt->execute();
+        $count = $stmt->affected_rows;
         echo "tblActivityLog:        $count row(s) older than {$retentionDays} day(s) deleted\n";
         $totalDeleted += $count;
+        $stmt->close();
     }
-} catch (PDOException $e) {
+} catch (\mysqli_sql_exception $e) {
     echo "tblActivityLog:        ERROR — " . $e->getMessage() . "\n";
 }
 
 echo str_repeat('-', 50) . "\n";
 echo "Total deleted: $totalDeleted row(s)\n";
 echo "Cleanup complete.\n";
+
+$db->close();

--- a/appWeb/public_html/manage/activity-log.php
+++ b/appWeb/public_html/manage/activity-log.php
@@ -150,7 +150,13 @@ $totalPages = $total > 0 ? (int)ceil($total / $pageSize) : 1;
    hand-maintained list to drift. */
 $distinctActions = [];
 try {
-    $stmt = $db->query("SELECT DISTINCT Action FROM tblActivityLog WHERE CreatedAt >= '" . addslashes($since) . "' ORDER BY Action ASC");
+    $stmt = $db->prepare(
+        'SELECT DISTINCT Action
+           FROM tblActivityLog
+          WHERE CreatedAt >= :since
+          ORDER BY Action ASC'
+    );
+    $stmt->execute([':since' => $since]);
     $distinctActions = $stmt->fetchAll(PDO::FETCH_COLUMN);
 } catch (\Throwable $_e) { /* empty list is fine */ }
 

--- a/appWeb/public_html/manage/data-health.php
+++ b/appWeb/public_html/manage/data-health.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'config.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
 
 requireGlobalAdmin();
 $currentUser = getCurrentUser();
@@ -24,15 +25,28 @@ $activePage  = 'data-health';
 $flash   = '';
 $error   = '';
 
-/* getDb() can throw if MySQL credentials are wrong or the server is
-   unreachable — previously that fatal killed the page output before a
-   single byte reached the browser, so admins saw a blank screen with
-   no clue what went wrong. Catch, record, and render the admin layout
-   anyway with the error surfaced. */
+/* Allowlist of tables this page reports counts for. Used both in the
+   loop that drives the report AND as the runtime guard at the query
+   site (#558). Lifting this out of an inline array literal keeps the
+   safety locally provable: the in_array() check at line ~95 doesn't
+   have to trust that the loop variable came from this list — it can
+   prove it. If the loop is ever refactored into a function that
+   accepts a $tbl parameter, the guard remains in place. */
+const HEALTH_TABLES = [
+    'tblSongs', 'tblSongbooks', 'tblUsers', 'tblUserSetlists',
+    'tblSharedSetlists', 'tblSongRequests', 'tblSongRevisions',
+    'tblUserGroups', 'tblOrganisations',
+];
+
+/* getDbMysqli() can throw if MySQL credentials are wrong or the
+   server is unreachable — previously that fatal killed the page
+   output before a single byte reached the browser, so admins saw a
+   blank screen with no clue what went wrong. Catch, record, and
+   render the admin layout anyway with the error surfaced. */
 try {
-    $db = getDb();
+    $db = getDbMysqli();
 } catch (\Throwable $e) {
-    error_log('[manage/data-health.php] getDb failed: ' . $e->getMessage());
+    error_log('[manage/data-health.php] getDbMysqli failed: ' . $e->getMessage());
     $db = null;
     $error = 'Database is currently unreachable. ' . $e->getMessage();
 }
@@ -84,15 +98,23 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 /* ---- Gather health ---- */
 $tableCounts = [];
-foreach (['tblSongs', 'tblSongbooks', 'tblUsers', 'tblUserSetlists',
-          'tblSharedSetlists', 'tblSongRequests', 'tblSongRevisions',
-          'tblUserGroups', 'tblOrganisations'] as $tbl) {
+foreach (HEALTH_TABLES as $tbl) {
     if ($db === null) {
         $tableCounts[$tbl] = null;
         continue;
     }
+    /* Belt-and-braces allowlist guard. Technically redundant given the
+       loop iterates HEALTH_TABLES, but it makes the safety provable at
+       the query site without the reader having to trace control flow.
+       SQL identifiers (table names) cannot be parameterised — `?` only
+       binds values — so the guard + backticks is the correct pattern. */
+    if (!in_array($tbl, HEALTH_TABLES, true)) { continue; }
     try {
-        $tableCounts[$tbl] = (int)$db->query('SELECT COUNT(*) FROM ' . $tbl)->fetchColumn();
+        $stmt = $db->prepare('SELECT COUNT(*) FROM `' . $tbl . '`');
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_row();
+        $tableCounts[$tbl] = (int)($row[0] ?? 0);
+        $stmt->close();
     } catch (\Throwable $_e) {
         /* "Table missing" is the expected reason on a fresh deploy —
            the UI surfaces it as null. Log anyway so non-missing
@@ -126,8 +148,11 @@ if ($shareDirPath && is_dir($shareDirPath)) {
             $files
         ));
         try {
-            $stmt = $db->query('SELECT ShareId FROM tblSharedSetlists');
-            $inDb = array_fill_keys(array_column($stmt->fetchAll(PDO::FETCH_ASSOC), 'ShareId'), true);
+            $stmt = $db->prepare('SELECT ShareId FROM tblSharedSetlists');
+            $stmt->execute();
+            $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+            $stmt->close();
+            $inDb = array_fill_keys(array_column($rows, 'ShareId'), true);
             foreach ($idsOnDisk as $id) {
                 if (!isset($inDb[$id])) $unimportedShareIds[] = $id;
             }


### PR DESCRIPTION
## Summary

Implements the **Tier 1 + Tier 2 findings** from the PHP/MySQL safety audit on 2026-04-27. Three small, contained fixes — one commit per issue, each independently revertable. None of them is exploitable today (all severities LOW per the audit's severity rubric); together they remove every `addslashes()`-for-SQL pattern from runtime code, take one of the three direct `new PDO(...)` instantiations off the books, and add an explicit defense-in-depth guard at one of the two remaining "interpolated identifier from internal source" sites.

## Commits (one per issue)

| Commit | Issue | Summary |
|---|---|---|
| [`9f376e4`](https://github.com/MWBMPartners/iHymns/commit/9f376e4) | Closes #556 | `manage/activity-log.php` — replace `addslashes()` SQL escape with `$db->prepare(':since')` matching the pattern already used 12 lines above |
| [`c9c533d`](https://github.com/MWBMPartners/iHymns/commit/c9c533d) | Closes #557 | `appWeb/.sql/cleanup.php` — migrate the periodic token-cleanup script from PDO to mysqli prepared statements end-to-end |
| [`706c17a`](https://github.com/MWBMPartners/iHymns/commit/706c17a) | Closes #558 | `manage/data-health.php` — migrate to mysqli + lift the table list into a named constant `HEALTH_TABLES` + add explicit `in_array` allowlist guard at the query site + backtick-wrap the dynamic table identifier |

## Why these three together

Per [CLAUDE.md](https://github.com/MWBMPartners/iHymns/blob/alpha/.claude/CLAUDE.md): "One PR per piece of work, multiple commits inside it. Group related work into a single PR with logical, well-scoped commits rather than splitting across several smaller PRs." All three fixes share the same theme — closing the small / contained findings from the audit before tackling the much larger Tier 3 umbrella migration ([#554](https://github.com/MWBMPartners/iHymns/issues/554)). Bundling them into one PR is one review, one alpha deploy, one verify pass for three commits that each fix a distinct issue. The commit history stays atomic so any single fix can be reverted with `git revert <sha>` without touching the other two.

## Tier 3 (PDO → mysqli umbrella) is **not** in this PR

The audit's largest finding — migrating the remaining 26 files / 142 invocations of `getDb()` to mysqli — is tracked under [#554](https://github.com/MWBMPartners/iHymns/issues/554) (umbrella) and [#555](https://github.com/MWBMPartners/iHymns/issues/555) (capstone deletion of `getDb()`). Both issues are now filed with full per-batch checklists, but no code in either is touched here. The Tier 3 work will land as a series of incremental PRs over weeks (estimated ~25-30 hours of focused work spread across 15-20 PRs, per the umbrella's own effort breakdown).

This PR's commit `706c17a` does opportunistically close the `manage/data-health.php` checkbox in [#554](https://github.com/MWBMPartners/iHymns/issues/554)'s Batch 3 list — Tier 2's data-health.php fix overlaps with that batch's scope, so combining them avoided the file being touched twice.

## What's not changed

- Zero changes to the public API (`api.php`).
- Zero changes to authentication or entitlements (`manage/includes/auth.php`, `includes/entitlements.php`).
- Zero changes to the editor (`manage/editor/`).
- Zero new dependencies, no schema changes.
- The PDO `getDb()` helper itself is untouched — its 26 remaining call sites still work exactly as before (the umbrella's incremental migration handles them one at a time).

## Test plan

### Pre-merge (already done locally)

- [x] `php -l appWeb/public_html/manage/activity-log.php` → No syntax errors
- [x] `php -l appWeb/.sql/cleanup.php` → No syntax errors
- [x] `php -l appWeb/public_html/manage/data-health.php` → No syntax errors
- [x] `grep -n 'addslashes' appWeb/public_html/manage/activity-log.php` → 0 results
- [x] `grep -nE 'PDO\\|getDb' appWeb/.sql/cleanup.php` → 0 results
- [x] `grep -nE 'PDO\\|getDb\\(\\)' appWeb/public_html/manage/data-health.php` → 0 results

### Post-deploy on alpha (recommend doing in this order)

- [ ] Sign in as a `global_admin`. Visit `/manage/activity-log` with each of the five `?days=` filter values (1, 7, 30, 90, 365) → confirm the action-filter dropdown populates correctly each time, no errors in `error_log`.
- [ ] Visit `/manage/data-health` → confirm all nine table-count rows render correctly (or `—` for any genuinely missing table on a fresh deploy). The "songs.json fallback" / "shared setlist" / "SQLite" sections all still render.
- [ ] On a non-prod DB (or a snapshot), `php appWeb/.sql/cleanup.php` from the CLI → confirm the per-table deletion-count output matches the format in the file's docblock and the totals line up. Also confirm no `Class "PDO" not found` or `Call to undefined method PDO::…` errors.
- [ ] On the same alpha DB, `/manage/setup-database` → click **4. Cleanup Expired Tokens** → confirm the inline output matches the CLI run.
- [ ] `tail -50 /path/to/error.log` after each of the above → no new entries from `[manage/activity-log.php]` / `[manage/data-health.php]` / cleanup.php.

## Rollback plan

If any commit causes a regression: `git revert <sha>` for the offending commit only — the other two commits are unaffected (each touches a different file, no shared dependencies).

Closes #556
Closes #557
Closes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)