### PR TITLE
feat(songbooks): controlled lookup table for Affiliation (closes #670)

### DIFF
--- a/appWeb/.sql/migrate-songbook-affiliations.php
+++ b/appWeb/.sql/migrate-songbook-affiliations.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Songbook Affiliations Lookup Table Migration (#670)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Closes the "Affiliation lookup table" out-of-scope item from #502.
+ * Previously the Affiliation column on tblSongbooks was free-text, which
+ * is a duplicate magnet — small typing variations
+ * ("Seventh-day Adventist Church" vs "Seventh-Day Adventist Church"
+ * vs "SDA Church") fragment any future filter / analytic.
+ *
+ * Adds tblSongbookAffiliations (Id PK, Name UNIQUE) as a parallel
+ * registry. tblSongbooks.Affiliation stays a denormalised VARCHAR (no
+ * FK) so existing free-text values that don't yet match the registry
+ * are not lost on this migration; the songbook editor's save handler
+ * is being updated alongside this script to INSERT IGNORE every
+ * non-empty value into the registry, making it self-populate from
+ * real use exactly like tblCreditPeople does for credit names (#545).
+ *
+ * Steps:
+ *   1. Probe INFORMATION_SCHEMA for tblSongbookAffiliations; CREATE
+ *      if absent.
+ *   2. Backfill the registry from every distinct non-empty Affiliation
+ *      already in tblSongbooks so the typeahead surfaces existing
+ *      values from day one.
+ *
+ * Idempotent — re-running is safe. The CREATE step skips if the
+ * table is already present; the backfill INSERTs use IGNORE so an
+ * existing registry row with the same Name is a silent no-op.
+ *
+ * USAGE:
+ *   CLI: php appWeb/.sql/migrate-songbook-affiliations.php
+ *   Web: /manage/setup-database → "Songbook Affiliations Migration"
+ *        (entry point requires global_admin)
+ *
+ * @migration-adds tblSongbookAffiliations
+ * @requires PHP 8.1+ with mysqli extension
+ */
+
+if (PHP_SAPI === 'cli') {
+    /* CLI bootstrap mirrors the other migrate-*.php files. */
+    /* Guarded require — see #652. The dashboard has already loaded
+       db_mysql.php via auth.php's bootstrap, so the function already
+       exists at this point in dashboard mode; the guard skips the
+       re-open that some hosts block from outside public_html/. */
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = true;
+} else {
+    if (!defined('IHYMNS_SETUP_DASHBOARD')) {
+        if (!function_exists('isAuthenticated')) {
+            require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+        }
+        if (!isAuthenticated()) {
+            http_response_code(401);
+            exit('Authentication required.');
+        }
+        $u = getCurrentUser();
+        if (!$u || $u['role'] !== 'global_admin') {
+            http_response_code(403);
+            exit('Global admin required.');
+        }
+    }
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = false;
+}
+
+function _migAffil_out(string $line): void
+{
+    global $isCli;
+    echo $line . ($isCli ? "\n" : "<br>\n");
+    /* CLI only — see migrate-credit-people-flags.php for rationale (#661):
+       the dashboard wraps this require in ob_start() so it can render
+       captured output inside its dedicated panel. Calling ob_flush()
+       here would punt the buffer past that wrapper. */
+    if ($isCli) {
+        flush();
+    }
+}
+
+function _migAffil_tableExists(mysqli $db, string $table): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? LIMIT 1'
+    );
+    $stmt->bind_param('s', $table);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+_migAffil_out('Songbook Affiliations migration starting…');
+
+$mysqli = getDbMysqli();
+if (!$mysqli) {
+    _migAffil_out('ERROR: could not connect to database.');
+    exit(1);
+}
+
+/* The base songbooks table must already exist — this migration backfills
+   from it. If a deployment somehow hits this migration before the core
+   schema is in place, bail with a clear pointer rather than failing
+   later in the SELECT. */
+if (!_migAffil_tableExists($mysqli, 'tblSongbooks')) {
+    _migAffil_out('ERROR: tblSongbooks not found. Run install.php first.');
+    exit(1);
+}
+
+/* ----------------------------------------------------------------------
+ * Step 1: create tblSongbookAffiliations if absent
+ * ---------------------------------------------------------------------- */
+if (_migAffil_tableExists($mysqli, 'tblSongbookAffiliations')) {
+    _migAffil_out('[skip] tblSongbookAffiliations already present.');
+} else {
+    $sql = "CREATE TABLE tblSongbookAffiliations (
+        Id          INT UNSIGNED    AUTO_INCREMENT PRIMARY KEY,
+        Name        VARCHAR(120)    NOT NULL,
+        CreatedAt   TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE KEY ux_affiliation_name (Name)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
+    if (!$mysqli->query($sql)) {
+        _migAffil_out('ERROR: creating tblSongbookAffiliations failed: ' . $mysqli->error);
+        exit(1);
+    }
+    _migAffil_out('[add ] tblSongbookAffiliations.');
+}
+
+/* ----------------------------------------------------------------------
+ * Step 2: backfill from existing tblSongbooks.Affiliation values
+ *
+ * One INSERT…SELECT, with IGNORE so re-runs (or a registry that already
+ * has some rows from the live save path) don't 1062-error on duplicate
+ * Name. SELECT DISTINCT collapses repeated values across multiple
+ * songbooks. The TRIM/LENGTH > 0 guards keep blank / whitespace-only
+ * rows out of the registry — the column is nullable but has historically
+ * also been written as '' on some code paths.
+ * ---------------------------------------------------------------------- */
+$sql = "INSERT IGNORE INTO tblSongbookAffiliations (Name)
+        SELECT DISTINCT TRIM(Affiliation)
+          FROM tblSongbooks
+         WHERE Affiliation IS NOT NULL
+           AND LENGTH(TRIM(Affiliation)) > 0";
+if (!$mysqli->query($sql)) {
+    _migAffil_out('WARN: backfill failed: ' . $mysqli->error);
+} else {
+    $seeded = $mysqli->affected_rows;
+    if ($seeded > 0) {
+        _migAffil_out("[seed] backfilled {$seeded} affiliation row" . ($seeded === 1 ? '' : 's') . ' from tblSongbooks.');
+    } else {
+        _migAffil_out('[seed] no affiliation values to backfill (registry already covers all songbooks).');
+    }
+}
+
+_migAffil_out('Songbook Affiliations migration finished.');

--- a/appWeb/.sql/schema.sql
+++ b/appWeb/.sql/schema.sql
@@ -40,11 +40,29 @@ CREATE TABLE IF NOT EXISTS tblSongbooks (
     Publisher       VARCHAR(255)    NULL DEFAULT NULL COMMENT 'Publisher or originator (e.g. Praise Trust, Hope Publishing) (#502)',
     PublicationYear VARCHAR(50)     NULL DEFAULT NULL COMMENT 'Year / edition range (free-form: 1986, 1986-2003, 2nd edition 2011) (#502)',
     Copyright       VARCHAR(500)    NULL DEFAULT NULL COMMENT 'Copyright notice for the collection as a whole (#502)',
-    Affiliation     VARCHAR(120)    NULL DEFAULT NULL COMMENT 'Denominational / religious affiliation; free-text for now, lookup table later (#502)',
+    Affiliation     VARCHAR(120)    NULL DEFAULT NULL COMMENT 'Denominational / religious affiliation; backed by tblSongbookAffiliations registry (#670)',
     CreatedAt       TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UpdatedAt       TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 
     INDEX idx_DisplayOrder (DisplayOrder)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+-- ----------------------------------------------------------------------------
+-- tblSongbookAffiliations (#670)
+-- Controlled vocabulary for the Affiliation column on tblSongbooks. Acts as a
+-- parallel registry — Affiliation stays a denormalised VARCHAR on tblSongbooks
+-- (no FK), but every non-empty value the songbook editor saves is also
+-- INSERT IGNOREd here so the typeahead can prevent duplicate-creation drift
+-- (e.g. "Seventh-day Adventist Church" vs "Seventh-Day Adventist Church"
+-- vs "SDA Church"). Same shape as tblCreditPeople below.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS tblSongbookAffiliations (
+    Id          INT UNSIGNED    AUTO_INCREMENT PRIMARY KEY,
+    Name        VARCHAR(120)    NOT NULL,
+    CreatedAt   TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    UNIQUE KEY ux_affiliation_name (Name)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -205,6 +205,7 @@ if ($action !== '') {
         'credit-people-slug' => 'migrate-credit-people-slug.php',
         'user-avatar-service' => 'migrate-user-avatar-service.php',
         'organisation-licences' => 'migrate-organisation-licences.php',
+        'songbook-affiliations' => 'migrate-songbook-affiliations.php',
         'cleanup'     => 'cleanup.php',
         'backup'      => 'backup.php',
         'restore'     => 'restore.php',
@@ -781,6 +782,25 @@ if ($hasCredentials && defined('DB_HOST')) {
                         </p>
                         <a href="?action=organisation-licences" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
                             Run Multi-licence Migration
+                        </a>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="card bg-dark border-secondary h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">3l. Songbook affiliations registry (#670)</h5>
+                        <p class="card-text text-secondary small">
+                            Closes the &ldquo;Affiliation lookup table&rdquo; out-of-scope
+                            item from #502. Adds <code>tblSongbookAffiliations</code> as
+                            a controlled vocabulary (Name UNIQUE) so the songbook editor
+                            can typeahead-suggest existing values instead of letting small
+                            typing variations create duplicate entries. Backfills the
+                            registry from every distinct non-empty <code>Affiliation</code>
+                            already in <code>tblSongbooks</code>. Idempotent — safe to re-run.
+                        </p>
+                        <a href="?action=songbook-affiliations" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
+                            Run Songbook Affiliations Migration
                         </a>
                     </div>
                 </div>

--- a/appWeb/public_html/manage/songbooks.php
+++ b/appWeb/public_html/manage/songbooks.php
@@ -34,6 +34,122 @@ $error   = '';
 $success = '';
 $db      = getDbMysqli();
 
+/* ---- GET ?action=affiliation_search&q=… (#670) -------------------------
+ * JSON typeahead endpoint for the Songbook edit modal's Affiliation
+ * field. Returns up to `limit` matching rows from
+ * tblSongbookAffiliations, ranked by current usage in tblSongbooks
+ * (most-cited first) so a curator's recent additions surface
+ * straight away. Same auth gate as the page itself
+ * (`manage_songbooks` entitlement); returns an empty list rather
+ * than 4xx when the query is empty so the caller's onInput handler
+ * stays trivial. Exits early so no page HTML follows.
+ * ----------------------------------------------------------------------- */
+if (($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'GET'
+    && ($_GET['action'] ?? '') === 'affiliation_search'
+) {
+    header('Content-Type: application/json; charset=UTF-8');
+    header('Cache-Control: no-store');
+    $q     = trim((string)($_GET['q'] ?? ''));
+    $limit = max(1, min(50, (int)($_GET['limit'] ?? 20)));
+
+    /* Empty query → empty list. We don't 400 because the typeahead
+       calls this on every keystroke, including the first one before
+       the user has typed anything. */
+    if ($q === '') {
+        echo json_encode(['suggestions' => []]);
+        exit;
+    }
+
+    /* Probe whether the registry table exists yet. New deployments
+       that haven't run migrate-songbook-affiliations.php should not
+       see a 500 — return an empty list and log a server-side note so
+       the migration prompt on /manage/setup-database is the cure. */
+    $hasRegistry = false;
+    try {
+        $probe = $db->prepare(
+            "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+              WHERE TABLE_SCHEMA = DATABASE()
+                AND TABLE_NAME = 'tblSongbookAffiliations' LIMIT 1"
+        );
+        $probe->execute();
+        $hasRegistry = $probe->get_result()->fetch_row() !== null;
+        $probe->close();
+    } catch (\Throwable $e) {
+        error_log('[affiliation_search] probe failed: ' . $e->getMessage());
+    }
+    if (!$hasRegistry) {
+        echo json_encode([
+            'suggestions' => [],
+            'note'        => 'tblSongbookAffiliations not yet created — run /manage/setup-database',
+        ]);
+        exit;
+    }
+
+    /* Substring match anywhere in the name (LIKE %q%). Real-world
+       affiliation strings are short enough that ranking by current
+       usage in tblSongbooks (a LEFT JOIN + COUNT) is fine; the
+       registry will be small (low hundreds at most). */
+    try {
+        $like = '%' . $q . '%';
+        $stmt = $db->prepare(
+            'SELECT a.Name AS name,
+                    (SELECT COUNT(*) FROM tblSongbooks b WHERE b.Affiliation = a.Name) AS songbookCount
+               FROM tblSongbookAffiliations a
+              WHERE a.Name LIKE ?
+              ORDER BY songbookCount DESC, a.Name ASC
+              LIMIT ?'
+        );
+        $stmt->bind_param('si', $like, $limit);
+        $stmt->execute();
+        $res = $stmt->get_result();
+        $suggestions = [];
+        while ($row = $res->fetch_assoc()) {
+            $suggestions[] = [
+                'name'          => (string)$row['name'],
+                'songbookCount' => (int)$row['songbookCount'],
+            ];
+        }
+        $stmt->close();
+        echo json_encode(['suggestions' => $suggestions], JSON_UNESCAPED_UNICODE);
+    } catch (\Throwable $e) {
+        error_log('[affiliation_search] ' . $e->getMessage());
+        http_response_code(500);
+        echo json_encode(['error' => 'Search failed.']);
+    }
+    exit;
+}
+
+/**
+ * INSERT IGNORE the supplied affiliation name into the registry so
+ * the typeahead surfaces it on the next save (#670). Silent no-op
+ * when the table doesn't exist (pre-migration deployments) so the
+ * songbook save path can't be broken by a half-applied schema. The
+ * tblCreditPeople sync in the editor's save_song path uses the same
+ * "best-effort registry sync" pattern (#545).
+ *
+ * @param ?string $name Affiliation name as typed; null/empty = no-op.
+ */
+$registerAffiliation = function (?string $name) use ($db): void {
+    if ($name === null) return;
+    $trimmed = trim($name);
+    if ($trimmed === '') return;
+    /* Cap to the column width so a crafted form post can't crash
+       the INSERT. mb_substr is unicode-safe for languages whose
+       glyphs are multi-byte (e.g. denomination names in Cyrillic). */
+    $trimmed = mb_substr($trimmed, 0, 120);
+    try {
+        $stmt = $db->prepare('INSERT IGNORE INTO tblSongbookAffiliations (Name) VALUES (?)');
+        $stmt->bind_param('s', $trimmed);
+        $stmt->execute();
+        $stmt->close();
+    } catch (\Throwable $e) {
+        /* Most likely cause: the migration hasn't been run yet so the
+           table doesn't exist. The save itself is unaffected — this is
+           best-effort registry sync. */
+        error_log('[songbooks] registry sync skipped: ' . $e->getMessage());
+    }
+};
+
 /* Helpers */
 $validateAbbr = function (string $abbr): ?string {
     $abbr = trim($abbr);
@@ -114,6 +230,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     'copyright'       => $copyright,
                     'affiliation'     => $affiliation,
                 ]);
+                /* Self-populate the affiliation registry so the next
+                   open of the typeahead surfaces this value (#670). */
+                $registerAffiliation($affiliation);
                 $success = "Songbook '{$abbr}' created.";
                 break;
             }
@@ -225,6 +344,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         'after'              => array_intersect_key($afterRow,  array_flip($changed)),
                         'songs_renamed_too'  => $alsoRename && $abbrChanged,
                     ]);
+                    /* Keep the affiliation registry in sync — only when the
+                       value actually changed and is non-empty (#670). */
+                    if (in_array('Affiliation', $changed, true)) {
+                        $registerAffiliation($affiliation);
+                    }
 
                     $success = $abbrChanged
                         ? "Songbook '{$oldAbbr}' → '{$newAbbr}'" . ($alsoRename ? ' (song references updated).' : ' (song references kept — resolve manually).')
@@ -522,8 +646,12 @@ $csrf = csrfToken();
                 </div>
                 <div class="col-sm-4">
                     <label class="form-label small">Affiliation</label>
-                    <input type="text" name="affiliation" class="form-control form-control-sm"
-                           maxlength="120" placeholder="e.g. Seventh-day Adventist, Non-denominational">
+                    <input type="text" name="affiliation"
+                           class="form-control form-control-sm js-affiliation-input"
+                           list="affiliations-datalist"
+                           autocomplete="off"
+                           maxlength="120"
+                           placeholder="e.g. Seventh-day Adventist, Non-denominational">
                 </div>
             </div>
 
@@ -592,10 +720,16 @@ $csrf = csrfToken();
                         </div>
                         <div class="mb-3">
                             <label class="form-label">Affiliation</label>
-                            <input type="text" class="form-control" name="affiliation" id="edit-affiliation"
-                                   maxlength="120" placeholder="e.g. Seventh-day Adventist, Non-denominational">
+                            <input type="text"
+                                   class="form-control js-affiliation-input"
+                                   name="affiliation" id="edit-affiliation"
+                                   list="affiliations-datalist"
+                                   autocomplete="off"
+                                   maxlength="120"
+                                   placeholder="e.g. Seventh-day Adventist, Non-denominational">
                             <div class="form-text small">
-                                Free-text for now; a controlled lookup table is planned (#502).
+                                Type to search existing affiliations or enter a new one — it
+                                will be added to the registry on save (#670).
                             </div>
                         </div>
 
@@ -681,6 +815,80 @@ $csrf = csrfToken();
     <script type="module">
         import { bootSortableTables } from '/js/modules/admin-table-sort.js?v=<?= filemtime(dirname(__DIR__) . '/js/modules/admin-table-sort.js') ?>';
         bootSortableTables();
+    </script>
+
+    <!-- Affiliation typeahead (#670).
+         A single <datalist> shared by every input.js-affiliation-input on
+         the page (the create form's affiliation field + the edit modal's
+         affiliation field). Each `input` event runs the same debounced
+         fetch against /manage/songbooks?action=affiliation_search and
+         rebuilds the datalist <option>s. The browser handles the dropdown
+         UI natively, so there's no third-party autocomplete library and
+         the user can still type a brand-new value if no match exists —
+         it lands in Affiliation on save and the server-side handler
+         self-registers it in tblSongbookAffiliations for next time. -->
+    <datalist id="affiliations-datalist"></datalist>
+    <script>
+    (function () {
+        const inputs   = document.querySelectorAll('.js-affiliation-input');
+        const datalist = document.getElementById('affiliations-datalist');
+        if (!inputs.length || !datalist) return;
+
+        let debounceTimer = null;
+        let inflight      = null;
+        const lookup = (query) => {
+            if (inflight) inflight.abort();
+            const ac = new AbortController();
+            inflight = ac;
+            const url = '/manage/songbooks?action=affiliation_search&q=' +
+                        encodeURIComponent(query) + '&limit=20';
+            fetch(url, { credentials: 'same-origin', signal: ac.signal })
+                .then(r => r.ok ? r.json() : { suggestions: [] })
+                .then(data => {
+                    const list = Array.isArray(data.suggestions) ? data.suggestions : [];
+                    /* Rebuild the datalist with one <option> per match.
+                       The `value` is what the input gets when picked;
+                       the `label` carries the usage count so curators
+                       can see how often each affiliation is in play. */
+                    datalist.innerHTML = list.map(s => {
+                        const v = (s.name || '').replace(/"/g, '&quot;');
+                        const c = (typeof s.songbookCount === 'number') ? s.songbookCount : 0;
+                        const tag = c > 0 ? ' (' + c + ' songbook' + (c === 1 ? '' : 's') + ')' : '';
+                        return '<option value="' + v + '" label="' + v + tag + '"></option>';
+                    }).join('');
+                })
+                .catch(err => {
+                    if (err.name !== 'AbortError') {
+                        /* Silent — the typeahead is a nicety, not critical
+                           path. Server-side errors are already in error_log
+                           via affiliation_search. */
+                    }
+                });
+        };
+
+        inputs.forEach(input => {
+            input.addEventListener('input', () => {
+                const q = input.value.trim();
+                /* Clear datalist when the input is empty so the dropdown
+                   doesn't show stale matches from a prior word. */
+                if (q === '') {
+                    datalist.innerHTML = '';
+                    return;
+                }
+                clearTimeout(debounceTimer);
+                /* 200 ms is the same debounce the editor's tag-search and
+                   credit-search use — feels instant but coalesces typing
+                   bursts into a single request. */
+                debounceTimer = setTimeout(() => lookup(q), 200);
+            });
+            /* Also trigger on focus when there's already a value (e.g.
+               opening the edit modal on a row that has an affiliation
+               populated) so the dropdown shows immediately on click. */
+            input.addEventListener('focus', () => {
+                if (input.value.trim() !== '') lookup(input.value.trim());
+            });
+        });
+    })();
     </script>
 
     <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>


### PR DESCRIPTION
## Summary

Closes the "Affiliation lookup table" out-of-scope item from #502. The Songbook editor's Affiliation field used to be free-text — a duplicate magnet, since "Seventh-day Adventist Church" / "Seventh-Day Adventist Church" / "SDA Church" all created distinct values that fragment any future filter or analytic.

This PR adds a **typeahead-backed controlled vocabulary** that self-populates from real use — every non-empty value the songbook editor saves is silently registered in the lookup table for the next typeahead.

Closes #670.

## Schema

`tblSongbookAffiliations` — Id PK, Name `VARCHAR(120)` UNIQUE, CreatedAt. **Parallel registry, not a foreign key**: `tblSongbooks.Affiliation` stays a denormalised VARCHAR so existing free-text values that don't yet match the registry survive this migration. Same shape `tblCreditPeople` uses for credit names (#545).

## Migration

- `appWeb/.sql/migrate-songbook-affiliations.php` — idempotent INFORMATION_SCHEMA probe → CREATE if absent, then `INSERT IGNORE` every distinct non-empty `Affiliation` already in `tblSongbooks` so the typeahead surfaces existing values from day one.
- Wired into `/manage/setup-database` as card **3l. Songbook affiliations registry (#670)**.

## API

```
GET /manage/songbooks?action=affiliation_search&q=<prefix>&limit=20
→ {"suggestions": [{"name": "Seventh-day Adventist Church", "songbookCount": 4}, …]}
```

- Same auth gate as the page itself (`manage_songbooks` entitlement).
- Probes for table existence so deployments that haven't run the migration return an empty list with a server-side note rather than 500-ing.
- Empty query returns empty list — keeps the client's `onInput` handler trivial.
- Ranked by current usage in `tblSongbooks` so curator-recent additions surface first.

## Auto-registration on save

`$registerAffiliation` closure called from both `case 'create'` and `case 'update'` with the value just saved. Best-effort `INSERT IGNORE` — a broken registry doesn't break the songbook save. Same pattern the editor's `save_song` path uses to keep `tblCreditPeople` in sync with credit-name inserts. Update path only re-registers when Affiliation actually changed.

## UI

- Both Affiliation inputs (create form + edit modal) gain `.js-affiliation-input` + `list="affiliations-datalist"` + `autocomplete="off"`.
- One shared `<datalist>` at the bottom of the page; one inline `<script>` debounces input events 200ms (same cadence as the editor's tag-search + credit-search) and rebuilds the datalist `<option>`s after each `affiliation_search` response.
- **No third-party autocomplete library, no chip widget** — the browser handles the dropdown UI natively across every engine.
- The user can still type a brand-new value if no match exists; it lands in Affiliation on save and auto-registers for next time.
- Edit modal helper text replaced: ~~"Free-text for now; a controlled lookup table is planned (#502)"~~ → "Type to search existing affiliations or enter a new one — it will be added to the registry on save (#670)".

## Test plan

- [ ] Run **3l** from `/manage/setup-database`. Output: `[add] tblSongbookAffiliations.` + `[seed] backfilled N affiliation row(s) from tblSongbooks.` (or `no affiliation values to backfill` on a fresh DB).
- [ ] Open `/manage/songbooks`, hit Edit on any songbook. Affiliation input shows the existing value. Click into it; the dropdown shows registry matches + a usage count `(N songbooks)` next to each.
- [ ] Type a new value (e.g. "Methodist Church"). Save. Re-open — typing "Meth" surfaces the new value with `(1 songbook)`.
- [ ] Type the same value with a small variation (`methodist church` lowercase). Save. The registry treats this as a new entry only if `Name` is byte-different — desired, since case is part of the curated vocabulary. Curators can pick the canonical form from the dropdown to avoid drift.
- [ ] Visit `/manage/songbooks?action=affiliation_search&q=ad` directly — JSON list with `Adventist`-prefixed names ranked by usage.
- [ ] Visit the page on a deployment that hasn't run the migration — typeahead silently shows no suggestions, save still works (best-effort registry sync logs a notice and moves on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)