### PR TITLE
feat(editor): support Verse-1-acts-as-chorus arrangements (closes #598)

### DIFF
--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -1194,8 +1194,22 @@ function autoGenerateArrangement(song) {
 
     if (refrainIndex === -1) return null;
 
-    /* Build arrangement: chorus/refrain after each verse, other components in place. */
+    /* Detect the SDAH-93-style "verse-1-acts-as-chorus" pattern (#598):
+       when the refrain comes BEFORE any verse in the components list,
+       the song convention is to open on the refrain too — not just
+       repeat it after each verse. Most ProPresenter / hymnal renderings
+       of this pattern (e.g. "All Things Bright and Beautiful") lead
+       with the refrain. */
+    var firstVerseIndex = -1;
+    for (var k = 0; k < song.components.length; k++) {
+        if (song.components[k].type === 'verse') { firstVerseIndex = k; break; }
+    }
+    var leadWithRefrain = (firstVerseIndex !== -1 && refrainIndex < firstVerseIndex);
+
+    /* Build arrangement: optional leading refrain, then chorus/refrain
+       after each verse, other components in place. */
     var arrangement = [];
+    if (leadWithRefrain) arrangement.push(refrainIndex);
     for (var j = 0; j < song.components.length; j++) {
         var comp = song.components[j];
         if (comp.type === 'verse') {

--- a/appWeb/public_html/manage/help.php
+++ b/appWeb/public_html/manage/help.php
@@ -435,7 +435,20 @@ foreach ($sections as $s) {
                         <dt>Metadata</dt>
                         <dd>Title, song number, songbook, CCLI number, Tune Name (e.g. <em>HYFRYDOL</em>), ISWC, language, region.</dd>
                         <dt>Structure</dt>
-                        <dd>The actual lyrics, broken into sections: verses, choruses, bridges, and so on. Drag to reorder; auto-resizing text areas grow as you type.</dd>
+                        <dd>
+                            The actual lyrics, broken into sections: verses, choruses, bridges, and so on. Drag to reorder; auto-resizing text areas grow as you type.
+                            <details class="mt-2">
+                                <summary class="small text-muted" style="cursor: pointer;">Verse-1-acts-as-chorus convention (e.g. SDAH-93 "All Things Bright and Beautiful")</summary>
+                                <div class="small text-muted mt-1">
+                                    Some hymns open with a stanza that's structurally a refrain — the song repeats it after every verse — but the hymnal still numbers it as <em>Verse 1</em>. To set these up:
+                                    <ol class="mb-0">
+                                        <li>Set the first component's <strong>Type</strong> to <strong>Refrain</strong>, leaving its number as <code>1</code>.</li>
+                                        <li>Click <strong>Chorus after each verse</strong> in the Arrangement quick-actions. Because the refrain comes before any verse, the arrangement starts <em>and</em> ends each cycle with the refrain — exactly the SDAH-93 playback pattern.</li>
+                                    </ol>
+                                    On the public song page, "Refrain" displays as "Chorus" via the standing alias so existing styling and screen-reader cues stay consistent.
+                                </div>
+                            </details>
+                        </dd>
                         <dt>Credits</dt>
                         <dd>Writer, composer, arranger, adaptor, translator, copyright holder. Names autocomplete from the <a href="#credit-people">Credit People</a> registry so you don't get duplicate spellings.</dd>
                         <dt>Tags</dt>


### PR DESCRIPTION
## Summary

- Extends `autoGenerateArrangement()` so that when the components list puts a Refrain (or Chorus) **before** any verse, the generated arrangement also leads with that refrain — the SDAH-93 ("All Things Bright and Beautiful") pattern. Songs with a trailing refrain or a refrain between verses keep their existing `[V, R, V, R]` shape.
- Adds a Help-docs note under the Structure tab explaining the convention: set Verse 1's type to **Refrain**, then click **Chorus after each verse** — both ends of each cycle now sit on the refrain, matching the printed hymnal.

## Why

Most acceptance criteria for #598 were already met by the long-standing Refrain → Chorus alias (preset availability, the four built-in presets, the public song view). The remaining gap was that one click of "Chorus after each verse" produced `[V, R, V, R, …]` even for songs that should open on the refrain. Curators were forced to drag-and-drop the leading R chip in manually, defeating the point of the preset.

## Test plan

- [ ] Open a song that begins with Verse 2 and has Verse 1 typed as Refrain (set up SDAH-93 if not already). Click **Chorus after each verse**. Confirm the generated sequence starts with the Refrain, alternates `V R V R …`, and ends with the Refrain.
- [ ] Open a regular `[V, V, V, C]` song. Click **Chorus after each verse**. Confirm the existing `[V, C, V, C, V, C]` shape is unchanged (no leading C).
- [ ] Open a `[V, C, V, V]` song (chorus between verses). Click the preset. Confirm `[V, C, V, C, V, C]` (no leading C — this song doesn't open on the chorus).
- [ ] Help → Manage Help → "Song Editor" section: verify the new `<details>` block titled *Verse-1-acts-as-chorus convention…* expands cleanly and reads correctly.
- [ ] No regression on the other three Arrangement presets (Verse · Pre-Chorus · Chorus, Verses · Bridge · Final Verse, Intro → Verses → Outro).

🤖 Generated with [Claude Code](https://claude.com/claude-code)