### PR TITLE
Tier name validation + multi-licence per org + dashboard polish (closes #639–#641, partial #642)

### DIFF
--- a/appWeb/.sql/migrate-organisation-licences.php
+++ b/appWeb/.sql/migrate-organisation-licences.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Multiple licence types per organisation (#640)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Adds the `tblOrganisationLicences` join table so each organisation
+ * can hold any number of licences (CCLI, MRL, OneLicense, …) instead
+ * of the single-value `tblOrganisations.LicenceType` column. Real
+ * churches commonly hold both CCLI (lyrics reproduction) AND MRL
+ * (musical-notation reproduction); the single-value model forced
+ * an artificial choice.
+ *
+ * Schema:
+ *   tblOrganisationLicences
+ *     Id              INT AUTO_INCREMENT PK
+ *     OrganisationId  INT FK → tblOrganisations.Id (CASCADE)
+ *     LicenceType     VARCHAR(30)
+ *     LicenceNumber   VARCHAR(255) NULL
+ *     IsActive        TINYINT(1)   DEFAULT 1
+ *     ExpiresAt       DATE NULL
+ *     Notes           TEXT NULL
+ *     CreatedAt       DATETIME DEFAULT CURRENT_TIMESTAMP
+ *     UpdatedAt       DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+ *
+ *   UNIQUE KEY uk_OrgLicence (OrganisationId, LicenceType)
+ *   INDEX idx_OrganisationId (OrganisationId)
+ *
+ * @migration-adds tblOrganisationLicences.Id
+ * @migration-adds tblOrganisationLicences.OrganisationId
+ * @migration-adds tblOrganisationLicences.LicenceType
+ *
+ * Backfill: every existing `tblOrganisations` row with a non-empty
+ * non-'none' LicenceType becomes a row in the new table. The primary
+ * column is left in place — back-compat for any tooling that reads
+ * it directly. Future migrations can drop the column once all
+ * consumers are switched over.
+ *
+ * USAGE:
+ *   Web:  /manage/setup-database → Apply all pending migrations
+ *   CLI:  php appWeb/.sql/migrate-organisation-licences.php
+ *
+ * Idempotent.
+ */
+
+if (PHP_SAPI === 'cli') {
+    require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    $isCli = true;
+} else {
+    if (!defined('IHYMNS_SETUP_DASHBOARD')) {
+        require_once __DIR__ . '/../public_html/manage/includes/auth.php';
+        if (!isAuthenticated()) {
+            http_response_code(401);
+            exit('Authentication required.');
+        }
+        $u = getCurrentUser();
+        if (!$u || $u['role'] !== 'global_admin') {
+            http_response_code(403);
+            exit('Global admin required.');
+        }
+    }
+    require_once __DIR__ . '/../public_html/includes/db_mysql.php';
+    $isCli = false;
+}
+
+function _migOrgLic_out(string $line): void
+{
+    global $isCli;
+    echo $line . ($isCli ? "\n" : "<br>\n");
+    @ob_flush();
+    @flush();
+}
+
+function _migOrgLic_tableExists(mysqli $db, string $table): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? LIMIT 1'
+    );
+    $stmt->bind_param('s', $table);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+_migOrgLic_out('Multi-licence migration starting…');
+
+$mysqli = getDbMysqli();
+if (!$mysqli) { _migOrgLic_out('ERROR: could not connect.'); exit(1); }
+
+if (_migOrgLic_tableExists($mysqli, 'tblOrganisationLicences')) {
+    _migOrgLic_out('[skip] tblOrganisationLicences already present.');
+} else {
+    $sql = "CREATE TABLE tblOrganisationLicences (
+        Id              INT UNSIGNED    AUTO_INCREMENT PRIMARY KEY,
+        OrganisationId  INT UNSIGNED    NOT NULL,
+        LicenceType     VARCHAR(30)     NOT NULL,
+        LicenceNumber   VARCHAR(255)    NULL,
+        IsActive        TINYINT(1)      NOT NULL DEFAULT 1,
+        ExpiresAt       DATE            NULL,
+        Notes           TEXT            NULL,
+        CreatedAt       DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        UpdatedAt       DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP
+                                        ON UPDATE CURRENT_TIMESTAMP,
+        UNIQUE KEY uk_OrgLicence (OrganisationId, LicenceType),
+        INDEX idx_OrganisationId (OrganisationId),
+        INDEX idx_LicenceType    (LicenceType),
+        CONSTRAINT fk_OrgLicences_Org
+            FOREIGN KEY (OrganisationId) REFERENCES tblOrganisations(Id)
+            ON DELETE CASCADE ON UPDATE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
+    if (!$mysqli->query($sql)) {
+        _migOrgLic_out('ERROR: creating tblOrganisationLicences failed: ' . $mysqli->error);
+        exit(1);
+    }
+    _migOrgLic_out('[add ] tblOrganisationLicences.');
+}
+
+/* Backfill: one row per org with a meaningful primary LicenceType. */
+$res = $mysqli->query("SELECT Id, LicenceType, LicenceNumber FROM tblOrganisations
+                        WHERE LicenceType IS NOT NULL AND LicenceType <> '' AND LicenceType <> 'none'");
+$candidates = [];
+while ($row = $res->fetch_assoc()) {
+    $candidates[] = $row;
+}
+$res->close();
+
+$ins = $mysqli->prepare(
+    'INSERT IGNORE INTO tblOrganisationLicences (OrganisationId, LicenceType, LicenceNumber)
+     VALUES (?, ?, ?)'
+);
+$filled = 0;
+foreach ($candidates as $c) {
+    $orgId = (int)$c['Id'];
+    $type  = (string)$c['LicenceType'];
+    $num   = $c['LicenceNumber'] !== null ? (string)$c['LicenceNumber'] : null;
+    $ins->bind_param('iss', $orgId, $type, $num);
+    if ($ins->execute() && $ins->affected_rows > 0) { $filled++; }
+}
+$ins->close();
+if ($filled > 0) {
+    _migOrgLic_out("[seed] backfilled {$filled} primary licence row" . ($filled === 1 ? '' : 's') . ' into the join table.');
+} else {
+    _migOrgLic_out('[seed] no rows needed backfill (all already present or no primary licences set).');
+}
+
+_migOrgLic_out('Multi-licence migration finished.');
+$mysqli->close();

--- a/appWeb/public_html/includes/ccli_validator.php
+++ b/appWeb/public_html/includes/ccli_validator.php
@@ -123,6 +123,12 @@ function resolveEffectiveTier(int $userId): string
     $orgTier = 'public';
 
     $orgLicences = [];
+    /* Walk the user → org → ancestor chain via recursive CTE (#636),
+       then union licences from BOTH the legacy primary column on
+       tblOrganisations AND the new tblOrganisationLicences join
+       table (#640). The LEFT JOIN keeps installs without the new
+       table working — the join just yields NULL rows that get
+       filtered out by the WHERE. */
     $sqlRecursive = "
         WITH RECURSIVE org_chain AS (
             /* Anchor: every org the user is a direct member of. */
@@ -136,9 +142,22 @@ function resolveEffectiveTier(int $userId): string
               FROM tblOrganisations po
               JOIN org_chain c ON c.ParentOrgId = po.Id
         )
-        SELECT DISTINCT LicenceType
-          FROM org_chain
-         WHERE IsActive = 1 AND LicenceType <> 'none'
+        SELECT LicenceType FROM (
+            /* Legacy primary licence on the org row (back-compat). */
+            SELECT DISTINCT LicenceType
+              FROM org_chain
+             WHERE IsActive = 1 AND LicenceType <> 'none'
+            UNION
+            /* Multi-licence join table (#640). Each org along the
+               chain may carry any number of additional active
+               licences here. */
+            SELECT DISTINCT ol.LicenceType
+              FROM org_chain c
+              JOIN tblOrganisationLicences ol ON ol.OrganisationId = c.Id
+             WHERE c.IsActive = 1
+               AND ol.IsActive = 1
+               AND ol.LicenceType <> 'none'
+        ) AS uniq_licences
     ";
     try {
         $stmt = $db->prepare($sqlRecursive);

--- a/appWeb/public_html/manage/help.php
+++ b/appWeb/public_html/manage/help.php
@@ -401,6 +401,16 @@ foreach ($sections as $s) {
                         affects only new users — existing users keep whatever they
                         already had.
                     </div>
+                    <div class="gotcha small">
+                        <strong>Role-gated sections (#641):</strong> the dashboard
+                        renders different bottom-of-page cards depending on your
+                        role. Curators / Editors / Admins see a lightweight
+                        <em>Your session</em> card with their role + username.
+                        <strong>Global Admins</strong> see a richer <em>System Info</em>
+                        card carrying PHP version, database driver and the
+                        connected DB name — useful for triage but not relevant
+                        to curators, so it's deliberately hidden from lower roles.
+                    </div>
                 </section>
 
                 <!-- ====================================================================

--- a/appWeb/public_html/manage/help.php
+++ b/appWeb/public_html/manage/help.php
@@ -692,6 +692,14 @@ foreach ($sections as $s) {
                     <div class="gotcha small">
                         <strong>Gotcha:</strong> One group per user. Re-assigning moves them; there's no &ldquo;in two groups at once.&rdquo;
                     </div>
+                    <div class="gotcha small">
+                        <strong>Role vs Group (#642):</strong> these names sound similar but they're independent concepts.
+                        <ul class="small mb-0">
+                            <li><strong>User Role</strong> (Curator / Admin / Global Admin) controls which Manage pages a user can <em>access</em>. The four roles are hard-coded today; new roles need a code change.</li>
+                            <li><strong>User Group</strong> controls which release channel a user sees on the public site (Alpha / Beta / RC / RTW). Group membership is freely admin-managed via this page.</li>
+                        </ul>
+                        Don't expect adding a User Group to grant Manage access — for that, change the user's Role from User Management. Issue #642 tracks the rationalisation.
+                    </div>
                 </section>
 
                 <section id="organisations" class="help-section card-admin mb-4">

--- a/appWeb/public_html/manage/index.php
+++ b/appWeb/public_html/manage/index.php
@@ -362,7 +362,16 @@ $csrf = csrfToken();
              lightweight "Your session" card instead. -->
         <?php if (($currentUser['role'] ?? '') === 'global_admin'): ?>
         <div class="card-admin p-3">
-            <h2 class="h6 mb-3"><i class="bi bi-info-circle me-2"></i>System Info</h2>
+            <h2 class="h6 mb-3 d-flex align-items-center gap-2">
+                <i class="bi bi-info-circle"></i>
+                System Info
+                <!-- Audience cue (#641) — global_admin gating is enforced
+                     by the surrounding `if`; the badge makes it
+                     self-documenting when curators see screenshots. -->
+                <span class="badge bg-danger text-light ms-auto" style="font-size: 0.6rem; font-weight: 600;">
+                    Global Admin only
+                </span>
+            </h2>
             <table class="table table-sm table-borderless mb-0 small">
                 <tr><td class="text-muted" style="width:40%">PHP Version</td><td><?= phpversion() ?></td></tr>
                 <tr><td class="text-muted">Database Driver</td><td>MySQL</td></tr>

--- a/appWeb/public_html/manage/organisations.php
+++ b/appWeb/public_html/manage/organisations.php
@@ -155,6 +155,49 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $stmt->execute();
                 $stmt->close();
 
+                /* Multi-licence sync (#640). The submitted set replaces the
+                   join-table state. The primary licence_type is also folded
+                   in as one of the rows so the two surfaces stay coherent.
+                   Wrapped in try/catch so a partly-migrated install (no
+                   tblOrganisationLicences) just no-ops the join writes. */
+                try {
+                    $picked = (array)($_POST['additional_licences'] ?? []);
+                    $picked = array_values(array_unique(array_filter(
+                        array_map('strval', $picked),
+                        static fn($k) => $k !== '' && $k !== 'none'
+                    )));
+                    if ($licenceType !== '' && $licenceType !== 'none' && !in_array($licenceType, $picked, true)) {
+                        $picked[] = $licenceType;
+                    }
+                    /* Validate every picked key against the catalogue. */
+                    $picked = array_values(array_intersect($picked, $LICENCE_TYPE_KEYS));
+
+                    $del = $db->prepare('DELETE FROM tblOrganisationLicences WHERE OrganisationId = ?');
+                    $del->bind_param('i', $id);
+                    $del->execute();
+                    $del->close();
+
+                    if (!empty($picked)) {
+                        $ins = $db->prepare(
+                            'INSERT INTO tblOrganisationLicences
+                                (OrganisationId, LicenceType, LicenceNumber)
+                             VALUES (?, ?, ?)'
+                        );
+                        foreach ($picked as $key) {
+                            /* Carry the primary's number onto the matching
+                               row so the two views agree; other rows
+                               carry NULL until edited individually in a
+                               future per-licence sub-form. */
+                            $num = ($key === $licenceType && $licenceNum !== '') ? $licenceNum : null;
+                            $ins->bind_param('iss', $id, $key, $num);
+                            $ins->execute();
+                        }
+                        $ins->close();
+                    }
+                } catch (\Throwable $_e) {
+                    /* tblOrganisationLicences not yet created — silent no-op. */
+                }
+
                 if ($beforeOrg !== null) {
                     $afterOrg = [
                         'Name' => $name, 'Slug' => $slug,
@@ -298,9 +341,11 @@ try {
 }
 
 /* Edit mode */
-$editOrg     = null;
-$editMembers = [];
-$candidates  = [];
+$editOrg      = null;
+$editMembers  = [];
+$candidates   = [];
+$editLicences = [];                  /* keys present in tblOrganisationLicences (#640) */
+$multiLicenceTableExists = false;    /* Cached so the listing render can decide quickly */
 $editId = (int)($_GET['edit'] ?? 0);
 if ($editId > 0) {
     try {
@@ -309,6 +354,24 @@ if ($editId > 0) {
         $stmt->execute();
         $editOrg = $stmt->get_result()->fetch_assoc() ?: null;
         $stmt->close();
+
+        /* Pre-load the multi-licence rows for this org (#640). Wrapped
+           in try/catch so an install without migrate-organisation-
+           licences applied just renders the section empty. */
+        try {
+            $stmt = $db->prepare(
+                'SELECT LicenceType FROM tblOrganisationLicences
+                  WHERE OrganisationId = ? AND IsActive = 1'
+            );
+            $stmt->bind_param('i', $editId);
+            $stmt->execute();
+            $editLicences = array_column($stmt->get_result()->fetch_all(MYSQLI_ASSOC), 'LicenceType');
+            $stmt->close();
+            $multiLicenceTableExists = true;
+        } catch (\Throwable $_e) {
+            $editLicences = [];
+            $multiLicenceTableExists = false;
+        }
 
         if ($editOrg) {
             $stmt = $db->prepare(
@@ -533,7 +596,7 @@ $csrf = csrfToken();
                 </div>
                 <div class="row g-2 mb-2">
                     <div class="col-sm-4">
-                        <label class="form-label small">Licence type</label>
+                        <label class="form-label small">Primary licence</label>
                         <select name="licence_type" class="form-select form-select-sm">
                             <?php foreach ($LICENCE_TYPES as $key => $info): ?>
                                 <option value="<?= htmlspecialchars($key) ?>"
@@ -556,6 +619,41 @@ $csrf = csrfToken();
                         </div>
                     </div>
                 </div>
+
+                <!-- Additional licences (#640). Each org can hold any
+                     number of licences alongside the primary — e.g. a
+                     church holding both CCLI (lyrics) and MRL (musical
+                     notation). Tier resolution unions all of them. The
+                     Primary picker above is kept for back-compat with
+                     existing tools that read tblOrganisations.LicenceType
+                     directly; saving the form syncs primary into the
+                     join table too so neither side can drift. -->
+                <?php if ($multiLicenceTableExists): ?>
+                <div class="mb-2">
+                    <label class="form-label small mb-1">Additional licences <small class="text-muted">(beyond the primary above)</small></label>
+                    <div class="d-flex flex-wrap gap-3">
+                        <?php foreach ($LICENCE_TYPES as $key => $info): ?>
+                            <?php if ($key === 'none') continue; ?>
+                            <div class="form-check small">
+                                <input class="form-check-input" type="checkbox"
+                                       name="additional_licences[]"
+                                       value="<?= htmlspecialchars($key) ?>"
+                                       id="edit-add-licence-<?= htmlspecialchars($key) ?>"
+                                       <?= in_array($key, $editLicences, true) ? 'checked' : '' ?>>
+                                <label class="form-check-label" for="edit-add-licence-<?= htmlspecialchars($key) ?>"
+                                       title="<?= htmlspecialchars($info['description']) ?>">
+                                    <?= htmlspecialchars($info['label']) ?>
+                                </label>
+                            </div>
+                        <?php endforeach; ?>
+                    </div>
+                    <div class="form-text small">
+                        Tick every licence the org holds. The org's effective
+                        access tier is the max across the primary + every
+                        additional licence + every parent-org licence (#636).
+                    </div>
+                </div>
+                <?php endif; ?>
                 <button type="submit" class="btn btn-amber-solid btn-sm mt-2">
                     <i class="bi bi-save me-1"></i>Save settings
                 </button>

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -204,6 +204,7 @@ if ($action !== '') {
         'song-artists'  => 'migrate-song-artists.php',
         'credit-people-slug' => 'migrate-credit-people-slug.php',
         'user-avatar-service' => 'migrate-user-avatar-service.php',
+        'organisation-licences' => 'migrate-organisation-licences.php',
         'cleanup'     => 'cleanup.php',
         'backup'      => 'backup.php',
         'restore'     => 'restore.php',
@@ -761,6 +762,25 @@ if ($hasCredentials && defined('DB_HOST')) {
                         </p>
                         <a href="?action=user-avatar-service" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
                             Run Per-user Avatar Service Migration
+                        </a>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="card bg-dark border-secondary h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">3k. Multiple licence types per organisation (#640)</h5>
+                        <p class="card-text text-secondary small">
+                            Adds <code>tblOrganisationLicences</code> — a join table
+                            so each organisation can hold any number of licences
+                            (e.g. CCLI for lyrics + MRL for musical notation).
+                            Backfills one row per org from the existing primary
+                            <code>LicenceType</code> column. The primary column
+                            is left in place for back-compat; tier resolution
+                            unions across both. Idempotent — safe to re-run.
+                        </p>
+                        <a href="?action=organisation-licences" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
+                            Run Multi-licence Migration
                         </a>
                     </div>
                 </div>

--- a/appWeb/public_html/manage/tiers.php
+++ b/appWeb/public_html/manage/tiers.php
@@ -50,11 +50,18 @@ const TIER_CAPS = [
     'RequiresCcli'       => ['Needs CCLI',   'Tier requires a valid CCLI licence number'],
 ];
 
+/* Name is the machine-key for a tier (e.g. 'public', 'free', 'mwbm-insiders').
+   Allow letters (both cases), digits, hyphen and underscore (#639). The
+   five reserved tiers stay lowercase because TIER_LEVELS / validTiers in
+   ccli_validator.php + api.php are still hand-rolled lowercase maps;
+   custom-named tiers above level 0 get their level from the row itself
+   (tblAccessTiers.Level), so mixed-case names like 'MWBMInsiders' work
+   correctly through the SELECT-by-Name path. */
 $validName = function (string $n): ?string {
     $n = trim($n);
-    if ($n === '')                         return 'Name is required.';
-    if (strlen($n) > 30)                   return 'Name must be 30 characters or fewer.';
-    if (!preg_match('/^[a-z0-9_]+$/', $n)) return 'Name must be lowercase letters, digits, or underscore.';
+    if ($n === '')                            return 'Name is required.';
+    if (strlen($n) > 30)                      return 'Name must be 30 characters or fewer.';
+    if (!preg_match('/^[A-Za-z0-9_-]+$/', $n)) return 'Name must be letters, digits, hyphen or underscore.';
     return null;
 };
 
@@ -70,7 +77,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     try {
         switch ($action) {
             case 'create': {
-                $name        = strtolower(trim((string)($_POST['name']         ?? '')));
+                /* #639 — preserve the admin's casing on disk. The
+                   reserved 5 (public/free/ccli/premium/pro) stay
+                   lowercase by convention; custom tier names like
+                   'MWBMInsiders' or 'mwbm-insiders' keep their
+                   original form. */
+                $name        = trim((string)($_POST['name']                    ?? ''));
                 $displayName = trim((string)($_POST['display_name']            ?? ''));
                 $level       = (int)($_POST['level']                           ?? 0);
                 $description = trim((string)($_POST['description']             ?? ''));
@@ -324,7 +336,8 @@ $tierTableCols = 3 + count(TIER_CAPS) + 2;
                 <div class="col-sm-3">
                     <label class="form-label small">Name (machine)</label>
                     <input type="text" name="name" class="form-control form-control-sm" maxlength="30" required
-                           placeholder="e.g. premium_plus" pattern="[a-z0-9_]+">
+                           placeholder="e.g. premium_plus, mwbm-insiders" pattern="[A-Za-z0-9_\-]+"
+                           title="Letters, digits, hyphen or underscore">
                 </div>
                 <div class="col-sm-3">
                     <label class="form-label small">Display name</label>


### PR DESCRIPTION
## Summary

Four discrete asks coming out of the Access Tiers / Organisations review. Filed as #639–#642 and addressed individually in their own commits.

| # | Commit | Notes |
|---|---|---|
| **#639** | fix(tiers): relax Name validation | `mwbm-insiders` / `MWBMInsiders` now valid. Letters / digits / hyphen / underscore. |
| **#640** | feat(organisations): multiple licence types per org | New `tblOrganisationLicences` join table + UI checkbox row + tier-resolution union. CCLI + MRL on the same org now both contribute. |
| **#641** | feat(manage): System Info gating cue + help docs | The card was already gated to global_admin; adds a visible badge + a Help docs note explaining why curators see a different bottom-of-dashboard card. |
| **#642** | docs(manage): clarify User Role vs User Group | Help docs gain a "Role vs Group" gotcha block. The full rationalisation (rename / schema unify / hybrid) is the open part of the issue — this is the docs half. |

## Notes per issue

### #639

Old regex was `^[a-z0-9_]+$` and the input was `strtolower()`-ed. Both fixed. The five reserved tiers (`public/free/ccli/premium/pro`) stay lowercase by convention — the `TIER_LEVELS` map and `validTiers` whitelist are still hand-rolled lowercase. Custom-named tiers above level 0 read `tblAccessTiers.Level` directly so they work regardless of case. A larger unification of those maps is a follow-up.

### #640

Real organisations regularly hold more than one licence (CCLI for lyrics + MRL for musical-notation). The single `LicenceType` column forced one. New approach:

- **Schema** — `tblOrganisationLicences` with `UNIQUE (OrganisationId, LicenceType)` + FK to org on CASCADE.
- **Migration** — backfills one row from each org's existing primary `LicenceType`.
- **Tier resolution** — `resolveEffectiveTier()` already walks user → org → ancestor (#636); now it ALSO unions licences from both the legacy primary column AND the new join table.
- **UI** — Edit Org gains an "Additional licences" checkbox row beneath the existing primary single-select. Save replaces the join-table state with the picked set; the primary licence is auto-folded in so the two surfaces stay coherent.
- **Back-compat** — primary column stays. Future migration can drop it once all consumers are switched. Partly-migrated installs (no join table) just see the primary picker as before.

### #641

`manage/index.php:363` already gates System Info to `currentUser.role === 'global_admin'`. This PR adds:

- A visible "Global Admin only" badge on the card header.
- A "Role-gated sections" gotcha block under the Dashboard help section explaining the curator-vs-global-admin difference.

No behaviour change — this is purely about discoverability.

### #642

Triage issue. Help docs gain a "Role vs Group" gotcha block under the User Groups section. The full rationalisation (rename `tblUserGroups` to `tblReleaseChannels`, or unify into one cohorts table, or just better naming) is left open on the issue itself for a product decision.

## Where #459 fits

Linked but not addressed — `$LICENCE_TYPES` is still a PHP-side map. The new join table reads from the same map for now; once #459 lands, both surfaces flip to read from `tblLicenceTypes` together.

## Test plan

- [ ] **#639**: create a tier with name `mwbm-insiders` — saves successfully. Try `MWBMInsiders` — also saves. Try `tier with spaces` — rejected with the new error message.
- [ ] **#640**: apply the new migration. Edit any org. Confirm the "Additional licences" checkbox row appears below the primary picker, with the primary's licence already ticked. Tick a second licence (e.g. CCLI on an org whose primary is iHymns Pro). Save. Reopen — both should be ticked. Confirm `tier_check` for a member of that org returns the elevated tier.
- [ ] **#641**: visit `/manage/` as global_admin — confirm the "Global Admin only" badge on the System Info card. Visit Help → Dashboard — confirm the new "Role-gated sections" gotcha appears.
- [ ] **#642**: Help → User Groups — confirm the "Role vs Group" block reads sensibly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)