### PR TITLE
Editor: consolidate IETF picker onto shared partial (closes #687)

### DIFF
--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -520,12 +520,15 @@ function selectSong(songId) {
     setVal('edit-ccli', song.ccli || '');
     setVal('edit-iswc', song.iswc || '');            /* #497 */
     setVal('edit-tune-name', song.tuneName || '');   /* #497 */
-    /* Parse IETF BCP 47 tag into sub-fields (#240). */
-    var ietf = parseIetfTag(song.language || 'en');
-    setVal('edit-lang-language', ietf.language);
-    setVal('edit-lang-script', ietf.script);
-    setVal('edit-lang-region', ietf.region);
-    composeIetfTag();
+    /* Hand the saved IETF BCP 47 tag to the shared picker (#687). The
+       picker is booted by the module script in index.php and stashed
+       on window.editSongIetfPicker; setTag() decomposes the tag,
+       resolves the codes against the live tblScripts / tblRegions
+       endpoints, and writes the composed tag back to the hidden
+       #edit-language field. */
+    if (window.editSongIetfPicker && typeof window.editSongIetfPicker.setTag === 'function') {
+        window.editSongIetfPicker.setTag(song.language || 'en');
+    }
 
     /* Populate the boolean checkboxes (#222, #225). */
     setChecked('edit-verified', !!song.verified);
@@ -654,23 +657,28 @@ function bindMetadataListeners() {
         });
     });
 
-    /* Language sub-fields — compose IETF BCP 47 tag on change (#240). */
-    ['edit-lang-language', 'edit-lang-script', 'edit-lang-region'].forEach(function (elId) {
-        var el = document.getElementById(elId);
-        if (!el) return;
-
-        ['input', 'change'].forEach(function (eventType) {
-            el.addEventListener(eventType, function () {
-                if (!currentSongId) return;
-                var song = findSongById(currentSongId);
-                if (!song) return;
-
-                /* Compose the three fields into a single IETF tag and store it. */
-                song.language = composeIetfTag();
-                markModified(song.id);
-            });
+    /* Language picker (#687) — the shared module composes the tag and
+       writes it into the hidden #edit-language field on every change.
+       We just watch that one hidden field and propagate to song.language.
+       Listening on the wrapper's three visible inputs gives us the
+       compose-on-blur behaviour the picker provides; listening on the
+       hidden field would only fire if some external code set its value
+       directly. */
+    var pickerRoot = document.querySelector('.ietf-picker[data-ietf-picker-id="edit-song"]');
+    if (pickerRoot) {
+        var commitLanguage = function () {
+            if (!currentSongId) return;
+            var song = findSongById(currentSongId);
+            if (!song) return;
+            var hidden = document.getElementById('edit-language');
+            if (!hidden) return;
+            song.language = hidden.value || 'en';
+            markModified(song.id);
+        };
+        ['input', 'change', 'blur'].forEach(function (eventType) {
+            pickerRoot.addEventListener(eventType, commitLanguage, true);
         });
-    });
+    }
 }
 
 /* ========================================================================
@@ -2956,163 +2964,6 @@ function setChecked(elementId, checked) {
     }
 }
 
-/* ----------------------------------------------------------------------
- * Language / Script / Region lookup tables (#489)
- *
- * The editor's three language inputs now display **full names** by
- * default — the average admin doesn't know that "Latn" is Latin or
- * that "cy" is Welsh. Each table is keyed by ISO code (which is what
- * MySQL actually stores, as part of the composed IETF BCP 47 tag) and
- * maps to the human-friendly name shown in the input.
- *
- * Keep in lock-step with the <datalist> options in index.php — an
- * option in the markup but absent from this table would resolve back
- * to its code on save (harmless but uglier).
- * ---------------------------------------------------------------------- */
-var LANG_CODE_TO_NAME = {
-    en:'English', fr:'French', de:'German', es:'Spanish', it:'Italian',
-    pt:'Portuguese', la:'Latin', cy:'Welsh', gd:'Scottish Gaelic',
-    ga:'Irish', nl:'Dutch', sv:'Swedish', no:'Norwegian', da:'Danish',
-    fi:'Finnish', pl:'Polish', cs:'Czech', hu:'Hungarian', ro:'Romanian',
-    ko:'Korean', ja:'Japanese', zh:'Chinese', ar:'Arabic', he:'Hebrew',
-    hi:'Hindi', sw:'Swahili', zu:'Zulu', xh:'Xhosa', af:'Afrikaans',
-    tl:'Tagalog',
-};
-var SCRIPT_CODE_TO_NAME = {
-    Latn:'Latin', Cyrl:'Cyrillic', Arab:'Arabic', Hebr:'Hebrew',
-    Deva:'Devanagari', Hans:'Simplified Chinese', Hant:'Traditional Chinese',
-    Hang:'Hangul', Kana:'Katakana', Grek:'Greek', Geor:'Georgian',
-    Armn:'Armenian', Thai:'Thai', Ethi:'Ethiopic',
-};
-var REGION_CODE_TO_NAME = {
-    GB:'United Kingdom', US:'United States', AU:'Australia', NZ:'New Zealand',
-    CA:'Canada', IE:'Ireland', ZA:'South Africa', FR:'France', DE:'Germany',
-    AT:'Austria', CH:'Switzerland', ES:'Spain', MX:'Mexico', IT:'Italy',
-    PT:'Portugal', BR:'Brazil', NL:'Netherlands', SE:'Sweden', NO:'Norway',
-    DK:'Denmark', FI:'Finland', PL:'Poland', CZ:'Czechia', HU:'Hungary',
-    RO:'Romania', KR:'South Korea', JP:'Japan', CN:'China', TW:'Taiwan',
-    IN:'India', PH:'Philippines', KE:'Kenya', NG:'Nigeria', GH:'Ghana',
-};
-
-/* Pre-compute reverse maps (lowercased name → code) for lookup. */
-var _LANG_NAME_TO_CODE = _flipLangMap(LANG_CODE_TO_NAME);
-var _SCRIPT_NAME_TO_CODE = _flipLangMap(SCRIPT_CODE_TO_NAME);
-var _REGION_NAME_TO_CODE = _flipLangMap(REGION_CODE_TO_NAME);
-
-function _flipLangMap(src) {
-    var out = {};
-    Object.keys(src).forEach(function (code) {
-        out[src[code].toLowerCase()] = code;
-    });
-    return out;
-}
-
-/**
- * Resolve a free-text input value to its canonical ISO code.
- * Accepts either the full name ("English", case-insensitive) or the
- * bare code ("en"). Returns the input unchanged if it can't be
- * resolved — we don't want to silently discard a value the admin
- * deliberately typed for a language we don't yet list.
- *
- * @param {string} value   Raw value from a language/script/region input
- * @param {"language"|"script"|"region"} dim
- * @returns {string} ISO code (or original value if not recognised)
- */
-function resolveLangCode(value, dim) {
-    var v = (value || '').trim();
-    if (!v) return '';
-    var lower = v.toLowerCase();
-    var nameMap = dim === 'language' ? _LANG_NAME_TO_CODE
-                : dim === 'script'   ? _SCRIPT_NAME_TO_CODE
-                : dim === 'region'   ? _REGION_NAME_TO_CODE
-                : {};
-    if (nameMap[lower] != null) return nameMap[lower];
-
-    /* Fall through to code-normalisation. The datalist no longer
-       offers raw codes, but power users may still type them. */
-    if (dim === 'language') return lower.toLowerCase();
-    if (dim === 'region')   return v.toUpperCase();
-    if (dim === 'script') {
-        return v.length > 0
-            ? v.charAt(0).toUpperCase() + v.slice(1).toLowerCase()
-            : '';
-    }
-    return v;
-}
-
-/**
- * Convert an ISO code back to its full display name, falling back to
- * the code itself (useful for inputs populated from existing songs
- * with codes the lookup table doesn't yet know).
- */
-function resolveLangName(code, dim) {
-    var map = dim === 'language' ? LANG_CODE_TO_NAME
-            : dim === 'script'   ? SCRIPT_CODE_TO_NAME
-            : dim === 'region'   ? REGION_CODE_TO_NAME
-            : {};
-    return map[code] != null ? map[code] : (code || '');
-}
-
-/**
- * parseIetfTag(tag)
- * -----------------
- * Splits an IETF BCP 47 language tag into its constituent parts,
- * mapping each code to its human-friendly display name (#489). The
- * returned values are what the three editor inputs should show.
- *
- * @param {string} tag - e.g. "en", "en-GB", "zh-Hant-TW"
- * @returns {{ language: string, script: string, region: string }}
- *          display names (e.g. "English", "Latin", "United Kingdom")
- */
-function parseIetfTag(tag) {
-    var parts = (tag || 'en').split('-');
-    var langCode = parts[0] || 'en';
-    var scriptCode = '';
-    var regionCode = '';
-
-    for (var i = 1; i < parts.length; i++) {
-        var p = parts[i];
-        if (p.length === 4 && /^[A-Z][a-z]{3}$/.test(p)) {
-            scriptCode = p;
-        } else if (p.length === 2 && /^[A-Z]{2}$/.test(p)) {
-            regionCode = p;
-        }
-    }
-
-    return {
-        language: resolveLangName(langCode,  'language'),
-        script:   resolveLangName(scriptCode,'script'),
-        region:   resolveLangName(regionCode,'region'),
-    };
-}
-
-/**
- * composeIetfTag()
- * ----------------
- * Reads the three language sub-fields from the DOM (which carry full
- * names after #489), resolves each back to an ISO code, and composes
- * the IETF BCP 47 tag. Updates the hidden edit-language field and
- * the preview element.
- *
- * @returns {string} The composed IETF tag (e.g. "en-Latn-GB")
- */
-function composeIetfTag() {
-    var langCode   = resolveLangCode(getVal('edit-lang-language'), 'language') || 'en';
-    var scriptCode = resolveLangCode(getVal('edit-lang-script'),   'script');
-    var regionCode = resolveLangCode(getVal('edit-lang-region'),   'region');
-
-    var tag = langCode;
-    if (scriptCode) tag += '-' + scriptCode;
-    if (regionCode) tag += '-' + regionCode;
-
-    /* Update the hidden field and preview. */
-    setVal('edit-language', tag);
-    var preview = document.getElementById('edit-lang-preview');
-    if (preview) preview.textContent = tag;
-
-    return tag;
-}
-
 /**
  * getVal(elementId)
  * -----------------
@@ -3263,11 +3114,11 @@ function clearEditForm() {
     setVal('edit-ccli', '');
     setVal('edit-iswc', '');           /* #497 */
     setVal('edit-tune-name', '');      /* #497 */
-    /* Default to the display name not the raw code (#489). */
-    setVal('edit-lang-language', resolveLangName('en', 'language'));
-    setVal('edit-lang-script', '');
-    setVal('edit-lang-region', '');
-    composeIetfTag();
+    /* Reset the IETF picker to a blank state (#687). The shared module
+       resolves "" → empty inputs and a "—" preview. */
+    if (window.editSongIetfPicker && typeof window.editSongIetfPicker.setTag === 'function') {
+        window.editSongIetfPicker.setTag('');
+    }
     setVal('edit-copyright', '');
 
     /* Clear boolean checkboxes (#222, #225). */

--- a/appWeb/public_html/manage/editor/index.php
+++ b/appWeb/public_html/manage/editor/index.php
@@ -599,124 +599,25 @@ $currentUser = getCurrentUser();
                             </div>
                         </div>
 
-                        <!-- Language — IETF BCP 47 composed from Language + Script + Region (#240) -->
-                        <div class="mb-3">
-                            <label class="form-label"><i class="bi bi-translate me-1"></i>Language (IETF BCP 47)</label>
-                            <div class="row g-2">
-                                <!-- Language (required) — shows full names (#489).
-                                     Datalist values are full names; editor.js resolves
-                                     them to ISO 639 codes when composing the IETF tag. -->
-                                <div class="col-4">
-                                    <label for="edit-lang-language" class="form-label" style="font-size:0.75rem;">Language</label>
-                                    <input type="text" class="form-control form-control-sm" id="edit-lang-language"
-                                        placeholder="e.g. English" list="lang-language-list" required>
-                                    <datalist id="lang-language-list">
-                                        <option value="English">en</option>
-                                        <option value="French">fr</option>
-                                        <option value="German">de</option>
-                                        <option value="Spanish">es</option>
-                                        <option value="Italian">it</option>
-                                        <option value="Portuguese">pt</option>
-                                        <option value="Latin">la</option>
-                                        <option value="Welsh">cy</option>
-                                        <option value="Scottish Gaelic">gd</option>
-                                        <option value="Irish">ga</option>
-                                        <option value="Dutch">nl</option>
-                                        <option value="Swedish">sv</option>
-                                        <option value="Norwegian">no</option>
-                                        <option value="Danish">da</option>
-                                        <option value="Finnish">fi</option>
-                                        <option value="Polish">pl</option>
-                                        <option value="Czech">cs</option>
-                                        <option value="Hungarian">hu</option>
-                                        <option value="Romanian">ro</option>
-                                        <option value="Korean">ko</option>
-                                        <option value="Japanese">ja</option>
-                                        <option value="Chinese">zh</option>
-                                        <option value="Arabic">ar</option>
-                                        <option value="Hebrew">he</option>
-                                        <option value="Hindi">hi</option>
-                                        <option value="Swahili">sw</option>
-                                        <option value="Zulu">zu</option>
-                                        <option value="Xhosa">xh</option>
-                                        <option value="Afrikaans">af</option>
-                                        <option value="Tagalog">tl</option>
-                                    </datalist>
-                                </div>
-                                <!-- Script (optional) — full names (#489) -->
-                                <div class="col-4">
-                                    <label for="edit-lang-script" class="form-label" style="font-size:0.75rem;">Script</label>
-                                    <input type="text" class="form-control form-control-sm" id="edit-lang-script"
-                                        placeholder="e.g. Latin" list="lang-script-list">
-                                    <datalist id="lang-script-list">
-                                        <option value="Latin">Latn</option>
-                                        <option value="Cyrillic">Cyrl</option>
-                                        <option value="Arabic">Arab</option>
-                                        <option value="Hebrew">Hebr</option>
-                                        <option value="Devanagari">Deva</option>
-                                        <option value="Simplified Chinese">Hans</option>
-                                        <option value="Traditional Chinese">Hant</option>
-                                        <option value="Hangul">Hang</option>
-                                        <option value="Katakana">Kana</option>
-                                        <option value="Greek">Grek</option>
-                                        <option value="Georgian">Geor</option>
-                                        <option value="Armenian">Armn</option>
-                                        <option value="Thai">Thai</option>
-                                        <option value="Ethiopic">Ethi</option>
-                                    </datalist>
-                                </div>
-                                <!-- Region (optional) — full names (#489) -->
-                                <div class="col-4">
-                                    <label for="edit-lang-region" class="form-label" style="font-size:0.75rem;">Region</label>
-                                    <input type="text" class="form-control form-control-sm" id="edit-lang-region"
-                                        placeholder="e.g. United Kingdom" list="lang-region-list">
-                                    <datalist id="lang-region-list">
-                                        <option value="United Kingdom">GB</option>
-                                        <option value="United States">US</option>
-                                        <option value="Australia">AU</option>
-                                        <option value="New Zealand">NZ</option>
-                                        <option value="Canada">CA</option>
-                                        <option value="Ireland">IE</option>
-                                        <option value="South Africa">ZA</option>
-                                        <option value="France">FR</option>
-                                        <option value="Germany">DE</option>
-                                        <option value="Austria">AT</option>
-                                        <option value="Switzerland">CH</option>
-                                        <option value="Spain">ES</option>
-                                        <option value="Mexico">MX</option>
-                                        <option value="Italy">IT</option>
-                                        <option value="Portugal">PT</option>
-                                        <option value="Brazil">BR</option>
-                                        <option value="Netherlands">NL</option>
-                                        <option value="Sweden">SE</option>
-                                        <option value="Norway">NO</option>
-                                        <option value="Denmark">DK</option>
-                                        <option value="Finland">FI</option>
-                                        <option value="Poland">PL</option>
-                                        <option value="Czechia">CZ</option>
-                                        <option value="Hungary">HU</option>
-                                        <option value="Romania">RO</option>
-                                        <option value="South Korea">KR</option>
-                                        <option value="Japan">JP</option>
-                                        <option value="China">CN</option>
-                                        <option value="Taiwan">TW</option>
-                                        <option value="India">IN</option>
-                                        <option value="Philippines">PH</option>
-                                        <option value="Kenya">KE</option>
-                                        <option value="Nigeria">NG</option>
-                                        <option value="Ghana">GH</option>
-                                    </datalist>
-                                </div>
-                            </div>
-                            <!-- Composed IETF tag preview -->
-                            <div class="mt-1 d-flex align-items-center gap-2">
-                                <span class="form-text" style="color: var(--ih-text-muted); font-size: 0.75rem;">
-                                    IETF tag:
-                                </span>
-                                <code id="edit-lang-preview" style="font-size: 0.8rem;">en</code>
-                                <input type="hidden" id="edit-language">
-                            </div>
-                        </div>
+                        <!-- Language — IETF BCP 47 picker (shared with /manage/songbooks
+                             via the partial introduced by #685). The hidden output gets a
+                             stable id="edit-language" so editor.js can read the composed
+                             tag via getElementById without going through a form POST.
+                             Closes #687 — the editor's inline copy of the picker has been
+                             removed in favour of this single source of truth, so curators
+                             see the same vocabulary (live tblScripts + tblRegions, ~28 +
+                             ~255 entries) on both surfaces. -->
+                        <?php
+                            $idPrefix = 'edit-song';
+                            $name     = 'language';
+                            $tag      = '';
+                            $outputId = 'edit-language';
+                            require dirname(__DIR__) . DIRECTORY_SEPARATOR
+                                . 'includes' . DIRECTORY_SEPARATOR
+                                . 'partials' . DIRECTORY_SEPARATOR
+                                . 'ietf-language-picker.php';
+                            unset($idPrefix, $name, $tag, $outputId);
+                        ?>
 
                         <!-- Status & Copyright Flags (#222, #225) -->
                         <hr style="border-color: var(--ih-border);">
@@ -1435,6 +1336,27 @@ $currentUser = getCurrentUser();
     <!-- Editor JavaScript — all interactive logic (loading, saving, editing, previewing)
          is handled in this separate file to keep concerns separated -->
     <script src="editor.js"></script>
+
+    <!-- IETF BCP 47 picker boot (#687). The shared module is the same one
+         that powers /manage/songbooks. We expose the booted instance on
+         window.editSongIetfPicker so editor.js (a classic script that
+         can't `import`) can call setTag()/getTag() on it. The module is
+         auto-deferred, so it executes after editor.js but before
+         DOMContentLoaded — which means by the time editor.js's init()
+         fires (on DOMContentLoaded) and starts loading songs into the
+         form, the picker is already booted. -->
+    <?php
+        $_ietfModulePath = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'js' . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR . 'ietf-language-picker.js';
+        $_ietfModuleVersion = is_file($_ietfModulePath) ? (string)filemtime($_ietfModulePath) : '1';
+    ?>
+    <script type="module">
+        import { bootIetfLanguagePicker }
+            from '/js/modules/ietf-language-picker.js?v=<?= htmlspecialchars($_ietfModuleVersion, ENT_QUOTES) ?>';
+        const root = document.querySelector('.ietf-picker[data-ietf-picker-id="edit-song"]');
+        if (root) {
+            window.editSongIetfPicker = bootIetfLanguagePicker(root);
+        }
+    </script>
 
     <!-- ============================================================
          Find Missing Numbers modal (#285)

--- a/appWeb/public_html/manage/includes/partials/ietf-language-picker.php
+++ b/appWeb/public_html/manage/includes/partials/ietf-language-picker.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
  *     $tag      = 'pt-BR';                 // saved BCP 47 tag (or empty)
  *     $label    = 'Language (IETF BCP 47)'; // optional override
  *     $help     = '';                      // optional sub-label hint
+ *     $outputId = 'edit-language';         // optional id="" on the hidden output
  *     require __DIR__ . '/includes/partials/ietf-language-picker.php';
  *   ?>
  *
@@ -26,6 +27,11 @@ declare(strict_types=1);
  * The PHP side just emits the markup + the saved tag; the JS module
  * decomposes it on boot, queries the typeaheads, and writes the
  * composed tag back into the hidden field on every input change.
+ *
+ * $outputId (optional): legacy callers — the song editor uses a
+ * non-form save flow that reads the composed tag via getElementById,
+ * so the hidden output needs a stable id. Form-POST callers leave
+ * this blank and lookup-by-name suffices.
  */
 
 /* Defensive defaults — if the caller forgot to set any of these,
@@ -35,6 +41,11 @@ $name     = isset($name)     ? (string)$name     : 'language';
 $tag      = isset($tag)      ? (string)$tag      : '';
 $label    = isset($label)    ? (string)$label    : 'Language (IETF BCP 47)';
 $help     = isset($help)     ? (string)$help     : 'Optional. Pick a language; add a script (Latin / Cyrillic / …) or region (United Kingdom / Brazil / …) only if it differs from the default.';
+$outputId = isset($outputId) ? (string)$outputId : '';
+
+/* Sanitise the output id with the same rule as the prefix so a
+   typo can't produce broken HTML. Empty stays empty. */
+$outputIdSafe = $outputId !== '' ? preg_replace('/[^A-Za-z0-9_-]/', '-', $outputId) : '';
 
 /* Sanitise the id so a future caller passing "edit modal" doesn't
    produce broken HTML. Strip everything but [a-z0-9-]. */
@@ -94,6 +105,7 @@ $idSafe = preg_replace('/[^a-z0-9-]/i', '-', $idPrefix);
 
     <input type="hidden"
            class="ietf-tag-output"
+           <?php if ($outputIdSafe !== ''): ?>id="<?= htmlspecialchars($outputIdSafe, ENT_QUOTES, 'UTF-8') ?>"<?php endif; ?>
            name="<?= htmlspecialchars($name, ENT_QUOTES, 'UTF-8') ?>"
            value="<?= htmlspecialchars($tag, ENT_QUOTES, 'UTF-8') ?>">
 


### PR DESCRIPTION
## Summary

Closes #687. Removes the song editor's inline IETF BCP 47 picker (introduced way back in #240 / #489) and points it at the shared partial + module that already power the songbook editor. Curators now see the same UI, the same vocabulary, and the same compose/decompose semantics on both \`/manage/editor\` and \`/manage/songbooks\`.

The shared sources are live from \`tblScripts\` (~28 entries) and \`tblRegions\` (~255 entries), seeded by migration card 3o, so the editor goes from a hand-curated 30-language / 14-script / 33-region subset to the full ISO 15924 / ISO 3166-1 catalogue.

## What changed

| File | Before | After |
|------|--------|-------|
| \`partials/ietf-language-picker.php\` | hidden output had no \`id\` | optional \`\$outputId\` param emits \`id=\"\"\` for non-form callers |
| \`editor/index.php\` | 117-line inline markup (3 \<input\>+\<datalist\> + helper trio) | one \`require\` of the partial + a small module boot script |
| \`editor.js\` | \`composeIetfTag\` + \`parseIetfTag\` + \`resolveLangCode\` + \`resolveLangName\` + \`_flipLangMap\` + 3 lookup tables (~210 LoC) | gone — replaced by \`window.editSongIetfPicker.setTag()\` / \`getTag()\` calls |

Net diff: **+87 / −302** (–215 lines). One source of truth for the picker, end-to-end.

## Test plan

- [ ] Open \`/manage/editor\`; confirm the picker renders the same as on \`/manage/songbooks\` (column widths, label, IETF preview).
- [ ] Load a song with \`language=\"en\"\` — Language=\"English\", Script empty, Region empty.
- [ ] Load a song with \`language=\"pt-BR\"\` — Language=\"Portuguese\", Script empty, Region=\"Brazil\".
- [ ] Load a song with \`language=\"zh-Hans\"\` — Language=\"Chinese\", Script=\"Simplified Chinese\" (Hans), Region empty.
- [ ] Type into Language → Script → Region; confirm the IETF tag preview updates and the hidden \`#edit-language\` carries the composed tag.
- [ ] Save a modified song; confirm \`song.language\` round-trips through the existing \`save_song\` endpoint and the new server-side validator (#681 / PR #686) accepts the tag.
- [ ] Auto-save: edit a language sub-field → wait the debounce → confirm the save fires with the new composed tag.
- [ ] Switch songs (load a different language) and back; confirm the picker re-decomposes correctly without leaking state.
- [ ] No JS console errors on the editor page (the module script must boot before any song is loaded — it does, because module scripts are deferred).

## Migrations

None. The partial / module already exist on alpha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)