### PR TITLE
fix(css): vendor-prefix .drag-handle user-select for Safari/iOS

### DIFF
--- a/appWeb/public_html/css/admin.css
+++ b/appWeb/public_html/css/admin.css
@@ -582,6 +582,13 @@ body:has(.navbar-admin) {
     color: var(--text-muted);
     font-size: 1.2rem;
     padding: 0.25rem;
+    /* Vendor-prefixed user-select for Safari (3+) and Safari on iOS — the
+       drag handle is text-content-adjacent and would otherwise let a
+       drag-init highlight a few characters before the drag starts. Same
+       4-line convention as .admin-sort-th below and .song-lyrics in app.css. */
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
     user-select: none;
     transition: color var(--transition-fast);
 }

--- a/appWeb/public_html/css/app.css
+++ b/appWeb/public_html/css/app.css
@@ -363,6 +363,13 @@
 
 html {
     scroll-behavior: smooth;
+    /* Stop iOS / Android Chrome from auto-bumping body text size on
+       rotation. Three forms because the property is in transition:
+       Safari/iOS only know the -webkit- form, Firefox only knows the
+       -moz- form, Chromium 54+ supports the unprefixed standard. The
+       Edge Tools linter flags the unprefixed line as "not supported in
+       Firefox/Safari" — true, but the prefixed lines above cover those;
+       the standard form is for forward-compat. */
     -webkit-text-size-adjust: 100%;
     -moz-text-size-adjust: 100%;
     text-size-adjust: 100%;


### PR DESCRIPTION
## Summary

Two-part response to the Edge Tools "Problems" panel diagnostics:

1. **`admin.css:585`** — `user-select: none;` on `.drag-handle` had no `-webkit-user-select` partner, so Safari and Safari on iOS would briefly highlight neighbouring text before a drag gesture engages. Added the established 4-line block (`-webkit-`, `-moz-`, `-ms-`, plain) used everywhere else in the codebase (`.admin-sort-th`, `.song-lyrics`, practice-level rules).

2. **`app.css:368`** — the unprefixed `text-size-adjust: 100%;` is flagged as "not supported in Firefox, Safari" but the prefixed lines above (`-webkit-` and `-moz-`) already cover those engines; the standard form is for Chromium 54+ forward-compat. Added a comment explaining the layering so the warning reads as intentional.

## Out of scope here

- **`deploy.yml` SFTP_KEY context warnings** — GitHub Actions extension false positives. The secrets are configured in repo settings but the local linter can't see GitHub-side state. No code change makes these warnings disappear.
- **`setup-database.php`** — lints clean (`php -l` reports no syntax errors). The diagnostic isn't expanded in the screenshot so I can't see what rule fired. If you can grab the message text I'll fix it under a separate issue.

## Test plan

- [ ] Open `/manage/editor` on iOS Safari, drag a component handle — no transient text highlight on the surrounding cell.
- [ ] Reopen the Problems panel — the `'user-select' is not supported` row on `admin.css:585` is gone.
- [ ] No visual regression on desktop Chrome / Firefox / Edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)