### PR TITLE
fix(song-request): point song-page link at /request-a-song; deduplicate /help form (closes #656)

### DIFF
--- a/appWeb/public_html/includes/pages/help.php
+++ b/appWeb/public_html/includes/pages/help.php
@@ -351,7 +351,11 @@ declare(strict_types=1);
     </div>
 
     <!-- ============================================================
-         SONG REQUEST FORM — Suggest a missing song
+         SUGGEST A MISSING SONG — CTA to the dedicated form page (#656)
+         The actual submission form lives at /request-a-song where it
+         has the page to itself, supports offline queueing, and returns
+         a tracking-id reference. We keep a card here so help-page
+         readers still see the feature exists.
          ============================================================ -->
     <div class="card mb-3 mt-4">
         <div class="card-body">
@@ -359,51 +363,16 @@ declare(strict_types=1);
                 <i class="fa-solid fa-paper-plane me-2" aria-hidden="true"></i>
                 Suggest a Missing Song
             </h5>
-            <p class="text-muted small">Can't find a song? Let us know and we'll try to add it.</p>
-            <form id="song-request-form">
-                <input type="text" class="form-control mb-2" name="title" placeholder="Song title" required>
-                <input type="text" class="form-control mb-2" name="songbook" placeholder="Songbook (if known)">
-                <input type="text" class="form-control mb-2" name="song_number" placeholder="Song number (if known)">
-                <textarea class="form-control mb-2" name="details" rows="2" placeholder="Any additional details (first line of lyrics, etc.)"></textarea>
-                <input type="email" class="form-control mb-2" name="contact_email" placeholder="Your email (optional, for follow-up)">
-                <button type="submit" class="btn btn-primary">
-                    <i class="fa-solid fa-paper-plane me-1" aria-hidden="true"></i>
-                    Submit Request
-                </button>
-            </form>
-            <div id="song-request-result" class="mt-2"></div>
+            <p class="text-muted small mb-3">
+                Can't find a song? Let us know and we'll try to add it.
+                You can also reach this from the &ldquo;Report a missing
+                song&rdquo; link at the bottom of any song page.
+            </p>
+            <a href="/request-a-song" data-navigate="request-a-song" class="btn btn-primary">
+                <i class="fa-solid fa-paper-plane me-1" aria-hidden="true"></i>
+                Open the request form
+            </a>
         </div>
     </div>
-
-    <script>
-        document.getElementById('song-request-form')?.addEventListener('submit', async (e) => {
-            e.preventDefault();
-            const form = e.target;
-            const btn = form.querySelector('button[type="submit"]');
-            btn.disabled = true;
-            btn.innerHTML = '<i class="fa-solid fa-spinner fa-spin me-1"></i>Submitting...';
-            try {
-                const data = Object.fromEntries(new FormData(form));
-                const res = await fetch('/api?action=song_request', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify(data)
-                });
-                const result = await res.json();
-                const el = document.getElementById('song-request-result');
-                if (result.ok) {
-                    el.innerHTML = '<div class="alert alert-success"><i class="fa-solid fa-check-circle me-1"></i>Thank you! Your suggestion has been submitted.</div>';
-                    form.reset();
-                } else {
-                    el.innerHTML = '<div class="alert alert-danger"><i class="fa-solid fa-triangle-exclamation me-1"></i>' + (result.error || 'Failed to submit.') + '</div>';
-                }
-            } catch {
-                document.getElementById('song-request-result').innerHTML = '<div class="alert alert-danger"><i class="fa-solid fa-triangle-exclamation me-1"></i>Network error. Please try again.</div>';
-            } finally {
-                btn.disabled = false;
-                btn.innerHTML = '<i class="fa-solid fa-paper-plane me-1"></i>Submit Request';
-            }
-        });
-    </script>
 
 </section>

--- a/appWeb/public_html/includes/pages/song.php
+++ b/appWeb/public_html/includes/pages/song.php
@@ -579,9 +579,11 @@ unset($_t);
         </footer>
     <?php endif; ?>
 
-    <!-- Report missing song link -->
+    <!-- Report missing song link — points at the dedicated form page (#656)
+         rather than dumping the user at the bottom of the long /help
+         article where the request form used to live. -->
     <div class="mt-3">
-        <a href="/help" data-navigate="help" class="text-muted small text-decoration-none">
+        <a href="/request-a-song" data-navigate="request-a-song" class="text-muted small text-decoration-none">
             <i class="fa-solid fa-flag me-1" aria-hidden="true"></i>
             Report a missing song or suggest a correction
         </a>

--- a/appWeb/public_html/manage/help.php
+++ b/appWeb/public_html/manage/help.php
@@ -492,7 +492,7 @@ foreach ($sections as $s) {
                         <span class="badge bg-danger">global_admin</span>
                     </p>
                     <p>
-                        End users in the main app can submit a "Request a song" form. Those submissions land here so an editor can triage them.
+                        End users in the main app can submit a song request via the dedicated <a href="/request-a-song">/request-a-song</a> page &mdash; reachable from the &ldquo;Report a missing song or suggest a correction&rdquo; link at the bottom of every song page, the &ldquo;Suggest a Missing Song&rdquo; CTA on <a href="/help">/help</a>, and a deep-link from the editor's missing-numbers tool with the songbook + number prefilled. Submissions queue offline and replay automatically when the user is back online; each submission also returns a tracking ID the user can quote when following up. All paths land in this triage list.
                     </p>
                     <h3 class="h6">Key actions</h3>
                     <ul>


### PR DESCRIPTION
## Summary

- **song.php** — the footer link &ldquo;Report a missing song or suggest a correction&rdquo; now navigates to `/request-a-song` instead of `/help`. Users land directly on a focused single-purpose form.
- **help.php** — the duplicated inline form (and its 30 lines of submit-handler script posting to the older `song_request` API) is gone. A CTA card stays in the same spot, pointing readers at `/request-a-song`. Help-page readers still see the feature exists.
- **manage/help.php** — the Song Requests admin docs now enumerate all three entry paths (song-page footer, /help CTA, editor missing-numbers deep-link) and mention the offline-queue + tracking-id behaviour so admins understand what users see when following up.

Closes #656.

## Why

The dedicated `/request-a-song` page already exists ([includes/pages/request-a-song.php](appWeb/public_html/includes/pages/request-a-song.php)) and is the better target — it's a single-purpose page with offline queueing and a tracking-id reference, already used as the deep-link target from `manage/missing-numbers.php` and `manage/editor/index.php`. The link from the song page used to dump users at the bottom of an 11-section help-page accordion, where the form was easily missed on mobile. Pointing the link at the dedicated page is one tap to the form. Removing the duplicate inline form on /help eliminates the divergent flow (different API endpoint, no offline support, no tracking-id) and gives us a single canonical surface.

## Commits

1. `fix(song)` — link target /help → /request-a-song
2. `fix(help)` — remove duplicated form, replace with CTA card
3. `docs(manage)` — Song Requests admin section refresh

## Test plan

- [ ] Open any song page on alpha, scroll to the bottom — &ldquo;Report a missing song&rdquo; link routes to `/request-a-song` (confirm via Network tab + visible URL)
- [ ] Open `/help` — &ldquo;Suggest a Missing Song&rdquo; card shows intro text + a single &ldquo;Open the request form&rdquo; button that navigates to `/request-a-song`
- [ ] Submit a request on `/request-a-song` — confirms it lands in `/manage/requests` with status `pending` and a tracking ID
- [ ] Toggle offline → submit on `/request-a-song` → toggle online → confirm the queued request drains and lands in tblSongRequests
- [ ] Open `/manage/help` and verify the Song Requests section now describes all three entry paths and the offline/tracking behaviour
- [ ] Confirm no broken anchors (e.g. nothing else in the codebase still links to `/help#song-request-form` or similar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)