### PR TITLE
feat(song-view): credits+copyright footer at end of lyrics; finish CCLI/ISWC layout (closes #601, #600)

### DIFF
--- a/appWeb/public_html/css/app.css
+++ b/appWeb/public_html/css/app.css
@@ -1178,9 +1178,23 @@ body.banner-visible.search-open .main-content {
     -webkit-touch-callout: none;
 }
 
-/* Song copyright */
+/* Song copyright (legacy class — retained because print.css still
+   references it for hymnal-style print output of older templates). */
 .song-copyright {
     font-size: 0.85rem;
+}
+
+/* Right-aligned credits + copyright footer at end of lyrics (#601).
+   Mirrors the hymnal / projection convention: small italic-ish text,
+   right-aligned, immediately after the last verse so users projecting
+   or printing have the attribution visible without scrolling back to
+   the header. */
+.song-credits-footer {
+    font-size: 0.85rem;
+    line-height: 1.4;
+}
+.song-credits-footer > div + div {
+    margin-top: 0.1rem;
 }
 
 /* ---------------------------------------------------------------------------

--- a/appWeb/public_html/css/print.css
+++ b/appWeb/public_html/css/print.css
@@ -78,12 +78,18 @@
         text-decoration: none !important;
     }
 
-    /* Copyright */
-    .song-copyright {
+    /* Copyright + credits footer (#601). Same hymnal-style print
+       treatment for both — small grey block under a thin rule. The
+       on-screen .song-credits-footer is right-aligned via flex/text-end
+       in app.css; for print we keep it left-aligned because printers
+       often clip right-aligned content near the page margin. */
+    .song-copyright,
+    .song-credits-footer {
         border-top: 1px solid #cccccc !important;
         padding-top: 0.5rem !important;
         font-size: 9pt !important;
         color: #666666 !important;
+        text-align: left !important;
     }
 
     /* Page breaks */

--- a/appWeb/public_html/includes/pages/song.php
+++ b/appWeb/public_html/includes/pages/song.php
@@ -49,6 +49,9 @@ $ccli        = $song['ccli']        ?? '';
 $hasAudio    = !empty($song['hasAudio']);
 $hasSheet    = !empty($song['hasSheetMusic']);
 $components  = $song['components'] ?? [];
+$lyricsPublicDomain = !empty($song['lyricsPublicDomain']);
+$musicPublicDomain  = !empty($song['musicPublicDomain']);
+$fullyPublicDomain  = $lyricsPublicDomain && $musicPublicDomain;
 
 /* ===================================================================
  * Translations (#281) — list of other-language versions of this song
@@ -310,11 +313,11 @@ unset($_t);
             <?php endif; ?>
 
             <!-- Copyright, CCLI Song Number, ISWC in song header (#497).
-                 ID labels (CCLI / ISWC) now bold and separated from the
-                 value with a definite gap so the eye scans them as a
-                 parallel column to the people-credit rows above (#600).
-                 Copyright stays as plain text — it's a sentence, not a
-                 labelled field. -->
+                 ID labels (CCLI / ISWC) are bold with a definite gap
+                 between label and value (#600). The two ID rows sit
+                 in a flex row that wraps: side-by-side at wide widths,
+                 stacked at narrow. Copyright stays on its own line
+                 above — it's prose, not a labelled field. -->
             <?php if (!empty($copyright) || !empty($ccli) || $iswc !== ''): ?>
                 <div class="song-meta-copyright mb-3">
                     <?php if (!empty($copyright)): ?>
@@ -323,17 +326,21 @@ unset($_t);
                             <?= htmlspecialchars($copyright) ?>
                         </p>
                     <?php endif; ?>
-                    <?php if (!empty($ccli)): ?>
-                        <p class="mb-<?= $iswc !== '' ? '1' : '0' ?> small text-muted">
-                            <i class="fa-solid fa-hashtag me-2" aria-hidden="true"></i>
-                            <strong>CCLI Song #</strong>&nbsp;<?= htmlspecialchars($ccli) ?>
-                        </p>
-                    <?php endif; ?>
-                    <?php if ($iswc !== ''): ?>
-                        <p class="mb-0 small text-muted" title="International Standard Musical Work Code">
-                            <i class="fa-solid fa-barcode me-2" aria-hidden="true"></i>
-                            <strong>ISWC:</strong>&nbsp;<?= htmlspecialchars($iswc) ?>
-                        </p>
+                    <?php if (!empty($ccli) || $iswc !== ''): ?>
+                        <div class="song-id-row d-flex flex-wrap column-gap-4 row-gap-1">
+                            <?php if (!empty($ccli)): ?>
+                                <span class="small text-muted">
+                                    <i class="fa-solid fa-hashtag me-2" aria-hidden="true"></i>
+                                    <strong>CCLI Song #</strong>&nbsp;<?= htmlspecialchars($ccli) ?>
+                                </span>
+                            <?php endif; ?>
+                            <?php if ($iswc !== ''): ?>
+                                <span class="small text-muted" title="International Standard Musical Work Code">
+                                    <i class="fa-solid fa-barcode me-2" aria-hidden="true"></i>
+                                    <strong>ISWC:</strong>&nbsp;<?= htmlspecialchars($iswc) ?>
+                                </span>
+                            <?php endif; ?>
+                        </div>
                     <?php endif; ?>
                 </div>
             <?php endif; ?>
@@ -524,22 +531,49 @@ unset($_t);
         <?php endforeach; ?>
     </div>
 
-    <!-- Copyright notice -->
-    <?php if (!empty($copyright) || !empty($ccli)): ?>
-        <div class="song-copyright mt-4 pt-3 border-top" role="contentinfo">
-            <?php if (!empty($copyright)): ?>
-                <p class="text-muted small mb-1">
+    <!-- Credits + copyright footer at end of lyrics (#601). Mirrors the
+         hymnal / projection convention: a small right-aligned block
+         after the last verse listing Words / Music / Adapted by /
+         Translated by / Tune, then the copyright line. The same data
+         is already rendered in the header, but the footer is the copy
+         users see when projecting or when they have scrolled past the
+         masthead. The .song-credits-footer class is kept distinct from
+         the older .song-copyright (used only by print.css) so the
+         right-aligned layout doesn't bleed into print rules. */ -->
+    <?php if (
+        !empty($_creditRows) && $_hasAnyCredit
+        || $tuneName !== ''
+        || (!$fullyPublicDomain && !empty($copyright))
+        || $fullyPublicDomain
+    ): ?>
+        <footer class="song-credits-footer text-end small text-muted mt-4 pt-3 border-top" role="contentinfo">
+            <?php if ($_hasAnyCredit): ?>
+                <?php foreach ($_creditRows as $row): ?>
+                    <?php [$rowId, $rowLabel, , $rowNames] = $row; ?>
+                    <?php if (empty($rowNames)) continue; ?>
+                    <div data-credit-kind="<?= htmlspecialchars($rowId) ?>">
+                        <strong><?= htmlspecialchars($rowLabel) ?>:</strong>
+                        <?= htmlspecialchars(implode('; ', $rowNames)) ?>
+                    </div>
+                <?php endforeach; ?>
+            <?php endif; ?>
+            <?php if ($tuneName !== ''): ?>
+                <div data-credit-kind="tune">
+                    <strong>Tune:</strong> <?= htmlspecialchars($tuneName) ?>
+                </div>
+            <?php endif; ?>
+            <?php if ($fullyPublicDomain): ?>
+                <div class="mt-1" data-credit-kind="public-domain">
+                    <i class="fa-regular fa-copyright me-1" aria-hidden="true"></i>
+                    Public Domain
+                </div>
+            <?php elseif (!empty($copyright)): ?>
+                <div class="mt-1" data-credit-kind="copyright">
                     <i class="fa-regular fa-copyright me-1" aria-hidden="true"></i>
                     <?= htmlspecialchars($copyright) ?>
-                </p>
+                </div>
             <?php endif; ?>
-            <?php if (!empty($ccli)): ?>
-                <p class="text-muted small mb-0">
-                    <i class="fa-solid fa-hashtag me-1" aria-hidden="true"></i>
-                    CCLI Song #<?= htmlspecialchars($ccli) ?>
-                </p>
-            <?php endif; ?>
-        </div>
+        </footer>
     <?php endif; ?>
 
     <!-- Report missing song link -->


### PR DESCRIPTION
## Summary

- **#601** — Adds a right-aligned `<footer class="song-credits-footer">` after the last lyric component listing Words / Music / Arranged by / Adapted by / Translated by / Tune (when set) plus the copyright. When both PD flags are ticked the copyright line becomes "Public Domain". Mirrors the hymnal / projection convention.
- **#600** — Finishes the side-by-side responsive layout for the CCLI / ISWC ID rows in the header (bold labels and visible gap already shipped in #607). The two IDs now share a flex row at wide widths and stack at narrow ones.

## Why

Users scrolling to the bottom of a song saw only the copyright today, not the writer/composer attribution. Worship displays, hymnals, and song-sheets all put both at the foot of the lyrics by convention. The header copy stays put; this is the redundant-but-useful copy for projecting and printing.

For #600, the bold-label half landed weeks ago but the responsive layout was missed — the issue stayed open and the audit caught it.

## Notes

- The footer reuses the `$_creditRows` / `$tuneName` computed for the header, so the existing Words & Music combine rule (#603) and the refrain → chorus alias both apply automatically.
- `.song-copyright` (the older class) is kept in `app.css` because `print.css` still targets it for older hymnal-style print templates. The new `.song-credits-footer` layers on top with right-aligned typography; print rules force text-align:left so printers don't clip near-margin text.
- No JS changes — pure server-side render.

## Test plan

- [ ] Open a copyrighted song (e.g. SDAH-93). Confirm the new footer appears below the last verse, right-aligned, listing Words / Music / Tune / Copyright.
- [ ] Open a song with identical writer + composer (e.g. Stuart Townend solo): confirm the footer shows a single combined "Words & Music" line.
- [ ] Open a fully public-domain song (both PD checkboxes ticked, e.g. SDAH-1): confirm the footer shows "Public Domain" instead of a copyright statement.
- [ ] Open a song with only Words PD or only Music PD: confirm the copyright statement still renders normally.
- [ ] Open a song with both CCLI and ISWC: at wide widths confirm the two ID rows sit side-by-side with a visible gap; resize narrow and confirm they stack.
- [ ] Open a song with only CCLI (no ISWC): confirm graceful single-item rendering, no flex artefacts.
- [ ] Print preview a song: confirm the footer renders left-aligned (not right) under the existing print rules; confirm no double-rendering of credits/copyright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)