### PR TITLE
feat(avatar): per-user avatar-service preference + privacy-policy mention (closes #616)

### DIFF
--- a/appWeb/.sql/migrate-user-avatar-service.php
+++ b/appWeb/.sql/migrate-user-avatar-service.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Per-user avatar-service preference (#616 / #581 follow-up)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Adds the `AvatarService` column to `tblUsers` so each signed-in user
+ * can choose how their avatar is resolved — overriding the project-
+ * level default in APP_CONFIG['avatar']['service']. This is the
+ * per-user opt-out half of #581's acceptance criteria.
+ *
+ * Schema:
+ *   tblUsers.AvatarService VARCHAR(16) NULL
+ *
+ *   NULL    = inherit project default (Gravatar unless APP_CONFIG says
+ *             otherwise) — this is the legacy / first-time-user state.
+ *   string  = one of 'gravatar' | 'libravatar' | 'dicebear' | 'none'.
+ *
+ * @migration-adds tblUsers.AvatarService
+ *
+ * USAGE:
+ *   Web:  /manage/setup-database → Apply all pending migrations
+ *   CLI:  php appWeb/.sql/migrate-user-avatar-service.php
+ *
+ * Idempotent — re-running is safe; the column-exists check skips the
+ * ALTER, no backfill needed (NULL is the "inherit" sentinel).
+ */
+
+if (PHP_SAPI === 'cli') {
+    require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    $isCli = true;
+} else {
+    if (!defined('IHYMNS_SETUP_DASHBOARD')) {
+        require_once __DIR__ . '/../public_html/manage/includes/auth.php';
+        if (!isAuthenticated()) {
+            http_response_code(401);
+            exit('Authentication required.');
+        }
+        $u = getCurrentUser();
+        if (!$u || $u['role'] !== 'global_admin') {
+            http_response_code(403);
+            exit('Global admin required.');
+        }
+    }
+    require_once __DIR__ . '/../public_html/includes/db_mysql.php';
+    $isCli = false;
+}
+
+function _migAvatarSvc_out(string $line): void
+{
+    global $isCli;
+    echo $line . ($isCli ? "\n" : "<br>\n");
+    @ob_flush();
+    @flush();
+}
+
+function _migAvatarSvc_columnExists(mysqli $db, string $table, string $column): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+          WHERE TABLE_SCHEMA = DATABASE()
+            AND TABLE_NAME   = ?
+            AND COLUMN_NAME  = ?
+          LIMIT 1'
+    );
+    $stmt->bind_param('ss', $table, $column);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+_migAvatarSvc_out('User avatar-service migration starting…');
+
+$mysqli = getDbMysqli();
+if (!$mysqli) {
+    _migAvatarSvc_out('ERROR: could not connect to database.');
+    exit(1);
+}
+
+if (_migAvatarSvc_columnExists($mysqli, 'tblUsers', 'AvatarService')) {
+    _migAvatarSvc_out('[skip] tblUsers.AvatarService already present.');
+} else {
+    $sql = 'ALTER TABLE tblUsers
+            ADD COLUMN AvatarService VARCHAR(16) NULL';
+    if (!$mysqli->query($sql)) {
+        _migAvatarSvc_out('ERROR: adding AvatarService failed: ' . $mysqli->error);
+        exit(1);
+    }
+    _migAvatarSvc_out('[add ] tblUsers.AvatarService.');
+}
+
+_migAvatarSvc_out('User avatar-service migration finished.');
+$mysqli->close();

--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -900,10 +900,11 @@ if ($action !== null) {
             sendJson([
                 'token' => $token,
                 'user'  => [
-                    'id'           => $userId,
-                    'username'     => $username,
-                    'display_name' => $displayName,
-                    'role'         => $role,
+                    'id'             => $userId,
+                    'username'       => $username,
+                    'display_name'   => $displayName,
+                    'role'           => $role,
+                    'avatar_service' => null,   /* #616 — fresh registration inherits project default */
                 ],
             ], 201);
             break;
@@ -958,7 +959,19 @@ if ($action !== null) {
                 break;
             }
 
-            $stmt = $db->prepare('SELECT Id, Username, PasswordHash, DisplayName, Role, IsActive FROM tblUsers WHERE Username = ?');
+            /* AvatarService (#616) only included when the column exists
+               so a partly-migrated install can still log users in. */
+            $hasAvatarSvcCol = false;
+            $colCheck = $db->query(
+                "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+                  WHERE TABLE_SCHEMA = DATABASE()
+                    AND TABLE_NAME   = 'tblUsers'
+                    AND COLUMN_NAME  = 'AvatarService' LIMIT 1"
+            );
+            if ($colCheck && $colCheck->fetch_row() !== null) { $hasAvatarSvcCol = true; }
+            if ($colCheck) { $colCheck->close(); }
+            $avatarSvcSel = $hasAvatarSvcCol ? ', AvatarService' : ', NULL AS AvatarService';
+            $stmt = $db->prepare("SELECT Id, Username, PasswordHash, DisplayName, Role, IsActive {$avatarSvcSel} FROM tblUsers WHERE Username = ?");
             $stmt->bind_param('s', $username);
             $stmt->execute();
             $user = $stmt->get_result()->fetch_assoc();
@@ -1056,10 +1069,11 @@ if ($action !== null) {
             sendJson([
                 'token' => $token,
                 'user'  => [
-                    'id'           => (int)$user['Id'],
-                    'username'     => $user['Username'],
-                    'display_name' => $user['DisplayName'],
-                    'role'         => $user['Role'],
+                    'id'             => (int)$user['Id'],
+                    'username'       => $user['Username'],
+                    'display_name'   => $user['DisplayName'],
+                    'role'           => $user['Role'],
+                    'avatar_service' => $user['AvatarService'] ?? null,   /* #616 */
                 ],
             ]);
             break;
@@ -1121,10 +1135,11 @@ if ($action !== null) {
 
             sendJson([
                 'user' => [
-                    'id'           => $authUser['Id'],
-                    'username'     => $authUser['Username'],
-                    'display_name' => $authUser['DisplayName'],
-                    'role'         => $authUser['Role'],
+                    'id'             => $authUser['Id'],
+                    'username'       => $authUser['Username'],
+                    'display_name'   => $authUser['DisplayName'],
+                    'role'           => $authUser['Role'],
+                    'avatar_service' => $authUser['AvatarService'] ?? null,   /* #616 */
                 ],
             ]);
             break;
@@ -2195,12 +2210,86 @@ if ($action !== null) {
             sendJson([
                 'ok'   => true,
                 'user' => [
-                    'id'           => $authUser['Id'],
-                    'username'     => $authUser['Username'],
-                    'display_name' => $newDisplayName,
-                    'email'        => $newEmail,
-                    'role'         => $authUser['Role'],
+                    'id'             => $authUser['Id'],
+                    'username'       => $authUser['Username'],
+                    'display_name'   => $newDisplayName,
+                    'email'          => $newEmail,
+                    'role'           => $authUser['Role'],
+                    'avatar_service' => $authUser['AvatarService'] ?? null,   /* #616 */
                 ],
+            ]);
+            break;
+
+        /* -----------------------------------------------------------------
+         * Update the authenticated user's avatar-service preference (#616).
+         *
+         * POST body (JSON): { "avatar_service": "gravatar"|"libravatar"
+         *                                     |"dicebear"|"none"|null }
+         * NULL clears the override (= inherit project default).
+         * Requires: Authorization: Bearer <token>
+         * ----------------------------------------------------------------- */
+        case 'auth_update_avatar_service':
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+
+            $authUser = getAuthenticatedUser();
+            if (!$authUser) {
+                sendJson(['error' => 'Not authenticated.'], 401);
+                break;
+            }
+
+            $rawBody = file_get_contents('php://input');
+            $body = json_decode($rawBody, true);
+            $svc  = $body['avatar_service'] ?? null;
+
+            /* Allowed: NULL ('inherit project default') or one of the
+               recognised resolver names. Mirrors USER_AVATAR_SERVICES
+               in includes/avatar.php — kept hand-typed here so the API
+               doesn't require the helper to be loaded. */
+            $allowed = ['gravatar', 'libravatar', 'dicebear', 'none'];
+            if ($svc !== null) {
+                if (!is_string($svc)) {
+                    sendJson(['error' => 'avatar_service must be a string or null.'], 400);
+                    break;
+                }
+                $svc = strtolower(trim($svc));
+                if ($svc === '') {
+                    $svc = null;
+                } elseif (!in_array($svc, $allowed, true)) {
+                    sendJson(['error' => 'avatar_service must be one of: ' . implode(', ', $allowed) . ', or null.'], 400);
+                    break;
+                }
+            }
+
+            $db = getDbMysqli();
+            $colCheck = $db->query(
+                "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+                  WHERE TABLE_SCHEMA = DATABASE()
+                    AND TABLE_NAME   = 'tblUsers'
+                    AND COLUMN_NAME  = 'AvatarService' LIMIT 1"
+            );
+            $hasCol = ($colCheck && $colCheck->fetch_row() !== null);
+            if ($colCheck) { $colCheck->close(); }
+            if (!$hasCol) {
+                sendJson([
+                    'error' => 'Avatar-service preference not yet enabled — administrator must apply migrate-user-avatar-service first.',
+                ], 503);
+                break;
+            }
+
+            $stmt = $db->prepare(
+                'UPDATE tblUsers SET AvatarService = ?, UpdatedAt = NOW() WHERE Id = ?'
+            );
+            $authUserId = (int)$authUser['Id'];
+            $stmt->bind_param('si', $svc, $authUserId);
+            $stmt->execute();
+            $stmt->close();
+
+            sendJson([
+                'ok'             => true,
+                'avatar_service' => $svc,
             ]);
             break;
 
@@ -5714,11 +5803,31 @@ function getAuthenticatedUser(): ?array
     $db = getDbMysqli();
     $hashedToken = hash('sha256', $token);
     $now = gmdate('c');
+
+    /* AvatarService (#616) is selected only when the column exists, so
+       a partly-migrated install keeps working. The check is cached for
+       the lifetime of the request via a static. */
+    static $hasAvatarSvcCol = null;
+    if ($hasAvatarSvcCol === null) {
+        $r = $db->query(
+            "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+              WHERE TABLE_SCHEMA = DATABASE()
+                AND TABLE_NAME   = 'tblUsers'
+                AND COLUMN_NAME  = 'AvatarService' LIMIT 1"
+        );
+        $hasAvatarSvcCol = ($r && $r->fetch_row() !== null);
+        if ($r) $r->close();
+    }
+    $avatarSvcCol = $hasAvatarSvcCol ? ', u.AvatarService' : ', NULL AS AvatarService';
+    $emailCol     = ', u.Email';
+
     $stmt = $db->prepare(
-        'SELECT u.Id, u.Username, u.DisplayName, u.Role
+        "SELECT u.Id, u.Username, u.DisplayName, u.Role
+                {$emailCol}
+                {$avatarSvcCol}
          FROM tblApiTokens t
          JOIN tblUsers u ON u.Id = t.UserId
-         WHERE t.Token = ? AND t.ExpiresAt > ? AND u.IsActive = 1'
+         WHERE t.Token = ? AND t.ExpiresAt > ? AND u.IsActive = 1"
     );
     $stmt->bind_param('ss', $hashedToken, $now);
     $stmt->execute();

--- a/appWeb/public_html/includes/avatar.php
+++ b/appWeb/public_html/includes/avatar.php
@@ -24,14 +24,26 @@ declare(strict_types=1);
  */
 
 /**
+ * Allowed values for the per-user override and the project-level config.
+ * Anything else collapses to the project default. Exposed as a constant
+ * so the API and Settings UI can validate against the same list.
+ */
+const USER_AVATAR_SERVICES = ['gravatar', 'libravatar', 'dicebear', 'none'];
+
+/**
  * Compute the avatar URL for a user.
  *
- * @param string|null $email  The user's email address. Empty / null
- *                            returns the static fallback identicon.
- * @param int         $size   Pixel size requested from the resolver.
- * @return string             Absolute URL ready to drop into <img src>.
+ * @param string|null $email        The user's email address. Empty / null
+ *                                  returns the static fallback identicon.
+ * @param int         $size         Pixel size requested from the resolver.
+ * @param string|null $userOverride Per-user service preference (#616).
+ *                                  NULL = inherit project default; otherwise
+ *                                  one of USER_AVATAR_SERVICES. Unknown
+ *                                  values are silently ignored, falling
+ *                                  back to the project default.
+ * @return string                   Absolute URL ready to drop into <img src>.
  */
-function userAvatarUrl(?string $email, int $size = 64): string
+function userAvatarUrl(?string $email, int $size = 64, ?string $userOverride = null): string
 {
     $cfg = (defined('APP_CONFIG') && is_array(APP_CONFIG) && isset(APP_CONFIG['avatar']))
          ? APP_CONFIG['avatar']
@@ -39,6 +51,16 @@ function userAvatarUrl(?string $email, int $size = 64): string
     $service = strtolower((string)($cfg['service'] ?? 'gravatar'));
     $default = (string)($cfg['default'] ?? 'identicon');
     $rating  = (string)($cfg['rating']  ?? 'g');
+
+    /* Per-user override (#616) — takes precedence over the project
+       default when set to one of the recognised values. NULL or an
+       unknown string falls through to the project setting. */
+    if ($userOverride !== null) {
+        $userOverride = strtolower(trim($userOverride));
+        if (in_array($userOverride, USER_AVATAR_SERVICES, true)) {
+            $service = $userOverride;
+        }
+    }
 
     $email = trim((string)$email);
 

--- a/appWeb/public_html/includes/pages/privacy.php
+++ b/appWeb/public_html/includes/pages/privacy.php
@@ -221,6 +221,21 @@ $appUrl = $app["Application"]["Website"]["URL"];
                 <li><strong>Plausible Analytics</strong> (if enabled) — privacy-focused, cookieless analytics. <a href="https://plausible.io/data-policy" target="_blank" rel="noopener noreferrer">Data policy</a></li>
                 <li><strong>Matomo</strong> (if enabled) — self-hosted analytics</li>
                 <li><strong>Fathom Analytics</strong> (if enabled) — privacy-focused analytics. <a href="https://usefathom.com/legal/privacy" target="_blank" rel="noopener noreferrer">Privacy policy</a></li>
+                <li>
+                    <strong>Avatar resolvers</strong> (signed-in users only) —
+                    a SHA-256 hash of your email address may be sent to one of
+                    Gravatar (default), Libravatar, or DiceBear so that your
+                    circular avatar can be resolved. Gravatar / Libravatar
+                    return your registered avatar (or a generated identicon);
+                    DiceBear renders a deterministic geometric pattern from
+                    the hash without performing a registered-avatar lookup.
+                    The full email never leaves <?= htmlspecialchars($appName) ?>'s servers — only its hash. You can change your
+                    avatar source — or disable third-party requests entirely —
+                    in Settings &gt; Profile &gt; Avatar source.
+                    <a href="https://gravatar.com/support/data-and-privacy/" target="_blank" rel="noopener noreferrer">Gravatar privacy</a> ·
+                    <a href="https://www.libravatar.org/privacy/" target="_blank" rel="noopener noreferrer">Libravatar privacy</a> ·
+                    <a href="https://www.dicebear.com/legal/privacy-policy/" target="_blank" rel="noopener noreferrer">DiceBear privacy</a>
+                </li>
             </ul>
         </div>
     </div>

--- a/appWeb/public_html/includes/pages/settings.php
+++ b/appWeb/public_html/includes/pages/settings.php
@@ -133,6 +133,65 @@ declare(strict_types=1);
                     </button>
                 </form>
 
+                <!-- Avatar service preference (#616). Per-user override
+                     of the project-level APP_CONFIG['avatar']['service']
+                     setting from #581. Stored on tblUsers.AvatarService;
+                     NULL = inherit project default. The radio set
+                     covers the privacy / look-and-feel trade-offs
+                     called out in #581's privacy section. -->
+                <form id="avatar-form" class="mb-3 pt-3 border-top" autocomplete="off">
+                    <h3 class="h6 mb-1">Avatar source</h3>
+                    <p class="text-muted small mb-2">
+                        How your circular avatar is generated when you're signed in.
+                        Some options send a hash of your email address to a third party;
+                        others stay entirely on this device.
+                    </p>
+                    <div id="avatar-msg" class="alert d-none py-2 small" role="alert"></div>
+
+                    <div class="form-check small">
+                        <input class="form-check-input" type="radio" name="avatar_service" value="" id="avatar-svc-default">
+                        <label class="form-check-label" for="avatar-svc-default">
+                            <strong>Use site default</strong>
+                            — whatever the operator has chosen (currently Gravatar unless changed).
+                        </label>
+                    </div>
+                    <div class="form-check small">
+                        <input class="form-check-input" type="radio" name="avatar_service" value="gravatar" id="avatar-svc-gravatar">
+                        <label class="form-check-label" for="avatar-svc-gravatar">
+                            <strong>Gravatar</strong>
+                            — your email hash is sent to gravatar.com, which returns your
+                            registered avatar (or a generated identicon).
+                        </label>
+                    </div>
+                    <div class="form-check small">
+                        <input class="form-check-input" type="radio" name="avatar_service" value="libravatar" id="avatar-svc-libravatar">
+                        <label class="form-check-label" for="avatar-svc-libravatar">
+                            <strong>Libravatar</strong>
+                            — federated, Gravatar-protocol-compatible alternative.
+                        </label>
+                    </div>
+                    <div class="form-check small">
+                        <input class="form-check-input" type="radio" name="avatar_service" value="dicebear" id="avatar-svc-dicebear">
+                        <label class="form-check-label" for="avatar-svc-dicebear">
+                            <strong>DiceBear identicon</strong>
+                            — a deterministic geometric pattern from the email hash.
+                            No registered-avatar lookup; no third party sees your email.
+                        </label>
+                    </div>
+                    <div class="form-check small mb-2">
+                        <input class="form-check-input" type="radio" name="avatar_service" value="none" id="avatar-svc-none">
+                        <label class="form-check-label" for="avatar-svc-none">
+                            <strong>None</strong>
+                            — the generic person icon that signed-out users see.
+                        </label>
+                    </div>
+
+                    <button type="submit" class="btn btn-primary btn-sm" id="avatar-save-btn">
+                        <i class="fa-solid fa-floppy-disk me-1" aria-hidden="true"></i>
+                        Save avatar source
+                    </button>
+                </form>
+
                 <!-- Change username form — separate because it requires
                      the current password and has its own validation rules. -->
                 <form id="username-form" class="mb-3" autocomplete="off">

--- a/appWeb/public_html/js/modules/settings.js
+++ b/appWeb/public_html/js/modules/settings.js
@@ -266,6 +266,12 @@ export class Settings {
             if (profUsername) profUsername.value = user?.username || '';
             if (profDisplay)  profDisplay.value  = user?.display_name || '';
             if (profEmail)    profEmail.value    = user?.email || '';
+
+            /* #616 — pre-tick the avatar-source radio matching the user's
+               stored preference (NULL = "Use site default"). */
+            const svc = (user?.avatar_service ?? '').toString();
+            const radio = document.querySelector(`#avatar-form input[name="avatar_service"][value="${CSS.escape(svc)}"]`);
+            if (radio) radio.checked = true;
         }
     }
 
@@ -1473,6 +1479,54 @@ export class Settings {
                     show('Profile saved.', 'success');
                 } else {
                     show(result.error || 'Could not save profile.', 'danger');
+                }
+            });
+        }
+
+        /* Avatar service preference (#616) — POSTs the chosen radio
+           value to auth_update_avatar_service. Empty string ('Use
+           site default') is sent as null so the column gets cleared
+           and inheritance kicks in. */
+        const avatarForm = document.getElementById('avatar-form');
+        if (avatarForm && !avatarForm.dataset.bound) {
+            avatarForm.dataset.bound = '1';
+            avatarForm.addEventListener('submit', async (e) => {
+                e.preventDefault();
+                const picked = avatarForm.querySelector('input[name="avatar_service"]:checked');
+                const value = picked ? picked.value : '';
+                const msg = document.getElementById('avatar-msg');
+                const show = (text, kind) => {
+                    if (!msg) return;
+                    msg.className = 'alert py-2 small alert-' + kind;
+                    msg.textContent = text;
+                    msg.classList.remove('d-none');
+                };
+                try {
+                    const res = await fetch(`${this.app.config.apiUrl}?action=auth_update_avatar_service`, {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'X-Requested-With': 'XMLHttpRequest',
+                            ...auth.authHeaders(),
+                        },
+                        body: JSON.stringify({ avatar_service: value === '' ? null : value }),
+                    });
+                    const data = await res.json();
+                    if (!res.ok) {
+                        show(data.error || 'Could not save avatar source.', 'danger');
+                        return;
+                    }
+                    /* Update the cached user record so the header swaps
+                       immediately without a re-login. saveCredentials
+                       broadcasts ihymns:auth-changed which triggers
+                       _updateHeaderState → new avatar URL. */
+                    const cached = auth.getUser() || {};
+                    cached.avatar_service = data.avatar_service;
+                    const token = auth.getToken();
+                    if (token) auth.saveCredentials(token, cached);
+                    show('Avatar source saved.', 'success');
+                } catch {
+                    show('Network error. Please try again.', 'danger');
                 }
             });
         }

--- a/appWeb/public_html/js/modules/user-auth.js
+++ b/appWeb/public_html/js/modules/user-auth.js
@@ -604,7 +604,10 @@ export class UserAuth {
         const slot = document.getElementById('header-user-icon');
         if (!slot) return;
         if (loggedIn && user) {
-            this._gravatarUrl(user.email || user.username, 64).then(url => {
+            /* #616 — honour the per-user avatar-service preference. NULL
+               or unrecognised string falls through to the default
+               (Gravatar) inside _avatarUrl. */
+            this._avatarUrl(user.email || user.username, 64, user.avatar_service).then(url => {
                 /* User may have signed out by the time the hash resolves. */
                 if (!this.isLoggedIn()) return;
                 const current = document.getElementById('header-user-icon');
@@ -636,25 +639,47 @@ export class UserAuth {
     }
 
     /**
-     * Build a Gravatar URL. Uses SHA-256 via SubtleCrypto since
-     * Gravatar accepts both MD5 (legacy) and SHA-256 (since 2022) —
-     * SHA-256 lets us avoid shipping a hand-rolled hash. Mirrors PHP
-     * `userAvatarUrl()` so signed-in users see the same avatar in
-     * both surfaces.
+     * Build an avatar URL. Mirrors PHP `userAvatarUrl()` so signed-in
+     * users see the same avatar in both surfaces. Uses SHA-256 via
+     * SubtleCrypto (Gravatar accepts both MD5 (legacy) and SHA-256
+     * (since 2022) — SHA-256 lets us avoid shipping a hand-rolled
+     * hash).
      *
      * @param {string} email
      * @param {number} size
+     * @param {string|null} userOverride Per-user resolver preference
+     *        (#616). NULL = use Gravatar (the default for the JS path).
+     *        One of 'gravatar' | 'libravatar' | 'dicebear' | 'none'.
      * @returns {Promise<string>}
      */
-    async _gravatarUrl(email, size = 64) {
+    async _avatarUrl(email, size = 64, userOverride = null) {
         const e = (email || '').trim().toLowerCase();
         if (!e || !crypto?.subtle) return '/assets/avatar-fallback.svg';
+        const service = (typeof userOverride === 'string' ? userOverride.trim().toLowerCase() : '') || 'gravatar';
+        if (service === 'none') return '/assets/avatar-fallback.svg';
+
         const buf = new TextEncoder().encode(e);
         const hash = await crypto.subtle.digest('SHA-256', buf);
         const hex = Array.from(new Uint8Array(hash))
             .map(b => b.toString(16).padStart(2, '0'))
             .join('');
+
+        if (service === 'libravatar') {
+            return `https://seccdn.libravatar.org/avatar/${hex}?s=${size}&d=identicon&r=g`;
+        }
+        if (service === 'dicebear') {
+            return `https://api.dicebear.com/7.x/identicon/svg?seed=${encodeURIComponent(hex)}&size=${size}`;
+        }
+        /* gravatar (default) — and any unknown string */
         return `https://www.gravatar.com/avatar/${hex}?s=${size}&d=identicon&r=g`;
+    }
+
+    /* Backwards-compatible alias for the old name (#616). Kept so any
+       external caller still using `_gravatarUrl(email, size)` keeps
+       working — it just calls through to the new resolver with no
+       per-user override. */
+    _gravatarUrl(email, size = 64) {
+        return this._avatarUrl(email, size, null);
     }
 
     /**

--- a/appWeb/public_html/manage/includes/admin-nav.php
+++ b/appWeb/public_html/manage/includes/admin-nav.php
@@ -62,9 +62,10 @@ $_visibleAdminLinks = visibleAdminLinks($_role);
    once each. Email may be missing on legacy accounts → helper falls
    back to the static SVG identicon so the markup never breaks. */
 require_once __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'avatar.php';
-$_userEmail      = $currentUser['email'] ?? '';
-$_avatarUrlSmall = userAvatarUrl($_userEmail, 32);
-$_avatarUrlLarge = userAvatarUrl($_userEmail, 64);
+$_userEmail      = $currentUser['email']          ?? '';
+$_userAvatarSvc  = $currentUser['avatar_service'] ?? null;  /* #616 — NULL = inherit project default */
+$_avatarUrlSmall = userAvatarUrl($_userEmail, 32, $_userAvatarSvc);
+$_avatarUrlLarge = userAvatarUrl($_userEmail, 64, $_userAvatarSvc);
 
 ?>
 <header class="app-header navbar-admin" role="banner">

--- a/appWeb/public_html/manage/includes/auth.php
+++ b/appWeb/public_html/manage/includes/auth.php
@@ -244,14 +244,33 @@ function getCurrentUser(): ?array
        consistently. Passing a null key to the typed hasRole()
        parameter previously fatal-errored the admin dashboard mid-
        render. */
+    /* AvatarService (#616) is included via COALESCE-on-COLUMN_EXISTS
+       so the admin nav still renders on a partly-migrated install
+       that hasn't yet applied migrate-user-avatar-service. NULL value
+       means "inherit project default" — admin-nav.php passes it
+       straight to userAvatarUrl()'s third arg, which treats NULL as
+       "use APP_CONFIG default". */
+    $hasAvatarService = false;
+    $colCheck = $db->query(
+        "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+          WHERE TABLE_SCHEMA = DATABASE()
+            AND TABLE_NAME   = 'tblUsers'
+            AND COLUMN_NAME  = 'AvatarService' LIMIT 1"
+    );
+    if ($colCheck && $colCheck->fetch_row() !== null) { $hasAvatarService = true; }
+    if ($colCheck) { $colCheck->close(); }
+
+    $avatarSvcCol = $hasAvatarService ? ', AvatarService AS avatar_service' : ', NULL AS avatar_service';
+
     $stmt = $db->prepare(
-        'SELECT Id AS id,
+        "SELECT Id AS id,
                 Username AS username,
                 DisplayName AS display_name,
                 Role AS role,
                 Email AS email
+                {$avatarSvcCol}
          FROM tblUsers
-         WHERE Id = ? AND IsActive = 1'
+         WHERE Id = ? AND IsActive = 1"
     );
     $userId = (int)$_SESSION['user_id'];
     $stmt->bind_param('i', $userId);

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -203,6 +203,7 @@ if ($action !== '') {
         'credit-people-flags' => 'migrate-credit-people-flags.php',
         'song-artists'  => 'migrate-song-artists.php',
         'credit-people-slug' => 'migrate-credit-people-slug.php',
+        'user-avatar-service' => 'migrate-user-avatar-service.php',
         'cleanup'     => 'cleanup.php',
         'backup'      => 'backup.php',
         'restore'     => 'restore.php',
@@ -739,6 +740,27 @@ if ($hasCredentials && defined('DB_HOST')) {
                         </p>
                         <a href="?action=credit-people-slug" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
                             Run Credit People Slug Migration
+                        </a>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="card bg-dark border-secondary h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">3j. Per-user avatar service (#616)</h5>
+                        <p class="card-text text-secondary small">
+                            Adds <code>tblUsers.AvatarService</code> so each
+                            signed-in user can override the project-level
+                            avatar resolver default — Gravatar, Libravatar,
+                            DiceBear identicon (no third-party request), or
+                            None. NULL on this column means "inherit project
+                            default", so existing users behave identically
+                            until they choose to opt in or out via Settings
+                            &gt; Profile &gt; Avatar source. Idempotent —
+                            safe to re-run.
+                        </p>
+                        <a href="?action=user-avatar-service" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
+                            Run Per-user Avatar Service Migration
                         </a>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary

Closes the per-user opt-out half of #581's original acceptance criteria. Every signed-in user can now choose how their avatar is resolved (or disable it entirely), overriding the project-level default. Privacy policy is updated to reflect this.

## What ships

| Layer | Change |
|---|---|
| Schema | `tblUsers.AvatarService VARCHAR(16) NULL` — NULL = inherit project default |
| Migration | `migrate-user-avatar-service.php` — idempotent ALTER, no backfill needed |
| Setup dashboard | New "3j. Per-user avatar service" card |
| PHP helper | `userAvatarUrl()` gains a third arg for the per-user override; new `USER_AVATAR_SERVICES` constant |
| Admin nav | Passes the override through to `userAvatarUrl()` |
| Main-app API | `getAuthenticatedUser`, `auth_login`, `auth_register`, `auth_me`, `auth_update_profile` all return `avatar_service` |
| New API endpoint | `POST ?action=auth_update_avatar_service` with `{ avatar_service: "gravatar"\|"libravatar"\|"dicebear"\|"none"\|null }` |
| JS resolver | `_avatarUrl(email, size, override)` — Gravatar / Libravatar / DiceBear / none; `_gravatarUrl` stays as a backwards-compat alias |
| Settings UI | Radio group on Profile tab — Use site default / Gravatar / Libravatar / DiceBear / None — with privacy-relevant one-liners |
| Privacy policy | New bullet under "Third-Party Services" naming the three providers, the SHA-256 email-hash flow, and the per-user opt-out |

## Tolerant of partly-migrated installs

Every place that touches `AvatarService` first probes INFORMATION_SCHEMA so the column not existing yet is graceful — admin nav still renders, login still works, the new endpoint returns 503 with a clear pointer to the migration card.

## Test plan

- [ ] Apply `?action=user-avatar-service` migration on `/manage/setup-database`. Confirm `DESCRIBE tblUsers` shows the new column.
- [ ] Sign in to the main app. Visit Settings → Profile. Confirm the new "Avatar source" section appears below Save profile, with "Use site default" pre-selected.
- [ ] Pick **DiceBear identicon**. Click Save. Confirm the header avatar swaps to the DiceBear SVG without a page reload.
- [ ] Pick **None**. Confirm the avatar swaps to the static `/assets/avatar-fallback.svg`.
- [ ] Pick **Use site default**. Confirm the avatar swaps back to whatever the project default is (Gravatar unless `APP_CONFIG['avatar']['service']` is set differently).
- [ ] Cross-surface check: visit `/manage/`. Confirm the admin-nav avatar matches the choice you just made (i.e. byte-identical URL — same SHA-256 hash).
- [ ] Sign out, sign back in. Confirm the choice persisted (round-trips via auth_login response).
- [ ] On a fresh install with the migration NOT applied, confirm: signing in works (avatar_service comes back as null), the Settings radio group still renders, but submitting it returns the 503 with the migration pointer.
- [ ] Visit `/privacy`. Confirm the new "Avatar resolvers" bullet shows under "Third-Party Services" with links to all three providers' own privacy pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)