### PR TITLE
fix(login): post-login default to Dashboard, not Editor (closes #693)

### DIFF
--- a/appWeb/public_html/manage/login.php
+++ b/appWeb/public_html/manage/login.php
@@ -16,9 +16,16 @@ if (needsSetup()) {
     exit;
 }
 
-/* Already logged in? Go to editor */
+/* Already logged in? Go to the Dashboard (#693). The post-login
+   default used to be /manage/editor/, but that surprised curators who
+   clicked "Manage" from the brand dropdown expecting the admin
+   Dashboard — they kept landing on the Song Editor on first visit
+   (when no $_SESSION['redirect_after_login'] was queued by an upstream
+   requireAuth bounce). The Dashboard is the correct landing surface
+   for "Manage", and curators who specifically want the editor have
+   the Song Editor card a single click away. */
 if (isAuthenticated()) {
-    $redirect = $_SESSION['redirect_after_login'] ?? '/manage/editor/';
+    $redirect = $_SESSION['redirect_after_login'] ?? '/manage/';
     unset($_SESSION['redirect_after_login']);
     header('Location: ' . $redirect);
     exit;
@@ -46,7 +53,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     } else {
         $user = attemptLogin($username, $password);
         if ($user) {
-            $redirect = $_SESSION['redirect_after_login'] ?? '/manage/editor/';
+            /* Default to /manage/ (Dashboard) — see #693 explanation
+               above the matching block at the top of this file. */
+            $redirect = $_SESSION['redirect_after_login'] ?? '/manage/';
             unset($_SESSION['redirect_after_login']);
             header('Location: ' . $redirect);
             exit;


### PR DESCRIPTION
## Summary

Closes #693. Fixes the \"first click on Manage loads the Song Editor instead of the Dashboard\" surprise.

## Root cause

\`/manage/login.php\` had two \`redirect_after_login\` fallbacks, both defaulting to \`/manage/editor/\` when no upstream \`requireAuth()\` had queued a target URL:

\`\`\`php
$redirect = \$_SESSION['redirect_after_login'] ?? '/manage/editor/';
\`\`\`

The cold-session repro:

1. User clicks **Manage** from the brand dropdown — link points at \`/manage/\`.
2. \`requireAuth()\` bounces them to \`/manage/login\`. The bounce DOES set \`redirect_after_login = /manage/\`, so the form has the correct target.
3. **However**: if the user previously visited \`/manage/login\` directly (e.g. from the cookie banner / bookmark / a stale tab), the queued target was already consumed by the earlier visit. On the next form submit, the fallback kicks in → \`/manage/editor/\` → Editor loads instead of Dashboard.
4. Subsequent clicks on **Manage** are already authenticated; they resolve to \`/manage/index.php\` (the Dashboard) directly, bypassing login.php entirely. That's why only the first click misbehaves.

## Fix

Both fallbacks now default to \`/manage/\` (the Dashboard). Curators who want the Editor reach it via the Song Editor card on the Dashboard — one click away, same as every other admin surface.

Comments at both call sites cross-reference #693 so a future maintainer who finds either fallback understands the choice.

## Migrations

None.

## Test plan

- [ ] Log out. From the public app, click Manage in the brand dropdown. Confirm post-login lands on \`/manage/\` (Dashboard), not \`/manage/editor/\`.
- [ ] Log out. Visit \`/manage/login\` directly, sign in, confirm Dashboard loads.
- [ ] Log out. Visit \`/manage/songbooks\` directly (auth bounce), sign in, confirm Songbooks page loads (not Dashboard, not Editor — the original target).
- [ ] Already-logged-in user: visit \`/manage/login\` and confirm the redirect goes to Dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)