### PR TITLE
Songbooks UX + Activity Log polish + migration runner diagnostics (closes #715-#718, #720, #721, #723)

### DIFF
--- a/.claude/ProjectBrief.md
+++ b/.claude/ProjectBrief.md
@@ -213,3 +213,5 @@ Active in-flight items deferred from the second-cycle batch (will land in their 
 - **#707** — Org-admin role + per-org member/licence management at /manage/my-organisations. Issue filed; multi-PR scope.
 - **#709** — tblUserSetlists empty despite migrations + legacy JSON files not imported. Needs investigation into where legacy setlists were originally stored.
 - **#713** — Rolling Manage-area sweep tracker for catch-all-with-error_log-no-logActivityError pattern. Several pages threaded; the rest catalogued in the issue checklist.
+- **#719** — Comprehensive API parity audit + OpenAPI refresh + in-app docs + Wiki refresh. Multi-PR tracker (5 sub-PRs). Realistic timeline ~1 week of focused work.
+- **#722** — Schema Audit drift: 3 uncovered columns + 18 orphans-in-DB. Needs new migration scripts for orphans (tblOrganisationLicences full table, tblSongArtists full table, tblUsers.AvatarService, tblCreditPeople.Slug/IsSpecialCase/IsGroup) + schema.sql cleanup for the typo "uncovered" entries.

--- a/.claude/project-rules.md
+++ b/.claude/project-rules.md
@@ -131,6 +131,18 @@ These are project conventions worth knowing when touching adjacent code, establi
 
   And note: SQL string literals always use single quotes (`'pending'`, not `"pending"`). MySQL's default mode treats both as strings, but `sql_mode='ANSI_QUOTES'` parses double-quoted as a column reference — and the song-request endpoint had exactly that bug for a while (#711).
 
+- **Shared colour-picker partial (#715).** Hex-colour text inputs on `/manage/*` go through `manage/includes/partials/colour-picker.php` + the `js/modules/colour-picker.js` boot. The partial emits a native `<input type="color">` swatch alongside the hex text input, two-way bound. Empty text → swatch shows a neutral seed but the saved value stays empty so the auto-pick path (#677) runs at render. New consumers should pull this partial rather than rolling their own.
+
+- **Misc-pinned-bottom + non-official alphabetical (#717 / #718).** Two related sort rules:
+  - `/manage/songbooks` quick-sort presets pin the Misc songbook (`Abbreviation = 'Misc'`) to the bottom regardless of name/abbr direction. Implementation: short-circuit in the `sortByKey` JS helper before the regular compare.
+  - Songs within a songbook sort by Number when the songbook is `IsOfficial = 1` AND has at least one numbered hymn; else sort alphabetically by Title. Hybrid books (mostly numbered with an un-numbered supplement) put numbered first, alphabetical tail second. Implemented via a CASE branch in `SongData::getSongs()`'s ORDER BY.
+
+- **Database Setup bulk-run (#708 / #720).** The "Apply all pending migrations" button walks `$migrationOrder` (separate list from `$scriptMap`). When adding a new `migrate-*.php` register it in BOTH places, in deployment order, AND add the per-card UI block. The bulk-run handler:
+  - Captures the first-failing-step's metadata so the page renders a prominent banner ABOVE the (potentially long, scrollable) output panel — operators can spot the failure without scrolling.
+  - Has a `register_shutdown_function` that catches PHP fatals (E_ERROR / E_PARSE / etc.) which bypass try/catch, so even a fatal mid-bulk gets surfaced before the page renders.
+
+- **Activity Log local-time + UA wrapping (#721 / #723).** The `/manage/activity-log` listing renders the When column in the user's local timezone via inline `Intl.DateTimeFormat`, falling back to UTC if Intl is unavailable. UA strings render in full (no server-side substr cap) with `.activity-ua { word-break: break-word; overflow-wrap: anywhere }` so long UAs wrap rather than truncate.
+
 ## 11. Activity logging — what NEVER goes in `tblActivityLog.Details` (#535)
 
 Every meaningful action writes a row to `tblActivityLog` via

--- a/appWeb/public_html/includes/SongData.php
+++ b/appWeb/public_html/includes/SongData.php
@@ -431,6 +431,30 @@ class SongData
 
         $whereClause = !empty($where) ? 'WHERE ' . implode(' AND ', $where) : '';
 
+        /* #718 — Non-official songbooks (and any songbook where every
+           song's Number is NULL) sort their songs alphabetically by
+           Title. Officially-published hymnals with numbered hymns
+           keep the by-Number sort.
+
+           SQL evaluates the branch per-row via a JOIN to
+           tblSongbooks.IsOfficial:
+             - IsOfficial = 1 AND Number IS NOT NULL → numbered (rank 0)
+             - otherwise                             → alphabetical (rank 1)
+
+           Within each songbook (clustered by SongbookAbbr), numbered
+           rows come first (Number ASC), then any un-numbered entries
+           in alphabetical order. Non-official songbooks therefore
+           render as a flat alphabetical list because every row gets
+           rank 1 + uses the title key.
+
+           LOWER(s.Title) suffices as the alphabetical key — the
+           leading-article strip from #717 / #674 is desktop-only
+           (JS) for the songbook list; doing it in SQL would require
+           REGEXP_REPLACE which is MySQL 8.0+ only and the project
+           supports 5.7+. Acceptable degradation: "The Solid Rock"
+           sorts under T in the un-numbered tail. Future enhancement:
+           add a generated column TitleSortKey on tblSongs that
+           strips the article at write-time. */
         $sql = "SELECT s.SongId AS id, s.Number AS number, s.Title AS title, s.SongbookAbbr AS songbook,
                        s.SongbookName AS songbookName, s.Language AS language, s.Copyright AS copyright,
                        s.TuneName AS tuneName, s.Ccli AS ccli, s.Iswc AS iswc,
@@ -438,8 +462,15 @@ class SongData
                        s.MusicPublicDomain AS musicPublicDomain,
                        s.HasAudio AS hasAudio, s.HasSheetMusic AS hasSheetMusic
                 FROM tblSongs s
+                LEFT JOIN tblSongbooks b ON b.Abbreviation = s.SongbookAbbr
                 {$whereClause}
-                ORDER BY s.SongbookAbbr, s.Number";
+                ORDER BY s.SongbookAbbr ASC,
+                         CASE
+                            WHEN b.IsOfficial = 1 AND s.Number IS NOT NULL THEN 0
+                            ELSE 1
+                         END ASC,
+                         s.Number ASC,
+                         LOWER(s.Title) ASC";
 
         $stmt = $this->db->prepare($sql);
         if (!empty($params)) {

--- a/appWeb/public_html/js/modules/colour-picker.js
+++ b/appWeb/public_html/js/modules/colour-picker.js
@@ -1,0 +1,78 @@
+/**
+ * Colour picker (#715)
+ *
+ * Two-way bind between a native <input type="color"> swatch and the
+ * sibling <input type="text"> hex field. Used wherever a curator
+ * historically had to type "#1a73e8" by hand — songbooks editor today,
+ * and any future field that adopts the colour-picker partial.
+ *
+ * Markup contract — caller renders something like:
+ *
+ *   <div class="colour-picker" data-colour-picker-id="edit">
+ *     <input type="color" class="colour-picker-swatch" value="#1a73e8">
+ *     <input type="text"  class="colour-picker-text"   value="#1a73e8">
+ *   </div>
+ *
+ * Boot every instance on the page in one call:
+ *
+ *   import { bootColourPickers } from '/js/modules/colour-picker.js';
+ *   bootColourPickers();   // walks the document
+ *
+ * Or boot a single instance:
+ *
+ *   bootColourPicker(document.querySelector('.colour-picker'));
+ */
+
+/* Empty-or-valid hex check — what the form's `pattern=` attribute
+   already enforces, mirrored here so we don't push garbage into the
+   swatch (the native <input type="color"> silently snaps invalid
+   values to #000000, which is a confusing user experience). */
+const HEX_RE = /^#[0-9A-Fa-f]{6}$/;
+
+/**
+ * Boot one colour-picker instance. Idempotent — safe to call twice on
+ * the same root.
+ */
+export function bootColourPicker(rootEl) {
+    if (!rootEl || rootEl.dataset.colourPickerBooted === '1') return;
+    rootEl.dataset.colourPickerBooted = '1';
+
+    const swatch = rootEl.querySelector('.colour-picker-swatch');
+    const text   = rootEl.querySelector('.colour-picker-text');
+    if (!swatch || !text) return;
+
+    /* Swatch → text. The native picker emits #RRGGBB lowercase already;
+       we still uppercase the alpha-hex characters to match the codebase
+       convention used elsewhere (config.php palette constants etc.). */
+    swatch.addEventListener('input', () => {
+        text.value = swatch.value.toUpperCase().replace(/^#([0-9A-F]{6})$/i,
+            (_m, hex) => '#' + hex.toLowerCase());
+        text.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    /* Text → swatch. Only sync when the typed value is a complete
+       6-char hex; partial input ("#1a7") leaves the swatch untouched
+       so the user doesn't see it flicker between colours mid-keystroke. */
+    text.addEventListener('input', () => {
+        const v = text.value.trim();
+        if (HEX_RE.test(v)) {
+            swatch.value = v.toLowerCase();
+        }
+    });
+}
+
+/**
+ * Boot every .colour-picker instance currently in the document.
+ * Use this on page-load; for dynamically-inserted markup (e.g. a
+ * modal whose content arrives after init), call bootColourPicker(el)
+ * on the specific root once it's in the DOM.
+ */
+export function bootColourPickers(root = document) {
+    const els = root.querySelectorAll('.colour-picker[data-colour-picker-id]');
+    els.forEach(bootColourPicker);
+}
+
+/* Convenience for classic-script callers that can't import. */
+if (typeof window !== 'undefined') {
+    window.colourPicker = { bootColourPicker, bootColourPickers };
+}

--- a/appWeb/public_html/manage/activity-log.php
+++ b/appWeb/public_html/manage/activity-log.php
@@ -355,7 +355,12 @@ $buildQuery = function (array $overrides = []) {
                 <table class="table table-sm table-dark table-hover align-middle">
                     <thead>
                         <tr>
-                            <th style="width: 11rem;">When (UTC)</th>
+                            <?php /* Header label flips between (local) and (UTC) at runtime
+                                     once the inline script below has rewritten the cells.
+                                     If the script doesn't run (CSP block, ancient browser),
+                                     the cells stay UTC and the header keeps its initial
+                                     "(UTC)" suffix. (#723) */ ?>
+                            <th style="width: 11rem;" id="activity-when-header">When (UTC)</th>
                             <th style="width: 10rem;">User</th>
                             <th>Action</th>
                             <th>Entity</th>
@@ -374,7 +379,12 @@ $buildQuery = function (array $overrides = []) {
                         $rowId = (int)$r['Id'];
                     ?>
                         <tr class="activity-row">
-                            <td class="text-muted small">
+                            <td class="text-muted small activity-when"
+                                data-utc="<?= htmlspecialchars(
+                                    str_replace(' ', 'T', (string)$r['CreatedAt']) . 'Z',
+                                    ENT_QUOTES, 'UTF-8'
+                                ) ?>"
+                                title="<?= htmlspecialchars((string)$r['CreatedAt'], ENT_QUOTES, 'UTF-8') ?> UTC">
                                 <?= htmlspecialchars((string)$r['CreatedAt'], ENT_QUOTES, 'UTF-8') ?>
                             </td>
                             <td>
@@ -421,8 +431,14 @@ $buildQuery = function (array $overrides = []) {
                                         · <?= (int)$r['DurationMs'] ?> ms
                                     <?php endif; ?>
                                     <?php if (!empty($r['UserAgent'])): ?>
-                                        · UA: <span title="<?= htmlspecialchars((string)$r['UserAgent'], ENT_QUOTES, 'UTF-8') ?>">
-                                            <?= htmlspecialchars(substr((string)$r['UserAgent'], 0, 80), ENT_QUOTES, 'UTF-8') ?>
+                                        <?php /* Render the full UA inline (no 80-char substr cap)
+                                                 — long UAs wrap to a second line via the
+                                                 .activity-ua wrapper class, which uses
+                                                 word-break:break-word + max-width:100% so
+                                                 long unbroken tokens still wrap rather than
+                                                 overflow the row. (#721) */ ?>
+                                        · UA: <span class="activity-ua" title="<?= htmlspecialchars((string)$r['UserAgent'], ENT_QUOTES, 'UTF-8') ?>">
+                                            <?= htmlspecialchars((string)$r['UserAgent'], ENT_QUOTES, 'UTF-8') ?>
                                         </span>
                                     <?php endif; ?>
                                 </div>
@@ -460,6 +476,52 @@ $buildQuery = function (array $overrides = []) {
             <?php endif; ?>
         <?php endif; ?>
     </div>
+
+    <!-- Local-time conversion + UA-wrap styling (#721 / #723).
+         Each .activity-when cell carries data-utc="2026-04-30T13:53:42Z";
+         this script formats it via the browser's Intl.DateTimeFormat in
+         the user's local timezone and replaces the cell's text. If Intl
+         isn't available (very old browser) the cells stay UTC and the
+         header label stays "When (UTC)". -->
+    <style>
+        .activity-ua {
+            display: inline-block;
+            max-width: 100%;
+            word-break: break-word;
+            overflow-wrap: anywhere;
+        }
+    </style>
+    <script>
+    (function () {
+        try {
+            if (typeof Intl === 'undefined' || !Intl.DateTimeFormat) return;
+            var fmt = new Intl.DateTimeFormat(undefined, {
+                year:   'numeric', month:  '2-digit', day:    '2-digit',
+                hour:   '2-digit', minute: '2-digit', second: '2-digit',
+                hour12: false,
+            });
+            var cells = document.querySelectorAll('.activity-when[data-utc]');
+            if (!cells.length) return;
+            cells.forEach(function (cell) {
+                var iso = cell.getAttribute('data-utc');
+                if (!iso) return;
+                var d = new Date(iso);
+                if (isNaN(d.getTime())) return;
+                /* Reformat to "YYYY-MM-DD HH:MM:SS" — matches the
+                   table's existing visual cadence; some locales would
+                   otherwise produce "30/04/2026, 14:53:42" which jars
+                   in a tabular layout. */
+                var parts = fmt.formatToParts(d).reduce(function (acc, p) {
+                    if (p.type !== 'literal') acc[p.type] = p.value; return acc;
+                }, {});
+                cell.textContent = parts.year + '-' + parts.month + '-' + parts.day
+                    + ' ' + parts.hour + ':' + parts.minute + ':' + parts.second;
+            });
+            var header = document.getElementById('activity-when-header');
+            if (header) header.textContent = 'When (local)';
+        } catch (_e) { /* fail-soft — leave UTC text in place */ }
+    })();
+    </script>
 
     <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>
 </body>

--- a/appWeb/public_html/manage/includes/partials/colour-picker.php
+++ b/appWeb/public_html/manage/includes/partials/colour-picker.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Colour Picker partial (#715)
+ *
+ * A composite control: a native <input type="color"> swatch alongside
+ * the existing <input type="text"> for the hex value. Both are bound
+ * via js/modules/colour-picker.js — typing a hex updates the swatch,
+ * picking from the swatch fills the text input. Empty text → swatch
+ * shows a neutral default but the saved value remains "" so the
+ * server-side auto-pick (#677) can choose a palette tone at render.
+ *
+ * Caller contract:
+ *
+ *   <?php
+ *     $name        = 'colour';      // POST field name on the text input
+ *     $value       = $colour;       // current hex (or '' if not set)
+ *     $idPrefix    = 'edit';        // unique per instance on a page
+ *     $label       = 'Colour (hex)';// optional override
+ *     $placeholder = '#1a73e8';     // optional placeholder
+ *     require __DIR__ . '/includes/partials/colour-picker.php';
+ *   ?>
+ *
+ * Used by: /manage/songbooks (create form + edit modal). New consumers
+ * should pull this partial rather than rolling their own.
+ */
+
+/* Prevent direct access */
+if (basename($_SERVER['SCRIPT_FILENAME'] ?? '') === basename(__FILE__)) {
+    http_response_code(403);
+    exit('Access denied.');
+}
+
+/* Defensive defaults so a forgetful caller still renders a usable
+   widget rather than crashing. */
+$name        = isset($name)        ? (string)$name        : 'colour';
+$value       = isset($value)       ? (string)$value       : '';
+$idPrefix    = isset($idPrefix)    ? (string)$idPrefix    : 'colour';
+$label       = isset($label)       ? (string)$label       : 'Colour (hex)';
+$placeholder = isset($placeholder) ? (string)$placeholder : '#1a73e8';
+$required    = isset($required)    ? (bool)$required      : false;
+
+/* Sanitise the id prefix the same way the IETF picker partial does. */
+$idSafe = preg_replace('/[^A-Za-z0-9_-]/', '-', $idPrefix);
+
+/* The native <input type="color"> requires a 6-char hex; if the saved
+   value is shorter (e.g. "#abc") we still echo it on the text input
+   but seed the swatch with a sensible default so the colour picker
+   widget renders in a usable state. */
+$swatchSeed = preg_match('/^#[0-9A-Fa-f]{6}$/', $value) ? $value : '#cccccc';
+?>
+<div class="colour-picker d-flex align-items-center gap-2"
+     data-colour-picker-id="<?= htmlspecialchars($idSafe, ENT_QUOTES, 'UTF-8') ?>">
+    <input type="color"
+           class="form-control form-control-color colour-picker-swatch"
+           value="<?= htmlspecialchars($swatchSeed, ENT_QUOTES, 'UTF-8') ?>"
+           aria-label="<?= htmlspecialchars($label, ENT_QUOTES, 'UTF-8') ?> swatch"
+           style="width: 2.5rem; flex: 0 0 auto; padding: 0.125rem;">
+    <input type="text"
+           name="<?= htmlspecialchars($name, ENT_QUOTES, 'UTF-8') ?>"
+           id="<?= htmlspecialchars($idSafe, ENT_QUOTES, 'UTF-8') ?>-text"
+           class="form-control form-control-sm colour-picker-text"
+           value="<?= htmlspecialchars($value, ENT_QUOTES, 'UTF-8') ?>"
+           pattern="#[0-9A-Fa-f]{6}"
+           placeholder="<?= htmlspecialchars($placeholder, ENT_QUOTES, 'UTF-8') ?>"
+           autocomplete="off"
+           <?= $required ? 'required' : '' ?>>
+</div>

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -178,6 +178,14 @@ if (isset($_GET['saved'])) {
 $action = $_GET['action'] ?? '';
 $actionOutput = '';
 $actionSuccess = false;
+/* Captured during bulk-run so the failure can be surfaced as a visible
+   banner ABOVE the (potentially long, scrollable) output panel. (#720) */
+$bulkFirstFailStep    = null;
+$bulkFirstFailMessage = '';
+$bulkFirstFailFile    = '';
+$bulkFirstFailLine    = 0;
+$bulkTotalRan         = 0;
+$bulkTotalFailed      = 0;
 
 if ($action !== '') {
     /* Signal to the included scripts that they're being run from the
@@ -273,6 +281,35 @@ if ($action !== '') {
             $totalFailed = 0;
             $startedAt = microtime(true);
             $actionSuccess = true;
+            /* First-failing-step is captured so we can surface it as a
+               prominent banner ABOVE the output panel — the original
+               implementation wrote the FAILED line into the panel where
+               it could be missed if the panel's overflow scrolled past
+               it. (#720) */
+            $firstFailStep    = null;
+            $firstFailMessage = '';
+            $firstFailFile    = '';
+            $firstFailLine    = 0;
+
+            /* Catch fatal errors mid-bulk (PHP Fatal in an included
+               migration script bypasses the try/catch). The shutdown
+               handler captures the last error and surfaces it the
+               same way as a caught Throwable. (#720) */
+            register_shutdown_function(function () {
+                $err = error_get_last();
+                if (!$err) return;
+                if (!in_array($err['type'], [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR], true)) {
+                    return;
+                }
+                /* Best-effort flush so the operator at least sees the
+                   fatal in the output panel even if the bulk loop
+                   never reached its summary footer. */
+                echo "\n\n══════════════════════════════════════════════════════\n";
+                echo "✗ FATAL DURING BULK RUN: " . $err['message'] . "\n";
+                echo "  File: " . basename($err['file']) . ":" . $err['line'] . "\n";
+                echo "══════════════════════════════════════════════════════\n";
+            });
+
             foreach ($migrationOrder as $migAction) {
                 $migScript = $scriptMap[$migAction] ?? null;
                 if ($migScript === null) {
@@ -296,6 +333,12 @@ if ($action !== '') {
                 } catch (\Throwable $e) {
                     $totalFailed++;
                     $actionSuccess = false;
+                    if ($firstFailStep === null) {
+                        $firstFailStep    = $migAction;
+                        $firstFailMessage = $e->getMessage();
+                        $firstFailFile    = basename((string)$e->getFile());
+                        $firstFailLine    = (int)$e->getLine();
+                    }
                     echo "\n  ✗ {$migAction} FAILED: " . htmlspecialchars($e->getMessage()) . "\n";
                     if ($e->getFile()) {
                         echo "    File: " . htmlspecialchars(basename($e->getFile())) . ":" . $e->getLine() . "\n";
@@ -304,6 +347,15 @@ if ($action !== '') {
                     break;
                 }
             }
+            /* Promote captured failure data to the outer scope so the
+               render below can surface a visible "Failed at" banner. */
+            $bulkFirstFailStep    = $firstFailStep;
+            $bulkFirstFailMessage = $firstFailMessage;
+            $bulkFirstFailFile    = $firstFailFile;
+            $bulkFirstFailLine    = $firstFailLine;
+            $bulkTotalRan         = $totalRan;
+            $bulkTotalFailed      = $totalFailed;
+
             $totalElapsed = round((microtime(true) - $startedAt) * 1000);
             echo "═══════════════════════════════════════════════════════\n";
             echo "Bulk run finished — {$totalRan} migration"
@@ -516,6 +568,39 @@ if ($hasCredentials && defined('DB_HOST')) {
                 <span class="badge bg-danger ms-2">Error</span>
             <?php endif; ?>
         </h4>
+
+        <?php if ($action === 'apply-all-migrations' && $bulkFirstFailStep !== null): ?>
+            <!-- Prominent failure banner ABOVE the (potentially long,
+                 scrollable) output panel so the operator sees exactly
+                 which step broke and the message detail without having
+                 to scroll the panel to find it. (#720) -->
+            <div class="alert alert-danger" role="alert">
+                <h5 class="alert-heading mb-2">
+                    <i class="bi bi-exclamation-triangle-fill me-1"></i>
+                    Bulk run failed at step:
+                    <code><?= htmlspecialchars($bulkFirstFailStep) ?></code>
+                </h5>
+                <p class="mb-2">
+                    <strong><?= $bulkTotalRan ?></strong>
+                    migration<?= $bulkTotalRan === 1 ? '' : 's' ?>
+                    completed before this step;
+                    <strong><?= $bulkTotalFailed ?></strong>
+                    failed; remaining steps were not attempted.
+                </p>
+                <p class="mb-1">
+                    <strong>Cause:</strong>
+                    <code><?= htmlspecialchars($bulkFirstFailMessage) ?></code>
+                </p>
+                <?php if ($bulkFirstFailFile !== ''): ?>
+                    <p class="mb-0 small text-muted">
+                        At
+                        <code><?= htmlspecialchars($bulkFirstFailFile) ?>:<?= (int)$bulkFirstFailLine ?></code>
+                        — full per-step output below.
+                    </p>
+                <?php endif; ?>
+            </div>
+        <?php endif; ?>
+
         <div class="output-log"><?= $actionOutput ?></div>
 
     <?php else: ?>

--- a/appWeb/public_html/manage/songbooks.php
+++ b/appWeb/public_html/manage/songbooks.php
@@ -1055,8 +1055,19 @@ $csrf = csrfToken();
                 </div>
                 <div class="col-sm-2">
                     <label class="form-label small">Colour (hex)</label>
-                    <input type="text" name="colour" class="form-control form-control-sm"
-                           pattern="#[0-9A-Fa-f]{6}" placeholder="#1a73e8">
+                    <?php
+                        /* Shared colour picker partial — native swatch
+                           bound to the hex text input (#715). */
+                        $name        = 'colour';
+                        $value       = '';
+                        $idPrefix    = 'create-songbook-colour';
+                        $placeholder = '#1a73e8';
+                        require __DIR__ . DIRECTORY_SEPARATOR
+                            . 'includes' . DIRECTORY_SEPARATOR
+                            . 'partials' . DIRECTORY_SEPARATOR
+                            . 'colour-picker.php';
+                        unset($name, $value, $idPrefix, $placeholder);
+                    ?>
                 </div>
                 <div class="col-sm-2">
                     <label class="form-label small">Display order</label>
@@ -1230,8 +1241,22 @@ $csrf = csrfToken();
                         <div class="row g-2 mb-3">
                             <div class="col-sm-6">
                                 <label class="form-label">Colour (hex)</label>
-                                <input type="text" class="form-control" name="colour" id="edit-colour"
-                                       pattern="#[0-9A-Fa-f]{6}" placeholder="#1a73e8">
+                                <?php
+                                    /* Shared colour picker partial (#715). The text
+                                       input keeps id="edit-colour" via the partial's
+                                       internal scheme — the JS that opens this modal
+                                       still sets the value via querySelector on
+                                       the .colour-picker-text class instead of by id. */
+                                    $name        = 'colour';
+                                    $value       = '';
+                                    $idPrefix    = 'edit-songbook-colour';
+                                    $placeholder = '#1a73e8';
+                                    require __DIR__ . DIRECTORY_SEPARATOR
+                                        . 'includes' . DIRECTORY_SEPARATOR
+                                        . 'partials' . DIRECTORY_SEPARATOR
+                                        . 'colour-picker.php';
+                                    unset($name, $value, $idPrefix, $placeholder);
+                                ?>
                             </div>
                             <div class="col-sm-6">
                                 <label class="form-label">Display order</label>
@@ -1448,7 +1473,26 @@ $csrf = csrfToken();
             document.getElementById('edit-id').value                = row.id;
             document.getElementById('edit-abbr-label').textContent  = row.abbreviation;
             document.getElementById('edit-name').value              = row.name;
-            document.getElementById('edit-colour').value            = row.colour || '';
+            /* The colour field is now wrapped in the shared colour-picker
+               partial (#715), which gives the text input the id
+               edit-songbook-colour-text and adds a sibling swatch.
+               Setting the text input's value also fires an `input` event
+               so the boot-script's text→swatch sync handler updates the
+               native picker preview to match. */
+            (function () {
+                const colourText   = document.getElementById('edit-songbook-colour-text');
+                const colourSwatch = document.querySelector(
+                    '[data-colour-picker-id="edit-songbook-colour"] .colour-picker-swatch'
+                );
+                const v = row.colour || '';
+                if (colourText) {
+                    colourText.value = v;
+                    colourText.dispatchEvent(new Event('input', { bubbles: true }));
+                }
+                if (colourSwatch && /^#[0-9A-Fa-f]{6}$/.test(v)) {
+                    colourSwatch.value = v.toLowerCase();
+                }
+            })();
             document.getElementById('edit-order').value             = row.display_order || 0;
 
             /* #502 metadata fields */
@@ -1516,6 +1560,16 @@ $csrf = csrfToken();
         if (createPicker) bootIetfLanguagePicker(createPicker);
         const editPicker   = document.querySelector('[data-ietf-picker-id="edit-songbook"]');
         if (editPicker)   window.editIetfPicker = bootIetfLanguagePicker(editPicker);
+    </script>
+
+    <!-- Colour picker boot (#715). Wires the native swatch ↔ hex
+         text two-way binding for every .colour-picker on the page —
+         currently the create form's Colour field + the edit modal's
+         Colour field. Both render via the shared
+         manage/includes/partials/colour-picker.php. -->
+    <script type="module">
+        import { bootColourPickers } from '/js/modules/colour-picker.js?v=<?= filemtime(dirname(__DIR__) . '/js/modules/colour-picker.js') ?>';
+        bootColourPickers();
     </script>
 
     <!-- Drag-and-drop reorder + Sort by Name/Abbr presets (#674).

--- a/appWeb/public_html/manage/songbooks.php
+++ b/appWeb/public_html/manage/songbooks.php
@@ -752,6 +752,78 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 break;
             }
 
+            case 'auto_colour_fill':
+            case 'auto_colour_reassign': {
+                /* Bulk auto-colour action (#716). Two modes:
+                     fill      — only rows where Colour IS NULL or '' get a
+                                 newly-picked palette colour. Existing values
+                                 left alone.
+                     reassign  — every row gets a fresh colour. Destructive,
+                                 hence the confirm-by-typing-REASSIGN-ALL gate
+                                 enforced both client-side AND server-side.
+                   Admin / global_admin only. */
+                if (!in_array(($currentUser['role'] ?? ''), ['admin', 'global_admin'], true)) {
+                    $error = 'Admin role required for the auto-colour bulk action.';
+                    break;
+                }
+                $mode = $action === 'auto_colour_reassign' ? 'reassign' : 'fill';
+                if ($mode === 'reassign') {
+                    /* Server-side typed-confirmation gate — even if the
+                       client-side disable was bypassed, the action only
+                       runs when the curator typed the literal phrase. */
+                    $typed = trim((string)($_POST['confirm_phrase'] ?? ''));
+                    if ($typed !== 'REASSIGN ALL') {
+                        $error = 'Reassign-all needs the phrase REASSIGN ALL typed exactly.';
+                        break;
+                    }
+                }
+                /* Walk every songbook abbreviation, pick a colour, write back.
+                   Uses pickAutoSongbookColour() which reads the in-use set
+                   from tblSongbooks AS WE WRITE — so each successive pick
+                   factors in the colours the loop has just assigned. */
+                $stmt = $db->prepare('SELECT Id, Abbreviation, Colour FROM tblSongbooks ORDER BY Id');
+                $stmt->execute();
+                $books = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+                $stmt->close();
+
+                $db->begin_transaction();
+                $changed = 0;
+                try {
+                    $up = $db->prepare('UPDATE tblSongbooks SET Colour = ? WHERE Id = ?');
+                    foreach ($books as $b) {
+                        $existing = trim((string)($b['Colour'] ?? ''));
+                        $needsAssign = $mode === 'reassign'
+                            ? true
+                            : !preg_match('/^#[0-9A-Fa-f]{6}$/', $existing);
+                        if (!$needsAssign) continue;
+                        $newColour = pickAutoSongbookColour($db, (string)$b['Abbreviation']);
+                        $bookId    = (int)$b['Id'];
+                        $up->bind_param('si', $newColour, $bookId);
+                        $up->execute();
+                        $changed++;
+                    }
+                    $up->close();
+                    $db->commit();
+
+                    logActivity(
+                        $mode === 'reassign'
+                            ? 'songbook.auto_colour_reassign'
+                            : 'songbook.auto_colour_fill',
+                        'songbook', '',
+                        ['count' => $changed, 'mode' => $mode]
+                    );
+                    $success = $mode === 'reassign'
+                        ? "Reassigned colours on {$changed} songbook"
+                          . ($changed === 1 ? '' : 's') . '.'
+                        : "Auto-coloured {$changed} songbook"
+                          . ($changed === 1 ? '' : 's') . ' that had no colour set.';
+                } catch (\Throwable $e) {
+                    $db->rollback();
+                    throw $e;
+                }
+                break;
+            }
+
             default:
                 $error = 'Unknown action.';
         }
@@ -1034,6 +1106,45 @@ $csrf = csrfToken();
                 <small class="text-muted ms-2">Lower numbers render first. Any non-negative integer is fine — gaps of 10 between rows give you room to slot in a new book later, but you can use 1, 2, 3, … or anything else (#672).</small>
             <?php endif; ?>
         </form>
+
+        <?php if (in_array(($currentUser['role'] ?? ''), ['admin', 'global_admin'], true)): ?>
+        <!-- Auto-colour bulk action panel (#716). Admin / global_admin only.
+             Two modes: fill (only rows with no colour set) and reassign
+             (every row, gated by typed-confirmation). -->
+        <div class="card-admin p-3 mb-4">
+            <h2 class="h6 mb-3"><i class="bi bi-palette me-2"></i>Auto-colour songbooks</h2>
+            <p class="small text-muted mb-3">
+                Pick palette colours from the active theme so the catalogue stays visually consistent. Existing curator-typed colours are preserved unless the destructive Reassign mode is used.
+            </p>
+            <div class="d-flex flex-wrap gap-2 align-items-end">
+                <form method="POST" class="d-inline-block"
+                      onsubmit="return confirm('Auto-colour every songbook that currently has no colour assigned?');">
+                    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                    <input type="hidden" name="action" value="auto_colour_fill">
+                    <button type="submit" class="btn btn-amber btn-sm">
+                        <i class="bi bi-droplet-half me-1"></i>Fill missing colours
+                    </button>
+                </form>
+                <form method="POST" class="d-inline-flex align-items-end gap-2"
+                      onsubmit="
+                        if (this.querySelector('input[name=confirm_phrase]').value !== 'REASSIGN ALL') {
+                            alert('Type the phrase REASSIGN ALL to enable this destructive action.');
+                            return false;
+                        }
+                        return confirm('REASSIGN colours on EVERY songbook? Existing curator-typed values will be overwritten. This cannot be undone.');
+                      ">
+                    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                    <input type="hidden" name="action" value="auto_colour_reassign">
+                    <input type="text" name="confirm_phrase" class="form-control form-control-sm"
+                           placeholder="Type: REASSIGN ALL" autocomplete="off"
+                           style="max-width: 11rem;">
+                    <button type="submit" class="btn btn-outline-danger btn-sm">
+                        <i class="bi bi-shuffle me-1"></i>Reassign all (destructive)
+                    </button>
+                </form>
+            </div>
+        </div>
+        <?php endif; ?>
 
         <!-- Create -->
         <form method="POST" class="card-admin p-3 mb-4">

--- a/appWeb/public_html/manage/songbooks.php
+++ b/appWeb/public_html/manage/songbooks.php
@@ -1627,8 +1627,24 @@ $csrf = csrfToken();
         const stripArticle = (s) =>
             (s || '').replace(/^\s*(the|an|a)\s+/i, '').toLowerCase();
 
+        /* "Miscellaneous" (abbreviation: Misc) is a catch-all for
+           orphan / outside-canon songs. It must always sit at the
+           bottom of every name- or abbr-sort regardless of direction
+           — otherwise it ends up among the M's (asc) or at the very
+           top (desc) and confuses curators. (#717) */
+        const isMiscRow = (tr) =>
+            (tr.dataset.sortAbbr || '').toLowerCase() === 'misc';
+
         const sortByKey = (keyFn, dir) => {
             const sorted = rows().sort((a, b) => {
+                /* Misc-pinned-bottom rule: any Misc row always sorts
+                   AFTER any non-Misc row. Two Misc rows fall back to
+                   the regular key compare (rare in practice — there's
+                   normally only one Misc songbook). */
+                const aMisc = isMiscRow(a);
+                const bMisc = isMiscRow(b);
+                if (aMisc && !bMisc) return 1;
+                if (!aMisc && bMisc) return -1;
                 const cmp = keyFn(a).localeCompare(keyFn(b));
                 return dir === 'asc' ? cmp : -cmp;
             });


### PR DESCRIPTION
## Summary

Seven commits, seven issues closed. All small-to-medium UX/UI improvements + a diagnostic upgrade to the bulk-migration runner.

| Commit | Closes | Headline |
|---|---|---|
| df6911e | **#715** | Native `<input type="color">` swatch on Songbooks Colour (hex) field — shared partial + module |
| 376024b | **#717** | Miscellaneous songbook pinned to bottom of every name/abbr sort |
| 6375243 | **#718** | Non-official songbooks sort their songs alphabetically by title (numbered books unchanged) |
| ffacfc3 | **#720** | Bulk-migration runner: prominent failure banner above output + catches PHP fatals via shutdown handler |
| f920c49 | **#721, #723** | Activity Log: full UA wrap (no substr cap) + When column rendered in user-local timezone via Intl |
| 474685b | **#716** | Songbooks bulk auto-colour: Fill-missing + Reassign-all (typed-confirmation gated) |
| 2721e94 | refs #682 | .claude/ProjectBrief + project-rules refreshed with the new conventions |

## Out of scope (deferred to follow-up tracking issues)

The user's broader queue includes several large items that are repeated across messages. Each is a multi-session effort and warrants its own focused PR rather than being squeezed in here:

- **#706** — Songbook cascade-delete with two-step confirmation modal. Transactional FK chain across 8+ tables.
- **#707** — Org-admin role + per-org member/licence management. Multi-PR scope.
- **#709** — Setlist migration empty / legacy JSON not imported. Needs investigation.
- **#713** — Rolling Manage-area sweep tail. Several pages already threaded; remaining catalogued in the issue.
- **#719** — Comprehensive API parity audit + OpenAPI refresh + in-app docs + GitHub Wiki update. **Multi-PR tracker** (5 sub-PRs, ~1 week of focused work). Wiki lives in a separate repo and warrants its own session.
- **#722** — Schema Audit drift: 3 uncovered columns + 18 orphans-in-DB. Needs new migration scripts + schema.sql cleanup. Multi-migration tracker.
- **ChristInSong scraper run + ZIP for import** — standalone task, both endpoints are ready; just hasn't been kicked off.

## Migrations

None.

## Test plan

- [ ] /manage/songbooks: Add a songbook — Colour field shows the native swatch + hex text. Pick a colour → text fills. Type a hex → swatch syncs.
- [ ] /manage/songbooks: Edit modal — same. Saved colour pre-populates both inputs.
- [ ] /manage/songbooks: Quick-sort Name A→Z — Misc songbook is the LAST row. Same on Name Z→A and the Abbr presets.
- [ ] Visit a non-official songbook's detail page or the editor's grouped view — songs appear alphabetically by title.
- [ ] Visit an official hymnal (SDAH, MP) — songs still appear in number order.
- [ ] /manage/setup-database: click Apply all → if anything fails, prominent red banner above the output panel names the failing step + cause.
- [ ] /manage/activity-log: When column shows local-time on first paint (via Intl). Hover to see UTC tooltip. UA line wraps to a second line for long UAs rather than truncating.
- [ ] /manage/songbooks (admin/global_admin): "Fill missing colours" button assigns colours to rows with no Colour. Editor users don't see the button.
- [ ] "Reassign all" requires typing the literal phrase REASSIGN ALL — both client- and server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)