### PR TITLE
feat(editor): toolbar cleanup — drop Load JSON/URL, disable Save/Validate when idle, rename History → Revisions (#589, #590, #591)

### DIFF
--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -3717,7 +3717,14 @@ function updateHistoryButtonState() {
     }
 
     var historyBtn = document.getElementById('btn-history');
-    if (historyBtn) historyBtn.disabled = !hasSong;
+    if (historyBtn) {
+        historyBtn.disabled = !hasSong;
+        /* Renamed History → Revisions (#591) for consistency with the
+           /manage/revisions admin menu entry. ID stays for back-compat. */
+        historyBtn.title = hasSong
+            ? 'Show revision history for the selected song'
+            : 'Select a song to enable Revisions';
+    }
 }
 
 function openHistoryModal(songId) {

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -3280,34 +3280,12 @@ function bindGlobalEventListeners() {
         });
     }
 
-    /* ---- Load from file button ---- */
-    var loadFileBtn = document.getElementById('btn-load-file');
-    if (loadFileBtn) {
-        loadFileBtn.addEventListener('click', function () {
-            /* Create a temporary file input and trigger it. */
-            var input = document.createElement('input');
-            input.type = 'file';
-            input.accept = '.json,application/json';
-            input.addEventListener('change', function () {
-                if (input.files && input.files[0]) {
-                    loadSongsFromFile(input.files[0]);
-                }
-            });
-            input.click();
-        });
-    }
-
-    /* ---- Load from URL button ---- */
-    var loadURLBtn = document.getElementById('btn-load-url');
-    if (loadURLBtn) {
-        loadURLBtn.addEventListener('click', function () {
-            /* Prompt the user for a URL, pre-filling the default. */
-            var url = prompt('Enter songs.json URL:', DEFAULT_SONGS_URL);
-            if (url) {
-                loadSongsFromURL(url);
-            }
-        });
-    }
+    /* Load JSON / Load URL click handlers removed alongside the buttons
+       in #589. The editor auto-loads from MySQL via `?action=load` on
+       init (see loadSongsFromURL(DEFAULT_SONGS_URL) at the bottom of
+       this section), so a curator never needs to load from a file or
+       remote URL. The Import button below still uses importJSON() for
+       merging external data when an admin really needs to. */
 
     /* ---- Save button — writes to MySQL, falls back to JSON download ---- */
     var saveBtn = document.getElementById('btn-save');

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -2653,6 +2653,12 @@ function updateStatusBar() {
             warningEl.style.display = 'none';   // hide warning
         }
     }
+
+    /* Toolbar buttons (#590) — Save / Validate / History reflect the
+       current selection + load state. Piggybacking on updateStatusBar
+       ensures every meaningful state change (load, save, select,
+       deselect, add, delete) refreshes the buttons too. */
+    updateHistoryButtonState();
 }
 
 /* ========================================================================
@@ -3676,9 +3682,42 @@ function bindHistoryListener() {
     });
 }
 
+/**
+ * updateHistoryButtonState()
+ * --------------------------
+ * Toggle Save / Validate / History buttons in step with the current
+ * selection + load state (#590). Called from every place currentSongId
+ * changes plus after the auto-load completes so the buttons accurately
+ * reflect what the curator can actually do.
+ *
+ *   Save      — needs a selected song
+ *   History   — needs a selected song (revisions are per-song)
+ *   Validate  — needs at least one song loaded; catalogue-wide, no
+ *               selection required.
+ */
 function updateHistoryButtonState() {
-    var btn = document.getElementById('btn-history');
-    if (btn) btn.disabled = !currentSongId;
+    var hasSong  = !!currentSongId;
+    var hasSongs = (typeof songData !== 'undefined' && songData
+        && Array.isArray(songData.songs) && songData.songs.length > 0);
+
+    var saveBtn = document.getElementById('btn-save');
+    if (saveBtn) {
+        saveBtn.disabled = !hasSong;
+        saveBtn.title = hasSong
+            ? 'Save all changes to the database'
+            : 'Select a song to enable Save';
+    }
+
+    var validateBtn = document.getElementById('btn-validate');
+    if (validateBtn) {
+        validateBtn.disabled = !hasSongs;
+        validateBtn.title = hasSongs
+            ? 'Validate every song in the loaded catalogue'
+            : 'Songs are still loading…';
+    }
+
+    var historyBtn = document.getElementById('btn-history');
+    if (historyBtn) historyBtn.disabled = !hasSong;
 }
 
 function openHistoryModal(songId) {

--- a/appWeb/public_html/manage/editor/index.php
+++ b/appWeb/public_html/manage/editor/index.php
@@ -129,25 +129,11 @@ $currentUser = getCurrentUser();
         <!-- Action buttons group — aligned to the right -->
         <div class="d-flex align-items-center gap-2">
 
-            <!-- LOAD JSON — Triggers the hidden file input to select a songs.json file -->
-            <button
-                type="button"
-                class="btn btn-sm btn-amber"
-                id="btn-load-file"
-                title="Load a songs.json file from disk"
-            >
-                <i class="bi bi-folder2-open me-1"></i>Load JSON
-            </button>
-
-            <!-- LOAD FROM URL — Load songs.json from a remote URL (#235) -->
-            <button
-                type="button"
-                class="btn btn-sm btn-outline-amber"
-                id="btn-load-url"
-                title="Load songs.json from a URL"
-            >
-                <i class="bi bi-link-45deg me-1"></i>Load URL
-            </button>
+            <!-- LOAD JSON / LOAD URL buttons removed (#589). The editor
+                 auto-loads from the MySQL backend via `?action=load` on
+                 init, so a curator never needs to point it at a file or
+                 remote URL. The Import button below still exists for
+                 emergency restore from a JSON / CSV file. -->
 
             <!-- SAVE — Writes all songs to MySQL (primary path). If the DB
                  is unavailable, the editor falls back to a JSON download so

--- a/appWeb/public_html/manage/editor/index.php
+++ b/appWeb/public_html/manage/editor/index.php
@@ -137,22 +137,29 @@ $currentUser = getCurrentUser();
 
             <!-- SAVE — Writes all songs to MySQL (primary path). If the DB
                  is unavailable, the editor falls back to a JSON download so
-                 you never lose changes. -->
+                 you never lose changes. Starts disabled (#590) — the JS
+                 enables it when a song is selected so curators can't
+                 click into a no-op. -->
             <button
                 type="button"
                 class="btn btn-sm btn-amber-solid"
                 id="btn-save"
-                title="Save all changes to the database"
+                title="Select a song to enable Save"
+                disabled
             >
                 <i class="bi bi-floppy me-1"></i>Save
             </button>
 
-            <!-- VALIDATE — Check all songs for data quality issues (#235) -->
+            <!-- VALIDATE — Check the entire loaded catalogue for data
+                 quality issues (#235). Catalogue-wide, not per-song —
+                 starts disabled until the editor has finished loading
+                 songs (#590), then enables. -->
             <button
                 type="button"
                 class="btn btn-sm btn-outline-success"
                 id="btn-validate"
-                title="Validate all song data for errors"
+                title="Validate every song in the loaded catalogue"
+                disabled
             >
                 <i class="bi bi-check-circle me-1"></i>Validate
             </button>

--- a/appWeb/public_html/manage/editor/index.php
+++ b/appWeb/public_html/manage/editor/index.php
@@ -164,19 +164,25 @@ $currentUser = getCurrentUser();
                 <i class="bi bi-check-circle me-1"></i>Validate
             </button>
 
-            <!-- HISTORY — Show revision history for the currently-selected
-                 song, with a restore action per revision (#400). -->
+            <!-- REVISIONS — Show revision history for the currently-selected
+                 song, with a restore action per revision (#400). Renamed
+                 from "History" in #591 for consistency with the
+                 /manage/revisions admin menu entry; the underlying button
+                 ID is preserved (`btn-history`) so existing JS handlers
+                 keep working. -->
             <button
                 type="button"
                 class="btn btn-sm btn-outline-info"
                 id="btn-history"
-                title="Show revision history for the selected song"
+                title="Select a song to enable Revisions"
                 disabled
             >
-                <i class="bi bi-clock-history me-1"></i>History
+                <i class="bi bi-clock-history me-1"></i>Revisions
             </button>
 
-            <!-- EXPORT DROPDOWN — Provides JSON and CSV export options -->
+            <!-- EXPORT DROPDOWN — Provides JSON and CSV export options.
+                 Tooltip clarifies the scope (#591): exports the entire
+                 currently-loaded catalogue, not the selected song. -->
             <div class="dropdown">
                 <button
                     class="btn btn-sm btn-amber dropdown-toggle"
@@ -184,7 +190,7 @@ $currentUser = getCurrentUser();
                     id="dropdownExport"
                     data-bs-toggle="dropdown"
                     aria-expanded="false"
-                    title="Export songs in different formats"
+                    title="Export the entire loaded catalogue (JSON or CSV)"
                 >
                     <i class="bi bi-box-arrow-up me-1"></i>Export
                 </button>

--- a/appWeb/public_html/manage/help.php
+++ b/appWeb/public_html/manage/help.php
@@ -448,7 +448,7 @@ foreach ($sections as $s) {
                         <li><strong>Save</strong> writes everything to the database. Auto-save runs in the background while you work, but always click Save before navigating away.</li>
                         <li><strong>Validate</strong> runs every song past a quality check (missing required fields, invalid language tags, orphaned references) and lists any problems.</li>
                         <li><strong>Import</strong> from JSON or CSV. <strong>Export</strong> the current view as JSON or CSV.</li>
-                        <li><strong>History</strong> for the selected song shows a diff of every previous edit and a Restore button.</li>
+                        <li><strong>Revisions</strong> for the selected song shows a diff of every previous edit and a Restore button.</li>
                     </ul>
                     <div class="gotcha small">
                         <strong>Gotcha:</strong> Closing the tab while there are unsaved changes loses them — auto-save catches most things, but treat Save as the source of truth.
@@ -457,7 +457,7 @@ foreach ($sections as $s) {
                         <strong>Gotcha:</strong> A song's ID is set when it's first created and never changes. Renaming the title doesn't rename the ID. Numbering is independent of ID.
                     </div>
                     <div class="gotcha small">
-                        <strong>Gotcha:</strong> Deleting a song is permanent. Use <strong>History &rarr; Restore</strong> if you need an old version <em>before</em> you save further edits over it.
+                        <strong>Gotcha:</strong> Deleting a song is permanent. Use <strong>Revisions &rarr; Restore</strong> if you need an old version <em>before</em> you save further edits over it.
                     </div>
                 </section>
 
@@ -496,7 +496,7 @@ foreach ($sections as $s) {
                     <h3 class="h6">Key actions</h3>
                     <ul>
                         <li>Filter by user, song ID (partial match works), action (create / edit / restore / delete), and time range (7 / 30 / 90 / 365 days).</li>
-                        <li>Click a row to open that song in the editor; the History modal there shows the diff and lets you Restore.</li>
+                        <li>Click a row to open that song in the editor; the Revisions modal there shows the diff and lets you Restore.</li>
                     </ul>
                     <div class="gotcha small">
                         <strong>Gotcha:</strong> Revisions are immutable. Restore creates a <em>new</em> revision rather than rewriting history, so the trail stays honest.
@@ -880,7 +880,7 @@ foreach ($sections as $s) {
 
                     <h3 class="h6">&ldquo;I deleted a song by mistake.&rdquo;</h3>
                     <p class="small">
-                        Open <a href="#revisions">Revisions Audit</a>, find the song's last edit before the delete, click through to the editor, and use <strong>History &rarr; Restore</strong>. Revisions are kept indefinitely so older deletes are still recoverable.
+                        Open <a href="#revisions">Revisions Audit</a>, find the song's last edit before the delete, click through to the editor, and use <strong>Revisions &rarr; Restore</strong>. Revisions are kept indefinitely so older deletes are still recoverable.
                     </p>
 
                     <h3 class="h6">&ldquo;The dashboard / a /manage page is blank.&rdquo;</h3>


### PR DESCRIPTION
Three editor-toolbar fixes, all in [manage/editor/index.php](appWeb/public_html/manage/editor/index.php) + [manage/editor/editor.js](appWeb/public_html/manage/editor/editor.js). Each commit closes one issue.

| Commit | Issue | What |
|---|---|---|
| 122300b | [#589](https://github.com/MWBMPartners/iHymns/issues/589) | Remove Load JSON + Load URL buttons (legacy from JSON-data-source era) |
| 63a310a | [#590](https://github.com/MWBMPartners/iHymns/issues/590) | Disable Save (no song selected) and Validate (songs not yet loaded); clarify tooltips |
| 3d1ba0c | [#591](https://github.com/MWBMPartners/iHymns/issues/591) | Rename History → Revisions for consistency with /manage/revisions; clarify Export tooltip |

## Why one PR

All three are toolbar cleanups in the same surface. Verifying any of them on alpha is a single page open of `/manage/editor/`.

## Approach notes

- **#589** — buttons removed; underlying `loadSongsFromFile()` / `loadSongsFromURL()` helpers kept because the auto-load on init still uses `loadSongsFromURL(DEFAULT_SONGS_URL)` to bootstrap from the editor PHP API.
- **#590** — generalised `updateHistoryButtonState()` to also toggle Save and Validate, then piggybacked on `updateStatusBar()` so every meaningful state change re-evaluates the buttons. No new event wiring.
- **#591** — kept the `btn-history` id so JS and the modal-show wiring don't need touching; only the visible label, tooltip, and help docs changed.

## Verified

- `php -l` clean on `editor/index.php` and `manage/help.php`.
- `node --check` clean on `editor.js`.

## Test plan

- [ ] CI Lint & Validate passes.
- [ ] Open `/manage/editor/` — confirm Load JSON / Load URL no longer appear.
- [ ] Confirm Save and Validate are visibly disabled before any song is selected; Save becomes enabled on selecting a song.
- [ ] Confirm Validate becomes enabled once songs finish loading.
- [ ] Confirm History button now reads **Revisions** and stays disabled until a song is selected.
- [ ] Hover the Export dropdown — tooltip reads "Export the entire loaded catalogue".
- [ ] Open `/manage/help` — confirm the editor section reads "Revisions" not "History" everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)