### PR TITLE
ci: monthly maintenance automation — issues sweep + HA audit (closes #704)

### DIFF
--- a/.github/workflows/maintenance-ha-integrity-audit.yml
+++ b/.github/workflows/maintenance-ha-integrity-audit.yml
@@ -1,0 +1,196 @@
+# =============================================================================
+# iHymns — Monthly HA Cross-Source Integrity Audit
+#
+# Copyright (c) 2026 MWBM Partners Ltd. All rights reserved.
+# This software is proprietary. Unauthorized copying, modification, or
+# distribution is strictly prohibited.
+#
+# PURPOSE:
+# Runs the multilingual scraper's cross-source integrity check (#699
+# Phase C) against the Spanish HA songbook (Himnario Adventista) and
+# files the findings as a committed audit report + a PR for review.
+#
+# WHY HA SPECIFICALLY (and not all 4 overlap songbooks):
+# The 2026-04-30 audit ran SDAH (695, 100% clean) → CH (702, 100%
+# clean) → HASD (275/610, ~11% data-quality issues) → HA. By the
+# time it reached HA the SDAHymnal-network rate limit had kicked in
+# and HA returned 0 hymns. The earlier 25-hymn HA sample showed
+# ~96% diff rate including HA #003 being completely different
+# hymns (`Unidos En Espíritu` in CIS vs `¡Santo! ¡Santo! ¡Santo!`
+# on himnario.net) — suggesting different *editions* of the Spanish
+# hymnal. A fresh, isolated session is needed to confirm.
+#
+# Running just HA (rather than all 4 overlap songbooks) keeps the
+# request volume low enough to avoid the rate-limit cutoff that bit
+# the all-4-in-sequence run.
+#
+# WHEN IT RUNS:
+# - On a cron schedule — once a month, on a different day from the
+#   issues sweep so the two don't collide. 14th of each month at
+#   09:23 UTC.
+# - On manual dispatch from the Actions tab.
+#
+# WHAT IT DOES:
+# 1. Runs `SDAHymnals_SDAHymnal.org.py --site ha --prefer-source cis`
+#    against the existing CIS extracts (committed under
+#    .SourceSongData/ — but those are gitignored, so the workflow
+#    re-fetches them from the ChristInSong scraper as a setup step).
+# 2. Aggregates the per-hymn findings into a categorised summary:
+#    structural-only, encoding-corruption, OCR-style, title-mismatch.
+# 3. Writes the summary to .importers/audits/<YYYY-MM-DD>-ha-audit.md.
+# 4. Opens a PR against `alpha` with the report.
+#
+# RATE-LIMIT HANDLING:
+# If the audit returns 0 hymns + 10 consecutive skips, the workflow
+# logs the failure to its own job summary and exits successfully
+# (no PR opened — the next monthly run will retry from a fresher
+# session). A repeated failure 3 months in a row should prompt
+# manual investigation.
+# =============================================================================
+
+name: Maintenance — HA Integrity Audit
+
+on:
+  schedule:
+    # Run on the 14th of every month at 09:23 UTC. Two-week offset
+    # from the issues sweep on the 28th so the same Actions slot
+    # isn't bottlenecked.
+    - cron: '23 9 14 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# Don't let two manual dispatches stack — a single in-flight audit
+# is enough.
+concurrency:
+  group: maintenance-ha-integrity-audit
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    name: HA cross-source integrity audit
+    runs-on: ubuntu-latest
+    # An HA full-corpus pass is ~614 hymns × ~1s per hymn = ~10 min,
+    # plus the upstream ChristInSong pre-fetch which is comparable.
+    # 30-minute ceiling keeps the runner from hanging if a remote site
+    # stops responding.
+    timeout-minutes: 30
+    steps:
+      - name: Check out alpha
+        uses: actions/checkout@v4
+        with:
+          ref: alpha
+          # Fetch the full history so the new branch we'll push has
+          # a clean rebase target.
+          fetch-depth: 0
+          # Token with write scope for pushing the audit branch back.
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Pre-fetch the ChristInSong HA extract for comparison
+        # The audit compares fresh SDAHymnal scrapes against the
+        # existing CIS extracts. .SourceSongData/ is gitignored
+        # (it's working data, not source-of-truth), so we have to
+        # re-fetch via the ChristInSong scraper before the audit can
+        # do its diff. ChristInSong-side rate limits are separate
+        # from SDAHymnal-side, so this doesn't eat into the audit
+        # budget.
+        run: |
+          mkdir -p ".SourceSongData"
+          python3 .importers/scrapers/ChristInSong.app.py \
+              --site ha \
+              --output .SourceSongData \
+              --delay 1.0 \
+            || echo "::warning::ChristInSong pre-fetch errored — proceeding with whatever landed."
+
+      - name: Run the HA integrity audit
+        id: audit
+        run: |
+          # --prefer-source cis is read-only — no song files written.
+          # Output goes only to .SourceSongData/HA*/_integrity-check.md
+          # which is gitignored.
+          python3 .importers/scrapers/SDAHymnals_SDAHymnal.org.py \
+              --site ha \
+              --prefer-source cis \
+              --output .SourceSongData \
+              --delay 1.0 \
+              2>&1 | tee /tmp/audit.log
+
+          # Pull the saved+skipped counts from the summary line.
+          summary_line=$(grep -E "^HA: [0-9]+ hymns saved" /tmp/audit.log | tail -1)
+          echo "summary=$summary_line" >> "$GITHUB_OUTPUT"
+          # Extract the saved count for the rate-limit guard below.
+          saved=$(echo "$summary_line" | grep -oE '[0-9]+ hymns' | head -1 | grep -oE '[0-9]+' || echo "0")
+          echo "saved=$saved" >> "$GITHUB_OUTPUT"
+
+      - name: Detect rate-limit (saved == 0)
+        if: steps.audit.outputs.saved == '0'
+        run: |
+          {
+            echo "# Maintenance: HA Integrity Audit — rate-limited"
+            echo ""
+            echo "The scraper returned 0 hymns saved. Most likely cause: SDAHymnal-network daily rate limit kicked in before any hymn was retrieved."
+            echo ""
+            echo "**Action:** none — the next monthly run will retry from a fresh session. If this fails three months in a row, investigate manually (could be a UA block, an IP block on Actions runners, or an upstream layout change)."
+            echo ""
+            echo "Audit output line:"
+            echo ""
+            echo '```'
+            echo "${{ steps.audit.outputs.summary }}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          # Exit successfully — the rate limit is expected behaviour, not a failure.
+          exit 0
+
+      - name: Aggregate findings + write report
+        id: report
+        if: steps.audit.outputs.saved != '0'
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          # Run the aggregator from a separate file so YAML's block-scalar
+          # rules (blank-line termination) don't fight the multi-line
+          # markdown-template strings in the script.
+          python3 .github/workflows/scripts/ha-audit-aggregate.py
+
+      - name: Open PR with the audit report
+        if: steps.report.outputs.report_path != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPORT_PATH: ${{ steps.report.outputs.report_path }}
+          AUDIT_DATE:  ${{ steps.report.outputs.date }}
+          AUDIT_TOTAL: ${{ steps.report.outputs.total }}
+          AUDIT_IDENT: ${{ steps.report.outputs.identical }}
+          AUDIT_DIFF:  ${{ steps.report.outputs.differs }}
+        run: |
+          # The aggregator writes /tmp/commit-msg.txt and /tmp/pr-body.md
+          # alongside the audit report itself, so we don't have to wrestle
+          # multi-line strings through YAML block scalars here.
+          BRANCH="claude/audit-ha-${AUDIT_DATE}"
+          git checkout -b "$BRANCH"
+          git add "$REPORT_PATH"
+          git commit -F /tmp/commit-msg.txt
+          git push -u origin "$BRANCH"
+          gh pr create --base alpha \
+              --title "Audit: HA cross-source integrity (${AUDIT_DATE})" \
+              --body-file /tmp/pr-body.md
+          {
+            echo "# Maintenance: HA Integrity Audit — PR opened"
+            echo ""
+            echo "Branch: \`$BRANCH\`"
+            echo "Report: \`$REPORT_PATH\`"
+            echo "- Total audited: ${AUDIT_TOTAL}"
+            echo "- Identical: ${AUDIT_IDENT}"
+            echo "- Differ: ${AUDIT_DIFF}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/maintenance-issues-sweep.yml
+++ b/.github/workflows/maintenance-issues-sweep.yml
@@ -1,0 +1,205 @@
+# =============================================================================
+# iHymns — Monthly Issues Sweep
+#
+# Copyright (c) 2026 MWBM Partners Ltd. All rights reserved.
+# This software is proprietary. Unauthorized copying, modification, or
+# distribution is strictly prohibited.
+#
+# PURPOSE:
+# Closes GitHub issues that are referenced as `closes #N` (or `fixes #N` /
+# `resolves #N`) in commits merged onto the `alpha` branch but never
+# auto-closed by GitHub itself.
+#
+# WHY THIS IS NEEDED:
+# GitHub's auto-close mechanism only fires when a PR merges into the
+# repository's *default* branch (`main`). Day-to-day work on this repo
+# targets `alpha`, so issues marked `closes #N` in alpha-merged PRs
+# accumulate in the open queue. The 2026-04-30 sweep discovered ~50 such
+# issues; this workflow runs the same sweep automatically each month so
+# they don't pile up between manual cycles.
+#
+# WHEN IT RUNS:
+# - On a cron schedule (28th of each month at 09:23 UTC — picked off the
+#   :00 / :30 minute marks per the platform's rate-limit guidance).
+# - On manual dispatch from the Actions tab.
+#
+# WHAT IT DOES:
+# 1. Walks the last 300 commits on `alpha` and extracts every issue number
+#    referenced by `closes #N` / `fixes #N` / `resolves #N`, plus range
+#    patterns (`#626–#636`).
+# 2. Cross-references against `gh issue list --state open` and identifies
+#    issues that are open but already resolved.
+# 3. Closes each one with a comment crediting the merge commit.
+# 4. Posts a summary to the workflow's own job summary so the Actions tab
+#    shows what was closed.
+#
+# WHAT IT DOES NOT DO:
+# - It does not close issues that lack a `closes #N` reference, even if
+#   their PR has merged. The reference is the contract.
+# - It does not reopen issues. If an issue was closed by mistake, reopen
+#   it manually — the next run will not touch it.
+# - It does not assume any issue is "stale". This is purely about cleaning
+#   up the GitHub auto-close gap, not about triaging stale work.
+# =============================================================================
+
+name: Maintenance — Issues Sweep
+
+on:
+  schedule:
+    # Run on the 28th of every month at 09:23 UTC (off the busy
+    # :00 / :30 marks; jitter applied by the GitHub Actions scheduler).
+    - cron: '23 9 28 * *'
+  workflow_dispatch:
+    # Manual trigger from the Actions tab — useful right after a
+    # large merge cycle when you don't want to wait for the monthly run.
+
+permissions:
+  # `gh issue close -c` writes a comment + flips the state — needs
+  # both issues:write (close) and discussions are unaffected.
+  issues: write
+  # No code is touched, so contents:read is enough to read the alpha
+  # commit log via `git log`.
+  contents: read
+
+# Don't let two manual dispatches stack up.
+concurrency:
+  group: maintenance-issues-sweep
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    name: Close issues resolved on alpha
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out alpha (last 300 commits)
+        uses: actions/checkout@v4
+        with:
+          ref: alpha
+          # 300 commits matches the local sweep depth used in the
+          # 2026-04-30 cycle — covers ~3 months of activity.
+          fetch-depth: 300
+
+      - name: Build issue → commit map
+        id: scan
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 <<'PY'
+          import subprocess, re, json, os
+
+          # Pull the last 300 commits on alpha and extract any issue numbers
+          # referenced in their subject lines.
+          log = subprocess.run(
+              ['git', 'log', '-300', '--pretty=format:%H|%s', 'origin/alpha'],
+              capture_output=True, text=True, check=True
+          ).stdout
+
+          issue_to_commit = {}
+          for line in log.splitlines():
+              if '|' not in line:
+                  continue
+              sha, msg = line.split('|', 1)
+              short = sha[:7]
+              for m in re.findall(r'(?:closes|fixes|resolves)\s+#(\d+)',
+                                  msg, re.IGNORECASE):
+                  issue_to_commit.setdefault(int(m), (short, msg))
+              # Range patterns: "#626-#636" / "#626–#636"
+              for m in re.findall(r'#(\d+)\s*[–\-]\s*#(\d+)', msg):
+                  for n in range(int(m[0]), int(m[1]) + 1):
+                      issue_to_commit.setdefault(n, (short, msg))
+
+          # Currently open issues
+          out = subprocess.run(
+              ['gh', 'issue', 'list', '--state', 'open',
+               '--limit', '300', '--json', 'number'],
+              capture_output=True, text=True, check=True
+          ).stdout
+          open_nums = {i['number'] for i in json.loads(out)}
+
+          # Cross-reference
+          candidates = sorted(set(issue_to_commit) & open_nums)
+          payload = [
+              {'number': n, 'sha': issue_to_commit[n][0],
+               'subject': issue_to_commit[n][1]}
+              for n in candidates
+          ]
+
+          # Persist for the next step
+          with open('/tmp/sweep-candidates.json', 'w') as f:
+              json.dump(payload, f)
+
+          # Surface the count to the workflow so the close-step can decide
+          # whether to run + the summary can show the headline number.
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+              f.write(f"count={len(candidates)}\n")
+
+          print(f"Found {len(candidates)} open issues that should be closed.")
+          for c in payload:
+              print(f"  #{c['number']}  {c['sha']}  {c['subject'][:80]}")
+          PY
+
+      - name: Close resolved issues
+        if: steps.scan.outputs.count != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITHUB_REPOSITORY (e.g. "MWBMPartners/iHymns") is set
+          # automatically by the Actions runner.
+        run: |
+          python3 <<'PY'
+          import json, subprocess, sys, os
+
+          repo = os.environ['GITHUB_REPOSITORY']
+          data = json.load(open('/tmp/sweep-candidates.json'))
+          closed, failed = 0, []
+          summary_lines = ['## Closed issues', '',
+                           '| # | Closing commit | Subject |',
+                           '|---|---|---|']
+
+          for entry in data:
+              num, sha, subject = entry['number'], entry['sha'], entry['subject']
+              # Trim subject so the comment stays short; preserve the original
+              # so the run summary still reads cleanly.
+              subj_clean = subject[:80].replace('"', "'")
+              comment = (
+                  f"Closing — resolved on `alpha` by "
+                  f"[`{sha}`](https://github.com/{repo}/commit/{sha}) "
+                  f"(\"{subj_clean}\"). GitHub's auto-close didn't fire because "
+                  f"the repo's default branch is `main` but the PR merged into "
+                  f"`alpha`. Reopen if you spot a regression. "
+                  f"(Auto-swept by `.github/workflows/maintenance-issues-sweep.yml`.)"
+              )
+
+              r = subprocess.run(
+                  ['gh', 'issue', 'close', str(num), '-c', comment],
+                  capture_output=True, text=True
+              )
+              if r.returncode == 0:
+                  print(f"  ✓ closed #{num}")
+                  summary_lines.append(
+                      f"| #{num} | `{sha}` | {subj_clean} |"
+                  )
+                  closed += 1
+              else:
+                  print(f"  ✗ #{num}: {r.stderr.strip()[:120]}")
+                  failed.append(num)
+
+          summary_lines.insert(
+              0,
+              f"# Maintenance: Issues Sweep — closed {closed} / failed {len(failed)}"
+          )
+          with open(os.environ['GITHUB_STEP_SUMMARY'], 'a') as f:
+              f.write('\n'.join(summary_lines) + '\n')
+
+          if failed:
+              print(f"\nFailed to close: {failed}", file=sys.stderr)
+              sys.exit(1)
+          PY
+
+      - name: Nothing to do
+        if: steps.scan.outputs.count == '0'
+        run: |
+          {
+            echo "## Maintenance: Issues Sweep — nothing to do"
+            echo ""
+            echo "No open issues match a \`closes #N\` reference in the last 300 commits on \`alpha\`."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/scripts/ha-audit-aggregate.py
+++ b/.github/workflows/scripts/ha-audit-aggregate.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""
+ha-audit-aggregate.py — invoked by `.github/workflows/maintenance-ha-integrity-audit.yml`.
+
+Reads the per-hymn `_integrity-check.md` report the SDAHymnal scraper
+just emitted (under `.SourceSongData/Himnario Adventista [HA]/`),
+categorises each "differs" entry, and writes three files:
+
+  - .importers/audits/<YYYY-MM-DD>-ha-full-audit.md   (committable summary)
+  - /tmp/commit-msg.txt                                (commit message)
+  - /tmp/pr-body.md                                    (PR body)
+
+Plus emits four key=value lines into $GITHUB_OUTPUT so downstream steps
+in the workflow can read the headline numbers + the report path.
+
+Lives in this folder rather than inside the workflow's `run:` block
+because the report templates contain blank lines, which break YAML's
+block-scalar parser when inlined. Keeping the script in a real .py file
+sidesteps that entirely — the workflow just calls `python3 path/to/this`.
+
+Copyright (c) 2026 MWBM Partners Ltd. All rights reserved.
+"""
+
+import datetime
+import os
+import re
+import sys
+
+REPORT_DIR  = ".SourceSongData/Himnario Adventista [HA]"
+REPORT_PATH = os.path.join(REPORT_DIR, "_integrity-check.md")
+
+
+def main() -> int:
+    if not os.path.exists(REPORT_PATH):
+        print(
+            f"::error::Expected per-hymn report at {REPORT_PATH} but it doesn't "
+            f"exist. Did the scraper write to a different folder?",
+            file=sys.stderr,
+        )
+        return 1
+
+    body = open(REPORT_PATH, encoding="utf-8").read()
+    entries = re.findall(
+        r'### (\d+) — ([^()]+) \((identical|differs)\)'
+        r'(?:.*?```diff\n(.*?)```)?',
+        body, re.DOTALL,
+    )
+
+    identical = sum(1 for _, _, s, _ in entries if s == "identical")
+    differs   = sum(1 for _, _, s, _ in entries if s == "differs")
+    total     = identical + differs
+
+    # Categorise the differs by diff content. Heuristics match the
+    # 2026-04-30 manual analysis — see
+    # `.importers/audits/2026-04-30-cross-source-integrity.md` for
+    # the rationale per category.
+    cat_struct = cat_enc = cat_ocr = cat_other = 0
+    for _, _, status, diff_block in entries:
+        if status != "differs" or not diff_block:
+            continue
+        has_enc    = bool(re.search(r"[ăŕćśľ]", diff_block))
+        has_ocr    = bool(re.search(r"^-\s*0\s", diff_block, re.MULTILINE))
+        has_struct = (
+            diff_block.count("-coro") >= 1
+            or "coro:" in diff_block
+            or diff_block.count("-chorus") >= 1
+        )
+        if has_enc:
+            cat_enc += 1
+        elif has_ocr:
+            cat_ocr += 1
+        elif has_struct:
+            cat_struct += 1
+        else:
+            cat_other += 1
+
+    today = datetime.date.today().isoformat()
+    repo  = os.environ.get("GITHUB_REPOSITORY", "MWBMPartners/iHymns")
+
+    # --- Build the committable audit report (markdown) ---
+    pct = lambda n, d: f"{(n * 100 / d):.1f}%" if d else "—"
+    lines = [
+        f"# HA cross-source integrity audit — {today}",
+        "",
+        f"**Tracking issue:** [#699](https://github.com/{repo}/issues/699)",
+        "**Tooling:** `.importers/scrapers/SDAHymnals_SDAHymnal.org.py --site ha --prefer-source cis`",
+        "**Triggered by:** `.github/workflows/maintenance-ha-integrity-audit.yml`",
+        "",
+        "## Headline numbers",
+        "",
+        "| Metric | Count |",
+        "|---|---:|",
+        f"| Total hymns audited | **{total}** |",
+        f"| Identical | **{identical}** ({pct(identical, total)}) |",
+        f"| Differ | **{differs}** ({pct(differs, total)}) |",
+        "",
+        f"## Categorisation of the {differs} differing hymns",
+        "",
+        "| Category | Count | % of differs |",
+        "|---|---:|---:|",
+        f"| Structural only (chorus repetition / colon punctuation) | {cat_struct} | {pct(cat_struct, differs)} |",
+        f"| Encoding corruption (Latin-1 → Latin-2 mojibake in CIS) | {cat_enc} | {pct(cat_enc, differs)} |",
+        f"| OCR-style errors (digit `0` for letter `Ó`) | {cat_ocr} | {pct(cat_ocr, differs)} |",
+        f"| Other / mixed (likely title mismatches → different editions) | {cat_other} | {pct(cat_other, differs)} |",
+        "",
+        "## Interpretation",
+        "",
+        "- **Structural-only differences** are layout-only — same lyric, same hymn, different convention for representing the chorus. No action needed.",
+        "- **Encoding + OCR errors** indicate ChristInSong is the corrupted source for the affected hymns; SDAHymnal would be the cleaner re-import target.",
+        "- **Other / title-mismatch** suggests the two sources are different *editions* of the Spanish hymnal. If this category is large, the two sources may be complementary rather than redundant — keep both and cross-reference rather than choosing one.",
+        "",
+        "## Per-hymn detail",
+        "",
+        "The full per-hymn diff report is at `.SourceSongData/Himnario Adventista [HA]/_integrity-check.md` on the runner — gitignored, so not included here. To regenerate locally, run:",
+        "",
+        "```sh",
+        "python3 .importers/scrapers/SDAHymnals_SDAHymnal.org.py \\",
+        "    --site ha --prefer-source cis --output .SourceSongData --delay 1.0",
+        "```",
+        "",
+    ]
+    os.makedirs(".importers/audits", exist_ok=True)
+    out_path = f".importers/audits/{today}-ha-full-audit.md"
+    with open(out_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines))
+
+    # --- Build the commit message ---
+    commit_lines = [
+        f"docs(audit): HA cross-source integrity findings ({today}) (refs #699)",
+        "",
+        "Auto-generated by .github/workflows/maintenance-ha-integrity-audit.yml.",
+        "",
+        "Headline:",
+        f"- Total audited: {total}",
+        f"- Identical:     {identical}",
+        f"- Differ:        {differs}",
+        "",
+        "Full breakdown + categorisation in the committed report.",
+        "",
+        "Co-Authored-By: github-actions[bot] <noreply@github.com>",
+    ]
+    with open("/tmp/commit-msg.txt", "w", encoding="utf-8") as f:
+        f.write("\n".join(commit_lines))
+
+    # --- Build the PR body ---
+    pr_lines = [
+        "Auto-generated monthly audit (refs #699).",
+        "",
+        "## Headline",
+        "",
+        "| Metric | Count |",
+        "|---|---:|",
+        f"| Total audited | {total} |",
+        f"| Identical | {identical} ({pct(identical, total)}) |",
+        f"| Differ | {differs} ({pct(differs, total)}) |",
+        "",
+        "## Categorisation",
+        "",
+        "| Category | Count |",
+        "|---|---:|",
+        f"| Structural only | {cat_struct} |",
+        f"| Encoding corruption | {cat_enc} |",
+        f"| OCR-style | {cat_ocr} |",
+        f"| Other / title-mismatch | {cat_other} |",
+        "",
+        f"Full report committed at `{out_path}`.",
+        "",
+        "Triggered by the monthly cron in `.github/workflows/maintenance-ha-integrity-audit.yml`.",
+    ]
+    with open("/tmp/pr-body.md", "w", encoding="utf-8") as f:
+        f.write("\n".join(pr_lines))
+
+    # --- Surface to the workflow ---
+    with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+        f.write(f"report_path={out_path}\n")
+        f.write(f"total={total}\n")
+        f.write(f"identical={identical}\n")
+        f.write(f"differs={differs}\n")
+        f.write(f"date={today}\n")
+
+    print(f"Audit aggregation done. {total} compared, {identical} identical, {differs} differ.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes #704. Replaces the manual tracking-issue runbook with two GitHub Actions workflows that run on cron.

| Workflow | Cron | Purpose |
|---|---|---|
| \`maintenance-issues-sweep.yml\` | 28th @ 09:23 UTC | Closes GitHub issues marked \`closes #N\` in alpha-merged PRs but missed by GitHub's default-branch-only auto-close |
| \`maintenance-ha-integrity-audit.yml\` | 14th @ 09:23 UTC | Runs the cross-source integrity audit on HA, opens a PR with categorised findings |

Both also support \`workflow_dispatch\` for manual triggering.

## Why this design

### Issues sweep

The 2026-04-30 manual sweep closed 47 issues — caused by the auto-close gap (PRs merge into \`alpha\`, default branch is \`main\`, so GitHub doesn't fire). This recurring chore is fully mechanical: walk \`git log alpha\`, extract \`closes #N\` references, cross-reference with open issues, close. No human judgement needed → automate.

### HA audit

The 2026-04-30 manual audit ran SDAH (clean) → CH (clean) → HASD (~11% real divergences) → HA (rate-limited at 0/614). Earlier sample data suggested HA has different *editions* between sources (HA #003 was \`Unidos En Espíritu\` in CIS but \`¡Santo! ¡Santo! ¡Santo!\` on himnario.net). Running HA standalone monthly avoids the cumulative-rate-limit issue and gives us trend data over time.

The aggregator lives in a separate \`.py\` file because its markdown templates contain blank lines, which break YAML's block-scalar parser when inlined in a \`run:\` step.

## What was attempted first

A session-only cron via the runtime's CronCreate (one-shot, 4 weeks out, \`durable: true\`). Result: \`Session-only (not written to disk, dies when Claude exits)\` — \`durable\` was effectively ignored. Filed tracking issue #704 as a fallback runbook, then the user asked for true automation; this PR delivers that.

## Migrations

None.

## Test plan

- [ ] Merge this PR, then trigger \`Maintenance — Issues Sweep\` manually from the Actions tab. Confirm:
  - Run summary shows the headline number (closed N, failed M).
  - At least one issue actually transitions \`open → closed\` with the explanatory comment.
  - No issues that should stay open get closed (workflow is conservative — only acts on \`closes #N\` references).
- [ ] Trigger \`Maintenance — HA Integrity Audit\` manually. Confirm:
  - ChristInSong pre-fetch step succeeds (or warns gracefully if upstream is flaky).
  - Audit step runs and either reports \`saved=0\` (rate-limited, no PR) or proceeds.
  - On success, a PR appears against \`alpha\` titled \`Audit: HA cross-source integrity (<date>)\` with the committed report.
- [ ] After both have run once, confirm cron picks up future runs without intervention.

## Cleanup

After merge: close #704 (it links to this PR's automation as the replacement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)