### PR TITLE
P0: fix songbook save "Database error" — bind_param type/arg mismatch (closes #694)

### DIFF
--- a/appWeb/public_html/manage/songbooks.php
+++ b/appWeb/public_html/manage/songbooks.php
@@ -431,8 +431,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                    mysqli passes NULL correctly when a bound variable is null
                    even with type 's'. */
                 $orderInt = (int)($order ?: 0);
+                /* Type string is exactly 23 chars to match the 23 bound
+                   values: ssis (Abbr,Name,Order,Colour) + isssss
+                   (IsOfficial,Publisher,Year,Copyright,Affiliation) +
+                   s (Language) + 13 × s (bibliographic). The earlier
+                   24-char form had one stray trailing 's' which made
+                   PHP 8.5 mysqli throw "Number of variables doesn't
+                   match number of parameters" on every create —
+                   surfaced to the curator as the generic "Database
+                   error — check server logs" banner. (#694) */
                 $stmt->bind_param(
-                    'ssisisssssssssssssssssss',
+                    'ssisissssssssssssssssss',
                     $abbr, $name, $orderInt, $colour,
                     $isOfficial, $publisher, $pubYear, $copyright, $affiliation,
                     $language,
@@ -576,8 +585,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                                                                         ----
                                                                          23 */
                     $orderInt = (int)($order ?: 0);
+                    /* Type string is exactly 23 chars to match the 23
+                       bound values: ssi (Name,Colour,Order) + issss
+                       (IsOfficial,Publisher,Year,Copyright,Affiliation) +
+                       s (Language) + 13 × s (bibliographic) + i (Id).
+                       The earlier 24-char form had one stray trailing
+                       's' so every PHP 8.5 mysqli execute() threw
+                       "Number of variables doesn't match number of
+                       parameters" — surfaced to the curator as the
+                       generic "Database error — check server logs"
+                       banner whenever they touched the new
+                       bibliographic / Language fields. (#694) */
                     $stmt->bind_param(
-                        'ssiisssssssssssssssssssi',
+                        'ssiissssssssssssssssssi',
                         $name, $colour, $orderInt,
                         $isOfficial, $publisher, $pubYear, $copyright, $affiliation,
                         $language,


### PR DESCRIPTION
## Summary

P0 fix. Closes #694. Two \`mysqli_stmt::bind_param\` calls in \`/manage/songbooks.php\` (one in the **create** handler, one in the **update** handler) had a 24-character type string against 23 bound values — one stray trailing \`s\` each. PHP 8.5 mysqli throws \`\"Number of variables doesn't match number of parameters in prepared statement\"\`, which is caught at the page level and surfaced as the generic \"Database error — check server logs for details.\" banner.

The result: **every** save attempt that touched a songbook with the new bibliographic / authority-control / Language fields populated would fail. The user reported it via screenshot, trying to add an Internet Archive URL to **CH — The Church Hymnal**.

## Diagnosis

Counted bound values vs type-string length:

| Handler | Type string | Length | Bound values |
|---|---|---:|---:|
| CREATE | \`ssisisssssssssssssssssss\` (before) | **24** | 23 |
| UPDATE | \`ssiisssssssssssssssssssi\` (before) | **24** | 23 |

Both type strings now exactly match the documented layout in the comments above each call:

- **CREATE** = \`ssis\` (Abbr, Name, Order, Colour) + \`isssss\` (IsOfficial, Publisher, Year, Copyright, Affiliation) + \`s\` (Language) + 13×\`s\` (bibliographic) = **23 chars**.
- **UPDATE** = \`ssi\` (Name, Colour, Order) + \`isssss\` (IsOfficial, Publisher, Year, Copyright, Affiliation) + \`s\` (Language) + 13×\`s\` (bibliographic) + \`i\` (Id) = **23 chars**.

I also ran a Python sweep across every \`bind_param\` call under \`appWeb/public_html\`. **Zero** other mismatches — these were the only two.

## Migrations

None.

## Test plan

- [ ] /manage/songbooks → edit any songbook → fill in Internet Archive URL → Save Changes → confirm success banner.
- [ ] Same flow but populate Language sub-fields (e.g. \`en-GB\` via the IETF picker) → Save → confirm persists.
- [ ] Create a brand-new songbook with bibliographic + Language fields populated → confirm save succeeds.
- [ ] Reload the page; confirm the values landed in tblSongbooks (visible on the next edit modal).

## Follow-ups (separate PRs)

- **#693**: first click on Manage from brand dropdown loads Editor instead of Dashboard.
- **#695**: Activity Log should capture errors, not just successes, so future bugs surface in-app rather than relying on \`error_log\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)