### PR TITLE
Songbooks: bibliographic metadata + Language + DisplayOrder polish + drag-drop reorder + sort presets (closes #672, #673, #674)

### DIFF
--- a/appWeb/.sql/migrate-songbook-bibliographic.php
+++ b/appWeb/.sql/migrate-songbook-bibliographic.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Songbook Bibliographic & Authority-Identifier Migration (#672)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Adds 13 nullable metadata columns to tblSongbooks for canonical
+ * references to the wider bibliographic record (publisher website,
+ * Internet Archive, Wikipedia/WikiData, library catalogue identifiers
+ * like OCLC / ISBN / ARK / ISNI / VIAF / LCCN, and the LC
+ * Classification call number).
+ *
+ * The columns are all VARCHAR with no CHECK constraints — curators
+ * paste the canonical form from a library catalogue or authority
+ * file; light client-side validation hints at malformed URLs but
+ * the server accepts whatever lands.
+ *
+ * Schema additions:
+ *   tblSongbooks.WebsiteUrl          VARCHAR(500)
+ *   tblSongbooks.InternetArchiveUrl  VARCHAR(500)
+ *   tblSongbooks.WikipediaUrl        VARCHAR(500)
+ *   tblSongbooks.WikidataId          VARCHAR(20)
+ *   tblSongbooks.OclcNumber          VARCHAR(30)
+ *   tblSongbooks.OcnNumber           VARCHAR(30)
+ *   tblSongbooks.LcpNumber           VARCHAR(30)
+ *   tblSongbooks.Isbn                VARCHAR(20)
+ *   tblSongbooks.ArkId               VARCHAR(80)
+ *   tblSongbooks.IsniId              VARCHAR(25)
+ *   tblSongbooks.ViafId              VARCHAR(20)
+ *   tblSongbooks.Lccn                VARCHAR(20)
+ *   tblSongbooks.LcClass             VARCHAR(50)
+ *
+ * @migration-adds tblSongbooks.WebsiteUrl
+ * @migration-adds tblSongbooks.InternetArchiveUrl
+ * @migration-adds tblSongbooks.WikipediaUrl
+ * @migration-adds tblSongbooks.WikidataId
+ * @migration-adds tblSongbooks.OclcNumber
+ * @migration-adds tblSongbooks.OcnNumber
+ * @migration-adds tblSongbooks.LcpNumber
+ * @migration-adds tblSongbooks.Isbn
+ * @migration-adds tblSongbooks.ArkId
+ * @migration-adds tblSongbooks.IsniId
+ * @migration-adds tblSongbooks.ViafId
+ * @migration-adds tblSongbooks.Lccn
+ * @migration-adds tblSongbooks.LcClass
+ *
+ * Idempotent — re-running is safe; columns that already exist are
+ * skipped via the INFORMATION_SCHEMA probe.
+ *
+ * USAGE:
+ *   CLI: php appWeb/.sql/migrate-songbook-bibliographic.php
+ *   Web: /manage/setup-database → "Songbook Bibliographic Metadata"
+ *        (entry point requires global_admin)
+ */
+
+if (PHP_SAPI === 'cli') {
+    /* Guarded require — see #652. */
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = true;
+} else {
+    if (!defined('IHYMNS_SETUP_DASHBOARD')) {
+        if (!function_exists('isAuthenticated')) {
+            require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+        }
+        if (!isAuthenticated()) {
+            http_response_code(401);
+            exit('Authentication required.');
+        }
+        $u = getCurrentUser();
+        if (!$u || $u['role'] !== 'global_admin') {
+            http_response_code(403);
+            exit('Global admin required.');
+        }
+    }
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = false;
+}
+
+function _migSbBib_out(string $line): void
+{
+    global $isCli;
+    echo $line . ($isCli ? "\n" : "<br>\n");
+    /* CLI only — see migrate-credit-people-flags.php for rationale (#661). */
+    if ($isCli) {
+        flush();
+    }
+}
+
+function _migSbBib_columnExists(mysqli $db, string $table, string $column): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+          WHERE TABLE_SCHEMA = DATABASE()
+            AND TABLE_NAME   = ?
+            AND COLUMN_NAME  = ?
+          LIMIT 1'
+    );
+    $stmt->bind_param('ss', $table, $column);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+function _migSbBib_tableExists(mysqli $db, string $table): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? LIMIT 1'
+    );
+    $stmt->bind_param('s', $table);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+_migSbBib_out('Songbook bibliographic metadata migration starting…');
+
+$mysqli = getDbMysqli();
+if (!$mysqli) {
+    _migSbBib_out('ERROR: could not connect to database.');
+    exit(1);
+}
+
+if (!_migSbBib_tableExists($mysqli, 'tblSongbooks')) {
+    _migSbBib_out('ERROR: tblSongbooks not found. Run install.php first.');
+    exit(1);
+}
+
+/* The 13 new columns, in the order they should appear AFTER existing
+   metadata. The migration runs them through one ALTER TABLE per
+   missing column — a single ALTER with all 13 ADD COLUMN clauses
+   would be marginally faster but breaks the per-column [skip]/[add]
+   reporting the dashboard surfaces, and the table is small enough
+   that 13 ALTERs are still milliseconds.
+
+   `after` controls the column ordering in SHOW COLUMNS / phpMyAdmin
+   listings — purely cosmetic, since SELECT is column-name based. */
+$columns = [
+    ['name' => 'WebsiteUrl',         'type' => 'VARCHAR(500)', 'after' => 'Affiliation'],
+    ['name' => 'InternetArchiveUrl', 'type' => 'VARCHAR(500)', 'after' => 'WebsiteUrl'],
+    ['name' => 'WikipediaUrl',       'type' => 'VARCHAR(500)', 'after' => 'InternetArchiveUrl'],
+    ['name' => 'WikidataId',         'type' => 'VARCHAR(20)',  'after' => 'WikipediaUrl'],
+    ['name' => 'OclcNumber',         'type' => 'VARCHAR(30)',  'after' => 'WikidataId'],
+    ['name' => 'OcnNumber',          'type' => 'VARCHAR(30)',  'after' => 'OclcNumber'],
+    ['name' => 'LcpNumber',          'type' => 'VARCHAR(30)',  'after' => 'OcnNumber'],
+    ['name' => 'Isbn',               'type' => 'VARCHAR(20)',  'after' => 'LcpNumber'],
+    ['name' => 'ArkId',              'type' => 'VARCHAR(80)',  'after' => 'Isbn'],
+    ['name' => 'IsniId',             'type' => 'VARCHAR(25)',  'after' => 'ArkId'],
+    ['name' => 'ViafId',             'type' => 'VARCHAR(20)',  'after' => 'IsniId'],
+    ['name' => 'Lccn',               'type' => 'VARCHAR(20)',  'after' => 'ViafId'],
+    ['name' => 'LcClass',            'type' => 'VARCHAR(50)',  'after' => 'Lccn'],
+];
+
+$added = 0;
+$skipped = 0;
+foreach ($columns as $col) {
+    $name = $col['name'];
+    if (_migSbBib_columnExists($mysqli, 'tblSongbooks', $name)) {
+        _migSbBib_out("[skip] tblSongbooks.{$name} already present.");
+        $skipped++;
+        continue;
+    }
+    /* AFTER clause is concatenated unquoted because both sides are
+       known constants — never user-supplied. The column-existence
+       probe ensures we don't try to ADD a column that already exists. */
+    $sql = "ALTER TABLE tblSongbooks
+            ADD COLUMN {$name} {$col['type']} NULL DEFAULT NULL
+            AFTER {$col['after']}";
+    if (!$mysqli->query($sql)) {
+        _migSbBib_out("ERROR: adding {$name} failed: " . $mysqli->error);
+        exit(1);
+    }
+    _migSbBib_out("[add ] tblSongbooks.{$name}.");
+    $added++;
+}
+
+_migSbBib_out("Songbook bibliographic metadata migration finished. Added {$added}, skipped {$skipped}.");

--- a/appWeb/.sql/migrate-songbook-language.php
+++ b/appWeb/.sql/migrate-songbook-language.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Songbook Language Column Migration (#673)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Adds an optional Language VARCHAR(10) NULL column to tblSongbooks
+ * so a curator can tag a songbook with the ISO 639-1 code of its
+ * predominant language. Mirrors tblSongs.Language without the
+ * NOT NULL or DEFAULT 'en' (#673):
+ *
+ *   - NULLable so a curated grouping that mixes languages can sit
+ *     unmarked instead of being mislabelled "en".
+ *   - Soft validation via the tblLanguages-sourced dropdown in the
+ *     songbook editor; no FK so a new ISO code added to the
+ *     reference table doesn't require a CHECK refresh.
+ *
+ * @migration-adds tblSongbooks.Language
+ *
+ * Idempotent — re-running is safe; the column-existence probe
+ * (INFORMATION_SCHEMA.COLUMNS) skips the ALTER if it's already there.
+ *
+ * USAGE:
+ *   CLI: php appWeb/.sql/migrate-songbook-language.php
+ *   Web: /manage/setup-database → "Songbook Language Column Migration"
+ *        (entry point requires global_admin)
+ */
+
+if (PHP_SAPI === 'cli') {
+    /* Guarded require — see #652. */
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = true;
+} else {
+    if (!defined('IHYMNS_SETUP_DASHBOARD')) {
+        if (!function_exists('isAuthenticated')) {
+            require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+        }
+        if (!isAuthenticated()) {
+            http_response_code(401);
+            exit('Authentication required.');
+        }
+        $u = getCurrentUser();
+        if (!$u || $u['role'] !== 'global_admin') {
+            http_response_code(403);
+            exit('Global admin required.');
+        }
+    }
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = false;
+}
+
+function _migSbLang_out(string $line): void
+{
+    global $isCli;
+    echo $line . ($isCli ? "\n" : "<br>\n");
+    /* CLI only — see migrate-credit-people-flags.php for rationale (#661). */
+    if ($isCli) {
+        flush();
+    }
+}
+
+function _migSbLang_columnExists(mysqli $db, string $table, string $column): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+          WHERE TABLE_SCHEMA = DATABASE()
+            AND TABLE_NAME   = ?
+            AND COLUMN_NAME  = ?
+          LIMIT 1'
+    );
+    $stmt->bind_param('ss', $table, $column);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+function _migSbLang_tableExists(mysqli $db, string $table): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? LIMIT 1'
+    );
+    $stmt->bind_param('s', $table);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+_migSbLang_out('Songbook Language column migration starting…');
+
+$mysqli = getDbMysqli();
+if (!$mysqli) {
+    _migSbLang_out('ERROR: could not connect to database.');
+    exit(1);
+}
+
+if (!_migSbLang_tableExists($mysqli, 'tblSongbooks')) {
+    _migSbLang_out('ERROR: tblSongbooks not found. Run install.php first.');
+    exit(1);
+}
+
+if (_migSbLang_columnExists($mysqli, 'tblSongbooks', 'Language')) {
+    _migSbLang_out('[skip] tblSongbooks.Language already present.');
+} else {
+    /* AFTER Affiliation so the column lands next to the rest of the
+       basic metadata block (#502 + #670). The position is cosmetic
+       only — SELECT in SongData refers to columns by name. */
+    $sql = "ALTER TABLE tblSongbooks
+            ADD COLUMN Language VARCHAR(10) NULL DEFAULT NULL
+            AFTER Affiliation";
+    if (!$mysqli->query($sql)) {
+        _migSbLang_out('ERROR: adding Language failed: ' . $mysqli->error);
+        exit(1);
+    }
+    _migSbLang_out('[add ] tblSongbooks.Language.');
+}
+
+_migSbLang_out('Songbook Language column migration finished.');

--- a/appWeb/.sql/schema.sql
+++ b/appWeb/.sql/schema.sql
@@ -41,6 +41,7 @@ CREATE TABLE IF NOT EXISTS tblSongbooks (
     PublicationYear VARCHAR(50)     NULL DEFAULT NULL COMMENT 'Year / edition range (free-form: 1986, 1986-2003, 2nd edition 2011) (#502)',
     Copyright       VARCHAR(500)    NULL DEFAULT NULL COMMENT 'Copyright notice for the collection as a whole (#502)',
     Affiliation     VARCHAR(120)    NULL DEFAULT NULL COMMENT 'Denominational / religious affiliation; backed by tblSongbookAffiliations registry (#670)',
+    Language        VARCHAR(10)     NULL DEFAULT NULL COMMENT 'Optional ISO 639-1 code; NULL = not specified. Mirrors tblSongs.Language without the FK or NOT NULL — soft validation via the tblLanguages dropdown (#673)',
 
     /* Bibliographic + authority-control identifiers (#672). All
        optional, all VARCHAR — no FKs, no CHECK constraints. Curators

--- a/appWeb/.sql/schema.sql
+++ b/appWeb/.sql/schema.sql
@@ -41,6 +41,25 @@ CREATE TABLE IF NOT EXISTS tblSongbooks (
     PublicationYear VARCHAR(50)     NULL DEFAULT NULL COMMENT 'Year / edition range (free-form: 1986, 1986-2003, 2nd edition 2011) (#502)',
     Copyright       VARCHAR(500)    NULL DEFAULT NULL COMMENT 'Copyright notice for the collection as a whole (#502)',
     Affiliation     VARCHAR(120)    NULL DEFAULT NULL COMMENT 'Denominational / religious affiliation; backed by tblSongbookAffiliations registry (#670)',
+
+    /* Bibliographic + authority-control identifiers (#672). All
+       optional, all VARCHAR — no FKs, no CHECK constraints. Curators
+       fill these in by pasting the canonical form from a library
+       catalogue / WikiData / WorldCat. */
+    WebsiteUrl          VARCHAR(500)    NULL DEFAULT NULL COMMENT 'Publisher / official website URL for the songbook (#672)',
+    InternetArchiveUrl  VARCHAR(500)    NULL DEFAULT NULL COMMENT 'Internet Archive page (e.g. https://archive.org/details/<id>) or bare IA identifier (#672)',
+    WikipediaUrl        VARCHAR(500)    NULL DEFAULT NULL COMMENT 'Wikipedia article URL (#672)',
+    WikidataId          VARCHAR(20)     NULL DEFAULT NULL COMMENT 'WikiData Q-number (e.g. Q12345) (#672)',
+    OclcNumber          VARCHAR(30)     NULL DEFAULT NULL COMMENT 'OCLC WorldCat number (#672)',
+    OcnNumber           VARCHAR(30)     NULL DEFAULT NULL COMMENT 'OCLC Control Number (often prefixed ocn/ocm/on); kept distinct from OclcNumber so catalogues that record both can carry both (#672)',
+    LcpNumber           VARCHAR(30)     NULL DEFAULT NULL COMMENT 'Library of Congress permalink / project number (#672)',
+    Isbn                VARCHAR(20)     NULL DEFAULT NULL COMMENT 'ISBN-10 or ISBN-13 (dashes optional) (#672)',
+    ArkId               VARCHAR(80)     NULL DEFAULT NULL COMMENT 'Archival Resource Key (e.g. ark:/13960/t8jf3w89z) (#672)',
+    IsniId              VARCHAR(25)     NULL DEFAULT NULL COMMENT 'International Standard Name Identifier (16 digits, optional spacing) (#672)',
+    ViafId              VARCHAR(20)     NULL DEFAULT NULL COMMENT 'Virtual International Authority File ID (#672)',
+    Lccn                VARCHAR(20)     NULL DEFAULT NULL COMMENT 'Library of Congress Control Number (#672)',
+    LcClass             VARCHAR(50)     NULL DEFAULT NULL COMMENT 'Library of Congress Classification call number (#672)',
+
     CreatedAt       TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UpdatedAt       TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 

--- a/appWeb/public_html/includes/SongData.php
+++ b/appWeb/public_html/includes/SongData.php
@@ -248,7 +248,8 @@ class SongData
             return $books;
         }
 
-        $bibSelect = $this->_songbookBibSelect();
+        $bibSelect  = $this->_songbookBibSelect();
+        $langSelect = $this->_songbookLanguageSelect();
         $stmt = $this->db->prepare(
             "SELECT Abbreviation AS id, Name AS name, SongCount AS songCount,
                     Colour AS colour,
@@ -257,6 +258,7 @@ class SongData
                     PublicationYear AS publicationYear,
                     Copyright       AS copyright,
                     Affiliation     AS affiliation
+                    {$langSelect}
                     {$bibSelect}
              FROM tblSongbooks
              ORDER BY Name ASC"
@@ -316,6 +318,35 @@ class SongData
     private ?string $_bibSelectCache = null;
 
     /**
+     * Same shape as _songbookBibSelect() but for the optional Language
+     * column added in #673. Probe-once cache so getSongbooks() and
+     * getSongbook() called in the same request only pay one
+     * INFORMATION_SCHEMA round-trip between them.
+     */
+    private function _songbookLanguageSelect(): string
+    {
+        if (isset($this->_langSelectCache)) {
+            return $this->_langSelectCache;
+        }
+        $hasLangCol = false;
+        try {
+            $probe = $this->db->prepare(
+                "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+                  WHERE TABLE_SCHEMA = DATABASE()
+                    AND TABLE_NAME   = 'tblSongbooks'
+                    AND COLUMN_NAME  = 'Language'
+                  LIMIT 1"
+            );
+            $probe->execute();
+            $hasLangCol = $probe->get_result()->fetch_row() !== null;
+            $probe->close();
+        } catch (\Throwable $_e) { /* probe failure → no Language tail */ }
+        $this->_langSelectCache = $hasLangCol ? ', Language AS language' : '';
+        return $this->_langSelectCache;
+    }
+    private ?string $_langSelectCache = null;
+
+    /**
      * Get a single songbook by its abbreviation ID.
      *
      * @param string $id Songbook abbreviation (e.g., 'CP', 'MP')
@@ -330,7 +361,8 @@ class SongData
             }
             return null;
         }
-        $bibSelect = $this->_songbookBibSelect();
+        $bibSelect  = $this->_songbookBibSelect();
+        $langSelect = $this->_songbookLanguageSelect();
         $stmt = $this->db->prepare(
             "SELECT Abbreviation AS id, Name AS name, SongCount AS songCount,
                     Colour AS colour,
@@ -339,6 +371,7 @@ class SongData
                     PublicationYear AS publicationYear,
                     Copyright       AS copyright,
                     Affiliation     AS affiliation
+                    {$langSelect}
                     {$bibSelect}
              FROM tblSongbooks
              WHERE Abbreviation = ?"

--- a/appWeb/public_html/includes/SongData.php
+++ b/appWeb/public_html/includes/SongData.php
@@ -248,6 +248,7 @@ class SongData
             return $books;
         }
 
+        $bibSelect = $this->_songbookBibSelect();
         $stmt = $this->db->prepare(
             "SELECT Abbreviation AS id, Name AS name, SongCount AS songCount,
                     Colour AS colour,
@@ -256,6 +257,7 @@ class SongData
                     PublicationYear AS publicationYear,
                     Copyright       AS copyright,
                     Affiliation     AS affiliation
+                    {$bibSelect}
              FROM tblSongbooks
              ORDER BY Name ASC"
         );
@@ -274,6 +276,46 @@ class SongData
     }
 
     /**
+     * Build the trailing fragment of the SELECT for songbook bibliographic
+     * + authority-control identifier columns (#672). On a deployment that
+     * hasn't run migrate-songbook-bibliographic.php yet the columns
+     * aren't there and a SELECT that names them would 500 the songbooks
+     * API. Probe INFORMATION_SCHEMA once per object instance, then return
+     * either the full ", b.WebsiteUrl, b.OcnNumber, …" tail or an empty
+     * string. Cached on the instance because getSongbooks() and
+     * getSongbook() are commonly called in pairs on the same request.
+     */
+    private function _songbookBibSelect(): string
+    {
+        if (isset($this->_bibSelectCache)) {
+            return $this->_bibSelectCache;
+        }
+        $hasBibCols = false;
+        try {
+            $probe = $this->db->prepare(
+                "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+                  WHERE TABLE_SCHEMA = DATABASE()
+                    AND TABLE_NAME   = 'tblSongbooks'
+                    AND COLUMN_NAME  = 'WikidataId'
+                  LIMIT 1"
+            );
+            $probe->execute();
+            $hasBibCols = $probe->get_result()->fetch_row() !== null;
+            $probe->close();
+        } catch (\Throwable $_e) { /* probe failure → fall through to empty tail */ }
+        $this->_bibSelectCache = $hasBibCols
+            ? ', WebsiteUrl AS websiteUrl, InternetArchiveUrl AS internetArchiveUrl,
+               WikipediaUrl AS wikipediaUrl, WikidataId AS wikidataId,
+               OclcNumber AS oclcNumber, OcnNumber AS ocnNumber,
+               LcpNumber AS lcpNumber, Isbn AS isbn,
+               ArkId AS arkId, IsniId AS isniId,
+               ViafId AS viafId, Lccn AS lccn, LcClass AS lcClass'
+            : '';
+        return $this->_bibSelectCache;
+    }
+    private ?string $_bibSelectCache = null;
+
+    /**
      * Get a single songbook by its abbreviation ID.
      *
      * @param string $id Songbook abbreviation (e.g., 'CP', 'MP')
@@ -288,6 +330,7 @@ class SongData
             }
             return null;
         }
+        $bibSelect = $this->_songbookBibSelect();
         $stmt = $this->db->prepare(
             "SELECT Abbreviation AS id, Name AS name, SongCount AS songCount,
                     Colour AS colour,
@@ -296,6 +339,7 @@ class SongData
                     PublicationYear AS publicationYear,
                     Copyright       AS copyright,
                     Affiliation     AS affiliation
+                    {$bibSelect}
              FROM tblSongbooks
              WHERE Abbreviation = ?"
         );

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -207,6 +207,7 @@ if ($action !== '') {
         'organisation-licences' => 'migrate-organisation-licences.php',
         'songbook-affiliations' => 'migrate-songbook-affiliations.php',
         'songbook-bibliographic' => 'migrate-songbook-bibliographic.php',
+        'songbook-language'      => 'migrate-songbook-language.php',
         'cleanup'     => 'cleanup.php',
         'backup'      => 'backup.php',
         'restore'     => 'restore.php',
@@ -820,6 +821,24 @@ if ($hasCredentials && defined('DB_HOST')) {
                         </p>
                         <a href="?action=songbook-bibliographic" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
                             Run Songbook Bibliographic Migration
+                        </a>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="card bg-dark border-secondary h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">3n. Songbook language column (#673)</h5>
+                        <p class="card-text text-secondary small">
+                            Adds an optional <code>Language</code> column to
+                            <code>tblSongbooks</code> (ISO 639-1 code, NULLable) so a
+                            curator can tag a songbook with its predominant language.
+                            Mirrors <code>tblSongs.Language</code> without the NOT NULL
+                            or DEFAULT — empty selection saves as NULL. Idempotent —
+                            safe to re-run.
+                        </p>
+                        <a href="?action=songbook-language" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
+                            Run Songbook Language Migration
                         </a>
                     </div>
                 </div>

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -206,6 +206,7 @@ if ($action !== '') {
         'user-avatar-service' => 'migrate-user-avatar-service.php',
         'organisation-licences' => 'migrate-organisation-licences.php',
         'songbook-affiliations' => 'migrate-songbook-affiliations.php',
+        'songbook-bibliographic' => 'migrate-songbook-bibliographic.php',
         'cleanup'     => 'cleanup.php',
         'backup'      => 'backup.php',
         'restore'     => 'restore.php',
@@ -801,6 +802,24 @@ if ($hasCredentials && defined('DB_HOST')) {
                         </p>
                         <a href="?action=songbook-affiliations" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
                             Run Songbook Affiliations Migration
+                        </a>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="card bg-dark border-secondary h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">3m. Songbook bibliographic metadata (#672)</h5>
+                        <p class="card-text text-secondary small">
+                            Adds 13 nullable columns to <code>tblSongbooks</code> for
+                            canonical references to the wider bibliographic record:
+                            Website / Internet Archive / Wikipedia URLs, plus the
+                            authority identifiers WikiData, OCLC, OCN, LCP, ISBN,
+                            ARK, ISNI, VIAF, LCCN, and LC Class. All optional;
+                            no FKs. Idempotent — safe to re-run.
+                        </p>
+                        <a href="?action=songbook-bibliographic" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
+                            Run Songbook Bibliographic Migration
                         </a>
                     </div>
                 </div>

--- a/appWeb/public_html/manage/songbooks.php
+++ b/appWeb/public_html/manage/songbooks.php
@@ -634,7 +634,7 @@ $csrf = csrfToken();
                     <?php foreach ($rows as $r): ?>
                         <tr>
                             <td>
-                                <input type="number" min="0" step="10"
+                                <input type="number" min="0"
                                        class="form-control form-control-sm"
                                        name="display_order[<?= (int)$r['Id'] ?>]"
                                        value="<?= (int)$r['DisplayOrder'] ?>">
@@ -717,7 +717,7 @@ $csrf = csrfToken();
                 <button type="submit" class="btn btn-sm btn-amber-solid">
                     <i class="bi bi-save me-1"></i>Save display order
                 </button>
-                <small class="text-muted ms-2">Lower numbers render first. Step of 10 lets you insert between two rows.</small>
+                <small class="text-muted ms-2">Lower numbers render first. Any non-negative integer is fine — gaps of 10 between rows give you room to slot in a new book later, but you can use 1, 2, 3, … or anything else (#672).</small>
             <?php endif; ?>
         </form>
 
@@ -747,7 +747,7 @@ $csrf = csrfToken();
                 <div class="col-sm-2">
                     <label class="form-label small">Display order</label>
                     <input type="number" name="display_order" class="form-control form-control-sm"
-                           min="0" step="10" value="0">
+                           min="0" value="0">
                 </div>
             </div>
 
@@ -909,7 +909,7 @@ $csrf = csrfToken();
                             <div class="col-sm-6">
                                 <label class="form-label">Display order</label>
                                 <input type="number" class="form-control" name="display_order" id="edit-order"
-                                       min="0" step="10">
+                                       min="0">
                             </div>
                         </div>
 

--- a/appWeb/public_html/manage/songbooks.php
+++ b/appWeb/public_html/manage/songbooks.php
@@ -188,6 +188,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $pubYear    = trim((string)($_POST['publication_year'] ?? '')) ?: null;
                 $copyright  = trim((string)($_POST['copyright']        ?? '')) ?: null;
                 $affiliation= trim((string)($_POST['affiliation']      ?? '')) ?: null;
+                /* #673 — optional language. Empty selection saves as NULL.
+                   Capped to the column width so a tampered post can't
+                   blow up the INSERT. */
+                $language   = trim((string)($_POST['language']         ?? '')) ?: null;
+                if ($language !== null) $language = mb_substr($language, 0, 10);
 
                 /* #672 — bibliographic + authority-control identifiers.
                    All nullable, all VARCHAR. trim()→null normalises
@@ -223,28 +228,32 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     'INSERT INTO tblSongbooks
                         (Abbreviation, Name, DisplayOrder, Colour,
                          IsOfficial, Publisher, PublicationYear, Copyright, Affiliation,
+                         Language,
                          WebsiteUrl, InternetArchiveUrl, WikipediaUrl, WikidataId,
                          OclcNumber, OcnNumber, LcpNumber, Isbn, ArkId, IsniId,
                          ViafId, Lccn, LcClass)
                      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?,
+                             ?,
                              ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
                 );
                 /* Types breakdown:
                      Abbr(s), Name(s), DisplayOrder(i), Colour(s),               4
                      IsOfficial(i), Publisher(s), PubYear(s), Copyright(s),
                        Affiliation(s),                                            5
+                     Language(s) — #673                                            1
                      Website(s), IA(s), Wikipedia(s), Wikidata(s),
                        OCLC(s), OCN(s), LCP(s), ISBN(s), ARK(s), ISNI(s),
                        VIAF(s), LCCN(s), LcClass(s)                              13
                                                                             ----
-                                                                              22
+                                                                              23
                    mysqli passes NULL correctly when a bound variable is null
                    even with type 's'. */
                 $orderInt = (int)($order ?: 0);
                 $stmt->bind_param(
-                    'ssisissssssssssssssssss',
+                    'ssisisssssssssssssssssss',
                     $abbr, $name, $orderInt, $colour,
                     $isOfficial, $publisher, $pubYear, $copyright, $affiliation,
+                    $language,
                     $websiteUrl, $iaUrl, $wikipediaUrl, $wikidataId,
                     $oclcNumber, $ocnNumber, $lcpNumber, $isbn, $arkId, $isniId,
                     $viafId, $lccn, $lcClass
@@ -262,6 +271,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     'publication_year'=> $pubYear,
                     'copyright'       => $copyright,
                     'affiliation'     => $affiliation,
+                    'language'        => $language,
                     /* #672 — log only the keys that have a value, so
                        empty bibliographic blocks don't bloat the
                        activity-log row. */
@@ -301,6 +311,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $pubYear     = trim((string)($_POST['publication_year'] ?? '')) ?: null;
                 $copyright   = trim((string)($_POST['copyright']        ?? '')) ?: null;
                 $affiliation = trim((string)($_POST['affiliation']      ?? '')) ?: null;
+                /* #673 — optional language. */
+                $language    = trim((string)($_POST['language']         ?? '')) ?: null;
+                if ($language !== null) $language = mb_substr($language, 0, 10);
 
                 /* #672 — bibliographic + authority-control identifiers. */
                 $websiteUrl   = trim((string)($_POST['website_url']         ?? '')) ?: null;
@@ -325,6 +338,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $existing = $db->prepare(
                     'SELECT Abbreviation, Name, DisplayOrder, Colour, IsOfficial,
                             Publisher, PublicationYear, Copyright, Affiliation,
+                            Language,
                             WebsiteUrl, InternetArchiveUrl, WikipediaUrl, WikidataId,
                             OclcNumber, OcnNumber, LcpNumber, Isbn, ArkId, IsniId,
                             ViafId, Lccn, LcClass
@@ -359,6 +373,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                             SET Name = ?, Colour = ?, DisplayOrder = ?,
                                 IsOfficial = ?, Publisher = ?,
                                 PublicationYear = ?, Copyright = ?, Affiliation = ?,
+                                Language = ?,
                                 WebsiteUrl = ?, InternetArchiveUrl = ?,
                                 WikipediaUrl = ?, WikidataId = ?,
                                 OclcNumber = ?, OcnNumber = ?, LcpNumber = ?,
@@ -370,15 +385,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                          Name(s), Colour(s), Order(i),                   3
                          IsOfficial(i), Publisher(s), Year(s), Copy(s),
                            Affiliation(s),                               5
+                         Language(s) — #673                              1
                          13 × bibliographic-identifier strings           13
                          Id(i)                                            1
                                                                         ----
-                                                                         22 */
+                                                                         23 */
                     $orderInt = (int)($order ?: 0);
                     $stmt->bind_param(
-                        'ssiissssssssssssssssssi',
+                        'ssiisssssssssssssssssssi',
                         $name, $colour, $orderInt,
                         $isOfficial, $publisher, $pubYear, $copyright, $affiliation,
+                        $language,
                         $websiteUrl, $iaUrl, $wikipediaUrl, $wikidataId,
                         $oclcNumber, $ocnNumber, $lcpNumber, $isbn, $arkId, $isniId,
                         $viafId, $lccn, $lcClass,
@@ -416,6 +433,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         'PublicationYear'   => $pubYear,
                         'Copyright'         => $copyright,
                         'Affiliation'       => $affiliation,
+                        'Language'          => $language,
                         'WebsiteUrl'        => $websiteUrl,
                         'InternetArchiveUrl'=> $iaUrl,
                         'WikipediaUrl'      => $wikipediaUrl,
@@ -538,6 +556,30 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 }
 
+/* ----- Active languages for the songbook editor's optional
+ *       Language dropdown (#673). Sourced from tblLanguages so the
+ *       admin doesn't have to hard-code ISO codes. We pull this
+ *       once per page-load and pass it through to both the create
+ *       form and the edit modal. Best-effort — if tblLanguages is
+ *       missing (very old install) we fall back to a minimal English
+ *       option so the dropdown at least has something selectable.
+ * ----- */
+$languages = [];
+try {
+    $stmt = $db->prepare(
+        'SELECT Code, Name, NativeName
+           FROM tblLanguages
+          WHERE IsActive = 1
+          ORDER BY Name ASC'
+    );
+    $stmt->execute();
+    $languages = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+    $stmt->close();
+} catch (\Throwable $e) {
+    error_log('[manage/songbooks.php] could not load tblLanguages: ' . $e->getMessage());
+    $languages = [['Code' => 'en', 'Name' => 'English', 'NativeName' => 'English']];
+}
+
 /* ----- GET: list ----- */
 $rows = [];
 try {
@@ -565,10 +607,30 @@ try {
              b.OclcNumber, b.OcnNumber, b.LcpNumber, b.Isbn, b.ArkId, b.IsniId,
              b.ViafId, b.Lccn, b.LcClass'
         : '';
+
+    /* Same probe-then-conditional-SELECT pattern for the #673
+       Language column. A deployment that hasn't run
+       migrate-songbook-language.php yet renders without the
+       column; the edit-modal payload defaults Language to ''. */
+    $hasLangCol = false;
+    try {
+        $probe = $db->prepare(
+            "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+              WHERE TABLE_SCHEMA = DATABASE()
+                AND TABLE_NAME   = 'tblSongbooks'
+                AND COLUMN_NAME  = 'Language'
+              LIMIT 1"
+        );
+        $probe->execute();
+        $hasLangCol = $probe->get_result()->fetch_row() !== null;
+        $probe->close();
+    } catch (\Throwable $_e) { /* probe failure → fall through */ }
+    $langSelect = $hasLangCol ? ', b.Language' : '';
+
     $stmt = $db->prepare(
         'SELECT b.Id, b.Abbreviation, b.Name, b.SongCount, b.DisplayOrder, b.Colour,
                 b.IsOfficial, b.Publisher, b.PublicationYear,
-                b.Copyright, b.Affiliation' . $bibSelect . ',
+                b.Copyright, b.Affiliation' . $langSelect . $bibSelect . ',
                 COUNT(s.Id) AS ActualSongCount
            FROM tblSongbooks b
            LEFT JOIN tblSongs s ON s.SongbookAbbr = b.Abbreviation
@@ -673,6 +735,9 @@ $csrf = csrfToken();
                                             'publication_year'    => $r['PublicationYear'] ?? '',
                                             'copyright'           => $r['Copyright']       ?? '',
                                             'affiliation'         => $r['Affiliation']     ?? '',
+                                            /* #673 — Language defaults to '' so the dropdown
+                                               picks "— Not specified —" when absent. */
+                                            'language'            => $r['Language']        ?? '',
                                             /* #672 — fields default to '' so a row from a
                                                pre-migration deployment renders cleanly
                                                (the bibSelect probe above gates the SELECT). */
@@ -789,6 +854,26 @@ $csrf = csrfToken();
                            autocomplete="off"
                            maxlength="120"
                            placeholder="e.g. Seventh-day Adventist, Non-denominational">
+                </div>
+            </div>
+            <!-- #673 — optional Language. Sourced from tblLanguages so a curator
+                 doesn't have to remember ISO 639-1 codes. Empty selection saves
+                 as NULL ("not specified") since many curated groupings span
+                 languages. -->
+            <div class="row g-2 mt-2">
+                <div class="col-sm-4">
+                    <label class="form-label small">Language (optional)</label>
+                    <select name="language" class="form-select form-select-sm">
+                        <option value="">— Not specified —</option>
+                        <?php foreach ($languages as $lang): ?>
+                            <option value="<?= htmlspecialchars($lang['Code']) ?>">
+                                <?= htmlspecialchars($lang['Name']) ?>
+                                <?php if ($lang['NativeName'] !== '' && $lang['NativeName'] !== $lang['Name']): ?>
+                                    (<?= htmlspecialchars($lang['NativeName']) ?>)
+                                <?php endif; ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
                 </div>
             </div>
 
@@ -951,6 +1036,27 @@ $csrf = csrfToken();
                             <div class="form-text small">
                                 Type to search existing affiliations or enter a new one — it
                                 will be added to the registry on save (#670).
+                            </div>
+                        </div>
+
+                        <!-- #673 — optional Language. -->
+                        <div class="mb-3">
+                            <label class="form-label">Language (optional)</label>
+                            <select class="form-select" name="language" id="edit-language">
+                                <option value="">— Not specified —</option>
+                                <?php foreach ($languages as $lang): ?>
+                                    <option value="<?= htmlspecialchars($lang['Code']) ?>">
+                                        <?= htmlspecialchars($lang['Name']) ?>
+                                        <?php if ($lang['NativeName'] !== '' && $lang['NativeName'] !== $lang['Name']): ?>
+                                            (<?= htmlspecialchars($lang['NativeName']) ?>)
+                                        <?php endif; ?>
+                                    </option>
+                                <?php endforeach; ?>
+                            </select>
+                            <div class="form-text small">
+                                ISO 639-1 code, sourced from the active rows in
+                                <code>tblLanguages</code>. Leave blank for songbooks
+                                that span multiple languages.
                             </div>
                         </div>
 
@@ -1117,6 +1223,13 @@ $csrf = csrfToken();
             document.getElementById('edit-publication-year').value  = row.publication_year || '';
             document.getElementById('edit-copyright').value         = row.copyright        || '';
             document.getElementById('edit-affiliation').value       = row.affiliation      || '';
+
+            /* #673 — optional Language. The <select>'s value is set
+               directly; if the row's saved code isn't in the active
+               tblLanguages list the dropdown silently falls back to
+               "— Not specified —" (a deactivated language deserves a
+               curator's manual review, not a silent reset). */
+            document.getElementById('edit-language').value          = row.language         || '';
 
             /* #672 — bibliographic + authority-control identifiers. The
                row payload normalises every key to '' when the source

--- a/appWeb/public_html/manage/songbooks.php
+++ b/appWeb/public_html/manage/songbooks.php
@@ -189,6 +189,25 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $copyright  = trim((string)($_POST['copyright']        ?? '')) ?: null;
                 $affiliation= trim((string)($_POST['affiliation']      ?? '')) ?: null;
 
+                /* #672 — bibliographic + authority-control identifiers.
+                   All nullable, all VARCHAR. trim()→null normalises
+                   blank inputs so the column actually stores NULL
+                   rather than '' (avoids the typical "is it really
+                   missing" ambiguity in downstream queries). */
+                $websiteUrl   = trim((string)($_POST['website_url']         ?? '')) ?: null;
+                $iaUrl        = trim((string)($_POST['internet_archive_url']?? '')) ?: null;
+                $wikipediaUrl = trim((string)($_POST['wikipedia_url']       ?? '')) ?: null;
+                $wikidataId   = trim((string)($_POST['wikidata_id']         ?? '')) ?: null;
+                $oclcNumber   = trim((string)($_POST['oclc_number']         ?? '')) ?: null;
+                $ocnNumber    = trim((string)($_POST['ocn_number']          ?? '')) ?: null;
+                $lcpNumber    = trim((string)($_POST['lcp_number']          ?? '')) ?: null;
+                $isbn         = trim((string)($_POST['isbn']                ?? '')) ?: null;
+                $arkId        = trim((string)($_POST['ark_id']              ?? '')) ?: null;
+                $isniId       = trim((string)($_POST['isni_id']             ?? '')) ?: null;
+                $viafId       = trim((string)($_POST['viaf_id']             ?? '')) ?: null;
+                $lccn         = trim((string)($_POST['lccn']                ?? '')) ?: null;
+                $lcClass      = trim((string)($_POST['lc_class']            ?? '')) ?: null;
+
                 if ($e = $validateAbbr($abbr))   { $error = $e; break; }
                 if ($name === '')                { $error = 'Name is required.'; break; }
                 if ($e = $validateColour($colour)) { $error = $e; break; }
@@ -203,18 +222,32 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $stmt = $db->prepare(
                     'INSERT INTO tblSongbooks
                         (Abbreviation, Name, DisplayOrder, Colour,
-                         IsOfficial, Publisher, PublicationYear, Copyright, Affiliation)
-                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)'
+                         IsOfficial, Publisher, PublicationYear, Copyright, Affiliation,
+                         WebsiteUrl, InternetArchiveUrl, WikipediaUrl, WikidataId,
+                         OclcNumber, OcnNumber, LcpNumber, Isbn, ArkId, IsniId,
+                         ViafId, Lccn, LcClass)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?,
+                             ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
                 );
-                /* Types: Abbr(s), Name(s), DisplayOrder(i), Colour(s),
-                   IsOfficial(i), Publisher(s nullable), PublicationYear(s nullable),
-                   Copyright(s nullable), Affiliation(s nullable). mysqli passes
-                   NULL correctly when a bound variable is null even with type 's'. */
+                /* Types breakdown:
+                     Abbr(s), Name(s), DisplayOrder(i), Colour(s),               4
+                     IsOfficial(i), Publisher(s), PubYear(s), Copyright(s),
+                       Affiliation(s),                                            5
+                     Website(s), IA(s), Wikipedia(s), Wikidata(s),
+                       OCLC(s), OCN(s), LCP(s), ISBN(s), ARK(s), ISNI(s),
+                       VIAF(s), LCCN(s), LcClass(s)                              13
+                                                                            ----
+                                                                              22
+                   mysqli passes NULL correctly when a bound variable is null
+                   even with type 's'. */
                 $orderInt = (int)($order ?: 0);
                 $stmt->bind_param(
-                    'ssisissss',
+                    'ssisissssssssssssssssss',
                     $abbr, $name, $orderInt, $colour,
-                    $isOfficial, $publisher, $pubYear, $copyright, $affiliation
+                    $isOfficial, $publisher, $pubYear, $copyright, $affiliation,
+                    $websiteUrl, $iaUrl, $wikipediaUrl, $wikidataId,
+                    $oclcNumber, $ocnNumber, $lcpNumber, $isbn, $arkId, $isniId,
+                    $viafId, $lccn, $lcClass
                 );
                 $stmt->execute();
                 $newId = (int)$db->insert_id;
@@ -229,6 +262,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     'publication_year'=> $pubYear,
                     'copyright'       => $copyright,
                     'affiliation'     => $affiliation,
+                    /* #672 — log only the keys that have a value, so
+                       empty bibliographic blocks don't bloat the
+                       activity-log row. */
+                    'bibliographic'   => array_filter([
+                        'website_url'           => $websiteUrl,
+                        'internet_archive_url'  => $iaUrl,
+                        'wikipedia_url'         => $wikipediaUrl,
+                        'wikidata_id'           => $wikidataId,
+                        'oclc_number'           => $oclcNumber,
+                        'ocn_number'            => $ocnNumber,
+                        'lcp_number'            => $lcpNumber,
+                        'isbn'                  => $isbn,
+                        'ark_id'                => $arkId,
+                        'isni_id'               => $isniId,
+                        'viaf_id'               => $viafId,
+                        'lccn'                  => $lccn,
+                        'lc_class'              => $lcClass,
+                    ], fn($v) => $v !== null && $v !== ''),
                 ]);
                 /* Self-populate the affiliation registry so the next
                    open of the typeahead surfaces this value (#670). */
@@ -244,20 +295,39 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $order       = (int)($_POST['display_order']        ?? 0);
                 $newAbbr     = trim((string)($_POST['new_abbreviation'] ?? ''));
                 $alsoRename  = !empty($_POST['rename_song_refs']);
-                /* #502 — new metadata columns. */
+                /* #502 — basic metadata columns. */
                 $isOfficial  = !empty($_POST['is_official']) ? 1 : 0;
                 $publisher   = trim((string)($_POST['publisher']        ?? '')) ?: null;
                 $pubYear     = trim((string)($_POST['publication_year'] ?? '')) ?: null;
                 $copyright   = trim((string)($_POST['copyright']        ?? '')) ?: null;
                 $affiliation = trim((string)($_POST['affiliation']      ?? '')) ?: null;
 
+                /* #672 — bibliographic + authority-control identifiers. */
+                $websiteUrl   = trim((string)($_POST['website_url']         ?? '')) ?: null;
+                $iaUrl        = trim((string)($_POST['internet_archive_url']?? '')) ?: null;
+                $wikipediaUrl = trim((string)($_POST['wikipedia_url']       ?? '')) ?: null;
+                $wikidataId   = trim((string)($_POST['wikidata_id']         ?? '')) ?: null;
+                $oclcNumber   = trim((string)($_POST['oclc_number']         ?? '')) ?: null;
+                $ocnNumber    = trim((string)($_POST['ocn_number']          ?? '')) ?: null;
+                $lcpNumber    = trim((string)($_POST['lcp_number']          ?? '')) ?: null;
+                $isbn         = trim((string)($_POST['isbn']                ?? '')) ?: null;
+                $arkId        = trim((string)($_POST['ark_id']              ?? '')) ?: null;
+                $isniId       = trim((string)($_POST['isni_id']             ?? '')) ?: null;
+                $viafId       = trim((string)($_POST['viaf_id']             ?? '')) ?: null;
+                $lccn         = trim((string)($_POST['lccn']                ?? '')) ?: null;
+                $lcClass      = trim((string)($_POST['lc_class']            ?? '')) ?: null;
+
                 /* Fetch the full before-row so the audit log carries
                    a complete diff of which fields actually changed
                    (#535) — otherwise the timeline reader has to
-                   guess. */
+                   guess. SELECT extended for #672 metadata so the
+                   diff covers the new identifier columns too. */
                 $existing = $db->prepare(
                     'SELECT Abbreviation, Name, DisplayOrder, Colour, IsOfficial,
-                            Publisher, PublicationYear, Copyright, Affiliation
+                            Publisher, PublicationYear, Copyright, Affiliation,
+                            WebsiteUrl, InternetArchiveUrl, WikipediaUrl, WikidataId,
+                            OclcNumber, OcnNumber, LcpNumber, Isbn, ArkId, IsniId,
+                            ViafId, Lccn, LcClass
                        FROM tblSongbooks WHERE Id = ?'
                 );
                 $existing->bind_param('i', $id);
@@ -288,17 +358,30 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         'UPDATE tblSongbooks
                             SET Name = ?, Colour = ?, DisplayOrder = ?,
                                 IsOfficial = ?, Publisher = ?,
-                                PublicationYear = ?, Copyright = ?, Affiliation = ?
+                                PublicationYear = ?, Copyright = ?, Affiliation = ?,
+                                WebsiteUrl = ?, InternetArchiveUrl = ?,
+                                WikipediaUrl = ?, WikidataId = ?,
+                                OclcNumber = ?, OcnNumber = ?, LcpNumber = ?,
+                                Isbn = ?, ArkId = ?, IsniId = ?,
+                                ViafId = ?, Lccn = ?, LcClass = ?
                           WHERE Id = ?'
                     );
-                    /* Types: Name(s), Colour(s), DisplayOrder(i),
-                       IsOfficial(i), Publisher(s), PublicationYear(s),
-                       Copyright(s), Affiliation(s), Id(i). */
+                    /* Types breakdown:
+                         Name(s), Colour(s), Order(i),                   3
+                         IsOfficial(i), Publisher(s), Year(s), Copy(s),
+                           Affiliation(s),                               5
+                         13 × bibliographic-identifier strings           13
+                         Id(i)                                            1
+                                                                        ----
+                                                                         22 */
                     $orderInt = (int)($order ?: 0);
                     $stmt->bind_param(
-                        'ssiissssi',
+                        'ssiissssssssssssssssssi',
                         $name, $colour, $orderInt,
                         $isOfficial, $publisher, $pubYear, $copyright, $affiliation,
+                        $websiteUrl, $iaUrl, $wikipediaUrl, $wikidataId,
+                        $oclcNumber, $ocnNumber, $lcpNumber, $isbn, $arkId, $isniId,
+                        $viafId, $lccn, $lcClass,
                         $id
                     );
                     $stmt->execute();
@@ -321,17 +404,31 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     /* Audit (#535) — compute the changed-fields list
                        explicitly so the row stays small (the full
                        before-row is on $beforeRow and we don't need
-                       to dump every key). */
+                       to dump every key). Extended for #672 to cover
+                       the 13 new identifier columns. */
                     $afterRow = [
-                        'Abbreviation'   => $abbrChanged ? $newAbbr : $oldAbbr,
-                        'Name'           => $name,
-                        'DisplayOrder'   => $order ?: 0,
-                        'Colour'         => $colour,
-                        'IsOfficial'     => $isOfficial,
-                        'Publisher'      => $publisher,
-                        'PublicationYear'=> $pubYear,
-                        'Copyright'      => $copyright,
-                        'Affiliation'    => $affiliation,
+                        'Abbreviation'      => $abbrChanged ? $newAbbr : $oldAbbr,
+                        'Name'              => $name,
+                        'DisplayOrder'      => $order ?: 0,
+                        'Colour'            => $colour,
+                        'IsOfficial'        => $isOfficial,
+                        'Publisher'         => $publisher,
+                        'PublicationYear'   => $pubYear,
+                        'Copyright'         => $copyright,
+                        'Affiliation'       => $affiliation,
+                        'WebsiteUrl'        => $websiteUrl,
+                        'InternetArchiveUrl'=> $iaUrl,
+                        'WikipediaUrl'      => $wikipediaUrl,
+                        'WikidataId'        => $wikidataId,
+                        'OclcNumber'        => $oclcNumber,
+                        'OcnNumber'         => $ocnNumber,
+                        'LcpNumber'         => $lcpNumber,
+                        'Isbn'              => $isbn,
+                        'ArkId'             => $arkId,
+                        'IsniId'            => $isniId,
+                        'ViafId'            => $viafId,
+                        'Lccn'              => $lccn,
+                        'LcClass'           => $lcClass,
                     ];
                     $changed = [];
                     foreach ($afterRow as $k => $v) {
@@ -444,10 +541,34 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 /* ----- GET: list ----- */
 $rows = [];
 try {
+    /* Probe whether the #672 columns exist before SELECTing them.
+       A deployment that hasn't run migrate-songbook-bibliographic.php
+       yet should still render the songbook list — the new fields are
+       just absent from the edit-modal payload until the migration
+       runs. Cheaper than a try/catch + retry. */
+    $hasBibCols = false;
+    try {
+        $probe = $db->prepare(
+            "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+              WHERE TABLE_SCHEMA = DATABASE()
+                AND TABLE_NAME   = 'tblSongbooks'
+                AND COLUMN_NAME  = 'WikidataId'
+              LIMIT 1"
+        );
+        $probe->execute();
+        $hasBibCols = $probe->get_result()->fetch_row() !== null;
+        $probe->close();
+    } catch (\Throwable $_e) { /* probe failure → fall through to base SELECT */ }
+
+    $bibSelect = $hasBibCols
+        ? ', b.WebsiteUrl, b.InternetArchiveUrl, b.WikipediaUrl, b.WikidataId,
+             b.OclcNumber, b.OcnNumber, b.LcpNumber, b.Isbn, b.ArkId, b.IsniId,
+             b.ViafId, b.Lccn, b.LcClass'
+        : '';
     $stmt = $db->prepare(
         'SELECT b.Id, b.Abbreviation, b.Name, b.SongCount, b.DisplayOrder, b.Colour,
                 b.IsOfficial, b.Publisher, b.PublicationYear,
-                b.Copyright, b.Affiliation,
+                b.Copyright, b.Affiliation' . $bibSelect . ',
                 COUNT(s.Id) AS ActualSongCount
            FROM tblSongbooks b
            LEFT JOIN tblSongs s ON s.SongbookAbbr = b.Abbreviation
@@ -541,17 +662,33 @@ $csrf = csrfToken();
                             <td class="text-end">
                                 <button type="button" class="btn btn-sm btn-outline-info"
                                         onclick='openEditModal(<?= json_encode([
-                                            'id'               => (int)$r['Id'],
-                                            'abbreviation'     => $r['Abbreviation'],
-                                            'name'             => $r['Name'],
-                                            'colour'           => $r['Colour'],
-                                            'display_order'    => (int)$r['DisplayOrder'],
-                                            'song_count'       => (int)$r['ActualSongCount'],
-                                            'is_official'      => (int)$r['IsOfficial'] === 1,
-                                            'publisher'        => $r['Publisher']       ?? '',
-                                            'publication_year' => $r['PublicationYear'] ?? '',
-                                            'copyright'        => $r['Copyright']       ?? '',
-                                            'affiliation'      => $r['Affiliation']     ?? '',
+                                            'id'                  => (int)$r['Id'],
+                                            'abbreviation'        => $r['Abbreviation'],
+                                            'name'                => $r['Name'],
+                                            'colour'              => $r['Colour'],
+                                            'display_order'       => (int)$r['DisplayOrder'],
+                                            'song_count'          => (int)$r['ActualSongCount'],
+                                            'is_official'         => (int)$r['IsOfficial'] === 1,
+                                            'publisher'           => $r['Publisher']       ?? '',
+                                            'publication_year'    => $r['PublicationYear'] ?? '',
+                                            'copyright'           => $r['Copyright']       ?? '',
+                                            'affiliation'         => $r['Affiliation']     ?? '',
+                                            /* #672 — fields default to '' so a row from a
+                                               pre-migration deployment renders cleanly
+                                               (the bibSelect probe above gates the SELECT). */
+                                            'website_url'         => $r['WebsiteUrl']         ?? '',
+                                            'internet_archive_url'=> $r['InternetArchiveUrl'] ?? '',
+                                            'wikipedia_url'       => $r['WikipediaUrl']       ?? '',
+                                            'wikidata_id'         => $r['WikidataId']         ?? '',
+                                            'oclc_number'         => $r['OclcNumber']         ?? '',
+                                            'ocn_number'          => $r['OcnNumber']          ?? '',
+                                            'lcp_number'          => $r['LcpNumber']          ?? '',
+                                            'isbn'                => $r['Isbn']               ?? '',
+                                            'ark_id'              => $r['ArkId']              ?? '',
+                                            'isni_id'             => $r['IsniId']             ?? '',
+                                            'viaf_id'             => $r['ViafId']             ?? '',
+                                            'lccn'                => $r['Lccn']               ?? '',
+                                            'lc_class'            => $r['LcClass']            ?? '',
                                         ]) ?>)'
                                         title="Edit songbook">
                                     <i class="bi bi-pencil"></i>
@@ -655,6 +792,90 @@ $csrf = csrfToken();
                 </div>
             </div>
 
+            <!-- #672 — collapsed by default; the create form already has 8 visible
+                 fields and most curators don't need the bibliographic block on a
+                 brand-new songbook. <details> is native HTML5 — no JS needed. -->
+            <details class="mt-3">
+                <summary class="form-label small text-muted" style="cursor:pointer;">
+                    <i class="bi bi-link-45deg me-1"></i>Online links (optional)
+                </summary>
+                <div class="row g-2 mt-1">
+                    <div class="col-sm-4">
+                        <label class="form-label small">Official website</label>
+                        <input type="url" name="website_url" class="form-control form-control-sm"
+                               maxlength="500" placeholder="https://www.example.com">
+                    </div>
+                    <div class="col-sm-4">
+                        <label class="form-label small">Internet Archive URL</label>
+                        <input type="url" name="internet_archive_url" class="form-control form-control-sm"
+                               maxlength="500" placeholder="https://archive.org/details/…">
+                    </div>
+                    <div class="col-sm-4">
+                        <label class="form-label small">Wikipedia URL</label>
+                        <input type="url" name="wikipedia_url" class="form-control form-control-sm"
+                               maxlength="500" placeholder="https://en.wikipedia.org/wiki/…">
+                    </div>
+                </div>
+            </details>
+
+            <details class="mt-2">
+                <summary class="form-label small text-muted" style="cursor:pointer;">
+                    <i class="bi bi-card-list me-1"></i>Authority identifiers (optional)
+                </summary>
+                <div class="row g-2 mt-1">
+                    <div class="col-sm-3">
+                        <label class="form-label small">WikiData ID</label>
+                        <input type="text" name="wikidata_id" class="form-control form-control-sm"
+                               maxlength="20" placeholder="Q12345">
+                    </div>
+                    <div class="col-sm-3">
+                        <label class="form-label small">OCLC number</label>
+                        <input type="text" name="oclc_number" class="form-control form-control-sm"
+                               maxlength="30" placeholder="12345678">
+                    </div>
+                    <div class="col-sm-3">
+                        <label class="form-label small">OCN number</label>
+                        <input type="text" name="ocn_number" class="form-control form-control-sm"
+                               maxlength="30" placeholder="ocn123456789">
+                    </div>
+                    <div class="col-sm-3">
+                        <label class="form-label small">LCP number</label>
+                        <input type="text" name="lcp_number" class="form-control form-control-sm"
+                               maxlength="30" placeholder="LC2018012345">
+                    </div>
+                    <div class="col-sm-3">
+                        <label class="form-label small">ISBN</label>
+                        <input type="text" name="isbn" class="form-control form-control-sm"
+                               maxlength="20" placeholder="978-0-86065-654-1">
+                    </div>
+                    <div class="col-sm-3">
+                        <label class="form-label small">ARK ID</label>
+                        <input type="text" name="ark_id" class="form-control form-control-sm"
+                               maxlength="80" placeholder="ark:/13960/t8jf3w89z">
+                    </div>
+                    <div class="col-sm-3">
+                        <label class="form-label small">ISNI ID</label>
+                        <input type="text" name="isni_id" class="form-control form-control-sm"
+                               maxlength="25" placeholder="0000 0001 2345 6789">
+                    </div>
+                    <div class="col-sm-3">
+                        <label class="form-label small">VIAF ID</label>
+                        <input type="text" name="viaf_id" class="form-control form-control-sm"
+                               maxlength="20" placeholder="123456789">
+                    </div>
+                    <div class="col-sm-3">
+                        <label class="form-label small">LCCN</label>
+                        <input type="text" name="lccn" class="form-control form-control-sm"
+                               maxlength="20" placeholder="n79123456">
+                    </div>
+                    <div class="col-sm-9">
+                        <label class="form-label small">LC Classification</label>
+                        <input type="text" name="lc_class" class="form-control form-control-sm"
+                               maxlength="50" placeholder="M2117 .M5 1990">
+                    </div>
+                </div>
+            </details>
+
             <button type="submit" class="btn btn-amber-solid btn-sm mt-3">
                 <i class="bi bi-plus me-1"></i>Create songbook
             </button>
@@ -733,6 +954,105 @@ $csrf = csrfToken();
                             </div>
                         </div>
 
+                        <!-- #672 — collapsible "Online links" + "Authority identifiers".
+                             Closed by default so the modal still opens at the same height
+                             curators are used to. <details> is native HTML5; no JS needed
+                             to toggle. The same field IDs are populated in openEditModal()
+                             below from the row.* payload. -->
+                        <details class="mb-3">
+                            <summary class="form-label small text-muted" style="cursor:pointer;">
+                                <i class="bi bi-link-45deg me-1"></i>Online links (optional)
+                            </summary>
+                            <div class="mt-2">
+                                <div class="mb-2">
+                                    <label class="form-label small">Official website</label>
+                                    <input type="url" class="form-control form-control-sm"
+                                           name="website_url" id="edit-website-url"
+                                           maxlength="500" placeholder="https://www.example.com">
+                                </div>
+                                <div class="mb-2">
+                                    <label class="form-label small">Internet Archive URL</label>
+                                    <input type="url" class="form-control form-control-sm"
+                                           name="internet_archive_url" id="edit-internet-archive-url"
+                                           maxlength="500" placeholder="https://archive.org/details/…">
+                                </div>
+                                <div class="mb-2">
+                                    <label class="form-label small">Wikipedia URL</label>
+                                    <input type="url" class="form-control form-control-sm"
+                                           name="wikipedia_url" id="edit-wikipedia-url"
+                                           maxlength="500" placeholder="https://en.wikipedia.org/wiki/…">
+                                </div>
+                            </div>
+                        </details>
+
+                        <details class="mb-3">
+                            <summary class="form-label small text-muted" style="cursor:pointer;">
+                                <i class="bi bi-card-list me-1"></i>Authority identifiers (optional)
+                            </summary>
+                            <div class="row g-2 mt-2">
+                                <div class="col-sm-6">
+                                    <label class="form-label small">WikiData ID</label>
+                                    <input type="text" class="form-control form-control-sm"
+                                           name="wikidata_id" id="edit-wikidata-id"
+                                           maxlength="20" placeholder="Q12345">
+                                </div>
+                                <div class="col-sm-6">
+                                    <label class="form-label small">OCLC number</label>
+                                    <input type="text" class="form-control form-control-sm"
+                                           name="oclc_number" id="edit-oclc-number"
+                                           maxlength="30" placeholder="12345678">
+                                </div>
+                                <div class="col-sm-6">
+                                    <label class="form-label small">OCN number</label>
+                                    <input type="text" class="form-control form-control-sm"
+                                           name="ocn_number" id="edit-ocn-number"
+                                           maxlength="30" placeholder="ocn123456789">
+                                </div>
+                                <div class="col-sm-6">
+                                    <label class="form-label small">LCP number</label>
+                                    <input type="text" class="form-control form-control-sm"
+                                           name="lcp_number" id="edit-lcp-number"
+                                           maxlength="30" placeholder="LC2018012345">
+                                </div>
+                                <div class="col-sm-6">
+                                    <label class="form-label small">ISBN</label>
+                                    <input type="text" class="form-control form-control-sm"
+                                           name="isbn" id="edit-isbn"
+                                           maxlength="20" placeholder="978-0-86065-654-1">
+                                </div>
+                                <div class="col-sm-6">
+                                    <label class="form-label small">ARK ID</label>
+                                    <input type="text" class="form-control form-control-sm"
+                                           name="ark_id" id="edit-ark-id"
+                                           maxlength="80" placeholder="ark:/13960/t8jf3w89z">
+                                </div>
+                                <div class="col-sm-6">
+                                    <label class="form-label small">ISNI ID</label>
+                                    <input type="text" class="form-control form-control-sm"
+                                           name="isni_id" id="edit-isni-id"
+                                           maxlength="25" placeholder="0000 0001 2345 6789">
+                                </div>
+                                <div class="col-sm-6">
+                                    <label class="form-label small">VIAF ID</label>
+                                    <input type="text" class="form-control form-control-sm"
+                                           name="viaf_id" id="edit-viaf-id"
+                                           maxlength="20" placeholder="123456789">
+                                </div>
+                                <div class="col-sm-6">
+                                    <label class="form-label small">LCCN</label>
+                                    <input type="text" class="form-control form-control-sm"
+                                           name="lccn" id="edit-lccn"
+                                           maxlength="20" placeholder="n79123456">
+                                </div>
+                                <div class="col-sm-6">
+                                    <label class="form-label small">LC Classification</label>
+                                    <input type="text" class="form-control form-control-sm"
+                                           name="lc_class" id="edit-lc-class"
+                                           maxlength="50" placeholder="M2117 .M5 1990">
+                                </div>
+                            </div>
+                        </details>
+
                         <hr>
                         <div class="mb-3">
                             <label class="form-label">New abbreviation (optional)</label>
@@ -797,6 +1117,24 @@ $csrf = csrfToken();
             document.getElementById('edit-publication-year').value  = row.publication_year || '';
             document.getElementById('edit-copyright').value         = row.copyright        || '';
             document.getElementById('edit-affiliation').value       = row.affiliation      || '';
+
+            /* #672 — bibliographic + authority-control identifiers. The
+               row payload normalises every key to '' when the source
+               column was NULL (or missing entirely on a pre-migration
+               deployment) so each input always receives a string. */
+            document.getElementById('edit-website-url').value          = row.website_url          || '';
+            document.getElementById('edit-internet-archive-url').value = row.internet_archive_url || '';
+            document.getElementById('edit-wikipedia-url').value        = row.wikipedia_url        || '';
+            document.getElementById('edit-wikidata-id').value          = row.wikidata_id          || '';
+            document.getElementById('edit-oclc-number').value          = row.oclc_number          || '';
+            document.getElementById('edit-ocn-number').value           = row.ocn_number           || '';
+            document.getElementById('edit-lcp-number').value           = row.lcp_number           || '';
+            document.getElementById('edit-isbn').value                 = row.isbn                 || '';
+            document.getElementById('edit-ark-id').value               = row.ark_id               || '';
+            document.getElementById('edit-isni-id').value              = row.isni_id              || '';
+            document.getElementById('edit-viaf-id').value              = row.viaf_id              || '';
+            document.getElementById('edit-lccn').value                 = row.lccn                 || '';
+            document.getElementById('edit-lc-class').value             = row.lc_class             || '';
 
             document.getElementById('edit-new-abbr').value          = '';
             document.getElementById('edit-rename-refs').checked     = false;

--- a/appWeb/public_html/manage/songbooks.php
+++ b/appWeb/public_html/manage/songbooks.php
@@ -677,12 +677,39 @@ $csrf = csrfToken();
         <?php endif; ?>
 
         <!-- List + reorder -->
-        <form method="POST" class="card-admin p-3 mb-4">
+        <form method="POST" class="card-admin p-3 mb-4" id="songbook-list-form">
             <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
             <input type="hidden" name="action" value="reorder">
-            <table class="table table-sm mb-2 align-middle cp-sortable">
+
+            <!-- #674 — quick-sort presets. Renumber DisplayOrder in 10-spaced
+                 steps based on the chosen field; the user can review the
+                 new order and hit "Save display order" to persist (or
+                 navigate away to back out). Leading "The "/"A "/"An "
+                 are stripped for the Name sort so "The Church Hymnal"
+                 sorts among the C's, not the T's. -->
+            <?php if ($rows): ?>
+            <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
+                <small class="text-muted me-1">Quick sort:</small>
+                <button type="button" class="btn btn-sm btn-outline-secondary" data-sort-preset="name:asc">
+                    <i class="bi bi-sort-alpha-down me-1"></i>Name A→Z
+                </button>
+                <button type="button" class="btn btn-sm btn-outline-secondary" data-sort-preset="name:desc">
+                    <i class="bi bi-sort-alpha-up-alt me-1"></i>Name Z→A
+                </button>
+                <button type="button" class="btn btn-sm btn-outline-secondary" data-sort-preset="abbr:asc">
+                    <i class="bi bi-sort-alpha-down me-1"></i>Abbr A→Z
+                </button>
+                <button type="button" class="btn btn-sm btn-outline-secondary" data-sort-preset="abbr:desc">
+                    <i class="bi bi-sort-alpha-up-alt me-1"></i>Abbr Z→A
+                </button>
+                <small class="text-muted ms-1">— preview applied; hit <em>Save display order</em> to persist.</small>
+            </div>
+            <?php endif; ?>
+
+            <table class="table table-sm mb-2 align-middle cp-sortable" id="songbook-list-table">
                 <thead>
                     <tr class="text-muted small">
+                        <th style="width:1.5rem" aria-label="Drag to reorder"></th>
                         <th style="width:6rem">Order</th>
                         <th data-sort-key="abbr" data-sort-type="text">Abbr</th>
                         <th data-sort-key="name" data-sort-type="text">Name</th>
@@ -694,7 +721,15 @@ $csrf = csrfToken();
                 </thead>
                 <tbody>
                     <?php foreach ($rows as $r): ?>
-                        <tr>
+                        <tr class="songbook-row"
+                            data-row-id="<?= (int)$r['Id'] ?>"
+                            data-sort-name="<?= htmlspecialchars($r['Name']) ?>"
+                            data-sort-abbr="<?= htmlspecialchars($r['Abbreviation']) ?>">
+                            <td class="text-center align-middle">
+                                <span class="songbook-drag-handle" title="Drag to reorder" aria-hidden="true">
+                                    <i class="bi bi-grip-vertical"></i>
+                                </span>
+                            </td>
                             <td>
                                 <input type="number" min="0"
                                        class="form-control form-control-sm"
@@ -774,7 +809,7 @@ $csrf = csrfToken();
                         </tr>
                     <?php endforeach; ?>
                     <?php if (!$rows): ?>
-                        <tr><td colspan="7" class="text-muted text-center py-4">No songbooks yet. Add one below.</td></tr>
+                        <tr><td colspan="8" class="text-muted text-center py-4">No songbooks yet. Add one below.</td></tr>
                     <?php endif; ?>
                 </tbody>
             </table>
@@ -1266,6 +1301,140 @@ $csrf = csrfToken();
     <script type="module">
         import { bootSortableTables } from '/js/modules/admin-table-sort.js?v=<?= filemtime(dirname(__DIR__) . '/js/modules/admin-table-sort.js') ?>';
         bootSortableTables();
+    </script>
+
+    <!-- Drag-and-drop reorder + Sort by Name/Abbr presets (#674).
+         Vanilla HTML5 Drag-and-Drop on the songbook list table; no
+         third-party library. Touch users can still type a number into
+         each row's Order input + hit Save (the existing path) — a
+         touch-driven reorder UX would need significantly more code
+         and isn't blocking. The four sort-preset buttons renumber
+         in 10-spaced steps without saving so the curator can review
+         and back out. -->
+    <style>
+        .songbook-drag-handle {
+            cursor: grab;
+            color: var(--text-muted);
+            font-size: 1.05rem;
+            /* Vendor-prefixed user-select to suppress text selection
+               on Safari/iOS during a drag — same 4-line convention
+               used elsewhere (see admin.css drag-handle, #668). */
+            -webkit-user-select: none;
+            -moz-user-select: none;
+            -ms-user-select: none;
+            user-select: none;
+        }
+        .songbook-drag-handle:hover { color: var(--accent-solid); }
+        .songbook-row.dragging { opacity: 0.4; }
+        .songbook-row.drop-above td { box-shadow: 0 -2px 0 var(--accent-solid) inset; }
+        .songbook-row.drop-below td { box-shadow: 0  2px 0 var(--accent-solid) inset; }
+    </style>
+    <script>
+    (function () {
+        const tbody = document.querySelector('#songbook-list-table tbody');
+        if (!tbody) return;
+
+        /* Live snapshot of the current row order. Recomputed on every
+           DOM read because drag-drop reshuffles in place. */
+        const rows = () => Array.from(tbody.querySelectorAll('tr.songbook-row'));
+
+        /* Renumber the DisplayOrder <input>s in 10-spaced steps based
+           on the current visual row order. The "Save display order"
+           submit button picks them up via display_order[<id>]. */
+        const renumber = () => {
+            rows().forEach((tr, i) => {
+                const input = tr.querySelector('input[name^="display_order"]');
+                if (input) input.value = (i + 1) * 10;
+            });
+        };
+
+        /* ----- Sort presets ----- */
+        /* Strip a leading "The "/"A "/"An " (case-insensitive, with
+           trailing whitespace) so "The Church Hymnal" sorts among the
+           C's. Same convention as libraries / WikiData / iTunes.
+           Other-language articles (Spanish "El", French "Le/La", …)
+           are out of scope for v1; flag in the issue comment if a
+           curator hits the limit (#674). */
+        const stripArticle = (s) =>
+            (s || '').replace(/^\s*(the|an|a)\s+/i, '').toLowerCase();
+
+        const sortByKey = (keyFn, dir) => {
+            const sorted = rows().sort((a, b) => {
+                const cmp = keyFn(a).localeCompare(keyFn(b));
+                return dir === 'asc' ? cmp : -cmp;
+            });
+            sorted.forEach(tr => tbody.appendChild(tr));
+            renumber();
+        };
+        document.querySelectorAll('[data-sort-preset]').forEach(btn => {
+            btn.addEventListener('click', (e) => {
+                e.preventDefault();
+                const [field, dir] = btn.dataset.sortPreset.split(':');
+                const keyFn = field === 'name'
+                    ? (tr) => stripArticle(tr.dataset.sortName)
+                    : (tr) => (tr.dataset.sortAbbr || '').toLowerCase();
+                sortByKey(keyFn, dir);
+            });
+        });
+
+        /* ----- Drag and drop -----
+           HTML5 D&D: source row gets draggable=true while the user is
+           pressing the handle, source emits dragstart, every other
+           row's dragover decides whether to insert above or below
+           the cursor based on the row's vertical midpoint. Visual
+           feedback via .drop-above / .drop-below pseudo-classes that
+           paint a 2px accent bar on the relevant edge. */
+        let draggedRow = null;
+        const clearDropMarkers = () => {
+            rows().forEach(tr => tr.classList.remove('drop-above', 'drop-below'));
+        };
+
+        rows().forEach(tr => {
+            const handle = tr.querySelector('.songbook-drag-handle');
+            if (!handle) return;
+
+            /* Only enable draggable while the user is pressing the
+               handle so clicking elsewhere on the row (e.g. into the
+               Order input) doesn't kick off an accidental drag. */
+            handle.addEventListener('mousedown', () => { tr.draggable = true; });
+            tr.addEventListener('mouseup',   () => { tr.draggable = false; });
+
+            tr.addEventListener('dragstart', (e) => {
+                draggedRow = tr;
+                tr.classList.add('dragging');
+                e.dataTransfer.effectAllowed = 'move';
+                /* Set a payload so Firefox actually fires drag events. */
+                e.dataTransfer.setData('text/plain', tr.dataset.rowId || '');
+            });
+
+            tr.addEventListener('dragover', (e) => {
+                if (!draggedRow || draggedRow === tr) return;
+                e.preventDefault();
+                e.dataTransfer.dropEffect = 'move';
+                const rect = tr.getBoundingClientRect();
+                const above = e.clientY < (rect.top + rect.height / 2);
+                clearDropMarkers();
+                tr.classList.add(above ? 'drop-above' : 'drop-below');
+            });
+
+            tr.addEventListener('drop', (e) => {
+                if (!draggedRow || draggedRow === tr) return;
+                e.preventDefault();
+                const rect = tr.getBoundingClientRect();
+                const above = e.clientY < (rect.top + rect.height / 2);
+                if (above)  tr.parentNode.insertBefore(draggedRow, tr);
+                else        tr.parentNode.insertBefore(draggedRow, tr.nextSibling);
+            });
+
+            tr.addEventListener('dragend', () => {
+                if (draggedRow) draggedRow.classList.remove('dragging');
+                draggedRow = null;
+                tr.draggable = false;
+                clearDropMarkers();
+                renumber();
+            });
+        });
+    })();
     </script>
 
     <!-- Affiliation typeahead (#670).


### PR DESCRIPTION
## Summary

Four connected pieces of work on `/manage/songbooks`, one fresh PR. Each landed as its own commit so they can be reviewed (and reverted) individually.

| # | Closes | Commit |
| --- | --- | --- |
| 1 | #672 | `feat(songbooks): bibliographic + authority-identifier metadata` |
| 2 | — | `fix(songbooks): drop step="10" from DisplayOrder inputs` |
| 3 | #673 | `feat(songbooks): optional Language column` |
| 4 | #674 | `feat(songbooks): drag-drop reorder + Sort by Name/Abbr presets` |

### #672 — Bibliographic + authority-identifier metadata

Adds 13 nullable VARCHAR columns to `tblSongbooks`:

- **Online links**: `WebsiteUrl`, `InternetArchiveUrl`, `WikipediaUrl`
- **Authority identifiers**: `WikidataId`, `OclcNumber`, `OcnNumber`, `LcpNumber`, `Isbn`, `ArkId`, `IsniId`, `ViafId`, `Lccn`, `LcClass`

Idempotent migration (`migrate-songbook-bibliographic.php`) wired into `/manage/setup-database` as **3m**. Save handlers (`create` + `update`) extended to 22 bound parameters; audit-log diff covers all 13. Two collapsible `<details>` panels on the create form + edit modal — closed by default so the modal opens at the same height curators are used to. `SongData::getSongbooks()` and `getSongbook()` extended via a probe-once cache so a deployment that hasn't run the migration keeps working.

### Drop `step="10"`

User feedback: `step="10"` on the three DisplayOrder `<input type="number">` fields made it look like the field was capped at 100 and limited to multiples of 10 — both wrong, but the spinner only ever moved in increments of 10. Removed the attribute on all three inputs; updated the helper text below the table to make explicit that any non-negative integer is fine.

### #673 — Optional Language column

Adds `Language VARCHAR(10) NULL` to `tblSongbooks`. Mirrors `tblSongs.Language` without the `NOT NULL` or `DEFAULT 'en'` (many curated groupings span languages; "unmarked" reads better than mislabelled). No FK to `tblLanguages` — same convention as `tblSongs.Language`; validity enforced by the dropdown options sourced server-side.

Migration (`migrate-songbook-language.php`) wired in as **3n**. Create form + edit modal both gain a `<select>` populated server-side from `tblLanguages` with a leading "— Not specified —" option (saves NULL). Same probe-once pattern in `SongData` so pre-migration deployments keep working.

### #674 — Drag-drop reorder + Sort presets

Two new affordances on the list table for fast catalogue reordering:

- **Drag-and-drop**: each row gets a `bi-grip-vertical` handle on the leftmost cell. Vanilla HTML5 D&D, no third-party library. On drop, every `DisplayOrder` input is renumbered to a clean 10-spaced sequence; the user clicks **Save display order** to persist (or navigates away to back out — no auto-save).
- **Sort presets**: four buttons above the table — **Name A→Z**, **Name Z→A**, **Abbr A→Z**, **Abbr Z→A**. Same in-place renumber path.
- **Leading-article handling**: the Name comparator strips a leading `The `/`A `/`An ` (case-insensitive) so `The Church Hymnal` sorts among the C's, not the T's. Other-language articles (`El`, `Le/La`, …) are out of scope for v1 — flagged for follow-up.
- Touch users keep the typing + Save workflow; sort-preset buttons work for them too. Touch-driven reorder is a separate feature.

## Migrations to run on deploy

After this lands on `alpha` and gets to dev, four new cards appear under **Manage → Database Setup**. Run them in this order (each is idempotent so re-running is safe):

1. **3l. Songbook affiliations registry (#670)** — already shipped on alpha (PR #671); included here for completeness because the affiliation registry sits next to the new metadata in the same modal.
2. **3m. Songbook bibliographic metadata (#672)** — adds the 13 new columns. ~13 ALTERs each ~1 ms.
3. **3n. Songbook language column (#673)** — adds the one Language column.

If those have already been run on this deployment, the migration cards report `[skip]` for everything and exit cleanly — they're safe to re-click.

## Test plan

- [ ] Open `/manage/songbooks`; existing edit modal still opens, fields still pre-populate. Click into "Online links" / "Authority identifiers" — both panels expand.
- [ ] Add a brand-new songbook with all bibliographic fields populated (e.g. WikiData `Q123`, ISBN `978-…`, Wikipedia `https://…`). Save. Re-open the row — every field round-trips.
- [ ] Edit a songbook, leave most fields blank — saves NULL, doesn't crash.
- [ ] Set Language to "Spanish (Español)". Save. Re-open — the dropdown shows Spanish selected.
- [ ] Type `137` in a DisplayOrder input — the number persists, no validation reject.
- [ ] Click **Sort by Name A→Z** — `The Church Hymnal` ends up among the C-named entries; `A New Commandment` (if present) among the N's; `Abagusii` (no leading article) among the A's. Hit Save; refresh the page; ordering persists.
- [ ] Drag a row by its grip handle to a new position. Order inputs renumber to 10/20/30/…. Hit Save; refresh; ordering persists.
- [ ] Pre-migration check: temporarily revert `tblSongbooks` (drop the new columns) and reload `/manage/songbooks` — page renders, edit modal opens, saving without bibliographic fields succeeds; only the new fields are absent until the migration runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)