### PR TITLE
fix: 5 migration require paths + setup-database footer name (closes #649, #650)

### DIFF
--- a/appWeb/.sql/migrate-credit-people-flags.php
+++ b/appWeb/.sql/migrate-credit-people-flags.php
@@ -46,7 +46,7 @@ if (PHP_SAPI === 'cli') {
     $isCli = true;
 } else {
     if (!defined('IHYMNS_SETUP_DASHBOARD')) {
-        require_once __DIR__ . '/../public_html/manage/includes/auth.php';
+        require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
         if (!isAuthenticated()) {
             http_response_code(401);
             exit('Authentication required.');
@@ -57,7 +57,7 @@ if (PHP_SAPI === 'cli') {
             exit('Global admin required.');
         }
     }
-    require_once __DIR__ . '/../public_html/includes/db_mysql.php';
+    require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
     $isCli = false;
 }
 

--- a/appWeb/.sql/migrate-credit-people-slug.php
+++ b/appWeb/.sql/migrate-credit-people-slug.php
@@ -33,7 +33,7 @@ if (PHP_SAPI === 'cli') {
     $isCli = true;
 } else {
     if (!defined('IHYMNS_SETUP_DASHBOARD')) {
-        require_once __DIR__ . '/../public_html/manage/includes/auth.php';
+        require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
         if (!isAuthenticated()) {
             http_response_code(401);
             exit('Authentication required.');
@@ -44,7 +44,7 @@ if (PHP_SAPI === 'cli') {
             exit('Global admin required.');
         }
     }
-    require_once __DIR__ . '/../public_html/includes/db_mysql.php';
+    require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
     $isCli = false;
 }
 

--- a/appWeb/.sql/migrate-organisation-licences.php
+++ b/appWeb/.sql/migrate-organisation-licences.php
@@ -52,7 +52,7 @@ if (PHP_SAPI === 'cli') {
     $isCli = true;
 } else {
     if (!defined('IHYMNS_SETUP_DASHBOARD')) {
-        require_once __DIR__ . '/../public_html/manage/includes/auth.php';
+        require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
         if (!isAuthenticated()) {
             http_response_code(401);
             exit('Authentication required.');
@@ -63,7 +63,7 @@ if (PHP_SAPI === 'cli') {
             exit('Global admin required.');
         }
     }
-    require_once __DIR__ . '/../public_html/includes/db_mysql.php';
+    require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
     $isCli = false;
 }
 

--- a/appWeb/.sql/migrate-song-artists.php
+++ b/appWeb/.sql/migrate-song-artists.php
@@ -39,7 +39,7 @@ if (PHP_SAPI === 'cli') {
     $isCli = true;
 } else {
     if (!defined('IHYMNS_SETUP_DASHBOARD')) {
-        require_once __DIR__ . '/../public_html/manage/includes/auth.php';
+        require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
         if (!isAuthenticated()) {
             http_response_code(401);
             exit('Authentication required.');
@@ -50,7 +50,7 @@ if (PHP_SAPI === 'cli') {
             exit('Global admin required.');
         }
     }
-    require_once __DIR__ . '/../public_html/includes/db_mysql.php';
+    require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
     $isCli = false;
 }
 

--- a/appWeb/.sql/migrate-user-avatar-service.php
+++ b/appWeb/.sql/migrate-user-avatar-service.php
@@ -35,7 +35,7 @@ if (PHP_SAPI === 'cli') {
     $isCli = true;
 } else {
     if (!defined('IHYMNS_SETUP_DASHBOARD')) {
-        require_once __DIR__ . '/../public_html/manage/includes/auth.php';
+        require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
         if (!isAuthenticated()) {
             http_response_code(401);
             exit('Authentication required.');
@@ -46,7 +46,7 @@ if (PHP_SAPI === 'cli') {
             exit('Global admin required.');
         }
     }
-    require_once __DIR__ . '/../public_html/includes/db_mysql.php';
+    require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
     $isCli = false;
 }
 

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -1026,8 +1026,18 @@ if ($hasCredentials && defined('DB_HOST')) {
     <hr class="my-4">
     <p class="text-secondary text-center small">
         iHymns Database Administration &middot; v0.10.0
+        <?php
+            /* Footer name (#650) — match the header's first-word
+               derivation in admin-nav.php so 'Lance Manasse' reads as
+               'Lance' on both surfaces. Falls back to username when
+               DisplayName is empty. */
+            if (!$isInitialSetup && isset($currentUser)) {
+                $_displayName = (string)($currentUser['display_name'] ?? $currentUser['username'] ?? '');
+                $_footerName  = preg_split('/\s+/', trim($_displayName), 2)[0] ?: $_displayName;
+            }
+        ?>
         <?php if (!$isInitialSetup && isset($currentUser)): ?>
-            &middot; Logged in as <strong><?= htmlspecialchars($currentUser['username'] ?? '') ?></strong>
+            &middot; Logged in as <strong><?= htmlspecialchars($_footerName) ?></strong>
         <?php endif; ?>
     </p>
 </div>


### PR DESCRIPTION
## Summary

Two small fixes, one commit each:

### #649 — Migration scripts fail with "Failed opening required"

Five recently-shipped migrations failed when run via `/manage/setup-database` on the alpha server. Each had `require_once __DIR__ . '/../public_html/...'` for both `auth.php` and `db_mysql.php` — the literal `..` mid-path is rejected by some hosting environments (open_basedir, restricted PHP). The CLI branch of the same files already used the normalised `dirname(__DIR__)` form and worked fine.

Replaced the dirty pattern with `dirname(__DIR__) . '/public_html/...'` in both branches of all five files:

- `migrate-credit-people-flags.php`
- `migrate-song-artists.php`
- `migrate-credit-people-slug.php`
- `migrate-user-avatar-service.php`
- `migrate-organisation-licences.php`

### #650 — Setup-Database footer used username instead of first name

`/manage/setup-database` showed "Logged in as **admin**" (the raw username) while the page header read "Lance" (first word of `DisplayName`). Mirror the same `_headerName` derivation `admin-nav.php` uses so the two surfaces match. Falls back to the username when `DisplayName` is empty.

## Test plan

- [ ] **#649**: on alpha, click each of the five migration cards on `/manage/setup-database`. Confirm each runs to completion (no "Failed opening required" banner).
- [ ] **#649**: `php appWeb/.sql/migrate-*.php` still works from CLI (no regression on the unchanged-shape branch).
- [ ] **#650**: visit `/manage/setup-database`. Confirm the footer reads "Logged in as **Lance**" (or whatever the first word of your DisplayName is) — matching the header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)