### PR TITLE
fix(request): server-side prefill from ?songbook= & ?number= (closes #666)

### DIFF
--- a/appWeb/public_html/includes/pages/request-a-song.php
+++ b/appWeb/public_html/includes/pages/request-a-song.php
@@ -5,9 +5,31 @@
  *
  * Public-facing form that writes to tblSongRequests. Admins can
  * later triage submissions via the admin dashboard (follow-up).
+ *
+ * Deep-link prefill (#666): the editor's missing-numbers panel and
+ * the standalone admin missing-numbers page send users here with
+ * `?songbook=<ABBR>&number=<n>` query params. The router forwards
+ * those through to /api?page=request, so they arrive in $_GET on
+ * this partial — we echo them straight into the input value
+ * attributes so prefill works the moment the HTML reaches the
+ * browser, without depending on the inline-module rehydration
+ * that proved racy in #666 (SW caches + module-import timing).
  */
 
 declare(strict_types=1);
+
+/* Read + length-cap the prefill values to match the inputs' own
+   maxlength attributes so a crafted URL can't bypass the form's
+   caps. htmlspecialchars below makes the values safe to interpolate
+   inside the value="" attribute regardless of content. */
+$_prefillSongbook = isset($_GET['songbook']) ? trim((string)$_GET['songbook']) : '';
+if ($_prefillSongbook !== '') {
+    $_prefillSongbook = mb_substr($_prefillSongbook, 0, 100);
+}
+$_prefillNumber = isset($_GET['number']) ? trim((string)$_GET['number']) : '';
+if ($_prefillNumber !== '') {
+    $_prefillNumber = mb_substr($_prefillNumber, 0, 500);
+}
 
 ?>
 <section class="page-request-a-song" aria-label="Request a song">
@@ -40,12 +62,14 @@ declare(strict_types=1);
             <div class="col-md-8">
                 <label for="request-title" class="form-label">Song title <span class="text-danger">*</span></label>
                 <input type="text" class="form-control" id="request-title" name="title"
-                       required maxlength="500" autocomplete="off">
+                       required maxlength="500" autocomplete="off"
+                       value="<?= htmlspecialchars($_prefillNumber, ENT_QUOTES, 'UTF-8') ?>">
             </div>
             <div class="col-md-4">
                 <label for="request-songbook" class="form-label">Songbook <span class="text-muted">(optional)</span></label>
                 <input type="text" class="form-control" id="request-songbook" name="songbook"
-                       maxlength="100" placeholder="e.g. Mission Praise" autocomplete="off">
+                       maxlength="100" placeholder="e.g. Mission Praise" autocomplete="off"
+                       value="<?= htmlspecialchars($_prefillSongbook, ENT_QUOTES, 'UTF-8') ?>">
             </div>
             <div class="col-md-12">
                 <label for="request-details" class="form-label">Any extra details? <span class="text-muted">(first line of lyrics, writer name, etc.)</span></label>
@@ -100,23 +124,21 @@ declare(strict_types=1);
         const btn      = document.getElementById('request-submit-btn');
         const countEl  = document.getElementById('request-queued-count');
 
-        /* Prefill from query string (#660) — used by the editor's
-           missing-numbers panel and the standalone missing-numbers
-           page when an editor wants to log a request for a numbered
-           gap. Only writes into a field if the param is present and
-           non-empty; cap lengths to match the input maxlengths so a
-           crafted URL can't bypass the form's own caps. */
+        /* Prefill fallback (#660, #666). The PHP partial above already
+           bakes ?songbook= and ?number= into the input value="" attrs,
+           so by the time this script runs the fields are already
+           populated. This block is a defence-in-depth fallback for
+           edge cases where the partial was served from a cache that
+           predates the server-side bake — fill in fields that are
+           still empty, but never overwrite a value the user (or the
+           server) has already set. */
         const qp = new URLSearchParams(window.location.search);
         const prefillSongbook = (qp.get('songbook') || '').trim().slice(0, 100);
         const prefillNumber   = (qp.get('number')   || '').trim().slice(0, 500);
-        if (prefillSongbook) {
+        if (prefillSongbook && !form.elements['songbook'].value) {
             form.elements['songbook'].value = prefillSongbook;
         }
-        if (prefillNumber) {
-            /* The missing-numbers tools pass the song number; populate
-               the title field with it so the editor sees what number
-               they're requesting and only has to add the actual song
-               title. */
+        if (prefillNumber && !form.elements['title'].value) {
             form.elements['title'].value = prefillNumber;
         }
 

--- a/appWeb/public_html/js/modules/router.js
+++ b/appWeb/public_html/js/modules/router.js
@@ -198,11 +198,22 @@ export class Router {
             case 'privacy':
                 return { page: 'privacy', params: {} };
             case 'request':
-            case 'request-a-song':
+            case 'request-a-song': {
                 /* /request is the canonical URL (#658). /request-a-song
                    stays as a back-compat alias so older bookmarks /
-                   shared links / offline-queue submissions still resolve. */
-                return { page: 'request', params: {} };
+                   shared links / offline-queue submissions still resolve.
+                   Forward `?songbook=` and `?number=` through to the API
+                   so the partial can bake them into the form server-side
+                   (#666) — relying on a client-side prefill alone proved
+                   racy across SW caches + module-import timing. */
+                const sp = new URLSearchParams(window.location.search || '');
+                const params = {};
+                const sb = (sp.get('songbook') || '').trim();
+                const num = (sp.get('number')   || '').trim();
+                if (sb)  params.songbook = sb.slice(0, 100);
+                if (num) params.number   = num.slice(0, 500);
+                return { page: 'request', params };
+            }
             case 'login':
                 return { page: 'login', params: {} };
             default:
@@ -253,6 +264,15 @@ export class Router {
         /* Person page (#588) carries `slug`, not `id`. */
         if (params.slug) {
             url.searchParams.set('slug', params.slug);
+        }
+        /* Request-a-song deep-link prefill (#666) — forwarded straight
+           through to the partial so it can echo them into the input
+           value attributes server-side. */
+        if (params.songbook) {
+            url.searchParams.set('songbook', params.songbook);
+        }
+        if (params.number) {
+            url.searchParams.set('number', params.number);
         }
 
         return url.toString();


### PR DESCRIPTION
## Summary

The Song Editor's Find Missing Numbers modal renders a "Log request" button per missing number, opening `/request?songbook=<ABBR>&number=<n>` in a new tab. Per #660 the form should arrive with Songbook and Title prefilled, but the existing JS-based prefill ([request-a-song.php:103-121](appWeb/public_html/includes/pages/request-a-song.php#L103-L121)) was racy: the SPA router's `_executeInlineScripts` rehydrates the partial's inline `<script type="module">`, but the async module-import + service-worker fragment cache make that path unreliable enough that users see the URL with the right params but blank input fields.

This PR moves prefill **server-side** so it works the moment the HTML arrives in the browser, with no JS dependency. Closes #666.

## Changes

- **`router.js parseRoute`** for `request` / `request-a-song`: reads `songbook` + `number` out of `window.location.search` into `params`, length-capped to the form's own input maxlengths.
- **`router.js buildApiUrl`**: forwards `params.songbook` + `params.number` through to `/api?page=request` so the partial sees them in `$_GET`.
- **`includes/pages/request-a-song.php`**: reads `$_GET`, mb_substr-caps to the input maxlengths, `htmlspecialchars` on output, echoes into the `value=""` attributes of the title + songbook inputs. The form is prefilled before any JS runs.
- **Existing JS prefill** kept as a defence-in-depth fallback for stale-cached partials served before this change — now only writes a value if the field is still empty, so it never overwrites the server-side bake.

## Smoke tests (all pass locally)

| Case | Result |
| --- | --- |
| `/request?songbook=MP&number=13` | `title="13"`, `songbook="MP"` |
| XSS payload `?songbook="><script>alert(1)</script>` | Escaped — no raw `<script>` in rendered HTML |
| Over-length values (500-char strings) | Capped to 100 / 500 to match the input maxlengths |
| `/request` no params | Both fields empty as before |

## Test plan

- [ ] Open the Song Editor, pick a songbook, run **Find missing numbers**, click **Log request** on any missing range — new tab lands on `/request?songbook=<ABBR>&number=<n>` with both fields prefilled.
- [ ] Same from `/manage/missing-numbers` — admin standalone page.
- [ ] Visit `/request` directly — both fields empty.
- [ ] Hard reload the request page after a fresh deploy to clear any service-worker cache, then revisit a deep-link — fields still prefilled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)