### PR TITLE
fix(request): show full songbook name on prefill, not the abbreviation (closes #683)

### DIFF
--- a/appWeb/public_html/includes/pages/request-a-song.php
+++ b/appWeb/public_html/includes/pages/request-a-song.php
@@ -25,6 +25,40 @@ declare(strict_types=1);
 $_prefillSongbook = isset($_GET['songbook']) ? trim((string)$_GET['songbook']) : '';
 if ($_prefillSongbook !== '') {
     $_prefillSongbook = mb_substr($_prefillSongbook, 0, 100);
+    /* Resolve abbrev → full songbook name (#683). The deep-link from
+       the editor's Find-Missing-Numbers panel and the standalone
+       admin missing-numbers page sends `?songbook=<ABBREV>`; without
+       this lookup the form arrives showing "MP" instead of "Mission
+       Praise", which is confusing once the request lands in front
+       of a curator (or the user themselves). One prepared SELECT;
+       falls through to the raw param if no row matches (defensive —
+       covers a user typing a free-text value or a deleted songbook). */
+    try {
+        if (!function_exists('getDbMysqli')) {
+            require_once dirname(__DIR__, 2) . '/includes/db_mysql.php';
+        }
+        $_resolveDb = getDbMysqli();
+        if ($_resolveDb) {
+            $_lookup = $_resolveDb->prepare(
+                'SELECT Name FROM tblSongbooks WHERE Abbreviation = ? LIMIT 1'
+            );
+            if ($_lookup) {
+                $_lookup->bind_param('s', $_prefillSongbook);
+                $_lookup->execute();
+                $_row = $_lookup->get_result()->fetch_row();
+                $_lookup->close();
+                if ($_row && $_row[0] !== '') {
+                    /* mb_substr again so a column with a name longer
+                       than the input's maxlength still fits. */
+                    $_prefillSongbook = mb_substr((string)$_row[0], 0, 100);
+                }
+            }
+        }
+    } catch (\Throwable $_e) {
+        /* Best-effort lookup — a DB hiccup must not break the page
+           render. The user keeps the abbreviation as a fallback. */
+        error_log('[request-a-song] songbook abbrev lookup skipped: ' . $_e->getMessage());
+    }
 }
 $_prefillNumber = isset($_GET['number']) ? trim((string)$_GET['number']) : '';
 if ($_prefillNumber !== '') {


### PR DESCRIPTION
## Summary

Tiny follow-up to #666's server-side prefill. Deep-links from the editor's Find-Missing-Numbers panel + the standalone admin missing-numbers page open `/request?songbook=MP&number=13` — and per #666 the form now prefills correctly. But the **Songbook field shows `MP`** (the raw abbreviation) instead of the full hymnal name (`Mission Praise`). Confusing both for the user filling in the form and for the curator who eventually sees the request row.

This PR resolves the abbreviation server-side: one prepared `SELECT Name FROM tblSongbooks WHERE Abbreviation = ?`, swap the value if matched, fall through to the raw param if not.

## Changes

- [`request-a-song.php`](appWeb/public_html/includes/pages/request-a-song.php) — wraps the existing `$_prefillSongbook` block with a prepared lookup. `mb_substr` re-applied after the resolve so a long `Name` still fits the input's `maxlength=100`. DB hiccup is caught + logged; the page still renders with the raw abbrev as a fallback.

## Smoke test (locally simulated with a stubbed mysqli)

```
$_GET = ['songbook' => 'MP', 'number' => '13']
→ Songbook value="Mission Praise"
→ Title    value="13"
```

## Test plan

- [ ] On dev: open the Song Editor, hit **Find missing numbers**, click **Log request** on any range — new tab opens `/request?songbook=<ABBR>&number=<n>` with **Songbook = full name** and **Title = number**.
- [ ] Same from `/manage/missing-numbers`.
- [ ] `/request?songbook=Unknown` falls through to "Unknown" in the field rather than blanking it.
- [ ] `/request` (no params) opens blank as before.
- [ ] `/request?songbook=MP&number=13` on a fresh tab — even after a hard reload (so the inline-JS fallback from #666 doesn't write) the Songbook input shows the full name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)