### PR TITLE
fix(activity-log): default to never-prune; pruning is opt-in (#535)

### DIFF
--- a/appWeb/.sql/cleanup.php
+++ b/appWeb/.sql/cleanup.php
@@ -16,9 +16,12 @@ declare(strict_types=1);
  *   - tblEmailLoginTokens:   expired or used tokens
  *   - tblPasswordResetTokens: expired or used tokens
  *   - tblLoginAttempts:      entries older than 30 days
- *   - tblActivityLog:        entries older than the retention window
- *                            (configurable via tblAppSettings key
- *                            `activity_log_retention_days`, default 90)
+ *   - tblActivityLog:        entries older than the retention window,
+ *                            opt-in via tblAppSettings.activity_log_retention_days
+ *                            (positive integer = retention in days,
+ *                            1..3650). Default is 0 / unset = never
+ *                            prune — audit, compliance, and forensics
+ *                            all benefit from long retention.
  *
  * USAGE:
  *   CLI:  php appWeb/.sql/cleanup.php
@@ -140,20 +143,22 @@ try {
 }
 
 /* 5. tblActivityLog retention prune (#535).
-   Retention window is read from tblAppSettings::activity_log_retention_days
-   (default 90 days). Set to 0 to disable pruning entirely — useful
-   for forensics-heavy deployments that route long-term to a separate
-   archive table. Capped at sensible bounds (1..3650) so a fat-fingered
-   value can't either no-op or wipe years of history in one go. */
+   Pruning is OPT-IN — the default retention is 0 (unset), meaning
+   activity rows are kept indefinitely. Audit, compliance, and
+   forensics all benefit from long-term retention measured in years
+   rather than weeks; admins who actively want to bound the table's
+   growth set tblAppSettings.activity_log_retention_days to a
+   positive integer (1..3650 days, capped so a fat-fingered value
+   can't either no-op or wipe years of history in one go). */
 try {
     $stmt = $db->prepare("SELECT SettingValue FROM tblAppSettings WHERE SettingKey = 'activity_log_retention_days'");
     $stmt->execute();
     $row = $stmt->get_result()->fetch_row();
     $stmt->close();
     $raw = (string)($row[0] ?? '');
-    $retentionDays = $raw !== '' ? (int)$raw : 90;
-    if ($retentionDays === 0) {
-        echo "tblActivityLog:        skipped (retention = 0, pruning disabled)\n";
+    $retentionDays = $raw !== '' ? (int)$raw : 0;   /* 0 / unset = never prune */
+    if ($retentionDays <= 0) {
+        echo "tblActivityLog:        skipped (retention unset — pruning is opt-in)\n";
     } else {
         $retentionDays = max(1, min(3650, $retentionDays));
         $stmt = $db->prepare('DELETE FROM tblActivityLog WHERE CreatedAt < DATE_SUB(NOW(), INTERVAL ? DAY)');

--- a/appWeb/public_html/manage/activity-log.php
+++ b/appWeb/public_html/manage/activity-log.php
@@ -260,9 +260,11 @@ $buildQuery = function (array $overrides = []) {
         <p class="text-secondary small mb-4">
             Audit trail (#535) of every meaningful action — auth events,
             admin CRUD, user activity, API requests, system events.
-            Retention is configurable via <code>tblAppSettings.activity_log_retention_days</code>
-            (default 90 days); older rows are pruned by the daily
-            cleanup job.
+            Rows are kept indefinitely by default — the daily cleanup
+            job only prunes if an admin sets
+            <code>tblAppSettings.activity_log_retention_days</code> to
+            a positive integer (1..3650 days). Audit, compliance, and
+            forensics tend to want long retention, so pruning is opt-in.
         </p>
 
         <form method="GET" class="row g-2 mb-3 small">


### PR DESCRIPTION
## Summary

Flips the activity-log retention default from **"90 days, opt-out"** to **"never prune, opt-in"**:

- `cleanup.php` — when `tblAppSettings.activity_log_retention_days` is unset (or non-positive), the prune step now skips rather than defaulting to 90 days. To enable pruning an admin sets the value to a positive integer (1..3650, capped both ends).
- `activity-log.php` — the explanatory paragraph at the top of the page reads "kept indefinitely by default" with a clear note that pruning is opt-in.

## Why

Audit trails, compliance evidence, and forensics all benefit from long-term retention measured in years rather than weeks. A fresh install or an admin who hasn't thought about retention shouldn't silently lose 90-day-old rows behind their back. Admins who actively want to bound table growth still have the same lever — just set a positive integer.

## Origin

This was sitting on the orphaned `claude/activity-log-no-default-prune` branch (a single commit, no PR). That branch was based on a much older alpha (pre-PDO→mysqli) so a direct merge would have reverted dozens of unrelated files. This PR is the same logical change, cherry-picked onto current alpha as a clean two-file diff.

## Test plan

- [ ] On an alpha install with no `activity_log_retention_days` setting, run cleanup. Confirm the row reads `tblActivityLog: skipped (retention unset — pruning is opt-in)` and no rows are deleted.
- [ ] Set `tblAppSettings.activity_log_retention_days = 30`. Run cleanup. Confirm rows older than 30 days are deleted with the existing `tblActivityLog: N row(s) older than 30 day(s) deleted` message.
- [ ] Set the value to `0` or a negative number. Run cleanup. Confirm pruning is skipped (same as unset).
- [ ] Set the value to `5000` (above the 3650 cap). Run cleanup. Confirm the cap clamps it to 3650 (existing behaviour, unchanged).
- [ ] Visit `/manage/activity-log` and confirm the header paragraph reads "kept indefinitely by default" with the opt-in language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)