### PR TITLE
Hygiene pass — security + API completeness + OpenAPI + in-app docs (refs #682)

### DIFF
--- a/appWeb/public_html/api-docs.yaml
+++ b/appWeb/public_html/api-docs.yaml
@@ -637,6 +637,99 @@ paths:
                     nativeName: "Fran\u00E7ais"
                     textDirection: ltr
 
+  /api.php?action=scripts:
+    get:
+      operationId: listScripts
+      tags: [Languages]
+      summary: List available IETF BCP 47 scripts (#681 / #682)
+      description: |
+        Returns all active rows from `tblScripts` (ISO 15924). Used by
+        the IETF composite picker on the web admin and by native
+        clients that need to resolve a saved tag like `zh-Hans` into a
+        human-readable name.
+
+        Pre-migration deployments (where `tblScripts` doesn't exist
+        yet) get an empty list and a `note` field rather than a 500.
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema:
+            type: string
+            enum: [scripts]
+      responses:
+        "200":
+          description: Script list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  scripts:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Script"
+                  note:
+                    type: string
+                    description: Present only when the lookup table has not yet been created.
+              example:
+                scripts:
+                  - code: Latn
+                    name: Latin
+                    nativeName: Latin
+                  - code: Cyrl
+                    name: Cyrillic
+                    nativeName: "\u041A\u0438\u0440\u0438\u043B\u043B\u0438\u0446\u0430"
+                  - code: Hans
+                    name: Simplified Chinese
+                    nativeName: "\u7B80\u4F53\u5B57"
+
+  /api.php?action=regions:
+    get:
+      operationId: listRegions
+      tags: [Languages]
+      summary: List available IETF BCP 47 regions (#681 / #682)
+      description: |
+        Returns all active rows from `tblRegions` \u2014 ISO 3166-1 alpha-2
+        country codes plus M.49 numeric area codes for groupings like
+        `419` (Latin America & Caribbean). Same use case as
+        `action=scripts`: resolve a saved IETF tag's region subtag to
+        a human-readable name.
+
+        Pre-migration deployments get an empty list with a `note`.
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema:
+            type: string
+            enum: [regions]
+      responses:
+        "200":
+          description: Region list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  regions:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Region"
+                  note:
+                    type: string
+                    description: Present only when the lookup table has not yet been created.
+              example:
+                regions:
+                  - code: GB
+                    name: United Kingdom
+                  - code: US
+                    name: United States
+                  - code: BR
+                    name: Brazil
+                  - code: "419"
+                    name: Latin America and the Caribbean
+
   /api.php?action=song_translations:
     get:
       operationId: getSongTranslations
@@ -4848,7 +4941,14 @@ components:
 
     Songbook:
       type: object
-      description: A songbook / hymnal
+      description: |
+        A songbook / hymnal. The bibliographic + authority-control
+        fields (`websiteUrl` … `lcClass`) and `language` were added
+        across #672 / #673 / #681. They appear on every read path
+        whose backing `tblSongbooks` deployment has run the matching
+        migrations (`migrate-songbook-bibliographic` and
+        `migrate-songbook-language`); pre-migration deployments
+        simply omit the fields rather than returning nulls.
       properties:
         id:
           type: string
@@ -4862,6 +4962,101 @@ components:
           type: integer
           description: Number of songs in the songbook
           example: 650
+        colour:
+          type: string
+          nullable: true
+          description: 6-digit hex tile colour (#677). NULL means "use the auto-picked theme tone".
+          example: "#264a26"
+        isOfficial:
+          type: boolean
+          description: Whether this songbook is recognised as an official publication of an Adventist organisation (#502 / #670).
+          example: true
+        publisher:
+          type: string
+          nullable: true
+          description: Issuing publisher (free-text)
+          example: Pacific Press Publishing Association
+        publicationYear:
+          type: integer
+          nullable: true
+          description: Year of publication (4-digit Gregorian)
+          example: 1985
+        copyright:
+          type: string
+          nullable: true
+          description: Copyright statement
+          example: "© 1985 Review and Herald"
+        affiliation:
+          type: string
+          nullable: true
+          description: |
+            Issuing organisation, drawn from the curated registry
+            `tblSongbookAffiliations` (#670). Free-text fallback if
+            the registry doesn't carry the publisher yet.
+          example: General Conference of Seventh-day Adventists
+        language:
+          type: string
+          nullable: true
+          description: |
+            IETF BCP 47 tag for the songbook's primary language (#673
+            / #681). Composite — language[-script][-region]. May be
+            null if unknown / mixed.
+          example: en-GB
+        websiteUrl:
+          type: string
+          nullable: true
+          description: Official website (#672)
+          example: https://www.adventistmusic.org
+        internetArchiveUrl:
+          type: string
+          nullable: true
+          description: Internet Archive landing page for a digitised copy (#672)
+        wikipediaUrl:
+          type: string
+          nullable: true
+          description: Wikipedia article URL (#672)
+        wikidataId:
+          type: string
+          nullable: true
+          description: Wikidata QID (#672)
+          example: Q123456
+        oclcNumber:
+          type: string
+          nullable: true
+          description: OCLC WorldCat record number (#672)
+        ocnNumber:
+          type: string
+          nullable: true
+          description: OCLC OCN identifier (#672)
+        lcpNumber:
+          type: string
+          nullable: true
+          description: Library of Congress Permalink number (#672)
+        isbn:
+          type: string
+          nullable: true
+          description: ISBN-10 or ISBN-13 (#672)
+        arkId:
+          type: string
+          nullable: true
+          description: Archival Resource Key (ARK) (#672)
+        isniId:
+          type: string
+          nullable: true
+          description: International Standard Name Identifier (#672)
+        viafId:
+          type: string
+          nullable: true
+          description: Virtual International Authority File ID (#672)
+        lccn:
+          type: string
+          nullable: true
+          description: Library of Congress Control Number (#672)
+        lcClass:
+          type: string
+          nullable: true
+          description: Library of Congress Classification (#672)
+          example: M2117
 
     Stats:
       type: object
@@ -4902,6 +5097,44 @@ components:
           description: Text direction
           enum: [ltr, rtl]
           example: ltr
+
+    Script:
+      type: object
+      description: |
+        One row from `tblScripts` (ISO 15924). The `code` is the
+        canonical 4-letter Title Case identifier the IETF BCP 47
+        spec uses (#681).
+      properties:
+        code:
+          type: string
+          description: ISO 15924 script code (Title Case, 4 letters)
+          example: Latn
+        name:
+          type: string
+          description: Script name in English
+          example: Latin
+        nativeName:
+          type: string
+          description: Script name in its own writing system
+          example: Latin
+
+    Region:
+      type: object
+      description: |
+        One row from `tblRegions`. `code` is either the ISO 3166-1
+        alpha-2 country code (uppercase, 2 letters — e.g. `GB`) or a
+        UN M.49 numeric area code (3 digits — e.g. `419` = Latin
+        America & Caribbean). Either form is valid as the region
+        subtag of an IETF BCP 47 tag.
+      properties:
+        code:
+          type: string
+          description: ISO 3166-1 alpha-2 country code or 3-digit M.49 area code
+          example: GB
+        name:
+          type: string
+          description: Region name in English
+          example: United Kingdom
 
     SongTranslation:
       type: object

--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -1968,6 +1968,93 @@ if ($action !== null) {
             break;
 
         /* -----------------------------------------------------------------
+         * Get all available IETF BCP 47 scripts (#681 / #682)
+         *
+         * Mirrors `action=languages`: returns the full active list of
+         * ISO 15924 script codes from tblScripts so native clients
+         * (Apple / Android / FireOS) can render the same composite
+         * IETF picker the web admin already uses. The admin-only
+         * `action=script_search` typeahead on /manage/songbooks?
+         * is the prefix-search variant; this endpoint is a one-shot
+         * dump suitable for caching client-side. Pre-migration: empty
+         * list with a `note` rather than a 500.
+         * ----------------------------------------------------------------- */
+        case 'scripts':
+            $db = getDbMysqli();
+            $hasTable = false;
+            try {
+                $probe = $db->prepare(
+                    "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+                      WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tblScripts' LIMIT 1"
+                );
+                $probe->execute();
+                $hasTable = $probe->get_result()->fetch_row() !== null;
+                $probe->close();
+            } catch (\Throwable $_e) { /* probe failure → empty list */ }
+
+            if (!$hasTable) {
+                sendJson([
+                    'scripts' => [],
+                    'note'    => 'tblScripts not yet created — run /manage/setup-database',
+                ]);
+                break;
+            }
+
+            $stmt = $db->prepare(
+                'SELECT Code AS code, Name AS name, NativeName AS nativeName
+                 FROM tblScripts
+                 WHERE IsActive = 1
+                 ORDER BY Name ASC'
+            );
+            $stmt->execute();
+            $scripts = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+            $stmt->close();
+            sendJson(['scripts' => $scripts]);
+            break;
+
+        /* -----------------------------------------------------------------
+         * Get all available IETF BCP 47 regions (#681 / #682)
+         *
+         * Same shape as `action=scripts` for tblRegions — ISO 3166-1
+         * alpha-2 codes plus M.49 numeric area codes (e.g. 419 = Latin
+         * America & Caribbean). The list is bigger (~255 entries) so
+         * native clients usually fetch it once at first launch and
+         * cache. Pre-migration: empty list with a `note`.
+         * ----------------------------------------------------------------- */
+        case 'regions':
+            $db = getDbMysqli();
+            $hasTable = false;
+            try {
+                $probe = $db->prepare(
+                    "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+                      WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tblRegions' LIMIT 1"
+                );
+                $probe->execute();
+                $hasTable = $probe->get_result()->fetch_row() !== null;
+                $probe->close();
+            } catch (\Throwable $_e) { /* probe failure → empty list */ }
+
+            if (!$hasTable) {
+                sendJson([
+                    'regions' => [],
+                    'note'    => 'tblRegions not yet created — run /manage/setup-database',
+                ]);
+                break;
+            }
+
+            $stmt = $db->prepare(
+                'SELECT Code AS code, Name AS name
+                 FROM tblRegions
+                 WHERE IsActive = 1
+                 ORDER BY Name ASC'
+            );
+            $stmt->execute();
+            $regions = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+            $stmt->close();
+            sendJson(['regions' => $regions]);
+            break;
+
+        /* -----------------------------------------------------------------
          * Get translations for a specific song
          * Parameters: id (required) — source song ID
          * ----------------------------------------------------------------- */

--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -147,6 +147,30 @@ const _BULK_IMPORT_FILE_RE = '/^(?P<num>\d{1,5})\s*\((?P<abbr>[A-Za-z0-9_\-]+)\)
  */
 const _BULK_IMPORT_MAX_ENTRIES = 100000;
 
+/**
+ * Decompression-bomb defenses (#682). A zip can declare a tiny
+ * compressed size but a huge uncompressed payload — a 1 MB archive
+ * advertising 1 TB of content is a classic DoS shape. We reject
+ * anything where:
+ *
+ *   - any single entry's uncompressed size exceeds 5 MiB. A song
+ *     text file is at most a few KB; 5 MiB is ~3 orders of magnitude
+ *     above the realistic upper bound and still small enough that one
+ *     read won't blow PHP's memory limit.
+ *
+ *   - the cumulative uncompressed size across the archive exceeds
+ *     500 MiB. The biggest real bundle we know of (CIS, ~2,300 songs)
+ *     is well under 30 MiB uncompressed; 500 MiB tolerates a 15× size
+ *     jump while still tripping on a true bomb.
+ *
+ * Both caps run BEFORE any read — we use ZipArchive::statIndex to read
+ * the central-directory size header, which is what `unzip -l` shows
+ * and what an attacker would have to forge to bypass the check (the
+ * server-side library would then catch the discrepancy on extract).
+ */
+const _BULK_IMPORT_MAX_ENTRY_UNCOMPRESSED = 5 * 1024 * 1024;       // 5 MiB
+const _BULK_IMPORT_MAX_TOTAL_UNCOMPRESSED = 500 * 1024 * 1024;     // 500 MiB
+
 /* =========================================================================
  * REQUEST HANDLING
  * ========================================================================= */
@@ -2193,6 +2217,41 @@ function _bulkImport_processZip(string $zipPath, ?\mysqli $jobDb = null, ?int $j
                 $entryCount, _BULK_IMPORT_MAX_ENTRIES
             ),
         ];
+    }
+
+    /* Decompression-bomb pre-flight (#682). Walk the central directory
+       once and reject if any single entry — or the cumulative archive —
+       declares an uncompressed size above the cap. statIndex() returns
+       the size header, so we never read or decompress the entry just
+       to find out it's too big. */
+    $cumulativeUncompressed = 0;
+    for ($k = 0; $k < $entryCount; $k++) {
+        $stat = $zip->statIndex($k);
+        if ($stat === false) continue;
+        $size = (int)($stat['size'] ?? 0);
+        if ($size > _BULK_IMPORT_MAX_ENTRY_UNCOMPRESSED) {
+            $zip->close();
+            return [
+                'ok'    => false,
+                'error' => sprintf(
+                    'Entry "%s" reports an uncompressed size of %d bytes; per-entry cap is %d bytes.',
+                    (string)($stat['name'] ?? "(index $k)"),
+                    $size,
+                    _BULK_IMPORT_MAX_ENTRY_UNCOMPRESSED
+                ),
+            ];
+        }
+        $cumulativeUncompressed += $size;
+        if ($cumulativeUncompressed > _BULK_IMPORT_MAX_TOTAL_UNCOMPRESSED) {
+            $zip->close();
+            return [
+                'ok'    => false,
+                'error' => sprintf(
+                    'Cumulative uncompressed size exceeds the per-import cap of %d bytes.',
+                    _BULK_IMPORT_MAX_TOTAL_UNCOMPRESSED
+                ),
+            ];
+        }
     }
 
     $db = getDbMysqli();

--- a/appWeb/public_html/manage/help.php
+++ b/appWeb/public_html/manage/help.php
@@ -470,9 +470,32 @@ foreach ($sections as $s) {
                     <ul>
                         <li><strong>Save</strong> writes everything to the database. Auto-save runs in the background while you work, but always click Save before navigating away.</li>
                         <li><strong>Validate</strong> runs every song past a quality check (missing required fields, invalid language tags, orphaned references) and lists any problems.</li>
-                        <li><strong>Import</strong> from JSON or CSV. <strong>Export</strong> the current view as JSON or CSV.</li>
+                        <li><strong>Import</strong> from JSON or CSV — small, single-file. For mass onboarding (e.g. a complete new hymnal), see the <strong>Bulk Import ZIP</strong> section below.</li>
+                        <li><strong>Export</strong> the current view as JSON or CSV.</li>
                         <li><strong>Revisions</strong> for the selected song shows a diff of every previous edit and a Restore button.</li>
                     </ul>
+                    <h3 class="h6">Bulk Import ZIP (#664 / #676)</h3>
+                    <p>
+                        For onboarding an entire songbook at once. Upload a ZIP whose top-level folders match <code>&lt;Hymnal Name&gt; [&lt;ABBR&gt;]/</code> and whose files match <code>&lt;number&gt; (&lt;ABBR&gt;) - &lt;Title&gt;.txt</code>. The importer creates the songbook on first encounter, then parses + inserts every song.
+                    </p>
+                    <ul>
+                        <li><strong>INSERT-only contract:</strong> if a songbook or song already exists, it's left untouched — never overwritten. The summary reports created vs. existing counts so you can see what landed.</li>
+                        <li><strong>Live progress widget:</strong> the upload completes almost immediately; the actual import runs server-side. A small fixed-position card pinned bottom-right polls the job status, shows a progress bar, and survives navigation between admin pages and the public app. Hard-reload the page mid-import and the widget reattaches via localStorage.</li>
+                        <li><strong>Notification on completion:</strong> a row is written to <a href="#notifications">Notifications</a> when the worker finishes, and (if you've granted permission) a native browser notification fires.</li>
+                        <li><strong>Caps:</strong> 100 MB upload, 100,000 entries per archive, 5 MiB per uncompressed entry, 500 MiB cumulative uncompressed. These are zip-bomb defences (#682) — far above any real bundle.</li>
+                    </ul>
+                    <h3 class="h6">Language tagging (IETF BCP 47, #240 / #281 / #681 / #687)</h3>
+                    <p>
+                        The Metadata tab's Language field is a composite IETF picker — three sub-fields that compose into a single saved tag:
+                    </p>
+                    <ul>
+                        <li><strong>Language</strong> (required) — e.g. <em>English</em> (<code>en</code>) or <em>Portuguese</em> (<code>pt</code>).</li>
+                        <li><strong>Script</strong> (optional) — only when the script differs from the language default. e.g. <em>Simplified Chinese</em> for Mandarin written in Hans, or <em>Latin</em> for Serbian written Latn instead of the default Cyrl.</li>
+                        <li><strong>Region</strong> (optional) — e.g. <em>United Kingdom</em> for British English (<code>en-GB</code>) vs. <em>United States</em> for American English (<code>en-US</code>).</li>
+                    </ul>
+                    <p>
+                        The "IETF tag:" line below the picker shows the composed tag live as you type. The full ISO 15924 / ISO 3166-1 vocabulary is loaded from <code>tblScripts</code> + <code>tblRegions</code> (seeded by Database Setup card 3o), so the picker stays in sync with the songbook editor's identical picker — one source of truth across both surfaces.
+                    </p>
                     <div class="gotcha small">
                         <strong>Gotcha:</strong> Closing the tab while there are unsaved changes loses them — auto-save catches most things, but treat Save as the source of truth.
                     </div>
@@ -559,9 +582,13 @@ foreach ($sections as $s) {
                         <dt>Abbreviation</dt><dd>Short identifier (e.g. <code>HYM</code>). Unique. Max 10 chars, alphanumeric. This is the natural key referenced by every song.</dd>
                         <dt>Name</dt><dd>Friendly name (e.g. "Methodist Hymnal").</dd>
                         <dt>Display order</dt><dd>Numeric sort key — lower numbers appear first in the app.</dd>
-                        <dt>Colour</dt><dd>Hex code (<code>#RRGGBB</code>) used as the songbook badge colour. Leave blank to inherit a default.</dd>
-                        <dt>Publisher / Publication year / Copyright / Affiliation</dt><dd>Optional metadata for filtering and reports.</dd>
-                        <dt>Official flag</dt><dd>Marks "real" published books vs. user-curated collections.</dd>
+                        <dt>Colour</dt><dd>Hex code (<code>#RRGGBB</code>) used as the songbook tile colour on the home page. <strong>Leave blank</strong> to let the system auto-pick a tone from the current theme palette (#677) — the result is consistent with the rest of the UI and changes with the user's chosen theme.</dd>
+                        <dt>Official flag</dt><dd>Marks "real" published hymnals vs. user-curated collections / pseudo-songbooks. Used by the home-page filter to separate the two surfaces.</dd>
+                        <dt>Publisher / Publication year / Copyright</dt><dd>Issuing body, year of publication, and the copyright statement. Optional, surface in search and reports.</dd>
+                        <dt>Affiliation</dt><dd>Issuing organisation, drawn from a curated registry (#670). Type to search; new affiliations get added on save. Use this rather than free-text Publisher when the same organisation issues multiple songbooks.</dd>
+                        <dt>Language (IETF BCP 47)</dt><dd>The songbook's primary language as a composite IETF tag (#673 / #681) — same picker as the song editor, with three sub-fields: <strong>Language</strong> (required), <strong>Script</strong> (optional — only when the script differs from the language default), and <strong>Region</strong> (optional — e.g. <code>en-GB</code> vs <code>en-US</code>). Leave blank for multi-lingual collections.</dd>
+                        <dt>Online links — Official website / Internet Archive / Wikipedia (#672)</dt><dd>Free-text URLs. Used as outbound references on the songbook detail page so users can verify the source.</dd>
+                        <dt>Authority identifiers — WikiData ID, OCLC, OCN, LCP, ISBN, ARK, ISNI, VIAF, LCCN, LC Class (#672)</dt><dd>Standard cataloguing identifiers from major library and authority systems. All optional. Useful for cross-referencing and de-duplicating against external catalogues.</dd>
                     </dl>
                     <h3 class="h6">Renaming an abbreviation</h3>
                     <p>
@@ -569,6 +596,9 @@ foreach ($sections as $s) {
                     </p>
                     <div class="gotcha small">
                         <strong>Gotcha:</strong> Deleting a songbook does <em>not</em> delete its songs. The UI refuses if any song still references its abbreviation; reassign or delete those songs first.
+                    </div>
+                    <div class="gotcha small">
+                        <strong>Tip:</strong> The home-page tile grid (#678) shows official hymnals first, with a language filter (#679) that hides languages on demand. Songbooks without a Language field always show — useful for catch-all collections you don't want to risk filtering away.
                     </div>
                 </section>
 


### PR DESCRIPTION
## Summary

Partial discharge of the #682 hygiene tracker. Four self-contained, reviewable commits land here; the remaining items (issues sweep, .claude state refresh, accessibility audit) are deferred to a follow-up PR — they do not block the security + API + docs items in this batch.

| Concern | Commit | What |
|---|---|---|
| Security | 2dd15db | bulk_import_zip — reject decompression bombs via per-entry + cumulative uncompressed-size pre-flight (5 MiB / 500 MiB caps) |
| API completeness | ffabc01 | New public listings: action=scripts + action=regions, mirroring action=languages, for native clients to consume tblScripts / tblRegions without shipping their own subsets |
| OpenAPI | e61d86e | api-docs.yaml refreshed: paths for scripts + regions; Script + Region schemas; Songbook schema extended with the 13 bibliographic + auth-control fields (#672), affiliation (#670), Language (#673 / #681), colour, isOfficial, publisher, publicationYear, copyright |
| Docs | 6d4095f | /manage/help refreshed for the 2026-04 backlog: songbooks fields (auto-colour #677, language #681, bibliographic #672), bulk-import section (#664/#676), IETF picker section (#687) |

## What is NOT in this PR

- **Issues sweep** — close satisfied issues that didn't auto-close.
- **.claude state refresh** — ProjectBrief + project-rules.
- **Accessibility audit** — WCAG 2.1 AA spot-check of every page changed in 2026-04.

These warrant a follow-up PR with the same #682 reference. The four items in this batch are all independently reviewable + deployable.

## Migrations

None. All four commits are runtime-only.

## Test plan

- [ ] Lint clean: \`find appWeb -name '*.php' -exec php -l {} \;\` and \`find appWeb -name '*.js' -not -path '*/node_modules/*' -exec node --check {} \;\` (verified clean before commit a).
- [ ] Decomp bomb: build a 1 MB ZIP advertising a 100 MB single entry; upload via Editor → Bulk Import → confirm rejection with the size-cap error message.
- [ ] Decomp bomb cumulative: build a 5 MB ZIP whose entries sum to 600 MiB uncompressed; upload → confirm rejection.
- [ ] \`GET /api?action=scripts\` returns a JSON list of {code, name, nativeName} sorted by Name; pre-migration deployments return \`{scripts: [], note: …}\`.
- [ ] \`GET /api?action=regions\` returns {code, name} list; pre-migration → \`{regions: [], note: …}\`.
- [ ] OpenAPI: \`api-docs.yaml\` parses as YAML (verified locally with PyYAML); Swagger UI render unchanged for existing paths.
- [ ] /manage/help renders without errors, the new sections appear inline with the rest of the page styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)