### PR TITLE
refactor(manage): PDO→mysqli migration — #554 Batch 1 (tiers, groups, restrictions, requests)

### DIFF
--- a/appWeb/public_html/manage/groups.php
+++ b/appWeb/public_html/manage/groups.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
  */
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
 
 if (!isAuthenticated()) {
     header('Location: /manage/login');
@@ -25,7 +26,7 @@ $activePage = 'groups';
 
 $error   = '';
 $success = '';
-$db      = getDb();
+$db      = getDbMysqli();
 
 /* ----- POST actions ----- */
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -49,14 +50,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 if (strlen($name) > 100) { $error = 'Name must be 100 characters or fewer.'; break; }
 
                 $stmt = $db->prepare('SELECT Id FROM tblUserGroups WHERE Name = ?');
-                $stmt->execute([$name]);
-                if ($stmt->fetch()) { $error = 'A group with that name already exists.'; break; }
+                $stmt->bind_param('s', $name);
+                $stmt->execute();
+                $exists = $stmt->get_result()->fetch_row() !== null;
+                $stmt->close();
+                if ($exists) { $error = 'A group with that name already exists.'; break; }
 
                 $stmt = $db->prepare(
                     'INSERT INTO tblUserGroups (Name, Description, AccessAlpha, AccessBeta, AccessRc, AccessRtw)
                      VALUES (?, ?, ?, ?, ?, ?)'
                 );
-                $stmt->execute([$name, $desc, $aA, $aB, $aR, $aW]);
+                $stmt->bind_param('ssiiii', $name, $desc, $aA, $aB, $aR, $aW);
+                $stmt->execute();
+                $stmt->close();
                 $success = "Group '{$name}' created.";
                 break;
             }
@@ -73,8 +79,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 if ($name === '') { $error = 'Name is required.'; break; }
 
                 $stmt = $db->prepare('SELECT Id FROM tblUserGroups WHERE Name = ? AND Id <> ?');
-                $stmt->execute([$name, $id]);
-                if ($stmt->fetch()) { $error = 'Another group already uses that name.'; break; }
+                $stmt->bind_param('si', $name, $id);
+                $stmt->execute();
+                $exists = $stmt->get_result()->fetch_row() !== null;
+                $stmt->close();
+                if ($exists) { $error = 'Another group already uses that name.'; break; }
 
                 $stmt = $db->prepare(
                     'UPDATE tblUserGroups
@@ -82,7 +91,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                             AccessAlpha = ?, AccessBeta = ?, AccessRc = ?, AccessRtw = ?
                       WHERE Id = ?'
                 );
-                $stmt->execute([$name, $desc, $aA, $aB, $aR, $aW, $id]);
+                $stmt->bind_param('ssiiiii', $name, $desc, $aA, $aB, $aR, $aW, $id);
+                $stmt->execute();
+                $stmt->close();
                 $success = "Group '{$name}' updated.";
                 break;
             }
@@ -91,20 +102,28 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $id = (int)($_POST['id'] ?? 0);
 
                 $stmt = $db->prepare('SELECT Name FROM tblUserGroups WHERE Id = ?');
-                $stmt->execute([$id]);
-                $name = (string)($stmt->fetchColumn() ?: '');
+                $stmt->bind_param('i', $id);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_row();
+                $stmt->close();
+                $name = (string)($row[0] ?? '');
                 if ($name === '') { $error = 'Group not found.'; break; }
 
                 $stmt = $db->prepare('SELECT COUNT(*) FROM tblUsers WHERE GroupId = ?');
-                $stmt->execute([$id]);
-                $members = (int)$stmt->fetchColumn();
+                $stmt->bind_param('i', $id);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_row();
+                $stmt->close();
+                $members = (int)($row[0] ?? 0);
                 if ($members > 0) {
                     $error = "Cannot delete '{$name}': {$members} user(s) still belong to it. Move them to another group first.";
                     break;
                 }
 
                 $stmt = $db->prepare('DELETE FROM tblUserGroups WHERE Id = ?');
-                $stmt->execute([$id]);
+                $stmt->bind_param('i', $id);
+                $stmt->execute();
+                $stmt->close();
                 $success = "Group '{$name}' deleted.";
                 break;
             }
@@ -114,7 +133,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $userId  = (int)($_POST['user_id']  ?? 0);
                 if ($groupId <= 0 || $userId <= 0) { $error = 'Invalid request.'; break; }
                 $stmt = $db->prepare('UPDATE tblUsers SET GroupId = ?, UpdatedAt = CURRENT_TIMESTAMP WHERE Id = ?');
-                $stmt->execute([$groupId, $userId]);
+                $stmt->bind_param('ii', $groupId, $userId);
+                $stmt->execute();
+                $stmt->close();
                 $success = 'Member added.';
                 break;
             }
@@ -123,7 +144,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $userId = (int)($_POST['user_id'] ?? 0);
                 if ($userId <= 0) { $error = 'Invalid request.'; break; }
                 $stmt = $db->prepare('UPDATE tblUsers SET GroupId = NULL, UpdatedAt = CURRENT_TIMESTAMP WHERE Id = ?');
-                $stmt->execute([$userId]);
+                $stmt->bind_param('i', $userId);
+                $stmt->execute();
+                $stmt->close();
                 $success = 'Member removed from group.';
                 break;
             }
@@ -140,7 +163,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 /* ----- GET: fetch groups + members ----- */
 $groups = [];
 try {
-    $rs = $db->query(
+    $stmt = $db->prepare(
         'SELECT g.Id, g.Name, g.Description,
                 g.AccessAlpha, g.AccessBeta, g.AccessRc, g.AccessRtw,
                 COUNT(u.Id) AS MemberCount
@@ -149,7 +172,9 @@ try {
           GROUP BY g.Id
           ORDER BY g.Name ASC'
     );
-    $groups = $rs->fetchAll(PDO::FETCH_ASSOC);
+    $stmt->execute();
+    $groups = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+    $stmt->close();
 } catch (\Throwable $e) {
     error_log('[manage/groups.php] ' . $e->getMessage());
     $error = $error ?: 'Could not load groups.';
@@ -163,16 +188,20 @@ $editId = (int)($_GET['edit'] ?? 0);
 if ($editId > 0) {
     try {
         $stmt = $db->prepare('SELECT * FROM tblUserGroups WHERE Id = ?');
-        $stmt->execute([$editId]);
-        $editGroup = $stmt->fetch(PDO::FETCH_ASSOC) ?: null;
+        $stmt->bind_param('i', $editId);
+        $stmt->execute();
+        $editGroup = $stmt->get_result()->fetch_assoc() ?: null;
+        $stmt->close();
 
         if ($editGroup) {
             $stmt = $db->prepare(
                 'SELECT Id, Username, DisplayName, Role, IsActive
                    FROM tblUsers WHERE GroupId = ? ORDER BY Username ASC'
             );
-            $stmt->execute([$editId]);
-            $editMembers = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            $stmt->bind_param('i', $editId);
+            $stmt->execute();
+            $editMembers = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+            $stmt->close();
 
             $stmt = $db->prepare(
                 'SELECT Id, Username, DisplayName, Role
@@ -181,8 +210,10 @@ if ($editId > 0) {
                   ORDER BY Username ASC
                   LIMIT 500'
             );
-            $stmt->execute([$editId]);
-            $candidates = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            $stmt->bind_param('i', $editId);
+            $stmt->execute();
+            $candidates = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+            $stmt->close();
         }
     } catch (\Throwable $e) {
         error_log('[manage/groups.php] ' . $e->getMessage());

--- a/appWeb/public_html/manage/requests.php
+++ b/appWeb/public_html/manage/requests.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
  */
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
 
 if (!isAuthenticated()) {
     header('Location: /manage/login');
@@ -52,13 +53,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $err = 'Invalid request.';
     } else {
         try {
-            $db = getDb();
+            $db = getDbMysqli();
             $stmt = $db->prepare(
                 'UPDATE tblSongRequests
                     SET Status = ?, AdminNotes = ?, ResolvedSongId = ?
                   WHERE Id = ?'
             );
-            $stmt->execute([$newStatus, $adminNotes, $resolvedSong ?: null, $id]);
+            $resolved = $resolvedSong !== '' ? $resolvedSong : null;
+            $stmt->bind_param('sssi', $newStatus, $adminNotes, $resolved, $id);
+            $stmt->execute();
+            $stmt->close();
             $flash = 'Request #' . $id . ' updated.';
         } catch (\Throwable $e) {
             error_log('[manage/requests.php] ' . $e->getMessage());
@@ -70,15 +74,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 /* --- GET: fetch rows --- */
 $rows = [];
 try {
-    $db = getDb();
+    $db = getDbMysqli();
     if ($filter === 'all') {
-        $stmt = $db->query(
+        $stmt = $db->prepare(
             'SELECT r.*, u.Username AS requested_by
                FROM tblSongRequests r
                LEFT JOIN tblUsers u ON u.Id = r.UserId
               ORDER BY r.CreatedAt DESC
               LIMIT 500'
         );
+        $stmt->execute();
     } else {
         $stmt = $db->prepare(
             'SELECT r.*, u.Username AS requested_by
@@ -88,9 +93,11 @@ try {
               ORDER BY r.CreatedAt DESC
               LIMIT 500'
         );
-        $stmt->execute([$filter]);
+        $stmt->bind_param('s', $filter);
+        $stmt->execute();
     }
-    $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+    $stmt->close();
 } catch (\Throwable $e) {
     error_log('[manage/requests.php] ' . $e->getMessage());
     $err = 'Could not load requests — check server logs for details.';
@@ -98,10 +105,13 @@ try {
 
 $counts = [];
 try {
-    $cs = $db->query('SELECT Status, COUNT(*) AS cnt FROM tblSongRequests GROUP BY Status');
-    while ($row = $cs->fetch(PDO::FETCH_ASSOC)) {
+    $cs = $db->prepare('SELECT Status, COUNT(*) AS cnt FROM tblSongRequests GROUP BY Status');
+    $cs->execute();
+    $res = $cs->get_result();
+    while ($row = $res->fetch_assoc()) {
         $counts[$row['Status']] = (int)$row['cnt'];
     }
+    $cs->close();
 } catch (\Throwable $_e) {}
 
 ?>

--- a/appWeb/public_html/manage/restrictions.php
+++ b/appWeb/public_html/manage/restrictions.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
  */
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
 
 if (!isAuthenticated()) {
     header('Location: /manage/login');
@@ -40,7 +41,7 @@ $activePage = 'restrictions';
 
 $error   = '';
 $success = '';
-$db      = getDb();
+$db      = getDbMysqli();
 
 /* Allowed vocabularies — kept tight so the UI can't POST rubbish the
    evaluator will silently ignore. Keep in sync with content_access.php. */
@@ -127,10 +128,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         (EntityType, EntityId, RestrictionType, TargetType, TargetId, Effect, Priority, Reason)
                      VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
                 );
-                $stmt->execute([
+                /* Types: six string columns, then Priority(int), then Reason(string). */
+                $stmt->bind_param(
+                    'ssssssis',
                     $entityType, $entityId, $restrictionType,
-                    $targetType, $targetId, $effect, $priority, $reason,
-                ]);
+                    $targetType, $targetId, $effect, $priority, $reason
+                );
+                $stmt->execute();
+                $stmt->close();
                 $success = 'Restriction created.';
                 break;
             }
@@ -139,7 +144,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $id = (int)($_POST['id'] ?? 0);
                 if ($id <= 0) { $error = 'Invalid request.'; break; }
                 $stmt = $db->prepare('DELETE FROM tblContentRestrictions WHERE Id = ?');
-                $stmt->execute([$id]);
+                $stmt->bind_param('i', $id);
+                $stmt->execute();
+                $stmt->close();
                 $success = 'Restriction removed.';
                 break;
             }
@@ -177,8 +184,15 @@ try {
     }
     $sql .= ' ORDER BY Priority DESC, CreatedAt DESC LIMIT 500';
     $stmt = $db->prepare($sql);
-    $stmt->execute($args);
-    $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    /* Filter values are all strings (entity_type / restriction_type from
+       a closed allowlist). Type string is built from the args length so
+       we don't bind_param when there are no filters. */
+    if (!empty($args)) {
+        $stmt->bind_param(str_repeat('s', count($args)), ...$args);
+    }
+    $stmt->execute();
+    $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+    $stmt->close();
 } catch (\Throwable $e) {
     error_log('[manage/restrictions.php] ' . $e->getMessage());
     $error = $error ?: 'Could not load restrictions.';
@@ -187,16 +201,19 @@ try {
 /* Summary counts per entity type for the header pills */
 $counts = ['song' => 0, 'songbook' => 0, 'feature' => 0, 'total' => 0];
 try {
-    $rs = $db->query(
+    $stmt = $db->prepare(
         'SELECT EntityType, COUNT(*) AS n
            FROM tblContentRestrictions
           GROUP BY EntityType'
     );
-    foreach ($rs->fetchAll(PDO::FETCH_ASSOC) as $r) {
+    $stmt->execute();
+    $res = $stmt->get_result();
+    while ($r = $res->fetch_assoc()) {
         $t = (string)$r['EntityType'];
         if (isset($counts[$t])) $counts[$t] = (int)$r['n'];
         $counts['total'] += (int)$r['n'];
     }
+    $stmt->close();
 } catch (\Throwable $e) { /* ignore */ }
 
 /* Is the master gating switch enabled? Surface it prominently so admins
@@ -205,7 +222,9 @@ $gatingEnabled = false;
 try {
     $stmt = $db->prepare("SELECT SettingValue FROM tblAppSettings WHERE SettingKey = 'content_gating_enabled'");
     $stmt->execute();
-    $gatingEnabled = ((string)($stmt->fetchColumn() ?: '0')) === '1';
+    $row = $stmt->get_result()->fetch_row();
+    $stmt->close();
+    $gatingEnabled = ((string)($row[0] ?? '0')) === '1';
 } catch (\Throwable $e) { /* ignore */ }
 
 /* Preload songbooks + organisations for the #498 pickers. Both lists
@@ -214,19 +233,23 @@ try {
    stay AJAX-driven because their cardinalities are large. */
 $picker_songbooks = [];
 try {
-    $rs = $db->query(
+    $stmt = $db->prepare(
         'SELECT Abbreviation, Name, SongCount FROM tblSongbooks ORDER BY Name ASC'
     );
-    $picker_songbooks = $rs->fetchAll(PDO::FETCH_ASSOC);
+    $stmt->execute();
+    $picker_songbooks = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+    $stmt->close();
 } catch (\Throwable $_e) { /* empty list is a safe default */ }
 
 $picker_organisations = [];
 try {
-    $rs = $db->query(
+    $stmt = $db->prepare(
         'SELECT Id, Name, Slug, LicenceType FROM tblOrganisations
          WHERE IsActive = 1 ORDER BY Name ASC'
     );
-    $picker_organisations = $rs->fetchAll(PDO::FETCH_ASSOC);
+    $stmt->execute();
+    $picker_organisations = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+    $stmt->close();
 } catch (\Throwable $_e) { /* empty; the picker will fall back to live-search */ }
 
 $csrf = csrfToken();

--- a/appWeb/public_html/manage/tiers.php
+++ b/appWeb/public_html/manage/tiers.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
  */
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
 
 if (!isAuthenticated()) {
     header('Location: /manage/login');
@@ -34,7 +35,7 @@ $activePage = 'tiers';
 
 $error   = '';
 $success = '';
-$db      = getDb();
+$db      = getDbMysqli();
 
 /* Ordered list of capability columns — used for both the table header
    and as the authoritative input/update list, so adding a new capability
@@ -79,8 +80,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 if ($level < 0 || $level > 1000)  { $error = 'Level must be between 0 and 1000.'; break; }
 
                 $stmt = $db->prepare('SELECT Id FROM tblAccessTiers WHERE Name = ?');
-                $stmt->execute([$name]);
-                if ($stmt->fetch()) { $error = 'A tier with that name already exists.'; break; }
+                $stmt->bind_param('s', $name);
+                $stmt->execute();
+                $exists = $stmt->get_result()->fetch_row() !== null;
+                $stmt->close();
+                if ($exists) { $error = 'A tier with that name already exists.'; break; }
 
                 $caps = [];
                 foreach (array_keys(TIER_CAPS) as $col) {
@@ -90,8 +94,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $cols = array_merge(['Name','DisplayName','Level','Description'], array_keys(TIER_CAPS));
                 $placeholders = implode(', ', array_fill(0, count($cols), '?'));
                 $sql = 'INSERT INTO tblAccessTiers (' . implode(',', $cols) . ') VALUES (' . $placeholders . ')';
+                /* Type string: Name(s) DisplayName(s) Level(i) Description(s) +
+                   each TIER_CAPS column as int. Built dynamically so a new
+                   capability column auto-extends the bind without code change. */
+                $types  = 'ssis' . str_repeat('i', count(TIER_CAPS));
+                $values = array_merge([$name, $displayName, $level, $description], array_values($caps));
                 $stmt = $db->prepare($sql);
-                $stmt->execute(array_merge([$name, $displayName, $level, $description], array_values($caps)));
+                $stmt->bind_param($types, ...$values);
+                $stmt->execute();
+                $stmt->close();
                 $success = "Tier '{$name}' created.";
                 break;
             }
@@ -119,10 +130,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 }
                 $args[] = $id;
 
-                $stmt = $db->prepare(
+                /* Type string: DisplayName(s), Level(i), Description(s),
+                   each TIER_CAPS column as int, and finally Id(i). */
+                $types = 'sis' . str_repeat('i', count(TIER_CAPS)) . 'i';
+                $stmt  = $db->prepare(
                     'UPDATE tblAccessTiers SET ' . implode(', ', $sets) . ' WHERE Id = ?'
                 );
-                $stmt->execute($args);
+                $stmt->bind_param($types, ...$args);
+                $stmt->execute();
+                $stmt->close();
                 $success = 'Tier updated.';
                 break;
             }
@@ -130,20 +146,28 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             case 'delete': {
                 $id = (int)($_POST['id'] ?? 0);
                 $stmt = $db->prepare('SELECT Name FROM tblAccessTiers WHERE Id = ?');
-                $stmt->execute([$id]);
-                $name = (string)($stmt->fetchColumn() ?: '');
+                $stmt->bind_param('i', $id);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_row();
+                $stmt->close();
+                $name = (string)($row[0] ?? '');
                 if ($name === '') { $error = 'Tier not found.'; break; }
 
                 $stmt = $db->prepare('SELECT COUNT(*) FROM tblUsers WHERE AccessTier = ?');
-                $stmt->execute([$name]);
-                $inUse = (int)$stmt->fetchColumn();
+                $stmt->bind_param('s', $name);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_row();
+                $stmt->close();
+                $inUse = (int)($row[0] ?? 0);
                 if ($inUse > 0) {
                     $error = "Cannot delete '{$name}': {$inUse} user(s) are currently on this tier. Reassign them first.";
                     break;
                 }
 
                 $stmt = $db->prepare('DELETE FROM tblAccessTiers WHERE Id = ?');
-                $stmt->execute([$id]);
+                $stmt->bind_param('i', $id);
+                $stmt->execute();
+                $stmt->close();
                 $success = "Tier '{$name}' deleted.";
                 break;
             }
@@ -160,14 +184,20 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 /* ----- GET: tiers + per-tier user counts ----- */
 $tiers = [];
 try {
+    /* $capsCols is built from TIER_CAPS keys (a file-scope const), so the
+       interpolated identifier list cannot be user-influenced. SQL identifiers
+       can't be parameterised — this is the correct pattern for trusted
+       internal-source identifier lists. */
     $capsCols = implode(', ', array_keys(TIER_CAPS));
-    $rs = $db->query(
+    $stmt = $db->prepare(
         "SELECT t.Id, t.Name, t.DisplayName, t.Level, t.Description, $capsCols,
                 (SELECT COUNT(*) FROM tblUsers u WHERE u.AccessTier = t.Name) AS UserCount
            FROM tblAccessTiers t
           ORDER BY t.Level ASC, t.Name ASC"
     );
-    $tiers = $rs->fetchAll(PDO::FETCH_ASSOC);
+    $stmt->execute();
+    $tiers = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+    $stmt->close();
 } catch (\Throwable $e) {
     error_log('[manage/tiers.php] ' . $e->getMessage());
     $error = $error ?: 'Could not load tiers.';


### PR DESCRIPTION
## Summary

First batch of the [#554](https://github.com/MWBMPartners/iHymns/issues/554) PDO → mysqli umbrella migration. Mechanical conversion of four small / low-DB-churn `/manage/*` pages, one commit per file. **No behavioural change** in any file — same forms, same actions, same validators, same CSRF gates, same entitlement gates, same data shapes exposed to templates. The diffs are purely DB-API translation.

After this PR merges, `getDb()`'s call-site count drops from 26 files to 22, and the umbrella's [Batch 1 checklist](https://github.com/MWBMPartners/iHymns/issues/554) is fully ticked.

## Commits (one per file, in size order — smallest first)

| Commit | File | Lines | Statements converted |
|---|---|---|---|
| [`ec89376`](https://github.com/MWBMPartners/iHymns/commit/ec89376) | `manage/requests.php` | 246 | 4 |
| [`e634680`](https://github.com/MWBMPartners/iHymns/commit/e634680) | `manage/tiers.php` | 399 | 8 |
| [`56bee95`](https://github.com/MWBMPartners/iHymns/commit/56bee95) | `manage/groups.php` | 421 | 12 |
| [`a9f5cf2`](https://github.com/MWBMPartners/iHymns/commit/a9f5cf2) | `manage/restrictions.php` | 583 | 8 |

Each commit is independently revertable — if any one file shows a regression on alpha, `git revert <sha>` restores just that file's PDO behaviour without touching the other three.

## Conversion patterns applied (uniform across all four files)

Per the conversion crib in [#554](https://github.com/MWBMPartners/iHymns/issues/554):

| PDO | mysqli equivalent |
|---|---|
| `getDb()` | `getDbMysqli()` |
| `$stmt->execute([$values])` | `$stmt->bind_param($types, ...$values); $stmt->execute()` |
| `$stmt->fetch()` (existence check) | `$stmt->get_result()->fetch_row() !== null` |
| `$stmt->fetch(PDO::FETCH_ASSOC)` (single row) | `$stmt->get_result()->fetch_assoc()` |
| `$stmt->fetchColumn()` | `$stmt->get_result()->fetch_row()[0] ?? null` |
| `$stmt->fetchAll(PDO::FETCH_ASSOC)` | `$stmt->get_result()->fetch_all(MYSQLI_ASSOC)` |
| `$db->query('static SQL')` | `$db->prepare('static SQL'); $stmt->execute()` (kept as prepare for file-uniform style) |
| `catch (PDOException $e)` | unchanged — `\Throwable` already covers `mysqli_sql_exception` |

Plus three patterns the conversion crib doesn't fully cover:

1. **`require_once dirname(__DIR__).'/includes/db_mysql.php'`** is added alongside the existing `auth.php` require — `auth.php` only pulls in PDO's `db.php`, not mysqli's `db_mysql.php`.
2. **`$stmt->close()`** added after every statement. PDO destructs on out-of-scope, mysqli doesn't always. Explicit close avoids "commands out of sync" errors when multiple statements share the same connection per request.
3. **`bind_param` type strings worked out per-statement** based on column types. The dynamic-shape statements (variable-length INSERTs in `tiers.php`, variable-filter SELECT in `restrictions.php`) compute the type string with `str_repeat('i', count(TIER_CAPS))` or `str_repeat('s', count($args))` so the binding auto-extends if columns are added later.

## Edge cases handled

- **`requests.php` `ResolvedSongId` nullable string**: `$stmt->bind_param('sssi', …, $resolved, $id)` where `$resolved = $resolvedSong !== '' ? $resolvedSong : null` — mysqli passes NULL correctly even with type 's' when the bound variable is null.
- **`tiers.php` interpolated `$capsCols` identifier list**: same safe-but-internal pattern as the audit-flagged `data-health.php`. Source is a file-scope `const` (`TIER_CAPS`), never user-influenced. SQL identifiers can't be parameterised. Comment added explaining the safety.
- **`restrictions.php` zero-filter case**: when neither `?entity_type` nor `?restriction_type` is set, `$args` is empty. `bind_param` rejects an empty type string, so the call is skipped entirely (`if (!empty($args))`).
- **`groups.php` edit-mode block**: `?edit=<id>` triggers three follow-up queries (group detail, current members, candidate non-members). All converted; the `$editGroup === null` guard around the inner two queries is preserved so the block short-circuits cleanly when the id is bogus.

## Out of scope (unchanged in this PR)

- The other 22 `getDb()`-consuming files in `/manage/*`, `/includes/*`, and `api.php` — those land in subsequent #554 batches per the umbrella's roadmap.
- `getDb()` itself stays. Helper deletion is the capstone PR ([#555](https://github.com/MWBMPartners/iHymns/issues/555)), blocked until every consumer is migrated.
- The `addslashes()`-for-SQL hygiene fix on `manage/activity-log.php` already shipped via PR #559 (Tier 1 audit fix). When `activity-log.php` is migrated to mysqli later in #554 Batch 3, the prepared statement is already in place — only the binding API changes.

## Test plan

For each migrated file, verify on alpha after deploy:

### `manage/requests.php`
- [ ] Sign in with `review_song_requests` (editor or above). Page loads.
- [ ] Each filter button (Pending / Reviewed / Added / Declined / All) returns the expected rows + status-count badges.
- [ ] On any pending request, click "Review" → set status to "added", set ResolvedSongId, save → row updates, success banner appears.
- [ ] CSRF reject path: tamper with the token → 403.

### `manage/tiers.php`
- [ ] Sign in with `manage_access_tiers`. Page loads, all five seeded tiers (public / free / ccli / premium / pro) render with correct capability checkmarks and per-tier user counts.
- [ ] Create a new tier (e.g. "premium_plus" / level 60 / a couple of caps ticked) → row appears, success banner.
- [ ] Edit an existing tier (change Display name, toggle a cap) → save → matrix reflects the change.
- [ ] Try to delete a tier with users on it → blocked with the in-use error.
- [ ] Delete the test tier (no users on it) → row disappears.

### `manage/groups.php`
- [ ] Sign in with `manage_user_groups`. Page loads, all groups render with member counts.
- [ ] Create / edit / delete a test group with the four channel-access toggles.
- [ ] `?edit=<id>` on a group → membership panel renders with current members + candidate list.
- [ ] Add a candidate → moves to current members. Remove a member → returns to candidates.
- [ ] Delete a group with members → blocked.

### `manage/restrictions.php`
- [ ] Sign in with `manage_content_restrictions`. Page loads, gating-enabled banner reflects the `tblAppSettings.content_gating_enabled` value.
- [ ] Filter by `?entity_type=song` → only song rules. Combine with `?restriction_type=block_user` → both filters apply.
- [ ] Pickers (songbooks, organisations) populate from the DB.
- [ ] Create a test rule (e.g. block_platform on a song, target Apple) → row appears.
- [ ] Delete the test rule.

### General
- [ ] No new entries in `error_log` from any of the four migrated files.
- [ ] Sidebar nav still highlights the active page on each (`$activePage` set correctly).

## Rollback plan

If any single file regresses on alpha: `git revert <commit-sha>` for that one commit. The other three are independent and unaffected.

Refs #554 (closes Batch 1 — Batches 2 / 3 / 4 / 5 / 6 still to come per the umbrella roadmap).
Refs #555 (capstone, still blocked by remaining batches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)