### PR TITLE
Songbooks: IETF BCP 47 language tagging — schema, migration, typeahead, composite picker (closes #681)

### DIFF
--- a/.claude/ProjectBrief.md
+++ b/.claude/ProjectBrief.md
@@ -12,9 +12,9 @@ A multiplatform Christian lyrics application providing searchable hymn and worsh
 - **Copyright**: © 2026– MWBM Partners Ltd
 - **License**: Proprietary (third-party components retain their own licenses)
 - **GitHub Repo**: <https://github.com/MWBMPartners/iHymns>
-- **Current Version**: 0.10.0 (pre-release, Phase 1)
-- **Database**: MySQL 5.7+ (30+ tables, tblCamelCase naming)
-- **API**: 50+ JSON endpoints via `api.php`
+- **Current Version**: 0.25.0 Alpha (pre-release, Phase 1)
+- **Database**: MySQL 5.7+ (~40 tables, tblCamelCase naming). Songbook metadata extended in 2026-04 with bibliographic + authority-control identifiers (#672), an Affiliation registry (#670), and an optional Language column (#673 → IETF BCP 47 in #681)
+- **API**: 60+ JSON endpoints via `api.php`, plus the editor's separate `/manage/editor/api.php` (load / save_song / bulk_import_zip / typeaheads)
 
 ---
 
@@ -24,7 +24,7 @@ A multiplatform Christian lyrics application providing searchable hymn and worsh
 
 - Songs sourced from local `.SourceSongData/` text files
 - Parsed into JSON (`data/songs.json`), then migrated into **MySQL database**
-- 6 songbooks, 3,612 songs: CP (243), JP (617), MP (1355), SDAH (695), CH (702), Misc (0)
+- ~30 songbooks, 12,370+ songs after the CIS scrape (#663 / 2026-04-29). Original five English: CP (243), JP (617), MP (1355), SDAH (695), CH (702); plus 23 multi-language CIS hymnals (Spanish HA, Portuguese HASD, French DLG, Russian GASD, Twi TWI, Tonga TKMN, Tswana KMK, Sotho KP, Chichewa KMN, Shona KMNz, Venda NYD, Swahili NZK, Ndebele UKE, Xhosa UKEng, Xitsonga RRV, Gikuyu NCA, Abagusii OKON, Dholuo WN, Kinyarwanda IZGI, Tumbuka NMSDA, Sepedi KKK, Bemba BKMN, English CIS) plus Misc + AH/AYS/NAH placeholder books
 - MySQL with MySQLi prepared statements (song data) and PDO (auth/admin)
 - Database naming: `tblCamelCase` tables, `CamelCase` columns
 - User accounts with role hierarchy (global_admin/admin/editor/user)
@@ -205,4 +205,4 @@ See `DEV_NOTES.md` for full setup guide including Apple, Android, and Fire OS.
 
 ---
 
-Last updated: 2026-04-09
+Last updated: 2026-04-29

--- a/appWeb/.sql/migrate-ietf-bcp47-data.php
+++ b/appWeb/.sql/migrate-ietf-bcp47-data.php
@@ -1,0 +1,369 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — IETF BCP 47 reference data (#681)
+ *
+ * Static data-only file consumed by migrate-ietf-bcp47-language.php.
+ * Lives separately so the migration runner stays focused on logic and
+ * the data tables are easy to extend (just append new entries; re-run
+ * the migration; INSERT IGNORE picks up the new rows).
+ *
+ * SCRIPTS  — ISO 15924 four-letter codes. Curated to the ~25 most
+ *            commonly used in real-world hymnal corpora; extend as
+ *            curators encounter new ones.
+ * REGIONS  — ISO 3166-1 alpha-2 codes. Full set, sorted alphabetically
+ *            by code so a future diff is easy to read.
+ *
+ * Both arrays use the shape:
+ *     ['code' => 'Latn', 'name' => 'Latin', 'native' => '']
+ * (`native` is optional and omitted for region rows.)
+ */
+
+const SCRIPTS = [
+    ['code' => 'Latn', 'name' => 'Latin'],
+    ['code' => 'Cyrl', 'name' => 'Cyrillic'],
+    ['code' => 'Grek', 'name' => 'Greek'],
+    ['code' => 'Arab', 'name' => 'Arabic'],
+    ['code' => 'Hebr', 'name' => 'Hebrew'],
+    ['code' => 'Hans', 'name' => 'Han Simplified',  'native' => '简体中文'],
+    ['code' => 'Hant', 'name' => 'Han Traditional', 'native' => '繁體中文'],
+    ['code' => 'Jpan', 'name' => 'Japanese',        'native' => '日本語'],
+    ['code' => 'Kore', 'name' => 'Korean',          'native' => '한국어'],
+    ['code' => 'Deva', 'name' => 'Devanagari'],
+    ['code' => 'Beng', 'name' => 'Bengali'],
+    ['code' => 'Guru', 'name' => 'Gurmukhi'],
+    ['code' => 'Gujr', 'name' => 'Gujarati'],
+    ['code' => 'Knda', 'name' => 'Kannada'],
+    ['code' => 'Mlym', 'name' => 'Malayalam'],
+    ['code' => 'Taml', 'name' => 'Tamil'],
+    ['code' => 'Telu', 'name' => 'Telugu'],
+    ['code' => 'Thaa', 'name' => 'Thaana'],
+    ['code' => 'Thai', 'name' => 'Thai'],
+    ['code' => 'Mymr', 'name' => 'Myanmar'],
+    ['code' => 'Khmr', 'name' => 'Khmer'],
+    ['code' => 'Laoo', 'name' => 'Lao'],
+    ['code' => 'Sinh', 'name' => 'Sinhala'],
+    ['code' => 'Ethi', 'name' => 'Ethiopic'],
+    ['code' => 'Geor', 'name' => 'Georgian'],
+    ['code' => 'Armn', 'name' => 'Armenian'],
+    ['code' => 'Zyyy', 'name' => 'Common'],
+    ['code' => 'Zxxx', 'name' => 'Unwritten'],
+];
+
+const REGIONS = [
+    /* ISO 3166-1 alpha-2 (#681). Sorted by code. Extend at any time
+       and re-run the migration; INSERT IGNORE only adds new rows. */
+
+    /* A */
+    ['code' => 'AD', 'name' => 'Andorra'],
+    ['code' => 'AE', 'name' => 'United Arab Emirates'],
+    ['code' => 'AF', 'name' => 'Afghanistan'],
+    ['code' => 'AG', 'name' => 'Antigua and Barbuda'],
+    ['code' => 'AI', 'name' => 'Anguilla'],
+    ['code' => 'AL', 'name' => 'Albania'],
+    ['code' => 'AM', 'name' => 'Armenia'],
+    ['code' => 'AO', 'name' => 'Angola'],
+    ['code' => 'AQ', 'name' => 'Antarctica'],
+    ['code' => 'AR', 'name' => 'Argentina'],
+    ['code' => 'AS', 'name' => 'American Samoa'],
+    ['code' => 'AT', 'name' => 'Austria'],
+    ['code' => 'AU', 'name' => 'Australia'],
+    ['code' => 'AW', 'name' => 'Aruba'],
+    ['code' => 'AX', 'name' => 'Aland Islands'],
+    ['code' => 'AZ', 'name' => 'Azerbaijan'],
+
+    /* B */
+    ['code' => 'BA', 'name' => 'Bosnia and Herzegovina'],
+    ['code' => 'BB', 'name' => 'Barbados'],
+    ['code' => 'BD', 'name' => 'Bangladesh'],
+    ['code' => 'BE', 'name' => 'Belgium'],
+    ['code' => 'BF', 'name' => 'Burkina Faso'],
+    ['code' => 'BG', 'name' => 'Bulgaria'],
+    ['code' => 'BH', 'name' => 'Bahrain'],
+    ['code' => 'BI', 'name' => 'Burundi'],
+    ['code' => 'BJ', 'name' => 'Benin'],
+    ['code' => 'BL', 'name' => 'Saint Barthelemy'],
+    ['code' => 'BM', 'name' => 'Bermuda'],
+    ['code' => 'BN', 'name' => 'Brunei Darussalam'],
+    ['code' => 'BO', 'name' => 'Bolivia'],
+    ['code' => 'BQ', 'name' => 'Bonaire, Sint Eustatius and Saba'],
+    ['code' => 'BR', 'name' => 'Brazil'],
+    ['code' => 'BS', 'name' => 'Bahamas'],
+    ['code' => 'BT', 'name' => 'Bhutan'],
+    ['code' => 'BV', 'name' => 'Bouvet Island'],
+    ['code' => 'BW', 'name' => 'Botswana'],
+    ['code' => 'BY', 'name' => 'Belarus'],
+    ['code' => 'BZ', 'name' => 'Belize'],
+
+    /* C */
+    ['code' => 'CA', 'name' => 'Canada'],
+    ['code' => 'CC', 'name' => 'Cocos (Keeling) Islands'],
+    ['code' => 'CD', 'name' => 'Congo, Democratic Republic of the'],
+    ['code' => 'CF', 'name' => 'Central African Republic'],
+    ['code' => 'CG', 'name' => 'Congo'],
+    ['code' => 'CH', 'name' => 'Switzerland'],
+    ['code' => 'CI', 'name' => "Cote d'Ivoire"],
+    ['code' => 'CK', 'name' => 'Cook Islands'],
+    ['code' => 'CL', 'name' => 'Chile'],
+    ['code' => 'CM', 'name' => 'Cameroon'],
+    ['code' => 'CN', 'name' => 'China'],
+    ['code' => 'CO', 'name' => 'Colombia'],
+    ['code' => 'CR', 'name' => 'Costa Rica'],
+    ['code' => 'CU', 'name' => 'Cuba'],
+    ['code' => 'CV', 'name' => 'Cabo Verde'],
+    ['code' => 'CW', 'name' => 'Curacao'],
+    ['code' => 'CX', 'name' => 'Christmas Island'],
+    ['code' => 'CY', 'name' => 'Cyprus'],
+    ['code' => 'CZ', 'name' => 'Czechia'],
+
+    /* D */
+    ['code' => 'DE', 'name' => 'Germany'],
+    ['code' => 'DJ', 'name' => 'Djibouti'],
+    ['code' => 'DK', 'name' => 'Denmark'],
+    ['code' => 'DM', 'name' => 'Dominica'],
+    ['code' => 'DO', 'name' => 'Dominican Republic'],
+    ['code' => 'DZ', 'name' => 'Algeria'],
+
+    /* E */
+    ['code' => 'EC', 'name' => 'Ecuador'],
+    ['code' => 'EE', 'name' => 'Estonia'],
+    ['code' => 'EG', 'name' => 'Egypt'],
+    ['code' => 'EH', 'name' => 'Western Sahara'],
+    ['code' => 'ER', 'name' => 'Eritrea'],
+    ['code' => 'ES', 'name' => 'Spain'],
+    ['code' => 'ET', 'name' => 'Ethiopia'],
+
+    /* F */
+    ['code' => 'FI', 'name' => 'Finland'],
+    ['code' => 'FJ', 'name' => 'Fiji'],
+    ['code' => 'FK', 'name' => 'Falkland Islands'],
+    ['code' => 'FM', 'name' => 'Micronesia, Federated States of'],
+    ['code' => 'FO', 'name' => 'Faroe Islands'],
+    ['code' => 'FR', 'name' => 'France'],
+
+    /* G */
+    ['code' => 'GA', 'name' => 'Gabon'],
+    ['code' => 'GB', 'name' => 'United Kingdom'],
+    ['code' => 'GD', 'name' => 'Grenada'],
+    ['code' => 'GE', 'name' => 'Georgia'],
+    ['code' => 'GF', 'name' => 'French Guiana'],
+    ['code' => 'GG', 'name' => 'Guernsey'],
+    ['code' => 'GH', 'name' => 'Ghana'],
+    ['code' => 'GI', 'name' => 'Gibraltar'],
+    ['code' => 'GL', 'name' => 'Greenland'],
+    ['code' => 'GM', 'name' => 'Gambia'],
+    ['code' => 'GN', 'name' => 'Guinea'],
+    ['code' => 'GP', 'name' => 'Guadeloupe'],
+    ['code' => 'GQ', 'name' => 'Equatorial Guinea'],
+    ['code' => 'GR', 'name' => 'Greece'],
+    ['code' => 'GS', 'name' => 'South Georgia and the South Sandwich Islands'],
+    ['code' => 'GT', 'name' => 'Guatemala'],
+    ['code' => 'GU', 'name' => 'Guam'],
+    ['code' => 'GW', 'name' => 'Guinea-Bissau'],
+    ['code' => 'GY', 'name' => 'Guyana'],
+
+    /* H */
+    ['code' => 'HK', 'name' => 'Hong Kong'],
+    ['code' => 'HM', 'name' => 'Heard Island and McDonald Islands'],
+    ['code' => 'HN', 'name' => 'Honduras'],
+    ['code' => 'HR', 'name' => 'Croatia'],
+    ['code' => 'HT', 'name' => 'Haiti'],
+    ['code' => 'HU', 'name' => 'Hungary'],
+
+    /* I */
+    ['code' => 'ID', 'name' => 'Indonesia'],
+    ['code' => 'IE', 'name' => 'Ireland'],
+    ['code' => 'IL', 'name' => 'Israel'],
+    ['code' => 'IM', 'name' => 'Isle of Man'],
+    ['code' => 'IN', 'name' => 'India'],
+    ['code' => 'IO', 'name' => 'British Indian Ocean Territory'],
+    ['code' => 'IQ', 'name' => 'Iraq'],
+    ['code' => 'IR', 'name' => 'Iran'],
+    ['code' => 'IS', 'name' => 'Iceland'],
+    ['code' => 'IT', 'name' => 'Italy'],
+
+    /* J */
+    ['code' => 'JE', 'name' => 'Jersey'],
+    ['code' => 'JM', 'name' => 'Jamaica'],
+    ['code' => 'JO', 'name' => 'Jordan'],
+    ['code' => 'JP', 'name' => 'Japan'],
+
+    /* K */
+    ['code' => 'KE', 'name' => 'Kenya'],
+    ['code' => 'KG', 'name' => 'Kyrgyzstan'],
+    ['code' => 'KH', 'name' => 'Cambodia'],
+    ['code' => 'KI', 'name' => 'Kiribati'],
+    ['code' => 'KM', 'name' => 'Comoros'],
+    ['code' => 'KN', 'name' => 'Saint Kitts and Nevis'],
+    ['code' => 'KP', 'name' => "Korea, Democratic People's Republic of"],
+    ['code' => 'KR', 'name' => 'Korea, Republic of'],
+    ['code' => 'KW', 'name' => 'Kuwait'],
+    ['code' => 'KY', 'name' => 'Cayman Islands'],
+    ['code' => 'KZ', 'name' => 'Kazakhstan'],
+
+    /* L */
+    ['code' => 'LA', 'name' => "Lao People's Democratic Republic"],
+    ['code' => 'LB', 'name' => 'Lebanon'],
+    ['code' => 'LC', 'name' => 'Saint Lucia'],
+    ['code' => 'LI', 'name' => 'Liechtenstein'],
+    ['code' => 'LK', 'name' => 'Sri Lanka'],
+    ['code' => 'LR', 'name' => 'Liberia'],
+    ['code' => 'LS', 'name' => 'Lesotho'],
+    ['code' => 'LT', 'name' => 'Lithuania'],
+    ['code' => 'LU', 'name' => 'Luxembourg'],
+    ['code' => 'LV', 'name' => 'Latvia'],
+    ['code' => 'LY', 'name' => 'Libya'],
+
+    /* M */
+    ['code' => 'MA', 'name' => 'Morocco'],
+    ['code' => 'MC', 'name' => 'Monaco'],
+    ['code' => 'MD', 'name' => 'Moldova'],
+    ['code' => 'ME', 'name' => 'Montenegro'],
+    ['code' => 'MF', 'name' => 'Saint Martin (French part)'],
+    ['code' => 'MG', 'name' => 'Madagascar'],
+    ['code' => 'MH', 'name' => 'Marshall Islands'],
+    ['code' => 'MK', 'name' => 'North Macedonia'],
+    ['code' => 'ML', 'name' => 'Mali'],
+    ['code' => 'MM', 'name' => 'Myanmar'],
+    ['code' => 'MN', 'name' => 'Mongolia'],
+    ['code' => 'MO', 'name' => 'Macao'],
+    ['code' => 'MP', 'name' => 'Northern Mariana Islands'],
+    ['code' => 'MQ', 'name' => 'Martinique'],
+    ['code' => 'MR', 'name' => 'Mauritania'],
+    ['code' => 'MS', 'name' => 'Montserrat'],
+    ['code' => 'MT', 'name' => 'Malta'],
+    ['code' => 'MU', 'name' => 'Mauritius'],
+    ['code' => 'MV', 'name' => 'Maldives'],
+    ['code' => 'MW', 'name' => 'Malawi'],
+    ['code' => 'MX', 'name' => 'Mexico'],
+    ['code' => 'MY', 'name' => 'Malaysia'],
+    ['code' => 'MZ', 'name' => 'Mozambique'],
+
+    /* N */
+    ['code' => 'NA', 'name' => 'Namibia'],
+    ['code' => 'NC', 'name' => 'New Caledonia'],
+    ['code' => 'NE', 'name' => 'Niger'],
+    ['code' => 'NF', 'name' => 'Norfolk Island'],
+    ['code' => 'NG', 'name' => 'Nigeria'],
+    ['code' => 'NI', 'name' => 'Nicaragua'],
+    ['code' => 'NL', 'name' => 'Netherlands'],
+    ['code' => 'NO', 'name' => 'Norway'],
+    ['code' => 'NP', 'name' => 'Nepal'],
+    ['code' => 'NR', 'name' => 'Nauru'],
+    ['code' => 'NU', 'name' => 'Niue'],
+    ['code' => 'NZ', 'name' => 'New Zealand'],
+
+    /* O */
+    ['code' => 'OM', 'name' => 'Oman'],
+
+    /* P */
+    ['code' => 'PA', 'name' => 'Panama'],
+    ['code' => 'PE', 'name' => 'Peru'],
+    ['code' => 'PF', 'name' => 'French Polynesia'],
+    ['code' => 'PG', 'name' => 'Papua New Guinea'],
+    ['code' => 'PH', 'name' => 'Philippines'],
+    ['code' => 'PK', 'name' => 'Pakistan'],
+    ['code' => 'PL', 'name' => 'Poland'],
+    ['code' => 'PM', 'name' => 'Saint Pierre and Miquelon'],
+    ['code' => 'PN', 'name' => 'Pitcairn'],
+    ['code' => 'PR', 'name' => 'Puerto Rico'],
+    ['code' => 'PS', 'name' => 'Palestine, State of'],
+    ['code' => 'PT', 'name' => 'Portugal'],
+    ['code' => 'PW', 'name' => 'Palau'],
+    ['code' => 'PY', 'name' => 'Paraguay'],
+
+    /* Q */
+    ['code' => 'QA', 'name' => 'Qatar'],
+
+    /* R */
+    ['code' => 'RE', 'name' => 'Reunion'],
+    ['code' => 'RO', 'name' => 'Romania'],
+    ['code' => 'RS', 'name' => 'Serbia'],
+    ['code' => 'RU', 'name' => 'Russia'],
+    ['code' => 'RW', 'name' => 'Rwanda'],
+
+    /* S */
+    ['code' => 'SA', 'name' => 'Saudi Arabia'],
+    ['code' => 'SB', 'name' => 'Solomon Islands'],
+    ['code' => 'SC', 'name' => 'Seychelles'],
+    ['code' => 'SD', 'name' => 'Sudan'],
+    ['code' => 'SE', 'name' => 'Sweden'],
+    ['code' => 'SG', 'name' => 'Singapore'],
+    ['code' => 'SH', 'name' => 'Saint Helena, Ascension and Tristan da Cunha'],
+    ['code' => 'SI', 'name' => 'Slovenia'],
+    ['code' => 'SJ', 'name' => 'Svalbard and Jan Mayen'],
+    ['code' => 'SK', 'name' => 'Slovakia'],
+    ['code' => 'SL', 'name' => 'Sierra Leone'],
+    ['code' => 'SM', 'name' => 'San Marino'],
+    ['code' => 'SN', 'name' => 'Senegal'],
+    ['code' => 'SO', 'name' => 'Somalia'],
+    ['code' => 'SR', 'name' => 'Suriname'],
+    ['code' => 'SS', 'name' => 'South Sudan'],
+    ['code' => 'ST', 'name' => 'Sao Tome and Principe'],
+    ['code' => 'SV', 'name' => 'El Salvador'],
+    ['code' => 'SX', 'name' => 'Sint Maarten (Dutch part)'],
+    ['code' => 'SY', 'name' => 'Syria'],
+    ['code' => 'SZ', 'name' => 'Eswatini'],
+
+    /* T */
+    ['code' => 'TC', 'name' => 'Turks and Caicos Islands'],
+    ['code' => 'TD', 'name' => 'Chad'],
+    ['code' => 'TF', 'name' => 'French Southern Territories'],
+    ['code' => 'TG', 'name' => 'Togo'],
+    ['code' => 'TH', 'name' => 'Thailand'],
+    ['code' => 'TJ', 'name' => 'Tajikistan'],
+    ['code' => 'TK', 'name' => 'Tokelau'],
+    ['code' => 'TL', 'name' => 'Timor-Leste'],
+    ['code' => 'TM', 'name' => 'Turkmenistan'],
+    ['code' => 'TN', 'name' => 'Tunisia'],
+    ['code' => 'TO', 'name' => 'Tonga'],
+    ['code' => 'TR', 'name' => 'Turkiye'],
+    ['code' => 'TT', 'name' => 'Trinidad and Tobago'],
+    ['code' => 'TV', 'name' => 'Tuvalu'],
+    ['code' => 'TW', 'name' => 'Taiwan'],
+    ['code' => 'TZ', 'name' => 'Tanzania'],
+
+    /* U */
+    ['code' => 'UA', 'name' => 'Ukraine'],
+    ['code' => 'UG', 'name' => 'Uganda'],
+    ['code' => 'UM', 'name' => 'United States Minor Outlying Islands'],
+    ['code' => 'US', 'name' => 'United States'],
+    ['code' => 'UY', 'name' => 'Uruguay'],
+    ['code' => 'UZ', 'name' => 'Uzbekistan'],
+
+    /* V */
+    ['code' => 'VA', 'name' => 'Holy See'],
+    ['code' => 'VC', 'name' => 'Saint Vincent and the Grenadines'],
+    ['code' => 'VE', 'name' => 'Venezuela'],
+    ['code' => 'VG', 'name' => 'Virgin Islands, British'],
+    ['code' => 'VI', 'name' => 'Virgin Islands, U.S.'],
+    ['code' => 'VN', 'name' => 'Viet Nam'],
+    ['code' => 'VU', 'name' => 'Vanuatu'],
+
+    /* W */
+    ['code' => 'WF', 'name' => 'Wallis and Futuna'],
+    ['code' => 'WS', 'name' => 'Samoa'],
+
+    /* Y */
+    ['code' => 'YE', 'name' => 'Yemen'],
+    ['code' => 'YT', 'name' => 'Mayotte'],
+
+    /* Z */
+    ['code' => 'ZA', 'name' => 'South Africa'],
+    ['code' => 'ZM', 'name' => 'Zambia'],
+    ['code' => 'ZW', 'name' => 'Zimbabwe'],
+
+    /* M.49 area codes BCP 47 also accepts as the third subtag.
+       These are economic / geographic groupings, useful when a
+       songbook serves a region rather than a country (e.g.
+       "Latin America" for a Spanish-language collection). Only
+       the most-used groupings — extend if curators need more. */
+    ['code' => '419', 'name' => 'Latin America and the Caribbean'],
+    ['code' => '150', 'name' => 'Europe'],
+    ['code' => '002', 'name' => 'Africa'],
+    ['code' => '142', 'name' => 'Asia'],
+    ['code' => '009', 'name' => 'Oceania'],
+    ['code' => '019', 'name' => 'Americas'],
+];

--- a/appWeb/.sql/migrate-ietf-bcp47-language.php
+++ b/appWeb/.sql/migrate-ietf-bcp47-language.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — IETF BCP 47 Language Tagging Migration (#681)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Brings the schema into a state where every Language column on
+ * songs, songbooks, translations and song-requests can hold a full
+ * IETF BCP 47 tag (language[-script][-region], e.g. zh-Hans-CN,
+ * pt-BR, sr-Latn). Adds two reference tables — tblScripts and
+ * tblRegions — to back the composite picker's typeahead.
+ *
+ * Steps (idempotent — every probe / ALTER no-ops if already done):
+ *
+ *   1. CREATE tblScripts if absent.
+ *   2. CREATE tblRegions if absent.
+ *   3. Widen tblSongbooks.Language          VARCHAR(10) → VARCHAR(35)
+ *   4. Widen tblSongs.Language              VARCHAR(10) → VARCHAR(35)
+ *   5. Widen tblSongTranslations.TargetLanguage VARCHAR(10) → VARCHAR(35)
+ *   6. Widen tblSongRequests.Language       VARCHAR(10) → VARCHAR(35)
+ *   7. Seed tblScripts from the bundled ISO 15924 list.
+ *   8. Seed tblRegions from the bundled ISO 3166-1 alpha-2 list.
+ *
+ * Existing data (`en`, `fr`, `ru`, …) is already a valid BCP 47
+ * tag on its own, so no data migration is needed beyond the column
+ * widening. The seed data lives in this script (PHP arrays) rather
+ * than in schema.sql so a) we don't hand-edit a 250-line VALUES
+ * block in the schema and b) re-running the migration extends the
+ * reference tables when we add new entries to the array.
+ *
+ * @migration-adds tblScripts
+ * @migration-adds tblRegions
+ * @migration-modifies tblSongbooks.Language
+ * @migration-modifies tblSongs.Language
+ * @migration-modifies tblSongTranslations.TargetLanguage
+ * @migration-modifies tblSongRequests.Language
+ *
+ * USAGE:
+ *   CLI: php appWeb/.sql/migrate-ietf-bcp47-language.php
+ *   Web: /manage/setup-database → "IETF BCP 47 Language Migration"
+ *        (entry point requires global_admin)
+ */
+
+if (PHP_SAPI === 'cli') {
+    /* Guarded require — see #652. */
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = true;
+} else {
+    if (!defined('IHYMNS_SETUP_DASHBOARD')) {
+        if (!function_exists('isAuthenticated')) {
+            require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+        }
+        if (!isAuthenticated()) {
+            http_response_code(401);
+            exit('Authentication required.');
+        }
+        $u = getCurrentUser();
+        if (!$u || $u['role'] !== 'global_admin') {
+            http_response_code(403);
+            exit('Global admin required.');
+        }
+    }
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = false;
+}
+
+function _migBcp47_out(string $line): void
+{
+    global $isCli;
+    echo $line . ($isCli ? "\n" : "<br>\n");
+    /* CLI only — see migrate-credit-people-flags.php for rationale (#661). */
+    if ($isCli) {
+        flush();
+    }
+}
+
+function _migBcp47_tableExists(mysqli $db, string $table): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? LIMIT 1'
+    );
+    $stmt->bind_param('s', $table);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+function _migBcp47_columnWidth(mysqli $db, string $table, string $column): ?int
+{
+    $stmt = $db->prepare(
+        'SELECT CHARACTER_MAXIMUM_LENGTH
+           FROM INFORMATION_SCHEMA.COLUMNS
+          WHERE TABLE_SCHEMA = DATABASE()
+            AND TABLE_NAME   = ?
+            AND COLUMN_NAME  = ?
+          LIMIT 1'
+    );
+    $stmt->bind_param('ss', $table, $column);
+    $stmt->execute();
+    $row = $stmt->get_result()->fetch_row();
+    $stmt->close();
+    return $row ? (int)$row[0] : null;
+}
+
+_migBcp47_out('IETF BCP 47 language migration starting…');
+
+$mysqli = getDbMysqli();
+if (!$mysqli) {
+    _migBcp47_out('ERROR: could not connect to database.');
+    exit(1);
+}
+
+/* ----------------------------------------------------------------------
+ * Step 1: tblScripts
+ * ---------------------------------------------------------------------- */
+if (_migBcp47_tableExists($mysqli, 'tblScripts')) {
+    _migBcp47_out('[skip] tblScripts already present.');
+} else {
+    $sql = "CREATE TABLE tblScripts (
+        Code        VARCHAR(4)   NOT NULL PRIMARY KEY,
+        Name        VARCHAR(100) NOT NULL,
+        NativeName  VARCHAR(100) NOT NULL DEFAULT '',
+        IsActive    TINYINT(1)   NOT NULL DEFAULT 1,
+        CreatedAt   TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
+    if (!$mysqli->query($sql)) {
+        _migBcp47_out('ERROR: creating tblScripts failed: ' . $mysqli->error);
+        exit(1);
+    }
+    _migBcp47_out('[add ] tblScripts.');
+}
+
+/* ----------------------------------------------------------------------
+ * Step 2: tblRegions
+ * ---------------------------------------------------------------------- */
+if (_migBcp47_tableExists($mysqli, 'tblRegions')) {
+    _migBcp47_out('[skip] tblRegions already present.');
+} else {
+    $sql = "CREATE TABLE tblRegions (
+        Code        VARCHAR(3)   NOT NULL PRIMARY KEY,
+        Name        VARCHAR(150) NOT NULL,
+        IsActive    TINYINT(1)   NOT NULL DEFAULT 1,
+        CreatedAt   TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
+    if (!$mysqli->query($sql)) {
+        _migBcp47_out('ERROR: creating tblRegions failed: ' . $mysqli->error);
+        exit(1);
+    }
+    _migBcp47_out('[add ] tblRegions.');
+}
+
+/* ----------------------------------------------------------------------
+ * Steps 3-6: widen Language columns to VARCHAR(35)
+ *
+ * Each ALTER is gated on the current width so re-running the
+ * migration is a no-op once the columns are already wide. The
+ * MODIFY emits a clear `[skip]` / `[wide]` line per column so the
+ * dashboard transcript reads cleanly.
+ * ---------------------------------------------------------------------- */
+$columnsToWiden = [
+    ['table' => 'tblSongbooks',         'column' => 'Language',       'definition' => 'VARCHAR(35) NULL DEFAULT NULL'],
+    ['table' => 'tblSongs',             'column' => 'Language',       'definition' => "VARCHAR(35) NOT NULL DEFAULT 'en'"],
+    ['table' => 'tblSongTranslations',  'column' => 'TargetLanguage', 'definition' => 'VARCHAR(35) NOT NULL'],
+    ['table' => 'tblSongRequests',      'column' => 'Language',       'definition' => "VARCHAR(35) NOT NULL DEFAULT 'en'"],
+];
+foreach ($columnsToWiden as $col) {
+    $width = _migBcp47_columnWidth($mysqli, $col['table'], $col['column']);
+    if ($width === null) {
+        _migBcp47_out("[skip] {$col['table']}.{$col['column']} not present (parent table missing — run earlier migrations first).");
+        continue;
+    }
+    if ($width >= 35) {
+        _migBcp47_out("[skip] {$col['table']}.{$col['column']} already VARCHAR({$width}).");
+        continue;
+    }
+    $sql = "ALTER TABLE {$col['table']} MODIFY COLUMN {$col['column']} {$col['definition']}";
+    if (!$mysqli->query($sql)) {
+        _migBcp47_out("ERROR: widening {$col['table']}.{$col['column']} failed: " . $mysqli->error);
+        exit(1);
+    }
+    _migBcp47_out("[wide] {$col['table']}.{$col['column']} → VARCHAR(35).");
+}
+
+/* ----------------------------------------------------------------------
+ * Step 7: seed tblScripts
+ *
+ * Sourced from the bundled SCRIPTS array below. INSERT IGNORE means
+ * re-running adds new entries appended to the array without
+ * disturbing rows an admin manually flagged IsActive=0. Chunked into
+ * ~30-row INSERTs for readable transcript output (one log line per
+ * chunk) and to keep individual prepared-statement payloads small.
+ * ---------------------------------------------------------------------- */
+require __DIR__ . '/migrate-ietf-bcp47-data.php';   // SCRIPTS + REGIONS
+
+$scriptsAdded = 0;
+foreach (array_chunk(SCRIPTS, 30) as $chunk) {
+    $placeholders = [];
+    $types        = '';
+    $values       = [];
+    foreach ($chunk as $row) {
+        $placeholders[] = '(?, ?, ?)';
+        $types         .= 'sss';
+        $values[]       = $row['code'];
+        $values[]       = $row['name'];
+        $values[]       = $row['native'] ?? '';
+    }
+    $sql = 'INSERT IGNORE INTO tblScripts (Code, Name, NativeName) VALUES '
+         . implode(', ', $placeholders);
+    $stmt = $mysqli->prepare($sql);
+    $stmt->bind_param($types, ...$values);
+    $stmt->execute();
+    $scriptsAdded += $stmt->affected_rows;
+    $stmt->close();
+}
+_migBcp47_out("[seed] tblScripts: {$scriptsAdded} new row(s) (re-runs are silent no-ops).");
+
+/* ----------------------------------------------------------------------
+ * Step 8: seed tblRegions
+ * ---------------------------------------------------------------------- */
+$regionsAdded = 0;
+foreach (array_chunk(REGIONS, 50) as $chunk) {
+    $placeholders = [];
+    $types        = '';
+    $values       = [];
+    foreach ($chunk as $row) {
+        $placeholders[] = '(?, ?)';
+        $types         .= 'ss';
+        $values[]       = $row['code'];
+        $values[]       = $row['name'];
+    }
+    $sql = 'INSERT IGNORE INTO tblRegions (Code, Name) VALUES '
+         . implode(', ', $placeholders);
+    $stmt = $mysqli->prepare($sql);
+    $stmt->bind_param($types, ...$values);
+    $stmt->execute();
+    $regionsAdded += $stmt->affected_rows;
+    $stmt->close();
+}
+_migBcp47_out("[seed] tblRegions: {$regionsAdded} new row(s) (re-runs are silent no-ops).");
+
+_migBcp47_out('IETF BCP 47 language migration finished.');

--- a/appWeb/.sql/schema.sql
+++ b/appWeb/.sql/schema.sql
@@ -41,7 +41,7 @@ CREATE TABLE IF NOT EXISTS tblSongbooks (
     PublicationYear VARCHAR(50)     NULL DEFAULT NULL COMMENT 'Year / edition range (free-form: 1986, 1986-2003, 2nd edition 2011) (#502)',
     Copyright       VARCHAR(500)    NULL DEFAULT NULL COMMENT 'Copyright notice for the collection as a whole (#502)',
     Affiliation     VARCHAR(120)    NULL DEFAULT NULL COMMENT 'Denominational / religious affiliation; backed by tblSongbookAffiliations registry (#670)',
-    Language        VARCHAR(10)     NULL DEFAULT NULL COMMENT 'Optional ISO 639-1 code; NULL = not specified. Mirrors tblSongs.Language without the FK or NOT NULL — soft validation via the tblLanguages dropdown (#673)',
+    Language        VARCHAR(35)     NULL DEFAULT NULL COMMENT 'Optional IETF BCP 47 tag (language[-script][-region], e.g. en, pt-BR, zh-Hans-CN); NULL = not specified. Soft validation via the composite picker dropdowns; widened from VARCHAR(10) to fit script+region subtags (#681)',
 
     /* Bibliographic + authority-control identifiers (#672). All
        optional, all VARCHAR — no FKs, no CHECK constraints. Curators
@@ -100,7 +100,7 @@ CREATE TABLE IF NOT EXISTS tblSongs (
     Title               VARCHAR(500)    NOT NULL,
     SongbookAbbr        VARCHAR(10)     NOT NULL COMMENT 'FK to tblSongbooks.Abbreviation',
     SongbookName        VARCHAR(255)    NOT NULL COMMENT 'Denormalised songbook name for convenience',
-    Language            VARCHAR(10)     NOT NULL DEFAULT 'en',
+    Language            VARCHAR(35)     NOT NULL DEFAULT 'en' COMMENT 'IETF BCP 47 tag (language[-script][-region]); widened from VARCHAR(10) to fit script + region subtags (#681)',
     Copyright           VARCHAR(500)    NOT NULL DEFAULT '',
     TuneName            VARCHAR(120)    NULL DEFAULT NULL COMMENT 'Traditional tune name, e.g. HYFRYDOL, OLD HUNDREDTH (#497)',
     Ccli                VARCHAR(50)     NOT NULL DEFAULT '' COMMENT 'CCLI Song Number',
@@ -770,6 +770,37 @@ CREATE TABLE IF NOT EXISTS tblLanguages (
 
 
 -- ----------------------------------------------------------------------------
+-- tblScripts (#681)
+-- Reference table for ISO 15924 four-letter script codes (e.g. Latn, Cyrl,
+-- Hans, Hant, Arab). Used as the optional second subtag in an IETF BCP 47
+-- language tag (e.g. zh-Hans, sr-Latn). Curators pick from this list via the
+-- songbook + song editors' composite IETF language picker.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS tblScripts (
+    Code            VARCHAR(4)      NOT NULL PRIMARY KEY COMMENT 'ISO 15924 four-letter code (Title Case: Latn, Cyrl, Hans, …)',
+    Name            VARCHAR(100)    NOT NULL COMMENT 'English name (e.g. Latin, Cyrillic, Han Simplified)',
+    NativeName      VARCHAR(100)    NOT NULL DEFAULT '' COMMENT 'Native or contextual name where useful (e.g. 简体)',
+    IsActive        TINYINT(1)      NOT NULL DEFAULT 1,
+    CreatedAt       TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+-- ----------------------------------------------------------------------------
+-- tblRegions (#681)
+-- Reference table for ISO 3166-1 alpha-2 region codes (e.g. GB, US, BR, PT).
+-- Used as the optional third subtag in an IETF BCP 47 language tag (e.g.
+-- pt-BR, en-GB). VARCHAR(3) leaves room for the M.49 numeric area codes
+-- (e.g. 419 for Latin America) that BCP 47 also accepts.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS tblRegions (
+    Code            VARCHAR(3)      NOT NULL PRIMARY KEY COMMENT 'ISO 3166-1 alpha-2 (uppercase) or M.49 numeric area code',
+    Name            VARCHAR(150)    NOT NULL COMMENT 'English name (e.g. United Kingdom, Brazil)',
+    IsActive        TINYINT(1)      NOT NULL DEFAULT 1,
+    CreatedAt       TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+-- ----------------------------------------------------------------------------
 -- tblSongTranslations
 -- Links a song to its translation in another language.
 -- Each translation is itself a song record in tblSongs.
@@ -778,7 +809,7 @@ CREATE TABLE IF NOT EXISTS tblSongTranslations (
     Id                  INT UNSIGNED    AUTO_INCREMENT PRIMARY KEY,
     SourceSongId        VARCHAR(20)     NOT NULL COMMENT 'Original song ID',
     TranslatedSongId    VARCHAR(20)     NOT NULL COMMENT 'Translated song ID',
-    TargetLanguage      VARCHAR(10)     NOT NULL COMMENT 'ISO 639-1 code of translation',
+    TargetLanguage      VARCHAR(35)     NOT NULL COMMENT 'IETF BCP 47 tag of translation; widened from VARCHAR(10) to align with tblSongs.Language (#681)',
     Translator          VARCHAR(255)    NOT NULL DEFAULT '' COMMENT 'Translator name(s)',
     Verified            TINYINT(1)      NOT NULL DEFAULT 0,
     CreatedAt           TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -813,7 +844,7 @@ CREATE TABLE IF NOT EXISTS tblSongRequests (
     Title           VARCHAR(500)    NOT NULL COMMENT 'Requested song title',
     Songbook        VARCHAR(100)    NOT NULL DEFAULT '' COMMENT 'Songbook name or abbreviation (if known)',
     SongNumber      VARCHAR(20)     NOT NULL DEFAULT '' COMMENT 'Song number (if known)',
-    Language        VARCHAR(10)     NOT NULL DEFAULT 'en' COMMENT 'Language of the requested song',
+    Language        VARCHAR(35)     NOT NULL DEFAULT 'en' COMMENT 'IETF BCP 47 tag of requested song; widened from VARCHAR(10) for consistency (#681)',
     Details         TEXT            NOT NULL DEFAULT ('') COMMENT 'Additional info (first line of lyrics, etc.)',
     ContactEmail    VARCHAR(255)    NOT NULL DEFAULT '' COMMENT 'Optional email for follow-up',
     UserId          INT UNSIGNED    NULL DEFAULT NULL COMMENT 'FK to tblUsers (NULL for anonymous)',

--- a/appWeb/public_html/js/modules/ietf-language-picker.js
+++ b/appWeb/public_html/js/modules/ietf-language-picker.js
@@ -1,0 +1,326 @@
+/**
+ * IETF BCP 47 language picker (#681)
+ *
+ * One module, two surfaces: the songbook editor's create-form +
+ * edit-modal, and the song editor's Metadata tab. Renders three
+ * text inputs (Language, Script, Region) — each with its own
+ * datalist — plus a live "IETF tag:" preview and a hidden
+ * <input> that holds the composed tag for the form's existing
+ * save handler.
+ *
+ * The picker degrades gracefully:
+ *   - If the typeahead endpoints fail, the user can still type a
+ *     valid value into each input directly; the compose still
+ *     fires on blur.
+ *   - If the saved value doesn't decompose cleanly (legacy
+ *     ISO 639-1 like "en" — already a valid BCP 47 tag) the
+ *     Language input gets the language name and the other two
+ *     stay empty.
+ *
+ * Markup contract — caller renders something like:
+ *
+ *   <div class="ietf-picker" data-ietf-picker-id="edit">
+ *     <input class="ietf-picker-language" list="ietf-lang-list-edit">
+ *     <input class="ietf-picker-script"   list="ietf-script-list-edit">
+ *     <input class="ietf-picker-region"   list="ietf-region-list-edit">
+ *     <code class="ietf-tag-preview">…</code>
+ *     <input type="hidden" class="ietf-tag-output" name="language">
+ *     <datalist id="ietf-lang-list-edit"></datalist>
+ *     <datalist id="ietf-script-list-edit"></datalist>
+ *     <datalist id="ietf-region-list-edit"></datalist>
+ *   </div>
+ */
+
+/* Debounce so we don't fire one fetch per keystroke. 200ms matches
+   the affiliation typeahead (#670) and the editor's tag/credit
+   searches — feels instant to a curator, coalesces typing bursts
+   into a single request. */
+const DEBOUNCE_MS = 200;
+
+/* The endpoints that back the three inputs. All on /manage/songbooks
+   today; the editor surface (B6) reuses the same endpoints rather
+   than duplicating onto /manage/editor/api.php. */
+const LANG_URL   = '/api?action=languages';   // public — already exists
+const SCRIPT_URL = '/manage/songbooks?action=script_search';
+const REGION_URL = '/manage/songbooks?action=region_search';
+
+/**
+ * Tokenise a BCP 47 tag into its three subtags.
+ * Examples:
+ *   "en"          → { lang: "en",  script: "",     region: "" }
+ *   "pt-BR"       → { lang: "pt",  script: "",     region: "BR" }
+ *   "zh-Hans"     → { lang: "zh",  script: "Hans", region: "" }
+ *   "zh-Hans-CN"  → { lang: "zh",  script: "Hans", region: "CN" }
+ *   "419"         → invalid → falls through with lang=""
+ *
+ * The script subtag is uniquely 4 chars Title Case; the region
+ * subtag is uniquely 2 chars upper or 3-digit. Anything else after
+ * the language is ignored for v1 (variants, extensions, private-use
+ * — out of scope per #681).
+ */
+export function decomposeTag(tag) {
+    const parts = (tag || '').trim().split('-');
+    if (!parts.length || !/^[a-z]{2,3}$/i.test(parts[0])) {
+        return { lang: '', script: '', region: '' };
+    }
+    let lang = parts[0].toLowerCase();
+    let script = '';
+    let region = '';
+    for (let i = 1; i < parts.length; i++) {
+        const p = parts[i];
+        if (!script && /^[A-Za-z]{4}$/.test(p)) {
+            /* Title-case the script subtag (Latn, Cyrl, …). */
+            script = p.charAt(0).toUpperCase() + p.slice(1).toLowerCase();
+        } else if (!region && (/^[A-Za-z]{2}$/.test(p) || /^[0-9]{3}$/.test(p))) {
+            region = /^[0-9]+$/.test(p) ? p : p.toUpperCase();
+        }
+    }
+    return { lang, script, region };
+}
+
+/**
+ * Compose three subtags back into a BCP 47 tag. Empties drop out:
+ *   compose("en", "",     "GB")  → "en-GB"
+ *   compose("pt", "",     "BR")  → "pt-BR"
+ *   compose("zh", "Hans", "")    → "zh-Hans"
+ *   compose("",   "Latn", "GB")  → ""    (no language → no tag)
+ */
+export function composeTag(lang, script, region) {
+    if (!lang) return '';
+    return [
+        lang.toLowerCase(),
+        script ? script.charAt(0).toUpperCase() + script.slice(1).toLowerCase() : '',
+        region ? (/^[0-9]+$/.test(region) ? region : region.toUpperCase()) : '',
+    ].filter(Boolean).join('-');
+}
+
+/* ---------------------------------------------------------------------------
+ * Internal helpers
+ * --------------------------------------------------------------------------- */
+
+/* Cache the resolved name → code lookups per picker instance so a
+   curator who picks "Latin" twice doesn't trigger two fetches. */
+function cachedLookup() {
+    const cache = new Map();
+    return async (key, fetcher) => {
+        if (cache.has(key)) return cache.get(key);
+        const value = await fetcher();
+        cache.set(key, value);
+        return value;
+    };
+}
+
+/* Generic JSON fetch with same-origin credentials. Returns [] on any
+   error so the typeahead silently degrades to "no suggestions" rather
+   than spamming the console. */
+async function fetchJson(url) {
+    try {
+        const r = await fetch(url, { credentials: 'same-origin' });
+        if (!r.ok) return null;
+        return await r.json();
+    } catch (_e) {
+        return null;
+    }
+}
+
+/* Rebuild a datalist from a list of {code, name} suggestions. The
+   <option> value is what the input gets; we use the human Name
+   so the input shows "United Kingdom" not "GB". The Code is
+   tucked into the option's data-code so the compose step can
+   resolve it back. */
+function rebuildDatalist(datalistEl, suggestions, codeKey, nameKey, nativeKey) {
+    if (!datalistEl) return;
+    datalistEl.innerHTML = (suggestions || []).map(s => {
+        const code = (s[codeKey] || '').replace(/"/g, '&quot;');
+        const name = (s[nameKey] || '').replace(/"/g, '&quot;');
+        const native = (nativeKey && s[nativeKey] && s[nativeKey] !== s[nameKey])
+            ? ` (${s[nativeKey].replace(/"/g, '&quot;')})`
+            : '';
+        return `<option value="${name}" data-code="${code}" label="${name}${native} — ${code}"></option>`;
+    }).join('');
+}
+
+/* Resolve the input's typed value back to its canonical code by
+   matching against the current datalist's <option> elements. If
+   the user typed a name that isn't in the list, we fall through to
+   the typed text (so a freshly-added language/script/region the
+   typeahead hasn't surfaced yet still composes into a sensible
+   tag — they may have to type the canonical code directly). */
+function resolveCode(inputEl, datalistEl) {
+    const typed = (inputEl.value || '').trim();
+    if (!typed) return '';
+    const opt = Array.from(datalistEl?.options || []).find(
+        o => o.value.toLowerCase() === typed.toLowerCase()
+    );
+    return opt ? (opt.dataset.code || opt.value) : typed;
+}
+
+/* ---------------------------------------------------------------------------
+ * Public API
+ * --------------------------------------------------------------------------- */
+
+/**
+ * Boot one picker instance. Rebinds the inputs' input/blur events,
+ * loads the initial datalist contents, and exposes a small object
+ * with helpers the host page can call.
+ *
+ * Returns:
+ *   {
+ *     setTag(tag): replace the inputs to match a new saved tag
+ *     getTag():    read the currently composed tag
+ *   }
+ */
+export function bootIetfLanguagePicker(rootEl) {
+    if (!rootEl || rootEl.dataset.ietfPickerBooted === '1') return null;
+    rootEl.dataset.ietfPickerBooted = '1';
+
+    const langInput   = rootEl.querySelector('.ietf-picker-language');
+    const scriptInput = rootEl.querySelector('.ietf-picker-script');
+    const regionInput = rootEl.querySelector('.ietf-picker-region');
+    const tagPreview  = rootEl.querySelector('.ietf-tag-preview');
+    const tagOutput   = rootEl.querySelector('.ietf-tag-output');
+    const langList    = document.getElementById(langInput?.getAttribute('list'));
+    const scriptList  = document.getElementById(scriptInput?.getAttribute('list'));
+    const regionList  = document.getElementById(regionInput?.getAttribute('list'));
+
+    if (!langInput || !scriptInput || !regionInput || !tagOutput) return null;
+
+    const lookup = cachedLookup();
+
+    /* The full languages list comes from /api?action=languages — no
+       prefix typing needed since there are only ~14 active rows. */
+    const loadLanguages = async () => {
+        const data = await lookup('all-languages',
+            () => fetchJson(LANG_URL));
+        rebuildDatalist(langList, data?.languages || [],
+            'code', 'name', 'nativeName');
+    };
+
+    /* Scripts + regions DO use prefix typing — the lists are bigger
+       (28 + 255 entries). */
+    let scriptTimer = null;
+    const lookupScripts = (q) => {
+        clearTimeout(scriptTimer);
+        scriptTimer = setTimeout(async () => {
+            const url = `${SCRIPT_URL}&q=${encodeURIComponent(q)}&limit=20`;
+            const data = await fetchJson(url);
+            rebuildDatalist(scriptList, data?.suggestions || [],
+                'code', 'name', 'nativeName');
+        }, DEBOUNCE_MS);
+    };
+
+    let regionTimer = null;
+    const lookupRegions = (q) => {
+        clearTimeout(regionTimer);
+        regionTimer = setTimeout(async () => {
+            const url = `${REGION_URL}&q=${encodeURIComponent(q)}&limit=20`;
+            const data = await fetchJson(url);
+            rebuildDatalist(regionList, data?.suggestions || [],
+                'code', 'name');
+        }, DEBOUNCE_MS);
+    };
+
+    /* Update the live preview + hidden form field whenever any of
+       the three inputs change. Reads the canonical code from the
+       datalist's selected <option>; falls through to typed text. */
+    const refreshTag = () => {
+        const langCode   = resolveCode(langInput,   langList);
+        const scriptCode = resolveCode(scriptInput, scriptList);
+        const regionCode = resolveCode(regionInput, regionList);
+        const tag = composeTag(langCode, scriptCode, regionCode);
+        tagOutput.value = tag;
+        if (tagPreview) tagPreview.textContent = tag || '—';
+    };
+
+    /* Wire input + blur events on every input so the preview tracks
+       typing AND the eventual canonical-code resolution after the
+       user picks from the datalist (which fires `input` not
+       `change`). */
+    [langInput, scriptInput, regionInput].forEach(input => {
+        input.addEventListener('input', refreshTag);
+        input.addEventListener('blur',  refreshTag);
+    });
+
+    /* Lazy-load each list on first focus so opening a row that
+       doesn't exercise the picker doesn't pay the network cost. */
+    langInput.addEventListener('focus', loadLanguages, { once: true });
+    scriptInput.addEventListener('input', () => {
+        if (scriptInput.value.trim()) lookupScripts(scriptInput.value.trim());
+    });
+    regionInput.addEventListener('input', () => {
+        if (regionInput.value.trim()) lookupRegions(regionInput.value.trim());
+    });
+
+    /**
+     * Decompose a saved BCP 47 tag and pre-fill the inputs. Used
+     * by openEditModal when the user clicks Edit on a row — the
+     * partial is shared between rows in the modal.
+     */
+    const setTag = async (tag) => {
+        const { lang, script, region } = decomposeTag(tag);
+
+        /* Preload the languages list so we can resolve the code →
+           name BEFORE the user opens the dropdown. */
+        await loadLanguages();
+
+        /* Resolve language code → name. The languages endpoint
+           returns the full list, so we match against the datalist
+           options we just built. */
+        const langName = (() => {
+            if (!lang) return '';
+            const opt = Array.from(langList?.options || []).find(
+                o => (o.dataset.code || '').toLowerCase() === lang.toLowerCase()
+            );
+            return opt ? opt.value : lang;
+        })();
+        langInput.value = langName;
+
+        /* Script: load the matching row by exact code (limit=1) so
+           we get the friendly name. Empty if no script subtag. */
+        if (script) {
+            const data = await fetchJson(
+                `${SCRIPT_URL}&q=${encodeURIComponent(script)}&limit=10`
+            );
+            const match = (data?.suggestions || []).find(
+                s => (s.code || '').toLowerCase() === script.toLowerCase()
+            );
+            scriptInput.value = match ? match.name : script;
+            rebuildDatalist(scriptList, data?.suggestions || [],
+                'code', 'name', 'nativeName');
+        } else {
+            scriptInput.value = '';
+        }
+
+        /* Region: same pattern. */
+        if (region) {
+            const data = await fetchJson(
+                `${REGION_URL}&q=${encodeURIComponent(region)}&limit=10`
+            );
+            const match = (data?.suggestions || []).find(
+                s => (s.code || '').toLowerCase() === region.toLowerCase()
+            );
+            regionInput.value = match ? match.name : region;
+            rebuildDatalist(regionList, data?.suggestions || [], 'code', 'name');
+        } else {
+            regionInput.value = '';
+        }
+
+        refreshTag();
+    };
+
+    /* Pre-populate from the data-initial-tag attribute (server-side
+       could not resolve the human names without paying the lookup
+       cost; cleaner to hand off via a single attribute and let the
+       JS resolve). */
+    const initial = rootEl.dataset.initialTag || '';
+    if (initial) {
+        setTag(initial).catch(() => { /* swallow — degrade gracefully */ });
+    } else {
+        refreshTag();
+    }
+
+    return {
+        setTag,
+        getTag: () => tagOutput.value,
+    };
+}

--- a/appWeb/public_html/manage/includes/partials/ietf-language-picker.php
+++ b/appWeb/public_html/manage/includes/partials/ietf-language-picker.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — IETF BCP 47 language picker partial (#681)
+ *
+ * Renders three composable inputs (Language, Script, Region) plus
+ * a live "IETF tag:" preview and a hidden <input> that holds the
+ * composed tag. Used by:
+ *   - /manage/songbooks (create form + edit modal)
+ *   - /manage/editor    (per-song Metadata tab)
+ *
+ * Caller contract:
+ *
+ *   <?php
+ *     $idPrefix = 'edit';                  // unique per instance on a page
+ *     $name     = 'language';              // POST field name for the composed tag
+ *     $tag      = 'pt-BR';                 // saved BCP 47 tag (or empty)
+ *     $label    = 'Language (IETF BCP 47)'; // optional override
+ *     $help     = '';                      // optional sub-label hint
+ *     require __DIR__ . '/includes/partials/ietf-language-picker.php';
+ *   ?>
+ *
+ * The picker is JS-driven (js/modules/ietf-language-picker.js).
+ * The PHP side just emits the markup + the saved tag; the JS module
+ * decomposes it on boot, queries the typeaheads, and writes the
+ * composed tag back into the hidden field on every input change.
+ */
+
+/* Defensive defaults — if the caller forgot to set any of these,
+   render a blank picker rather than crashing. */
+$idPrefix = isset($idPrefix) ? (string)$idPrefix : 'ietf';
+$name     = isset($name)     ? (string)$name     : 'language';
+$tag      = isset($tag)      ? (string)$tag      : '';
+$label    = isset($label)    ? (string)$label    : 'Language (IETF BCP 47)';
+$help     = isset($help)     ? (string)$help     : 'Optional. Pick a language; add a script (Latin / Cyrillic / …) or region (United Kingdom / Brazil / …) only if it differs from the default.';
+
+/* Sanitise the id so a future caller passing "edit modal" doesn't
+   produce broken HTML. Strip everything but [a-z0-9-]. */
+$idSafe = preg_replace('/[^a-z0-9-]/i', '-', $idPrefix);
+?>
+<div class="ietf-picker mb-3"
+     data-ietf-picker-id="<?= htmlspecialchars($idSafe, ENT_QUOTES, 'UTF-8') ?>"
+     data-initial-tag="<?= htmlspecialchars($tag, ENT_QUOTES, 'UTF-8') ?>">
+
+    <label class="form-label">
+        <i class="bi bi-translate me-1" aria-hidden="true"></i><?= htmlspecialchars($label, ENT_QUOTES, 'UTF-8') ?>
+    </label>
+
+    <div class="row g-2">
+        <div class="col-md-5">
+            <label class="form-label small text-muted"
+                   for="<?= htmlspecialchars($idSafe, ENT_QUOTES, 'UTF-8') ?>-lang">
+                Language
+            </label>
+            <input type="text"
+                   class="form-control form-control-sm ietf-picker-language"
+                   id="<?= htmlspecialchars($idSafe, ENT_QUOTES, 'UTF-8') ?>-lang"
+                   list="ietf-lang-list-<?= htmlspecialchars($idSafe, ENT_QUOTES, 'UTF-8') ?>"
+                   autocomplete="off"
+                   placeholder="English">
+        </div>
+        <div class="col-md-3">
+            <label class="form-label small text-muted"
+                   for="<?= htmlspecialchars($idSafe, ENT_QUOTES, 'UTF-8') ?>-script">
+                Script
+            </label>
+            <input type="text"
+                   class="form-control form-control-sm ietf-picker-script"
+                   id="<?= htmlspecialchars($idSafe, ENT_QUOTES, 'UTF-8') ?>-script"
+                   list="ietf-script-list-<?= htmlspecialchars($idSafe, ENT_QUOTES, 'UTF-8') ?>"
+                   autocomplete="off"
+                   placeholder="e.g. Latin">
+        </div>
+        <div class="col-md-4">
+            <label class="form-label small text-muted"
+                   for="<?= htmlspecialchars($idSafe, ENT_QUOTES, 'UTF-8') ?>-region">
+                Region
+            </label>
+            <input type="text"
+                   class="form-control form-control-sm ietf-picker-region"
+                   id="<?= htmlspecialchars($idSafe, ENT_QUOTES, 'UTF-8') ?>-region"
+                   list="ietf-region-list-<?= htmlspecialchars($idSafe, ENT_QUOTES, 'UTF-8') ?>"
+                   autocomplete="off"
+                   placeholder="e.g. United Kingdom">
+        </div>
+    </div>
+
+    <div class="form-text small mt-1">
+        IETF tag: <code class="ietf-tag-preview"><?= htmlspecialchars($tag !== '' ? $tag : '—', ENT_QUOTES, 'UTF-8') ?></code>
+        <span class="text-muted ms-2"><?= htmlspecialchars($help, ENT_QUOTES, 'UTF-8') ?></span>
+    </div>
+
+    <input type="hidden"
+           class="ietf-tag-output"
+           name="<?= htmlspecialchars($name, ENT_QUOTES, 'UTF-8') ?>"
+           value="<?= htmlspecialchars($tag, ENT_QUOTES, 'UTF-8') ?>">
+
+    <!-- One <datalist> per input, scoped by the picker's idPrefix so
+         multiple instances on the same page (create form + edit
+         modal) don't share state. -->
+    <datalist id="ietf-lang-list-<?= htmlspecialchars($idSafe, ENT_QUOTES, 'UTF-8') ?>"></datalist>
+    <datalist id="ietf-script-list-<?= htmlspecialchars($idSafe, ENT_QUOTES, 'UTF-8') ?>"></datalist>
+    <datalist id="ietf-region-list-<?= htmlspecialchars($idSafe, ENT_QUOTES, 'UTF-8') ?>"></datalist>
+</div>

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -208,6 +208,7 @@ if ($action !== '') {
         'songbook-affiliations' => 'migrate-songbook-affiliations.php',
         'songbook-bibliographic' => 'migrate-songbook-bibliographic.php',
         'songbook-language'      => 'migrate-songbook-language.php',
+        'ietf-bcp47-language'    => 'migrate-ietf-bcp47-language.php',
         'cleanup'     => 'cleanup.php',
         'backup'      => 'backup.php',
         'restore'     => 'restore.php',
@@ -839,6 +840,28 @@ if ($hasCredentials && defined('DB_HOST')) {
                         </p>
                         <a href="?action=songbook-language" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
                             Run Songbook Language Migration
+                        </a>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="card bg-dark border-secondary h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">3o. IETF BCP 47 language tagging (#681)</h5>
+                        <p class="card-text text-secondary small">
+                            Brings every <code>Language</code> column on songs,
+                            songbooks, translations and song-requests up to
+                            <code>VARCHAR(35)</code> so they can hold a full IETF
+                            BCP 47 tag (language[-script][-region], e.g.
+                            <code>pt-BR</code>, <code>zh-Hans-CN</code>,
+                            <code>sr-Latn</code>). Adds <code>tblScripts</code>
+                            (~28 ISO 15924 codes) and <code>tblRegions</code>
+                            (~255 ISO 3166-1 codes + six M.49 area groupings)
+                            for the composite picker's typeahead. Idempotent
+                            — safe to re-run.
+                        </p>
+                        <a href="?action=ietf-bcp47-language" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
+                            Run IETF BCP 47 Language Migration
                         </a>
                     </div>
                 </div>

--- a/appWeb/public_html/manage/songbooks.php
+++ b/appWeb/public_html/manage/songbooks.php
@@ -301,6 +301,34 @@ $validateColour = function (string $c): ?string {
     return preg_match('/^#[0-9A-Fa-f]{6}$/', $c) ? null : 'Colour must be a #RRGGBB hex value (or blank).';
 };
 
+/**
+ * Validate an IETF BCP 47 language tag (#681). Empty is fine
+ * (NULL = "not specified" for songbooks). Otherwise must match
+ * the v1 grammar: lowercase 2-3 letter language, optional 4-letter
+ * Title Case script, optional 2-letter UPPER region or 3-digit
+ * numeric area code. Variants / extensions / private-use are out
+ * of scope for v1 per the issue brief.
+ *
+ * Returns null if valid (empty or matching), an error message
+ * string otherwise. Caller is responsible for calling mb_substr
+ * to cap to the column width regardless — the regex doesn't bound
+ * length on its own.
+ */
+$validateBcp47 = function (string $tag): ?string {
+    if ($tag === '') return null;
+    if (strlen($tag) > 35) {
+        return 'Language tag must be 35 characters or fewer.';
+    }
+    /* The full grammar of BCP 47 is much richer; this regex covers
+       the in-scope subset (#681). Anything beyond is rejected so a
+       tampered POST can't smuggle private-use subtags into a column
+       the rest of the system assumes is well-formed. */
+    if (!preg_match('/^[a-z]{2,3}(-[A-Z][a-z]{3})?(-[A-Z]{2}|-[0-9]{3})?$/', $tag)) {
+        return 'Language tag must be a valid IETF BCP 47 form (e.g. en, pt-BR, zh-Hans-CN).';
+    }
+    return null;
+};
+
 /* ----- POST actions ----- */
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!validateCsrf((string)($_POST['csrf_token'] ?? ''))) {
@@ -326,11 +354,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $pubYear    = trim((string)($_POST['publication_year'] ?? '')) ?: null;
                 $copyright  = trim((string)($_POST['copyright']        ?? '')) ?: null;
                 $affiliation= trim((string)($_POST['affiliation']      ?? '')) ?: null;
-                /* #673 — optional language. Empty selection saves as NULL.
-                   Capped to the column width so a tampered post can't
-                   blow up the INSERT. */
+                /* #673 / #681 — optional language. Empty selection saves
+                   as NULL. Now widened to 35 chars to fit a full IETF
+                   BCP 47 tag (lang[-Script][-Region]) and validated
+                   against the v1 grammar. */
                 $language   = trim((string)($_POST['language']         ?? '')) ?: null;
-                if ($language !== null) $language = mb_substr($language, 0, 10);
+                if ($language !== null) {
+                    $language = mb_substr($language, 0, 35);
+                    if ($e = $validateBcp47($language)) { $error = $e; break; }
+                }
 
                 /* #672 — bibliographic + authority-control identifiers.
                    All nullable, all VARCHAR. trim()→null normalises
@@ -449,9 +481,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $pubYear     = trim((string)($_POST['publication_year'] ?? '')) ?: null;
                 $copyright   = trim((string)($_POST['copyright']        ?? '')) ?: null;
                 $affiliation = trim((string)($_POST['affiliation']      ?? '')) ?: null;
-                /* #673 — optional language. */
+                /* #673 / #681 — optional language; full IETF BCP 47 tag. */
                 $language    = trim((string)($_POST['language']         ?? '')) ?: null;
-                if ($language !== null) $language = mb_substr($language, 0, 10);
+                if ($language !== null) {
+                    $language = mb_substr($language, 0, 35);
+                    if ($e = $validateBcp47($language)) { $error = $e; break; }
+                }
 
                 /* #672 — bibliographic + authority-control identifiers. */
                 $websiteUrl   = trim((string)($_POST['website_url']         ?? '')) ?: null;
@@ -1029,26 +1064,19 @@ $csrf = csrfToken();
                            placeholder="e.g. Seventh-day Adventist, Non-denominational">
                 </div>
             </div>
-            <!-- #673 — optional Language. Sourced from tblLanguages so a curator
-                 doesn't have to remember ISO 639-1 codes. Empty selection saves
-                 as NULL ("not specified") since many curated groupings span
-                 languages. -->
-            <div class="row g-2 mt-2">
-                <div class="col-sm-4">
-                    <label class="form-label small">Language (optional)</label>
-                    <select name="language" class="form-select form-select-sm">
-                        <option value="">— Not specified —</option>
-                        <?php foreach ($languages as $lang): ?>
-                            <option value="<?= htmlspecialchars($lang['Code']) ?>">
-                                <?= htmlspecialchars($lang['Name']) ?>
-                                <?php if ($lang['NativeName'] !== '' && $lang['NativeName'] !== $lang['Name']): ?>
-                                    (<?= htmlspecialchars($lang['NativeName']) ?>)
-                                <?php endif; ?>
-                            </option>
-                        <?php endforeach; ?>
-                    </select>
-                </div>
-            </div>
+            <!-- #681 — IETF BCP 47 composite picker. Replaces the
+                 single ISO 639-1 dropdown from #673. The shared
+                 partial under manage/includes/partials/ renders three
+                 inputs (Language, Script, Region) plus a hidden
+                 'language' field that holds the composed tag. -->
+            <?php
+                $idPrefix = 'create-songbook';
+                $name     = 'language';
+                $tag      = '';
+                $label    = 'Language (IETF BCP 47, optional)';
+                $help     = 'Empty = "not specified" (multi-lingual collection).';
+                require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'partials' . DIRECTORY_SEPARATOR . 'ietf-language-picker.php';
+            ?>
 
             <!-- #672 — collapsed by default; the create form already has 8 visible
                  fields and most curators don't need the bibliographic block on a
@@ -1212,26 +1240,18 @@ $csrf = csrfToken();
                             </div>
                         </div>
 
-                        <!-- #673 — optional Language. -->
-                        <div class="mb-3">
-                            <label class="form-label">Language (optional)</label>
-                            <select class="form-select" name="language" id="edit-language">
-                                <option value="">— Not specified —</option>
-                                <?php foreach ($languages as $lang): ?>
-                                    <option value="<?= htmlspecialchars($lang['Code']) ?>">
-                                        <?= htmlspecialchars($lang['Name']) ?>
-                                        <?php if ($lang['NativeName'] !== '' && $lang['NativeName'] !== $lang['Name']): ?>
-                                            (<?= htmlspecialchars($lang['NativeName']) ?>)
-                                        <?php endif; ?>
-                                    </option>
-                                <?php endforeach; ?>
-                            </select>
-                            <div class="form-text small">
-                                ISO 639-1 code, sourced from the active rows in
-                                <code>tblLanguages</code>. Leave blank for songbooks
-                                that span multiple languages.
-                            </div>
-                        </div>
+                        <!-- #681 — IETF BCP 47 composite picker (edit modal).
+                             Renders empty here; openEditModal() below calls
+                             editIetfPicker.setTag(row.language) on click to
+                             pre-fill the three inputs from the saved tag. -->
+                        <?php
+                            $idPrefix = 'edit-songbook';
+                            $name     = 'language';
+                            $tag      = '';
+                            $label    = 'Language (IETF BCP 47, optional)';
+                            $help     = 'Empty = "not specified" (multi-lingual collection).';
+                            require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'partials' . DIRECTORY_SEPARATOR . 'ietf-language-picker.php';
+                        ?>
 
                         <!-- #672 — collapsible "Online links" + "Authority identifiers".
                              Closed by default so the modal still opens at the same height
@@ -1397,12 +1417,15 @@ $csrf = csrfToken();
             document.getElementById('edit-copyright').value         = row.copyright        || '';
             document.getElementById('edit-affiliation').value       = row.affiliation      || '';
 
-            /* #673 — optional Language. The <select>'s value is set
-               directly; if the row's saved code isn't in the active
-               tblLanguages list the dropdown silently falls back to
-               "— Not specified —" (a deactivated language deserves a
-               curator's manual review, not a silent reset). */
-            document.getElementById('edit-language').value          = row.language         || '';
+            /* #681 — IETF BCP 47 composite picker. The picker's
+               setTag() decomposes the saved tag and pre-fills the
+               three inputs (with friendly names looked up from the
+               typeahead endpoints). Falls through silently if the
+               picker isn't booted yet — an empty saved tag opens
+               the modal with all three fields blank. */
+            if (typeof window.editIetfPicker?.setTag === 'function') {
+                window.editIetfPicker.setTag(row.language || '');
+            }
 
             /* #672 — bibliographic + authority-control identifiers. The
                row payload normalises every key to '' when the source
@@ -1439,6 +1462,19 @@ $csrf = csrfToken();
     <script type="module">
         import { bootSortableTables } from '/js/modules/admin-table-sort.js?v=<?= filemtime(dirname(__DIR__) . '/js/modules/admin-table-sort.js') ?>';
         bootSortableTables();
+    </script>
+
+    <!-- IETF BCP 47 composite language picker (#681). Boots the
+         create-form picker on page load (always blank initially)
+         and the edit-modal picker on first edit click — exposing
+         the latter as window.editIetfPicker so openEditModal() can
+         call setTag() with the row's saved tag. -->
+    <script type="module">
+        import { bootIetfLanguagePicker } from '/js/modules/ietf-language-picker.js?v=<?= filemtime(dirname(__DIR__) . '/js/modules/ietf-language-picker.js') ?>';
+        const createPicker = document.querySelector('[data-ietf-picker-id="create-songbook"]');
+        if (createPicker) bootIetfLanguagePicker(createPicker);
+        const editPicker   = document.querySelector('[data-ietf-picker-id="edit-songbook"]');
+        if (editPicker)   window.editIetfPicker = bootIetfLanguagePicker(editPicker);
     </script>
 
     <!-- Drag-and-drop reorder + Sort by Name/Abbr presets (#674).

--- a/appWeb/public_html/manage/songbooks.php
+++ b/appWeb/public_html/manage/songbooks.php
@@ -34,6 +34,144 @@ $error   = '';
 $success = '';
 $db      = getDbMysqli();
 
+/* ---- GET ?action=script_search&q=… (#681) ------------------------------
+ * JSON typeahead for the IETF BCP 47 picker's Script field. Matches
+ * substring (LIKE %q%) against tblScripts.Name OR tblScripts.Code so
+ * a curator can search either by friendly name ("Latin") or by ISO
+ * 15924 code ("Latn"). Empty query → empty list; pre-migration
+ * deployments → empty list with a `note` rather than a 500.
+ * ----------------------------------------------------------------------- */
+if (($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'GET'
+    && ($_GET['action'] ?? '') === 'script_search'
+) {
+    header('Content-Type: application/json; charset=UTF-8');
+    header('Cache-Control: no-store');
+    $q     = trim((string)($_GET['q'] ?? ''));
+    $limit = max(1, min(50, (int)($_GET['limit'] ?? 20)));
+    if ($q === '') {
+        echo json_encode(['suggestions' => []]);
+        exit;
+    }
+
+    $hasTable = false;
+    try {
+        $probe = $db->prepare(
+            "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+              WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tblScripts' LIMIT 1"
+        );
+        $probe->execute();
+        $hasTable = $probe->get_result()->fetch_row() !== null;
+        $probe->close();
+    } catch (\Throwable $e) {
+        error_log('[script_search] probe failed: ' . $e->getMessage());
+    }
+    if (!$hasTable) {
+        echo json_encode([
+            'suggestions' => [],
+            'note'        => 'tblScripts not yet created — run /manage/setup-database',
+        ]);
+        exit;
+    }
+
+    try {
+        $like = '%' . $q . '%';
+        $stmt = $db->prepare(
+            'SELECT Code AS code, Name AS name, NativeName AS nativeName
+               FROM tblScripts
+              WHERE IsActive = 1
+                AND (Name LIKE ? OR Code LIKE ?)
+              ORDER BY Name ASC
+              LIMIT ?'
+        );
+        $stmt->bind_param('ssi', $like, $like, $limit);
+        $stmt->execute();
+        $res = $stmt->get_result();
+        $suggestions = [];
+        while ($row = $res->fetch_assoc()) {
+            $suggestions[] = [
+                'code'       => (string)$row['code'],
+                'name'       => (string)$row['name'],
+                'nativeName' => (string)$row['nativeName'],
+            ];
+        }
+        $stmt->close();
+        echo json_encode(['suggestions' => $suggestions], JSON_UNESCAPED_UNICODE);
+    } catch (\Throwable $e) {
+        error_log('[script_search] ' . $e->getMessage());
+        http_response_code(500);
+        echo json_encode(['error' => 'Search failed.']);
+    }
+    exit;
+}
+
+/* ---- GET ?action=region_search&q=… (#681) ------------------------------
+ * Same shape as script_search, against tblRegions. Codes are
+ * uppercase ISO 3166-1 alpha-2 (or 3-digit M.49 numeric area codes
+ * for groupings like 419 = Latin America), so the typeahead matches
+ * either Name or Code as the user types.
+ * ----------------------------------------------------------------------- */
+if (($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'GET'
+    && ($_GET['action'] ?? '') === 'region_search'
+) {
+    header('Content-Type: application/json; charset=UTF-8');
+    header('Cache-Control: no-store');
+    $q     = trim((string)($_GET['q'] ?? ''));
+    $limit = max(1, min(50, (int)($_GET['limit'] ?? 20)));
+    if ($q === '') {
+        echo json_encode(['suggestions' => []]);
+        exit;
+    }
+
+    $hasTable = false;
+    try {
+        $probe = $db->prepare(
+            "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+              WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tblRegions' LIMIT 1"
+        );
+        $probe->execute();
+        $hasTable = $probe->get_result()->fetch_row() !== null;
+        $probe->close();
+    } catch (\Throwable $e) {
+        error_log('[region_search] probe failed: ' . $e->getMessage());
+    }
+    if (!$hasTable) {
+        echo json_encode([
+            'suggestions' => [],
+            'note'        => 'tblRegions not yet created — run /manage/setup-database',
+        ]);
+        exit;
+    }
+
+    try {
+        $like = '%' . $q . '%';
+        $stmt = $db->prepare(
+            'SELECT Code AS code, Name AS name
+               FROM tblRegions
+              WHERE IsActive = 1
+                AND (Name LIKE ? OR Code LIKE ?)
+              ORDER BY Name ASC
+              LIMIT ?'
+        );
+        $stmt->bind_param('ssi', $like, $like, $limit);
+        $stmt->execute();
+        $res = $stmt->get_result();
+        $suggestions = [];
+        while ($row = $res->fetch_assoc()) {
+            $suggestions[] = [
+                'code' => (string)$row['code'],
+                'name' => (string)$row['name'],
+            ];
+        }
+        $stmt->close();
+        echo json_encode(['suggestions' => $suggestions], JSON_UNESCAPED_UNICODE);
+    } catch (\Throwable $e) {
+        error_log('[region_search] ' . $e->getMessage());
+        http_response_code(500);
+        echo json_encode(['error' => 'Search failed.']);
+    }
+    exit;
+}
+
 /* ---- GET ?action=affiliation_search&q=… (#670) -------------------------
  * JSON typeahead endpoint for the Songbook edit modal's Affiliation
  * field. Returns up to `limit` matching rows from


### PR DESCRIPTION
## Summary

Implements IETF BCP 47 language tagging on the **songbook surface** — schema widening, two new reference tables, two typeahead endpoints, a reusable composite picker partial + its JS module, and integration into both the create form and the edit modal on `/manage/songbooks`.

The **song-editor surface** (`/manage/editor` per-song Metadata tab) is intentionally **deferred to a follow-up PR** — same pattern, different file, but `editor.js` is a large surface and shipping the songbook side in isolation lets it review + deploy + verify cleanly first. The reusable partial + JS module land here so the song-editor follow-up just plumbs the existing components into one more spot.

Closes #681.

## Six commits, one per concern

| # | Commit | What |
| --- | --- | --- |
| 1 | `schema:` | Widen 4 `Language` columns to VARCHAR(35); add `tblScripts` + `tblRegions` DDL |
| 2 | `chore(claude):` | Refresh `.claude/ProjectBrief.md` — version, table count, songbook list (was 3 weeks stale) |
| 3 | `migration:` | Idempotent runner + chunked-seed data file (28 ISO 15924 scripts + 255 ISO 3166-1 regions + 6 M.49 areas) |
| 4 | `chore(setup-database):` | Wire migration as card **3o** |
| 5 | `feat(songbooks):` | `script_search` + `region_search` typeahead endpoints |
| 6 | `feat(songbooks):` | Composite picker (partial + JS module) integrated into `/manage/songbooks` create form + edit modal, with server-side validation |

## What it looks like

The single `<select>` from #673 is replaced with a row of three text inputs:

```
🌐 Language (IETF BCP 47, optional)
[ Language ▾ ] [ Script ▾ ] [ Region ▾ ]
IETF tag: en-Latn-GB    Empty = "not specified" (multi-lingual collection).
```

Each input has its own `<datalist>` populated by the relevant typeahead. The hidden `<input name="language">` carries the composed tag (`en` / `pt-BR` / `zh-Hans-CN`) to the existing save handler.

## Server-side validation

New `$validateBcp47()` helper alongside `$validateAbbr` / `$validateColour`:

- Empty → null (NULL = "not specified", same as #673).
- Otherwise must match: `^[a-z]{2,3}(-[A-Z][a-z]{3})?(-[A-Z]{2}|-[0-9]{3})?$`
- Variants / extensions / private-use are out of scope for v1; rejected at the boundary so a tampered POST can't smuggle exotic subtags.

## Migration

After this lands on alpha + dev redeploys, run **card 3o "IETF BCP 47 language tagging"** on `/manage/setup-database`. The migration is idempotent — `[skip]` if already widened.

What it does:
- ALTER 4 Language columns to VARCHAR(35) (gated on `CHARACTER_MAXIMUM_LENGTH`).
- CREATE `tblScripts` + `tblRegions` (skip if exist).
- INSERT IGNORE 28 scripts + 255 regions in chunks of 30/50.

## Graceful degradation

- Typeahead endpoints unreachable → datalists stay empty; the user can still type a code directly into each input.
- Migration not yet run → `script_search` / `region_search` return `{suggestions: [], note: "tblScripts not yet created — run /manage/setup-database"}` rather than 500. The picker still works for the language subtag (since `tblLanguages` is older).
- Saved tags from #673 (plain ISO 639-1) decompose cleanly: `en` becomes `lang=en, script="", region=""`.

## Test plan

- [ ] Run migration card 3o on dev. Output: `[wide] tblSongbooks.Language → VARCHAR(35)` + 3 more `[wide]` lines + `[seed] tblScripts: 28 new row(s)` + `[seed] tblRegions: 255 new row(s)`. Re-run; every line `[skip]`.
- [ ] Open `/manage/songbooks`, click Edit on a row that has `Language = pt-BR`. Picker decomposes: Language="Portuguese", Script blank, Region="Brazil". `IETF tag: pt-BR` shows under the inputs.
- [ ] Type "United Kingdom" into Region while Language="English" → `IETF tag: en-GB`. Save. Re-open — still decomposes correctly.
- [ ] Type "Latin" into Script while Language="Serbian" + Region blank → `IETF tag: sr-Latn`. Save. Re-open — still decomposes.
- [ ] Tampered POST with `language=en-INVALID` → save handler rejects with the IETF validation error.
- [ ] Pre-migration check: temporarily drop `tblScripts` and confirm the page renders + the script input shows no suggestions; saving with just a Language still works.

## Out of scope (follow-ups already filed)

- **B6** (the song-editor surface) — same composite picker plumbed into `/manage/editor`'s Metadata tab. Tracked under #681 too; will ship as a focused PR once this lands and gets a verification pass.
- **Public API surface** — `/api?action=scripts` / `/api?action=regions` for native clients. Tracked in the post-batch hygiene #682.

🤖 Generated with [Claude Code](https://claude.com/claude-code)