### PR TITLE
refactor(manage): PDO→mysqli — #554 Batch 3 (analytics, activity-log, ccli-report, revisions, schema-audit, index)

### DIFF
--- a/appWeb/public_html/manage/activity-log.php
+++ b/appWeb/public_html/manage/activity-log.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
  */
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
 
 requireAuth();
 $currentUser = getCurrentUser();
@@ -26,7 +27,7 @@ if (!$currentUser || !in_array(($currentUser['role'] ?? ''), ['admin', 'global_a
 }
 
 $activePage = 'activity-log';
-$db = getDb();
+$db = getDbMysqli();
 
 /* Filter parsing — every filter is optional. Defaults give the
    admin "last 24 h, every action, every user" landing view. */
@@ -42,36 +43,56 @@ $filterSearch     = trim((string)($_GET['q'] ?? ''));
 
 $since = (new DateTime("-{$filterDays} days"))->format('Y-m-d H:i:s');
 
-$where  = ['a.CreatedAt >= :since'];
-$params = [':since' => $since];
+/* mysqli only supports positional `?` placeholders. The PDO version
+   used named params + reused them across multiple positions
+   (`:user` appears twice in the Username/Email LIKE clause; same
+   for `:search` in the Action/EntityId LIKE clause). For mysqli we
+   bind the value once per `?` position, so $params and $types stay
+   in lock-step with the order the ?s appear. The same arrays are
+   reused for the COUNT, paginated SELECT, and CSV export queries —
+   they all share the WHERE clause. */
+$where  = ['a.CreatedAt >= ?'];
+$params = [$since];
+$types  = 's';
 
 if ($filterAction !== '') {
-    $where[] = 'a.Action = :action';
-    $params[':action'] = $filterAction;
+    $where[]  = 'a.Action = ?';
+    $params[] = $filterAction;
+    $types   .= 's';
 }
 if ($filterUser !== '') {
-    $where[] = '(u.Username LIKE :user OR u.Email LIKE :user)';
-    $params[':user'] = '%' . $filterUser . '%';
+    $where[]  = '(u.Username LIKE ? OR u.Email LIKE ?)';
+    $userLike = '%' . $filterUser . '%';
+    $params[] = $userLike;
+    $params[] = $userLike;
+    $types   .= 'ss';
 }
 if (in_array($filterResult, ['success', 'failure', 'error'], true)) {
-    $where[] = 'a.Result = :result';
-    $params[':result'] = $filterResult;
+    $where[]  = 'a.Result = ?';
+    $params[] = $filterResult;
+    $types   .= 's';
 }
 if ($filterEntityType !== '') {
-    $where[] = 'a.EntityType = :entity_type';
-    $params[':entity_type'] = $filterEntityType;
+    $where[]  = 'a.EntityType = ?';
+    $params[] = $filterEntityType;
+    $types   .= 's';
 }
 if ($filterEntityId !== '') {
-    $where[] = 'a.EntityId = :entity_id';
-    $params[':entity_id'] = $filterEntityId;
+    $where[]  = 'a.EntityId = ?';
+    $params[] = $filterEntityId;
+    $types   .= 's';
 }
 if ($filterRequestId !== '') {
-    $where[] = 'a.RequestId = :request_id';
-    $params[':request_id'] = $filterRequestId;
+    $where[]  = 'a.RequestId = ?';
+    $params[] = $filterRequestId;
+    $types   .= 's';
 }
 if ($filterSearch !== '') {
-    $where[] = '(a.Action LIKE :search OR a.EntityId LIKE :search)';
-    $params[':search'] = '%' . $filterSearch . '%';
+    $where[]  = '(a.Action LIKE ? OR a.EntityId LIKE ?)';
+    $searchLike = '%' . $filterSearch . '%';
+    $params[] = $searchLike;
+    $params[] = $searchLike;
+    $types   .= 'ss';
 }
 $whereSql = 'WHERE ' . implode(' AND ', $where);
 
@@ -98,8 +119,10 @@ if (($_GET['export'] ?? '') === 'csv') {
            ORDER BY a.CreatedAt DESC
            LIMIT 10000'
     );
-    $stmt->execute($params);
-    while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+    $stmt->bind_param($types, ...$params);
+    $stmt->execute();
+    $res = $stmt->get_result();
+    while ($row = $res->fetch_assoc()) {
         fputcsv($out, [
             $row['Id'], $row['CreatedAt'], $row['Username'] ?? '', $row['Action'],
             $row['EntityType'], $row['EntityId'], $row['Result'],
@@ -107,6 +130,7 @@ if (($_GET['export'] ?? '') === 'csv') {
             $row['Method'] ?? '', $row['DurationMs'] ?? '', $row['Details'] ?? '',
         ]);
     }
+    $stmt->close();
     fclose($out);
     exit;
 }
@@ -124,8 +148,11 @@ try {
            FROM tblActivityLog a
            LEFT JOIN tblUsers u ON u.Id = a.UserId ' . $whereSql
     );
-    $countStmt->execute($params);
-    $total = (int)$countStmt->fetchColumn();
+    $countStmt->bind_param($types, ...$params);
+    $countStmt->execute();
+    $row = $countStmt->get_result()->fetch_row();
+    $total = (int)($row[0] ?? 0);
+    $countStmt->close();
 
     $stmt = $db->prepare(
         'SELECT a.Id, a.CreatedAt, a.Action, a.EntityType, a.EntityId, a.Result,
@@ -137,8 +164,10 @@ try {
            ORDER BY a.CreatedAt DESC
            LIMIT ' . (int)$pageSize . ' OFFSET ' . (int)$offset
     );
-    $stmt->execute($params);
-    $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    $stmt->bind_param($types, ...$params);
+    $stmt->execute();
+    $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+    $stmt->close();
 } catch (\Throwable $e) {
     error_log('[manage/activity-log.php] ' . $e->getMessage());
 }
@@ -153,11 +182,15 @@ try {
     $stmt = $db->prepare(
         'SELECT DISTINCT Action
            FROM tblActivityLog
-          WHERE CreatedAt >= :since
+          WHERE CreatedAt >= ?
           ORDER BY Action ASC'
     );
-    $stmt->execute([':since' => $since]);
-    $distinctActions = $stmt->fetchAll(PDO::FETCH_COLUMN);
+    $stmt->bind_param('s', $since);
+    $stmt->execute();
+    /* PDO::FETCH_COLUMN returned a flat array of column-0 values;
+       mysqli has no direct equivalent — pull all rows then array_column. */
+    $distinctActions = array_column($stmt->get_result()->fetch_all(MYSQLI_ASSOC), 'Action');
+    $stmt->close();
 } catch (\Throwable $_e) { /* empty list is fine */ }
 
 $resultBadgeClass = [

--- a/appWeb/public_html/manage/analytics.php
+++ b/appWeb/public_html/manage/analytics.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
  */
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
 requireAdmin();
 
 $activePage  = 'analytics';
@@ -25,7 +26,7 @@ if (!in_array($range, [7, 30, 90], true)) {
 }
 $since = (new DateTime("-{$range} days"))->format('Y-m-d H:i:s');
 
-$db = getDb();
+$db = getDbMysqli();
 
 /* -----------------------------------------------------------------
  * CSV export (#404). Any panel can be requested as download by
@@ -50,8 +51,11 @@ if ($exportPanel !== '') {
                       GROUP BY h.SongId
                       ORDER BY views DESC'
                 );
-                $stmt->execute([$since]);
-                while ($row = $stmt->fetch(PDO::FETCH_NUM)) { fputcsv($fp, $row); }
+                $stmt->bind_param('s', $since);
+                $stmt->execute();
+                $res = $stmt->get_result();
+                while ($row = $res->fetch_row()) { fputcsv($fp, $row); }
+                $stmt->close();
                 break;
             case 'top_books':
                 fputcsv($fp, ['SongbookAbbr', 'Views']);
@@ -63,8 +67,11 @@ if ($exportPanel !== '') {
                       GROUP BY s.SongbookAbbr
                       ORDER BY views DESC'
                 );
-                $stmt->execute([$since]);
-                while ($row = $stmt->fetch(PDO::FETCH_NUM)) { fputcsv($fp, $row); }
+                $stmt->bind_param('s', $since);
+                $stmt->execute();
+                $res = $stmt->get_result();
+                while ($row = $res->fetch_row()) { fputcsv($fp, $row); }
+                $stmt->close();
                 break;
             case 'searches':
                 fputcsv($fp, ['Query', 'ResultCount', 'Hits']);
@@ -76,8 +83,11 @@ if ($exportPanel !== '') {
                           GROUP BY Query, ResultCount
                           ORDER BY hits DESC'
                     );
-                    $stmt->execute([$since]);
-                    while ($row = $stmt->fetch(PDO::FETCH_NUM)) { fputcsv($fp, $row); }
+                    $stmt->bind_param('s', $since);
+                    $stmt->execute();
+                    $res = $stmt->get_result();
+                    while ($row = $res->fetch_row()) { fputcsv($fp, $row); }
+                    $stmt->close();
                 } catch (\Throwable $_e) { /* table absent */ }
                 break;
             default:
@@ -101,8 +111,10 @@ try {
           ORDER BY views DESC
           LIMIT 15'
     );
-    $stmt->execute([$since]);
-    $topSongs = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    $stmt->bind_param('s', $since);
+    $stmt->execute();
+    $topSongs = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+    $stmt->close();
 } catch (\Throwable $e) { /* table may be empty */ }
 
 /* --- Top songbooks --- */
@@ -116,8 +128,10 @@ try {
           GROUP BY s.SongbookAbbr
           ORDER BY views DESC'
     );
-    $stmt->execute([$since]);
-    $topBooks = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    $stmt->bind_param('s', $since);
+    $stmt->execute();
+    $topBooks = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+    $stmt->close();
 } catch (\Throwable $e) {}
 
 /* --- New logins + active users --- */
@@ -125,23 +139,37 @@ $loginCount = 0;
 $activeUsers = 0;
 try {
     $stmt = $db->prepare('SELECT COUNT(*) FROM tblLoginAttempts WHERE Success = 1 AND AttemptedAt >= ?');
-    $stmt->execute([$since]);
-    $loginCount = (int)$stmt->fetchColumn();
+    $stmt->bind_param('s', $since);
+    $stmt->execute();
+    $row = $stmt->get_result()->fetch_row();
+    $loginCount = (int)($row[0] ?? 0);
+    $stmt->close();
 
     $stmt = $db->prepare('SELECT COUNT(DISTINCT UserId) FROM tblSongHistory WHERE ViewedAt >= ? AND UserId IS NOT NULL');
-    $stmt->execute([$since]);
-    $activeUsers = (int)$stmt->fetchColumn();
+    $stmt->bind_param('s', $since);
+    $stmt->execute();
+    $row = $stmt->get_result()->fetch_row();
+    $activeUsers = (int)($row[0] ?? 0);
+    $stmt->close();
 } catch (\Throwable $e) {}
 
 /* --- Totals --- */
 $totalUsers = 0;
 try {
-    $totalUsers = (int)$db->query('SELECT COUNT(*) FROM tblUsers WHERE IsActive = 1')->fetchColumn();
+    $stmt = $db->prepare('SELECT COUNT(*) FROM tblUsers WHERE IsActive = 1');
+    $stmt->execute();
+    $row = $stmt->get_result()->fetch_row();
+    $totalUsers = (int)($row[0] ?? 0);
+    $stmt->close();
 } catch (\Throwable $e) {}
 
 $totalRequests = 0;
 try {
-    $totalRequests = (int)$db->query("SELECT COUNT(*) FROM tblSongRequests WHERE Status = 'pending'")->fetchColumn();
+    $stmt = $db->prepare("SELECT COUNT(*) FROM tblSongRequests WHERE Status = 'pending'");
+    $stmt->execute();
+    $row = $stmt->get_result()->fetch_row();
+    $totalRequests = (int)($row[0] ?? 0);
+    $stmt->close();
 } catch (\Throwable $e) {}
 
 ?>
@@ -245,8 +273,10 @@ try {
                       ORDER BY hits DESC
                       LIMIT 15'
                 );
-                $stmt->execute([$since]);
-                $topSearches = $stmt->fetchAll(PDO::FETCH_ASSOC);
+                $stmt->bind_param('s', $since);
+                $stmt->execute();
+                $topSearches = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+                $stmt->close();
 
                 $stmt = $db->prepare(
                     'SELECT Query, COUNT(*) AS hits
@@ -256,8 +286,10 @@ try {
                       ORDER BY hits DESC
                       LIMIT 10'
                 );
-                $stmt->execute([$since]);
-                $zeroResults = $stmt->fetchAll(PDO::FETCH_ASSOC);
+                $stmt->bind_param('s', $since);
+                $stmt->execute();
+                $zeroResults = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+                $stmt->close();
             } catch (\Throwable $_e) {}
         ?>
         <?php if (!$topSearches): ?>

--- a/appWeb/public_html/manage/ccli-report.php
+++ b/appWeb/public_html/manage/ccli-report.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
  */
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
 
 requireAuth();
 $currentUser = getCurrentUser();
@@ -50,8 +51,11 @@ if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $toDate))   $toDate   = $defaultTo;
 /* ========================================================================
  * Pull the report rows
  * ======================================================================== */
-$db = getDb();
+$db = getDbMysqli();
 
+/* $ccliFilter is built from a server-side bool ($showAll) and only
+   ever takes one of two literal values — never user input. Safe to
+   interpolate. */
 $ccliFilter = $showAll ? '' : "AND s.Ccli <> ''";
 
 try {
@@ -76,8 +80,10 @@ try {
           ORDER BY view_count DESC, s.Title ASC
           LIMIT 5000"
     );
-    $stmt->execute([$fromDate, $toDate]);
-    $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    $stmt->bind_param('ss', $fromDate, $toDate);
+    $stmt->execute();
+    $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+    $stmt->close();
 } catch (\Throwable $e) {
     error_log('[ccli-report] query failed: ' . $e->getMessage());
     $rows = [];

--- a/appWeb/public_html/manage/index.php
+++ b/appWeb/public_html/manage/index.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'card_layout.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
 
 /* Dashboard is now the single landing page for every management
    surface, so admit any signed-in user who holds at least one
@@ -45,13 +46,21 @@ $activePage  = 'dashboard';
 /* Gather stats — all queries updated for the v0.10 PascalCase schema
    (#407). Each is wrapped in try/catch so a missing table during early
    setup doesn't blank the whole dashboard. */
-$db = getDb();
+$db = getDbMysqli();
 
 $tryInt = function (string $sql, array $params = []) use ($db): int {
     try {
         $stmt = $db->prepare($sql);
-        $stmt->execute($params);
-        return (int)$stmt->fetchColumn();
+        /* All current callers pass string params; default to 's'×N
+           and skip bind_param when there are no params (mysqli rejects
+           an empty type string). */
+        if (!empty($params)) {
+            $stmt->bind_param(str_repeat('s', count($params)), ...$params);
+        }
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_row();
+        $stmt->close();
+        return (int)($row[0] ?? 0);
     } catch (\Throwable $_e) {
         return 0;
     }
@@ -70,22 +79,28 @@ $views24h      = $tryInt('SELECT COUNT(*) FROM tblSongHistory WHERE ViewedAt >= 
 /* User counts by role */
 $roleCounts = [];
 try {
-    $rs = $db->query('SELECT Role, COUNT(*) AS cnt FROM tblUsers WHERE IsActive = 1 GROUP BY Role');
-    while ($row = $rs->fetch(PDO::FETCH_ASSOC)) {
+    $stmt = $db->prepare('SELECT Role, COUNT(*) AS cnt FROM tblUsers WHERE IsActive = 1 GROUP BY Role');
+    $stmt->execute();
+    $res = $stmt->get_result();
+    while ($row = $res->fetch_assoc()) {
         $roleCounts[$row['Role']] = (int)$row['cnt'];
     }
+    $stmt->close();
 } catch (\Throwable $_e) {}
 
 /* Recent users (last 10) */
 $recentUsers = [];
 try {
-    $recentUsers = $db->query(
+    $stmt = $db->prepare(
         'SELECT Id AS id, Username AS username, DisplayName AS display_name,
                 Role AS role, IsActive AS is_active, CreatedAt AS created_at
            FROM tblUsers
           ORDER BY CreatedAt DESC
           LIMIT 10'
-    )->fetchAll(PDO::FETCH_ASSOC);
+    );
+    $stmt->execute();
+    $recentUsers = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+    $stmt->close();
 } catch (\Throwable $_e) {}
 
 $csrf = csrfToken();

--- a/appWeb/public_html/manage/revisions.php
+++ b/appWeb/public_html/manage/revisions.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
  */
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
 
 requireAuth();
 $currentUser = getCurrentUser();
@@ -21,7 +22,7 @@ if (!$currentUser || !userHasEntitlement('verify_songs', $currentUser['role'] ??
 }
 
 $activePage = 'revisions';
-$db = getDb();
+$db = getDbMysqli();
 
 $filterUser   = trim((string)($_GET['user']   ?? ''));
 $filterSong   = trim((string)($_GET['song']   ?? ''));
@@ -30,19 +31,31 @@ $filterDays   = (int)($_GET['days']   ?? 30);
 if (!in_array($filterDays, [7, 30, 90, 365], true)) { $filterDays = 30; }
 $since = (new DateTime("-{$filterDays} days"))->format('Y-m-d H:i:s');
 
-$where  = ['r.CreatedAt >= :since'];
-$params = [':since' => $since];
+/* mysqli takes positional `?` placeholders, not named ones — and a
+   placeholder repeated in the SQL needs the value bound twice (PDO
+   allowed reusing :user across multiple positions; mysqli doesn't).
+   Build $params + $types in lock-step with the order the ?s appear
+   in the WHERE clause. The same array is then passed to both the
+   COUNT(*) and the main SELECT — they share the WHERE clause. */
+$where  = ['r.CreatedAt >= ?'];
+$params = [$since];
+$types  = 's';
 if ($filterUser !== '') {
-    $where[] = '(u.Username LIKE :user OR u.Email LIKE :user)';
-    $params[':user'] = '%' . $filterUser . '%';
+    $where[]  = '(u.Username LIKE ? OR u.Email LIKE ?)';
+    $userLike = '%' . $filterUser . '%';
+    $params[] = $userLike;
+    $params[] = $userLike;
+    $types   .= 'ss';
 }
 if ($filterSong !== '') {
-    $where[] = 'r.SongId LIKE :song';
-    $params[':song'] = '%' . $filterSong . '%';
+    $where[]  = 'r.SongId LIKE ?';
+    $params[] = '%' . $filterSong . '%';
+    $types   .= 's';
 }
 if (in_array($filterAction, ['create', 'edit', 'restore', 'delete'], true)) {
-    $where[] = 'r.Action = :action';
-    $params[':action'] = $filterAction;
+    $where[]  = 'r.Action = ?';
+    $params[] = $filterAction;
+    $types   .= 's';
 }
 $whereSql = 'WHERE ' . implode(' AND ', $where);
 
@@ -54,8 +67,11 @@ try {
            FROM tblSongRevisions r
            LEFT JOIN tblUsers u ON u.Id = r.UserId ' . $whereSql
     );
-    $countStmt->execute($params);
-    $total = (int)$countStmt->fetchColumn();
+    $countStmt->bind_param($types, ...$params);
+    $countStmt->execute();
+    $row = $countStmt->get_result()->fetch_row();
+    $total = (int)($row[0] ?? 0);
+    $countStmt->close();
 
     $stmt = $db->prepare(
         'SELECT r.Id, r.SongId, r.Action, r.CreatedAt, r.UserId, u.Username,
@@ -66,8 +82,10 @@ try {
            ORDER BY r.CreatedAt DESC, r.Id DESC
            LIMIT 200'
     );
-    $stmt->execute($params);
-    $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    $stmt->bind_param($types, ...$params);
+    $stmt->execute();
+    $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+    $stmt->close();
 } catch (\Throwable $e) {
     error_log('[manage revisions] ' . $e->getMessage());
     $rows = [];

--- a/appWeb/public_html/manage/schema-audit.php
+++ b/appWeb/public_html/manage/schema-audit.php
@@ -31,6 +31,7 @@ declare(strict_types=1);
  */
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
 
 requireGlobalAdmin();
 $currentUser = getCurrentUser();
@@ -192,7 +193,7 @@ function _schemaAudit_scanMigrations(string $sqlDir): array
  *
  * @return array<string, string[]> tableName => [columnName, …]
  */
-function _schemaAudit_readDb(\PDO $db): array
+function _schemaAudit_readDb(\mysqli $db): array
 {
     $sql = "SELECT TABLE_NAME, COLUMN_NAME
               FROM INFORMATION_SCHEMA.COLUMNS
@@ -200,9 +201,12 @@ function _schemaAudit_readDb(\PDO $db): array
                AND TABLE_NAME LIKE 'tbl%'
              ORDER BY TABLE_NAME, ORDINAL_POSITION";
     $tables = [];
-    foreach ($db->query($sql, \PDO::FETCH_ASSOC) as $row) {
+    $stmt = $db->prepare($sql);
+    $stmt->execute();
+    foreach ($stmt->get_result()->fetch_all(MYSQLI_ASSOC) as $row) {
         $tables[$row['TABLE_NAME']][] = $row['COLUMN_NAME'];
     }
+    $stmt->close();
     return $tables;
 }
 
@@ -308,7 +312,7 @@ $schemaSrc = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . '.sql' . DIRECTORY_SEPA
 $sqlDir    = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . '.sql';
 
 try {
-    $db = getDb();
+    $db = getDbMysqli();
 
     if (!is_readable($schemaSrc)) {
         throw new \RuntimeException('schema.sql is not readable at ' . $schemaSrc);


### PR DESCRIPTION
## Summary

Third batch of the [#554](https://github.com/MWBMPartners/iHymns/issues/554) PDO → mysqli umbrella. Six high-traffic / read-heavy `/manage/*` pages migrated, one commit per file, in DB-site complexity order. **No behavioural change** in any file.

After this PR merges, `getDb()`'s call-site count drops 19 → 13 files, and Batch 3 is fully ticked (the seventh Batch 3 entry, `data-health.php`, was already done via the audit Tier 2 fix in PR #559).

## Commits (DB-site complexity order)

| Commit | File | DB sites | Notes |
|---|---|---|---|
| [`61e0fb0`](https://github.com/MWBMPartners/iHymns/commit/61e0fb0) | `manage/schema-audit.php` | 2 | `_schemaAudit_readDb` signature `\PDO` → `\mysqli`; INFORMATION_SCHEMA query converted |
| [`958562b`](https://github.com/MWBMPartners/iHymns/commit/958562b) | `manage/ccli-report.php` | 4 | Single SELECT with two date binds; `$ccliFilter` interpolation kept (server-side bool, two literal values) |
| [`35c4ebe`](https://github.com/MWBMPartners/iHymns/commit/35c4ebe) | `manage/revisions.php` | 7 | First named-param → positional-`?` conversion of the batch; `:user` reused at two positions, both bound |
| [`da1e619`](https://github.com/MWBMPartners/iHymns/commit/da1e619) | `manage/index.php` (admin dashboard) | 8 | `$tryInt` closure rewritten with empty-params guard; nine count queries on the admin landing |
| [`356c92e`](https://github.com/MWBMPartners/iHymns/commit/356c92e) | `manage/activity-log.php` | 13 | Eight optional filters with two reused (`:user`, `:search`); $types + $params reused across CSV export, count, paginated SELECT |
| [`a695505`](https://github.com/MWBMPartners/iHymns/commit/a695505) | `manage/analytics.php` | 30 | Largest by site count — 10+ prepared queries across two CSV-export branches and seven render queries |

Each commit independently revertable.

## New patterns added to the conversion crib

Three patterns this batch introduced that weren't in Batches 1 / 2:

| Pattern | First applied here | Notes |
|---|---|---|
| **Reused named param `:foo` across multiple `?` positions** | `revisions.php`, `activity-log.php` | PDO let `:user` be reused; mysqli requires the value bound for each `?`. Compute the value once (`$userLike = '%'.$user.'%'`), push onto `$params` once per occurrence. |
| **`PDO::FETCH_NUM` streaming loop → `fetch_row()`** | `analytics.php` (CSV exports) | `fetch_row()` returns numeric arrays, exact equivalent of `FETCH_NUM`. Both feed `fputcsv` directly. |
| **`PDO::FETCH_COLUMN` (flat array of column 0) → `array_column(fetch_all(MYSQLI_ASSOC), 'ColName')`** | `activity-log.php` (distinct-actions dropdown) | mysqli has no direct `FETCH_COLUMN`; pull all rows then extract the column. |
| **`$tryInt` closure pattern with empty-params guard** | `index.php` | Nine count queries reuse the same closure; bind_param is only called when `$params` is non-empty (mysqli rejects empty type strings). |

These have been added to the conversion crib in the umbrella's followup comment.

## What's not changed

- **`logActivity()` calls** in any of these files are untouched. Still PDO-backed via `includes/activity_log.php` (Batch 4 territory). Cross-API calls work fine because the two helpers manage independent connections.
- **`auth.php` user helpers** still PDO until Batch 4 (covers `manage/includes/auth.php`).
- HTML, filters, pagination, CSRF, entitlement gates, CSV formats, audit-log payloads — all preserved exactly.

## Test plan (per file, after deploy)

### `manage/schema-audit.php`
- [ ] Sign in with `drop_legacy_tables`. Page loads; the table-vs-DB matrix renders identically to before. Summary banner reflects ok / missing / uncovered / orphan counts.

### `manage/ccli-report.php`
- [ ] Sign in with `view_ccli_report`. Page loads with default 30-day range; usage counts render. Toggle `?show_all=1` → songs without CCLI numbers appear. CSV export downloads with the same column shape.

### `manage/revisions.php`
- [ ] Sign in with `verify_songs`. Page loads with default 30-day range. Filter by user (free-text) → matches Username OR Email. Filter by song id (LIKE). Filter by action. Combinations work.

### `manage/index.php`
- [ ] Sign in with any management entitlement. Dashboard cards show the 9 count stats correctly (users, active users, active tokens, setlists, songs, songbooks, pending requests, logins-24h, views-24h). Per-role counts correct. Recent users list shows the latest 10 in CreatedAt-desc order.

### `manage/activity-log.php`
- [ ] Sign in with `view_activity_log`. Default view (last 24h, all actions) renders. Each filter combination (action / user / result / entity_type / entity_id / request_id / search / days) works. Paginate forward / back. Export CSV with filters set → file matches the on-page rows.

### `manage/analytics.php`
- [ ] Sign in with admin. Each range (7 / 30 / 90) loads. Stat cards correct. Top songs / top songbooks / top searches / zero-result queries panels render. CSV export for each panel downloads with the right column headers.

### General
- [ ] No new entries in `error_log` from any of the six files.
- [ ] Sidebar nav highlights the active page on each.

## Cumulative progress after Batches 1+2+3

- **13 files migrated** (schema-audit, ccli-report, revisions, index, activity-log, analytics added in this batch; previously: requests, tiers, groups, restrictions, users, songbooks, organisations).
- **`getDb()` call-site count: 26 → 13** (50% migrated).
- **Remaining work: Batch 4 (10 files in `/includes/*` + `manage/includes/auth.php`), Batch 5 (`api.php` ~50 sites), Batch 6 (`editor/api.php` hybrid).**

## Rollback plan

Each commit reverts independently — `git revert <sha>` for whichever file regresses, the other five are unaffected.

Refs #554 (Batch 3 done after merge — Batches 4 / 5 / 6 still to come per the umbrella roadmap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)