### PR TITLE
feat(manage): sortable table headers across admin pages (closes #644)

### DIFF
--- a/appWeb/public_html/css/admin.css
+++ b/appWeb/public_html/css/admin.css
@@ -877,3 +877,31 @@ body:has(.navbar-admin) .modal-content {
 body:has(.navbar-admin) .modal-content.bg-dark {
     --bs-bg-opacity: 1;
 }
+
+/* ----------------------------------------------------------------------------
+   ADMIN SORTABLE TABLE HEADERS (#644)
+
+   Every <th> with data-sort-key gets `.admin-sort-th` from the boot
+   helper. Hover state hints the click target; the arrow span shows
+   the current direction (▲ asc, ▼ desc, blank = unsorted).
+---------------------------------------------------------------------------- */
+.admin-sort-th {
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    transition: background-color 120ms ease, color 120ms ease;
+}
+.admin-sort-th:hover {
+    color: var(--text-primary);
+    background-color: rgba(99, 102, 241, 0.06);
+}
+.admin-sort-th:focus-visible {
+    outline: 2px solid var(--accent-solid);
+    outline-offset: -2px;
+}
+.admin-sort-th .sort-arrow {
+    color: var(--accent-solid);
+    font-size: 0.75rem;
+    line-height: 1;
+}

--- a/appWeb/public_html/js/modules/admin-table-sort.js
+++ b/appWeb/public_html/js/modules/admin-table-sort.js
@@ -1,0 +1,209 @@
+/**
+ * iHymns — Admin table header sort (#644)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * Lightweight client-side sort for admin / manage tables. Opt-in via
+ * `class="cp-sortable"` (or any class — the bootSortableTables() entry
+ * point takes a selector) on the <table>; mark each <th> that should
+ * be sortable with `data-sort-key="…"` and an optional
+ * `data-sort-type="text|number|date"` (default text).
+ *
+ * Click cycles asc → desc → unsorted; arrows + aria-sort reflect the
+ * state. The sort is stable so re-sorting on a new column preserves
+ * the previous order as the secondary key.
+ *
+ * Each row's value for a column is read from the matching cell's
+ * text content unless a `data-sort-value` attribute on the <td>
+ * overrides it (handy for badge-cells like role pills where the
+ * displayed text isn't directly orderable).
+ *
+ * Keyboard: each header becomes role="button" + tabindex=0 so Enter
+ * and Space drive the cycle.
+ */
+
+const CYCLE_NEXT = { 'none': 'asc', 'asc': 'desc', 'desc': 'none' };
+
+/**
+ * Read the sort-comparable value for a row's cell.
+ *
+ * @param {HTMLTableRowElement} row
+ * @param {number} colIndex Column index (matches the <th>'s position).
+ * @returns {string} Raw string; the comparator coerces by type.
+ */
+function cellValue(row, colIndex) {
+    const cell = row.cells?.[colIndex];
+    if (!cell) return '';
+    const explicit = cell.getAttribute('data-sort-value');
+    return explicit !== null ? explicit : cell.textContent.trim();
+}
+
+/**
+ * Build a typed comparator. text / number / date are the supported
+ * values for `data-sort-type` on the header.
+ */
+function makeCompare(type, direction) {
+    const dir = direction === 'desc' ? -1 : 1;
+    if (type === 'number') {
+        return (a, b) => {
+            const x = parseFloat(a) || 0;
+            const y = parseFloat(b) || 0;
+            return (x - y) * dir;
+        };
+    }
+    if (type === 'date') {
+        return (a, b) => {
+            const x = Date.parse(a) || 0;
+            const y = Date.parse(b) || 0;
+            return (x - y) * dir;
+        };
+    }
+    /* text — locale + numeric so "Item 2" sorts before "Item 10". */
+    return (a, b) => a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' }) * dir;
+}
+
+/**
+ * Apply the sort state to a table. `state.column` is the column key
+ * (or null for unsorted) and `state.direction` is 'asc' | 'desc' |
+ * 'none'.
+ */
+function applySort(table, state) {
+    const tbody = table.tBodies[0];
+    if (!tbody) return;
+
+    const headers = Array.from(table.tHead?.rows[0]?.cells ?? [])
+        .map((th, i) => ({ th, key: th.getAttribute('data-sort-key'), type: th.getAttribute('data-sort-type') || 'text', index: i }));
+
+    /* Update aria-sort + arrow icons on every header. */
+    headers.forEach(h => {
+        if (!h.key) return;
+        h.th.setAttribute('aria-sort',
+            state.column === h.key && state.direction !== 'none'
+                ? (state.direction === 'asc' ? 'ascending' : 'descending')
+                : 'none');
+        const arrow = h.th.querySelector('.sort-arrow');
+        if (arrow) {
+            arrow.textContent =
+                state.column === h.key && state.direction === 'asc'  ? '▲' :
+                state.column === h.key && state.direction === 'desc' ? '▼' :
+                '';
+        }
+    });
+
+    if (state.column === null || state.direction === 'none') {
+        /* Restore the original DOM order — captured once when we
+           first attached. */
+        const originalRows = table._adminSortOriginalRows;
+        if (originalRows) {
+            originalRows.forEach(r => tbody.appendChild(r));
+        }
+        return;
+    }
+
+    const target = headers.find(h => h.key === state.column);
+    if (!target) return;
+
+    /* Sort visible rows only — so per-page filters that hide rows
+       (e.g. the search input on credit-people) don't shuffle hidden
+       rows around. The display-none rows stay in their current
+       relative position; we only reorder the visible ones. */
+    const allRows = Array.from(tbody.rows);
+    const visible = allRows.filter(r => r.offsetParent !== null);
+    const compare = makeCompare(target.type, state.direction);
+
+    /* Stable sort via map → sort → re-extract. */
+    const decorated = visible.map((row, i) => ({ row, key: cellValue(row, target.index), i }));
+    decorated.sort((a, b) => {
+        const cmp = compare(a.key, b.key);
+        return cmp !== 0 ? cmp : a.i - b.i;
+    });
+
+    /* Reinsert visible rows in their new order, preserving the
+       interleaved positions of any hidden rows. */
+    let visibleIdx = 0;
+    allRows.forEach(row => {
+        if (row.offsetParent === null) {
+            tbody.appendChild(row);
+        } else {
+            tbody.appendChild(decorated[visibleIdx++].row);
+        }
+    });
+}
+
+/**
+ * Wire one table for sortable headers.
+ */
+function bootTable(table) {
+    if (table._adminSortBound) return;
+    table._adminSortBound = true;
+
+    /* Capture the original row order once so 'unsorted' can restore. */
+    const tbody = table.tBodies[0];
+    if (!tbody) return;
+    table._adminSortOriginalRows = Array.from(tbody.rows);
+
+    const state = { column: null, direction: 'none' };
+
+    /* Decorate every sortable header. */
+    Array.from(table.tHead?.rows[0]?.cells ?? []).forEach(th => {
+        if (!th.getAttribute('data-sort-key')) return;
+        th.setAttribute('role', 'button');
+        th.setAttribute('tabindex', '0');
+        th.style.cursor = 'pointer';
+        th.classList.add('admin-sort-th');
+        if (!th.querySelector('.sort-arrow')) {
+            const arrow = document.createElement('span');
+            arrow.className = 'sort-arrow ms-1 small text-muted';
+            arrow.style.minWidth = '0.6em';
+            arrow.style.display = 'inline-block';
+            th.appendChild(arrow);
+        }
+        const cycle = () => {
+            const key = th.getAttribute('data-sort-key');
+            if (state.column !== key) {
+                state.column = key;
+                state.direction = 'asc';
+            } else {
+                state.direction = CYCLE_NEXT[state.direction];
+                if (state.direction === 'none') state.column = null;
+            }
+            applySort(table, state);
+        };
+        th.addEventListener('click', cycle);
+        th.addEventListener('keydown', e => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                cycle();
+            }
+        });
+    });
+
+    /* Apply the table's declared default sort, if any. */
+    const defaultKey = table.getAttribute('data-default-sort-key');
+    const defaultDir = table.getAttribute('data-default-sort-dir') || 'asc';
+    if (defaultKey) {
+        state.column = defaultKey;
+        state.direction = defaultDir === 'desc' ? 'desc' : 'asc';
+        applySort(table, state);
+    }
+}
+
+/**
+ * Find every matching table and wire it up. Idempotent — already-
+ * bound tables are skipped.
+ *
+ * @param {string} selector CSS selector for tables to make sortable.
+ *                          Defaults to `table.cp-sortable`.
+ */
+export function bootSortableTables(selector = 'table.cp-sortable') {
+    document.querySelectorAll(selector).forEach(bootTable);
+}
+
+/* Auto-wire on DOMContentLoaded for plain script-tag consumers. */
+if (typeof document !== 'undefined') {
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', () => bootSortableTables());
+    } else {
+        bootSortableTables();
+    }
+}

--- a/appWeb/public_html/manage/credit-people.php
+++ b/appWeb/public_html/manage/credit-people.php
@@ -1300,14 +1300,14 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
         <!-- People table -->
         <div class="card bg-dark border-secondary p-2 mb-3">
             <div class="table-responsive">
-                <table class="table table-sm table-hover align-middle mb-0">
+                <table class="table table-sm table-hover align-middle mb-0 cp-sortable">
                     <thead class="text-muted small">
                         <tr>
-                            <th scope="col">Name</th>
+                            <th scope="col" data-sort-key="name"   data-sort-type="text">Name</th>
                             <th scope="col" class="text-center">Roles</th>
-                            <th scope="col" class="text-end">Total uses</th>
-                            <th scope="col">Source</th>
-                            <th scope="col">Lifespan</th>
+                            <th scope="col" class="text-end" data-sort-key="total" data-sort-type="number">Total uses</th>
+                            <th scope="col" data-sort-key="source" data-sort-type="text">Source</th>
+                            <th scope="col" data-sort-key="lifespan" data-sort-type="text">Lifespan</th>
                             <th scope="col" class="text-end">Meta</th>
                             <th scope="col" class="text-end">Actions</th>
                         </tr>
@@ -1397,9 +1397,9 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
                                     <span class="badge role-pill role-ad" <?= $adaptors    ? '' : 'data-zero' ?>>Ad&middot;<?= $adaptors ?></span>
                                     <span class="badge role-pill role-t"  <?= $translators ? '' : 'data-zero' ?>>T&middot;<?= $translators ?></span>
                                 </td>
-                                <td class="text-end"><strong><?= number_format($p['total']) ?></strong></td>
-                                <td><?= $sourceBadge($p) ?></td>
-                                <td class="meta-col">
+                                <td class="text-end" data-sort-value="<?= (int)$p['total'] ?>"><strong><?= number_format($p['total']) ?></strong></td>
+                                <td data-sort-value="<?= htmlspecialchars($p['registry_id'] !== null && $p['total'] > 0 ? 'Both' : ($p['registry_id'] !== null ? 'Registry' : 'In use')) ?>"><?= $sourceBadge($p) ?></td>
+                                <td class="meta-col" data-sort-value="<?= htmlspecialchars((string)($p['birth_date'] ?? '')) ?>">
                                     <?php $life = $lifespan($p['birth_date'], $p['death_date']);
                                           echo $life !== '' ? $life : '<span class="text-secondary">—</span>'; ?>
                                 </td>
@@ -1884,6 +1884,14 @@ $totalRegistryOnly    = $totalNames - $totalInUse;
     </template>
 
     <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>
+
+    <!-- Sortable table headers (#644). Cycles asc → desc → unsorted on
+         click of any <th data-sort-key>. Sort runs over visible rows
+         only so it composes cleanly with the search/filter below. -->
+    <script type="module">
+        import { bootSortableTables } from '/js/modules/admin-table-sort.js?v=<?= filemtime(dirname(__DIR__) . '/js/modules/admin-table-sort.js') ?>';
+        bootSortableTables();
+    </script>
 
     <script>
         /* Client-side search + filter. The list is small enough that

--- a/appWeb/public_html/manage/groups.php
+++ b/appWeb/public_html/manage/groups.php
@@ -254,16 +254,16 @@ $csrf = csrfToken();
             <!-- List of groups -->
             <div class="card-admin p-3 mb-4">
                 <h2 class="h6 mb-3">All groups</h2>
-                <table class="table table-sm mb-0 align-middle">
+                <table class="table table-sm mb-0 align-middle cp-sortable">
                     <thead>
                         <tr class="text-muted small">
-                            <th>Name</th>
-                            <th>Description</th>
+                            <th data-sort-key="name"        data-sort-type="text">Name</th>
+                            <th data-sort-key="description" data-sort-type="text">Description</th>
                             <th class="text-center" title="Alpha">α</th>
                             <th class="text-center" title="Beta">β</th>
                             <th class="text-center" title="Release Candidate">RC</th>
                             <th class="text-center" title="Release to Web">RTW</th>
-                            <th class="text-center">Members</th>
+                            <th class="text-center" data-sort-key="members" data-sort-type="number">Members</th>
                             <th class="text-end">Actions</th>
                         </tr>
                     </thead>
@@ -446,6 +446,12 @@ $csrf = csrfToken();
 
     </div>
 
+
+    <!-- Sortable table headers (#644). -->
+    <script type="module">
+        import { bootSortableTables } from '/js/modules/admin-table-sort.js?v=<?= filemtime(dirname(__DIR__) . '/js/modules/admin-table-sort.js') ?>';
+        bootSortableTables();
+    </script>
 
     <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>
 </body>

--- a/appWeb/public_html/manage/organisations.php
+++ b/appWeb/public_html/manage/organisations.php
@@ -439,15 +439,15 @@ $csrf = csrfToken();
 
             <div class="card-admin p-3 mb-4">
                 <h2 class="h6 mb-3">All organisations</h2>
-                <table class="table table-sm mb-0 align-middle">
+                <table class="table table-sm mb-0 align-middle cp-sortable">
                     <thead>
                         <tr class="text-muted small">
-                            <th>Name</th>
-                            <th>Slug</th>
-                            <th>Parent</th>
-                            <th>Licence</th>
-                            <th class="text-center">Active</th>
-                            <th class="text-center">Members</th>
+                            <th data-sort-key="name"    data-sort-type="text">Name</th>
+                            <th data-sort-key="slug"    data-sort-type="text">Slug</th>
+                            <th data-sort-key="parent"  data-sort-type="text">Parent</th>
+                            <th data-sort-key="licence" data-sort-type="text">Licence</th>
+                            <th class="text-center" data-sort-key="active"  data-sort-type="text">Active</th>
+                            <th class="text-center" data-sort-key="members" data-sort-type="number">Members</th>
                             <th class="text-end">Actions</th>
                         </tr>
                     </thead>
@@ -469,7 +469,7 @@ $csrf = csrfToken();
                                         <small class="text-muted ms-1"><?= htmlspecialchars($o['LicenceNumber']) ?></small>
                                     <?php endif; ?>
                                 </td>
-                                <td class="text-center">
+                                <td class="text-center" data-sort-value="<?= (int)$o['IsActive'] ?>">
                                     <?= (int)$o['IsActive'] ? '<i class="bi bi-check-circle text-success"></i>' : '<i class="bi bi-x-circle text-muted"></i>' ?>
                                 </td>
                                 <td class="text-center"><?= (int)$o['MemberCount'] ?></td>
@@ -749,6 +749,12 @@ $csrf = csrfToken();
 
     </div>
 
+
+    <!-- Sortable table headers (#644). -->
+    <script type="module">
+        import { bootSortableTables } from '/js/modules/admin-table-sort.js?v=<?= filemtime(dirname(__DIR__) . '/js/modules/admin-table-sort.js') ?>';
+        bootSortableTables();
+    </script>
 
     <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>
 </body>

--- a/appWeb/public_html/manage/restrictions.php
+++ b/appWeb/public_html/manage/restrictions.php
@@ -338,15 +338,15 @@ $csrf = csrfToken();
         <div class="card-admin p-3 mb-4">
             <h2 class="h6 mb-3">Rules <span class="text-muted small">(<?= count($rows) ?> shown, newest first within priority)</span></h2>
             <div class="table-responsive">
-                <table class="table table-sm align-middle mb-0">
+                <table class="table table-sm align-middle mb-0 cp-sortable">
                     <thead>
                         <tr class="text-muted small">
-                            <th>Entity</th>
-                            <th>Restriction</th>
-                            <th>Target</th>
-                            <th class="text-center">Effect</th>
-                            <th class="text-center">Priority</th>
-                            <th>Reason</th>
+                            <th data-sort-key="entity"      data-sort-type="text">Entity</th>
+                            <th data-sort-key="restriction" data-sort-type="text">Restriction</th>
+                            <th data-sort-key="target"      data-sort-type="text">Target</th>
+                            <th class="text-center" data-sort-key="effect"   data-sort-type="text">Effect</th>
+                            <th class="text-center" data-sort-key="priority" data-sort-type="number">Priority</th>
+                            <th data-sort-key="reason" data-sort-type="text">Reason</th>
                             <th class="text-end">Actions</th>
                         </tr>
                     </thead>
@@ -600,6 +600,12 @@ $csrf = csrfToken();
 
     </div>
 
+
+    <!-- Sortable table headers (#644). -->
+    <script type="module">
+        import { bootSortableTables } from '/js/modules/admin-table-sort.js?v=<?= filemtime(dirname(__DIR__) . '/js/modules/admin-table-sort.js') ?>';
+        bootSortableTables();
+    </script>
 
     <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>
 </body>

--- a/appWeb/public_html/manage/songbooks.php
+++ b/appWeb/public_html/manage/songbooks.php
@@ -373,15 +373,15 @@ $csrf = csrfToken();
         <form method="POST" class="card-admin p-3 mb-4">
             <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
             <input type="hidden" name="action" value="reorder">
-            <table class="table table-sm mb-2 align-middle">
+            <table class="table table-sm mb-2 align-middle cp-sortable">
                 <thead>
                     <tr class="text-muted small">
                         <th style="width:6rem">Order</th>
-                        <th>Abbr</th>
-                        <th>Name</th>
-                        <th class="text-center" title="Official published hymnal (#502)">Official</th>
-                        <th class="text-center">Songs</th>
-                        <th>Colour</th>
+                        <th data-sort-key="abbr" data-sort-type="text">Abbr</th>
+                        <th data-sort-key="name" data-sort-type="text">Name</th>
+                        <th class="text-center" data-sort-key="official" data-sort-type="text" title="Official published hymnal (#502)">Official</th>
+                        <th class="text-center" data-sort-key="songs" data-sort-type="number">Songs</th>
+                        <th data-sort-key="colour" data-sort-type="text">Colour</th>
                         <th class="text-end">Actions</th>
                     </tr>
                 </thead>
@@ -675,6 +675,12 @@ $csrf = csrfToken();
             document.getElementById('delete-abbr-label').textContent = row.abbreviation;
             new bootstrap.Modal(document.getElementById('deleteModal')).show();
         }
+    </script>
+
+    <!-- Sortable table headers (#644). -->
+    <script type="module">
+        import { bootSortableTables } from '/js/modules/admin-table-sort.js?v=<?= filemtime(dirname(__DIR__) . '/js/modules/admin-table-sort.js') ?>';
+        bootSortableTables();
     </script>
 
     <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>

--- a/appWeb/public_html/manage/tiers.php
+++ b/appWeb/public_html/manage/tiers.php
@@ -256,16 +256,16 @@ $tierTableCols = 3 + count(TIER_CAPS) + 2;
         <div class="card-admin p-3 mb-4">
             <h2 class="h6 mb-3">All tiers</h2>
             <div class="table-responsive">
-                <table class="table table-sm align-middle mb-0">
+                <table class="table table-sm align-middle mb-0 cp-sortable" data-default-sort-key="level" data-default-sort-dir="asc">
                     <thead>
                         <tr class="text-muted small">
-                            <th>Name</th>
-                            <th>Display</th>
-                            <th class="text-center">Level</th>
+                            <th data-sort-key="name"    data-sort-type="text">Name</th>
+                            <th data-sort-key="display" data-sort-type="text">Display</th>
+                            <th class="text-center" data-sort-key="level" data-sort-type="number">Level</th>
                             <?php foreach (TIER_CAPS as $col => [$lbl, $hint]): ?>
                                 <th class="text-center" title="<?= htmlspecialchars($hint) ?>"><?= htmlspecialchars($lbl) ?></th>
                             <?php endforeach; ?>
-                            <th class="text-center">Users</th>
+                            <th class="text-center" data-sort-key="users" data-sort-type="number">Users</th>
                             <th class="text-end">Actions</th>
                         </tr>
                     </thead>
@@ -435,6 +435,12 @@ $tierTableCols = 3 + count(TIER_CAPS) + 2;
             });
             new bootstrap.Modal(document.getElementById('editTierModal')).show();
         }
+    </script>
+
+    <!-- Sortable table headers (#644). -->
+    <script type="module">
+        import { bootSortableTables } from '/js/modules/admin-table-sort.js?v=<?= filemtime(dirname(__DIR__) . '/js/modules/admin-table-sort.js') ?>';
+        bootSortableTables();
     </script>
 
     <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>

--- a/appWeb/public_html/manage/users.php
+++ b/appWeb/public_html/manage/users.php
@@ -305,16 +305,18 @@ function canManage(array $target, array $actor): bool {
         <div class="card-admin p-3 mb-4">
             <h2 class="h6 mb-3">All Users <span class="badge bg-secondary ms-1"><?= count($users) ?></span></h2>
             <div class="table-responsive">
-                <table class="table table-sm table-borderless mb-0">
+                <table class="table table-sm table-borderless mb-0 cp-sortable">
                     <thead>
                         <tr class="text-muted small">
-                            <th>Username</th>
-                            <th>Display Name</th>
-                            <th>Email</th>
-                            <th>Role</th>
-                            <th title="Access tier — controls lyrics / audio / MIDI / PDF / offline access for regular users">Tier</th>
-                            <th title="Organisations this user is a direct member of (#636) — the user inherits each org's licence-derived tier transitively up the nesting chain">Orgs</th>
-                            <th>Status</th>
+                            <th data-sort-key="username"     data-sort-type="text">Username</th>
+                            <th data-sort-key="display_name" data-sort-type="text">Display Name</th>
+                            <th data-sort-key="email"        data-sort-type="text">Email</th>
+                            <th data-sort-key="role"         data-sort-type="text">Role</th>
+                            <th data-sort-key="tier"         data-sort-type="text"
+                                title="Access tier — controls lyrics / audio / MIDI / PDF / offline access for regular users">Tier</th>
+                            <th data-sort-key="orgs"         data-sort-type="text"
+                                title="Organisations this user is a direct member of (#636) — the user inherits each org's licence-derived tier transitively up the nesting chain">Orgs</th>
+                            <th data-sort-key="status"       data-sort-type="text">Status</th>
                             <th class="text-end">Actions</th>
                         </tr>
                     </thead>
@@ -706,6 +708,12 @@ function canManage(array $target, array $actor): bool {
             setTimeout(() => { input.focus(); input.select(); }, 200);
         }
     </script>
+    <!-- Sortable table headers (#644). -->
+    <script type="module">
+        import { bootSortableTables } from '/js/modules/admin-table-sort.js?v=<?= filemtime(dirname(__DIR__) . '/js/modules/admin-table-sort.js') ?>';
+        bootSortableTables();
+    </script>
+
     <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Click any sortable column header in the Manage area to cycle **ascending → descending → unsorted**. Re-sorting on a different column preserves the previous order as the secondary key (stable). ▲ / ▼ arrow + `aria-sort` reflect the current state. Keyboard-accessible — `Enter` / `Space` drive the cycle.

A single shared JS module — `appWeb/public_html/js/modules/admin-table-sort.js` — does the work. Pages opt in by adding `class="cp-sortable"` to the `<table>` and `data-sort-key` (+ optional `data-sort-type`) to each `<th>` that should be sortable.

## Wired up in this PR

| Page | Sortable columns |
|---|---|
| Credit People | Name · Total uses · Source · Lifespan |
| Users | Username · Display Name · Email · Role · Tier · Orgs · Status |
| Songbooks | Abbr · Name · Official · Songs · Colour |
| Access Tiers | Name · Display · Level (default sort) · Users |
| Organisations | Name · Slug · Parent · Licence · Active · Members |
| User Groups | Name · Description · Members |
| Content Restrictions | Entity · Restriction · Target · Effect · Priority · Reason |

## Skipped on purpose

- **Entitlements** — it's a capability × role matrix, not a list to sort.
- **Activity Log** — already has its own filter UI; opening up sort would conflict with the per-page server-side filtering. Revisit if useful.

## Composability notes

- The module sorts **visible rows only**, so it composes cleanly with existing per-page search / filter inputs (which toggle `display: none` on rows).
- `data-sort-value` on a `<td>` overrides the text-derived value, which is how badge / icon cells (role pills, "In use"/"Both"/"Registry" source badges, "Active" check icons) get sorted by their underlying data.
- `data-default-sort-key` + `data-default-sort-dir="asc|desc"` on a `<table>` applies a sort on first paint (used for Tiers' default by Level).

## Test plan

- [ ] Visit `/manage/credit-people`. Click "Total uses" header — confirm rows sort descending-by-default-on-numeric-asc-cycle (1 click = ascending). Click again — descending. Third click — unsorted (back to server order).
- [ ] Sort by "Name", then by "Total uses": confirm rows of equal Total uses appear in the prior alphabetical order (stable secondary sort).
- [ ] Search for "townend" with a sort active: confirm only matching rows reorder; non-matching stay hidden.
- [ ] Press Tab onto a sortable header, hit Enter — confirm sort fires.
- [ ] Same checks on Users / Songbooks / Tiers / Organisations / Groups / Restrictions.
- [ ] DevTools: confirm `aria-sort` value flips `none` → `ascending` → `descending` → `none` on click cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)