### PR TITLE
feat(activity-log): thread error capture into remaining admin handlers (refs #695)

### DIFF
--- a/appWeb/public_html/manage/credit-people.php
+++ b/appWeb/public_html/manage/credit-people.php
@@ -276,6 +276,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET' && (string)($_GET['action'] ?? '') === 
         exit;
     } catch (\Throwable $e) {
         error_log('[manage/credit-people.php] view_songs failed: ' . $e->getMessage());
+        logActivityError('admin.credit_people.view_songs', 'credit_person', '', $e);
         http_response_code(500);
         echo json_encode(['error' => 'Could not load songs.']);
         exit;
@@ -921,6 +922,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
     } catch (\Throwable $e) {
         error_log('[manage/credit-people.php] action=' . $action . ': ' . $e->getMessage());
+        logActivityError('admin.credit_people.save', 'credit_person', '', $e, [
+            'action' => $action,
+        ]);
         if ($error === '') {
             /* This page is gated to global_admin — surfacing the
                actual exception message + file:line is a UX win and

--- a/appWeb/public_html/manage/groups.php
+++ b/appWeb/public_html/manage/groups.php
@@ -156,6 +156,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
     } catch (\Throwable $e) {
         error_log('[manage/groups.php] ' . $e->getMessage());
+        logActivityError('admin.groups.save', 'group',
+            (string)($_POST['id'] ?? ''), $e, [
+                'action' => $_POST['action'] ?? null,
+            ]);
         $error = $error ?: 'Database error — check server logs for details.';
     }
 }
@@ -177,6 +181,7 @@ try {
     $stmt->close();
 } catch (\Throwable $e) {
     error_log('[manage/groups.php] ' . $e->getMessage());
+    logActivityError('admin.groups.list', 'group', '', $e);
     $error = $error ?: 'Could not load groups.';
 }
 
@@ -217,6 +222,7 @@ if ($editId > 0) {
         }
     } catch (\Throwable $e) {
         error_log('[manage/groups.php] ' . $e->getMessage());
+        logActivityError('admin.groups.edit_load', 'group', (string)$editId, $e);
     }
 }
 

--- a/appWeb/public_html/manage/missing-numbers.php
+++ b/appWeb/public_html/manage/missing-numbers.php
@@ -62,6 +62,7 @@ try {
     }
 } catch (\Throwable $e) {
     error_log('[missing-numbers] ' . $e->getMessage());
+    logActivityError('admin.missing_numbers.load', 'songbook', '', $e);
     $reports  = [];
     $loadError = 'Could not load the missing-numbers report — see server logs.';
 }

--- a/appWeb/public_html/manage/revisions.php
+++ b/appWeb/public_html/manage/revisions.php
@@ -88,6 +88,7 @@ try {
     $stmt->close();
 } catch (\Throwable $e) {
     error_log('[manage revisions] ' . $e->getMessage());
+    logActivityError('admin.revisions.list', 'song_revision', '', $e);
     $rows = [];
 }
 


### PR DESCRIPTION
## Summary

Tail follow-up to PR #698. That PR wired \`logActivityError()\` into the three highest-bandwidth admin save flows (songbooks, requests, organisations). This PR picks up the four other admin pages that still catch \`\\Throwable\` and surface a generic banner without writing an in-app trail.

| Page | Action verbs |
|---|---|
| /manage/groups | \`admin.groups.save\` / \`.list\` / \`.edit_load\` |
| /manage/missing-numbers | \`admin.missing_numbers.load\` |
| /manage/credit-people | \`admin.credit_people.save\` / \`.view_songs\` |
| /manage/revisions | \`admin.revisions.list\` |

Verb naming follows the \`admin.<surface>.<action>\` pattern documented in project-rules §10 so the Activity Log viewer's Action filter narrows usefully (\`admin.groups.*\` shows every groups-page failure in one click).

\`error_log()\` calls retained as belt-and-braces — if the Activity Log itself is the thing that broke, the host server log still catches it.

## Out of scope

- \`data-health.php\` / \`schema-audit.php\` / \`activity-log.php\` itself — read-only diagnostic surfaces where the existing inline error display IS the user-facing channel; a duplicate Activity Log row would be noise.
- Pages that already \`error_log\` without catching at the page level (users.php, entitlements.php) — these throw straight into the global handler and are best left alone.

## Migrations

None.

## Test plan

- [ ] Force a save error on /manage/groups (e.g. duplicate group name); confirm an \`admin.groups.save\` error row appears in /manage/activity-log with Result=error filter.
- [ ] Same for /manage/credit-people (rename to a name that already exists).
- [ ] /manage/missing-numbers loaded against a deployment without tblSongs migration → \`admin.missing_numbers.load\` row.
- [ ] /manage/revisions: confirm normal traffic does NOT spam the log (catch-all only fires on actual exceptions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)