### PR TITLE
fix(help): align help-page accordion section headers (closes #654)

### DIFF
--- a/appWeb/public_html/css/app.css
+++ b/appWeb/public_html/css/app.css
@@ -1396,6 +1396,17 @@ body.banner-visible.search-open .main-content {
     box-shadow: 0 0 0 2px var(--accent-solid);
 }
 
+/* Pin the leading <i> in each help accordion-button to a fixed 1.25em
+   slot so the section labels start at the same x-position regardless
+   of which FA glyph leads the row (fa-rocket vs fa-heart vs fa-keyboard
+   etc. all have slightly different natural widths). Same convention as
+   the .dropdown-item rule above (#647); see #654. */
+.accordion-help .accordion-button > i:first-child {
+    display: inline-block;
+    width: 1.25em;
+    text-align: center;
+}
+
 /* ---------------------------------------------------------------------------
    About list (settings page)
    --------------------------------------------------------------------------- */


### PR DESCRIPTION
## Summary

- Pins the leading `<i>` inside each `.accordion-help .accordion-button` to a fixed 1.25em slot so the help-page section labels all start at the same x-position
- Same convention used for `.dropdown-item > i:first-child` in #647

Closes #654.

## Why

On `/help`, each accordion section header is `<i class="fa-solid fa-X me-2"></i> Section Title`. Font Awesome's natural glyph widths vary (fa-rocket wider than fa-heart, fa-magnifying-glass wider than fa-keyboard, etc.) so the labels visibly shift between rows. One CSS rule pins the icon to a 1.25em slot — matching FA's `fa-fw` convention — and the labels line up.

## Test plan

- [ ] Open `/help` and visually scan the 11 section headers — labels (Getting Started, Searching for Songs, Favourites, Themes, Mobile Install, Offline, Songbooks, Keyboard Shortcuts, Learning, Tips, Admin) all start at the same x-position
- [ ] Icons remain centred in their fixed slot
- [ ] Spacing between icon and label visually unchanged
- [ ] No regression to the inline icons inside accordion bodies (e.g. the heart on the favourites bullet, the share icon on the iOS install instructions) — those use `me-1` not `me-2` and are not first-child of `.accordion-button`

🤖 Generated with [Claude Code](https://claude.com/claude-code)