### PR TITLE
feat(credit-people): merge-modal preview counts + irreversibility ack (closes #583)

### DIFF
--- a/appWeb/public_html/manage/credit-people.php
+++ b/appWeb/public_html/manage/credit-people.php
@@ -1242,6 +1242,15 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
                                 'death_date'  => $p['death_date'],
                                 'is_special_case' => (int)($p['is_special_case'] ?? 0),
                                 'is_group'        => (int)($p['is_group']        ?? 0),
+                                /* Per-role counts so the Merge modal's
+                                   "Song-credit rows to re-point" preview
+                                   (#583) can render without a round-trip. */
+                                'writers'     => $writers,
+                                'composers'   => $composers,
+                                'arrangers'   => $arrangers,
+                                'adaptors'    => $adaptors,
+                                'translators' => $translators,
+                                'total'       => $p['total'],
                                 'links'       => $p['links'],
                                 'ipi'         => $p['ipi'],
                             ], JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_TAG | JSON_HEX_AMP | JSON_UNESCAPED_UNICODE);
@@ -1516,6 +1525,25 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
                             </div>
                         </div>
 
+                        <!-- Song-credit re-point preview (#583). The Source
+                             aggregate already carries per-role counts in its
+                             data-person attribute, so we render them inline
+                             when the modal opens — no extra round-trip. -->
+                        <div id="cp-merge-credit-preview" class="alert alert-info py-2 small mb-3 d-none">
+                            <div class="fw-semibold mb-1">
+                                <i class="bi bi-arrow-left-right me-1" aria-hidden="true"></i>
+                                Song-credit rows to re-point
+                            </div>
+                            <div class="d-flex flex-wrap gap-2 small">
+                                <span>Writer&nbsp;<strong id="cp-merge-count-writer">0</strong></span>
+                                <span>Composer&nbsp;<strong id="cp-merge-count-composer">0</strong></span>
+                                <span>Arranger&nbsp;<strong id="cp-merge-count-arranger">0</strong></span>
+                                <span>Adaptor&nbsp;<strong id="cp-merge-count-adaptor">0</strong></span>
+                                <span>Translator&nbsp;<strong id="cp-merge-count-translator">0</strong></span>
+                                <span class="ms-auto">Total&nbsp;<strong id="cp-merge-count-total">0</strong></span>
+                            </div>
+                        </div>
+
                         <div id="cp-merge-children" class="d-none">
                             <h6 class="small text-secondary mb-2">Source's links / IPI numbers</h6>
                             <p class="small text-secondary">
@@ -1530,10 +1558,21 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
                             <div id="cp-merge-children-ipi"></div>
                         </div>
 
-                        <div class="alert alert-warning py-2 small mb-0">
+                        <div class="alert alert-warning py-2 small mb-2">
                             Merging re-points every song-credit row from the source name to the target
                             name across the five song-credit tables, then removes the source registry
                             row. Tracked in the activity log with full per-table affected counts.
+                        </div>
+
+                        <!-- Explicit irreversibility ack (#583). The submit
+                             button stays disabled until both a target is
+                             picked AND this checkbox is ticked. -->
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" id="cp-merge-confirm" required>
+                            <label class="form-check-label small" for="cp-merge-confirm">
+                                I understand this is irreversible — the source registry row is
+                                deleted and every song-credit row is re-pointed to the target name.
+                            </label>
                         </div>
                     </div>
                     <div class="modal-footer border-secondary">
@@ -2016,6 +2055,24 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
                 sourceIdIn.value   = String(person.registry_id);
                 sourceNameIn.value = person.name || '';
 
+                /* Reset the irreversibility ack on every open so a prior
+                   ticked state doesn't carry across to a fresh merge. */
+                const confirmCb = document.getElementById('cp-merge-confirm');
+                if (confirmCb) confirmCb.checked = false;
+
+                /* Per-role re-point preview (#583). The byName aggregate
+                   already carries every count we need; just display them. */
+                const previewWrap = document.getElementById('cp-merge-credit-preview');
+                if (previewWrap) {
+                    document.getElementById('cp-merge-count-writer').textContent     = person.writers     || 0;
+                    document.getElementById('cp-merge-count-composer').textContent   = person.composers   || 0;
+                    document.getElementById('cp-merge-count-arranger').textContent   = person.arrangers   || 0;
+                    document.getElementById('cp-merge-count-adaptor').textContent    = person.adaptors    || 0;
+                    document.getElementById('cp-merge-count-translator').textContent = person.translators || 0;
+                    document.getElementById('cp-merge-count-total').textContent      = person.total       || 0;
+                    previewWrap.classList.remove('d-none');
+                }
+
                 /* Populate target dropdown — every registry row except
                    the source. Sorted alphabetically. */
                 targetSel.innerHTML = '<option value="">— pick the surviving person —</option>';
@@ -2082,10 +2139,18 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
                 modal.show();
             });
 
-            /* Submit button only enables once a target is picked. */
+            /* Submit button enables only when BOTH a target is picked
+               AND the irreversibility ack is ticked (#583). */
+            const confirmCb = document.getElementById('cp-merge-confirm');
+            function refreshSubmitState() {
+                const targetPicked = targetSel?.value !== '';
+                const acknowledged = !!confirmCb?.checked;
+                submitBtn.disabled = !(targetPicked && acknowledged);
+            }
             targetSel?.addEventListener('change', () => {
-                submitBtn.disabled = targetSel.value === '';
+                refreshSubmitState();
             });
+            confirmCb?.addEventListener('change', refreshSubmitState);
         })();
 
         /* =========================================================================


### PR DESCRIPTION
## Summary

Two focused improvements to the existing per-row Merge modal in `/manage/credit-people`:

1. **Song-credit re-point preview** — when the modal opens, it now displays per-table counts (Writer / Composer / Arranger / Adaptor / Translator) plus a total, sourced from the byName aggregate already loaded for the row. No extra round-trip.
2. **Irreversibility ack** — explicit "I understand this is irreversible" checkbox. The submit button is disabled until both a target is picked AND the ack is ticked. The ack resets on every modal-open.

## Why

The Merge button was already on each row (shipped in #545) and the modal walked through Pick → Migrate-children → Submit. The issue's acceptance criteria specifically called out:

- "Show a preview of what will change: count of song-credit rows that will be re-pointed across each of the five song-credit tables." — now satisfied by the Song-credit Rows panel.
- "Confirm step with explicit 'I understand this is irreversible' checkbox." — now gated.

## Out of scope (filed for future)

- "Step 2 — side-by-side metadata diff with radio buttons per field for each side" — picking which of birth/death place + date + notes survive vs. the target's. The current "target survives" semantic covers the common case (Stuart Townend as target keeps his bio); the per-field winners flow can be a polish follow-up.

## Test plan

- [ ] On `/manage/credit-people` find a row with > 0 uses (e.g. "Stuart Townend"). Click the Merge icon (`bi-union`). Confirm the new "Song-credit rows to re-point" panel shows the W / C / Ar / Ad / T counts that match the role-pill values on the row.
- [ ] Pick a target. Confirm the Merge button stays disabled.
- [ ] Tick the irreversibility checkbox. Confirm the Merge button now enables.
- [ ] Untick the checkbox. Confirm the Merge button disables again.
- [ ] Cancel and reopen the modal. Confirm the irreversibility checkbox starts unticked.
- [ ] Reproduce the issue's test case: merge Stuart Christopher Townend (1 use) into Stuart Townend (47 uses). Confirm afterwards that Stuart Townend has 48 total uses and Stuart Christopher Townend is gone.
- [ ] Confirm the activity-log entry records source / target names and per-table affected counts (already in the existing handler).

🤖 Generated with [Claude Code](https://claude.com/claude-code)