### PR TITLE
feat(audio): feature-detect Web Audio + hide Audio button if unsupported (#602)

### DIFF
--- a/appWeb/public_html/js/modules/audio.js
+++ b/appWeb/public_html/js/modules/audio.js
@@ -61,6 +61,42 @@ export class Audio {
     init() {}
 
     /**
+     * Whether this browser can actually play our MIDI files.
+     *
+     * Our pipeline is: fetch the .mid file → parse with our tiny
+     * MIDI-to-notes parser → schedule on a Tone.js PolySynth backed
+     * by the Web Audio API. So the only hard requirement is that
+     * Web Audio exists. Tone.js itself loads from CDN with a local
+     * fallback at click time, so we don't probe for it eagerly.
+     *
+     * Native MIDI playback (an `<audio src=".mid">`) is NOT what we
+     * use — checking `audio.canPlayType('audio/midi')` here would
+     * give a false negative on every modern browser even though our
+     * synth-based playback works fine. (#602)
+     *
+     * @returns {boolean}
+     */
+    static isSupported() {
+        return typeof window !== 'undefined' &&
+            (typeof window.AudioContext !== 'undefined' ||
+             typeof window.webkitAudioContext !== 'undefined');
+    }
+
+    /**
+     * Hide every `.btn-audio` on the page if this browser can't run
+     * our MIDI-via-Tone.js pipeline. Called from the router after
+     * each page load so a freshly-injected song view still respects
+     * the same gate. Idempotent. (#602)
+     */
+    hideButtonsIfUnsupported() {
+        if (Audio.isSupported()) return;
+        document.querySelectorAll('.btn-audio').forEach(btn => {
+            btn.classList.add('d-none');
+            btn.setAttribute('aria-hidden', 'true');
+        });
+    }
+
+    /**
      * Handle audio button click on a song page.
      * Creates/toggles the player UI and loads the MIDI file.
      *

--- a/appWeb/public_html/js/modules/router.js
+++ b/appWeb/public_html/js/modules/router.js
@@ -404,6 +404,14 @@ export class Router {
             this.app.transpose.initSongPage();
             this.app.readingProgress.initSongPage();
 
+            /* Audio button — hide if the browser can't actually play
+               our MIDI-via-Tone.js pipeline (#602). The audio module
+               feature-detects Web Audio support; if absent, every
+               .btn-audio on the page is hidden so curators don't see
+               a button that wouldn't work. Idempotent — safe to call
+               on every navigation. */
+            this.app.audio?.hideButtonsIfUnsupported?.();
+
             /* Edit button — show only to users whose role carries the
                `edit_songs` entitlement (#407). The PHP editor API
                re-checks the same map server-side, so hiding the button


### PR DESCRIPTION
Closes [#602](https://github.com/MWBMPartners/iHymns/issues/602).

## Why this isn't `canPlayType('audio/midi')`

iHymns doesn't use native MIDI playback (`<audio src=".mid">`) — it parses .mid files and synthesises them via the Web Audio API + Tone.js. So the correct feature-detect is "does Web Audio exist?", not whether the browser claims native MIDI support. Using `canPlayType` would give false-negatives on every modern browser even though the pipeline works fine.

## What this adds

- `Audio.isSupported()` — static, returns true if `window.AudioContext` or `window.webkitAudioContext` exists.
- `audio.hideButtonsIfUnsupported()` — finds every `.btn-audio` on the page and hides it when Web Audio is missing. Idempotent.

Wired into `router.afterPageLoad()` for song pages so freshly-injected HTML respects the same gate after SPA navigation.

## Browsers that fail the test today

Very old Safari (< 14.5 desktop / < 14 iOS), legacy IE, browsers with Web Audio explicitly disabled in privacy settings. Those users get the existing "no audio button" experience as if `$hasAudio` were false on the song.

## Verified
`node --check` clean on both modified files.

## Test plan
- [ ] CI Lint & Validate passes.
- [ ] Open a song with audio in a modern browser — Audio button shows; click works.
- [ ] In devtools, override `window.AudioContext = undefined` and reload — confirm the Audio button is hidden.
- [ ] Confirm sheet music / share / favourite buttons remain unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)