### PR TITLE
Request-a-song polish + db setup output panel fix (closes #658, #660, #661)

### DIFF
--- a/appWeb/.sql/migrate-credit-people-flags.php
+++ b/appWeb/.sql/migrate-credit-people-flags.php
@@ -101,8 +101,14 @@ function _migCpFlags_out(string $line): void
 {
     global $isCli;
     echo $line . ($isCli ? "\n" : "<br>\n");
-    @ob_flush();
-    @flush();
+    /* CLI only: stream line-by-line. In dashboard mode the parent
+       (setup-database.php) wraps this require in ob_start() so it
+       can render captured output inside its dedicated output panel —
+       calling ob_flush() here would punt the buffer past that wrapper
+       and the lines would render above the navbar. See #661. */
+    if ($isCli) {
+        flush();
+    }
 }
 
 function _migCpFlags_columnExists(mysqli $db, string $table, string $column): bool

--- a/appWeb/.sql/migrate-credit-people-slug.php
+++ b/appWeb/.sql/migrate-credit-people-slug.php
@@ -88,8 +88,10 @@ function _migCpSlug_out(string $line): void
 {
     global $isCli;
     echo $line . ($isCli ? "\n" : "<br>\n");
-    @ob_flush();
-    @flush();
+    /* CLI only — see migrate-credit-people-flags.php for rationale (#661). */
+    if ($isCli) {
+        flush();
+    }
 }
 
 function _migCpSlug_columnExists(mysqli $db, string $table, string $column): bool

--- a/appWeb/.sql/migrate-organisation-licences.php
+++ b/appWeb/.sql/migrate-organisation-licences.php
@@ -107,8 +107,10 @@ function _migOrgLic_out(string $line): void
 {
     global $isCli;
     echo $line . ($isCli ? "\n" : "<br>\n");
-    @ob_flush();
-    @flush();
+    /* CLI only — see migrate-credit-people-flags.php for rationale (#661). */
+    if ($isCli) {
+        flush();
+    }
 }
 
 function _migOrgLic_tableExists(mysqli $db, string $table): bool

--- a/appWeb/.sql/migrate-song-artists.php
+++ b/appWeb/.sql/migrate-song-artists.php
@@ -94,8 +94,10 @@ function _migArtists_out(string $line): void
 {
     global $isCli;
     echo $line . ($isCli ? "\n" : "<br>\n");
-    @ob_flush();
-    @flush();
+    /* CLI only — see migrate-credit-people-flags.php for rationale (#661). */
+    if ($isCli) {
+        flush();
+    }
 }
 
 function _migArtists_tableExists(mysqli $db, string $table): bool

--- a/appWeb/.sql/migrate-user-avatar-service.php
+++ b/appWeb/.sql/migrate-user-avatar-service.php
@@ -90,8 +90,10 @@ function _migAvatarSvc_out(string $line): void
 {
     global $isCli;
     echo $line . ($isCli ? "\n" : "<br>\n");
-    @ob_flush();
-    @flush();
+    /* CLI only — see migrate-credit-people-flags.php for rationale (#661). */
+    if ($isCli) {
+        flush();
+    }
 }
 
 function _migAvatarSvc_columnExists(mysqli $db, string $table, string $column): bool

--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -143,7 +143,7 @@ if ($page !== null) {
        still skip this path because they include user-specific data. */
     $_cacheablePages = [
         'home', 'songbooks', 'songbook', 'song', 'search',
-        'writer', 'person', 'help', 'terms', 'privacy', 'request-a-song',
+        'writer', 'person', 'help', 'terms', 'privacy', 'request', 'request-a-song',
     ];
     $_shouldCachePage = in_array($page, $_cacheablePages, true);
     if ($_shouldCachePage) {
@@ -243,7 +243,11 @@ if ($page !== null) {
             require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'pages' . DIRECTORY_SEPARATOR . 'privacy.php';
             break;
 
+        case 'request':
         case 'request-a-song':
+            /* /request is canonical (#658). request-a-song retained as
+               an alias for older bookmarks / shared links / offline-queue
+               replays. Both render the same page partial. */
             require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'pages' . DIRECTORY_SEPARATOR . 'request-a-song.php';
             break;
 

--- a/appWeb/public_html/includes/pages/help.php
+++ b/appWeb/public_html/includes/pages/help.php
@@ -306,7 +306,7 @@ declare(strict_types=1);
                 <div class="accordion-body">
                     <p>
                         Can't find a hymn? Submit it via
-                        <a href="/request-a-song" data-navigate="request-a-song">Request a Song</a>.
+                        <a href="/request" data-navigate="request">Request a Song</a>.
                         You'll get a tracking number; our curators triage submissions in
                         their admin queue.
                     </p>
@@ -352,7 +352,7 @@ declare(strict_types=1);
 
     <!-- ============================================================
          SUGGEST A MISSING SONG — CTA to the dedicated form page (#656)
-         The actual submission form lives at /request-a-song where it
+         The actual submission form lives at /request where it
          has the page to itself, supports offline queueing, and returns
          a tracking-id reference. We keep a card here so help-page
          readers still see the feature exists.
@@ -368,7 +368,7 @@ declare(strict_types=1);
                 You can also reach this from the &ldquo;Report a missing
                 song&rdquo; link at the bottom of any song page.
             </p>
-            <a href="/request-a-song" data-navigate="request-a-song" class="btn btn-primary">
+            <a href="/request" data-navigate="request" class="btn btn-primary">
                 <i class="fa-solid fa-paper-plane me-1" aria-hidden="true"></i>
                 Open the request form
             </a>

--- a/appWeb/public_html/includes/pages/request-a-song.php
+++ b/appWeb/public_html/includes/pages/request-a-song.php
@@ -100,6 +100,26 @@ declare(strict_types=1);
         const btn      = document.getElementById('request-submit-btn');
         const countEl  = document.getElementById('request-queued-count');
 
+        /* Prefill from query string (#660) — used by the editor's
+           missing-numbers panel and the standalone missing-numbers
+           page when an editor wants to log a request for a numbered
+           gap. Only writes into a field if the param is present and
+           non-empty; cap lengths to match the input maxlengths so a
+           crafted URL can't bypass the form's own caps. */
+        const qp = new URLSearchParams(window.location.search);
+        const prefillSongbook = (qp.get('songbook') || '').trim().slice(0, 100);
+        const prefillNumber   = (qp.get('number')   || '').trim().slice(0, 500);
+        if (prefillSongbook) {
+            form.elements['songbook'].value = prefillSongbook;
+        }
+        if (prefillNumber) {
+            /* The missing-numbers tools pass the song number; populate
+               the title field with it so the editor sees what number
+               they're requesting and only has to add the actual song
+               title. */
+            form.elements['title'].value = prefillNumber;
+        }
+
         const hideAll = () => {
             okEl.classList.add('d-none');
             queuedEl.classList.add('d-none');

--- a/appWeb/public_html/includes/pages/song.php
+++ b/appWeb/public_html/includes/pages/song.php
@@ -581,9 +581,10 @@ unset($_t);
 
     <!-- Report missing song link — points at the dedicated form page (#656)
          rather than dumping the user at the bottom of the long /help
-         article where the request form used to live. -->
+         article where the request form used to live. URL is /request (#658)
+         with /request-a-song retained as a back-compat alias. -->
     <div class="mt-3">
-        <a href="/request-a-song" data-navigate="request-a-song" class="text-muted small text-decoration-none">
+        <a href="/request" data-navigate="request" class="text-muted small text-decoration-none">
             <i class="fa-solid fa-flag me-1" aria-hidden="true"></i>
             Report a missing song or suggest a correction
         </a>

--- a/appWeb/public_html/js/modules/router.js
+++ b/appWeb/public_html/js/modules/router.js
@@ -197,8 +197,12 @@ export class Router {
                 return { page: 'terms', params: {} };
             case 'privacy':
                 return { page: 'privacy', params: {} };
+            case 'request':
             case 'request-a-song':
-                return { page: 'request-a-song', params: {} };
+                /* /request is the canonical URL (#658). /request-a-song
+                   stays as a back-compat alias so older bookmarks /
+                   shared links / offline-queue submissions still resolve. */
+                return { page: 'request', params: {} };
             case 'login':
                 return { page: 'login', params: {} };
             default:
@@ -386,7 +390,7 @@ export class Router {
             'help': 'Help — ' + appName,
             'terms': 'Terms of Use — ' + appName,
             'privacy': 'Privacy Policy — ' + appName,
-            'request-a-song': 'Request a Song — ' + appName,
+            'request': 'Request a Song — ' + appName,
         };
         document.title = titles[page] || appName;
     }

--- a/appWeb/public_html/manage/editor/index.php
+++ b/appWeb/public_html/manage/editor/index.php
@@ -1585,7 +1585,7 @@ $currentUser = getCurrentUser();
                                 <span class="badge bg-warning text-dark" style="min-width:7rem;">${label}</span>
                                 <span class="text-muted small flex-grow-1">${count} missing</span>
                                 <a class="btn btn-sm btn-outline-primary" target="_blank" rel="noopener"
-                                   href="/request-a-song?songbook=${encodeURIComponent(bookId)}&number=${run[0]}">
+                                   href="/request?songbook=${encodeURIComponent(bookId)}&number=${run[0]}">
                                     <i class="bi bi-lightbulb me-1" aria-hidden="true"></i>Log request
                                 </a>
                             </div>`;

--- a/appWeb/public_html/manage/help.php
+++ b/appWeb/public_html/manage/help.php
@@ -492,7 +492,7 @@ foreach ($sections as $s) {
                         <span class="badge bg-danger">global_admin</span>
                     </p>
                     <p>
-                        End users in the main app can submit a song request via the dedicated <a href="/request-a-song">/request-a-song</a> page &mdash; reachable from the &ldquo;Report a missing song or suggest a correction&rdquo; link at the bottom of every song page, the &ldquo;Suggest a Missing Song&rdquo; CTA on <a href="/help">/help</a>, and a deep-link from the editor's missing-numbers tool with the songbook + number prefilled. Submissions queue offline and replay automatically when the user is back online; each submission also returns a tracking ID the user can quote when following up. All paths land in this triage list.
+                        End users in the main app can submit a song request via the dedicated <a href="/request">/request</a> page &mdash; reachable from the &ldquo;Report a missing song or suggest a correction&rdquo; link at the bottom of every song page, the &ldquo;Suggest a Missing Song&rdquo; CTA on <a href="/help">/help</a>, and a deep-link from the editor's missing-numbers tool with the songbook + number prefilled. Submissions queue offline and replay automatically when the user is back online; each submission also returns a tracking ID the user can quote when following up. All paths land in this triage list.
                     </p>
                     <h3 class="h6">Key actions</h3>
                     <ul>

--- a/appWeb/public_html/manage/missing-numbers.php
+++ b/appWeb/public_html/manage/missing-numbers.php
@@ -226,7 +226,7 @@ foreach ($reports as $r) {
                                                         </td>
                                                         <td>
                                                             <a class="btn btn-sm btn-outline-primary"
-                                                               href="/request-a-song?songbook=<?= htmlspecialchars(urlencode($r['id'])) ?>&number=<?= (int)$first ?>"
+                                                               href="/request?songbook=<?= htmlspecialchars(urlencode($r['id'])) ?>&number=<?= (int)$first ?>"
                                                                target="_blank" rel="noopener">
                                                                 <i class="bi bi-lightbulb me-1" aria-hidden="true"></i>
                                                                 Log request


### PR DESCRIPTION
## Summary

Three connected fixes in one PR per the user's request, plus a verification on #659.

### #661 — Database Setup output renders above the navbar instead of in its panel
The 5 newer migrations (3g–3k) used `@ob_flush(); @flush();` in their `_mig*_out()` helpers, which punted captured output past the parent `ob_start()` that wraps every dashboard migration require. Fixed by matching the older migrations' pattern — only `flush()` in CLI mode, where there's no parent buffer.

### #658 — Rename `/request-a-song` → `/request`
`/request` is now canonical. `/request-a-song` retained as a back-compat alias so older bookmarks, shared links, and offline-queue replays from prior clients still resolve. All app surfaces updated (song-page footer, /help CTA, missing-numbers admin page, editor missing-numbers panel, manage/help docs, router title map, api.php cacheable-pages list).

### #660 — Editor missing-numbers prefill
The deep-link from missing-numbers (admin + editor) sends `?songbook=<id>&number=<n>` but the page was ignoring the params. The page now reads URLSearchParams on init and prefills `#request-songbook` and `#request-title` (with the song number, per the spec). Length-capped to the input maxlengths so a crafted URL can't bypass the form's caps.

### #659 — Page chrome (verified, closed)
Walked the rendering path — `index.php`'s SPA shell unconditionally renders `<header id="app-header">` and `<footer id="app-footer">` and the page partial mounts into `#page-content` for both cold-load (via `.htaccess` SPA rewrite) and SPA navigation. Closed with a comment explaining the verification; if there's a specific reproduction please reopen.

## Commits

1. `fix(sql)` — keep migration output inside the dashboard panel (closes #661)
2. `refactor(routes)` — rename /request-a-song to /request, keep alias (closes #658)
3. `feat(request)` — prefill songbook + title from query params (closes #660)

## Test plan

- [ ] **#661** — Run any of the new migrations from `/manage/setup-database` (3g–3k). Progress lines render inside the dedicated output panel (not above the navbar). CLI invocation (`php appWeb/.sql/migrate-credit-people-flags.php`) still streams progress line-by-line.
- [ ] **#658** — `/request` loads the request form. `/request-a-song` (back-compat) also loads it. Browser tab title shows "Request a Song — iHymns" on both. All app links (song-page footer, /help CTA, missing-numbers, editor) navigate to `/request`.
- [ ] **#660** — Visit `/request?songbook=MP&number=42` — Songbook field shows "MP", Title field shows "42". `/request` (no params) opens blank as before. Editor's missing-numbers Log-request button now lands editors on a pre-filled form.
- [ ] **#659** — Open `/request` on a fresh tab. Header (top app-bar with iHymns brand) and footer (Home / Search / Number / Books / Favourites) are visible. SPA navigation back to `/` and forward to `/request` keeps chrome present throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)