### PR TITLE
fix(editor): remove duplicate arrangement summary-chip row (closes #597)

### DIFF
--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -1202,16 +1202,14 @@ function autoGenerateArrangement(song) {
  * @param {Object} song - The song to render arrangement for.
  */
 function renderArrangement(song) {
-    var chipsContainer = document.getElementById('arrangement-chips');
-    var input          = document.getElementById('arrangement-input');
-    var feedback       = document.getElementById('arrangement-feedback');
-    var pool           = document.getElementById('arrangement-pool');
-    var strip          = document.getElementById('arrangement-strip');
+    var input    = document.getElementById('arrangement-input');
+    var feedback = document.getElementById('arrangement-feedback');
+    var pool     = document.getElementById('arrangement-pool');
+    var strip    = document.getElementById('arrangement-strip');
 
-    if (!chipsContainer || !input || !feedback) return;
+    if (!input || !feedback) return;
 
     /* Clear previous state. */
-    chipsContainer.innerHTML = '';
     if (pool)  pool.innerHTML  = '';
     if (strip) strip.innerHTML = '';
     feedback.style.display = 'none';
@@ -1225,11 +1223,10 @@ function renderArrangement(song) {
     /* Advanced text-mode mirror (kept for paste-in / power users). */
     input.value = arrangementToLabels(song);
 
-    /* Legacy summary chips row — kept for at-a-glance reading, even
-       though the builder below is the interactive surface now (#492). */
-    renderArrangementSummaryChips(song, chipsContainer);
-
-    /* Drag-drop builder (#492). */
+    /* Drag-drop builder (#492). The legacy `arrangement-chips`
+       summary row was removed in #597 — the strip below already
+       renders the playback order as draggable chips, and the
+       summary row was a non-interactive duplicate. */
     if (pool && strip) {
         renderArrangementPool(song, pool, strip);
         renderArrangementStrip(song, strip);
@@ -1237,31 +1234,6 @@ function renderArrangement(song) {
 
     /* Re-evaluate quick-action buttons for the song's component set (#493). */
     refreshArrangementPresetAvailability(song);
-}
-
-/**
- * Render the read-only chip summary at the top of the Arrangement
- * block. Matches the pre-#492 look of a coloured pill row, but is now
- * a display surface only — the interactive builder lives below.
- */
-function renderArrangementSummaryChips(song, chipsContainer) {
-    if (!song.arrangement || !Array.isArray(song.arrangement) || song.arrangement.length === 0) {
-        chipsContainer.classList.add('d-none');
-        return;
-    }
-    chipsContainer.classList.remove('d-none');
-    song.arrangement.forEach(function (idx, pos) {
-        var comp = song.components[idx];
-        if (!comp) return;
-        var chip = document.createElement('span');
-        chip.className = 'badge rounded-pill';
-        chip.textContent = getComponentLabel(comp);
-        chip.title = getComponentLabel(comp) + ' — position ' + (pos + 1);
-        var colors = COMP_COLORS[comp.type] || { bg: '#6b7280', text: '#ffffff' };
-        chip.style.backgroundColor = colors.bg;
-        chip.style.color = colors.text;
-        chipsContainer.appendChild(chip);
-    });
 }
 
 /**

--- a/appWeb/public_html/manage/editor/index.php
+++ b/appWeb/public_html/manage/editor/index.php
@@ -875,11 +875,12 @@ $currentUser = getCurrentUser();
                             </div>
                         </div>
 
-                        <!-- Legacy chips readout — preserved as a visual summary
-                             so the whole tab keeps the pill-row look from before
-                             #492. Updated by renderArrangement() whenever the
-                             strip changes. -->
-                        <div id="arrangement-chips" class="d-flex flex-wrap gap-1 mb-2 d-none"></div>
+                        <!-- Legacy summary-chip row removed (#597) — the
+                             #arrangement-strip row above already renders
+                             the playback order as draggable chips, and
+                             this row was a non-interactive duplicate of
+                             the same data which confused curators. -->
+
 
                         <!-- Validation feedback (used by the advanced text input
                              below and for preset application errors from #493). -->


### PR DESCRIPTION
## Summary

- Removes the third "verse cards" row from Structure → Arrangement (`#arrangement-chips`), a non-interactive mirror of the Sequence strip that confused curators (#597).
- Drops the now-orphaned `renderArrangementSummaryChips()` and its caller from `editor.js`; the strip itself (#492) remains the single interactive + display surface.
- Quick-action buttons (#493) and `refreshArrangementPresetAvailability()` are untouched and verified to not reference the removed element.

## Why

The summary row predated #492's drag-and-drop builder. Once the strip became the interactive chip row, the read-only summary above it duplicated the same data in the same visual style — exactly the confusion #597 reports. Removing it leaves Components (source) above Sequence (the actual ordered list), which matches the labels users already read.

## Test plan

- [ ] Open Editor → Structure on a multi-verse song (e.g. SDAH-93). Confirm only **Components** and **Sequence** rows render in the Arrangement block — no third duplicate row.
- [ ] Drag chips around in Sequence; confirm reorder still saves.
- [ ] Click `×` on a Sequence chip; confirm it removes that step.
- [ ] Click a chip in Components; confirm it appends to Sequence.
- [ ] Click each `.arrangement-preset` quick-action button (Chorus after each verse, Verse · Pre-Chorus · Chorus, Verses · Bridge · Final Verse, Intro → Verses → Outro); confirm they still apply and feedback shows.
- [ ] Type into the advanced text-mode field; confirm the strip mirrors changes.
- [ ] DevTools console: no errors referencing `arrangement-chips` or `renderArrangementSummaryChips`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)