### PR TITLE
fix(sql): function-exists guard around cross-tree require_once (closes #652)

### DIFF
--- a/appWeb/.sql/migrate-credit-people-flags.php
+++ b/appWeb/.sql/migrate-credit-people-flags.php
@@ -42,11 +42,35 @@ declare(strict_types=1);
 
 if (PHP_SAPI === 'cli') {
     /* CLI bootstrap mirrors the other migrate-*.php files. */
-    require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    /* Guarded require — see #652. The dashboard has already loaded
+
+       db_mysql.php via auth.php's bootstrap, so the function already
+
+       exists at this point in dashboard mode; the guard skips the
+
+       re-open that some hosts block from outside public_html/. */
+
+    if (!function_exists('getDbMysqli')) {
+
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+
+    }
     $isCli = true;
 } else {
     if (!defined('IHYMNS_SETUP_DASHBOARD')) {
-        require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+        /* Guarded: dashboard mode pre-loads auth.php transitively. The
+
+           guard also avoids re-opening the file from outside public_html/,
+
+           which some hosts (open_basedir / php-fpm chroot) refuse even
+
+           though the file is otherwise reachable (#652). */
+
+        if (!function_exists('isAuthenticated')) {
+
+            require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+
+        }
         if (!isAuthenticated()) {
             http_response_code(401);
             exit('Authentication required.');
@@ -57,7 +81,19 @@ if (PHP_SAPI === 'cli') {
             exit('Global admin required.');
         }
     }
-    require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    /* Guarded require — see #652. The dashboard has already loaded
+
+       db_mysql.php via auth.php's bootstrap, so the function already
+
+       exists at this point in dashboard mode; the guard skips the
+
+       re-open that some hosts block from outside public_html/. */
+
+    if (!function_exists('getDbMysqli')) {
+
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+
+    }
     $isCli = false;
 }
 

--- a/appWeb/.sql/migrate-credit-people-slug.php
+++ b/appWeb/.sql/migrate-credit-people-slug.php
@@ -29,11 +29,35 @@ declare(strict_types=1);
  */
 
 if (PHP_SAPI === 'cli') {
-    require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    /* Guarded require — see #652. The dashboard has already loaded
+
+       db_mysql.php via auth.php's bootstrap, so the function already
+
+       exists at this point in dashboard mode; the guard skips the
+
+       re-open that some hosts block from outside public_html/. */
+
+    if (!function_exists('getDbMysqli')) {
+
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+
+    }
     $isCli = true;
 } else {
     if (!defined('IHYMNS_SETUP_DASHBOARD')) {
-        require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+        /* Guarded: dashboard mode pre-loads auth.php transitively. The
+
+           guard also avoids re-opening the file from outside public_html/,
+
+           which some hosts (open_basedir / php-fpm chroot) refuse even
+
+           though the file is otherwise reachable (#652). */
+
+        if (!function_exists('isAuthenticated')) {
+
+            require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+
+        }
         if (!isAuthenticated()) {
             http_response_code(401);
             exit('Authentication required.');
@@ -44,7 +68,19 @@ if (PHP_SAPI === 'cli') {
             exit('Global admin required.');
         }
     }
-    require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    /* Guarded require — see #652. The dashboard has already loaded
+
+       db_mysql.php via auth.php's bootstrap, so the function already
+
+       exists at this point in dashboard mode; the guard skips the
+
+       re-open that some hosts block from outside public_html/. */
+
+    if (!function_exists('getDbMysqli')) {
+
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+
+    }
     $isCli = false;
 }
 

--- a/appWeb/.sql/migrate-organisation-licences.php
+++ b/appWeb/.sql/migrate-organisation-licences.php
@@ -48,11 +48,35 @@ declare(strict_types=1);
  */
 
 if (PHP_SAPI === 'cli') {
-    require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    /* Guarded require — see #652. The dashboard has already loaded
+
+       db_mysql.php via auth.php's bootstrap, so the function already
+
+       exists at this point in dashboard mode; the guard skips the
+
+       re-open that some hosts block from outside public_html/. */
+
+    if (!function_exists('getDbMysqli')) {
+
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+
+    }
     $isCli = true;
 } else {
     if (!defined('IHYMNS_SETUP_DASHBOARD')) {
-        require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+        /* Guarded: dashboard mode pre-loads auth.php transitively. The
+
+           guard also avoids re-opening the file from outside public_html/,
+
+           which some hosts (open_basedir / php-fpm chroot) refuse even
+
+           though the file is otherwise reachable (#652). */
+
+        if (!function_exists('isAuthenticated')) {
+
+            require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+
+        }
         if (!isAuthenticated()) {
             http_response_code(401);
             exit('Authentication required.');
@@ -63,7 +87,19 @@ if (PHP_SAPI === 'cli') {
             exit('Global admin required.');
         }
     }
-    require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    /* Guarded require — see #652. The dashboard has already loaded
+
+       db_mysql.php via auth.php's bootstrap, so the function already
+
+       exists at this point in dashboard mode; the guard skips the
+
+       re-open that some hosts block from outside public_html/. */
+
+    if (!function_exists('getDbMysqli')) {
+
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+
+    }
     $isCli = false;
 }
 

--- a/appWeb/.sql/migrate-song-artists.php
+++ b/appWeb/.sql/migrate-song-artists.php
@@ -35,11 +35,35 @@ declare(strict_types=1);
  */
 
 if (PHP_SAPI === 'cli') {
-    require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    /* Guarded require — see #652. The dashboard has already loaded
+
+       db_mysql.php via auth.php's bootstrap, so the function already
+
+       exists at this point in dashboard mode; the guard skips the
+
+       re-open that some hosts block from outside public_html/. */
+
+    if (!function_exists('getDbMysqli')) {
+
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+
+    }
     $isCli = true;
 } else {
     if (!defined('IHYMNS_SETUP_DASHBOARD')) {
-        require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+        /* Guarded: dashboard mode pre-loads auth.php transitively. The
+
+           guard also avoids re-opening the file from outside public_html/,
+
+           which some hosts (open_basedir / php-fpm chroot) refuse even
+
+           though the file is otherwise reachable (#652). */
+
+        if (!function_exists('isAuthenticated')) {
+
+            require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+
+        }
         if (!isAuthenticated()) {
             http_response_code(401);
             exit('Authentication required.');
@@ -50,7 +74,19 @@ if (PHP_SAPI === 'cli') {
             exit('Global admin required.');
         }
     }
-    require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    /* Guarded require — see #652. The dashboard has already loaded
+
+       db_mysql.php via auth.php's bootstrap, so the function already
+
+       exists at this point in dashboard mode; the guard skips the
+
+       re-open that some hosts block from outside public_html/. */
+
+    if (!function_exists('getDbMysqli')) {
+
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+
+    }
     $isCli = false;
 }
 

--- a/appWeb/.sql/migrate-user-avatar-service.php
+++ b/appWeb/.sql/migrate-user-avatar-service.php
@@ -31,11 +31,35 @@ declare(strict_types=1);
  */
 
 if (PHP_SAPI === 'cli') {
-    require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    /* Guarded require — see #652. The dashboard has already loaded
+
+       db_mysql.php via auth.php's bootstrap, so the function already
+
+       exists at this point in dashboard mode; the guard skips the
+
+       re-open that some hosts block from outside public_html/. */
+
+    if (!function_exists('getDbMysqli')) {
+
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+
+    }
     $isCli = true;
 } else {
     if (!defined('IHYMNS_SETUP_DASHBOARD')) {
-        require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+        /* Guarded: dashboard mode pre-loads auth.php transitively. The
+
+           guard also avoids re-opening the file from outside public_html/,
+
+           which some hosts (open_basedir / php-fpm chroot) refuse even
+
+           though the file is otherwise reachable (#652). */
+
+        if (!function_exists('isAuthenticated')) {
+
+            require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+
+        }
         if (!isAuthenticated()) {
             http_response_code(401);
             exit('Authentication required.');
@@ -46,7 +70,19 @@ if (PHP_SAPI === 'cli') {
             exit('Global admin required.');
         }
     }
-    require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    /* Guarded require — see #652. The dashboard has already loaded
+
+       db_mysql.php via auth.php's bootstrap, so the function already
+
+       exists at this point in dashboard mode; the guard skips the
+
+       re-open that some hosts block from outside public_html/. */
+
+    if (!function_exists('getDbMysqli')) {
+
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+
+    }
     $isCli = false;
 }
 


### PR DESCRIPTION
## Summary

PR #651 normalised the path string from `__DIR__ . '/../public_html/...'` to `dirname(__DIR__) . '/public_html/...'`. The deploy confirmed the new absolute path resolves correctly, but the migrations **still fail** with the same `Failed opening required` error — just with the now-clean absolute path.

## Real root cause

When the dashboard runs a migration via `require $scriptPath`, it has already loaded `auth.php` → `db_mysql.php` transitively. The migration then tries to re-`require_once` the same absolute file from a script that lives in `appWeb/.sql/` — outside `public_html/`. On alpha (and any host with stricter open_basedir / php-fpm chroot), the cross-tree open from `.sql/` → `public_html/` is blocked even though the dashboard's top-level open of the same path succeeded a moment earlier. PHP falls back to `include_path='.:'` and reports the failure.

The older migrations (`migrate-credit-people.php`, `migrate-credit-fields.php`, etc.) sidestep this entirely by never `require`-ing `db_mysql.php` — they load `db_credentials.php` directly.

## Fix

Guard each cross-tree `require_once` with a function-exists check, so the require is skipped whenever the helper is already loaded (i.e. dashboard mode):

```php
if (!function_exists('getDbMysqli')) {
    require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
}
```

…and the same guard for the `auth.php` pull. Applied identically across all five migrations:

- `migrate-credit-people-flags.php`
- `migrate-song-artists.php`
- `migrate-credit-people-slug.php`
- `migrate-user-avatar-service.php`
- `migrate-organisation-licences.php`

## Test plan

- [ ] On alpha, click each of the five migration cards on `/manage/setup-database`. Confirm each runs to completion (no "Failed opening required" banner).
- [ ] `php appWeb/.sql/migrate-*.php` from CLI: confirm the require still fires (`getDbMysqli` isn't pre-defined there) and the migration completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)