### PR TITLE
feat(songs): new Artist credit field — full vertical slice (closes #587)

### DIFF
--- a/appWeb/.sql/migrate-song-artists.php
+++ b/appWeb/.sql/migrate-song-artists.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Songs Artist credit migration (#587)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Adds the new `tblSongArtists` table — a sixth credit role parallel
+ * to writers / composers / arrangers / adaptors / translators. The
+ * Artist credit captures the recording / release artist of a
+ * contemporary worship song (e.g. "Hillsong Worship" for "What a
+ * Beautiful Name", "Matt Redman" for "10,000 Reasons"). Traditional
+ * hymns often leave it blank; the field is purely additive.
+ *
+ * Schema:
+ *   tblSongArtists.Id        INT AUTO_INCREMENT PRIMARY KEY
+ *   tblSongArtists.SongId    VARCHAR(20) NOT NULL  (FK → tblSongs.SongId)
+ *   tblSongArtists.Name      VARCHAR(255) NOT NULL
+ *   tblSongArtists.SortOrder SMALLINT NOT NULL DEFAULT 0
+ *
+ * @migration-adds tblSongArtists.Id
+ * @migration-adds tblSongArtists.SongId
+ * @migration-adds tblSongArtists.Name
+ * @migration-adds tblSongArtists.SortOrder
+ *
+ * USAGE:
+ *   Web:  /manage/setup-database → Apply all pending migrations
+ *   CLI:  php appWeb/.sql/migrate-song-artists.php
+ *
+ * Idempotent — re-running is safe; the table-exists check skips the
+ * CREATE if the table is already present.
+ */
+
+if (PHP_SAPI === 'cli') {
+    require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    $isCli = true;
+} else {
+    if (!defined('IHYMNS_SETUP_DASHBOARD')) {
+        require_once __DIR__ . '/../public_html/manage/includes/auth.php';
+        if (!isAuthenticated()) {
+            http_response_code(401);
+            exit('Authentication required.');
+        }
+        $u = getCurrentUser();
+        if (!$u || $u['role'] !== 'global_admin') {
+            http_response_code(403);
+            exit('Global admin required.');
+        }
+    }
+    require_once __DIR__ . '/../public_html/includes/db_mysql.php';
+    $isCli = false;
+}
+
+function _migArtists_out(string $line): void
+{
+    global $isCli;
+    echo $line . ($isCli ? "\n" : "<br>\n");
+    @ob_flush();
+    @flush();
+}
+
+function _migArtists_tableExists(mysqli $db, string $table): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? LIMIT 1'
+    );
+    $stmt->bind_param('s', $table);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+_migArtists_out('Songs Artist credit migration starting…');
+
+$mysqli = getDbMysqli();
+if (!$mysqli) {
+    _migArtists_out('ERROR: could not connect to database.');
+    exit(1);
+}
+
+if (_migArtists_tableExists($mysqli, 'tblSongArtists')) {
+    _migArtists_out('[skip] tblSongArtists already present.');
+} else {
+    $sql = "CREATE TABLE tblSongArtists (
+        Id          INT UNSIGNED    AUTO_INCREMENT PRIMARY KEY,
+        SongId      VARCHAR(20)     NOT NULL,
+        Name        VARCHAR(255)    NOT NULL,
+        SortOrder   SMALLINT        NOT NULL DEFAULT 0,
+        CreatedAt   DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        INDEX idx_SongId (SongId),
+        INDEX idx_Name   (Name),
+        CONSTRAINT fk_Artists_Song
+            FOREIGN KEY (SongId) REFERENCES tblSongs(SongId)
+            ON DELETE CASCADE ON UPDATE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
+
+    if (!$mysqli->query($sql)) {
+        _migArtists_out('ERROR: creating tblSongArtists failed: ' . $mysqli->error);
+        exit(1);
+    }
+    _migArtists_out('[add ] tblSongArtists.');
+}
+
+_migArtists_out('Songs Artist credit migration finished.');
+$mysqli->close();

--- a/appWeb/public_html/api-docs.yaml
+++ b/appWeb/public_html/api-docs.yaml
@@ -4782,6 +4782,12 @@ components:
             type: string
           description: Composer / tune names
           example: ["Virginia Harmony"]
+        artists:
+          type: array
+          items:
+            type: string
+          description: Recording / release artist names (#587). Most useful for contemporary worship songs; traditional hymns leave this blank.
+          example: ["Hillsong Worship"]
         components:
           type: array
           description: Ordered song components (verses, choruses, etc.)

--- a/appWeb/public_html/includes/SongData.php
+++ b/appWeb/public_html/includes/SongData.php
@@ -407,6 +407,7 @@ class SongData
             $arrangersMap   = $this->_getArrangersMap($songIds);
             $adaptorsMap    = $this->_getAdaptorsMap($songIds);
             $translatorsMap = $this->_getTranslatorsMap($songIds);
+            $artistsMap     = $this->_getArtistsMap($songIds);     /* #587 */
             $componentsMap  = $this->_getComponentsMap($songIds);
             /* Tags included in the bulk load (#496 follow-up) so the
                Song Editor's full-catalogue load + any client that
@@ -421,6 +422,7 @@ class SongData
                 $song['arrangers']   = $arrangersMap[$sid]   ?? [];
                 $song['adaptors']    = $adaptorsMap[$sid]    ?? [];
                 $song['translators'] = $translatorsMap[$sid] ?? [];
+                $song['artists']     = $artistsMap[$sid]     ?? [];   /* #587 */
                 $song['components']  = $componentsMap[$sid]  ?? [];
                 $song['tags']        = $tagsMap[$sid]        ?? [];
             }
@@ -1000,6 +1002,7 @@ class SongData
         $row['arrangers']    = $this->_getArrangers($songId);
         $row['adaptors']     = $this->_getAdaptors($songId);
         $row['translators']  = $this->_getTranslators($songId);
+        $row['artists']      = $this->_getArtists($songId);    /* #587 */
         $row['components']   = $this->_getComponents($songId);
         /* Tags attached here too so the single-song read path matches
            the bulk getSongs() shape (#496 follow-up). Uses the same
@@ -1273,6 +1276,78 @@ class SongData
         while ($row = $res->fetch_assoc()) { $out[] = $row['Name']; }
         $stmt->close();
         return $out;
+    }
+
+    /**
+     * @return string[]
+     * Artists (#587). Returns an empty array on installs where the
+     * tblSongArtists table hasn't been created yet, so the load path
+     * stays usable on a partly-migrated DB.
+     */
+    private function _getArtists(string $songId): array
+    {
+        if (!$this->_songArtistsTableExists()) return [];
+        $stmt = $this->db->prepare(
+            "SELECT Name FROM tblSongArtists WHERE SongId = ? ORDER BY SortOrder, Id"
+        );
+        $stmt->bind_param('s', $songId);
+        $stmt->execute();
+        $res = $stmt->get_result();
+        $out = [];
+        while ($row = $res->fetch_assoc()) { $out[] = $row['Name']; }
+        $stmt->close();
+        return $out;
+    }
+
+    /**
+     * Bulk-load artists keyed by SongId (#587). See `_getWritersMap()`.
+     *
+     * @param string[] $songIds
+     * @return array<string,string[]>
+     */
+    private function _getArtistsMap(array $songIds): array
+    {
+        if (empty($songIds))                     return [];
+        if (!$this->_songArtistsTableExists())   return [];
+        $placeholders = implode(',', array_fill(0, count($songIds), '?'));
+        $types = str_repeat('s', count($songIds));
+        $stmt = $this->db->prepare(
+            "SELECT SongId, Name FROM tblSongArtists
+             WHERE SongId IN ($placeholders)
+             ORDER BY SongId, SortOrder, Id"
+        );
+        $stmt->bind_param($types, ...$songIds);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        $map = [];
+        while ($row = $result->fetch_assoc()) {
+            $map[$row['SongId']][] = $row['Name'];
+        }
+        $stmt->close();
+        return $map;
+    }
+
+    /**
+     * Cached check for the tblSongArtists table (#587). The table
+     * arrives via migrate-song-artists.php — until that's been
+     * applied, every credit-load helper that touches it must no-op.
+     * INFORMATION_SCHEMA is queried once per request.
+     */
+    private ?bool $_songArtistsTableExistsCached = null;
+    private function _songArtistsTableExists(): bool
+    {
+        if ($this->_songArtistsTableExistsCached !== null) {
+            return $this->_songArtistsTableExistsCached;
+        }
+        $stmt = $this->db->prepare(
+            "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+              WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tblSongArtists' LIMIT 1"
+        );
+        $stmt->execute();
+        $exists = $stmt->get_result()->fetch_row() !== null;
+        $stmt->close();
+        $this->_songArtistsTableExistsCached = $exists;
+        return $exists;
     }
 
     /**

--- a/appWeb/public_html/includes/pages/song.php
+++ b/appWeb/public_html/includes/pages/song.php
@@ -42,6 +42,7 @@ $composers   = $song['composers']   ?? [];
 $arrangers   = $song['arrangers']   ?? [];   /* #497 */
 $adaptors    = $song['adaptors']    ?? [];   /* #497 */
 $translators = $song['translators'] ?? [];   /* #497 */
+$artists     = $song['artists']     ?? [];   /* #587 — recording / release artist */
 $tuneName    = $song['tuneName']    ?? '';   /* #497 */
 $iswc        = $song['iswc']        ?? '';   /* #497 */
 $copyright   = $song['copyright']   ?? '';
@@ -217,6 +218,7 @@ unset($_t);
                     ['arranged',    'Arranged by',   'fa-solid fa-sliders',     $arrangers],
                     ['adapted',     'Adapted by',    'fa-solid fa-compact-disc',$adaptors],
                     ['translated',  'Translated by', 'fa-solid fa-language',    $translators],
+                    ['artist',      'Artist',        'fa-solid fa-microphone',  $artists],         /* #587 */
                 ];
             } else {
                 $_creditRows = [
@@ -225,6 +227,7 @@ unset($_t);
                     ['arranged',    'Arranged by', 'fa-solid fa-sliders',     $arrangers],
                     ['adapted',     'Adapted by',  'fa-solid fa-compact-disc',$adaptors],
                     ['translated',  'Translated by','fa-solid fa-language',   $translators],
+                    ['artist',      'Artist',      'fa-solid fa-microphone',  $artists],          /* #587 */
                 ];
             }
             $_hasAnyCredit = false;

--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -56,6 +56,28 @@ require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_
 require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
 require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'SongData.php';
 
+/**
+ * Cached check for the tblSongArtists table (#587). The table arrives
+ * via migrate-song-artists.php; until that migration has been
+ * applied, the save_song path needs to skip both the DELETE and the
+ * INSERT for artists rather than 500ing on a partly-migrated install.
+ * Static cache so the INFORMATION_SCHEMA round-trip happens once per
+ * request even when save_song runs in a loop.
+ */
+function _songArtistsTableExists(\mysqli $db): bool
+{
+    static $cached = null;
+    if ($cached !== null) return $cached;
+    $stmt = $db->prepare(
+        "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tblSongArtists' LIMIT 1"
+    );
+    $stmt->execute();
+    $cached = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $cached;
+}
+
 /* =========================================================================
  * REQUEST HANDLING
  * ========================================================================= */
@@ -533,8 +555,17 @@ switch ($action) {
                tables from #497 are cleaned up here too. */
             foreach ([
                 'tblSongWriters', 'tblSongComposers', 'tblSongArrangers',
-                'tblSongAdaptors', 'tblSongTranslators', 'tblSongComponents',
+                'tblSongAdaptors', 'tblSongTranslators', 'tblSongArtists',
+                'tblSongComponents',
             ] as $childTable) {
+                /* tblSongArtists (#587) only exists once
+                   migrate-song-artists.php has been applied. Skip the
+                   DELETE on a partly-migrated install rather than 500ing
+                   the save path; the schema-audit page (#518) flags the
+                   missing table separately. */
+                if ($childTable === 'tblSongArtists' && !_songArtistsTableExists($db)) {
+                    continue;
+                }
                 $del = $db->prepare("DELETE FROM {$childTable} WHERE SongId = ?");
                 $del->bind_param('s', $songId);
                 $del->execute();
@@ -543,7 +574,9 @@ switch ($action) {
 
             /* Insert credit collections. Each collection is a separate
                prepared statement to keep the field name explicit at each
-               call site. */
+               call site. The artists insert (#587) is gated on the
+               table existing — same partly-migrated tolerance as the
+               DELETE above. */
             $creditInserts = [
                 'writers'     => 'INSERT INTO tblSongWriters     (SongId, Name) VALUES (?, ?)',
                 'composers'   => 'INSERT INTO tblSongComposers   (SongId, Name) VALUES (?, ?)',
@@ -551,6 +584,14 @@ switch ($action) {
                 'adaptors'    => 'INSERT INTO tblSongAdaptors    (SongId, Name) VALUES (?, ?)',
                 'translators' => 'INSERT INTO tblSongTranslators (SongId, Name) VALUES (?, ?)',
             ];
+            if (_songArtistsTableExists($db)) {
+                /* SortOrder defaults to 0 — display order falls back to
+                   Id (insertion order) which matches how the editor
+                   sends the artists array. Same 2-param shape as the
+                   other credit inserts so the existing loop below works
+                   without a special case. */
+                $creditInserts['artists'] = 'INSERT INTO tblSongArtists (SongId, Name) VALUES (?, ?)';
+            }
             $regNames = [];
             foreach ($creditInserts as $key => $sql) {
                 $stmt = $db->prepare($sql);

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -546,6 +546,7 @@ function selectSong(songId) {
     renderArrangers(song);    /* #497 */
     renderAdaptors(song);     /* #497 */
     renderTranslators(song);  /* #497 */
+    renderArtists(song);      /* #587 */
 
     /* Render the translations (cross-song link) panel (#352). */
     renderTranslations(song);
@@ -1687,6 +1688,7 @@ var CREDIT_KIND_FOR_KEY = {
     arrangers:   'arranger',
     adaptors:    'adaptor',
     translators: 'translator',
+    artists:     'artist',     /* #587 */
 };
 
 function renderCreditChipList(song, key, containerId, addLabel) {
@@ -1730,6 +1732,10 @@ function renderAdaptors(song) {
 
 function renderTranslators(song) {
     renderCreditChipList(song, 'translators', 'translators-container', 'Add Translator');
+}
+
+function renderArtists(song) {
+    renderCreditChipList(song, 'artists',     'artists-container',     'Add Artist');
 }
 
 /* ----------------------------------------------------------------------

--- a/appWeb/public_html/manage/editor/index.php
+++ b/appWeb/public_html/manage/editor/index.php
@@ -1063,6 +1063,15 @@ $currentUser = getCurrentUser();
                             <div id="translators-container"></div>
                         </div>
 
+                        <!-- Artists Section (#587) — recording / release artist -->
+                        <div class="mb-4">
+                            <label class="form-label">
+                                <i class="bi bi-mic me-1"></i>Artists
+                                <small class="text-muted ms-1">(recording / release artist — useful for contemporary worship songs)</small>
+                            </label>
+                            <div id="artists-container"></div>
+                        </div>
+
                         <!-- Translations Section — linked translations in other languages (#352) -->
                         <div class="mb-4">
                             <label class="form-label">

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -201,6 +201,7 @@ if ($action !== '') {
         'activity-log-expand' => 'migrate-activity-log-expand.php',
         'credit-people' => 'migrate-credit-people.php',
         'credit-people-flags' => 'migrate-credit-people-flags.php',
+        'song-artists'  => 'migrate-song-artists.php',
         'cleanup'     => 'cleanup.php',
         'backup'      => 'backup.php',
         'restore'     => 'restore.php',
@@ -697,6 +698,27 @@ if ($hasCredentials && defined('DB_HOST')) {
                         </p>
                         <a href="?action=credit-people-flags" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
                             Run Credit People Flags Migration
+                        </a>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="card bg-dark border-secondary h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">3h. Songs Artist credit (#587)</h5>
+                        <p class="card-text text-secondary small">
+                            Adds <code>tblSongArtists</code> — a sixth credit role
+                            parallel to the existing five (writers / composers /
+                            arrangers / adaptors / translators). Captures the
+                            recording / release artist of contemporary worship
+                            songs (e.g. <em>Hillsong Worship</em> for "What a
+                            Beautiful Name") and feeds the future ProPresenter
+                            export. Names auto-register in <code>tblCreditPeople</code>
+                            via the same INSERT-IGNORE pattern as the other roles.
+                            Idempotent — safe to re-run.
+                        </p>
+                        <a href="?action=song-artists" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
+                            Run Songs Artist Migration
                         </a>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary

Adds a sixth credit role to Songs — **Artist** — parallel to the existing five (writers / composers / arrangers / adaptors / translators). Captures the recording / release artist of contemporary worship songs (e.g. *Hillsong Worship* for "What a Beautiful Name", *Matt Redman* for "10,000 Reasons"). Traditional hymns often leave it blank; the field is purely additive across the stack.

## What ships in this PR

| Layer | Change |
|---|---|
| Schema | New `tblSongArtists` (Id, SongId, Name, SortOrder, CreatedAt) with FK to tblSongs |
| Migration | `appWeb/.sql/migrate-song-artists.php` — idempotent, follows the credit-fields pattern |
| Setup dashboard | New "3h. Songs Artist credit" card + entry in `\$scriptMap` |
| Editor (server) | `save_song` writes / replaces tblSongArtists rows; `_songArtistsTableExists()` guards the partly-migrated case |
| Editor (UI) | New `#artists-container` chip-list under Translators; identical autocomplete (live-search via `credit_search?kind=artist`) |
| Load path | `SongData::_getArtists()` + `_getArtistsMap()` attach `artists: string[]` to every song from `exportAsJson()` and `getSong()` |
| Public song view | `song.php` `\$_creditRows` gains an "Artist" entry — header credits and the end-of-lyrics footer (#601) both pick it up automatically |
| OpenAPI | Song schema gains `artists: string[]` with example |
| Registry | Names auto-register in `tblCreditPeople` through the existing INSERT-IGNORE pass over `\$regNames` — no extra code |

## Why

The current credit roles cover authorship but not "who released the recording" — for contemporary worship songs the recording artist is often the most useful identifier and the field that ProPresenter / similar exports expect. Combined with #585 (Group flag), real recording artists (most are bands) read correctly in the registry. ProPresenter export (#412 / similar) can now map `artists[0]` to the destination `Artist` field cleanly.

## Test plan

- [ ] Apply `?action=song-artists` migration on `/manage/setup-database`. Confirm `tblSongArtists` exists via `DESCRIBE` and the migration card reports `[add] tblSongArtists.` first run, `[skip]` thereafter.
- [ ] Open a song in the editor (e.g. one labelled "What a Beautiful Name" if seeded, otherwise any song). Add "Hillsong Worship" via the new Artists chip list. Save.
- [ ] Reload the editor. Confirm the Artist still shows (load → save round-trip).
- [ ] Visit the public song view. Confirm the Artist row renders in the header credits (microphone icon, bold "Artist:" label) and in the end-of-lyrics footer.
- [ ] Confirm "Hillsong Worship" appears in `/manage/credit-people` registry list (auto-registered via the INSERT-IGNORE).
- [ ] On a partly-migrated install (delete tblSongArtists temporarily), confirm the editor still saves writers / composers / etc. without 500ing — the artists branch just no-ops.
- [ ] `php -l` clean across all changed PHP files; `node --check` clean on editor.js.

## Out of scope

- Per-artist landing page (filed as #588 — Credit Person public page).
- ProPresenter export wiring (the consumer; filed as #412).

🤖 Generated with [Claude Code](https://claude.com/claude-code)