### PR TITLE
fix(header): avatar size + dropdown-item icon alignment (closes #646, #647)

### DIFF
--- a/appWeb/public_html/css/admin.css
+++ b/appWeb/public_html/css/admin.css
@@ -247,11 +247,15 @@ body:has(.navbar-admin) {
 .admin-account-btn:focus {
     color: var(--text-primary);
 }
-/* Avatar image inside the trigger — render at the same 32px circle
-   the dropdown header uses, centred inside the 40px hit area. */
+/* Avatar image inside the trigger (#646). Sized to match the optical
+   weight of the neighbouring Font-Awesome / Bootstrap-Icons glyphs,
+   which render at roughly 1rem ≈ 16px in a header-icon button. A
+   filled 24px circle next to a ~16-18px line glyph reads as the
+   same visual size; 32px (the previous setting) read distinctly
+   bigger. The 40px hit area on the parent button is unchanged. */
 .admin-account-btn img {
-    width: 32px;
-    height: 32px;
+    width: 24px;
+    height: 24px;
     object-fit: cover;
     border-radius: 50%;
     display: block;

--- a/appWeb/public_html/css/app.css
+++ b/appWeb/public_html/css/app.css
@@ -433,13 +433,15 @@ body {
     transition: background-color var(--transition-fast), transform var(--transition-fast);
 }
 
-/* Header user-avatar image: same 40x40 footprint as the icon
-   buttons so the right-edge cluster doesn't reflow when the avatar
-   loads after the SubtleCrypto hash resolves. */
+/* Header user-avatar image (#646). Sized to match the optical weight
+   of the FA / BI glyphs in the adjacent header buttons (~16-18px line
+   icons) — a 24px filled circle reads as the same visual size; 32px
+   read distinctly bigger. The 40×40 .btn-header-icon hit area is
+   unchanged so the right-edge cluster still doesn't reflow. */
 .btn-header-icon img,
 .header-user-avatar {
-    width: 32px;
-    height: 32px;
+    width: 24px;
+    height: 24px;
     object-fit: cover;
     border-radius: 50%;
 }

--- a/appWeb/public_html/css/app.css
+++ b/appWeb/public_html/css/app.css
@@ -321,7 +321,20 @@
     align-items: center;
 }
 
-#theme-dropdown-btn + .dropdown-menu .dropdown-item i {
+/* Site-wide dropdown-item icon alignment (#647). Font Awesome and
+   Bootstrap Icons glyphs have variable natural widths — fa-gears is
+   wider than fa-house, bi-stars is wider than bi-people, so without
+   a fixed slot the text labels after each icon misalign by a few
+   pixels (visible as e.g. "Manage" sitting further right than its
+   siblings in the iHymns brand dropdown).
+
+   Pin the leading <i> in any .dropdown-item to FA's `fa-fw` 1.25em
+   width with centred glyph alignment. Existing me-2 / me-1 spacing
+   rules continue to drive the icon→text gap; this rule only fixes
+   the icon's horizontal slot. Applies on both surfaces (main app
+   + admin) since admin.css layers on top of app.css. */
+.dropdown-item > i:first-child {
+    display: inline-block;
     width: 1.25em;
     text-align: center;
 }

--- a/appWeb/public_html/js/modules/user-auth.js
+++ b/appWeb/public_html/js/modules/user-auth.js
@@ -617,8 +617,10 @@ export class UserAuth {
                 img.id = 'header-user-icon';
                 img.src = url;
                 img.alt = '';
-                img.width = 32;
-                img.height = 32;
+                /* 24px to match the optical weight of the FA / BI glyphs
+                   in the adjacent header buttons (#646). */
+                img.width = 24;
+                img.height = 24;
                 img.className = 'rounded-circle header-user-avatar';
                 img.loading = 'lazy';
                 img.referrerPolicy = 'no-referrer';

--- a/appWeb/public_html/manage/includes/admin-nav.php
+++ b/appWeb/public_html/manage/includes/admin-nav.php
@@ -157,7 +157,7 @@ $_avatarUrlLarge = userAvatarUrl($_userEmail, 64, $_userAvatarSvc);
                             id="admin-user-btn">
                         <img src="<?= htmlspecialchars($_avatarUrlSmall) ?>"
                              alt=""
-                             width="32" height="32"
+                             width="24" height="24"
                              class="rounded-circle"
                              loading="lazy"
                              referrerpolicy="no-referrer"


### PR DESCRIPTION
## Summary

Two small visual nits, one commit each:

### #646 — Avatar trigger still bigger than its neighbours

Even after the 40×40 hit-area fix in #633, the inner image was 32px — a filled circle next to ~16-18px line glyphs (FA / BI) reads bigger by a third in optical weight. Drop the inner image to **24px** in all four places it's specified so the two surfaces stay byte-identical:

- `appWeb/public_html/css/admin.css` — `.admin-account-btn img`
- `appWeb/public_html/css/app.css` — `.btn-header-icon img / .header-user-avatar`
- `appWeb/public_html/js/modules/user-auth.js` — `img.width / img.height`
- `appWeb/public_html/manage/includes/admin-nav.php` — `<img width / height>`

The 40×40 `.btn-header-icon` hit area is unchanged; the avatar just sits as a smaller centred dot inside it. The dropdown-body avatar (40px in the menu header card) is untouched — that one is intentionally larger inside the menu.

### #647 — Dropdown-item text labels mis-align

Font Awesome and Bootstrap Icons glyphs have variable natural widths — `fa-gears` is wider than `fa-house`, so "Manage" in the iHymns brand dropdown sat a few pixels further right than its siblings.

Single CSS rule in `app.css` pins the leading `<i>` of any `.dropdown-item` to a 1.25em slot with centred glyph alignment (FA's `fa-fw` convention). One source-of-truth — applies to every dropdown across both surfaces (main app + admin) since `admin.css` layers on top.

## Test plan

- [ ] **#646**: visit `/manage/` signed in. Confirm the avatar circle is the same visible diameter as the theme-dropdown icon. Visit `/`; same check against the bell / theme / shuffle icons. Sign out + back in; confirm the JS-rendered img also lands at 24px.
- [ ] **#647**: open the iHymns brand dropdown on `/`. Confirm Home / Songbooks / Favourites / Set Lists / Statistics / Manage / Help all start their text at the same x-offset. Open the user-account dropdown on `/`; same check. Open the admin brand + account dropdowns on `/manage/`; same check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)