### PR TITLE
feat(manage): credit-people actions — Add / Edit / Rename / Merge / Delete / View Songs (closes #545)

### DIFF
--- a/appWeb/public_html/manage/credit-people.php
+++ b/appWeb/public_html/manage/credit-people.php
@@ -3,32 +3,40 @@
 declare(strict_types=1);
 
 /**
- * iHymns — Admin: Credit People (#545, read-only list slice)
+ * iHymns — Admin: Credit People (#545)
  *
- * Catalogue-wide view of every individual credited on songs, unioned
+ * Catalogue-wide CRUD for the people credited on songs, unioned
  * across tblSongWriters / tblSongComposers / tblSongArrangers /
  * tblSongAdaptors / tblSongTranslators, plus the registry rows in
  * tblCreditPeople (which may exist without any current song citing
  * them — pre-registered names for upcoming songs, or names whose
  * usage was cleaned up but the metadata is being kept).
  *
- * This first slice is READ-ONLY:
- *   - Sorts the table client-side.
- *   - Filters by role + free-text search client-side.
- *   - Surfaces the same data the eventual rename / merge / detail
- *     workflows will operate on.
- *   - Adds NO mutations (no POST handlers, no CSRF token usage yet).
- *
- * The Add / Rename / Merge / Person-detail-drawer / Delete actions
- * land in a follow-up PR against the same #545. Splitting like this
- * lets the schema (#553) and the listing query bed in on alpha
- * before we layer mutating endpoints on top.
+ * Surfaces:
+ *   - List view: every distinct name with per-role usage, lifespan,
+ *     link / IPI counts. Filterable + searchable client-side.
+ *   - Person detail drawer: full edit form for biographical
+ *     metadata (notes, birth/death place + date), repeating
+ *     external link sub-form, repeating IPI Name Number sub-form.
+ *     Drives both Add and Update.
+ *   - Rename modal: changes the canonical name, cascading the
+ *     update across the five song-credit tables AND the registry
+ *     row, atomically inside a transaction.
+ *   - Merge modal: collapses two registry entries into one,
+ *     re-pointing every song-credit row from source name → target
+ *     name, with the source registry row removed and the
+ *     ON DELETE CASCADE FK cleaning up its child rows. Admin
+ *     chooses which links / IPI rows to keep on the surviving row.
+ *   - Delete: removes a registry row, refusing by default if any
+ *     song still cites the name; a force flag overrides.
+ *   - View Songs: read-only modal listing every song that cites the
+ *     person, grouped by role.
  *
  * Database access uses mysqli prepared statements throughout
- * (project policy, set 2026-04-27). The two queries on this page
- * are static SQL, so they don't strictly need bound parameters, but
- * we run them via `prepare()` + `execute()` anyway to match the
- * pattern that the follow-up POST handlers will use.
+ * (project policy, set 2026-04-27). All mutating actions run inside
+ * $db->begin_transaction() so a partial failure rolls back cleanly.
+ * Every action emits a tblActivityLog row via logActivity() with
+ * EntityType='credit_person'.
  */
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
@@ -47,7 +55,622 @@ if (!$currentUser || !userHasEntitlement('manage_credit_people', $currentUser['r
 }
 $activePage = 'credit-people';
 
-$error = '';
+$error   = '';
+$success = '';
+$csrf    = csrfToken();
+
+/* ----------------------------------------------------------------------
+ * Activity-log helper
+ *
+ * Every mutating action on this page emits a tblActivityLog row via
+ * logActivity() (which still lives in /includes/activity_log.php
+ * and is PDO-backed until the umbrella migration #554 Batch 4 lands;
+ * mixing the two helpers in the same request is fine — they manage
+ * independent connections).
+ *
+ * The closure bakes in the EntityType so per-action call sites stay
+ * tight and any future rename of the type string is a one-line
+ * change here. Silent no-op if the activity-log table is missing
+ * (matches the pattern in songbooks.php / organisations.php).
+ * ---------------------------------------------------------------------- */
+$logCreditPerson = static function (string $action, string $entityId, array $details): void {
+    if (function_exists('logActivity')) {
+        try {
+            logActivity('credit_person.' . $action, 'credit_person', $entityId, $details);
+        } catch (\Throwable $_e) { /* audit is best-effort */ }
+    }
+};
+
+/* ----------------------------------------------------------------------
+ * Helpers — link / IPI sub-form normalisation
+ *
+ * The Add and Update_person actions both accept arrays of links and
+ * IPI numbers in the POST body, posted as `links[i][type|url|label]`
+ * and `ipi[i][number|name_used|notes]`. Empty rows (no URL / no
+ * IPI number) are silently dropped. Returns a clean array of
+ * row-shaped arrays ready to INSERT.
+ * ---------------------------------------------------------------------- */
+$normaliseLinks = static function (mixed $raw): array {
+    if (!is_array($raw)) return [];
+    $out = [];
+    foreach ($raw as $i => $row) {
+        if (!is_array($row)) continue;
+        $url = trim((string)($row['url'] ?? ''));
+        if ($url === '') continue;
+        $out[] = [
+            'type'       => trim((string)($row['type']  ?? 'other')),
+            'url'        => $url,
+            'label'      => trim((string)($row['label'] ?? '')) ?: null,
+            'sort_order' => (int)($row['sort_order'] ?? $i),
+        ];
+    }
+    return $out;
+};
+$normaliseIpi = static function (mixed $raw): array {
+    if (!is_array($raw)) return [];
+    $out = [];
+    foreach ($raw as $row) {
+        if (!is_array($row)) continue;
+        $num = trim((string)($row['number'] ?? ''));
+        if ($num === '') continue;
+        $out[] = [
+            'number'    => $num,
+            'name_used' => trim((string)($row['name_used'] ?? '')) ?: null,
+            'notes'     => trim((string)($row['notes']     ?? '')) ?: null,
+        ];
+    }
+    return $out;
+};
+
+/* ----------------------------------------------------------------------
+ * POST dispatch
+ *
+ * All actions are CSRF-checked + entitlement-gated (the entitlement
+ * gate is the page-level requireAuth + userHasEntitlement above; the
+ * gate covers every action below). Each action runs inside a single
+ * $db->begin_transaction() so a partial failure (e.g. a child-row
+ * INSERT failing after the parent UPDATE landed) rolls back cleanly.
+ * ---------------------------------------------------------------------- */
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!validateCsrf((string)($_POST['csrf_token'] ?? ''))) {
+        http_response_code(403);
+        echo 'Invalid CSRF token';
+        exit;
+    }
+
+    $action = (string)($_POST['action'] ?? '');
+    try {
+        $db = getDbMysqli();
+
+        switch ($action) {
+            /* --------------------------------------------------------
+             * add — create a new registry row (+ optional child rows)
+             * -------------------------------------------------------- */
+            case 'add': {
+                $name        = trim((string)($_POST['name']         ?? ''));
+                $notesRaw    = trim((string)($_POST['notes']        ?? ''));
+                $birthPlace  = trim((string)($_POST['birth_place']  ?? '')) ?: null;
+                $birthDate   = trim((string)($_POST['birth_date']   ?? '')) ?: null;
+                $deathPlace  = trim((string)($_POST['death_place']  ?? '')) ?: null;
+                $deathDate   = trim((string)($_POST['death_date']   ?? '')) ?: null;
+                $notes       = $notesRaw !== '' ? $notesRaw : null;
+                $links       = $normaliseLinks($_POST['links'] ?? null);
+                $ipi         = $normaliseIpi($_POST['ipi']     ?? null);
+
+                if ($name === '')                       { $error = 'Name is required.'; break; }
+                if (mb_strlen($name) > 255)             { $error = 'Name must be 255 characters or fewer.'; break; }
+                if ($birthDate && !preg_match('/^\d{4}-\d{2}-\d{2}$/', $birthDate)) { $error = 'Birth date must be YYYY-MM-DD.'; break; }
+                if ($deathDate && !preg_match('/^\d{4}-\d{2}-\d{2}$/', $deathDate)) { $error = 'Death date must be YYYY-MM-DD.'; break; }
+
+                /* Uniqueness check before opening the transaction so we
+                   don't have to reason about MySQL's UNIQUE-violation
+                   error code path. */
+                $stmt = $db->prepare('SELECT Id FROM tblCreditPeople WHERE Name = ?');
+                $stmt->bind_param('s', $name);
+                $stmt->execute();
+                $exists = $stmt->get_result()->fetch_row() !== null;
+                $stmt->close();
+                if ($exists) { $error = "A person with the name '{$name}' is already registered."; break; }
+
+                $db->begin_transaction();
+                try {
+                    $stmt = $db->prepare(
+                        'INSERT INTO tblCreditPeople
+                            (Name, Notes, BirthPlace, BirthDate, DeathPlace, DeathDate)
+                         VALUES (?, ?, ?, ?, ?, ?)'
+                    );
+                    /* All six columns are strings (nullable). DATE columns
+                       accept the YYYY-MM-DD format we validated above; null
+                       passes through correctly with type 's'. */
+                    $stmt->bind_param('ssssss', $name, $notes, $birthPlace, $birthDate, $deathPlace, $deathDate);
+                    $stmt->execute();
+                    $newId = (int)$db->insert_id;
+                    $stmt->close();
+
+                    if ($links) {
+                        $linkStmt = $db->prepare(
+                            'INSERT INTO tblCreditPersonLinks
+                                (CreditPersonId, LinkType, Url, Label, SortOrder)
+                             VALUES (?, ?, ?, ?, ?)'
+                        );
+                        foreach ($links as $l) {
+                            $linkStmt->bind_param('isssi',
+                                $newId, $l['type'], $l['url'], $l['label'], $l['sort_order']);
+                            $linkStmt->execute();
+                        }
+                        $linkStmt->close();
+                    }
+                    if ($ipi) {
+                        $ipiStmt = $db->prepare(
+                            'INSERT INTO tblCreditPersonIPI
+                                (CreditPersonId, IPINumber, NameUsed, Notes)
+                             VALUES (?, ?, ?, ?)'
+                        );
+                        foreach ($ipi as $r) {
+                            $ipiStmt->bind_param('isss',
+                                $newId, $r['number'], $r['name_used'], $r['notes']);
+                            $ipiStmt->execute();
+                        }
+                        $ipiStmt->close();
+                    }
+                    $db->commit();
+
+                    $logCreditPerson('add', (string)$newId, [
+                        'name'        => $name,
+                        'fields'      => array_filter([
+                            'birth_place' => $birthPlace,
+                            'birth_date'  => $birthDate,
+                            'death_place' => $deathPlace,
+                            'death_date'  => $deathDate,
+                            'notes'       => $notes,
+                        ], static fn($v) => $v !== null),
+                        'link_count'  => count($links),
+                        'ipi_count'   => count($ipi),
+                    ]);
+                    $success = "Person '{$name}' added to the registry.";
+                } catch (\Throwable $e) {
+                    $db->rollback();
+                    throw $e;
+                }
+                break;
+            }
+
+            /* --------------------------------------------------------
+             * update_person — edit metadata + replace child rows for
+             *                 an existing registry row.
+             *
+             * The Name column is NOT changed by this action — renames
+             * have their own handler because their blast radius is
+             * cross-table. If the form's name field differs from the
+             * stored name we reject and direct the admin to use Rename.
+             * -------------------------------------------------------- */
+            case 'update_person': {
+                $id          = (int)($_POST['id']          ?? 0);
+                $name        = trim((string)($_POST['name']         ?? ''));
+                $notesRaw    = trim((string)($_POST['notes']        ?? ''));
+                $birthPlace  = trim((string)($_POST['birth_place']  ?? '')) ?: null;
+                $birthDate   = trim((string)($_POST['birth_date']   ?? '')) ?: null;
+                $deathPlace  = trim((string)($_POST['death_place']  ?? '')) ?: null;
+                $deathDate   = trim((string)($_POST['death_date']   ?? '')) ?: null;
+                $notes       = $notesRaw !== '' ? $notesRaw : null;
+                $links       = $normaliseLinks($_POST['links'] ?? null);
+                $ipi         = $normaliseIpi($_POST['ipi']     ?? null);
+
+                if ($id <= 0)                           { $error = 'Person id missing.'; break; }
+                if ($name === '')                       { $error = 'Name is required.'; break; }
+                if ($birthDate && !preg_match('/^\d{4}-\d{2}-\d{2}$/', $birthDate)) { $error = 'Birth date must be YYYY-MM-DD.'; break; }
+                if ($deathDate && !preg_match('/^\d{4}-\d{2}-\d{2}$/', $deathDate)) { $error = 'Death date must be YYYY-MM-DD.'; break; }
+
+                /* Pull the before-row both as a sanity check (id valid?)
+                   and to compute the audit-log diff. */
+                $stmt = $db->prepare(
+                    'SELECT Name, Notes, BirthPlace, BirthDate, DeathPlace, DeathDate
+                       FROM tblCreditPeople WHERE Id = ?'
+                );
+                $stmt->bind_param('i', $id);
+                $stmt->execute();
+                $beforeRow = $stmt->get_result()->fetch_assoc() ?: null;
+                $stmt->close();
+                if ($beforeRow === null) { $error = 'Person not found.'; break; }
+
+                if ((string)$beforeRow['Name'] !== $name) {
+                    $error = 'Use the Rename action to change a person\'s name — the change cascades to every song that cites them, so it has its own confirmation flow.';
+                    break;
+                }
+
+                $db->begin_transaction();
+                try {
+                    /* Update the registry row. Name is not in the SET
+                       clause — renames go through the rename action. */
+                    $stmt = $db->prepare(
+                        'UPDATE tblCreditPeople
+                            SET Notes = ?, BirthPlace = ?, BirthDate = ?,
+                                DeathPlace = ?, DeathDate = ?
+                          WHERE Id = ?'
+                    );
+                    $stmt->bind_param('sssssi',
+                        $notes, $birthPlace, $birthDate, $deathPlace, $deathDate, $id);
+                    $stmt->execute();
+                    $stmt->close();
+
+                    /* Child rows: DELETE then INSERT — simpler than
+                       diffing and the per-person row counts are small
+                       (typically < 10 each). The child Ids change as a
+                       side effect, but no other table references them. */
+                    $del = $db->prepare('DELETE FROM tblCreditPersonLinks WHERE CreditPersonId = ?');
+                    $del->bind_param('i', $id);
+                    $del->execute();
+                    $del->close();
+                    if ($links) {
+                        $linkStmt = $db->prepare(
+                            'INSERT INTO tblCreditPersonLinks
+                                (CreditPersonId, LinkType, Url, Label, SortOrder)
+                             VALUES (?, ?, ?, ?, ?)'
+                        );
+                        foreach ($links as $l) {
+                            $linkStmt->bind_param('isssi',
+                                $id, $l['type'], $l['url'], $l['label'], $l['sort_order']);
+                            $linkStmt->execute();
+                        }
+                        $linkStmt->close();
+                    }
+
+                    $del = $db->prepare('DELETE FROM tblCreditPersonIPI WHERE CreditPersonId = ?');
+                    $del->bind_param('i', $id);
+                    $del->execute();
+                    $del->close();
+                    if ($ipi) {
+                        $ipiStmt = $db->prepare(
+                            'INSERT INTO tblCreditPersonIPI
+                                (CreditPersonId, IPINumber, NameUsed, Notes)
+                             VALUES (?, ?, ?, ?)'
+                        );
+                        foreach ($ipi as $r) {
+                            $ipiStmt->bind_param('isss',
+                                $id, $r['number'], $r['name_used'], $r['notes']);
+                            $ipiStmt->execute();
+                        }
+                        $ipiStmt->close();
+                    }
+                    $db->commit();
+
+                    /* Compute the changed-fields list for audit. The
+                       child-table replacement is captured as counts
+                       only — diffing a links list is more noise than
+                       signal in the activity-log timeline. */
+                    $afterRow = [
+                        'Notes'      => $notes,
+                        'BirthPlace' => $birthPlace,
+                        'BirthDate'  => $birthDate,
+                        'DeathPlace' => $deathPlace,
+                        'DeathDate'  => $deathDate,
+                    ];
+                    $changed = [];
+                    foreach ($afterRow as $k => $v) {
+                        if ((string)($beforeRow[$k] ?? '') !== (string)($v ?? '')) {
+                            $changed[] = $k;
+                        }
+                    }
+                    $logCreditPerson('update_person', (string)$id, [
+                        'name'       => $name,
+                        'fields'     => $changed,
+                        'before'     => array_intersect_key($beforeRow, array_flip($changed)),
+                        'after'      => array_intersect_key($afterRow,  array_flip($changed)),
+                        'link_count' => count($links),
+                        'ipi_count'  => count($ipi),
+                    ]);
+                    $success = "Person '{$name}' updated.";
+                } catch (\Throwable $e) {
+                    $db->rollback();
+                    throw $e;
+                }
+                break;
+            }
+
+            /* --------------------------------------------------------
+             * rename — change the canonical name, cascading the UPDATE
+             *          across all five song-credit tables AND the
+             *          registry row inside one transaction.
+             *
+             * Refuses if the new name already belongs to a different
+             * registry row (would clash with the UNIQUE Name index
+             * and forces the admin to think about whether they
+             * actually meant Merge instead).
+             * -------------------------------------------------------- */
+            case 'rename': {
+                $id      = (int)($_POST['id'] ?? 0);
+                $newName = trim((string)($_POST['new_name'] ?? ''));
+
+                if ($id <= 0)                  { $error = 'Person id missing.'; break; }
+                if ($newName === '')           { $error = 'New name is required.'; break; }
+                if (mb_strlen($newName) > 255) { $error = 'Name must be 255 characters or fewer.'; break; }
+
+                /* Look up the current name + check that the target
+                   spelling isn't already in use by a different row. */
+                $stmt = $db->prepare('SELECT Name FROM tblCreditPeople WHERE Id = ?');
+                $stmt->bind_param('i', $id);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_row();
+                $stmt->close();
+                $oldName = (string)($row[0] ?? '');
+                if ($oldName === '') { $error = 'Person not found.'; break; }
+                if ($oldName === $newName) { $error = 'New name is the same as the current name.'; break; }
+
+                $stmt = $db->prepare('SELECT Id FROM tblCreditPeople WHERE Name = ? AND Id <> ?');
+                $stmt->bind_param('si', $newName, $id);
+                $stmt->execute();
+                $clash = $stmt->get_result()->fetch_row() !== null;
+                $stmt->close();
+                if ($clash) {
+                    $error = "Another registry row already uses '{$newName}'. Use Merge if you want to combine them.";
+                    break;
+                }
+
+                $db->begin_transaction();
+                try {
+                    /* Cascade the rename across the five song-credit
+                       tables. A song that cites the old spelling under
+                       multiple roles is updated in each table. */
+                    $tables = [
+                        'tblSongWriters', 'tblSongComposers', 'tblSongArrangers',
+                        'tblSongAdaptors', 'tblSongTranslators',
+                    ];
+                    $affected = [];
+                    foreach ($tables as $tbl) {
+                        $stmt = $db->prepare("UPDATE {$tbl} SET Name = ? WHERE Name = ?");
+                        $stmt->bind_param('ss', $newName, $oldName);
+                        $stmt->execute();
+                        $affected[$tbl] = $stmt->affected_rows;
+                        $stmt->close();
+                    }
+
+                    /* Update the registry row last — if any of the five
+                       cascades fail, rollback restores everything. */
+                    $stmt = $db->prepare('UPDATE tblCreditPeople SET Name = ? WHERE Id = ?');
+                    $stmt->bind_param('si', $newName, $id);
+                    $stmt->execute();
+                    $stmt->close();
+
+                    $db->commit();
+
+                    $logCreditPerson('rename', (string)$id, [
+                        'before'   => ['name' => $oldName],
+                        'after'    => ['name' => $newName],
+                        'affected' => [
+                            'writers'     => $affected['tblSongWriters'],
+                            'composers'   => $affected['tblSongComposers'],
+                            'arrangers'   => $affected['tblSongArrangers'],
+                            'adaptors'    => $affected['tblSongAdaptors'],
+                            'translators' => $affected['tblSongTranslators'],
+                        ],
+                    ]);
+                    $totalRenamed = array_sum($affected);
+                    $success = "Renamed '{$oldName}' → '{$newName}' across {$totalRenamed} song-credit row(s).";
+                } catch (\Throwable $e) {
+                    $db->rollback();
+                    throw $e;
+                }
+                break;
+            }
+
+            /* --------------------------------------------------------
+             * merge — collapse two registry entries into one.
+             *
+             * Re-points every song-credit row from the source name to
+             * the target name across all five tables, then deletes
+             * the source registry row. ON DELETE CASCADE on the two
+             * child tables removes the source's links + IPI rows.
+             *
+             * The admin selected which links / IPI rows to keep on
+             * the surviving target via keep_links[] / keep_ipi[]
+             * checkboxes — defaults to "keep all from both sides
+             * with exact-match dedupe" which the JS pre-ticks.
+             *
+             * For the kept child rows from the source side, we
+             * re-point CreditPersonId from source to target BEFORE
+             * deleting the source row. That avoids the cascade
+             * dropping rows we wanted to migrate.
+             * -------------------------------------------------------- */
+            case 'merge': {
+                $sourceId   = (int)($_POST['source_id'] ?? 0);
+                $targetId   = (int)($_POST['target_id'] ?? 0);
+                $keepLinks  = array_map('intval', (array)($_POST['keep_link_ids'] ?? []));
+                $keepIpi    = array_map('intval', (array)($_POST['keep_ipi_ids']  ?? []));
+
+                if ($sourceId <= 0 || $targetId <= 0) { $error = 'Both source and target are required.'; break; }
+                if ($sourceId === $targetId)          { $error = 'Source and target must be different people.'; break; }
+
+                /* Look up both rows. Source name is what we cascade
+                   in the song-credit tables; target name is the
+                   surviving spelling. */
+                $stmt = $db->prepare('SELECT Id, Name FROM tblCreditPeople WHERE Id IN (?, ?)');
+                $stmt->bind_param('ii', $sourceId, $targetId);
+                $stmt->execute();
+                $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+                $stmt->close();
+                $byId = [];
+                foreach ($rows as $r) { $byId[(int)$r['Id']] = (string)$r['Name']; }
+                if (!isset($byId[$sourceId])) { $error = 'Source person not found.'; break; }
+                if (!isset($byId[$targetId])) { $error = 'Target person not found.'; break; }
+                $sourceName = $byId[$sourceId];
+                $targetName = $byId[$targetId];
+
+                $db->begin_transaction();
+                try {
+                    /* Re-point song-credit rows: source name → target
+                       name across all five tables. */
+                    $tables = [
+                        'tblSongWriters', 'tblSongComposers', 'tblSongArrangers',
+                        'tblSongAdaptors', 'tblSongTranslators',
+                    ];
+                    $affected = [];
+                    foreach ($tables as $tbl) {
+                        $stmt = $db->prepare("UPDATE {$tbl} SET Name = ? WHERE Name = ?");
+                        $stmt->bind_param('ss', $targetName, $sourceName);
+                        $stmt->execute();
+                        $affected[$tbl] = $stmt->affected_rows;
+                        $stmt->close();
+                    }
+
+                    /* Migrate the chosen child rows from source →
+                       target. Anything not in keep_link_ids / keep_ipi_ids
+                       gets dropped via the cascade when the source
+                       registry row is deleted below. */
+                    $linksKept = 0;
+                    $linksDropped = 0;
+                    $ipiKept = 0;
+                    $ipiDropped = 0;
+
+                    /* Count links currently on the source so we can report
+                       kept-vs-dropped accurately. */
+                    $stmt = $db->prepare('SELECT Id FROM tblCreditPersonLinks WHERE CreditPersonId = ?');
+                    $stmt->bind_param('i', $sourceId);
+                    $stmt->execute();
+                    $sourceLinkIds = array_column($stmt->get_result()->fetch_all(MYSQLI_ASSOC), 'Id');
+                    $stmt->close();
+
+                    $stmt = $db->prepare('SELECT Id FROM tblCreditPersonIPI WHERE CreditPersonId = ?');
+                    $stmt->bind_param('i', $sourceId);
+                    $stmt->execute();
+                    $sourceIpiIds = array_column($stmt->get_result()->fetch_all(MYSQLI_ASSOC), 'Id');
+                    $stmt->close();
+
+                    /* Re-point each kept child row. Anything from
+                       keep_links that isn't actually on the source is
+                       silently ignored — the form might be stale. */
+                    if ($keepLinks && $sourceLinkIds) {
+                        $toMove = array_intersect($keepLinks, array_map('intval', $sourceLinkIds));
+                        if ($toMove) {
+                            $upd = $db->prepare(
+                                'UPDATE tblCreditPersonLinks SET CreditPersonId = ? WHERE Id = ? AND CreditPersonId = ?'
+                            );
+                            foreach ($toMove as $lid) {
+                                $upd->bind_param('iii', $targetId, $lid, $sourceId);
+                                $upd->execute();
+                                $linksKept += $upd->affected_rows;
+                            }
+                            $upd->close();
+                        }
+                    }
+                    $linksDropped = max(0, count($sourceLinkIds) - $linksKept);
+
+                    if ($keepIpi && $sourceIpiIds) {
+                        $toMove = array_intersect($keepIpi, array_map('intval', $sourceIpiIds));
+                        if ($toMove) {
+                            $upd = $db->prepare(
+                                'UPDATE tblCreditPersonIPI SET CreditPersonId = ? WHERE Id = ? AND CreditPersonId = ?'
+                            );
+                            foreach ($toMove as $iid) {
+                                $upd->bind_param('iii', $targetId, $iid, $sourceId);
+                                $upd->execute();
+                                $ipiKept += $upd->affected_rows;
+                            }
+                            $upd->close();
+                        }
+                    }
+                    $ipiDropped = max(0, count($sourceIpiIds) - $ipiKept);
+
+                    /* Drop the source registry row. Cascade removes any
+                       child rows the admin chose not to migrate. */
+                    $stmt = $db->prepare('DELETE FROM tblCreditPeople WHERE Id = ?');
+                    $stmt->bind_param('i', $sourceId);
+                    $stmt->execute();
+                    $stmt->close();
+
+                    $db->commit();
+
+                    $logCreditPerson('merge', (string)$targetId, [
+                        'source'     => ['id' => $sourceId, 'name' => $sourceName],
+                        'target'     => ['id' => $targetId, 'name' => $targetName],
+                        'affected'   => [
+                            'writers'     => $affected['tblSongWriters'],
+                            'composers'   => $affected['tblSongComposers'],
+                            'arrangers'   => $affected['tblSongArrangers'],
+                            'adaptors'    => $affected['tblSongAdaptors'],
+                            'translators' => $affected['tblSongTranslators'],
+                        ],
+                        'child_rows' => [
+                            'links_kept'    => $linksKept,
+                            'links_dropped' => $linksDropped,
+                            'ipi_kept'      => $ipiKept,
+                            'ipi_dropped'   => $ipiDropped,
+                        ],
+                    ]);
+                    $totalRenamed = array_sum($affected);
+                    $success = "Merged '{$sourceName}' → '{$targetName}' ({$totalRenamed} song-credit row(s) re-pointed).";
+                } catch (\Throwable $e) {
+                    $db->rollback();
+                    throw $e;
+                }
+                break;
+            }
+
+            /* --------------------------------------------------------
+             * delete_from_registry — remove a registry row.
+             *
+             * Refuses by default if any song-credit table still cites
+             * the name. The admin can override with force=1 to wipe
+             * a registry row whose name is still in use; this is the
+             * "drop a seed entry that was never adopted" use case the
+             * issue body mentions.
+             * -------------------------------------------------------- */
+            case 'delete_from_registry': {
+                $id    = (int)($_POST['id']    ?? 0);
+                $force = !empty($_POST['force']);
+                if ($id <= 0) { $error = 'Person id missing.'; break; }
+
+                $stmt = $db->prepare('SELECT Name FROM tblCreditPeople WHERE Id = ?');
+                $stmt->bind_param('i', $id);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_row();
+                $stmt->close();
+                $name = (string)($row[0] ?? '');
+                if ($name === '') { $error = 'Person not found.'; break; }
+
+                /* Count how many song-credit rows still cite this name
+                   across the five tables — a single UNION ALL keeps
+                   the round-trip count to one. */
+                $stmt = $db->prepare(
+                    "SELECT (
+                        (SELECT COUNT(*) FROM tblSongWriters     WHERE Name = ?) +
+                        (SELECT COUNT(*) FROM tblSongComposers   WHERE Name = ?) +
+                        (SELECT COUNT(*) FROM tblSongArrangers   WHERE Name = ?) +
+                        (SELECT COUNT(*) FROM tblSongAdaptors    WHERE Name = ?) +
+                        (SELECT COUNT(*) FROM tblSongTranslators WHERE Name = ?)
+                     ) AS total"
+                );
+                $stmt->bind_param('sssss', $name, $name, $name, $name, $name);
+                $stmt->execute();
+                $usage = (int)($stmt->get_result()->fetch_row()[0] ?? 0);
+                $stmt->close();
+
+                if ($usage > 0 && !$force) {
+                    $error = "Cannot delete '{$name}': {$usage} song-credit row(s) still cite this name. Tick the override box to delete anyway (the song credits stay — only the registry row is removed).";
+                    break;
+                }
+
+                $stmt = $db->prepare('DELETE FROM tblCreditPeople WHERE Id = ?');
+                $stmt->bind_param('i', $id);
+                $stmt->execute();
+                $stmt->close();
+
+                $logCreditPerson('delete_from_registry', (string)$id, [
+                    'name'         => $name,
+                    'had_credits'  => $usage > 0,
+                    'force'        => $force,
+                ]);
+                $success = "Registry entry for '{$name}' removed.";
+                break;
+            }
+
+            default:
+                $error = 'Unknown action.';
+        }
+    } catch (\Throwable $e) {
+        error_log('[manage/credit-people.php] action=' . $action . ': ' . $e->getMessage());
+        $error = $error ?: 'Database error — check server logs for details.';
+    }
+}
 
 /* ----------------------------------------------------------------------
  * Data load
@@ -282,6 +905,9 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
             cleanup.
         </div>
 
+        <?php if ($success): ?>
+            <div class="alert alert-success py-2"><?= htmlspecialchars($success) ?></div>
+        <?php endif; ?>
         <?php if ($error): ?>
             <div class="alert alert-danger py-2"><?= htmlspecialchars($error) ?></div>
         <?php endif; ?>

--- a/appWeb/public_html/manage/credit-people.php
+++ b/appWeb/public_html/manage/credit-people.php
@@ -1109,19 +1109,31 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
                                     <?php endif; ?>
                                 </td>
                                 <td class="text-end action-col">
-                                    <?php if ($p['registry_id'] !== null): ?>
-                                        <button type="button" class="btn btn-sm btn-outline-info cp-edit-btn"
-                                                title="Edit person details"
-                                                aria-label="Edit person <?= htmlspecialchars($p['name'], ENT_QUOTES) ?>">
-                                            <i class="bi bi-pencil" aria-hidden="true"></i>
-                                        </button>
-                                    <?php else: ?>
-                                        <button type="button" class="btn btn-sm btn-outline-info cp-edit-btn"
-                                                title="Add to registry — fills in the name + opens the detail drawer for this person"
-                                                aria-label="Add <?= htmlspecialchars($p['name'], ENT_QUOTES) ?> to the registry">
-                                            <i class="bi bi-plus-circle" aria-hidden="true"></i>
-                                        </button>
-                                    <?php endif; ?>
+                                    <div class="btn-group btn-group-sm" role="group" aria-label="Row actions">
+                                        <?php if ($p['registry_id'] !== null): ?>
+                                            <button type="button" class="btn btn-outline-info cp-edit-btn"
+                                                    title="Edit person details"
+                                                    aria-label="Edit person <?= htmlspecialchars($p['name'], ENT_QUOTES) ?>">
+                                                <i class="bi bi-pencil" aria-hidden="true"></i>
+                                            </button>
+                                            <button type="button" class="btn btn-outline-warning cp-rename-btn"
+                                                    title="Rename — cascades to every song that cites this person"
+                                                    aria-label="Rename person <?= htmlspecialchars($p['name'], ENT_QUOTES) ?>">
+                                                <i class="bi bi-pencil-square" aria-hidden="true"></i>
+                                            </button>
+                                            <button type="button" class="btn btn-outline-warning cp-merge-btn"
+                                                    title="Merge into another person — combines two registry rows"
+                                                    aria-label="Merge person <?= htmlspecialchars($p['name'], ENT_QUOTES) ?>">
+                                                <i class="bi bi-union" aria-hidden="true"></i>
+                                            </button>
+                                        <?php else: ?>
+                                            <button type="button" class="btn btn-outline-info cp-edit-btn"
+                                                    title="Add to registry — fills in the name + opens the detail drawer for this person"
+                                                    aria-label="Add <?= htmlspecialchars($p['name'], ENT_QUOTES) ?> to the registry">
+                                                <i class="bi bi-plus-circle" aria-hidden="true"></i>
+                                            </button>
+                                        <?php endif; ?>
+                                    </div>
                                 </td>
                             </tr>
                         <?php endforeach; ?>
@@ -1133,6 +1145,111 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
             </div>
         </div>
 
+    </div>
+
+    <!-- =========================================================================
+         Rename modal — changes the canonical name + cascades to the
+         five song-credit tables.
+         ========================================================================= -->
+    <div class="modal fade" id="cpRenameModal" tabindex="-1" aria-labelledby="cpRenameLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content bg-dark border-secondary">
+                <form method="POST">
+                    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                    <input type="hidden" name="action" value="rename">
+                    <input type="hidden" name="id" id="cp-rename-id" value="">
+                    <div class="modal-header border-secondary">
+                        <h5 class="modal-title" id="cpRenameLabel">
+                            <i class="bi bi-pencil-square me-2"></i>Rename person
+                        </h5>
+                        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <div class="mb-2">
+                            <label class="form-label small">Current name</label>
+                            <input type="text" class="form-control form-control-sm" id="cp-rename-current" readonly>
+                        </div>
+                        <div class="mb-2">
+                            <label class="form-label small" for="cp-rename-new">New name <span class="text-danger">*</span></label>
+                            <input type="text" class="form-control form-control-sm" id="cp-rename-new" name="new_name" maxlength="255" required>
+                        </div>
+                        <div class="alert alert-warning py-2 small mb-0" id="cp-rename-impact">
+                            Renaming will update the spelling on every song that currently cites this person.
+                        </div>
+                    </div>
+                    <div class="modal-footer border-secondary">
+                        <button type="button" class="btn btn-outline-secondary btn-sm" data-bs-dismiss="modal">Cancel</button>
+                        <button type="submit" class="btn btn-warning btn-sm">
+                            <i class="bi bi-pencil-square me-1"></i>Rename and cascade
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <!-- =========================================================================
+         Merge modal — collapses two registry rows into one. The admin
+         picks a target from the dropdown of all other registry rows;
+         the source's links / IPI are listed with checkboxes (default
+         checked) so the admin can drop duplicates before they migrate.
+         ========================================================================= -->
+    <div class="modal fade" id="cpMergeModal" tabindex="-1" aria-labelledby="cpMergeLabel" aria-hidden="true">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content bg-dark border-secondary">
+                <form method="POST">
+                    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                    <input type="hidden" name="action" value="merge">
+                    <input type="hidden" name="source_id" id="cp-merge-source-id" value="">
+                    <div class="modal-header border-secondary">
+                        <h5 class="modal-title" id="cpMergeLabel">
+                            <i class="bi bi-union me-2"></i>Merge person into another
+                        </h5>
+                        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <div class="row g-2 mb-3">
+                            <div class="col-6">
+                                <label class="form-label small">Source (will be removed)</label>
+                                <input type="text" class="form-control form-control-sm" id="cp-merge-source-name" readonly>
+                            </div>
+                            <div class="col-6">
+                                <label class="form-label small" for="cp-merge-target">Target (survives) <span class="text-danger">*</span></label>
+                                <select class="form-select form-select-sm" id="cp-merge-target" name="target_id" required>
+                                    <option value="">— pick the surviving person —</option>
+                                </select>
+                            </div>
+                        </div>
+
+                        <div id="cp-merge-children" class="d-none">
+                            <h6 class="small text-secondary mb-2">Source's links / IPI numbers</h6>
+                            <p class="small text-secondary">
+                                Untick any rows you want to drop. Anything ticked moves to the target;
+                                anything unticked is removed when the source row is deleted.
+                                The target's own links / IPI are unaffected.
+                            </p>
+                            <div id="cp-merge-children-empty" class="alert alert-secondary py-2 small mb-2 d-none">
+                                Source has no links or IPI numbers — nothing to migrate.
+                            </div>
+                            <div id="cp-merge-children-links"  class="mb-2"></div>
+                            <div id="cp-merge-children-ipi"></div>
+                        </div>
+
+                        <div class="alert alert-warning py-2 small mb-0">
+                            Merging re-points every song-credit row from the source name to the target
+                            name across the five song-credit tables, then removes the source registry
+                            row. Tracked in the activity log with full per-table affected counts.
+                        </div>
+                    </div>
+                    <div class="modal-footer border-secondary">
+                        <button type="button" class="btn btn-outline-secondary btn-sm" data-bs-dismiss="modal">Cancel</button>
+                        <button type="submit" class="btn btn-warning btn-sm" id="cp-merge-submit" disabled>
+                            <i class="bi bi-union me-1"></i>Merge
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
     </div>
 
     <!-- =========================================================================
@@ -1446,6 +1563,172 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
                 if (!remove) return;
                 const row = remove.closest('.cp-link-row, .cp-ipi-row');
                 if (row) row.remove();
+            });
+        })();
+
+        /* =========================================================================
+           Rename modal — opens with the row's current name shown
+           read-only and a new-name input. Submit POSTs action=rename.
+           ========================================================================= */
+        (function () {
+            const modalEl = document.getElementById('cpRenameModal');
+            if (!modalEl) return;
+            const modal     = bootstrap.Modal.getOrCreateInstance(modalEl);
+            const idIn      = document.getElementById('cp-rename-id');
+            const currentIn = document.getElementById('cp-rename-current');
+            const newIn     = document.getElementById('cp-rename-new');
+            const impactEl  = document.getElementById('cp-rename-impact');
+
+            document.addEventListener('click', (ev) => {
+                const btn = ev.target.closest('.cp-rename-btn');
+                if (!btn) return;
+                const row = btn.closest('tr');
+                if (!row) return;
+                const raw = row.getAttribute('data-person');
+                if (!raw) return;
+                let person; try { person = JSON.parse(raw); } catch (_) { return; }
+                if (!person.registry_id) return;
+
+                /* Build a "this will affect …" line from the role
+                   counts already on the row. */
+                const cells = row.querySelectorAll('.role-pill');
+                const counts = {};
+                cells.forEach(p => {
+                    const txt = p.textContent.trim();
+                    const [k, v] = txt.split('·');
+                    if (k && v) counts[k] = parseInt(v, 10) || 0;
+                });
+                const total = Object.values(counts).reduce((a, b) => a + b, 0);
+                if (total === 0) {
+                    impactEl.textContent = 'This person isn\'t cited by any song yet — only the registry row will be updated.';
+                } else {
+                    const parts = [];
+                    if (counts.W  > 0) parts.push(counts.W  + ' writer(s)');
+                    if (counts.C  > 0) parts.push(counts.C  + ' composer(s)');
+                    if (counts.Ar > 0) parts.push(counts.Ar + ' arranger(s)');
+                    if (counts.Ad > 0) parts.push(counts.Ad + ' adaptor(s)');
+                    if (counts.T  > 0) parts.push(counts.T  + ' translator(s)');
+                    impactEl.textContent = 'Will update ' + total + ' song-credit row(s): '
+                        + parts.join(', ') + '.';
+                }
+
+                idIn.value     = String(person.registry_id);
+                currentIn.value= person.name || '';
+                newIn.value    = person.name || '';
+                modal.show();
+                setTimeout(() => { newIn.focus(); newIn.select(); }, 200);
+            });
+        })();
+
+        /* =========================================================================
+           Merge modal — opens with the source row pre-set, populates
+           the target dropdown from every OTHER registry row, and
+           shows the source's links / IPI for migrate-or-drop selection.
+           ========================================================================= */
+        (function () {
+            const modalEl = document.getElementById('cpMergeModal');
+            if (!modalEl) return;
+            const modal      = bootstrap.Modal.getOrCreateInstance(modalEl);
+            const sourceIdIn = document.getElementById('cp-merge-source-id');
+            const sourceNameIn = document.getElementById('cp-merge-source-name');
+            const targetSel  = document.getElementById('cp-merge-target');
+            const childrenWrap = document.getElementById('cp-merge-children');
+            const childrenEmpty = document.getElementById('cp-merge-children-empty');
+            const linksBox   = document.getElementById('cp-merge-children-links');
+            const ipiBox     = document.getElementById('cp-merge-children-ipi');
+            const submitBtn  = document.getElementById('cp-merge-submit');
+
+            /* Build the registry-row index once on page load. Used to
+               populate the target dropdown excluding the source. */
+            const registry = [];
+            document.querySelectorAll('#cp-tbody tr[data-person]').forEach(r => {
+                let p; try { p = JSON.parse(r.getAttribute('data-person')); } catch (_) { return; }
+                if (p.registry_id) registry.push({ id: p.registry_id, name: p.name });
+            });
+            registry.sort((a, b) => a.name.localeCompare(b.name));
+
+            document.addEventListener('click', (ev) => {
+                const btn = ev.target.closest('.cp-merge-btn');
+                if (!btn) return;
+                const row = btn.closest('tr');
+                if (!row) return;
+                const raw = row.getAttribute('data-person');
+                if (!raw) return;
+                let person; try { person = JSON.parse(raw); } catch (_) { return; }
+                if (!person.registry_id) return;
+
+                sourceIdIn.value   = String(person.registry_id);
+                sourceNameIn.value = person.name || '';
+
+                /* Populate target dropdown — every registry row except
+                   the source. Sorted alphabetically. */
+                targetSel.innerHTML = '<option value="">— pick the surviving person —</option>';
+                registry.forEach(p => {
+                    if (p.id === person.registry_id) return;
+                    const opt = document.createElement('option');
+                    opt.value = String(p.id);
+                    opt.textContent = p.name;
+                    targetSel.appendChild(opt);
+                });
+
+                /* Source children — render each link + IPI as a
+                   checkbox row (default checked = keep on target). */
+                linksBox.innerHTML = '';
+                ipiBox.innerHTML   = '';
+                const links = person.links || [];
+                const ipi   = person.ipi   || [];
+                if (links.length === 0 && ipi.length === 0) {
+                    childrenEmpty.classList.remove('d-none');
+                } else {
+                    childrenEmpty.classList.add('d-none');
+                    if (links.length) {
+                        const head = document.createElement('div');
+                        head.className = 'small text-secondary mb-1';
+                        head.textContent = 'External links (' + links.length + ')';
+                        linksBox.appendChild(head);
+                        links.forEach(l => {
+                            const wrap = document.createElement('div');
+                            wrap.className = 'form-check small';
+                            wrap.innerHTML = '<input class="form-check-input" type="checkbox" name="keep_link_ids[]" value="' + l.id + '" id="cp-merge-link-' + l.id + '" checked>'
+                                           + '<label class="form-check-label" for="cp-merge-link-' + l.id + '">'
+                                           + '<code class="me-1">' + (l.type || 'other') + '</code>'
+                                           + (l.label ? l.label + ' — ' : '')
+                                           + '<a href="#" class="text-info text-decoration-none cp-merge-link-href"></a>'
+                                           + '</label>';
+                            const a = wrap.querySelector('.cp-merge-link-href');
+                            a.textContent = l.url;
+                            a.setAttribute('href', l.url);
+                            a.setAttribute('target', '_blank');
+                            a.setAttribute('rel', 'noopener');
+                            linksBox.appendChild(wrap);
+                        });
+                    }
+                    if (ipi.length) {
+                        const head = document.createElement('div');
+                        head.className = 'small text-secondary mb-1 mt-2';
+                        head.textContent = 'IPI Name Numbers (' + ipi.length + ')';
+                        ipiBox.appendChild(head);
+                        ipi.forEach(r => {
+                            const wrap = document.createElement('div');
+                            wrap.className = 'form-check small';
+                            wrap.innerHTML = '<input class="form-check-input" type="checkbox" name="keep_ipi_ids[]" value="' + r.id + '" id="cp-merge-ipi-' + r.id + '" checked>'
+                                           + '<label class="form-check-label" for="cp-merge-ipi-' + r.id + '">'
+                                           + '<code class="me-1">' + r.number + '</code>'
+                                           + (r.name_used ? '(as ' + r.name_used + ') ' : '')
+                                           + (r.notes ? '— ' + r.notes : '')
+                                           + '</label>';
+                            ipiBox.appendChild(wrap);
+                        });
+                    }
+                }
+                childrenWrap.classList.remove('d-none');
+                submitBtn.disabled = true; /* enabled once a target is picked */
+                modal.show();
+            });
+
+            /* Submit button only enables once a target is picked. */
+            targetSel?.addEventListener('change', () => {
+                submitBtn.disabled = targetSel.value === '';
             });
         })();
     </script>

--- a/appWeb/public_html/manage/credit-people.php
+++ b/appWeb/public_html/manage/credit-people.php
@@ -123,6 +123,83 @@ $normaliseIpi = static function (mixed $raw): array {
 };
 
 /* ----------------------------------------------------------------------
+ * GET endpoint — view_songs JSON
+ *
+ * Returns the list of songs that cite the given person, grouped by
+ * role. Used by the View Songs modal. Standalone — short-circuits
+ * the rest of the page (returns JSON, then exit).
+ *
+ * GET ?action=view_songs&id=<registry-id>
+ *
+ * Looks up the person's name from the registry row, then queries the
+ * five song-credit tables joined to tblSongs for the human-friendly
+ * Title + SongbookAbbr + Number used in the modal listing.
+ * ---------------------------------------------------------------------- */
+if ($_SERVER['REQUEST_METHOD'] === 'GET' && (string)($_GET['action'] ?? '') === 'view_songs') {
+    header('Content-Type: application/json; charset=UTF-8');
+    header('X-Content-Type-Options: nosniff');
+    header('Cache-Control: no-store');
+
+    $personId = (int)($_GET['id'] ?? 0);
+    if ($personId <= 0) {
+        http_response_code(400);
+        echo json_encode(['error' => 'id is required']);
+        exit;
+    }
+
+    try {
+        $db = getDbMysqli();
+        $stmt = $db->prepare('SELECT Name FROM tblCreditPeople WHERE Id = ?');
+        $stmt->bind_param('i', $personId);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_row();
+        $stmt->close();
+        $name = (string)($row[0] ?? '');
+        if ($name === '') {
+            http_response_code(404);
+            echo json_encode(['error' => 'Person not found.']);
+            exit;
+        }
+
+        /* For each role table, fetch the songs that cite this name.
+           Joining to tblSongs on SongId gives us the human-friendly
+           Title + SongbookAbbr + Number for the modal. */
+        $tables = [
+            'writer'     => 'tblSongWriters',
+            'composer'   => 'tblSongComposers',
+            'arranger'   => 'tblSongArrangers',
+            'adaptor'    => 'tblSongAdaptors',
+            'translator' => 'tblSongTranslators',
+        ];
+        $byRole = [];
+        foreach ($tables as $role => $tbl) {
+            $sql = "SELECT s.SongId, s.Title, s.SongbookAbbr, s.Number
+                      FROM {$tbl} c
+                      JOIN tblSongs s ON s.SongId = c.SongId
+                     WHERE c.Name = ?
+                     ORDER BY s.SongbookAbbr ASC, s.Number ASC, s.Title ASC";
+            $stmt = $db->prepare($sql);
+            $stmt->bind_param('s', $name);
+            $stmt->execute();
+            $byRole[$role] = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+            $stmt->close();
+        }
+
+        echo json_encode([
+            'name'    => $name,
+            'by_role' => $byRole,
+            'total'   => array_sum(array_map('count', $byRole)),
+        ]);
+        exit;
+    } catch (\Throwable $e) {
+        error_log('[manage/credit-people.php] view_songs failed: ' . $e->getMessage());
+        http_response_code(500);
+        echo json_encode(['error' => 'Could not load songs.']);
+        exit;
+    }
+}
+
+/* ----------------------------------------------------------------------
  * POST dispatch
  *
  * All actions are CSRF-checked + entitlement-gated (the entitlement
@@ -1126,6 +1203,16 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
                                                     aria-label="Merge person <?= htmlspecialchars($p['name'], ENT_QUOTES) ?>">
                                                 <i class="bi bi-union" aria-hidden="true"></i>
                                             </button>
+                                            <button type="button" class="btn btn-outline-secondary cp-view-songs-btn"
+                                                    title="View songs that cite this person"
+                                                    aria-label="View songs that cite <?= htmlspecialchars($p['name'], ENT_QUOTES) ?>">
+                                                <i class="bi bi-music-note-list" aria-hidden="true"></i>
+                                            </button>
+                                            <button type="button" class="btn btn-outline-danger cp-delete-btn"
+                                                    title="Remove from registry"
+                                                    aria-label="Remove <?= htmlspecialchars($p['name'], ENT_QUOTES) ?> from the registry">
+                                                <i class="bi bi-trash" aria-hidden="true"></i>
+                                            </button>
                                         <?php else: ?>
                                             <button type="button" class="btn btn-outline-info cp-edit-btn"
                                                     title="Add to registry — fills in the name + opens the detail drawer for this person"
@@ -1145,6 +1232,97 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
             </div>
         </div>
 
+    </div>
+
+    <!-- =========================================================================
+         Delete-from-registry modal — removes the registry row only.
+         Shows a force-anyway checkbox when the person is still cited
+         by at least one song; the song credits stay either way (they
+         live in the five song-credit tables, not the registry).
+         ========================================================================= -->
+    <div class="modal fade" id="cpDeleteModal" tabindex="-1" aria-labelledby="cpDeleteLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content bg-dark border-secondary">
+                <form method="POST">
+                    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                    <input type="hidden" name="action" value="delete_from_registry">
+                    <input type="hidden" name="id" id="cp-delete-id" value="">
+                    <div class="modal-header border-secondary">
+                        <h5 class="modal-title" id="cpDeleteLabel">
+                            <i class="bi bi-trash me-2"></i>Remove from registry
+                        </h5>
+                        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <p class="mb-3">
+                            Remove the registry row for
+                            <strong id="cp-delete-name"></strong>?
+                        </p>
+
+                        <div id="cp-delete-in-use" class="d-none alert alert-warning py-2 small mb-3">
+                            <i class="bi bi-exclamation-triangle me-1"></i>
+                            This person is still cited by
+                            <strong id="cp-delete-usage-count"></strong>
+                            song-credit row(s). The song credits stay either way —
+                            this only removes the registry entry's biographical
+                            metadata, links and IPI numbers.
+                            <div class="form-check mt-2">
+                                <input type="checkbox" class="form-check-input" id="cp-delete-force" name="force" value="1">
+                                <label class="form-check-label" for="cp-delete-force">
+                                    Yes, remove the registry row anyway
+                                </label>
+                            </div>
+                        </div>
+
+                        <div id="cp-delete-not-in-use" class="d-none alert alert-secondary py-2 small mb-0">
+                            No songs currently cite this person — safe to remove.
+                            Deletes the registry row plus its links / IPI rows
+                            (cascade).
+                        </div>
+                    </div>
+                    <div class="modal-footer border-secondary">
+                        <button type="button" class="btn btn-outline-secondary btn-sm" data-bs-dismiss="modal">Cancel</button>
+                        <button type="submit" class="btn btn-danger btn-sm" id="cp-delete-submit">
+                            <i class="bi bi-trash me-1"></i>Remove
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <!-- =========================================================================
+         View Songs modal — read-only listing of every song that cites
+         the person, grouped by role. Lazy-loaded from
+         GET ?action=view_songs&id=<id>.
+         ========================================================================= -->
+    <div class="modal fade" id="cpViewSongsModal" tabindex="-1" aria-labelledby="cpViewSongsLabel" aria-hidden="true">
+        <div class="modal-dialog modal-lg modal-dialog-scrollable">
+            <div class="modal-content bg-dark border-secondary">
+                <div class="modal-header border-secondary">
+                    <h5 class="modal-title" id="cpViewSongsLabel">
+                        <i class="bi bi-music-note-list me-2"></i>
+                        Songs citing <strong id="cp-view-songs-name"></strong>
+                    </h5>
+                    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div id="cp-view-songs-loading" class="text-center py-3 text-secondary small d-none">
+                        <span class="spinner-border spinner-border-sm me-2"></span>Loading…
+                    </div>
+                    <div id="cp-view-songs-error" class="alert alert-danger py-2 small d-none"></div>
+                    <div id="cp-view-songs-body"></div>
+                    <div id="cp-view-songs-empty" class="alert alert-secondary py-2 small d-none">
+                        No songs currently cite this person — the registry row
+                        exists in isolation (pre-registered, or all citations
+                        have been re-pointed elsewhere).
+                    </div>
+                </div>
+                <div class="modal-footer border-secondary">
+                    <button type="button" class="btn btn-outline-secondary btn-sm" data-bs-dismiss="modal">Close</button>
+                </div>
+            </div>
+        </div>
     </div>
 
     <!-- =========================================================================
@@ -1729,6 +1907,146 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
             /* Submit button only enables once a target is picked. */
             targetSel?.addEventListener('change', () => {
                 submitBtn.disabled = targetSel.value === '';
+            });
+        })();
+
+        /* =========================================================================
+           Delete-from-registry modal — read the row's role-pill counts
+           to decide whether to show the force-anyway path.
+           ========================================================================= */
+        (function () {
+            const modalEl = document.getElementById('cpDeleteModal');
+            if (!modalEl) return;
+            const modal      = bootstrap.Modal.getOrCreateInstance(modalEl);
+            const idIn       = document.getElementById('cp-delete-id');
+            const nameEl     = document.getElementById('cp-delete-name');
+            const inUseEl    = document.getElementById('cp-delete-in-use');
+            const notInUseEl = document.getElementById('cp-delete-not-in-use');
+            const usageCnt   = document.getElementById('cp-delete-usage-count');
+            const forceCb    = document.getElementById('cp-delete-force');
+            const submitBtn  = document.getElementById('cp-delete-submit');
+
+            document.addEventListener('click', (ev) => {
+                const btn = ev.target.closest('.cp-delete-btn');
+                if (!btn) return;
+                const row = btn.closest('tr');
+                if (!row) return;
+                const raw = row.getAttribute('data-person');
+                if (!raw) return;
+                let person; try { person = JSON.parse(raw); } catch (_) { return; }
+                if (!person.registry_id) return;
+
+                /* Read total usage from the row's "Total uses" cell. */
+                const totalCell = row.querySelector('td.text-end strong');
+                const usage = parseInt((totalCell?.textContent || '0').replace(/[,]/g, ''), 10) || 0;
+
+                idIn.value      = String(person.registry_id);
+                nameEl.textContent = person.name || '';
+                forceCb.checked = false;
+
+                if (usage > 0) {
+                    inUseEl.classList.remove('d-none');
+                    notInUseEl.classList.add('d-none');
+                    usageCnt.textContent = usage.toLocaleString();
+                    submitBtn.disabled = true;
+                    submitBtn.innerHTML = '<i class="bi bi-trash me-1"></i>Force remove';
+                } else {
+                    inUseEl.classList.add('d-none');
+                    notInUseEl.classList.remove('d-none');
+                    submitBtn.disabled = false;
+                    submitBtn.innerHTML = '<i class="bi bi-trash me-1"></i>Remove';
+                }
+                modal.show();
+            });
+
+            forceCb?.addEventListener('change', () => {
+                submitBtn.disabled = !forceCb.checked;
+            });
+        })();
+
+        /* =========================================================================
+           View Songs modal — fetches GET ?action=view_songs&id=<id>
+           on open and renders the per-role groups.
+           ========================================================================= */
+        (function () {
+            const modalEl = document.getElementById('cpViewSongsModal');
+            if (!modalEl) return;
+            const modal     = bootstrap.Modal.getOrCreateInstance(modalEl);
+            const nameEl    = document.getElementById('cp-view-songs-name');
+            const loadingEl = document.getElementById('cp-view-songs-loading');
+            const errorEl   = document.getElementById('cp-view-songs-error');
+            const bodyEl    = document.getElementById('cp-view-songs-body');
+            const emptyEl   = document.getElementById('cp-view-songs-empty');
+
+            const ROLE_LABELS = {
+                writer:     'Writers',
+                composer:   'Composers',
+                arranger:   'Arrangers',
+                adaptor:    'Adaptors',
+                translator: 'Translators',
+            };
+
+            function renderRoleGroup(role, songs) {
+                if (!songs.length) return '';
+                const items = songs.map(s => {
+                    const ref = (s.SongbookAbbr || '?') + (s.Number ? '-' + s.Number : '');
+                    const title = s.Title || '(untitled)';
+                    return '<li class="small">'
+                        + '<code class="me-2">' + ref + '</code>'
+                        + title
+                        + '</li>';
+                }).join('');
+                return '<div class="mb-3">'
+                    + '<h6 class="small text-secondary mb-1">'
+                    +   ROLE_LABELS[role] + ' <span class="badge bg-secondary-subtle text-secondary-emphasis ms-1">' + songs.length + '</span>'
+                    + '</h6>'
+                    + '<ul class="list-unstyled mb-0">' + items + '</ul>'
+                    + '</div>';
+            }
+
+            document.addEventListener('click', (ev) => {
+                const btn = ev.target.closest('.cp-view-songs-btn');
+                if (!btn) return;
+                const row = btn.closest('tr');
+                if (!row) return;
+                const raw = row.getAttribute('data-person');
+                if (!raw) return;
+                let person; try { person = JSON.parse(raw); } catch (_) { return; }
+                if (!person.registry_id) return;
+
+                nameEl.textContent = person.name || '';
+                bodyEl.innerHTML = '';
+                errorEl.classList.add('d-none');
+                emptyEl.classList.add('d-none');
+                loadingEl.classList.remove('d-none');
+                modal.show();
+
+                fetch('/manage/credit-people?action=view_songs&id=' + encodeURIComponent(person.registry_id), {
+                    credentials: 'same-origin',
+                    headers: { 'Accept': 'application/json' },
+                })
+                    .then(r => r.json().then(j => ({ ok: r.ok, j })))
+                    .then(({ ok, j }) => {
+                        loadingEl.classList.add('d-none');
+                        if (!ok || j.error) {
+                            errorEl.textContent = j.error || ('HTTP error');
+                            errorEl.classList.remove('d-none');
+                            return;
+                        }
+                        if (!j.total) {
+                            emptyEl.classList.remove('d-none');
+                            return;
+                        }
+                        const html = ['writer', 'composer', 'arranger', 'adaptor', 'translator']
+                            .map(role => renderRoleGroup(role, j.by_role[role] || []))
+                            .join('');
+                        bodyEl.innerHTML = html;
+                    })
+                    .catch(err => {
+                        loadingEl.classList.add('d-none');
+                        errorEl.textContent = String(err.message || err);
+                        errorEl.classList.remove('d-none');
+                    });
             });
         })();
     </script>

--- a/appWeb/public_html/manage/credit-people.php
+++ b/appWeb/public_html/manage/credit-people.php
@@ -742,6 +742,46 @@ try {
     $registryRows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
     $stmt->close();
 
+    /* Q3 + Q4 — pull every link / IPI row across all people so the
+       Edit drawer can pre-fill without an extra round-trip. The two
+       child tables are small (a handful of rows per person, low
+       hundreds total), so loading them all is cheaper than fetching
+       per-person on demand from JS. */
+    $linksByPerson = [];
+    $ipiByPerson   = [];
+    $stmt = $db->prepare(
+        'SELECT Id, CreditPersonId, LinkType, Url, Label, SortOrder
+           FROM tblCreditPersonLinks
+          ORDER BY CreditPersonId ASC, SortOrder ASC, Id ASC'
+    );
+    $stmt->execute();
+    foreach ($stmt->get_result()->fetch_all(MYSQLI_ASSOC) as $l) {
+        $linksByPerson[(int)$l['CreditPersonId']][] = [
+            'id'         => (int)$l['Id'],
+            'type'       => (string)$l['LinkType'],
+            'url'        => (string)$l['Url'],
+            'label'      => $l['Label'],
+            'sort_order' => (int)$l['SortOrder'],
+        ];
+    }
+    $stmt->close();
+
+    $stmt = $db->prepare(
+        'SELECT Id, CreditPersonId, IPINumber, NameUsed, Notes
+           FROM tblCreditPersonIPI
+          ORDER BY CreditPersonId ASC, Id ASC'
+    );
+    $stmt->execute();
+    foreach ($stmt->get_result()->fetch_all(MYSQLI_ASSOC) as $r) {
+        $ipiByPerson[(int)$r['CreditPersonId']][] = [
+            'id'        => (int)$r['Id'],
+            'number'    => (string)$r['IPINumber'],
+            'name_used' => $r['NameUsed'],
+            'notes'     => $r['Notes'],
+        ];
+    }
+    $stmt->close();
+
     /* Merge — keyed by Name. A name may appear in usage only,
        registry only, or both. */
     $byName = [];
@@ -764,6 +804,8 @@ try {
             'updated_at'  => null,
             'link_count'  => 0,
             'ipi_count'   => 0,
+            'links'       => [],
+            'ipi'         => [],
         ];
     }
     foreach ($registryRows as $r) {
@@ -798,6 +840,11 @@ try {
         $byName[$name]['updated_at']  = $r['UpdatedAt'];
         $byName[$name]['link_count']  = (int)$r['LinkCount'];
         $byName[$name]['ipi_count']   = (int)$r['IPICount'];
+        /* Full child rows for the Edit drawer's pre-fill. Empty arrays
+           default for registry rows with no children — the drawer's JS
+           handles the empty case as "no rows yet". */
+        $byName[$name]['links'] = $linksByPerson[(int)$r['Id']] ?? [];
+        $byName[$name]['ipi']   = $ipiByPerson[(int)$r['Id']]   ?? [];
     }
 
     /* Sort: highest-usage first, then alphabetical. Registry-only
@@ -895,16 +942,6 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
             or registry-only names that are waiting on a song to cite them.
         </p>
 
-        <!-- Slice scope notice -->
-        <div class="alert alert-info py-2 small mb-3">
-            <i class="bi bi-info-circle me-1"></i>
-            <strong>Read-only view (v1).</strong>
-            Add / Rename / Merge / Edit-detail / Delete actions land in the next PR
-            against #545. The data here is the same data those mutations will
-            operate on, so you can use this view today to plan which names need
-            cleanup.
-        </div>
-
         <?php if ($success): ?>
             <div class="alert alert-success py-2"><?= htmlspecialchars($success) ?></div>
         <?php endif; ?>
@@ -954,7 +991,7 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
                         </button>
                     </div>
                 </div>
-                <div class="col-md-7">
+                <div class="col-md-5">
                     <div class="btn-group btn-group-sm flex-wrap" role="group" aria-label="Filter by role">
                         <button type="button" class="btn btn-outline-secondary filter-btn active" data-filter="all">All</button>
                         <button type="button" class="btn btn-outline-secondary filter-btn" data-filter="writer">Writers</button>
@@ -964,6 +1001,11 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
                         <button type="button" class="btn btn-outline-secondary filter-btn" data-filter="translator">Translators</button>
                         <button type="button" class="btn btn-outline-secondary filter-btn" data-filter="registry-only">Registry-only</button>
                     </div>
+                </div>
+                <div class="col-md-2 text-md-end">
+                    <button type="button" class="btn btn-amber-solid btn-sm" id="cp-add-btn">
+                        <i class="bi bi-plus-circle me-1"></i>Add person
+                    </button>
                 </div>
             </div>
         </div>
@@ -980,6 +1022,7 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
                             <th scope="col">Source</th>
                             <th scope="col">Lifespan</th>
                             <th scope="col" class="text-end">Meta</th>
+                            <th scope="col" class="text-end">Actions</th>
                         </tr>
                     </thead>
                     <tbody id="cp-tbody">
@@ -1004,10 +1047,29 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
                                 (string)$p['death_place'],
                                 (string)$p['notes'],
                             ])));
+                            /* Embed the full person payload in a data
+                               attribute so the Edit button can pre-fill
+                               the drawer without an extra round-trip.
+                               JSON_HEX_* flags + ENT_QUOTES on the
+                               attribute container keep apostrophes /
+                               quotes / angle brackets safe. Nulls in the
+                               PHP array become null literals in JSON. */
+                            $personJson = json_encode([
+                                'registry_id' => $p['registry_id'],
+                                'name'        => $p['name'],
+                                'notes'       => $p['notes'],
+                                'birth_place' => $p['birth_place'],
+                                'birth_date'  => $p['birth_date'],
+                                'death_place' => $p['death_place'],
+                                'death_date'  => $p['death_date'],
+                                'links'       => $p['links'],
+                                'ipi'         => $p['ipi'],
+                            ], JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_TAG | JSON_HEX_AMP | JSON_UNESCAPED_UNICODE);
                         ?>
                             <tr data-roles="<?= htmlspecialchars($rolesCsv) ?>"
                                 data-registry-only="<?= $isRegistryOnly ? '1' : '0' ?>"
-                                data-haystack="<?= htmlspecialchars($haystack) ?>">
+                                data-haystack="<?= htmlspecialchars($haystack) ?>"
+                                data-person='<?= htmlspecialchars($personJson, ENT_QUOTES) ?>'>
                                 <td class="person-name">
                                     <?= htmlspecialchars($p['name']) ?>
                                     <?php if ($p['notes']): ?>
@@ -1046,10 +1108,25 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
                                         <span class="text-secondary">—</span>
                                     <?php endif; ?>
                                 </td>
+                                <td class="text-end action-col">
+                                    <?php if ($p['registry_id'] !== null): ?>
+                                        <button type="button" class="btn btn-sm btn-outline-info cp-edit-btn"
+                                                title="Edit person details"
+                                                aria-label="Edit person <?= htmlspecialchars($p['name'], ENT_QUOTES) ?>">
+                                            <i class="bi bi-pencil" aria-hidden="true"></i>
+                                        </button>
+                                    <?php else: ?>
+                                        <button type="button" class="btn btn-sm btn-outline-info cp-edit-btn"
+                                                title="Add to registry — fills in the name + opens the detail drawer for this person"
+                                                aria-label="Add <?= htmlspecialchars($p['name'], ENT_QUOTES) ?> to the registry">
+                                            <i class="bi bi-plus-circle" aria-hidden="true"></i>
+                                        </button>
+                                    <?php endif; ?>
+                                </td>
                             </tr>
                         <?php endforeach; ?>
                         <tr class="empty-row" id="cp-empty-row" style="display:none;">
-                            <td colspan="6">No names match the current search / filter.</td>
+                            <td colspan="7">No names match the current search / filter.</td>
                         </tr>
                     </tbody>
                 </table>
@@ -1057,6 +1134,132 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
         </div>
 
     </div>
+
+    <!-- =========================================================================
+         Person detail drawer — drives both Add and Update_person actions.
+         Bootstrap right-side offcanvas with a form inside; the form's
+         method/action are fixed (POST to this page); the action input
+         and id input switch between 'add' / 'update_person' depending
+         on which button opened the drawer.
+         ========================================================================= -->
+    <div class="offcanvas offcanvas-end" tabindex="-1" id="cpDrawer" aria-labelledby="cpDrawerLabel" style="width: min(560px, 95vw);">
+        <div class="offcanvas-header border-bottom border-secondary">
+            <h5 class="offcanvas-title" id="cpDrawerLabel">
+                <i class="bi bi-person-badge me-2"></i>
+                <span id="cp-drawer-title">Add person</span>
+            </h5>
+            <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+        </div>
+        <form method="POST" id="cp-drawer-form" class="offcanvas-body d-flex flex-column gap-3">
+            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+            <input type="hidden" name="action" id="cp-drawer-action" value="add">
+            <input type="hidden" name="id"     id="cp-drawer-id"     value="">
+
+            <!-- Identity -->
+            <div>
+                <label class="form-label small mb-1" for="cp-drawer-name">Name <span class="text-danger">*</span></label>
+                <input type="text" class="form-control form-control-sm" id="cp-drawer-name" name="name" maxlength="255" required>
+                <div class="form-text small" id="cp-drawer-name-help">
+                    The canonical spelling. To rename, save first, then use the Rename action — renames cascade to every song that cites this person.
+                </div>
+            </div>
+
+            <!-- Birth -->
+            <div class="row g-2">
+                <div class="col-7">
+                    <label class="form-label small mb-1" for="cp-drawer-birth-place">Birth place</label>
+                    <input type="text" class="form-control form-control-sm" id="cp-drawer-birth-place" name="birth_place" maxlength="255" placeholder="e.g. London, England">
+                </div>
+                <div class="col-5">
+                    <label class="form-label small mb-1" for="cp-drawer-birth-date">Birth date</label>
+                    <input type="date" class="form-control form-control-sm" id="cp-drawer-birth-date" name="birth_date">
+                </div>
+            </div>
+
+            <!-- Death -->
+            <div class="row g-2">
+                <div class="col-7">
+                    <label class="form-label small mb-1" for="cp-drawer-death-place">Death place</label>
+                    <input type="text" class="form-control form-control-sm" id="cp-drawer-death-place" name="death_place" maxlength="255">
+                </div>
+                <div class="col-5">
+                    <label class="form-label small mb-1" for="cp-drawer-death-date">Death date</label>
+                    <input type="date" class="form-control form-control-sm" id="cp-drawer-death-date" name="death_date">
+                </div>
+            </div>
+
+            <!-- External links — repeating sub-form -->
+            <div>
+                <div class="d-flex justify-content-between align-items-center mb-1">
+                    <label class="form-label small mb-0">External links</label>
+                    <button type="button" class="btn btn-sm btn-outline-secondary" id="cp-add-link-btn">
+                        <i class="bi bi-plus me-1"></i>Add link
+                    </button>
+                </div>
+                <div id="cp-links-container" class="d-flex flex-column gap-2"></div>
+                <div class="form-text small">Wikipedia, official website, MusicBrainz, Discogs, IMSLP, Hymnary — anything an editor or curator might want to follow.</div>
+            </div>
+
+            <!-- IPI numbers — repeating sub-form -->
+            <div>
+                <div class="d-flex justify-content-between align-items-center mb-1">
+                    <label class="form-label small mb-0">IPI Name Numbers</label>
+                    <button type="button" class="btn btn-sm btn-outline-secondary" id="cp-add-ipi-btn">
+                        <i class="bi bi-plus me-1"></i>Add IPI
+                    </button>
+                </div>
+                <div id="cp-ipi-container" class="d-flex flex-column gap-2"></div>
+                <div class="form-text small">A single individual can hold more than one IPI Name Number when they're registered under different performing names.</div>
+            </div>
+
+            <!-- Notes -->
+            <div>
+                <label class="form-label small mb-1" for="cp-drawer-notes">Notes</label>
+                <textarea class="form-control form-control-sm" id="cp-drawer-notes" name="notes" rows="3" placeholder="Anything that doesn't fit the structured fields above."></textarea>
+            </div>
+
+            <!-- Footer -->
+            <div class="d-flex justify-content-end gap-2 mt-auto pt-3 border-top border-secondary">
+                <button type="button" class="btn btn-outline-secondary btn-sm" data-bs-dismiss="offcanvas">Cancel</button>
+                <button type="submit" class="btn btn-amber-solid btn-sm">
+                    <i class="bi bi-save me-1"></i>Save
+                </button>
+            </div>
+        </form>
+    </div>
+
+    <!-- Templates for the repeating sub-form rows. {i} placeholder gets
+         replaced by the JS with the row's array index so PHP receives
+         them as $_POST['links'][i][...] and $_POST['ipi'][i][...]. -->
+    <template id="cp-link-row-template">
+        <div class="d-flex gap-1 align-items-start cp-link-row" data-row-kind="link">
+            <select class="form-select form-select-sm" style="max-width: 130px;" name="links[{i}][type]">
+                <option value="wikipedia">Wikipedia</option>
+                <option value="official">Official site</option>
+                <option value="musicbrainz">MusicBrainz</option>
+                <option value="discogs">Discogs</option>
+                <option value="imslp">IMSLP</option>
+                <option value="hymnary">Hymnary</option>
+                <option value="other">Other</option>
+            </select>
+            <input type="url" class="form-control form-control-sm" name="links[{i}][url]" placeholder="https://…" required>
+            <input type="text" class="form-control form-control-sm" style="max-width: 140px;" name="links[{i}][label]" placeholder="Label (optional)">
+            <input type="hidden" name="links[{i}][sort_order]" value="{i}">
+            <button type="button" class="btn btn-sm btn-outline-danger cp-row-remove" title="Remove this link" aria-label="Remove this link">
+                <i class="bi bi-x" aria-hidden="true"></i>
+            </button>
+        </div>
+    </template>
+    <template id="cp-ipi-row-template">
+        <div class="d-flex gap-1 align-items-start cp-ipi-row" data-row-kind="ipi">
+            <input type="text" class="form-control form-control-sm" style="max-width: 140px;" name="ipi[{i}][number]" placeholder="IPI number" required>
+            <input type="text" class="form-control form-control-sm" style="max-width: 180px;" name="ipi[{i}][name_used]" placeholder="Name used (optional)">
+            <input type="text" class="form-control form-control-sm" name="ipi[{i}][notes]" placeholder="Notes (optional)">
+            <button type="button" class="btn btn-sm btn-outline-danger cp-row-remove" title="Remove this IPI" aria-label="Remove this IPI">
+                <i class="bi bi-x" aria-hidden="true"></i>
+            </button>
+        </div>
+    </template>
 
     <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>
 
@@ -1105,6 +1308,145 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
                 activeFilter = b.dataset.filter || 'all';
                 apply();
             }));
+        })();
+
+        /* =========================================================================
+           Person detail drawer — drives Add and Update_person actions.
+           Open from:
+             - #cp-add-btn          → empty drawer, action=add
+             - .cp-edit-btn (per-row) → pre-filled drawer
+                                          - action=add if row has no registry_id
+                                          - action=update_person otherwise
+           ========================================================================= */
+        (function () {
+            const drawerEl  = document.getElementById('cpDrawer');
+            const form      = document.getElementById('cp-drawer-form');
+            const titleEl   = document.getElementById('cp-drawer-title');
+            const nameHelp  = document.getElementById('cp-drawer-name-help');
+            const actionIn  = document.getElementById('cp-drawer-action');
+            const idIn      = document.getElementById('cp-drawer-id');
+            const nameIn    = document.getElementById('cp-drawer-name');
+            const linksBox  = document.getElementById('cp-links-container');
+            const ipiBox    = document.getElementById('cp-ipi-container');
+            const linkTpl   = document.getElementById('cp-link-row-template');
+            const ipiTpl    = document.getElementById('cp-ipi-row-template');
+            const addBtn    = document.getElementById('cp-add-btn');
+            const addLinkBtn= document.getElementById('cp-add-link-btn');
+            const addIpiBtn = document.getElementById('cp-add-ipi-btn');
+            if (!drawerEl || !form) return;
+
+            const drawer = bootstrap.Offcanvas.getOrCreateInstance(drawerEl);
+            let linkIndex = 0;
+            let ipiIndex  = 0;
+
+            /* Append a new sub-form row, optionally pre-filled. The
+               template's {i} placeholders get replaced with the
+               current per-kind index so PHP receives the rows as a
+               densely-keyed array. */
+            function addLinkRow(prefill) {
+                const html = linkTpl.innerHTML.replaceAll('{i}', String(linkIndex++));
+                linksBox.insertAdjacentHTML('beforeend', html);
+                const row = linksBox.lastElementChild;
+                if (prefill) {
+                    const sel = row.querySelector('select');
+                    if (sel) sel.value = prefill.type || 'other';
+                    const url = row.querySelector('input[type="url"]');
+                    if (url) url.value = prefill.url || '';
+                    const lbl = row.querySelector('input[name$="[label]"]');
+                    if (lbl) lbl.value = prefill.label || '';
+                    const ord = row.querySelector('input[name$="[sort_order]"]');
+                    if (ord && prefill.sort_order !== undefined) ord.value = prefill.sort_order;
+                }
+                return row;
+            }
+            function addIpiRow(prefill) {
+                const html = ipiTpl.innerHTML.replaceAll('{i}', String(ipiIndex++));
+                ipiBox.insertAdjacentHTML('beforeend', html);
+                const row = ipiBox.lastElementChild;
+                if (prefill) {
+                    row.querySelector('input[name$="[number]"]').value    = prefill.number    || '';
+                    row.querySelector('input[name$="[name_used]"]').value = prefill.name_used || '';
+                    row.querySelector('input[name$="[notes]"]').value     = prefill.notes     || '';
+                }
+                return row;
+            }
+
+            function resetDrawer() {
+                form.reset();
+                linksBox.innerHTML = '';
+                ipiBox.innerHTML   = '';
+                linkIndex = 0;
+                ipiIndex  = 0;
+            }
+
+            /* Open empty drawer for Add. */
+            addBtn?.addEventListener('click', () => {
+                resetDrawer();
+                actionIn.value = 'add';
+                idIn.value     = '';
+                titleEl.textContent = 'Add person';
+                nameIn.readOnly = false;
+                nameHelp.textContent = 'The canonical spelling. To rename later, save first, then use the Rename action — renames cascade to every song that cites this person.';
+                drawer.show();
+                setTimeout(() => nameIn.focus(), 200);
+            });
+
+            /* Open pre-filled drawer for Edit. Reads the person JSON
+               from the row's data-person attribute. */
+            document.addEventListener('click', (ev) => {
+                const btn = ev.target.closest('.cp-edit-btn');
+                if (!btn) return;
+                const row = btn.closest('tr');
+                if (!row) return;
+                const raw = row.getAttribute('data-person');
+                if (!raw) return;
+                let person;
+                try { person = JSON.parse(raw); }
+                catch (_) { return; }
+
+                resetDrawer();
+                if (person.registry_id) {
+                    actionIn.value = 'update_person';
+                    idIn.value     = String(person.registry_id);
+                    titleEl.textContent = 'Edit person — ' + person.name;
+                    nameIn.value    = person.name || '';
+                    nameIn.readOnly = true;
+                    nameHelp.textContent = 'Locked when editing — use the Rename action to change the canonical name and cascade across the catalogue.';
+                } else {
+                    /* In-use name not yet in the registry — pre-fill the
+                       name and let the admin enrich it. The action stays
+                       'add' (this is a new registry row); the form's
+                       INSERT IGNORE-style uniqueness check on the server
+                       handles the case where the name was added by a
+                       concurrent editor save in the meantime. */
+                    actionIn.value = 'add';
+                    idIn.value     = '';
+                    titleEl.textContent = 'Add to registry — ' + person.name;
+                    nameIn.value    = person.name || '';
+                    nameIn.readOnly = false;
+                    nameHelp.textContent = 'This name is already credited on songs — adding to the registry lets you attach biographical metadata. The Name field is the canonical spelling that the song-credit tables already use; editing it here would create a mismatch, so leave it as-is and use Rename later if you need to change it.';
+                }
+                document.getElementById('cp-drawer-birth-place').value = person.birth_place || '';
+                document.getElementById('cp-drawer-birth-date').value  = person.birth_date  || '';
+                document.getElementById('cp-drawer-death-place').value = person.death_place || '';
+                document.getElementById('cp-drawer-death-date').value  = person.death_date  || '';
+                document.getElementById('cp-drawer-notes').value       = person.notes       || '';
+                (person.links || []).forEach(l => addLinkRow(l));
+                (person.ipi   || []).forEach(r => addIpiRow(r));
+                drawer.show();
+            });
+
+            /* Add-row buttons inside the drawer. */
+            addLinkBtn?.addEventListener('click', () => addLinkRow());
+            addIpiBtn?.addEventListener('click',  () => addIpiRow());
+
+            /* Remove-row delegation. */
+            drawerEl.addEventListener('click', (ev) => {
+                const remove = ev.target.closest('.cp-row-remove');
+                if (!remove) return;
+                const row = remove.closest('.cp-link-row, .cp-ipi-row');
+                if (row) row.remove();
+            });
         })();
     </script>
 

--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -172,6 +172,13 @@ switch ($action) {
             $stmtArranger   = $db->prepare("INSERT INTO tblSongArrangers   (SongId, Name) VALUES (?, ?)");
             $stmtAdaptor    = $db->prepare("INSERT INTO tblSongAdaptors    (SongId, Name) VALUES (?, ?)");
             $stmtTranslator = $db->prepare("INSERT INTO tblSongTranslators (SongId, Name) VALUES (?, ?)");
+            /* Silently keep the credit-people registry in sync with every
+               name that lands in the five song-credit tables (#545).
+               INSERT IGNORE on the unique Name index — adding a name
+               that's already in the registry is a no-op. The registry
+               row carries no metadata at this point; the People page
+               (/manage/credit-people) is where that gets enriched. */
+            $stmtRegistry = $db->prepare("INSERT IGNORE INTO tblCreditPeople (Name) VALUES (?)");
             $stmtComponent  = $db->prepare(
                 "INSERT INTO tblSongComponents (SongId, Type, Number, SortOrder, LinesJson)
                  VALUES (?, ?, ?, ?, ?)"
@@ -224,12 +231,22 @@ switch ($action) {
                 );
                 $stmtSong->execute();
 
-                /* Credit collections — one table each. */
-                foreach ($song['writers']     ?? [] as $v) { if (is_string($v) && $v !== '') { $stmtWriter->bind_param('ss', $songId, $v);     $stmtWriter->execute(); } }
-                foreach ($song['composers']   ?? [] as $v) { if (is_string($v) && $v !== '') { $stmtComposer->bind_param('ss', $songId, $v);   $stmtComposer->execute(); } }
-                foreach ($song['arrangers']   ?? [] as $v) { if (is_string($v) && $v !== '') { $stmtArranger->bind_param('ss', $songId, $v);   $stmtArranger->execute(); } }
-                foreach ($song['adaptors']    ?? [] as $v) { if (is_string($v) && $v !== '') { $stmtAdaptor->bind_param('ss', $songId, $v);    $stmtAdaptor->execute(); } }
-                foreach ($song['translators'] ?? [] as $v) { if (is_string($v) && $v !== '') { $stmtTranslator->bind_param('ss', $songId, $v); $stmtTranslator->execute(); } }
+                /* Credit collections — one table each. The registry sync
+                   (INSERT IGNORE into tblCreditPeople) runs once per
+                   credited name across all five collections, deduped
+                   per song so we don't fire identical INSERTs five
+                   times for someone credited in multiple roles on the
+                   same song. (#545) */
+                $regNames = [];
+                foreach ($song['writers']     ?? [] as $v) { if (is_string($v) && $v !== '') { $stmtWriter->bind_param('ss', $songId, $v);     $stmtWriter->execute();     $regNames[$v] = true; } }
+                foreach ($song['composers']   ?? [] as $v) { if (is_string($v) && $v !== '') { $stmtComposer->bind_param('ss', $songId, $v);   $stmtComposer->execute();   $regNames[$v] = true; } }
+                foreach ($song['arrangers']   ?? [] as $v) { if (is_string($v) && $v !== '') { $stmtArranger->bind_param('ss', $songId, $v);   $stmtArranger->execute();   $regNames[$v] = true; } }
+                foreach ($song['adaptors']    ?? [] as $v) { if (is_string($v) && $v !== '') { $stmtAdaptor->bind_param('ss', $songId, $v);    $stmtAdaptor->execute();    $regNames[$v] = true; } }
+                foreach ($song['translators'] ?? [] as $v) { if (is_string($v) && $v !== '') { $stmtTranslator->bind_param('ss', $songId, $v); $stmtTranslator->execute(); $regNames[$v] = true; } }
+                foreach (array_keys($regNames) as $regName) {
+                    $stmtRegistry->bind_param('s', $regName);
+                    $stmtRegistry->execute();
+                }
 
                 /* Components */
                 $sortOrder = 0;
@@ -250,6 +267,7 @@ switch ($action) {
             $stmtAdaptor->close();
             $stmtTranslator->close();
             $stmtComponent->close();
+            $stmtRegistry->close();
 
             /*
              * Import translation links from songs.json (#352).
@@ -526,14 +544,31 @@ switch ($action) {
                 'adaptors'    => 'INSERT INTO tblSongAdaptors    (SongId, Name) VALUES (?, ?)',
                 'translators' => 'INSERT INTO tblSongTranslators (SongId, Name) VALUES (?, ?)',
             ];
+            $regNames = [];
             foreach ($creditInserts as $key => $sql) {
                 $stmt = $db->prepare($sql);
                 foreach ($song[$key] ?? [] as $name) {
                     if (!is_string($name) || $name === '') continue;
                     $stmt->bind_param('ss', $songId, $name);
                     $stmt->execute();
+                    $regNames[$name] = true;
                 }
                 $stmt->close();
+            }
+            /* Silently keep the credit-people registry in sync (#545).
+               INSERT IGNORE on the unique Name index — names already in
+               the registry are no-ops. The registry row carries no
+               metadata at this point; the People page
+               (/manage/credit-people) is where that gets enriched.
+               Deduped above so a name credited in multiple roles on the
+               same song fires once, not five times. */
+            if (!empty($regNames)) {
+                $stmtRegistry = $db->prepare('INSERT IGNORE INTO tblCreditPeople (Name) VALUES (?)');
+                foreach (array_keys($regNames) as $regName) {
+                    $stmtRegistry->bind_param('s', $regName);
+                    $stmtRegistry->execute();
+                }
+                $stmtRegistry->close();
             }
 
             $insComp = $db->prepare(
@@ -1072,6 +1107,24 @@ switch ($action) {
                                  FROM {$table}
                                  WHERE Name LIKE ?
                                  GROUP BY Name";
+                $params[] = $like;
+                $types   .= 's';
+            }
+            /* When the caller searches "any" role (the default for the
+               editor's chip autocomplete), also surface registry rows
+               from tblCreditPeople — pre-registered names that no song
+               currently cites still need to be selectable. The
+               synthesized 'registry' kindLabel collapses via the outer
+               GROUP BY, so a registry-only name lands as a single
+               suggestion with usage=0. The role-specific searches
+               (kind=writer / composer / etc.) intentionally exclude
+               the registry — those callers want to know how this
+               person is currently credited, not whether their name
+               exists in the catalogue. (#545) */
+            if ($kind === 'any') {
+                $unionParts[] = "SELECT Name, 'registry' AS kindLabel, 0 AS cnt
+                                 FROM tblCreditPeople
+                                 WHERE Name LIKE ?";
                 $params[] = $like;
                 $types   .= 's';
             }


### PR DESCRIPTION
## Summary

Completes [#545](https://github.com/MWBMPartners/iHymns/issues/545) — the full action surface for the credit-people area, building on the read-only list page that landed in PR #560 and the schema in PR #553. Five commits, one per logical slice, each independently revertable. After this PR merges, every workflow listed in the #545 issue body is functional in the admin UI.

## Commits

| # | Commit | Slice | Lines |
|---|---|---|---|
| C1 | [`fc54a9b`](https://github.com/MWBMPartners/iHymns/commit/fc54a9b) | Editor `credit_search` registry surfacing + silent `INSERT IGNORE` on save (`editor/api.php`) | +59/-6 |
| C2 | [`e6a064b`](https://github.com/MWBMPartners/iHymns/commit/e6a064b) | POST dispatch + 5 action handlers + activity-log scaffolding (no UI yet) | +644/-18 |
| C3 | [`06ba335`](https://github.com/MWBMPartners/iHymns/commit/06ba335) | Person detail drawer + Add button + Edit-row UI + drawer JS | +355/-13 |
| C4 | [`11a7a69`](https://github.com/MWBMPartners/iHymns/commit/11a7a69) | Rename modal + Merge modal + buttons + JS | +296/-13 |
| C5 | [`ac9d7f4`](https://github.com/MWBMPartners/iHymns/commit/ac9d7f4) | Delete-from-registry modal + View Songs modal + new `view_songs` JSON endpoint | +318/0 |

`credit-people.php` grew from 486 lines (after PR #560) to **2055 lines**. `editor/api.php` gained 53 net lines.

## What lands

### Editor integration (C1)
- `credit_search` extension: when called with `kind=any` (the default for the chip autocomplete), the union now also surfaces names from `tblCreditPeople` that no song currently cites — pre-registered names show up alongside in-use ones. Role-specific searches intentionally exclude the registry.
- Silent `INSERT IGNORE INTO tblCreditPeople (Name)` on every save (both bulk import and per-song) — every credited name now flows into the registry on the next request, deduped per song so a person credited in multiple roles fires once not five times.

### Admin page actions (C2-C5)
| Action | Trigger | Surface | Backend |
|---|---|---|---|
| **Add** | "Add person" button (top right) | Drawer (empty) | INSERT registry + child rows in one transaction |
| **Edit** | Per-row pencil button | Drawer (pre-filled from row JSON) | UPDATE registry + DELETE/INSERT child rows. Name field locked. |
| **Add to registry** (in-use names not yet registered) | Per-row plus-circle button | Drawer (name pre-filled) | Same as Add, but with the existing in-use name as starting point |
| **Rename** | Per-row pencil-square button | Modal showing current → new with role-count impact preview | Cascade `UPDATE Name` across all 5 song-credit tables + registry row, in one transaction |
| **Merge** | Per-row union button | Modal with target picker + child-row reconciliation checkboxes | Cross-table UPDATE re-pointing source → target, child-row migration, source registry row deleted |
| **View Songs** | Per-row music-note-list button | Modal with grouped read-only listing | `GET ?action=view_songs&id=N` returns JSON, JS renders per-role groups |
| **Delete** | Per-row trash button | Modal with safety guard (force-anyway when usage > 0) | DELETE registry row; ON DELETE CASCADE removes children |

### Activity-log payloads
Per the spec in [#545](https://github.com/MWBMPartners/iHymns/issues/545), every mutation writes a `tblActivityLog` row via the `$logCreditPerson` closure:
- `credit_person.add` — `{ name, fields:{birth_*, death_*, notes}, link_count, ipi_count }`
- `credit_person.update_person` — `{ name, fields:[changed], before, after, link_count, ipi_count }`
- `credit_person.rename` — `{ before:{name}, after:{name}, affected:{ writers, composers, arrangers, adaptors, translators } }`
- `credit_person.merge` — `{ source:{id, name}, target:{id, name}, affected, child_rows:{links_kept, links_dropped, ipi_kept, ipi_dropped} }`
- `credit_person.delete_from_registry` — `{ name, had_credits, force }`

## Design notes

- **mysqli prepared statements throughout.** Every action handler runs inside `$db->begin_transaction()` with `try { … } catch { rollback(); throw; }` so a partial failure rolls back cleanly.
- **CSRF on every form** (added once in C2).
- **Person detail drawer** uses Bootstrap right-side offcanvas (~560 px wide). Repeating sub-forms for links and IPI use HTML `<template>` + `{i}` placeholder that the JS replaces with a per-kind monotonic index — so removing a row mid-form doesn't collapse remaining indexes (PHP doesn't care about array key gaps).
- **Edit drawer pre-fill** reads from `data-person='…'` attributes embedded in each row at render time. The full link/IPI rows are loaded once at page load (two extra queries — both child tables are small) and merged into each row's payload, so opening the drawer is instant with no extra round-trip.
- **Merge modal** populates the target dropdown from a JS-side index built once on page load from every registry row except the source. Submit stays disabled until a target is chosen. The source's child rows render as default-checked checkboxes; unticked ones get dropped via the cascade when the source registry row is deleted.
- **Delete modal** reads the row's "Total uses" cell to decide between safe-delete (zero usage, immediate confirm) vs force-delete (non-zero, requires explicit acknowledgement). The C2 handler repeats the usage check authoritatively — JS state is for UX, not security.
- **View Songs modal** is the only AJAX surface on the page (`GET ?action=view_songs&id=N`). Renders a per-role group with a count badge and a `<code>SongbookAbbr-Number</code>` ref + title for each song, in stable sort order.
- **Button colour discipline:** Edit/View are `btn-outline-info` and `btn-outline-secondary`; Rename/Merge are `btn-outline-warning` (amber — broad blast radius but reversible); Delete is the only `btn-outline-danger` (red — destructive removal).

## Test plan

Each action gets one happy-path + one edge-case run. After deploy on alpha, sign in as a `global_admin` and visit `/manage/credit-people`.

### Editor integration (C1)
- [ ] Open `/manage/editor/`, type a partial name in a credit chip → registry-only entries appear in the dropdown alongside in-use ones.
- [ ] Save a song with a brand-new credit name (e.g. "Smoke Test Person") → reload `/manage/credit-people` → "Smoke Test Person" appears as a registry row in the "Both" source.
- [ ] Save the same song twice → registry has exactly one row (INSERT IGNORE is a no-op on the second save).

### Add (C3)
- [ ] Click "Add person", fill the drawer with a name + birth date + one Wikipedia link + one IPI number → save → row appears, success banner.
- [ ] Try to add a duplicate name → blocked with the C2 uniqueness error.

### Edit (C3)
- [ ] Click pencil on an existing registry row → drawer opens with everything pre-filled, name field is locked.
- [ ] Change birth date + add another link + remove one IPI row → save → reload → changes persisted.
- [ ] On a row where the name is in use but no registry row exists yet (e.g. "S. Townend" if MP-1072 doesn't already have a registry entry), click the plus-circle button → drawer opens with name pre-filled, name field editable.

### Rename (C4)
- [ ] On a registry row with songs cited, click the pencil-square Rename button → modal shows current name + impact preview ("Will update N song-credit row(s): ...").
- [ ] Submit with a new name → reload → all songs that previously cited the old name now cite the new one. Activity log shows the per-table affected counts.
- [ ] Try to rename to a name that's already in another registry row → blocked with the "use Merge instead" error.

### Merge (C4)
- [ ] On a registry row, click the union Merge button → modal shows source + target dropdown of every other registry row.
- [ ] Pick a target → submit button enables. The source's links + IPI render as default-checked checkboxes.
- [ ] Untick one of the source's links → submit → reload → that link is gone, the others migrated to the target. Source registry row is gone. Songs that cited the source name now cite the target.
- [ ] Try to merge a person into themselves (manually crafted POST) → server rejects.

### Delete (C5)
- [ ] On a registry-only row (no songs cite it), click trash → "safe to remove" alert, submit enabled. Submit → row gone.
- [ ] On a registry row with songs cited, click trash → "still cited by N row(s)" warning + force checkbox; submit disabled until checked. Tick + submit → registry row gone but song credits intact.

### View Songs (C5)
- [ ] On a row with usage, click the music-note-list View Songs button → modal opens, spinner briefly visible, then per-role groups render with refs + titles in stable sort order.
- [ ] On a registry-only row (zero usage), click View Songs → modal shows the empty-state alert.

### General
- [ ] No new entries in `error_log` from any action.
- [ ] Sidebar nav still highlights "Credit People" on the page.
- [ ] CSRF tamper: open the drawer, modify the hidden `csrf_token` value via DevTools, submit → 403.

## Out of scope

- The umbrella `/manage/*` PDO → mysqli migration (#554) — `logActivity()` is still PDO-backed; works fine alongside this page's mysqli code because the two helpers manage independent connections.
- Public per-person bio pages — the new biographical fields, links, and IPI numbers are admin-only in this PR. A future enhancement could surface them on the existing `/writer/<slug>` and similar public pages.
- Bulk CSV import of canonical names — out of scope for v1 per the issue body's parking-lot list.

Closes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)