### PR TITLE
refactor(manage): PDO→mysqli migration — #554 Batch 2 (users, songbooks, organisations)

### DIFF
--- a/appWeb/public_html/manage/organisations.php
+++ b/appWeb/public_html/manage/organisations.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
  */
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
 
 if (!isAuthenticated()) {
     header('Location: /manage/login');
@@ -25,7 +26,7 @@ $activePage = 'organisations';
 
 $error   = '';
 $success = '';
-$db      = getDb();
+$db      = getDbMysqli();
 
 /* Machine key → human label + short description. The key is what the
    DB / evaluator reference; the label is what every UI surface renders
@@ -72,16 +73,28 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 if (!in_array($licenceType, $LICENCE_TYPE_KEYS, true)) { $error = 'Unknown licence type.'; break; }
 
                 $stmt = $db->prepare('SELECT Id FROM tblOrganisations WHERE Slug = ?');
-                $stmt->execute([$slug]);
-                if ($stmt->fetch()) { $error = 'That slug is already in use.'; break; }
+                $stmt->bind_param('s', $slug);
+                $stmt->execute();
+                $exists = $stmt->get_result()->fetch_row() !== null;
+                $stmt->close();
+                if ($exists) { $error = 'That slug is already in use.'; break; }
 
                 $stmt = $db->prepare(
                     'INSERT INTO tblOrganisations
                         (Name, Slug, ParentOrgId, Description, LicenceType, LicenceNumber, IsActive)
                      VALUES (?, ?, ?, ?, ?, ?, ?)'
                 );
-                $stmt->execute([$name, $slug, $parent ?: null, $desc, $licenceType, $licenceNum, $active]);
-                $newOrgId = (int)$db->lastInsertId();
+                /* Types: Name(s), Slug(s), ParentOrgId(i nullable),
+                   Description(s), LicenceType(s), LicenceNumber(s), IsActive(i).
+                   mysqli passes NULL correctly when bound variable is null. */
+                $parentOrNull = $parent ?: null;
+                $stmt->bind_param(
+                    'ssisssi',
+                    $name, $slug, $parentOrNull, $desc, $licenceType, $licenceNum, $active
+                );
+                $stmt->execute();
+                $newOrgId = (int)$db->insert_id;
+                $stmt->close();
                 logActivity('org.create', 'organisation', (string)$newOrgId, [
                     'name'           => $name,
                     'slug'           => $slug,
@@ -109,16 +122,21 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 if ($parent === $id) { $error = 'An organisation cannot be its own parent.'; break; }
 
                 $stmt = $db->prepare('SELECT Id FROM tblOrganisations WHERE Slug = ? AND Id <> ?');
-                $stmt->execute([$slug, $id]);
-                if ($stmt->fetch()) { $error = 'That slug is already in use.'; break; }
+                $stmt->bind_param('si', $slug, $id);
+                $stmt->execute();
+                $exists = $stmt->get_result()->fetch_row() !== null;
+                $stmt->close();
+                if ($exists) { $error = 'That slug is already in use.'; break; }
 
                 /* Capture before-row for the audit diff (#535). */
                 $beforeStmt = $db->prepare(
                     'SELECT Name, Slug, ParentOrgId, Description, LicenceType, LicenceNumber, IsActive
                        FROM tblOrganisations WHERE Id = ?'
                 );
-                $beforeStmt->execute([$id]);
-                $beforeOrg = $beforeStmt->fetch(PDO::FETCH_ASSOC) ?: null;
+                $beforeStmt->bind_param('i', $id);
+                $beforeStmt->execute();
+                $beforeOrg = $beforeStmt->get_result()->fetch_assoc() ?: null;
+                $beforeStmt->close();
 
                 $stmt = $db->prepare(
                     'UPDATE tblOrganisations
@@ -126,7 +144,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                             LicenceType = ?, LicenceNumber = ?, IsActive = ?
                       WHERE Id = ?'
                 );
-                $stmt->execute([$name, $slug, $parent ?: null, $desc, $licenceType, $licenceNum, $active, $id]);
+                /* Types: Name(s), Slug(s), ParentOrgId(i nullable),
+                   Description(s), LicenceType(s), LicenceNumber(s),
+                   IsActive(i), Id(i). */
+                $parentOrNull = $parent ?: null;
+                $stmt->bind_param(
+                    'ssisssii',
+                    $name, $slug, $parentOrNull, $desc, $licenceType, $licenceNum, $active, $id
+                );
+                $stmt->execute();
+                $stmt->close();
 
                 if ($beforeOrg !== null) {
                     $afterOrg = [
@@ -154,22 +181,33 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $id = (int)($_POST['id'] ?? 0);
 
                 $stmt = $db->prepare('SELECT Name FROM tblOrganisations WHERE Id = ?');
-                $stmt->execute([$id]);
-                $name = (string)($stmt->fetchColumn() ?: '');
+                $stmt->bind_param('i', $id);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_row();
+                $stmt->close();
+                $name = (string)($row[0] ?? '');
                 if ($name === '') { $error = 'Organisation not found.'; break; }
 
                 $stmt = $db->prepare('SELECT COUNT(*) FROM tblOrganisationMembers WHERE OrgId = ?');
-                $stmt->execute([$id]);
-                $members = (int)$stmt->fetchColumn();
+                $stmt->bind_param('i', $id);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_row();
+                $stmt->close();
+                $members = (int)($row[0] ?? 0);
                 if ($members > 0) { $error = "Cannot delete '{$name}': {$members} member(s) still listed."; break; }
 
                 $stmt = $db->prepare('SELECT COUNT(*) FROM tblOrganisations WHERE ParentOrgId = ?');
-                $stmt->execute([$id]);
-                $children = (int)$stmt->fetchColumn();
+                $stmt->bind_param('i', $id);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_row();
+                $stmt->close();
+                $children = (int)($row[0] ?? 0);
                 if ($children > 0) { $error = "Cannot delete '{$name}': {$children} sub-organisation(s) still reference it as parent."; break; }
 
                 $stmt = $db->prepare('DELETE FROM tblOrganisations WHERE Id = ?');
-                $stmt->execute([$id]);
+                $stmt->bind_param('i', $id);
+                $stmt->execute();
+                $stmt->close();
                 logActivity('org.delete', 'organisation', (string)$id, ['name' => $name]);
                 $success = "Organisation '{$name}' deleted.";
                 break;
@@ -187,7 +225,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                      VALUES (?, ?, ?)
                      ON DUPLICATE KEY UPDATE Role = VALUES(Role)'
                 );
-                $stmt->execute([$userId, $orgId, $role]);
+                $stmt->bind_param('iis', $userId, $orgId, $role);
+                $stmt->execute();
+                $stmt->close();
                 logActivity('org.member_add', 'organisation', (string)$orgId, [
                     'user_id' => $userId,
                     'role'    => $role,
@@ -204,7 +244,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 if (!in_array($role, $MEMBER_ROLES, true)) { $error = 'Unknown member role.'; break; }
 
                 $stmt = $db->prepare('UPDATE tblOrganisationMembers SET Role = ? WHERE OrgId = ? AND UserId = ?');
-                $stmt->execute([$role, $orgId, $userId]);
+                $stmt->bind_param('sii', $role, $orgId, $userId);
+                $stmt->execute();
+                $stmt->close();
                 logActivity('org.member_role_change', 'organisation', (string)$orgId, [
                     'user_id' => $userId,
                     'role'    => $role,
@@ -218,7 +260,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $userId = (int)($_POST['user_id'] ?? 0);
                 if ($orgId <= 0 || $userId <= 0) { $error = 'Invalid request.'; break; }
                 $stmt = $db->prepare('DELETE FROM tblOrganisationMembers WHERE OrgId = ? AND UserId = ?');
-                $stmt->execute([$orgId, $userId]);
+                $stmt->bind_param('ii', $orgId, $userId);
+                $stmt->execute();
+                $stmt->close();
                 logActivity('org.member_remove', 'organisation', (string)$orgId, [
                     'user_id' => $userId,
                 ]);
@@ -238,14 +282,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 /* ----- Fetch list ----- */
 $orgs = [];
 try {
-    $rs = $db->query(
+    $stmt = $db->prepare(
         'SELECT o.*, p.Name AS ParentName,
                 (SELECT COUNT(*) FROM tblOrganisationMembers WHERE OrgId = o.Id) AS MemberCount
            FROM tblOrganisations o
            LEFT JOIN tblOrganisations p ON p.Id = o.ParentOrgId
           ORDER BY o.Name ASC'
     );
-    $orgs = $rs->fetchAll(PDO::FETCH_ASSOC);
+    $stmt->execute();
+    $orgs = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+    $stmt->close();
 } catch (\Throwable $e) {
     error_log('[manage/organisations.php] ' . $e->getMessage());
     $error = $error ?: 'Could not load organisations.';
@@ -259,8 +305,10 @@ $editId = (int)($_GET['edit'] ?? 0);
 if ($editId > 0) {
     try {
         $stmt = $db->prepare('SELECT * FROM tblOrganisations WHERE Id = ?');
-        $stmt->execute([$editId]);
-        $editOrg = $stmt->fetch(PDO::FETCH_ASSOC) ?: null;
+        $stmt->bind_param('i', $editId);
+        $stmt->execute();
+        $editOrg = $stmt->get_result()->fetch_assoc() ?: null;
+        $stmt->close();
 
         if ($editOrg) {
             $stmt = $db->prepare(
@@ -271,8 +319,10 @@ if ($editId > 0) {
                   WHERE m.OrgId = ?
                   ORDER BY m.JoinedAt DESC'
             );
-            $stmt->execute([$editId]);
-            $editMembers = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            $stmt->bind_param('i', $editId);
+            $stmt->execute();
+            $editMembers = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+            $stmt->close();
 
             $stmt = $db->prepare(
                 'SELECT u.Id, u.Username, u.DisplayName
@@ -282,8 +332,10 @@ if ($editId > 0) {
                   ORDER BY u.Username ASC
                   LIMIT 500'
             );
-            $stmt->execute([$editId]);
-            $candidates = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            $stmt->bind_param('i', $editId);
+            $stmt->execute();
+            $candidates = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+            $stmt->close();
         }
     } catch (\Throwable $e) {
         error_log('[manage/organisations.php] ' . $e->getMessage());

--- a/appWeb/public_html/manage/songbooks.php
+++ b/appWeb/public_html/manage/songbooks.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
 
 if (!isAuthenticated()) {
     header('Location: /manage/login');
@@ -31,7 +32,7 @@ $activePage = 'songbooks';
 
 $error   = '';
 $success = '';
-$db      = getDb();
+$db      = getDbMysqli();
 
 /* Helpers */
 $validateAbbr = function (string $abbr): ?string {
@@ -77,8 +78,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 if ($e = $validateColour($colour)) { $error = $e; break; }
 
                 $stmt = $db->prepare('SELECT Id FROM tblSongbooks WHERE Abbreviation = ?');
-                $stmt->execute([$abbr]);
-                if ($stmt->fetch()) { $error = 'Abbreviation already exists.'; break; }
+                $stmt->bind_param('s', $abbr);
+                $stmt->execute();
+                $exists = $stmt->get_result()->fetch_row() !== null;
+                $stmt->close();
+                if ($exists) { $error = 'Abbreviation already exists.'; break; }
 
                 $stmt = $db->prepare(
                     'INSERT INTO tblSongbooks
@@ -86,11 +90,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                          IsOfficial, Publisher, PublicationYear, Copyright, Affiliation)
                      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)'
                 );
-                $stmt->execute([
-                    $abbr, $name, $order ?: 0, $colour,
-                    $isOfficial, $publisher, $pubYear, $copyright, $affiliation,
-                ]);
-                $newId = (int)$db->lastInsertId();
+                /* Types: Abbr(s), Name(s), DisplayOrder(i), Colour(s),
+                   IsOfficial(i), Publisher(s nullable), PublicationYear(s nullable),
+                   Copyright(s nullable), Affiliation(s nullable). mysqli passes
+                   NULL correctly when a bound variable is null even with type 's'. */
+                $orderInt = (int)($order ?: 0);
+                $stmt->bind_param(
+                    'ssisissss',
+                    $abbr, $name, $orderInt, $colour,
+                    $isOfficial, $publisher, $pubYear, $copyright, $affiliation
+                );
+                $stmt->execute();
+                $newId = (int)$db->insert_id;
+                $stmt->close();
                 logActivity('songbook.create', 'songbook', (string)$newId, [
                     'abbreviation'    => $abbr,
                     'name'            => $name,
@@ -129,8 +141,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                             Publisher, PublicationYear, Copyright, Affiliation
                        FROM tblSongbooks WHERE Id = ?'
                 );
-                $existing->execute([$id]);
-                $beforeRow = $existing->fetch(PDO::FETCH_ASSOC) ?: null;
+                $existing->bind_param('i', $id);
+                $existing->execute();
+                $beforeRow = $existing->get_result()->fetch_assoc() ?: null;
+                $existing->close();
                 $oldAbbr = $beforeRow ? (string)$beforeRow['Abbreviation'] : '';
                 if ($oldAbbr === '') { $error = 'Songbook not found.'; break; }
 
@@ -142,11 +156,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 if ($abbrChanged) {
                     if ($e = $validateAbbr($newAbbr)) { $error = $e; break; }
                     $dup = $db->prepare('SELECT Id FROM tblSongbooks WHERE Abbreviation = ? AND Id <> ?');
-                    $dup->execute([$newAbbr, $id]);
-                    if ($dup->fetch()) { $error = 'That abbreviation is already taken.'; break; }
+                    $dup->bind_param('si', $newAbbr, $id);
+                    $dup->execute();
+                    $dupExists = $dup->get_result()->fetch_row() !== null;
+                    $dup->close();
+                    if ($dupExists) { $error = 'That abbreviation is already taken.'; break; }
                 }
 
-                $db->beginTransaction();
+                $db->begin_transaction();
                 try {
                     $stmt = $db->prepare(
                         'UPDATE tblSongbooks
@@ -155,18 +172,29 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                                 PublicationYear = ?, Copyright = ?, Affiliation = ?
                           WHERE Id = ?'
                     );
-                    $stmt->execute([
-                        $name, $colour, $order ?: 0,
+                    /* Types: Name(s), Colour(s), DisplayOrder(i),
+                       IsOfficial(i), Publisher(s), PublicationYear(s),
+                       Copyright(s), Affiliation(s), Id(i). */
+                    $orderInt = (int)($order ?: 0);
+                    $stmt->bind_param(
+                        'ssiissssi',
+                        $name, $colour, $orderInt,
                         $isOfficial, $publisher, $pubYear, $copyright, $affiliation,
-                        $id,
-                    ]);
+                        $id
+                    );
+                    $stmt->execute();
+                    $stmt->close();
 
                     if ($abbrChanged) {
                         $stmt = $db->prepare('UPDATE tblSongbooks SET Abbreviation = ? WHERE Id = ?');
-                        $stmt->execute([$newAbbr, $id]);
+                        $stmt->bind_param('si', $newAbbr, $id);
+                        $stmt->execute();
+                        $stmt->close();
                         if ($alsoRename) {
                             $stmt = $db->prepare('UPDATE tblSongs SET SongbookAbbr = ? WHERE SongbookAbbr = ?');
-                            $stmt->execute([$newAbbr, $oldAbbr]);
+                            $stmt->bind_param('ss', $newAbbr, $oldAbbr);
+                            $stmt->execute();
+                            $stmt->close();
                         }
                     }
                     $db->commit();
@@ -202,7 +230,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         ? "Songbook '{$oldAbbr}' → '{$newAbbr}'" . ($alsoRename ? ' (song references updated).' : ' (song references kept — resolve manually).')
                         : "Songbook '{$oldAbbr}' updated.";
                 } catch (\Throwable $e) {
-                    $db->rollBack();
+                    $db->rollback();
                     throw $e;
                 }
                 break;
@@ -213,12 +241,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $orders = $_POST['display_order'] ?? [];
                 if (!is_array($orders)) { $error = 'Invalid reorder payload.'; break; }
 
-                $db->beginTransaction();
+                $db->begin_transaction();
                 try {
                     $stmt = $db->prepare('UPDATE tblSongbooks SET DisplayOrder = ? WHERE Id = ?');
                     foreach ($orders as $id => $value) {
-                        $stmt->execute([(int)$value, (int)$id]);
+                        $valueInt = (int)$value;
+                        $idInt    = (int)$id;
+                        $stmt->bind_param('ii', $valueInt, $idInt);
+                        $stmt->execute();
                     }
+                    $stmt->close();
                     $db->commit();
 
                     /* Single audit row for the bulk reorder rather
@@ -232,7 +264,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
                     $success = 'Display order saved.';
                 } catch (\Throwable $e) {
-                    $db->rollBack();
+                    $db->rollback();
                     throw $e;
                 }
                 break;
@@ -242,20 +274,28 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $id = (int)($_POST['id'] ?? 0);
 
                 $stmt = $db->prepare('SELECT Abbreviation FROM tblSongbooks WHERE Id = ?');
-                $stmt->execute([$id]);
-                $abbr = (string)($stmt->fetchColumn() ?: '');
+                $stmt->bind_param('i', $id);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_row();
+                $stmt->close();
+                $abbr = (string)($row[0] ?? '');
                 if ($abbr === '') { $error = 'Songbook not found.'; break; }
 
                 $stmt = $db->prepare('SELECT COUNT(*) FROM tblSongs WHERE SongbookAbbr = ?');
-                $stmt->execute([$abbr]);
-                $songCount = (int)$stmt->fetchColumn();
+                $stmt->bind_param('s', $abbr);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_row();
+                $stmt->close();
+                $songCount = (int)($row[0] ?? 0);
                 if ($songCount > 0) {
                     $error = "Cannot delete '{$abbr}': {$songCount} song(s) still reference it. Reassign them first.";
                     break;
                 }
 
                 $stmt = $db->prepare('DELETE FROM tblSongbooks WHERE Id = ?');
-                $stmt->execute([$id]);
+                $stmt->bind_param('i', $id);
+                $stmt->execute();
+                $stmt->close();
 
                 /* Audit (#535) — capturing abbreviation in Details
                    means the row remains useful even after the FK
@@ -280,7 +320,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 /* ----- GET: list ----- */
 $rows = [];
 try {
-    $rs = $db->query(
+    $stmt = $db->prepare(
         'SELECT b.Id, b.Abbreviation, b.Name, b.SongCount, b.DisplayOrder, b.Colour,
                 b.IsOfficial, b.Publisher, b.PublicationYear,
                 b.Copyright, b.Affiliation,
@@ -290,7 +330,9 @@ try {
           GROUP BY b.Id
           ORDER BY b.DisplayOrder ASC, b.Name ASC'
     );
-    $rows = $rs->fetchAll(PDO::FETCH_ASSOC);
+    $stmt->execute();
+    $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+    $stmt->close();
 } catch (\Throwable $e) {
     error_log('[manage/songbooks.php] ' . $e->getMessage());
     $error = $error ?: 'Could not load songbooks — check server logs for details.';

--- a/appWeb/public_html/manage/users.php
+++ b/appWeb/public_html/manage/users.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
  */
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
 requireAdmin();
 
 $currentUser = getCurrentUser();
@@ -161,14 +162,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 } elseif ($newTier === '') {
                     $error = 'Pick a tier.';
                 } else {
-                    $db = getDb();
+                    $db = getDbMysqli();
                     $stmt = $db->prepare('SELECT 1 FROM tblAccessTiers WHERE Name = ?');
-                    $stmt->execute([$newTier]);
-                    if (!$stmt->fetch()) {
+                    $stmt->bind_param('s', $newTier);
+                    $stmt->execute();
+                    $exists = $stmt->get_result()->fetch_row() !== null;
+                    $stmt->close();
+                    if (!$exists) {
                         $error = 'Unknown access tier.';
                     } else {
                         $stmt = $db->prepare('UPDATE tblUsers SET AccessTier = ?, UpdatedAt = CURRENT_TIMESTAMP WHERE Id = ?');
-                        $stmt->execute([$newTier, $targetId]);
+                        $stmt->bind_param('si', $newTier, $targetId);
+                        $stmt->execute();
+                        $stmt->close();
                         $success = 'Access tier updated for "' . $target['username'] . '".';
                     }
                 }
@@ -200,17 +206,28 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
  * FETCH DATA
  * ========================================================================= */
 
-$db = getDb();
-$users = $db->query('SELECT Id AS id, Username AS username, DisplayName AS display_name, Email AS email, Role AS role, IsActive AS is_active, AccessTier AS access_tier, CreatedAt AS created_at FROM tblUsers ORDER BY CreatedAt ASC')->fetchAll(PDO::FETCH_ASSOC);
+$db = getDbMysqli();
+$stmt = $db->prepare(
+    'SELECT Id AS id, Username AS username, DisplayName AS display_name, Email AS email,
+            Role AS role, IsActive AS is_active, AccessTier AS access_tier, CreatedAt AS created_at
+       FROM tblUsers
+      ORDER BY CreatedAt ASC'
+);
+$stmt->execute();
+$users = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+$stmt->close();
 
 /* Available access tiers for the Change-tier modal. Falls back to an empty
    list if the table is missing (e.g. pre-migration DB) — in that case the
    Tier button is hidden rather than breaking the page. */
 $accessTiers = [];
 try {
-    $accessTiers = $db->query(
+    $stmt = $db->prepare(
         'SELECT Name, DisplayName, Level FROM tblAccessTiers ORDER BY Level ASC, Name ASC'
-    )->fetchAll(PDO::FETCH_ASSOC);
+    );
+    $stmt->execute();
+    $accessTiers = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+    $stmt->close();
 } catch (\Throwable $_e) { /* tier table not installed yet — hide control */ }
 
 $canAssignTier = !empty($accessTiers) && userHasEntitlement('assign_user_tier', $currentUser['role'] ?? null);


### PR DESCRIPTION
## Summary

Second batch of the [#554](https://github.com/MWBMPartners/iHymns/issues/554) PDO → mysqli umbrella. Three entitlement-adjacent `/manage/*` pages — same mechanical conversion as Batch 1, with extra care taken on the auth-side-effect surfaces the umbrella body flagged. **No behavioural change** in any file. After this merges, `getDb()`'s call-site count drops from 22 files to 19, and Batch 2 is fully ticked.

## Commits (one per file, in DB-site complexity order)

| Commit | File | Lines | DB statements |
|---|---|---|---|
| [`6b590c3`](https://github.com/MWBMPartners/iHymns/commit/6b590c3) | `manage/users.php` | 651 | 5 |
| [`7eab2eb`](https://github.com/MWBMPartners/iHymns/commit/7eab2eb) | `manage/songbooks.php` | 640 | 19 |
| [`4e8c56a`](https://github.com/MWBMPartners/iHymns/commit/4e8c56a) | `manage/organisations.php` | 605 | 27 |

Each commit independently revertable.

## Patterns reused from Batch 1's conversion crib

Same uniform conversions documented in [PR #561](https://github.com/MWBMPartners/iHymns/pull/561) and the Batch 1 followup [comment on #554](https://github.com/MWBMPartners/iHymns/issues/554#issuecomment-4327018678). Plus the additional patterns this batch needed:

| Pattern | First applied here | Notes |
|---|---|---|
| **Transaction API rename** | `songbooks.php` | `beginTransaction()` → `begin_transaction()`, `rollBack()` → `rollback()` (case-sensitive in mysqli). Two transactional blocks (the `update` action's UPDATE + cascading rename, and the bulk `reorder` action) preserve their `try { … } catch { rollback(); throw; }` shape. |
| **`lastInsertId()` → `insert_id`** | `songbooks.php`, `organisations.php` | Property access, not method call. |
| **9-column INSERT with mixed types** | `songbooks.php` | `bind_param('ssisissss', …)` for tblSongbooks. Worked out per-column. |
| **8-column UPDATE with trailing Id** | `songbooks.php`, `organisations.php` | `bind_param('ssiissssi', …)` and `'ssisssii'` respectively. |
| **Nullable FK column with type 'i'** | `organisations.php` | `$parentOrNull = $parent ?: null` before bind. mysqli sends NULL even with type 'i' when the bound variable is null. |
| **`ON DUPLICATE KEY UPDATE`** | `organisations.php` | The `add_member` INSERT-or-update path keeps its UPSERT semantics; mysqli executes the statement identically to PDO. |
| **Reused prepared statement in a loop** | `songbooks.php` | The bulk `reorder` action's foreach calls `bind_param` + `execute` per iteration on a single prepared `UPDATE tblSongbooks SET DisplayOrder = ? WHERE Id = ?`. `$stmt->close()` happens once after the loop. |

## What's not changed

- **`logActivity()` calls everywhere are untouched.** That helper still uses PDO via `getDb()` internally and lives in [`includes/activity_log.php`](https://github.com/MWBMPartners/iHymns/blob/alpha/appWeb/public_html/includes/activity_log.php) (Batch 4 territory). The two helpers manage independent connections, so calling `logActivity()` from a now-mysqli page works correctly.
- **`auth.php` user-mutation helpers** (`createUser`, `deleteUser`, `updateUser`, `updateRole`, etc.) remain PDO-backed for the same reason — they're in [`manage/includes/auth.php`](https://github.com/MWBMPartners/iHymns/blob/alpha/appWeb/public_html/manage/includes/auth.php) which Batch 4 will migrate.
- All HTML, modals, validators, slug helpers, licence-type vocabulary, CSRF handling, entitlement gates, and template data shapes preserved exactly.

## Test plan (per file, after deploy)

### `manage/users.php`
- [ ] Sign in with `view_users`. User table renders with all columns (display name, email, role, active, access tier, created).
- [ ] As a user with `assign_user_tier`, change a user's tier → success banner, value persists on reload.
- [ ] As a user without `assign_user_tier`, the Tier button is hidden.
- [ ] Tier table missing (force by renaming `tblAccessTiers`) → page still renders, Tier control hidden.
- [ ] Create / Edit / Delete actions still work via the existing auth.php helpers (they stay on PDO until Batch 4).

### `manage/songbooks.php`
- [ ] Page lists all songbooks with their colours, display order, song counts, and #502 metadata fields.
- [ ] Create a test songbook with full metadata (Publisher / PublicationYear / Copyright / Affiliation) → row appears, success banner.
- [ ] Edit the test songbook (change Display name + Colour + clear Affiliation) → diff persists, audit-log entry shows correct `before` / `after` / `fields` payload.
- [ ] Edit the test songbook with `new_abbreviation` set + `rename_song_refs` checked → both `tblSongbooks.Abbreviation` and `tblSongs.SongbookAbbr` updated atomically. Verify the transaction rolls back cleanly if you simulate an error mid-block (e.g. introduce a bogus column briefly).
- [ ] Drag-reorder the songbooks → all DisplayOrder values update; one consolidated `songbook.reorder` audit-log entry written.
- [ ] Delete a songbook with no songs → row deleted, audit-log entry. Try to delete one with songs → blocked with a count-aware error.

### `manage/organisations.php`
- [ ] Page lists all orgs with parent name, member count, licence info.
- [ ] Create a test org with parent set + slug + licence type/number → row appears, audit-log entry.
- [ ] Edit the test org (change name, slug, parent, licence type, IsActive) → diff persists; audit-log shows `before`/`after`/`fields` for only the changed fields.
- [ ] Slug-uniqueness guard: try to create / rename to a slug already in use → blocked.
- [ ] Self-parent guard: try to set ParentOrgId = own Id → blocked.
- [ ] `?edit=<id>` → membership panel renders with current members + candidate non-members.
- [ ] Add a candidate as `member` → moves to current members.
- [ ] Update a member's role from the dropdown → reflected in the table, audit-log entry.
- [ ] Remove a member → row goes from current members to candidates.
- [ ] Try to delete an org with members → blocked. Try to delete an org with sub-orgs → blocked. Then remove members + reparent sub-orgs and retry → succeeds.

### General
- [ ] No new entries in `error_log` from any of the three migrated files.
- [ ] Sidebar nav still highlights the active page on each (`$activePage` set correctly).

## Rollback plan

Each commit reverts independently — `git revert <sha>` for whichever file regresses, the other two are unaffected.

Refs #554 (Batch 2 done after merge — Batches 3 / 4 / 5 / 6 still to come per the umbrella roadmap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)