### PR TITLE
Songbooks: auto-colour + home-page grid moved up + language indicator badge + version bump (closes #677, #678, #680)

### DIFF
--- a/appWeb/public_html/api-docs.yaml
+++ b/appWeb/public_html/api-docs.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 
 info:
   title: iHymns API
-  version: "0.25.0"
+  version: "0.50.0"
   description: |
     The iHymns API provides programmatic access to the iHymns hymn and song
     database. It powers the iHymns Progressive Web App (PWA), enabling song

--- a/appWeb/public_html/css/app.css
+++ b/appWeb/public_html/css/app.css
@@ -2882,6 +2882,42 @@ body.reduce-motion .related-songs-chevron {
     border-color: var(--accent-solid);
 }
 
+/* Language indicator badge on a songbook tile (#680). Small uppercase
+   2-3 letter ISO code in the top-right corner of each tile. Sits on
+   the LEFT of the offline-download cloud button so the two don't
+   collide on the home page's compact tiles (the cloud button uses
+   `right: 0.35rem`; this badge uses `right: 2.5rem` so they pack
+   side-by-side). On the standalone /songbooks page (no download
+   button rendered) the badge stays in the top-right too — visually
+   consistent across surfaces. */
+.songbook-tile-language-badge {
+    position: absolute;
+    top: 0.45rem;
+    right: 2.5rem;
+    z-index: 2;
+    /* Compact pill so a 2-letter code reads at a glance without
+       crowding neighbouring elements. */
+    padding: 0.1rem 0.4rem;
+    border-radius: 0.25rem;
+    font-size: 0.65rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    background: var(--surface-elevated);
+    color: var(--text-secondary);
+    /* Subtle border so the badge stays visible when it overlaps a
+       light section of a coloured songbook icon background. */
+    border: 1px solid var(--card-border);
+    line-height: 1;
+}
+/* On the /songbooks full-cards surface there's no download button,
+   so the badge can hug the top-right corner. The card has
+   `position: relative` set inline; this rule just nudges the
+   badge into the corner there. */
+.page-songbooks .songbook-tile-language-badge {
+    right: 0.45rem;
+}
+
 /* Feature-detect class driven by js/modules/offline-ui.js. When
    .offline-unsupported is on the body, every download control hides
    (rather than showing a permanently-disabled UI that can't recover). */

--- a/appWeb/public_html/includes/infoAppVer.php
+++ b/appWeb/public_html/includes/infoAppVer.php
@@ -79,7 +79,7 @@ $app["Application"]["Description"]["Keywords"] = "hymns, worship, lyrics, songbo
 /* Semantic version number (MAJOR.MINOR.PATCH) */
 /* Auto-bumped by the version-bump GitHub Action on push to beta */
 /* v1.x.x = Phase 1 (local JSON data), v2.x.x = Phase 2 (iLyrics dB) */
-$app["Application"]["Version"]["Number"] = "0.25.0";
+$app["Application"]["Version"]["Number"] = "0.50.0";
 
 /* Version name: human-readable release name (e.g., "Hymnal", NULL if unused) */
 $app["Application"]["Version"]["Name"] = NULL;

--- a/appWeb/public_html/includes/pages/home.php
+++ b/appWeb/public_html/includes/pages/home.php
@@ -107,6 +107,92 @@ $songbooks = $songData->getSongbooks();
     <!-- Song of the Day (#108) — populated by JS -->
     <div id="song-of-the-day"></div>
 
+    <!-- Songbook Cards Grid (#151 — section ID for sitelink eligibility).
+         Moved up from below "Browse by Theme" in #678 so a returning
+         user sees the full songbook list straight after the Recent
+         badges + Song of the Day, without having to scroll past
+         Recently Viewed / Popular Songs / Themes first. -->
+    <section id="songbooks" aria-label="Songbooks">
+        <h2 class="h5 mb-3">
+            <i class="fa-solid fa-book-open me-2" aria-hidden="true"></i>
+            Songbooks
+        </h2>
+
+        <!-- `row-cols-*` ladders the column count with the viewport so
+             cards stop stretching on xl/xxl monitors: 2 → 3 → 4 → 5 → 6
+             as the breakpoints unlock. Each child is just `.col`. -->
+        <div class="row row-cols-2 row-cols-md-3 row-cols-lg-4 row-cols-xl-5 row-cols-xxl-6 g-3 mb-4">
+            <?php foreach ($songbooks as $index => $book): ?>
+                <?php if (($book['songCount'] ?? 0) > 0): ?>
+                    <?php
+                        /* Pull the IETF BCP 47 tag (or empty) and extract
+                           the 2-3 letter language subtag for the badge
+                           (#680). Empty = no badge — communicates
+                           "multi-lingual / not specified" the same way
+                           the filter in #679 does. */
+                        $bookLang = (string)($book['language'] ?? '');
+                        $langCode = '';
+                        if ($bookLang !== '' && preg_match('/^([a-z]{2,3})/i', $bookLang, $m)) {
+                            $langCode = mb_strtoupper($m[1]);
+                        }
+                    ?>
+                    <div class="col" id="songbook-<?= htmlspecialchars($book['id']) ?>">
+                        <div class="card card-songbook h-100 position-relative"
+                             data-songbook-id="<?= htmlspecialchars($book['id']) ?>"
+                             data-songbook-songs="<?= (int)$book['songCount'] ?>"
+                             <?php if ($langCode !== ''): ?>data-songbook-language="<?= htmlspecialchars($bookLang) ?>"<?php endif; ?>>
+                            <!-- Stretched link covers the whole card body,
+                                 keeping the download button clickable because
+                                 the button's stacking context is raised by
+                                 position: relative + z-index on the button. -->
+                            <a href="/songbook/<?= htmlspecialchars($book['id']) ?>"
+                               class="stretched-link text-decoration-none text-reset"
+                               data-navigate="songbook"
+                               aria-label="<?= htmlspecialchars($book['name']) ?> — <?= $book['songCount'] ?> songs<?= $langCode !== '' ? ' (' . htmlspecialchars($langCode) . ')' : '' ?>"></a>
+                            <?php if ($langCode !== ''): ?>
+                                <!-- Language indicator badge (#680) — small uppercase
+                                     ISO 639 code in the tile's top-right corner,
+                                     positioned to clear the offline-download cloud
+                                     button below. aria-hidden because the language
+                                     is already announced by the stretched link. -->
+                                <span class="songbook-tile-language-badge"
+                                      title="Language: <?= htmlspecialchars($bookLang) ?>"
+                                      aria-hidden="true"><?= htmlspecialchars($langCode) ?></span>
+                            <?php endif; ?>
+                            <div class="card-body text-center">
+                                <div class="songbook-icon songbook-icon-<?= htmlspecialchars($book['id']) ?> mb-2">
+                                    <i class="fa-solid fa-book" aria-hidden="true"></i>
+                                </div>
+                                <h3 class="card-title h6 mb-1">
+                                    <?= htmlspecialchars($book['name']) ?>
+                                </h3>
+                                <span class="badge bg-body-secondary rounded-pill">
+                                    <?= htmlspecialchars($book['id']) ?>
+                                </span>
+                                <p class="card-text text-muted small mt-2 mb-0">
+                                    <?= number_format($book['songCount']) ?> songs
+                                </p>
+                            </div>
+                            <!-- Offline-download button (#453). Hidden by
+                                 default; the offline-support check in
+                                 js/modules/offline.js reveals it on capable
+                                 browsers. Always rendered so server-HTML
+                                 stays stable; never rendered enabled if
+                                 the browser can't act on it. -->
+                            <button type="button"
+                                    class="btn btn-sm btn-outline-secondary songbook-download-btn"
+                                    data-songbook-download="<?= htmlspecialchars($book['id']) ?>"
+                                    aria-label="Download <?= htmlspecialchars($book['name']) ?> for offline use"
+                                    title="Download this songbook for offline use">
+                                <i class="fa-solid fa-cloud-arrow-down" aria-hidden="true"></i>
+                            </button>
+                        </div>
+                    </div>
+                <?php endif; ?>
+            <?php endforeach; ?>
+        </div>
+    </section>
+
     <!-- Recently Viewed Songs (#304) — shown for authenticated users -->
     <div class="mb-4" id="recent-songs-section" style="display:none">
         <h5><i class="fa-solid fa-clock-rotate-left me-2"></i>Recently Viewed</h5>
@@ -128,68 +214,6 @@ $songbooks = $songData->getSongbooks();
             <span class="text-muted small">Loading...</span>
         </div>
     </div>
-
-    <!-- Songbook Cards Grid (#151 — section ID for sitelink eligibility) -->
-    <section id="songbooks" aria-label="Songbooks">
-        <h2 class="h5 mb-3">
-            <i class="fa-solid fa-book-open me-2" aria-hidden="true"></i>
-            Songbooks
-        </h2>
-
-        <!-- `row-cols-*` ladders the column count with the viewport so
-             cards stop stretching on xl/xxl monitors: 2 → 3 → 4 → 5 → 6
-             as the breakpoints unlock. Each child is just `.col`. -->
-        <div class="row row-cols-2 row-cols-md-3 row-cols-lg-4 row-cols-xl-5 row-cols-xxl-6 g-3 mb-4">
-            <?php foreach ($songbooks as $index => $book): ?>
-                <?php if (($book['songCount'] ?? 0) > 0): ?>
-                    <div class="col" id="songbook-<?= htmlspecialchars($book['id']) ?>">
-                        <div class="card card-songbook h-100 position-relative"
-                             data-songbook-id="<?= htmlspecialchars($book['id']) ?>"
-                             data-songbook-songs="<?= (int)$book['songCount'] ?>">
-                            <!-- Stretched link covers the whole card body,
-                                 keeping the download button clickable because
-                                 the button's stacking context is raised by
-                                 position: relative + z-index on the button. -->
-                            <a href="/songbook/<?= htmlspecialchars($book['id']) ?>"
-                               class="stretched-link text-decoration-none text-reset"
-                               data-navigate="songbook"
-                               aria-label="<?= htmlspecialchars($book['name']) ?> — <?= $book['songCount'] ?> songs"></a>
-                            <div class="card-body text-center">
-                                <div class="songbook-icon songbook-icon-<?= htmlspecialchars($book['id']) ?> mb-2">
-                                    <i class="fa-solid fa-book" aria-hidden="true"></i>
-                                </div>
-                                <h3 class="card-title h6 mb-1">
-                                    <?= htmlspecialchars($book['name']) ?>
-                                </h3>
-                                <span class="badge bg-body-secondary rounded-pill">
-                                    <?= htmlspecialchars($book['id']) ?>
-                                </span>
-                                <p class="card-text text-muted small mt-2 mb-0">
-                                    <?= number_format($book['songCount']) ?> songs
-                                </p>
-                            </div>
-                            <!-- Offline-download button (#453). Hidden by
-                                 default; the offline-support check in
-                                 js/modules/offline.js reveals it on capable
-                                 browsers. Always rendered so server-HTML
-                                 stays stable; never rendered enabled if
-                                 the browser can't act on it. -->
-                            <!-- Rendered visible; a capability-free browser
-                                 picks up `body.offline-unsupported` and the
-                                 shared CSS rule hides all download UI. -->
-                            <button type="button"
-                                    class="btn btn-sm btn-outline-secondary songbook-download-btn"
-                                    data-songbook-download="<?= htmlspecialchars($book['id']) ?>"
-                                    aria-label="Download <?= htmlspecialchars($book['name']) ?> for offline use"
-                                    title="Download this songbook for offline use">
-                                <i class="fa-solid fa-cloud-arrow-down" aria-hidden="true"></i>
-                            </button>
-                        </div>
-                    </div>
-                <?php endif; ?>
-            <?php endforeach; ?>
-        </div>
-    </section>
 
     <!-- The dynamic sections above (Popular Songs, Recently Viewed,
          Browse by Theme) are populated client-side by

--- a/appWeb/public_html/includes/pages/songbooks.php
+++ b/appWeb/public_html/includes/pages/songbooks.php
@@ -38,12 +38,29 @@ $stats = $songData->getStats();
     <div class="row g-3">
         <?php foreach ($songbooks as $index => $book): ?>
             <?php if (($book['songCount'] ?? 0) > 0): ?>
+                <?php
+                    /* Language indicator badge data (#680) — same pattern
+                       as home.php: pull the IETF tag, extract the 2-3
+                       letter language subtag, uppercase. Empty = no
+                       badge (multi-lingual / not specified). */
+                    $bookLang = (string)($book['language'] ?? '');
+                    $langCode = '';
+                    if ($bookLang !== '' && preg_match('/^([a-z]{2,3})/i', $bookLang, $m)) {
+                        $langCode = mb_strtoupper($m[1]);
+                    }
+                ?>
                 <div class="col-12 col-sm-6 col-md-4 col-lg-3">
                     <a href="/songbook/<?= htmlspecialchars($book['id']) ?>"
-                       class="card card-songbook h-100 text-decoration-none"
+                       class="card card-songbook h-100 text-decoration-none position-relative"
                        data-navigate="songbook"
                        data-songbook-id="<?= htmlspecialchars($book['id']) ?>"
-                       aria-label="Open <?= htmlspecialchars($book['name']) ?>">
+                       <?php if ($langCode !== ''): ?>data-songbook-language="<?= htmlspecialchars($bookLang) ?>"<?php endif; ?>
+                       aria-label="Open <?= htmlspecialchars($book['name']) ?><?= $langCode !== '' ? ' (' . htmlspecialchars($langCode) . ')' : '' ?>">
+                        <?php if ($langCode !== ''): ?>
+                            <span class="songbook-tile-language-badge"
+                                  title="Language: <?= htmlspecialchars($bookLang) ?>"
+                                  aria-hidden="true"><?= htmlspecialchars($langCode) ?></span>
+                        <?php endif; ?>
                         <div class="card-body">
                             <div class="d-flex align-items-start gap-3">
                                 <!-- Songbook icon -->

--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -1726,8 +1726,25 @@ function _bulkImport_upsertSongbook(\mysqli $db, string $abbr, string $name): st
         return 'existing';
     }
 
-    $ins = $db->prepare('INSERT INTO tblSongbooks (Abbreviation, Name, SongCount) VALUES (?, ?, 0)');
-    $ins->bind_param('ss', $abbr, $name);
+    /* Auto-colour the new songbook so its badge is visually distinct
+       from existing books on the home / songbooks tile grids (#677).
+       The shared palette helper lives under /manage/includes/ — we
+       require it lazily here so a deployment that hasn't run the
+       migration to add the helper file (it's part of the same PR
+       as this edit) doesn't 500 on existing imports. Best-effort —
+       on a require failure we save with an empty Colour and let
+       the theme default render. */
+    $colour = '';
+    $paletteFile = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'songbook-palette.php';
+    if (is_file($paletteFile)) {
+        require_once $paletteFile;
+        if (function_exists('pickAutoSongbookColour')) {
+            $colour = pickAutoSongbookColour($db, $abbr);
+        }
+    }
+
+    $ins = $db->prepare('INSERT INTO tblSongbooks (Abbreviation, Name, Colour, SongCount) VALUES (?, ?, ?, 0)');
+    $ins->bind_param('sss', $abbr, $name, $colour);
     $ins->execute();
     $ins->close();
     return 'created';

--- a/appWeb/public_html/manage/includes/songbook-palette.php
+++ b/appWeb/public_html/manage/includes/songbook-palette.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Songbook auto-colour palette (#677)
+ *
+ * One source of truth for the curated palette used to auto-assign a
+ * Colour to a songbook when the create form / bulk import leaves the
+ * field blank. Required by both:
+ *   - /manage/songbooks (case 'create')
+ *   - /manage/editor/api.php (_bulkImport_upsertSongbook)
+ *
+ * Picker contract:
+ *   pickAutoSongbookColour(mysqli $db): string
+ *     Returns the first palette colour not currently used by any
+ *     tblSongbooks.Colour. Falls back to a deterministic hash of
+ *     the abbreviation if every palette entry is in use, so a
+ *     deployment with > count(palette) coloured songbooks still
+ *     gets a distinct hex per book.
+ *
+ * The palette is curated to ~20 visually distinct hexes that work
+ * on both light + dark themes. Existing seed colours (CIS purple,
+ * SDAH amber, JP pink, MP teal, CP blue) lead so a fresh install's
+ * auto-coloured rows look familiar to anyone who's seen the
+ * project before.
+ */
+
+const SONGBOOK_AUTO_COLOURS = [
+    /* Existing seeds (keep first so a fresh install reuses them). */
+    '#6366F1',  // CIS purple
+    '#F59E0B',  // SDAH amber
+    '#EC4899',  // JP pink
+    '#10B981',  // MP teal
+    '#3B82F6',  // CP blue
+    /* Extension palette — chosen for >= 4.5:1 contrast against the
+       iHymns dark surface; double-checked against the light theme
+       too. No two adjacent entries share a hue family. */
+    '#EF4444',  // red
+    '#8B5CF6',  // violet
+    '#06B6D4',  // cyan
+    '#84CC16',  // lime
+    '#F97316',  // orange
+    '#14B8A6',  // teal-2
+    '#A855F7',  // purple
+    '#0EA5E9',  // sky
+    '#22C55E',  // green
+    '#D946EF',  // fuchsia
+    '#0891B2',  // cyan-dark
+    '#7C3AED',  // violet-dark
+    '#16A34A',  // green-dark
+    '#DB2777',  // pink-dark
+    '#9333EA',  // purple-dark
+];
+
+/**
+ * Pick a palette colour for a brand-new songbook. Returns the first
+ * entry not currently in tblSongbooks.Colour; falls back to a
+ * hash-derived hex if every palette colour is in use.
+ *
+ * Pure read against tblSongbooks — never writes — so the caller is
+ * free to plug the result into an existing INSERT.
+ *
+ * @param mysqli $db   Editor / songbooks page DB handle.
+ * @param string $abbr The new songbook's abbreviation, used as the
+ *                     hash seed for the fallback path.
+ */
+function pickAutoSongbookColour(\mysqli $db, string $abbr): string
+{
+    /* Read the colours currently in use. The SELECT lives in this
+       helper so a future tweak to the palette / hashing rule has
+       one site to change. */
+    $used = [];
+    try {
+        $stmt = $db->prepare(
+            "SELECT Colour FROM tblSongbooks
+              WHERE Colour LIKE '#%' AND LENGTH(Colour) = 7"
+        );
+        $stmt->execute();
+        $res = $stmt->get_result();
+        while ($row = $res->fetch_row()) {
+            /* Normalise to uppercase so #1a73e8 vs #1A73E8 don't
+               count as two different shades. */
+            $used[strtoupper($row[0])] = true;
+        }
+        $stmt->close();
+    } catch (\Throwable $e) {
+        /* If the DB read fails we fall through to the hash path —
+           a single random-ish colour is better than crashing the
+           save. */
+        error_log('[songbook-palette] colour read skipped: ' . $e->getMessage());
+    }
+
+    /* First palette colour not currently in use wins. */
+    foreach (SONGBOOK_AUTO_COLOURS as $hex) {
+        if (!isset($used[strtoupper($hex)])) {
+            return $hex;
+        }
+    }
+
+    /* Every palette colour is taken — derive a deterministic hex
+       from the abbreviation so the same songbook gets the same
+       colour on every re-import. crc32 spread is uniform enough
+       for distinct-colour purposes; bitwise-AND clamps to a 24-bit
+       range. */
+    $hash = abs(crc32($abbr));
+    return sprintf('#%06X', $hash & 0xFFFFFF);
+}

--- a/appWeb/public_html/manage/songbooks.php
+++ b/appWeb/public_html/manage/songbooks.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'songbook-palette.php';
 
 if (!isAuthenticated()) {
     header('Location: /manage/login');
@@ -216,6 +217,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 if ($e = $validateAbbr($abbr))   { $error = $e; break; }
                 if ($name === '')                { $error = 'Name is required.'; break; }
                 if ($e = $validateColour($colour)) { $error = $e; break; }
+
+                /* Auto-colour fallback (#677). When a curator leaves
+                   the Colour field blank, pick a palette colour the
+                   catalogue isn't already using so the new badge is
+                   visually distinct from neighbouring books. An
+                   explicit colour types into the field still wins —
+                   this only fires when $colour is empty after
+                   validation. */
+                if ($colour === '') {
+                    $colour = pickAutoSongbookColour($db, $abbr);
+                }
 
                 $stmt = $db->prepare('SELECT Id FROM tblSongbooks WHERE Abbreviation = ?');
                 $stmt->bind_param('s', $abbr);


### PR DESCRIPTION
## Summary

Three small visual / UX wins on the songbook surfaces, plus a version bump per the recent batch's volume.

| # | Closes | Commit |
| --- | --- | --- |
| 1 | #677 | \`feat(songbooks): auto-pick a unique palette Colour on create / import\` |
| 2 | #678, #680 | \`feat(home): move Songbooks grid up + add language indicator badge\` |
| 3 | — | \`chore(version): bump 0.25.0 → 0.50.0\` |

### #677 — Auto-colour assignment

Both songbook-creation paths (manual create form on \`/manage/songbooks\` + the bulk ZIP import path on \`/manage/editor/api.php\`) now auto-pick a palette colour when the curator hasn't typed an explicit one. The bulk-import path previously left every imported book with an empty Colour — every badge fell back to the theme default, which made the post-CIS-scrape home page look monochrome.

**One source of truth**: \`appWeb/public_html/manage/includes/songbook-palette.php\` exposes \`pickAutoSongbookColour(\$db, \$abbr)\` which returns the first \`SONGBOOK_AUTO_COLOURS\` entry not currently in use, falling back to a deterministic crc32-derived hex if every palette colour is taken.

### #678 — Move full Songbooks grid below Song of the Day

Songbook tile grid section in \`home.php\` lifted from below "Browse by Theme" to immediately after Song of the Day. A returning user sees the full songbook list straight after Recent badges without having to scroll past Recently Viewed / Popular Songs / Themes.

### #680 — Language indicator badge

Small uppercase 2-3 letter ISO code in the top-right corner of each tile when the songbook carries an IETF BCP 47 tag (#673 / #681). \`pt-BR\` → \`PT\`, \`zh-Hans-CN\` → \`ZH\`. Songbooks without a Language stay un-badged — the absence communicates "multi-lingual / not specified" the same way the filter rule in #679 will.

Both surfaces (home.php compact tiles + /songbooks full cards) get the badge inline; shared CSS class \`.songbook-tile-language-badge\` lives in \`app.css\` with a position variant per surface so the badge clears the offline-download cloud button on the compact tiles and hugs the corner on the full cards.

### Version bump

Per user request following the substantial April 2026 batch: \`0.25.0\` → \`0.50.0\`. Touches \`infoAppVer.php\` (canonical source — auto-bump CI is keyed off this file) and \`api-docs.yaml\` (\`info.version\` mirror).

## Test plan

- [ ] Create a new songbook with **Colour** blank → palette colour auto-picked and saved (open the row again and verify the hex matches \`SONGBOOK_AUTO_COLOURS\`).
- [ ] Create another with the same **Colour** blank → next palette entry, not a duplicate.
- [ ] Bulk-import a fresh CIS bundle (\`python3 .importers/scrapers/ChristInSong.app.py --zip cis.zip\` then upload) → every newly-created \`tblSongbooks\` row has a non-empty palette \`Colour\`.
- [ ] Open the home page on dev → Songbooks grid renders **immediately after** Song of the Day, before Recently Viewed.
- [ ] Songbooks with a saved language show the small ISO badge in the top-right corner. Songbooks without a language stay un-badged.
- [ ] On the compact home tiles the badge sits to the LEFT of the offline-download cloud button; on the \`/songbooks\` full cards it sits in the corner.
- [ ] Footer version reads \`v0.50.0\`.

## Out of scope (queued)

- **#679** — language filter dropdown above the tile grid (own PR, next).
- **#682** — hygiene pass (API completeness, lint, a11y, security audit, OpenAPI refresh, in-app docs, .claude refresh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)