### PR TITLE
fix(editor): bulk_import_zip — Undefined constant + raise cap to 100,000 (hotfix)

### DIFF
--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -79,6 +79,45 @@ function _songArtistsTableExists(\mysqli $db): bool
 }
 
 /* =========================================================================
+ * BULK_IMPORT_ZIP constants (#664)
+ *
+ * Declared up here — ABOVE the switch — because PHP's top-level `const`
+ * keyword defines the constant at the moment execution reaches the line,
+ * not at compile time. The bulk-import helpers at the bottom of this
+ * file reference these constants from inside the switch case, so the
+ * declarations have to be evaluated before the switch runs or the
+ * helpers blow up with "Undefined constant" the first time anyone
+ * uploads a zip.
+ * ========================================================================= */
+
+/**
+ * Folder name regex: matches "Christ in Song [CIS]" (the hymnal title
+ * followed by a space, an opening square bracket, the abbreviation, and a
+ * closing bracket). Anchored to the entire path-segment string so we
+ * don't match accidental "[" inside titles.
+ */
+const _BULK_IMPORT_FOLDER_RE = '/^(?P<name>.+?)\s*\[(?P<abbr>[A-Za-z0-9_\-]+)\]$/u';
+
+/**
+ * Filename regex: "001 (CIS) - Watchman Blow The Gospel Trumpet.txt".
+ * Captures the (zero-padded) number, the abbreviation in parentheses,
+ * and the title. Tolerant of variable padding widths (3- or 4-digit).
+ */
+const _BULK_IMPORT_FILE_RE = '/^(?P<num>\d{1,5})\s*\((?P<abbr>[A-Za-z0-9_\-]+)\)\s*-\s*(?P<title>.+)\.txt$/u';
+
+/**
+ * Maximum number of *real* zip entries to process in one request — the
+ * count after we strip __MACOSX/, .DS_Store and bare directory entries
+ * (see _bulkImport_processZip). The cap is a defensive guardrail
+ * against a malformed/zip-bomb archive that's tiny on disk but expands
+ * into a million entries; real auth + the 100 MB upload cap are the
+ * actual access controls. 100,000 covers any realistic future bundle
+ * (every published Adventist hymnal worldwide is well under 50,000)
+ * while still tripping on a true zip bomb.
+ */
+const _BULK_IMPORT_MAX_ENTRIES = 100000;
+
+/* =========================================================================
  * REQUEST HANDLING
  * ========================================================================= */
 
@@ -1387,28 +1426,12 @@ switch ($action) {
  * comparing source-of-truth lyrics to the live database row.
  * =========================================================================== */
 
-/**
- * Folder name regex: matches "Christ in Song [CIS]" (the hymnal title
- * followed by a space, an opening square bracket, the abbreviation, and a
- * closing bracket). Anchored to the entire path-segment string so we
- * don't match accidental "[" inside titles.
- */
-const _BULK_IMPORT_FOLDER_RE = '/^(?P<name>.+?)\s*\[(?P<abbr>[A-Za-z0-9_\-]+)\]$/u';
-
-/**
- * Filename regex: "001 (CIS) - Watchman Blow The Gospel Trumpet.txt".
- * Captures the (zero-padded) number, the abbreviation in parentheses,
- * and the title. Tolerant of variable padding widths (3- or 4-digit).
- */
-const _BULK_IMPORT_FILE_RE = '/^(?P<num>\d{1,5})\s*\((?P<abbr>[A-Za-z0-9_\-]+)\)\s*-\s*(?P<title>.+)\.txt$/u';
-
-/**
- * Maximum number of zip entries to process in one request. Defends
- * against zip-bombs (a small archive that expands into a million empty
- * files, exhausting inodes / memory). 10,000 is well above any real
- * hymnal corpus we ship — the SDAH at 695 + MP at 1655 is < 2,500.
- */
-const _BULK_IMPORT_MAX_ENTRIES = 10000;
+/* The _BULK_IMPORT_FOLDER_RE / _BULK_IMPORT_FILE_RE / _BULK_IMPORT_MAX_ENTRIES
+   constants are now declared above the switch (search this file for
+   "BULK_IMPORT_ZIP constants"). Top-level `const` declarations are
+   evaluated at runtime when the line is reached, not at compile time
+   — leaving them down here meant they were undefined when the switch
+   case called into the helper function above. */
 
 /**
  * Section-marker → component-type map. Anything not in the map (e.g.


### PR DESCRIPTION
## Why this is urgent

User attempted to bulk-import \`Archive 2.zip\` (8,763 songs across 23 CIS hymnals) via the Song Editor's Import button on dev.ihymns.app and hit:

\`\`\`
Import failed: Import failed: Undefined constant "_BULK_IMPORT_MAX_ENTRIES"
\`\`\`

Every bulk import currently fails with the same error — the endpoint is broken for everyone, not just one zip.

## Root cause

PHP's top-level \`const\` keyword defines a constant **at the moment execution reaches the line**, not at compile time. The three bulk-import constants (\`_BULK_IMPORT_FOLDER_RE\`, \`_BULK_IMPORT_FILE_RE\`, \`_BULK_IMPORT_MAX_ENTRIES\`) lived in the helpers block at the *bottom* of \`/manage/editor/api.php\`.

Function declarations **are** hoisted in PHP, so \`_bulkImport_processZip()\` is callable from inside the switch case at the top of the file. But its body references \`_BULK_IMPORT_MAX_ENTRIES\` — and the \`const\` line that defines it sits below the \`switch\`, which exits via \`break;\` before reaching it. Result: constants undefined → fatal at first use.

This was a latent bug that didn't surface during local smoke-tests because those tests required the helpers file in isolation, evaluating the const lines along the way.

## Fix

1. **Move the three \`const\` declarations above the switch** ([editor/api.php:99-118](appWeb/public_html/manage/editor/api.php#L99-L118)) so they evaluate before any case can hit the helpers. Replaced the original block with a back-pointer comment so a future maintainer doesn't re-introduce the bug by moving them back.

2. **Raise \`_BULK_IMPORT_MAX_ENTRIES\`** from \`10,000\` → \`100,000\` (the previously-agreed option 1). The old cap was chosen for the 3,612-entry SDAH+MP+CH workload; 100K covers any realistic future bundle while still tripping a true zip bomb.

## Verified

- \`php -l\` clean
- Smoke-test confirms all three constants resolve and the folder + file regexes still match (\`Christ in Song [CIS]\` → \`abbr=CIS\`; \`001 (CIS) - Test.txt\` → \`num=001 abbr=CIS\`)
- After this lands on \`alpha\` and deploys to dev, the same Archive 2.zip upload should produce the expected JSON summary (\`songbooks_created: 23\`, \`songs_created: 8758\`, \`songs_failed: 5\`).

## Out of scope

The broader **security audit hardening** I owe (per-entry decompression cap, field-length caps, exception-message scrubbing, etc.) is intentionally NOT in this PR — keeping the hotfix small and focused so it can land + deploy fast. I'll open a follow-up PR for the audit work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)