### PR TITLE
feat(nav): reorder main app brand dropdown — Help to bottom (#582)

### DIFF
--- a/appWeb/public_html/index.php
+++ b/appWeb/public_html/index.php
@@ -600,22 +600,28 @@ if (!empty($breadcrumbItems)) {
                         <li><a class="dropdown-item" href="/stats" data-navigate="stats">
                             <i class="fa-solid fa-chart-simple me-2" aria-hidden="true"></i> Statistics
                         </a></li>
-                        <li><a class="dropdown-item" href="/help" data-navigate="help">
-                            <i class="fa-solid fa-circle-question me-2" aria-hidden="true"></i> Help
-                        </a></li>
 
                         <!-- Single "Manage" entry — opens /manage/ which
                              shows per-entitlement cards for every
                              curator and administration surface. Visible
                              to any signed-in user with at least one
                              management entitlement (toggled by
-                             user-auth.js). -->
-                        <li id="nav-manage-divider" class="d-none"><hr class="dropdown-divider"></li>
+                             user-auth.js). Sits in the same operations
+                             group as Statistics (#582). -->
                         <li id="nav-manage-li" class="d-none">
                             <a class="dropdown-item" href="/manage/">
                                 <i class="fa-solid fa-gears me-2" aria-hidden="true"></i> Manage
                             </a>
                         </li>
+
+                        <!-- Help moved to the bottom (#582) — support
+                             content is the natural last section in the
+                             menu, separated from operations by its own
+                             divider. -->
+                        <li><hr class="dropdown-divider"></li>
+                        <li><a class="dropdown-item" href="/help" data-navigate="help">
+                            <i class="fa-solid fa-circle-question me-2" aria-hidden="true"></i> Help
+                        </a></li>
                     </ul>
                 </div>
 

--- a/appWeb/public_html/js/modules/user-auth.js
+++ b/appWeb/public_html/js/modules/user-auth.js
@@ -587,10 +587,11 @@ export class UserAuth {
         const canManage = loggedIn && manageEntitlements.some(
             ent => userHasEntitlement(ent, role)
         );
-        ['nav-manage-divider', 'nav-manage-li'].forEach(id => {
-            const el = document.getElementById(id);
-            if (el) el.classList.toggle('d-none', !canManage);
-        });
+        /* Manage now sits in the Operations group with Statistics
+           (no longer needs its own divider) per the dropdown reorder
+           in #582. Only the <li> itself toggles. */
+        const manageLi = document.getElementById('nav-manage-li');
+        if (manageLi) manageLi.classList.toggle('d-none', !canManage);
 
         /* Update icon style */
         const icon = document.getElementById('header-user-icon');


### PR DESCRIPTION
Closes [#582](https://github.com/MWBMPartners/iHymns/issues/582).

Reorders the brand dropdown into three logical groups:

```
Home / Songbooks / Favourites / Set Lists      ← daily nav
────
Statistics / Manage                            ← operations
────
Help                                           ← support
```

Help moves from the middle to its own bottom group; Manage moves up alongside Statistics. The previous order surfaced Help between Statistics and Manage which interrupted the flow from "data" → "admin".

Side effect: removed `nav-manage-divider` since Manage now lives inside an always-visible group; the corresponding JS toggle in `user-auth.js` is simplified. The Manage entry's own visibility toggle stays so unauthorised users still don't see it.

## Verified
- `php -l` clean
- `node --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)