### PR TITLE
refactor(api): PDO→mysqli — #554 Batch 5d (completes api.php — 32 endpoints + 2 helpers)

### DIFF
--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -3680,14 +3680,18 @@ if ($action !== null) {
                 break;
             }
 
-            $db = getDb();
+            $db = getDbMysqli();
             $stmt = $db->prepare(
                 'SELECT PreferencesJson FROM tblUserPreferences WHERE UserId = ?'
             );
-            $stmt->execute([$authUser['Id']]);
-            $prefsJson = $stmt->fetchColumn();
+            $authUserId = (int)$authUser['Id'];
+            $stmt->bind_param('i', $authUserId);
+            $stmt->execute();
+            $row = $stmt->get_result()->fetch_row();
+            $stmt->close();
+            $prefsJson = (string)($row[0] ?? '');
 
-            $preferences = $prefsJson ? (json_decode($prefsJson, true) ?: []) : [];
+            $preferences = $prefsJson !== '' ? (json_decode($prefsJson, true) ?: []) : [];
 
             sendJson(['preferences' => $preferences]);
             break;
@@ -3727,7 +3731,7 @@ if ($action !== null) {
                 break;
             }
 
-            $db = getDb();
+            $db = getDbMysqli();
             $stmt = $db->prepare(
                 'INSERT INTO tblUserPreferences (UserId, PreferencesJson)
                  VALUES (?, ?)
@@ -3735,7 +3739,10 @@ if ($action !== null) {
                     PreferencesJson = VALUES(PreferencesJson),
                     UpdatedAt = NOW()'
             );
-            $stmt->execute([$authUser['Id'], $prefsJson]);
+            $authUserId = (int)$authUser['Id'];
+            $stmt->bind_param('is', $authUserId, $prefsJson);
+            $stmt->execute();
+            $stmt->close();
 
             sendJson(['ok' => true]);
             break;
@@ -3762,14 +3769,18 @@ if ($action !== null) {
                 break;
             }
 
-            $db = getDb();
+            $db = getDbMysqli();
 
             /* Verify the authenticated user owns this setlist */
             $stmt = $db->prepare(
                 'SELECT SetlistId FROM tblUserSetlists WHERE SetlistId = ? AND UserId = ?'
             );
-            $stmt->execute([$collabSetlistId, $authUser['Id']]);
-            if (!$stmt->fetch()) {
+            $authUserId = (int)$authUser['Id'];
+            $stmt->bind_param('si', $collabSetlistId, $authUserId);
+            $stmt->execute();
+            $owns = $stmt->get_result()->fetch_row() !== null;
+            $stmt->close();
+            if (!$owns) {
                 sendJson(['error' => 'You do not own this setlist or it does not exist.'], 403);
                 break;
             }
@@ -3783,8 +3794,10 @@ if ($action !== null) {
                  WHERE c.SetlistId = ?
                  ORDER BY c.CreatedAt ASC'
             );
-            $stmt->execute([$collabSetlistId]);
-            $collaborators = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            $stmt->bind_param('s', $collabSetlistId);
+            $stmt->execute();
+            $collaborators = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+            $stmt->close();
 
             foreach ($collaborators as &$collab) {
                 $collab['id'] = (int)$collab['id'];
@@ -3831,22 +3844,28 @@ if ($action !== null) {
                 break;
             }
 
-            $db = getDb();
+            $db = getDbMysqli();
+            $authUserId = (int)$authUser['Id'];
 
             /* Verify ownership */
             $stmt = $db->prepare(
                 'SELECT SetlistId FROM tblUserSetlists WHERE SetlistId = ? AND UserId = ?'
             );
-            $stmt->execute([$addSetlistId, $authUser['Id']]);
-            if (!$stmt->fetch()) {
+            $stmt->bind_param('si', $addSetlistId, $authUserId);
+            $stmt->execute();
+            $owns = $stmt->get_result()->fetch_row() !== null;
+            $stmt->close();
+            if (!$owns) {
                 sendJson(['error' => 'You do not own this setlist or it does not exist.'], 403);
                 break;
             }
 
             /* Find the user to add */
             $stmt = $db->prepare('SELECT Id FROM tblUsers WHERE Username = ? AND IsActive = 1');
-            $stmt->execute([$addUsername]);
-            $targetUser = $stmt->fetch(PDO::FETCH_ASSOC);
+            $stmt->bind_param('s', $addUsername);
+            $stmt->execute();
+            $targetUser = $stmt->get_result()->fetch_assoc();
+            $stmt->close();
 
             if (!$targetUser) {
                 sendJson(['error' => 'User not found.'], 404);
@@ -3856,7 +3875,7 @@ if ($action !== null) {
             $targetUserId = (int)$targetUser['Id'];
 
             /* Cannot add yourself */
-            if ($targetUserId === $authUser['Id']) {
+            if ($targetUserId === $authUserId) {
                 sendJson(['error' => 'You cannot add yourself as a collaborator.'], 400);
                 break;
             }
@@ -3867,7 +3886,9 @@ if ($action !== null) {
                  VALUES (?, ?, ?)
                  ON DUPLICATE KEY UPDATE Permission = VALUES(Permission)'
             );
-            $stmt->execute([$addSetlistId, $targetUserId, $addPermission]);
+            $stmt->bind_param('sis', $addSetlistId, $targetUserId, $addPermission);
+            $stmt->execute();
+            $stmt->close();
 
             sendJson(['ok' => true], 201);
             break;
@@ -3902,14 +3923,18 @@ if ($action !== null) {
                 break;
             }
 
-            $db = getDb();
+            $db = getDbMysqli();
+            $authUserId = (int)$authUser['Id'];
 
             /* Verify ownership */
             $stmt = $db->prepare(
                 'SELECT SetlistId FROM tblUserSetlists WHERE SetlistId = ? AND UserId = ?'
             );
-            $stmt->execute([$rmSetlistId, $authUser['Id']]);
-            if (!$stmt->fetch()) {
+            $stmt->bind_param('si', $rmSetlistId, $authUserId);
+            $stmt->execute();
+            $owns = $stmt->get_result()->fetch_row() !== null;
+            $stmt->close();
+            if (!$owns) {
                 sendJson(['error' => 'You do not own this setlist or it does not exist.'], 403);
                 break;
             }
@@ -3917,7 +3942,9 @@ if ($action !== null) {
             $stmt = $db->prepare(
                 'DELETE FROM tblSetlistCollaborators WHERE Id = ? AND SetlistId = ?'
             );
-            $stmt->execute([$rmCollabId, $rmSetlistId]);
+            $stmt->bind_param('is', $rmCollabId, $rmSetlistId);
+            $stmt->execute();
+            $stmt->close();
 
             sendJson(['ok' => true]);
             break;
@@ -3943,7 +3970,7 @@ if ($action !== null) {
                 break;
             }
 
-            $db = getDb();
+            $db = getDbMysqli();
             $stmt = $db->prepare(
                 'SELECT r.Id AS id, r.SongId AS songId, r.Action AS action,
                         r.Status AS status, r.ChangesJson AS changesJson,
@@ -3958,8 +3985,10 @@ if ($action !== null) {
                  ORDER BY r.CreatedAt DESC
                  LIMIT 100'
             );
-            $stmt->execute([$revSongId]);
-            $revisions = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            $stmt->bind_param('s', $revSongId);
+            $stmt->execute();
+            $revisions = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+            $stmt->close();
 
             foreach ($revisions as &$rev) {
                 $rev['id'] = (int)$rev['id'];
@@ -3982,8 +4011,8 @@ if ($action !== null) {
                 break;
             }
 
-            $db = getDb();
-            $stmt = $db->query(
+            $db = getDbMysqli();
+            $stmt = $db->prepare(
                 'SELECT r.Id AS id, r.SongId AS songId, r.Action AS action,
                         r.Status AS status, r.ChangesJson AS changesJson,
                         r.Notes AS notes, r.CreatedAt AS createdAt,
@@ -3994,7 +4023,9 @@ if ($action !== null) {
                  ORDER BY r.CreatedAt ASC
                  LIMIT 200'
             );
-            $revisions = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            $stmt->execute();
+            $revisions = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+            $stmt->close();
 
             foreach ($revisions as &$rev) {
                 $rev['id'] = (int)$rev['id'];
@@ -4023,12 +4054,14 @@ if ($action !== null) {
                 break;
             }
 
-            $db = getDb();
+            $db = getDbMysqli();
 
             /* Verify the source song exists and get its songbook */
             $stmt = $db->prepare('SELECT SongId, SongbookAbbr FROM tblSongs WHERE SongId = ?');
-            $stmt->execute([$songId]);
-            $sourceSong = $stmt->fetch(PDO::FETCH_ASSOC);
+            $stmt->bind_param('s', $songId);
+            $stmt->execute();
+            $sourceSong = $stmt->get_result()->fetch_assoc();
+            $stmt->close();
             if (!$sourceSong) {
                 sendJson(['error' => 'Song not found.'], 404);
                 break;
@@ -4047,14 +4080,16 @@ if ($action !== null) {
                  WHERE w1.SongId = ?
                  LIMIT 20'
             );
-            $stmt->execute([$songId]);
-            foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $stmt->bind_param('s', $songId);
+            $stmt->execute();
+            foreach ($stmt->get_result()->fetch_all(MYSQLI_ASSOC) as $row) {
                 if (isset($seenIds[$row['id']])) continue;
                 $seenIds[$row['id']] = true;
                 $row['number'] = (int)$row['number'];
                 $row['reason'] = 'Same writer: ' . $row['reason'];
                 $related[] = $row;
             }
+            $stmt->close();
 
             /* 2. Songs by the same composer(s) */
             $stmt = $db->prepare(
@@ -4066,14 +4101,16 @@ if ($action !== null) {
                  WHERE c1.SongId = ?
                  LIMIT 20'
             );
-            $stmt->execute([$songId]);
-            foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $stmt->bind_param('s', $songId);
+            $stmt->execute();
+            foreach ($stmt->get_result()->fetch_all(MYSQLI_ASSOC) as $row) {
                 if (isset($seenIds[$row['id']])) continue;
                 $seenIds[$row['id']] = true;
                 $row['number'] = (int)$row['number'];
                 $row['reason'] = 'Same composer: ' . $row['reason'];
                 $related[] = $row;
             }
+            $stmt->close();
 
             /* 3. Songs with shared tags */
             $stmt = $db->prepare(
@@ -4086,16 +4123,20 @@ if ($action !== null) {
                  WHERE tm1.SongId = ?
                  LIMIT 20'
             );
-            $stmt->execute([$songId]);
-            foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $stmt->bind_param('s', $songId);
+            $stmt->execute();
+            foreach ($stmt->get_result()->fetch_all(MYSQLI_ASSOC) as $row) {
                 if (isset($seenIds[$row['id']])) continue;
                 $seenIds[$row['id']] = true;
                 $row['number'] = (int)$row['number'];
                 $row['reason'] = 'Shared tag: ' . $row['reason'];
                 $related[] = $row;
             }
+            $stmt->close();
 
-            /* 4. Same songbook (fill remaining slots) */
+            /* 4. Same songbook (fill remaining slots).
+               Dynamic IN-list of song IDs to exclude (all strings),
+               with the songbook code as the first bind. */
             if (count($related) < $relLimit) {
                 $remaining = $relLimit - count($related);
                 $excludeIds = array_keys($seenIds);
@@ -4109,12 +4150,14 @@ if ($action !== null) {
                      LIMIT " . (int)$remaining
                 );
                 $params = array_merge([$sourceSong['SongbookAbbr']], $excludeIds);
-                $stmt->execute($params);
-                foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+                $stmt->bind_param(str_repeat('s', count($params)), ...$params);
+                $stmt->execute();
+                foreach ($stmt->get_result()->fetch_all(MYSQLI_ASSOC) as $row) {
                     $row['number'] = (int)$row['number'];
                     $row['reason'] = 'Same songbook';
                     $related[] = $row;
                 }
+                $stmt->close();
             }
 
             /* Trim to requested limit */
@@ -4143,29 +4186,35 @@ if ($action !== null) {
                 break;
             }
 
-            $db = getDb();
+            $db = getDbMysqli();
 
             /* Fetch all songs with writers and composers */
-            $stmt = $db->query(
+            $stmt = $db->prepare(
                 'SELECT s.SongId, s.Number, s.Title, s.SongbookAbbr, s.SongbookName,
                         s.Language, s.Copyright, s.Ccli, s.Verified, s.HasAudio, s.HasSheetMusic,
                         s.LyricsText
                  FROM tblSongs s
                  ORDER BY s.SongbookAbbr, s.Number'
             );
-            $songs = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            $stmt->execute();
+            $songs = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+            $stmt->close();
 
             /* Pre-fetch writers and composers keyed by SongId */
             $writerMap = [];
             $composerMap = [];
-            $wStmt = $db->query('SELECT SongId, Name FROM tblSongWriters ORDER BY SongId, Id');
-            foreach ($wStmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $wStmt = $db->prepare('SELECT SongId, Name FROM tblSongWriters ORDER BY SongId, Id');
+            $wStmt->execute();
+            foreach ($wStmt->get_result()->fetch_all(MYSQLI_ASSOC) as $row) {
                 $writerMap[$row['SongId']][] = $row['Name'];
             }
-            $cStmt = $db->query('SELECT SongId, Name FROM tblSongComposers ORDER BY SongId, Id');
-            foreach ($cStmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $wStmt->close();
+            $cStmt = $db->prepare('SELECT SongId, Name FROM tblSongComposers ORDER BY SongId, Id');
+            $cStmt->execute();
+            foreach ($cStmt->get_result()->fetch_all(MYSQLI_ASSOC) as $row) {
                 $composerMap[$row['SongId']][] = $row['Name'];
             }
+            $cStmt->close();
 
             switch ($format) {
                 case 'json':
@@ -4298,16 +4347,19 @@ if ($action !== null) {
             $filterBook = isset($_GET['songbook']) ? trim($_GET['songbook']) : null;
             if ($filterBook === '') $filterBook = null;
 
-            $db = getDb();
+            $db = getDbMysqli();
 
             /* Get songbooks to report on */
             if ($filterBook) {
                 $stmt = $db->prepare('SELECT Abbreviation FROM tblSongbooks WHERE Abbreviation = ?');
-                $stmt->execute([$filterBook]);
+                $stmt->bind_param('s', $filterBook);
+                $stmt->execute();
             } else {
-                $stmt = $db->query('SELECT Abbreviation FROM tblSongbooks ORDER BY Abbreviation');
+                $stmt = $db->prepare('SELECT Abbreviation FROM tblSongbooks ORDER BY Abbreviation');
+                $stmt->execute();
             }
-            $bookAbbrs = $stmt->fetchAll(PDO::FETCH_COLUMN);
+            $bookAbbrs = array_column($stmt->get_result()->fetch_all(MYSQLI_ASSOC), 'Abbreviation');
+            $stmt->close();
 
             if (empty($bookAbbrs)) {
                 sendJson(['error' => 'Songbook not found.'], 404);
@@ -4327,8 +4379,10 @@ if ($action !== null) {
                         SUM(Copyright != \'\') AS withCopyright
                      FROM tblSongs WHERE SongbookAbbr = ?'
                 );
-                $stmt->execute([$abbr]);
-                $counts = $stmt->fetch(PDO::FETCH_ASSOC);
+                $stmt->bind_param('s', $abbr);
+                $stmt->execute();
+                $counts = $stmt->get_result()->fetch_assoc();
+                $stmt->close();
 
                 $totalSongs = (int)$counts['totalSongs'];
 
@@ -4339,8 +4393,11 @@ if ($action !== null) {
                      JOIN tblSongWriters w ON w.SongId = s.SongId
                      WHERE s.SongbookAbbr = ?'
                 );
-                $stmt->execute([$abbr]);
-                $withWriters = (int)$stmt->fetchColumn();
+                $stmt->bind_param('s', $abbr);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_row();
+                $stmt->close();
+                $withWriters = (int)($row[0] ?? 0);
 
                 /* Composers count */
                 $stmt = $db->prepare(
@@ -4349,15 +4406,20 @@ if ($action !== null) {
                      JOIN tblSongComposers c ON c.SongId = s.SongId
                      WHERE s.SongbookAbbr = ?'
                 );
-                $stmt->execute([$abbr]);
-                $withComposers = (int)$stmt->fetchColumn();
+                $stmt->bind_param('s', $abbr);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_row();
+                $stmt->close();
+                $withComposers = (int)($row[0] ?? 0);
 
                 /* Missing numbers: find gaps in the number sequence */
                 $stmt = $db->prepare(
                     'SELECT Number FROM tblSongs WHERE SongbookAbbr = ? ORDER BY Number'
                 );
-                $stmt->execute([$abbr]);
-                $existingNumbers = $stmt->fetchAll(PDO::FETCH_COLUMN);
+                $stmt->bind_param('s', $abbr);
+                $stmt->execute();
+                $existingNumbers = array_column($stmt->get_result()->fetch_all(MYSQLI_ASSOC), 'Number');
+                $stmt->close();
                 $existingNumbers = array_map('intval', $existingNumbers);
 
                 $missingNumbers = [];
@@ -4431,12 +4493,14 @@ if ($action !== null) {
                 break;
             }
 
-            $db = getDb();
+            $db = getDbMysqli();
 
             /* Verify revision exists and is pending */
             $stmt = $db->prepare('SELECT Id, Status FROM tblSongRevisions WHERE Id = ?');
-            $stmt->execute([$revisionId]);
-            $revision = $stmt->fetch(PDO::FETCH_ASSOC);
+            $stmt->bind_param('i', $revisionId);
+            $stmt->execute();
+            $revision = $stmt->get_result()->fetch_assoc();
+            $stmt->close();
 
             if (!$revision) {
                 sendJson(['error' => 'Revision not found.'], 404);
@@ -4451,7 +4515,10 @@ if ($action !== null) {
             $stmt = $db->prepare(
                 'UPDATE tblSongRevisions SET Status = ?, ReviewedBy = ?, ReviewNote = ? WHERE Id = ?'
             );
-            $stmt->execute([$newStatus, $authUser['Id'], $reviewNote, $revisionId]);
+            $authUserId = (int)$authUser['Id'];
+            $stmt->bind_param('sisi', $newStatus, $authUserId, $reviewNote, $revisionId);
+            $stmt->execute();
+            $stmt->close();
 
             sendJson(['ok' => true, 'status' => $newStatus]);
             break;
@@ -4491,18 +4558,23 @@ if ($action !== null) {
                 break;
             }
 
-            $db = getDb();
+            $db = getDbMysqli();
+            $authUserId = (int)$authUser['Id'];
 
             /* Upsert: delete any existing subscription with the same endpoint for this user,
              * then insert the new one */
             $stmt = $db->prepare('DELETE FROM tblPushSubscriptions WHERE UserId = ? AND Endpoint = ?');
-            $stmt->execute([$authUser['Id'], $pushEndpoint]);
+            $stmt->bind_param('is', $authUserId, $pushEndpoint);
+            $stmt->execute();
+            $stmt->close();
 
             $stmt = $db->prepare(
                 'INSERT INTO tblPushSubscriptions (UserId, Endpoint, P256dhKey, AuthKey)
                  VALUES (?, ?, ?, ?)'
             );
-            $stmt->execute([$authUser['Id'], $pushEndpoint, $pushP256dh, $pushAuth]);
+            $stmt->bind_param('isss', $authUserId, $pushEndpoint, $pushP256dh, $pushAuth);
+            $stmt->execute();
+            $stmt->close();
 
             sendJson(['ok' => true]);
             break;
@@ -4533,11 +4605,15 @@ if ($action !== null) {
                 break;
             }
 
-            $db = getDb();
+            $db = getDbMysqli();
             $stmt = $db->prepare('DELETE FROM tblPushSubscriptions WHERE Endpoint = ? AND UserId = ?');
-            $stmt->execute([$pushEndpoint, $authUser['Id']]);
+            $authUserId = (int)$authUser['Id'];
+            $stmt->bind_param('si', $pushEndpoint, $authUserId);
+            $stmt->execute();
+            $deleted = $stmt->affected_rows;
+            $stmt->close();
 
-            sendJson(['ok' => true, 'deleted' => $stmt->rowCount()]);
+            sendJson(['ok' => true, 'deleted' => $deleted]);
             break;
 
         /* -----------------------------------------------------------------
@@ -4558,28 +4634,35 @@ if ($action !== null) {
                 break;
             }
 
-            $db = getDb();
+            $db = getDbMysqli();
             $now = gmdate('c');
 
             /* Expired API tokens */
             $stmt = $db->prepare('DELETE FROM tblApiTokens WHERE ExpiresAt < ?');
-            $stmt->execute([$now]);
-            $deletedApiTokens = $stmt->rowCount();
+            $stmt->bind_param('s', $now);
+            $stmt->execute();
+            $deletedApiTokens = $stmt->affected_rows;
+            $stmt->close();
 
             /* Expired or used email login tokens */
             $stmt = $db->prepare('DELETE FROM tblEmailLoginTokens WHERE ExpiresAt < ? OR Used = 1');
-            $stmt->execute([$now]);
-            $deletedEmailTokens = $stmt->rowCount();
+            $stmt->bind_param('s', $now);
+            $stmt->execute();
+            $deletedEmailTokens = $stmt->affected_rows;
+            $stmt->close();
 
             /* Expired or used password reset tokens */
             $stmt = $db->prepare('DELETE FROM tblPasswordResetTokens WHERE ExpiresAt < ? OR Used = 1');
-            $stmt->execute([$now]);
-            $deletedResetTokens = $stmt->rowCount();
+            $stmt->bind_param('s', $now);
+            $stmt->execute();
+            $deletedResetTokens = $stmt->affected_rows;
+            $stmt->close();
 
             /* Old login attempts (30+ days) */
             $stmt = $db->prepare('DELETE FROM tblLoginAttempts WHERE AttemptedAt < DATE_SUB(NOW(), INTERVAL 30 DAY)');
             $stmt->execute();
-            $deletedLoginAttempts = $stmt->rowCount();
+            $deletedLoginAttempts = $stmt->affected_rows;
+            $stmt->close();
 
             sendJson([
                 'ok' => true,
@@ -4632,19 +4715,29 @@ if ($action !== null) {
             }
 
             /* Save to user profile */
-            $db = getDb();
+            $db = getDbMysqli();
+            $authUserId = (int)$authUser['Id'];
+            $normalized = $validation['normalized'];
             $stmt = $db->prepare(
                 'UPDATE tblUsers SET CcliNumber = ?, CcliVerified = 1, UpdatedAt = NOW() WHERE Id = ?'
             );
-            $stmt->execute([$validation['normalized'], $authUser['Id']]);
+            $stmt->bind_param('si', $normalized, $authUserId);
+            $stmt->execute();
+            $stmt->close();
 
             /* If user is on 'free' tier, auto-upgrade to 'ccli' */
             $stmt = $db->prepare('SELECT AccessTier FROM tblUsers WHERE Id = ?');
-            $stmt->execute([$authUser['Id']]);
-            $currentTier = $stmt->fetchColumn();
+            $stmt->bind_param('i', $authUserId);
+            $stmt->execute();
+            $row = $stmt->get_result()->fetch_row();
+            $stmt->close();
+            $currentTier = (string)($row[0] ?? '');
             if ($currentTier === 'free' || $currentTier === 'public') {
                 $stmt = $db->prepare('UPDATE tblUsers SET AccessTier = ? WHERE Id = ?');
-                $stmt->execute(['ccli', $authUser['Id']]);
+                $ccliTier = 'ccli';
+                $stmt->bind_param('si', $ccliTier, $authUserId);
+                $stmt->execute();
+                $stmt->close();
             }
 
             sendJson([
@@ -4676,10 +4769,13 @@ if ($action !== null) {
             if ($authUser) {
                 /* Resolve effective tier: highest of personal + org tiers */
                 $userTier = resolveEffectiveTier($authUser['Id']);
-                $db = getDb();
+                $db = getDbMysqli();
                 $stmt = $db->prepare('SELECT CcliNumber, CcliVerified FROM tblUsers WHERE Id = ?');
-                $stmt->execute([$authUser['Id']]);
-                $userData = $stmt->fetch(PDO::FETCH_ASSOC);
+                $authUserId = (int)$authUser['Id'];
+                $stmt->bind_param('i', $authUserId);
+                $stmt->execute();
+                $userData = $stmt->get_result()->fetch_assoc();
+                $stmt->close();
                 $hasCcli = !empty($userData['CcliNumber']) && $userData['CcliVerified'];
             }
 
@@ -4692,8 +4788,8 @@ if ($action !== null) {
          * Get available access tiers (public)
          * ----------------------------------------------------------------- */
         case 'access_tiers':
-            $db = getDb();
-            $stmt = $db->query(
+            $db = getDbMysqli();
+            $stmt = $db->prepare(
                 'SELECT Name AS name, DisplayName AS displayName, Level AS level,
                         Description AS description, CanViewLyrics AS canViewLyrics,
                         CanViewCopyrighted AS canViewCopyrighted, CanPlayAudio AS canPlayAudio,
@@ -4701,7 +4797,9 @@ if ($action !== null) {
                         CanOfflineSave AS canOfflineSave, RequiresCcli AS requiresCcli
                  FROM tblAccessTiers ORDER BY Level ASC'
             );
-            $tiers = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            $stmt->execute();
+            $tiers = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+            $stmt->close();
             foreach ($tiers as &$t) {
                 $t['level'] = (int)$t['level'];
                 foreach (['canViewLyrics','canViewCopyrighted','canPlayAudio','canDownloadMidi','canDownloadPdf','canOfflineSave','requiresCcli'] as $k) {
@@ -4740,9 +4838,11 @@ if ($action !== null) {
                 break;
             }
 
-            $db = getDb();
+            $db = getDbMysqli();
             $stmt = $db->prepare('UPDATE tblUsers SET AccessTier = ?, UpdatedAt = NOW() WHERE Id = ?');
-            $stmt->execute([$newTier, $targetUserId]);
+            $stmt->bind_param('si', $newTier, $targetUserId);
+            $stmt->execute();
+            $stmt->close();
 
             sendJson(['ok' => true, 'tier' => $newTier]);
             break;
@@ -4778,9 +4878,12 @@ if ($action !== null) {
 
             if ($ccliInput === '') {
                 /* Clear CCLI number */
-                $db = getDb();
+                $db = getDbMysqli();
                 $stmt = $db->prepare('UPDATE tblUsers SET CcliNumber = ?, CcliVerified = 0, UpdatedAt = NOW() WHERE Id = ?');
-                $stmt->execute(['', $targetUserId]);
+                $emptyStr = '';
+                $stmt->bind_param('si', $emptyStr, $targetUserId);
+                $stmt->execute();
+                $stmt->close();
                 sendJson(['ok' => true, 'cleared' => true]);
                 break;
             }
@@ -4791,11 +4894,14 @@ if ($action !== null) {
                 break;
             }
 
-            $db = getDb();
+            $db = getDbMysqli();
             $stmt = $db->prepare('UPDATE tblUsers SET CcliNumber = ?, CcliVerified = 1, UpdatedAt = NOW() WHERE Id = ?');
-            $stmt->execute([$validation['normalized'], $targetUserId]);
+            $normalized = $validation['normalized'];
+            $stmt->bind_param('si', $normalized, $targetUserId);
+            $stmt->execute();
+            $stmt->close();
 
-            sendJson(['ok' => true, 'normalized' => $validation['normalized']]);
+            sendJson(['ok' => true, 'normalized' => $normalized]);
             break;
 
         case 'admin_organisations':
@@ -4805,8 +4911,8 @@ if ($action !== null) {
                 break;
             }
 
-            $db = getDb();
-            $stmt = $db->query(
+            $db = getDbMysqli();
+            $stmt = $db->prepare(
                 'SELECT o.Id AS id, o.Name AS name, o.Slug AS slug,
                         o.ParentOrgId AS parentOrgId, o.LicenceType AS licenceType,
                         o.LicenceNumber AS licenceNumber, o.LicenceExpiresAt AS licenceExpiresAt,
@@ -4815,7 +4921,9 @@ if ($action !== null) {
                  FROM tblOrganisations o
                  ORDER BY o.Name ASC'
             );
-            $orgs = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            $stmt->execute();
+            $orgs = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+            $stmt->close();
             foreach ($orgs as &$org) {
                 $org['id'] = (int)$org['id'];
                 $org['parentOrgId'] = $org['parentOrgId'] ? (int)$org['parentOrgId'] : null;
@@ -4861,22 +4969,30 @@ if ($action !== null) {
             }
 
             try {
-                $db = getDb();
+                $db = getDbMysqli();
+                $authUserId = (int)$authUser['Id'];
                 /* Verify the caller owns the setlist */
                 $own = $db->prepare('SELECT 1 FROM tblUserSetlists WHERE UserId = ? AND SetlistId = ? LIMIT 1');
-                $own->execute([(int)$authUser['Id'], $setlistId]);
-                if (!$own->fetchColumn()) {
+                $own->bind_param('is', $authUserId, $setlistId);
+                $own->execute();
+                $owns = $own->get_result()->fetch_row() !== null;
+                $own->close();
+                if (!$owns) {
                     sendJson(['error' => 'Setlist not found.'], 404);
                     break;
                 }
                 /* Replace any existing schedule for this (user, setlist) pair. */
                 $del = $db->prepare('DELETE FROM tblSetlistSchedule WHERE UserId = ? AND SetlistId = ?');
-                $del->execute([(int)$authUser['Id'], $setlistId]);
+                $del->bind_param('is', $authUserId, $setlistId);
+                $del->execute();
+                $del->close();
                 $ins = $db->prepare(
                     'INSERT INTO tblSetlistSchedule (SetlistId, UserId, ScheduledDate, Notes)
                      VALUES (?, ?, ?, ?)'
                 );
-                $ins->execute([$setlistId, (int)$authUser['Id'], $dateStr, $notes]);
+                $ins->bind_param('siss', $setlistId, $authUserId, $dateStr, $notes);
+                $ins->execute();
+                $ins->close();
                 logActivity('setlist.schedule_set', 'setlist', $setlistId, [
                     'date'      => $dateStr,
                     'has_notes' => $notes !== '',
@@ -4901,10 +5017,14 @@ if ($action !== null) {
             if ($setlistId === '') { sendJson(['error' => 'setlistId required.'], 400); break; }
 
             try {
-                $db = getDb();
+                $db = getDbMysqli();
                 $stmt = $db->prepare('DELETE FROM tblSetlistSchedule WHERE UserId = ? AND SetlistId = ?');
-                $stmt->execute([(int)$authUser['Id'], $setlistId]);
-                if ($stmt->rowCount() > 0) {
+                $authUserId = (int)$authUser['Id'];
+                $stmt->bind_param('is', $authUserId, $setlistId);
+                $stmt->execute();
+                $affected = $stmt->affected_rows;
+                $stmt->close();
+                if ($affected > 0) {
                     logActivity('setlist.schedule_clear', 'setlist', $setlistId);
                 }
                 sendJson(['ok' => true]);
@@ -4920,7 +5040,7 @@ if ($action !== null) {
             if (!$authUser) { sendJson(['error' => 'Unauthorized'], 401); break; }
 
             try {
-                $db = getDb();
+                $db = getDbMysqli();
                 $stmt = $db->prepare(
                     'SELECT s.SetlistId, s.ScheduledDate, s.Notes, l.Name AS name
                        FROM tblSetlistSchedule s
@@ -4930,8 +5050,11 @@ if ($action !== null) {
                       ORDER BY s.ScheduledDate ASC
                       LIMIT 25'
                 );
-                $stmt->execute([(int)$authUser['Id']]);
-                $upcoming = $stmt->fetchAll(PDO::FETCH_ASSOC);
+                $authUserId = (int)$authUser['Id'];
+                $stmt->bind_param('i', $authUserId);
+                $stmt->execute();
+                $upcoming = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+                $stmt->close();
                 sendJson(['upcoming' => $upcoming]);
             } catch (\Throwable $e) {
                 error_log('[setlist_schedule_upcoming] ' . $e->getMessage());
@@ -4955,15 +5078,18 @@ if ($action !== null) {
             $setlistId = trim((string)($_GET['setlistId'] ?? ''));
             if ($setlistId === '') { sendJson(['error' => 'setlistId required.'], 400); break; }
             try {
-                $db = getDb();
+                $db = getDbMysqli();
                 $stmt = $db->prepare(
                     'SELECT ScheduledDate, Notes
                        FROM tblSetlistSchedule
                       WHERE UserId = ? AND SetlistId = ?
                       LIMIT 1'
                 );
-                $stmt->execute([(int)$authUser['Id'], $setlistId]);
-                $row = $stmt->fetch(PDO::FETCH_ASSOC);
+                $authUserId = (int)$authUser['Id'];
+                $stmt->bind_param('is', $authUserId, $setlistId);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_assoc();
+                $stmt->close();
                 sendJson(['schedule' => $row ?: null]);
             } catch (\Throwable $e) {
                 error_log('[setlist_schedule_current] ' . $e->getMessage());
@@ -5001,21 +5127,28 @@ if ($action !== null) {
                 break;
             }
             try {
-                $db = getDb();
+                $db = getDbMysqli();
+                $authUserId = (int)$authUser['Id'];
                 /* Owner check */
                 $own = $db->prepare('SELECT 1 FROM tblUserSetlists WHERE UserId = ? AND SetlistId = ? LIMIT 1');
-                $own->execute([(int)$authUser['Id'], $setlistId]);
-                if (!$own->fetchColumn()) { sendJson(['error' => 'Setlist not found.'], 404); break; }
+                $own->bind_param('is', $authUserId, $setlistId);
+                $own->execute();
+                $owns = $own->get_result()->fetch_row() !== null;
+                $own->close();
+                if (!$owns) { sendJson(['error' => 'Setlist not found.'], 404); break; }
 
                 /* Resolve collaborator by email */
                 $usr = $db->prepare('SELECT Id, Username FROM tblUsers WHERE Email = ? LIMIT 1');
-                $usr->execute([$collabEml]);
-                $collab = $usr->fetch(PDO::FETCH_ASSOC);
+                $usr->bind_param('s', $collabEml);
+                $usr->execute();
+                $collab = $usr->get_result()->fetch_assoc();
+                $usr->close();
                 if (!$collab) {
                     sendJson(['error' => 'No user with that email yet — ask them to sign in first.'], 404);
                     break;
                 }
-                if ((int)$collab['Id'] === (int)$authUser['Id']) {
+                $collabId = (int)$collab['Id'];
+                if ($collabId === $authUserId) {
                     sendJson(['error' => 'You cannot invite yourself.'], 400);
                     break;
                 }
@@ -5025,7 +5158,9 @@ if ($action !== null) {
                      VALUES (?, ?, ?, ?)
                      ON DUPLICATE KEY UPDATE Permission = VALUES(Permission)'
                 );
-                $ins->execute([(int)$authUser['Id'], $setlistId, (int)$collab['Id'], $permission]);
+                $ins->bind_param('isis', $authUserId, $setlistId, $collabId, $permission);
+                $ins->execute();
+                $ins->close();
 
                 /* Record the invite into the rate-limit counter so the
                    per-user/hour cap can actually trip. Bucket key
@@ -5061,7 +5196,7 @@ if ($action !== null) {
             $setlistId = trim((string)($_GET['setlistId'] ?? ''));
             if ($setlistId === '') { sendJson(['error' => 'setlistId required.'], 400); break; }
             try {
-                $db = getDb();
+                $db = getDbMysqli();
                 $stmt = $db->prepare(
                     'SELECT c.CollaboratorId AS id, u.Username AS username, u.Email AS email,
                             c.Permission AS permission, c.InvitedAt AS invitedAt
@@ -5070,8 +5205,11 @@ if ($action !== null) {
                       WHERE c.SetlistOwnerId = ? AND c.SetlistId = ?
                       ORDER BY c.InvitedAt DESC'
                 );
-                $stmt->execute([(int)$authUser['Id'], $setlistId]);
-                $list = $stmt->fetchAll(PDO::FETCH_ASSOC);
+                $authUserId = (int)$authUser['Id'];
+                $stmt->bind_param('is', $authUserId, $setlistId);
+                $stmt->execute();
+                $list = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+                $stmt->close();
                 sendJson(['collaborators' => $list]);
             } catch (\Throwable $e) {
                 error_log('[setlist_collab_list] ' . $e->getMessage());
@@ -5094,18 +5232,22 @@ if ($action !== null) {
                 break;
             }
             try {
-                $db = getDb();
+                $db = getDbMysqli();
                 $stmt = $db->prepare(
                     'DELETE FROM tblSetlistCollaborators
                       WHERE SetlistOwnerId = ? AND SetlistId = ? AND CollaboratorId = ?'
                 );
-                $stmt->execute([(int)$authUser['Id'], $setlistId, $collabId]);
-                if ($stmt->rowCount() > 0) {
+                $authUserId = (int)$authUser['Id'];
+                $stmt->bind_param('isi', $authUserId, $setlistId, $collabId);
+                $stmt->execute();
+                $removed = $stmt->affected_rows;
+                $stmt->close();
+                if ($removed > 0) {
                     logActivity('setlist.collab_remove', 'setlist', $setlistId, [
                         'collaborator_id' => $collabId,
                     ]);
                 }
-                sendJson(['ok' => true, 'removed' => $stmt->rowCount()]);
+                sendJson(['ok' => true, 'removed' => $removed]);
             } catch (\Throwable $e) {
                 error_log('[setlist_collab_remove] ' . $e->getMessage());
                 logActivityError('setlist.collab_remove', 'setlist', $setlistId, $e);
@@ -5117,7 +5259,7 @@ if ($action !== null) {
             $authUser = getAuthenticatedUser();
             if (!$authUser) { sendJson(['error' => 'Unauthorized'], 401); break; }
             try {
-                $db = getDb();
+                $db = getDbMysqli();
                 $stmt = $db->prepare(
                     'SELECT c.SetlistOwnerId AS ownerId, u.Username AS ownerName,
                             c.SetlistId AS setlistId, c.Permission AS permission,
@@ -5129,8 +5271,11 @@ if ($action !== null) {
                       WHERE c.CollaboratorId = ?
                       ORDER BY c.InvitedAt DESC'
                 );
-                $stmt->execute([(int)$authUser['Id']]);
-                $shared = $stmt->fetchAll(PDO::FETCH_ASSOC);
+                $authUserId = (int)$authUser['Id'];
+                $stmt->bind_param('i', $authUserId);
+                $stmt->execute();
+                $shared = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+                $stmt->close();
                 sendJson(['shared' => $shared]);
             } catch (\Throwable $e) {
                 error_log('[setlist_collab_shared_with_me] ' . $e->getMessage());
@@ -5172,14 +5317,17 @@ if ($action !== null) {
             }
 
             try {
-                $db = getDb();
+                $db = getDbMysqli();
 
                 /* Rate-limit: reject if this IP has ≥5 submissions in the last 24 h. */
                 $stmt = $db->prepare(
                     'SELECT COUNT(*) FROM tblSongRequests WHERE IpAddress = ? AND CreatedAt > (NOW() - INTERVAL 1 DAY)'
                 );
-                $stmt->execute([$ip]);
-                if ((int)$stmt->fetchColumn() >= 5) {
+                $stmt->bind_param('s', $ip);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_row();
+                $stmt->close();
+                if ((int)($row[0] ?? 0) >= 5) {
                     sendJson(['error' => 'You have submitted several requests recently. Please try again tomorrow.'], 429);
                     break;
                 }
@@ -5193,8 +5341,11 @@ if ($action !== null) {
                         (Title, Songbook, Details, ContactEmail, UserId, IpAddress, Status)
                      VALUES (?, ?, ?, ?, ?, ?, "pending")'
                 );
-                $stmt->execute([$title, $book, $details, $email, $userId, $ip]);
-                $trackingId = (int)$db->lastInsertId();
+                /* UserId(i nullable) — anonymous submissions OK. */
+                $stmt->bind_param('ssssis', $title, $book, $details, $email, $userId, $ip);
+                $stmt->execute();
+                $trackingId = (int)$db->insert_id;
+                $stmt->close();
 
                 /* Audit (#535). Public endpoint — userId may be null
                    for anonymous submissions; logActivityResolveUserId()
@@ -5283,7 +5434,7 @@ if ($action !== null) {
                 break;
             }
             try {
-                $db = getDb();
+                $db = getDbMysqli();
                 $stmt = $db->prepare(
                     'SELECT Id AS id,
                             Type AS type,
@@ -5297,8 +5448,11 @@ if ($action !== null) {
                       ORDER BY IsRead ASC, CreatedAt DESC
                       LIMIT 50'
                 );
-                $stmt->execute([(int)$authUser['Id']]);
-                $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+                $authUserId = (int)$authUser['Id'];
+                $stmt->bind_param('i', $authUserId);
+                $stmt->execute();
+                $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+                $stmt->close();
                 foreach ($rows as &$r) {
                     $r['id']      = (int)$r['id'];
                     $r['is_read'] = (bool)$r['is_read'];
@@ -5329,14 +5483,17 @@ if ($action !== null) {
             $body   = json_decode(file_get_contents('php://input'), true) ?: [];
             $userId = (int)$authUser['Id'];
             try {
-                $db = getDb();
+                $db = getDbMysqli();
                 if (!empty($body['all'])) {
                     $stmt = $db->prepare(
                         'UPDATE tblNotifications SET IsRead = 1
                           WHERE UserId = ? AND IsRead = 0'
                     );
-                    $stmt->execute([$userId]);
-                    sendJson(['ok' => true, 'affected' => $stmt->rowCount()]);
+                    $stmt->bind_param('i', $userId);
+                    $stmt->execute();
+                    $affected = $stmt->affected_rows;
+                    $stmt->close();
+                    sendJson(['ok' => true, 'affected' => $affected]);
                     break;
                 }
                 $ids = array_values(array_filter(array_map('intval', (array)($body['ids'] ?? [])), fn($i) => $i > 0));
@@ -5349,8 +5506,13 @@ if ($action !== null) {
                     "UPDATE tblNotifications SET IsRead = 1
                       WHERE UserId = ? AND Id IN ($placeholders)"
                 );
-                $stmt->execute(array_merge([$userId], $ids));
-                sendJson(['ok' => true, 'affected' => $stmt->rowCount()]);
+                /* Dynamic IN-list: UserId(i) + ids…(all i). */
+                $params = array_merge([$userId], $ids);
+                $stmt->bind_param(str_repeat('i', count($params)), ...$params);
+                $stmt->execute();
+                $affected = $stmt->affected_rows;
+                $stmt->close();
+                sendJson(['ok' => true, 'affected' => $affected]);
             } catch (\Throwable $e) {
                 error_log('[notifications_mark_read] ' . $e->getMessage());
                 sendJson(['error' => 'Could not mark as read.'], 500);
@@ -5508,14 +5670,17 @@ function slideAuthTokenExpiry(string $rawToken): void
         $newExpiresAt = gmdate('c', $newExpiresTs);
         $threshold    = gmdate('c', time() + 29 * 86400);
 
-        $db = getDb();
+        $db = getDbMysqli();
         $stmt = $db->prepare(
             'UPDATE tblApiTokens SET ExpiresAt = ? WHERE Token = ? AND ExpiresAt < ?'
         );
-        $stmt->execute([$newExpiresAt, $hashedToken, $threshold]);
+        $stmt->bind_param('sss', $newExpiresAt, $hashedToken, $threshold);
+        $stmt->execute();
+        $bumped = $stmt->affected_rows > 0;
+        $stmt->close();
 
         /* If the DB row was bumped, push the cookie forward as well. */
-        if ($stmt->rowCount() > 0) {
+        if ($bumped) {
             setAuthTokenCookie($rawToken, $newExpiresTs);
         }
     } catch (\Throwable $e) {
@@ -5537,16 +5702,19 @@ function getAuthenticatedUser(): ?array
     $token = getAuthBearerToken();
     if (!$token) return null;
 
-    $db = getDb();
+    $db = getDbMysqli();
     $hashedToken = hash('sha256', $token);
+    $now = gmdate('c');
     $stmt = $db->prepare(
         'SELECT u.Id, u.Username, u.DisplayName, u.Role
          FROM tblApiTokens t
          JOIN tblUsers u ON u.Id = t.UserId
          WHERE t.Token = ? AND t.ExpiresAt > ? AND u.IsActive = 1'
     );
-    $stmt->execute([$hashedToken, gmdate('c')]);
-    $user = $stmt->fetch(PDO::FETCH_ASSOC);
+    $stmt->bind_param('ss', $hashedToken, $now);
+    $stmt->execute();
+    $user = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
 
     if (!$user) return null;
 


### PR DESCRIPTION
## Summary

**Final slice of api.php migration.** Stacked on [PR #570 (Batch 5c)](https://github.com/MWBMPartners/iHymns/pull/570) which stacks on [PR #569 (Batch 5b)](https://github.com/MWBMPartners/iHymns/pull/569). Once 5b + 5c land on alpha, this PR's base will be retargeted to alpha.

**After all four PRs (5a + 5b + 5c + 5d) merge, api.php contains ZERO `getDb()` calls.** The only remaining repo-wide PDO callers will be `editor/api.php` (Batch 6) and the `db.php` helper itself.

32 endpoints + 2 module-level helpers (`slideAuthTokenExpiry`, `getAuthenticatedUser`). Single commit. **No behavioural change.**

## Endpoints converted

**User preferences (2):** `user_preferences`, `user_preferences_sync`.
**Setlist collaborators — original API (3):** `setlist_collaborators`, `setlist_collaborator_add`, `setlist_collaborator_remove`.
**Song revisions (2):** `song_revisions`, `admin_pending_revisions`.
**Related songs (1):** Multi-source recommendation engine with dynamic IN-list for the same-songbook exclusion.
**Admin export (1):** Bulk JSON / CSV / XML / OpenSong / VideoPsalm export with pre-fetch maps.
**Admin songbook health (1):** Per-songbook completion dashboard with multiple metric queries in a loop.
**Admin revision review (1):** Approve / reject pending revisions.
**Push notifications (2):** `push_subscribe` (delete-then-insert upsert), `push_unsubscribe`.
**Admin cleanup (1):** Token / login-attempt expiry sweeps (4 DELETEs).
**CCLI + tier system (5):** `ccli_validate`, `tier_check`, `access_tiers`, `admin_set_user_tier`, `admin_set_user_ccli`.
**Admin organisations (1):** Admin org list with member counts.
**Setlist scheduling (4):** `setlist_schedule_set`, `setlist_schedule_clear`, `setlist_schedule_upcoming`, `setlist_schedule_current`.
**Setlist collaboration — invite-by-email API (4):** `setlist_collab_invite`, `setlist_collab_list`, `setlist_collab_remove`, `setlist_collab_shared_with_me`.
**Public song-request submission (1):** `song_request_submit` with rate-limit + honeypot + nullable-FK INSERT.
**Notifications (2):** `notifications_list`, `notifications_mark_read` with optional dynamic IN-list for batch UPDATE.

## Module-level helpers converted

| Helper | What it does | Why critical |
|---|---|---|
| `slideAuthTokenExpiry()` | Sliding 30-day token expiry | Called from every authenticated request via `getAuthenticatedUser()` |
| `getAuthenticatedUser()` | Bearer-token resolver | The canonical "who's calling" gate; entry point for almost every authenticated endpoint above |

## Patterns reused (no new tricks needed)

All conversion patterns established in earlier batches were sufficient:
- Same-userId-bound-twice for OR-on-id queries.
- Dynamic IN-list with `str_repeat` for multi-id batch operations (`related_songs` same-songbook exclusion, `notifications_mark_read` ids-array UPDATE).
- Nullable FK with type `'i'` for anonymous song requests + view tracking.
- Reused prepared statement in a loop (`admin_songbook_health` iterates per songbook).
- `affected_rows` captured before `close()`.

## Test plan (post-deploy on alpha — high-blast-radius surface)

After all four PRs merge, the entire public + admin API needs verification:

- [ ] **Sign in** end-to-end (every method) — token issued, `getAuthenticatedUser()` resolves correctly on subsequent requests.
- [ ] **Sliding expiry** — make an authenticated request with a token close to expiry; confirm the cookie + DB row both push forward by 30 days.
- [ ] **User preferences** GET + POST round-trip.
- [ ] **Setlist collaborator** invite (by email), list, remove via both old and new APIs.
- [ ] **Setlist scheduling** — set, clear, upcoming, current.
- [ ] **Push subscribe** + unsubscribe.
- [ ] **CCLI validate** as user → tier auto-upgrades from free → ccli.
- [ ] **Admin set tier / set CCLI** as admin.
- [ ] **Admin export** all five formats download cleanly.
- [ ] **Admin songbook-health** loads metrics for each songbook.
- [ ] **Admin revision review** — approve and reject a pending revision.
- [ ] **Admin cleanup** — clears expired tokens / login attempts.
- [ ] **Submit a song request** as anonymous (no token) → row with `UserId = NULL`.
- [ ] **Notifications** — list + mark-all-read + mark-specific-ids-read.
- [ ] **No new `error_log` entries** from `[api/...]` prefixes for any of the above.

## Cumulative progress

| Stage | `getDb()` callers | api.php count | Status |
|---|---|---|---|
| Before Batch 5 | 3 files (api.php, editor/api.php, db.php helper) | ~80 | — |
| After 5a merges | 3 | ~70 | #567 done |
| After 5b merges | 3 | ~50 | #569 in review |
| After 5c merges | 3 | ~30 | #570 in review |
| **After 5d merges** | **2 files** (editor/api.php, db.php helper) | **0** | This PR |
| After Batch 6 | 1 file (db.php helper) | 0 | TODO |
| After capstone #555 | 0 | 0 | TODO |

After this PR + 5b + 5c land, **24 / 26 files migrated (~92%)**. Only Batch 6 (`editor/api.php` — already mostly mysqli) and the capstone deletion of `getDb()` + `db.php` remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)