### PR TITLE
Bug-batch + user↔org tier resolution (closes #626–#636)

### DIFF
--- a/appWeb/public_html/css/admin.css
+++ b/appWeb/public_html/css/admin.css
@@ -208,6 +208,13 @@ body:has(.navbar-admin) {
     color: transparent;
     font-weight: 700;
     font-size: 1.15rem;
+    /* Brand button (#632) — the dropdown-toggle is rendered as a
+       <button>, which carries the browser-default button border /
+       background unless explicitly cleared. The main-app brand on
+       index.php sits inside .btn-* which already does this; the admin
+       version doesn't, so the rectangle was bleeding through. */
+    border: none;
+    background-color: transparent;
 }
 .navbar-admin .navbar-brand:hover,
 .navbar-editor .navbar-brand:hover {

--- a/appWeb/public_html/css/admin.css
+++ b/appWeb/public_html/css/admin.css
@@ -837,3 +837,25 @@ body:has(.navbar-admin) {
         gap: 0.35rem !important;
     }
 }
+
+/* ----------------------------------------------------------------------------
+   ADMIN MODAL — opaque background (#631)
+
+   Bootstrap's `bg-dark` on `.modal-content` resolves through
+   `--bs-bg-opacity`, which under some cascade orderings ends up
+   tinting partly-transparent. Page text under the modal then bleeds
+   through, making the modal hard to read (Edit Tier in Access Tiers
+   was the canonical repro).
+
+   Pin every admin modal's `.modal-content` to the same solid
+   --surface-card the cards underneath use, with the page's
+   --card-border. Scoped via `body:has(.navbar-admin)` so the
+   main-app modals on `/` keep their own theme.
+---------------------------------------------------------------------------- */
+body:has(.navbar-admin) .modal-content {
+    background-color: var(--surface-card) !important;
+    border: 1px solid var(--card-border);
+}
+body:has(.navbar-admin) .modal-content.bg-dark {
+    --bs-bg-opacity: 1;
+}

--- a/appWeb/public_html/css/admin.css
+++ b/appWeb/public_html/css/admin.css
@@ -227,24 +227,35 @@ body:has(.navbar-admin) {
     color: var(--accent-solid);
 }
 
-/* Account dropdown trigger — avatar on xs, avatar + first name + role
-   badge on sm+. Shares `.btn-header-icon` for the hover/press feel,
-   but must relax that class's fixed 40×40 so the inline name + badge
-   don't overflow the box and paint over the hamburger to its right.
-   A 40px min keeps the xs icon-only state visually consistent with
-   the other header icon buttons. */
+/* Account dropdown trigger (#633) — single 40×40 circular avatar
+   matching the other header icon buttons. The pre-#615 incarnation
+   carried inline name + role-badge content alongside the icon, so
+   the rule had to flex to `width: auto` with min-40px to fit the
+   text. Since the redesign moved name + role inside the dropdown
+   body, the trigger only ever holds the 32px avatar — pin width
+   and height to the same 40×40 footprint as the theme button + the
+   hamburger so the row reads as one cohesive control set. */
 .admin-account-btn {
-    width: auto;
-    height: auto;
+    width: 40px;
+    height: 40px;
     min-width: 40px;
     min-height: 40px;
-    padding: 0.25rem 0.6rem;
-    font-size: 0.85rem;
+    padding: 0;
     color: var(--text-secondary);
 }
 .admin-account-btn:hover,
 .admin-account-btn:focus {
     color: var(--text-primary);
+}
+/* Avatar image inside the trigger — render at the same 32px circle
+   the dropdown header uses, centred inside the 40px hit area. */
+.admin-account-btn img {
+    width: 32px;
+    height: 32px;
+    object-fit: cover;
+    border-radius: 50%;
+    display: block;
+    margin: 0 auto;
 }
 
 /* Offcanvas surface nav — slide-out list launched by the hamburger.

--- a/appWeb/public_html/css/app.css
+++ b/appWeb/public_html/css/app.css
@@ -351,6 +351,7 @@
 html {
     scroll-behavior: smooth;
     -webkit-text-size-adjust: 100%;
+    -moz-text-size-adjust: 100%;
     text-size-adjust: 100%;
 }
 
@@ -390,8 +391,8 @@ body {
     right: 0;
     z-index: 1030;
     background: var(--header-bg);
-    backdrop-filter: blur(16px) saturate(180%);
     -webkit-backdrop-filter: blur(16px) saturate(180%);
+    backdrop-filter: blur(16px) saturate(180%);
     box-shadow: var(--header-shadow);
     border-bottom: 1px solid var(--card-border);
 }
@@ -666,8 +667,8 @@ body.banner-visible.search-open .main-content {
     right: 0;
     z-index: 1030;
     background: var(--footer-bg);
-    backdrop-filter: blur(16px) saturate(180%);
     -webkit-backdrop-filter: blur(16px) saturate(180%);
+    backdrop-filter: blur(16px) saturate(180%);
     box-shadow: var(--footer-shadow);
     border-top: 1px solid var(--card-border);
 }
@@ -1436,8 +1437,8 @@ body.banner-visible.search-open .main-content {
 /* Reduced transparency mode */
 body.reduce-transparency .app-header,
 body.reduce-transparency .app-footer {
-    backdrop-filter: none;
     -webkit-backdrop-filter: none;
+    backdrop-filter: none;
     background: var(--surface-card);
 }
 
@@ -2540,8 +2541,8 @@ body.reduce-motion .related-songs-chevron {
     padding: 12px 16px;
     background: var(--glass-bg);
     border-top: 1px solid var(--glass-border);
-    backdrop-filter: blur(16px) saturate(180%);
     -webkit-backdrop-filter: blur(16px) saturate(180%);
+    backdrop-filter: blur(16px) saturate(180%);
     box-shadow: 0 -2px 16px rgba(0, 0, 0, 0.12);
     transform: translateY(100%);
     opacity: 0;
@@ -2578,8 +2579,8 @@ body.reduce-motion .related-songs-chevron {
 [data-ihymns-theme="high-contrast"] .analytics-consent-banner {
     background: #ffffff;
     border-top: 3px solid #000000;
-    backdrop-filter: none;
     -webkit-backdrop-filter: none;
+    backdrop-filter: none;
 }
 
 [data-ihymns-theme="high-contrast"] .analytics-consent-banner .btn-outline-light {
@@ -2770,6 +2771,9 @@ body.reduce-motion .related-songs-chevron {
     border-radius: var(--radius-sm);
     cursor: pointer;
     transition: color var(--transition-fast), background-color var(--transition-fast);
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
     user-select: none;
 }
 .song-lyrics[data-practice-level="2"] .lyric-line::before {
@@ -2784,6 +2788,9 @@ body.reduce-motion .related-songs-chevron {
 .song-lyrics[data-practice-level="2"] .lyric-line:hover {
     color: var(--text-primary);
     background-color: transparent;
+    -webkit-user-select: text;
+    -moz-user-select: text;
+    -ms-user-select: text;
     user-select: text;
 }
 .song-lyrics[data-practice-level="2"] .lyric-line.revealed::before,

--- a/appWeb/public_html/css/print.css
+++ b/appWeb/public_html/css/print.css
@@ -35,7 +35,11 @@
 
     .main-content {
         padding: 0 !important;
-        min-height: auto !important;
+        /* Firefox <= 21 doesn't honour `min-height: auto`; replace
+           with the explicit zero. Browsers that resolve `auto` and
+           those that don't both end up at the same effective
+           rendering for this print-rule. */
+        min-height: 0 !important;
     }
 
     .page-content {

--- a/appWeb/public_html/includes/ccli_validator.php
+++ b/appWeb/public_html/includes/ccli_validator.php
@@ -113,22 +113,55 @@ function resolveEffectiveTier(int $userId): string
     $stmt->close();
     $personalTier = (string)($row[0] ?? 'public') ?: 'public';
 
-    /* Get highest org-level tier from all memberships.
-     * Org tier comes from tblContentLicences linked to the org,
-     * or from tblOrganisations.LicenceType mapped to a tier. */
+    /* Get highest org-level tier from all memberships, walking up the
+     * nesting chain (#636). A direct membership of "Hillsong London"
+     * also inherits the licence/tier of its parent "Hillsong Worship"
+     * — using a recursive CTE up tblOrganisations.ParentOrgId so the
+     * walker stays a single round-trip regardless of nesting depth.
+     * Falls back to the old single-level query on MySQL versions
+     * that don't support WITH RECURSIVE (pre-8.0). */
     $orgTier = 'public';
 
-    /* Check org licence types and map to tiers */
-    $stmt = $db->prepare(
-        'SELECT DISTINCT o.LicenceType
-         FROM tblOrganisations o
-         JOIN tblOrganisationMembers m ON m.OrgId = o.Id
-         WHERE m.UserId = ? AND o.IsActive = 1 AND o.LicenceType != \'none\''
-    );
-    $stmt->bind_param('i', $userId);
-    $stmt->execute();
-    $orgLicences = array_column($stmt->get_result()->fetch_all(MYSQLI_ASSOC), 'LicenceType');
-    $stmt->close();
+    $orgLicences = [];
+    $sqlRecursive = "
+        WITH RECURSIVE org_chain AS (
+            /* Anchor: every org the user is a direct member of. */
+            SELECT o.Id, o.LicenceType, o.IsActive, o.ParentOrgId
+              FROM tblOrganisations o
+              JOIN tblOrganisationMembers m ON m.OrgId = o.Id
+             WHERE m.UserId = ?
+            UNION ALL
+            /* Recursive step: parent orgs along the nesting chain. */
+            SELECT po.Id, po.LicenceType, po.IsActive, po.ParentOrgId
+              FROM tblOrganisations po
+              JOIN org_chain c ON c.ParentOrgId = po.Id
+        )
+        SELECT DISTINCT LicenceType
+          FROM org_chain
+         WHERE IsActive = 1 AND LicenceType <> 'none'
+    ";
+    try {
+        $stmt = $db->prepare($sqlRecursive);
+        if ($stmt) {
+            $stmt->bind_param('i', $userId);
+            $stmt->execute();
+            $orgLicences = array_column($stmt->get_result()->fetch_all(MYSQLI_ASSOC), 'LicenceType');
+            $stmt->close();
+        }
+    } catch (\Throwable $_e) {
+        /* MySQL < 8.0 / MariaDB without recursive CTE — fall back to
+         * the direct-membership query so the page keeps working. */
+        $stmt = $db->prepare(
+            'SELECT DISTINCT o.LicenceType
+             FROM tblOrganisations o
+             JOIN tblOrganisationMembers m ON m.OrgId = o.Id
+             WHERE m.UserId = ? AND o.IsActive = 1 AND o.LicenceType <> \'none\''
+        );
+        $stmt->bind_param('i', $userId);
+        $stmt->execute();
+        $orgLicences = array_column($stmt->get_result()->fetch_all(MYSQLI_ASSOC), 'LicenceType');
+        $stmt->close();
+    }
 
     /* Map org licence types to access tiers */
     $licenceToTier = [

--- a/appWeb/public_html/includes/pages/settings.php
+++ b/appWeb/public_html/includes/pages/settings.php
@@ -18,6 +18,19 @@
 
 declare(strict_types=1);
 
+/**
+ * Variables provided by the calling context (api.php / index.php
+ * before this template is included). Declared here so intelephense
+ * can resolve the references in the body of the file (#634); the
+ * runtime injection itself is unchanged.
+ *
+ * @var array $app  Parsed iHymns application metadata from
+ *                  /includes/infoAppVer.php — keys read below
+ *                  include Application.Name, Application.Version,
+ *                  Application.Vendor.Name, Application.License.User
+ *                  and Application.Version.Repo.Commit.
+ */
+
 ?>
 
 <!-- ================================================================

--- a/appWeb/public_html/manage/credit-people.php
+++ b/appWeb/public_html/manage/credit-people.php
@@ -582,12 +582,35 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
              * actually meant Merge instead).
              * -------------------------------------------------------- */
             case 'rename': {
-                $id      = (int)($_POST['id'] ?? 0);
-                $newName = trim((string)($_POST['new_name'] ?? ''));
+                $id          = (int)($_POST['id'] ?? 0);
+                $sourceName  = trim((string)($_POST['source_name'] ?? ''));
+                $newName     = trim((string)($_POST['new_name'] ?? ''));
 
-                if ($id <= 0)                  { $error = 'Person id missing.'; break; }
+                if ($id <= 0 && $sourceName === '') { $error = 'Person id or source name missing.'; break; }
                 if ($newName === '')           { $error = 'New name is required.'; break; }
                 if (mb_strlen($newName) > 255) { $error = 'Name must be 255 characters or fewer.'; break; }
+
+                /* In-use-only rename support (#626). When the row isn't
+                   in the registry yet (Stuart Townend duplicate case),
+                   the JS posts source_name instead of (or alongside)
+                   id; we auto-register a row for it on the fly so the
+                   rest of the rename code path doesn't have to branch. */
+                if ($id <= 0 && $sourceName !== '') {
+                    $reg = $db->prepare('SELECT Id FROM tblCreditPeople WHERE Name = ?');
+                    $reg->bind_param('s', $sourceName);
+                    $reg->execute();
+                    $regRow = $reg->get_result()->fetch_row();
+                    $reg->close();
+                    if ($regRow) {
+                        $id = (int)$regRow[0];
+                    } else {
+                        $ins = $db->prepare('INSERT INTO tblCreditPeople (Name) VALUES (?)');
+                        $ins->bind_param('s', $sourceName);
+                        $ins->execute();
+                        $id = (int)$db->insert_id;
+                        $ins->close();
+                    }
+                }
 
                 /* Look up the current name + check that the target
                    spelling isn't already in use by a different row. */
@@ -678,8 +701,34 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             case 'merge': {
                 $sourceId   = (int)($_POST['source_id'] ?? 0);
                 $targetId   = (int)($_POST['target_id'] ?? 0);
+                $sourceName = trim((string)($_POST['source_name'] ?? ''));
+                $targetName = trim((string)($_POST['target_name'] ?? ''));
                 $keepLinks  = array_map('intval', (array)($_POST['keep_link_ids'] ?? []));
                 $keepIpi    = array_map('intval', (array)($_POST['keep_ipi_ids']  ?? []));
+
+                /* In-use-only merge support (#626) — the JS posts a
+                   *_name fallback when a row isn't yet in the registry
+                   (e.g. Stuart Townend duplicates). Auto-register
+                   either side as needed so the rest of the merge code
+                   path can assume both sides have a registry id. */
+                $resolvePersonId = static function (int $id, string $name) use ($db): int {
+                    if ($id > 0)       return $id;
+                    if ($name === '')  return 0;
+                    $stmt = $db->prepare('SELECT Id FROM tblCreditPeople WHERE Name = ?');
+                    $stmt->bind_param('s', $name);
+                    $stmt->execute();
+                    $row = $stmt->get_result()->fetch_row();
+                    $stmt->close();
+                    if ($row) return (int)$row[0];
+                    $ins = $db->prepare('INSERT INTO tblCreditPeople (Name) VALUES (?)');
+                    $ins->bind_param('s', $name);
+                    $ins->execute();
+                    $newId = (int)$db->insert_id;
+                    $ins->close();
+                    return $newId;
+                };
+                $sourceId = $resolvePersonId($sourceId, $sourceName);
+                $targetId = $resolvePersonId($targetId, $targetName);
 
                 if ($sourceId <= 0 || $targetId <= 0) { $error = 'Both source and target are required.'; break; }
                 if ($sourceId === $targetId)          { $error = 'Source and target must be different people.'; break; }
@@ -1373,19 +1422,38 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
                                 </td>
                                 <td class="text-end action-col">
                                     <div class="btn-group btn-group-sm" role="group" aria-label="Row actions">
-                                        <?php if ($p['registry_id'] !== null): ?>
+                                        <?php
+                                            /* Merge / Rename / Delete are available for any row that
+                                               either has a registry entry OR has at least one credited
+                                               use (#626). The Merge handler auto-registers source/target
+                                               on submit if needed, so the UI no longer hides the action
+                                               from in-use-only rows like the Stuart Townend duplicates. */
+                                            $hasUse      = (int)$p['total'] > 0;
+                                            $inRegistry  = $p['registry_id'] !== null;
+                                            $hasActions  = $inRegistry || $hasUse;
+                                        ?>
+                                        <?php if (!$inRegistry && $hasUse): ?>
+                                            <button type="button" class="btn btn-outline-info cp-edit-btn"
+                                                    title="Add to registry — opens the detail drawer pre-filled with this person"
+                                                    aria-label="Add <?= htmlspecialchars($p['name'], ENT_QUOTES) ?> to the registry">
+                                                <i class="bi bi-plus-circle" aria-hidden="true"></i>
+                                            </button>
+                                        <?php elseif ($inRegistry): ?>
                                             <button type="button" class="btn btn-outline-info cp-edit-btn"
                                                     title="Edit person details"
                                                     aria-label="Edit person <?= htmlspecialchars($p['name'], ENT_QUOTES) ?>">
                                                 <i class="bi bi-pencil" aria-hidden="true"></i>
                                             </button>
+                                        <?php endif; ?>
+
+                                        <?php if ($hasActions): ?>
                                             <button type="button" class="btn btn-outline-warning cp-rename-btn"
                                                     title="Rename — cascades to every song that cites this person"
                                                     aria-label="Rename person <?= htmlspecialchars($p['name'], ENT_QUOTES) ?>">
                                                 <i class="bi bi-pencil-square" aria-hidden="true"></i>
                                             </button>
                                             <button type="button" class="btn btn-outline-warning cp-merge-btn"
-                                                    title="Merge into another person — combines two registry rows"
+                                                    title="Merge into another person — combines two names into one"
                                                     aria-label="Merge person <?= htmlspecialchars($p['name'], ENT_QUOTES) ?>">
                                                 <i class="bi bi-union" aria-hidden="true"></i>
                                             </button>
@@ -1394,17 +1462,13 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
                                                     aria-label="View songs that cite <?= htmlspecialchars($p['name'], ENT_QUOTES) ?>">
                                                 <i class="bi bi-music-note-list" aria-hidden="true"></i>
                                             </button>
-                                            <button type="button" class="btn btn-outline-danger cp-delete-btn"
-                                                    title="Remove from registry"
-                                                    aria-label="Remove <?= htmlspecialchars($p['name'], ENT_QUOTES) ?> from the registry">
-                                                <i class="bi bi-trash" aria-hidden="true"></i>
-                                            </button>
-                                        <?php else: ?>
-                                            <button type="button" class="btn btn-outline-info cp-edit-btn"
-                                                    title="Add to registry — fills in the name + opens the detail drawer for this person"
-                                                    aria-label="Add <?= htmlspecialchars($p['name'], ENT_QUOTES) ?> to the registry">
-                                                <i class="bi bi-plus-circle" aria-hidden="true"></i>
-                                            </button>
+                                            <?php if ($inRegistry): ?>
+                                                <button type="button" class="btn btn-outline-danger cp-delete-btn"
+                                                        title="Remove from registry"
+                                                        aria-label="Remove <?= htmlspecialchars($p['name'], ENT_QUOTES) ?> from the registry">
+                                                    <i class="bi bi-trash" aria-hidden="true"></i>
+                                                </button>
+                                            <?php endif; ?>
                                         <?php endif; ?>
                                     </div>
                                 </td>
@@ -1522,6 +1586,9 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
                     <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
                     <input type="hidden" name="action" value="rename">
                     <input type="hidden" name="id" id="cp-rename-id" value="">
+                    <!-- #626 — fallback for in-use-only rows; the server
+                         auto-registers by name when id is empty. -->
+                    <input type="hidden" name="source_name" id="cp-rename-source-name" value="">
                     <div class="modal-header border-secondary">
                         <h5 class="modal-title" id="cpRenameLabel">
                             <i class="bi bi-pencil-square me-2"></i>Rename person
@@ -1565,6 +1632,14 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
                     <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
                     <input type="hidden" name="action" value="merge">
                     <input type="hidden" name="source_id" id="cp-merge-source-id" value="">
+                    <!-- #626 — name fallbacks for in-use-only rows; the
+                         server auto-registers them on submit. The select
+                         element below carries an "id:N" / "name:X" key
+                         that the submit handler routes into either
+                         target_id or target_name before posting. -->
+                    <input type="hidden" name="source_name" id="cp-merge-source-name-hidden" value="">
+                    <input type="hidden" name="target_id"   id="cp-merge-target-id-hidden"   value="">
+                    <input type="hidden" name="target_name" id="cp-merge-target-name-hidden" value="">
                     <div class="modal-header border-secondary">
                         <h5 class="modal-title" id="cpMergeLabel">
                             <i class="bi bi-union me-2"></i>Merge person into another
@@ -1579,7 +1654,11 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
                             </div>
                             <div class="col-6">
                                 <label class="form-label small" for="cp-merge-target">Target (survives) <span class="text-danger">*</span></label>
-                                <select class="form-select form-select-sm" id="cp-merge-target" name="target_id" required>
+                                <!-- name omitted — the picked option's
+                                     value is an "id:N" / "name:X" key
+                                     that submit JS routes to either
+                                     target_id or target_name (#626). -->
+                                <select class="form-select form-select-sm" id="cp-merge-target" required>
                                     <option value="">— pick the surviving person —</option>
                                 </select>
                             </div>
@@ -2042,7 +2121,9 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
                 const raw = row.getAttribute('data-person');
                 if (!raw) return;
                 let person; try { person = JSON.parse(raw); } catch (_) { return; }
-                if (!person.registry_id) return;
+                /* In-use-only rows pass through too (#626) — the
+                   server's rename handler auto-registers the row by
+                   name on submit. */
 
                 /* Build a "this will affect …" line from the role
                    counts already on the row. */
@@ -2067,7 +2148,11 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
                         + parts.join(', ') + '.';
                 }
 
-                idIn.value     = String(person.registry_id);
+                idIn.value     = person.registry_id ? String(person.registry_id) : '';
+                /* In-use-only rows post the name as a fallback so the
+                   server can auto-register before renaming (#626). */
+                const sourceNameIn = document.getElementById('cp-rename-source-name');
+                if (sourceNameIn) sourceNameIn.value = person.registry_id ? '' : (person.name || '');
                 currentIn.value= person.name || '';
                 newIn.value    = person.name || '';
                 modal.show();
@@ -2093,12 +2178,22 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
             const ipiBox     = document.getElementById('cp-merge-children-ipi');
             const submitBtn  = document.getElementById('cp-merge-submit');
 
-            /* Build the registry-row index once on page load. Used to
-               populate the target dropdown excluding the source. */
+            /* Build the all-people index once on page load (#626). Used
+               to populate the target dropdown excluding the source. The
+               index now includes in-use-only rows, not just registry
+               rows — the server auto-registers either side on submit
+               so the dropdown can offer any name. */
             const registry = [];
             document.querySelectorAll('#cp-tbody tr[data-person]').forEach(r => {
                 let p; try { p = JSON.parse(r.getAttribute('data-person')); } catch (_) { return; }
-                if (p.registry_id) registry.push({ id: p.registry_id, name: p.name });
+                if (p.registry_id) {
+                    registry.push({ id: p.registry_id, name: p.name, key: 'id:' + p.registry_id });
+                } else if (p.total > 0) {
+                    /* In-use-only — the merge handler will INSERT IGNORE
+                       on submit. Encode the name as the option value so
+                       the form posts target_name when picked. */
+                    registry.push({ id: 0, name: p.name, key: 'name:' + p.name });
+                }
             });
             registry.sort((a, b) => a.name.localeCompare(b.name));
 
@@ -2110,10 +2205,15 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
                 const raw = row.getAttribute('data-person');
                 if (!raw) return;
                 let person; try { person = JSON.parse(raw); } catch (_) { return; }
-                if (!person.registry_id) return;
+                /* In-use-only sources flow through too (#626) — the
+                   server auto-registers by name if source_id is empty. */
 
-                sourceIdIn.value   = String(person.registry_id);
+                sourceIdIn.value   = person.registry_id ? String(person.registry_id) : '';
                 sourceNameIn.value = person.name || '';
+                /* Hidden field that tells the server to auto-register
+                   the source by name when source_id is missing. */
+                const sourceNameHidden = document.getElementById('cp-merge-source-name-hidden');
+                if (sourceNameHidden) sourceNameHidden.value = person.registry_id ? '' : (person.name || '');
 
                 /* Reset the irreversibility ack on every open so a prior
                    ticked state doesn't carry across to a fresh merge. */
@@ -2133,14 +2233,19 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
                     previewWrap.classList.remove('d-none');
                 }
 
-                /* Populate target dropdown — every registry row except
-                   the source. Sorted alphabetically. */
+                /* Populate target dropdown — every name except the
+                   source itself. The option `value` is the same `key`
+                   that distinguishes id-vs-name (e.g. "id:42" or
+                   "name:Stuart Townend") so the submit handler can
+                   route the right field to the server. Sorted
+                   alphabetically. */
                 targetSel.innerHTML = '<option value="">— pick the surviving person —</option>';
                 registry.forEach(p => {
-                    if (p.id === person.registry_id) return;
+                    if (p.id && p.id === person.registry_id) return;
+                    if (!p.id && p.name === person.name)     return;
                     const opt = document.createElement('option');
-                    opt.value = String(p.id);
-                    opt.textContent = p.name;
+                    opt.value = p.key;
+                    opt.textContent = p.name + (p.id ? '' : ' (not yet in registry)');
                     targetSel.appendChild(opt);
                 });
 
@@ -2211,6 +2316,23 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
                 refreshSubmitState();
             });
             confirmCb?.addEventListener('change', refreshSubmitState);
+
+            /* On submit, translate the picked option's key into the
+               correct hidden field (#626). The select carries
+               "id:N" for registry rows and "name:X" for in-use-only
+               rows; the server handler accepts either. */
+            modalEl.querySelector('form')?.addEventListener('submit', () => {
+                const picked = targetSel?.value || '';
+                const idHidden   = document.getElementById('cp-merge-target-id-hidden');
+                const nameHidden = document.getElementById('cp-merge-target-name-hidden');
+                if (idHidden)   idHidden.value   = '';
+                if (nameHidden) nameHidden.value = '';
+                if (picked.startsWith('id:')) {
+                    if (idHidden) idHidden.value = picked.slice(3);
+                } else if (picked.startsWith('name:')) {
+                    if (nameHidden) nameHidden.value = picked.slice(5);
+                }
+            });
         })();
 
         /* =========================================================================

--- a/appWeb/public_html/manage/credit-people.php
+++ b/appWeb/public_html/manage/credit-people.php
@@ -819,7 +819,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
     } catch (\Throwable $e) {
         error_log('[manage/credit-people.php] action=' . $action . ': ' . $e->getMessage());
-        $error = $error ?: 'Database error — check server logs for details.';
+        if ($error === '') {
+            /* This page is gated to global_admin — surfacing the
+               actual exception message + file:line is a UX win and
+               carries no security trade-off (global admins are
+               trusted with DB internals). Closes #635. */
+            $where = $e->getFile() ? (' ' . basename($e->getFile()) . ':' . $e->getLine()) : '';
+            $error = 'Database error: ' . $e->getMessage() . $where;
+        }
     }
 }
 

--- a/appWeb/public_html/manage/credit-people.php
+++ b/appWeb/public_html/manage/credit-people.php
@@ -145,6 +145,29 @@ $LINK_TYPE_CATALOGUE = [
 /* Flat lookup used by the validator + by the JS-side serialiser. */
 $LINK_TYPE_KEYS = array_keys(array_merge(...array_values($LINK_TYPE_CATALOGUE)));
 
+/**
+ * Cached check for the IsSpecialCase / IsGroup columns from #584/#585
+ * (closes #630). Both columns ship together via migrate-credit-people-
+ * flags.php, so detecting one is sufficient to assume both. The result
+ * is cached for the request lifetime via a static so the add / update_
+ * person paths don't pay the INFORMATION_SCHEMA round-trip twice.
+ */
+function _cpFlagsColumnsExist(\mysqli $db): bool
+{
+    static $cached = null;
+    if ($cached !== null) return $cached;
+    $stmt = $db->prepare(
+        "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+          WHERE TABLE_SCHEMA = DATABASE()
+            AND TABLE_NAME   = 'tblCreditPeople'
+            AND COLUMN_NAME  = 'IsSpecialCase' LIMIT 1"
+    );
+    $stmt->execute();
+    $cached = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $cached;
+}
+
 $normaliseLinks = static function (mixed $raw) use ($LINK_TYPE_KEYS): array {
     if (!is_array($raw)) return [];
     $out = [];
@@ -318,17 +341,33 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
                 $db->begin_transaction();
                 try {
-                    $stmt = $db->prepare(
-                        'INSERT INTO tblCreditPeople
-                            (Name, Notes, BirthPlace, BirthDate, DeathPlace, DeathDate, IsSpecialCase, IsGroup)
-                         VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
-                    );
-                    /* Six string fields (nullable, accept YYYY-MM-DD with
-                       type 's') plus the two integer flags from #584 / #585. */
-                    $stmt->bind_param('ssssssii',
-                        $name, $notes, $birthPlace, $birthDate, $deathPlace, $deathDate,
-                        $isSpecialCase, $isGroup
-                    );
+                    /* Detect whether the flag columns from #584/#585 are
+                       present yet (#630). On a partly-migrated install
+                       — flags migration not applied — the INSERT must
+                       skip those columns rather than throw "Unknown
+                       column", which is what surfaced as the
+                       "Database error" banner before #635 unmasked it. */
+                    $hasFlagsCols = _cpFlagsColumnsExist($db);
+                    if ($hasFlagsCols) {
+                        $stmt = $db->prepare(
+                            'INSERT INTO tblCreditPeople
+                                (Name, Notes, BirthPlace, BirthDate, DeathPlace, DeathDate, IsSpecialCase, IsGroup)
+                             VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
+                        );
+                        $stmt->bind_param('ssssssii',
+                            $name, $notes, $birthPlace, $birthDate, $deathPlace, $deathDate,
+                            $isSpecialCase, $isGroup
+                        );
+                    } else {
+                        $stmt = $db->prepare(
+                            'INSERT INTO tblCreditPeople
+                                (Name, Notes, BirthPlace, BirthDate, DeathPlace, DeathDate)
+                             VALUES (?, ?, ?, ?, ?, ?)'
+                        );
+                        $stmt->bind_param('ssssss',
+                            $name, $notes, $birthPlace, $birthDate, $deathPlace, $deathDate
+                        );
+                    }
                     $stmt->execute();
                     $newId = (int)$db->insert_id;
                     $stmt->close();
@@ -431,16 +470,30 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 try {
                     /* Update the registry row. Name is not in the SET
                        clause — renames go through the rename action. */
-                    $stmt = $db->prepare(
-                        'UPDATE tblCreditPeople
-                            SET Notes = ?, BirthPlace = ?, BirthDate = ?,
-                                DeathPlace = ?, DeathDate = ?,
-                                IsSpecialCase = ?, IsGroup = ?
-                          WHERE Id = ?'
-                    );
-                    $stmt->bind_param('sssssiii',
-                        $notes, $birthPlace, $birthDate, $deathPlace, $deathDate,
-                        $isSpecialCase, $isGroup, $id);
+                    /* Gate the flag-column writes on column existence
+                       (#630). Same partly-migrated tolerance as the
+                       add path. */
+                    if (_cpFlagsColumnsExist($db)) {
+                        $stmt = $db->prepare(
+                            'UPDATE tblCreditPeople
+                                SET Notes = ?, BirthPlace = ?, BirthDate = ?,
+                                    DeathPlace = ?, DeathDate = ?,
+                                    IsSpecialCase = ?, IsGroup = ?
+                              WHERE Id = ?'
+                        );
+                        $stmt->bind_param('sssssiii',
+                            $notes, $birthPlace, $birthDate, $deathPlace, $deathDate,
+                            $isSpecialCase, $isGroup, $id);
+                    } else {
+                        $stmt = $db->prepare(
+                            'UPDATE tblCreditPeople
+                                SET Notes = ?, BirthPlace = ?, BirthDate = ?,
+                                    DeathPlace = ?, DeathDate = ?
+                              WHERE Id = ?'
+                        );
+                        $stmt->bind_param('sssssi',
+                            $notes, $birthPlace, $birthDate, $deathPlace, $deathDate, $id);
+                    }
                     $stmt->execute();
                     $stmt->close();
 

--- a/appWeb/public_html/manage/credit-people.php
+++ b/appWeb/public_html/manage/credit-people.php
@@ -1777,7 +1777,7 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
             </div>
 
             <!-- Birth / Founded -->
-            <div class="row g-2">
+            <div class="row g-2" data-flag-section="birth">
                 <div class="col-7">
                     <label class="form-label small mb-1" for="cp-drawer-birth-place">
                         <span data-flag-label="individual">Birth place</span><span data-flag-label="group" class="d-none">Founded location</span>
@@ -1786,23 +1786,23 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
                 </div>
                 <div class="col-5">
                     <label class="form-label small mb-1" for="cp-drawer-birth-date">
-                        <span data-flag-label="individual">Birth date</span><span data-flag-label="group" class="d-none">Founded</span>
+                        <span data-flag-label="individual">Birth date</span><span data-flag-label="group" class="d-none">Founded date</span>
                     </label>
                     <input type="date" class="form-control form-control-sm" id="cp-drawer-birth-date" name="birth_date">
                 </div>
             </div>
 
-            <!-- Death / Dissolved -->
-            <div class="row g-2">
+            <!-- Death / Disbandment -->
+            <div class="row g-2" data-flag-section="death">
                 <div class="col-7">
                     <label class="form-label small mb-1" for="cp-drawer-death-place">
-                        <span data-flag-label="individual">Death place</span><span data-flag-label="group" class="d-none">Dissolved location</span>
+                        <span data-flag-label="individual">Death place</span><span data-flag-label="group" class="d-none">Disbandment location</span>
                     </label>
                     <input type="text" class="form-control form-control-sm" id="cp-drawer-death-place" name="death_place" maxlength="255">
                 </div>
                 <div class="col-5">
                     <label class="form-label small mb-1" for="cp-drawer-death-date">
-                        <span data-flag-label="individual">Death date</span><span data-flag-label="group" class="d-none">Dissolved</span>
+                        <span data-flag-label="individual">Death date</span><span data-flag-label="group" class="d-none">Disbandment date</span>
                     </label>
                     <input type="date" class="form-control form-control-sm" id="cp-drawer-death-date" name="death_date">
                 </div>
@@ -1821,7 +1821,7 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
             </div>
 
             <!-- IPI numbers — repeating sub-form -->
-            <div>
+            <div data-flag-section="ipi">
                 <div class="d-flex justify-content-between align-items-center mb-1">
                     <label class="form-label small mb-0">IPI Name Numbers</label>
                     <button type="button" class="btn btn-sm btn-outline-secondary" id="cp-add-ipi-btn">
@@ -1990,6 +1990,10 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
                     row.querySelector('input[name$="[name_used]"]').value = prefill.name_used || '';
                     row.querySelector('input[name$="[notes]"]').value     = prefill.notes     || '';
                 }
+                /* Re-apply the flag rules (#628) — ensures rows added
+                   AFTER the modal is open inherit the correct disabled
+                   state when Special case is ticked. */
+                if (typeof applyFlagLabels === 'function') applyFlagLabels();
                 return row;
             }
 
@@ -2069,14 +2073,54 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
             /* Mutually-exclusive checkboxes + label-swap for groups. */
             const specialCaseCb = document.getElementById('cp-drawer-is-special-case');
             const groupCb       = document.getElementById('cp-drawer-is-group');
+            const birthPlaceIn  = document.getElementById('cp-drawer-birth-place');
+            const birthDateIn   = document.getElementById('cp-drawer-birth-date');
+            const deathPlaceIn  = document.getElementById('cp-drawer-death-place');
+            const deathDateIn   = document.getElementById('cp-drawer-death-date');
+            const addIpiButton  = document.getElementById('cp-add-ipi-btn');
+            const ipiSection    = document.querySelector('[data-flag-section="ipi"]');
+
             function applyFlagLabels() {
-                const isGroup = !!groupCb?.checked;
+                const isGroup       = !!groupCb?.checked;
+                const isSpecialCase = !!specialCaseCb?.checked;
+
+                /* Label swap (#629) — birth/death → founded/disbandment
+                   when Group is ticked. */
                 document.querySelectorAll('[data-flag-label="individual"]').forEach(el => {
                     el.classList.toggle('d-none', isGroup);
                 });
                 document.querySelectorAll('[data-flag-label="group"]').forEach(el => {
                     el.classList.toggle('d-none', !isGroup);
                 });
+
+                /* Field disable rules (#628 / #629):
+                   - Special case → bio inputs (place + date) AND the
+                     entire IPI section disabled. Special-case rows
+                     (Anonymous / Traditional / Public Domain / Unknown)
+                     have no real bio.
+                   - Group → place inputs disabled (no single physical
+                     birth/death location for a band). Date inputs
+                     stay editable as Founded / Disbandment dates.
+                   - Default (individual) → everything editable. */
+                const placesDisabled = isSpecialCase || isGroup;
+                const datesDisabled  = isSpecialCase;
+                const ipiDisabled    = isSpecialCase;
+
+                if (birthPlaceIn) birthPlaceIn.disabled = placesDisabled;
+                if (deathPlaceIn) deathPlaceIn.disabled = placesDisabled;
+                if (birthDateIn)  birthDateIn.disabled  = datesDisabled;
+                if (deathDateIn)  deathDateIn.disabled  = datesDisabled;
+
+                /* Disable the Add IPI button + every existing IPI row's
+                   inputs. The container holds the rows added via the
+                   template so we walk the children. */
+                if (addIpiButton) addIpiButton.disabled = ipiDisabled;
+                if (ipiSection) {
+                    ipiSection.querySelectorAll('input').forEach(inp => {
+                        inp.disabled = ipiDisabled;
+                    });
+                    ipiSection.classList.toggle('opacity-50', ipiDisabled);
+                }
             }
             specialCaseCb?.addEventListener('change', () => {
                 if (specialCaseCb.checked && groupCb) groupCb.checked = false;

--- a/appWeb/public_html/manage/users.php
+++ b/appWeb/public_html/manage/users.php
@@ -217,6 +217,34 @@ $stmt->execute();
 $users = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
 $stmt->close();
 
+/* Organisation memberships per user (#636). One round-trip groups
+   the rows by UserId so the table renderer below can drop the list
+   into a new column without an N+1 query. The table is gated on
+   existence — pre-migration installs (or installs that never created
+   any org) just see no extra column data. */
+$orgsByUserId = [];
+try {
+    $stmt = $db->prepare(
+        'SELECT m.UserId, o.Id AS org_id, o.Name AS org_name, m.Role AS member_role
+           FROM tblOrganisationMembers m
+           JOIN tblOrganisations o ON o.Id = m.OrgId
+          ORDER BY o.Name ASC'
+    );
+    $stmt->execute();
+    foreach ($stmt->get_result()->fetch_all(MYSQLI_ASSOC) as $row) {
+        $orgsByUserId[(int)$row['UserId']][] = [
+            'id'   => (int)$row['org_id'],
+            'name' => (string)$row['org_name'],
+            'role' => (string)($row['member_role'] ?? ''),
+        ];
+    }
+    $stmt->close();
+} catch (\Throwable $_e) {
+    /* Org tables missing on a partly-migrated install — hide the
+       column rather than breaking the page. */
+    $orgsByUserId = [];
+}
+
 /* Available access tiers for the Change-tier modal. Falls back to an empty
    list if the table is missing (e.g. pre-migration DB) — in that case the
    Tier button is hidden rather than breaking the page. */
@@ -285,6 +313,7 @@ function canManage(array $target, array $actor): bool {
                             <th>Email</th>
                             <th>Role</th>
                             <th title="Access tier — controls lyrics / audio / MIDI / PDF / offline access for regular users">Tier</th>
+                            <th title="Organisations this user is a direct member of (#636) — the user inherits each org's licence-derived tier transitively up the nesting chain">Orgs</th>
                             <th>Status</th>
                             <th class="text-end">Actions</th>
                         </tr>
@@ -313,6 +342,20 @@ function canManage(array $target, array $actor): bool {
                                 <span class="badge bg-dark border border-secondary text-light" style="font-size: 0.7rem;">
                                     <?= htmlspecialchars((string)($u['access_tier'] ?? 'free')) ?>
                                 </span>
+                            </td>
+                            <td class="small">
+                                <?php
+                                    $userOrgs = $orgsByUserId[(int)$u['id']] ?? [];
+                                    if (empty($userOrgs)):
+                                ?>
+                                    <span class="text-muted">—</span>
+                                <?php else: ?>
+                                    <?php foreach ($userOrgs as $i => $org): ?>
+                                        <a class="badge bg-info-subtle text-info-emphasis text-decoration-none"
+                                           href="/manage/organisations.php?edit=<?= (int)$org['id'] ?>"
+                                           title="<?= htmlspecialchars($org['name']) ?><?= $org['role'] !== '' ? ' — ' . htmlspecialchars($org['role']) : '' ?>"><?= htmlspecialchars($org['name']) ?></a><?= $i < count($userOrgs) - 1 ? ' ' : '' ?>
+                                    <?php endforeach; ?>
+                                <?php endif; ?>
                             </td>
                             <td>
                                 <?php if ($u['is_active']): ?>


### PR DESCRIPTION
## Summary

Eleven discrete fixes / small features filed as #626–#636, each landed as its own commit so the per-issue audit trail stays clean. Drilling down (most-impactful first):

| # | Commit | Notes |
|---|---|---|
| **#626** | feat(credit-people): merge / rename / delete actions for in-use rows | Surfaces Merge for in-use-only rows (Stuart Townend duplicate case) — server auto-registers source/target on submit |
| **#627** | fix(css): browser-compat fixes | user-select / text-size-adjust / backdrop-filter / min-height across app.css + print.css |
| **#628 + #629** | fix(credit-people): special-case + group field disabling | Special case → disables bio + IPI; Group → disables places + relabels "Founded date" / "Disbandment date" |
| **#630** | fix(credit-people): tolerate partly-migrated flags columns | Add/Edit no longer 500s on installs that haven't applied migrate-credit-people-flags |
| **#631** | fix(manage): admin modals get an opaque background | Page text no longer bleeds through the Edit Tier modal etc. |
| **#632** | fix(manage): brand button has no border | Removes the OS-default `<button>` border so the admin brand reads flush like the main-app one |
| **#633** | fix(manage): admin avatar pinned to 40×40 | Brings the avatar trigger to the same footprint as the theme dropdown / hamburger |
| **#634** | fix(settings): @var \$app docblock | Removes the 12 intelephense "Undefined variable" warnings on settings.php |
| **#635** | fix(manage): surface real exception in credit-people banner | The generic "Database error" string is replaced with the actual exception message + file:line — `/manage/` is gated to global_admin so no security trade-off |
| **#636** (2 commits) | feat(tier) + feat(manage) | (a) resolveEffectiveTier walks the parent-org chain via recursive CTE; (b) Users page gains an Orgs column showing each user's memberships |

## Notes on #636

When I started this I thought the user↔org linkage didn't exist. It does — `tblOrganisationMembers` (Id, UserId, OrgId, Role, …) has been there since #545's era and `Manage > People > Organisations > Edit` already manages it. The actual gaps were:

1. `resolveEffectiveTier()` only walked **direct** memberships — a user belonging to "Hillsong London" didn't inherit the tier of its parent "Hillsong Worship". The new recursive CTE walks `tblOrganisations.ParentOrgId` so any ancestor's licence-derived tier counts.
2. Users page had no membership surface — admins had to flip to Organisations to see what orgs a user belongs to. Now it's a column.

The geolocation-based unlock (org address + service window → unlock for visitors inside the perimeter) is filed separately as **#637** — aspirational, depends on the data work here.

## Related issues

- #624 — Auto-delete-branch workflow not firing (filed earlier this session). This PR's branch will probably need manual deletion after merge for the same reason.

## Test plan

- [ ] **#626**: open `/manage/credit-people`, search "townend". Confirm Merge / Rename buttons now appear on Stuart Townend (47 uses) and Stuart Christopher Townend (1 use). Click Merge on the latter, pick Stuart Townend as target, tick the irreversibility ack, submit. Confirm Stuart Townend ends up at 48 uses, Stuart Christopher Townend gone.
- [ ] **#627**: open VS Code Problems panel; confirm app.css + print.css warnings are cleared.
- [ ] **#628 / #629**: open Credit Person edit drawer. Tick **Special case** — confirm Birth/Death place + dates + IPI section all disable + go opacity-50. Tick **Group** instead — confirm places disable, dates relabel "Founded date" / "Disbandment date" and stay editable. Untick — everything restores.
- [ ] **#630**: on a partly-migrated install (no migrate-credit-people-flags), Add Person succeeds.
- [ ] **#631**: open Manage > Content > Access Tiers > Edit. Confirm the modal has an opaque background, no page text bleeding through.
- [ ] **#632**: visit any /manage/* page. Confirm the iHymns Admin brand has no rectangular outline.
- [ ] **#633**: same page. Confirm the avatar button is the same size as the theme / hamburger icons.
- [ ] **#634**: open settings.php in VS Code. Confirm no "Undefined variable \$app" warnings.
- [ ] **#635**: trigger a known DB error (e.g. duplicate Name on Add). Confirm the banner surfaces the actual error message + file:line.
- [ ] **#636**: belong to a leaf org with `LicenceType='ccli'` and a parent org with `LicenceType='premium'`; confirm `tier_check?check=play_audio` returns the elevated tier. Visit Manage > Users; confirm the Orgs column shows each user's memberships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)