### PR TITLE
fix(manage): adopt API-token session so signed-in users skip /manage/login (#578)

### DIFF
--- a/appWeb/public_html/manage/includes/auth.php
+++ b/appWeb/public_html/manage/includes/auth.php
@@ -121,12 +121,109 @@ function initSession(): void
 /**
  * Check whether a user is currently logged in.
  *
+ * If the PHP session has no user but the cross-subdomain `ihymns_auth`
+ * cookie carries a valid API token (set by main-app sign-in via
+ * `auth_login` / `auth_email_login_verify` / `auth_register`), promote
+ * that token into the admin session so a user signed in on the main
+ * app doesn't get bounced to /manage/login when they click Manage.
+ * Without this, the two auth surfaces are independent — the main app
+ * uses the Bearer/cookie token, /manage/ uses PHP $_SESSION — and a
+ * curator/admin who's already signed in had to sign in twice. (#578)
+ *
  * @return bool True if authenticated
  */
 function isAuthenticated(): bool
 {
     initSession();
-    return isset($_SESSION['user_id']) && isset($_SESSION['username']);
+    if (isset($_SESSION['user_id']) && isset($_SESSION['username'])) {
+        return true;
+    }
+    return adoptApiTokenSession();
+}
+
+/**
+ * If the request carries a valid `ihymns_auth` cookie (the API token
+ * issued by the main-app sign-in flow), look it up in tblApiTokens and
+ * seed $_SESSION as if the user had signed in via /manage/login. The
+ * token must be unexpired and the user active. Sliding-expiry behaviour
+ * mirrors the main API (`getAuthenticatedUser` in api.php) so the same
+ * user being active on /manage/ keeps the token alive.
+ *
+ * Returns true on success (session now populated), false otherwise.
+ */
+function adoptApiTokenSession(): bool
+{
+    /* Cookie name + shape must match api.php. The cookie is httponly so
+       JS can't read it but the request carries it for us. */
+    if (empty($_COOKIE['ihymns_auth'])) {
+        return false;
+    }
+    $token = (string)$_COOKIE['ihymns_auth'];
+    if (!preg_match('/^[a-f0-9]{64}$/i', $token)) {
+        return false;
+    }
+
+    try {
+        $db          = getDbMysqli();
+        $hashedToken = hash('sha256', $token);
+        $now         = gmdate('c');
+        $stmt        = $db->prepare(
+            'SELECT u.Id        AS id,
+                    u.Username  AS username,
+                    t.ExpiresAt AS expires_at
+               FROM tblApiTokens t
+               JOIN tblUsers     u ON u.Id = t.UserId
+              WHERE t.Token     = ?
+                AND t.ExpiresAt > ?
+                AND u.IsActive  = 1'
+        );
+        $stmt->bind_param('ss', $hashedToken, $now);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+    } catch (\Throwable $e) {
+        error_log('[manage/auth] adoptApiTokenSession failed: ' . $e->getMessage());
+        return false;
+    }
+
+    if (!$row) {
+        return false;
+    }
+
+    /* Promote the token into $_SESSION exactly as /manage/login.php's
+       successful POST handler would. The rest of the admin surface
+       reads $_SESSION['user_id'] / ['username'] and never touches the
+       cookie directly, so this keeps the call sites unchanged. */
+    $_SESSION['user_id']       = (int)$row['id'];
+    $_SESSION['username']      = (string)$row['username'];
+    $_SESSION['last_activity'] = time();
+
+    /* Slide the token expiry (#390) so an active manage-side user
+       keeps their main-app sign-in alive too. The DB write is gated
+       to once-per-day-per-token by the main API helper; we duplicate
+       that gate here to keep the two paths consistent without having
+       to share code. */
+    try {
+        $cap = $row['expires_at'];
+        if (is_string($cap) && $cap !== '') {
+            $capTs    = strtotime($cap);
+            $nowTs    = time();
+            $newCapTs = $nowTs + 30 * 86400;
+            if ($capTs && ($newCapTs - $capTs) >= 86400) {
+                $stmt = $db->prepare(
+                    'UPDATE tblApiTokens SET ExpiresAt = ? WHERE Token = ? AND ExpiresAt < ?'
+                );
+                $newCap = gmdate('c', $newCapTs);
+                $stmt->bind_param('sss', $newCap, $hashedToken, $newCap);
+                $stmt->execute();
+                $stmt->close();
+            }
+        }
+    } catch (\Throwable $e) {
+        error_log('[manage/auth] sliding-expiry failed: ' . $e->getMessage());
+    }
+
+    return true;
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes [#578](https://github.com/MWBMPartners/iHymns/issues/578).

A user signed into the main app via `auth_login` / email-magic-link / `auth_register` holds a Bearer token in the **`ihymns_auth`** cookie (Domain=`.ihymns.app`, HttpOnly, sliding 30-day expiry). The `/manage/` surface checks PHP `$_SESSION` instead — independent state — so clicking **Manage** in the main-app dropdown bounced the user to `/manage/login` even though they were already authenticated.

## Fix

`isAuthenticated()` in `manage/includes/auth.php` now **promotes a valid `ihymns_auth` cookie into the admin session**:

1. If `$_SESSION['user_id']` is present, return true (current behaviour).
2. Otherwise, if the request carries a hex-shaped `ihymns_auth` cookie, look it up in `tblApiTokens` (joined to `tblUsers`, must be unexpired and the user active).
3. On success, seed `$_SESSION['user_id']` / `['username']` / `['last_activity']` exactly as `/manage/login.php`'s successful POST handler would.
4. Slide the token's expiry once per day so an active `/manage/` user keeps their main-app sign-in alive — mirroring `api.php`'s `getAuthenticatedUser`.
5. Fail-paths log and return false so a transient DB blip falls through to the existing `/manage/login` redirect rather than blocking with a 500.

The rest of the admin code reads `$_SESSION` and never touches the cookie directly, so no other call sites change.

## Verified

- `php -l` clean on the modified file.
- Logic walk-through against the existing `/manage/login.php` POST handler — the seeded session has the same shape.

## Test plan

- [ ] CI Lint & Validate passes.
- [ ] On alpha: sign into the main app, click **Manage** in the brand dropdown — confirm landing on `/manage/` dashboard, NOT `/manage/login`.
- [ ] Sign out from the main-app menu, then visit `/manage/` — confirm redirect to `/manage/login` still happens (no regression for actually-signed-out users).
- [ ] Sign in to main app, then sign in via `/manage/login` separately — confirm both paths populate the same session and don't conflict.
- [ ] Sliding-expiry: confirm `tblApiTokens.ExpiresAt` advances after first `/manage/` hit on a freshly-issued token (a single new row in activity log per day).

🤖 Generated with [Claude Code](https://claude.com/claude-code)