### PR TITLE
feat(org-admin): edit endpoints — member + licence management on /manage/my-organisations (closes #707)

### DIFF
--- a/appWeb/public_html/manage/includes/admin-links.php
+++ b/appWeb/public_html/manage/includes/admin-links.php
@@ -43,6 +43,11 @@ $_adminLinks = [
     ['users',           '/manage/users',           'bi-people',         'Users',                'view_users',                  'People'     ],
     ['groups',          '/manage/groups',          'bi-people-fill',    'User Groups',          'manage_user_groups',          'People'     ],
     ['organisations',   '/manage/organisations',   'bi-building',       'Organisations',        'manage_organisations',        'People'     ],
+    /* My Organisations (#707) — the entitlement is open to every signed-in
+       role; admin-nav.php applies a data-driven hide via
+       userHasOwnOrganisation() so non-admins only see this link when they
+       hold an admin/owner row in tblOrganisationMembers. */
+    ['my-organisations','/manage/my-organisations','bi-buildings',      'My Organisations',     'manage_own_organisation',     'People'     ],
     ['entitlements',    '/manage/entitlements',    'bi-key',            'Entitlements',         'manage_entitlements',         'People'     ],
     ['analytics',       '/manage/analytics',       'bi-graph-up',       'Analytics',            'view_analytics',              'Operations' ],
     ['ccli-report',     '/manage/ccli-report',     'bi-receipt',        'CCLI Usage Report',    'view_ccli_report',            'Operations' ],

--- a/appWeb/public_html/manage/includes/admin-nav.php
+++ b/appWeb/public_html/manage/includes/admin-nav.php
@@ -56,6 +56,24 @@ $_roleBadge   = match($_role) {
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'admin-links.php';
 $_visibleAdminLinks = visibleAdminLinks($_role);
 
+/* Data-driven hide for `my-organisations` (#707). The entitlement
+   `manage_own_organisation` is open to every signed-in role so the
+   role-based filter alone would surface the link to every user.
+   The actual restriction is "user holds an admin or owner row in
+   tblOrganisationMembers" — checked via userHasOwnOrganisation().
+   system_admin / global_admin keep the link unconditionally
+   because they can manage any org via /manage/organisations. */
+if (!in_array($_role, ['admin', 'global_admin'], true)) {
+    $_userIdForOrgCheck = (int)($currentUser['id'] ?? $currentUser['Id'] ?? 0);
+    if (function_exists('userHasOwnOrganisation')
+        && !userHasOwnOrganisation($_userIdForOrgCheck)) {
+        $_visibleAdminLinks = array_values(array_filter(
+            $_visibleAdminLinks,
+            static fn(array $l): bool => $l[0] !== 'my-organisations'
+        ));
+    }
+}
+
 /* Gravatar/Libravatar/DiceBear avatar URL for the signed-in user
    (#581). The dropdown header carries a 64px copy; the toggle button
    carries a 32px copy so the network/cache pays for both sizes only

--- a/appWeb/public_html/manage/my-organisations.php
+++ b/appWeb/public_html/manage/my-organisations.php
@@ -67,11 +67,246 @@ if (!$systemAdmin) {
 $activePage = 'my-organisations';
 
 $db = getDbMysqli();
+$error   = '';
+$success = '';
+
+/* Member-role + licence-type allowlists. Match the values
+   organisations.php uses so member rows + licence rows from this
+   page are interchangeable with the system-admin page. */
+$MEMBER_ROLES = ['member', 'admin', 'owner'];
+$LICENCE_TYPES = ['ccli', 'mrl', 'ihymns_basic', 'ihymns_pro', 'custom'];
 
 /* Resolve which org IDs to show.
    - system-admin / global_admin → every org.
    - otherwise → only orgs where the current user has admin/owner role. */
 $ownedOrgIds = $systemAdmin ? null : userIsOrgAdminOf($userId);
+
+/* Row-level org-ownership gate for every action. system-admin /
+   global_admin can act on any org; everyone else can only act on
+   orgs they hold admin/owner role on. Returns true if allowed,
+   false otherwise. (#707) */
+$canActOnOrg = function (int $orgId) use ($systemAdmin, $userId): bool {
+    if ($orgId <= 0) return false;
+    if ($systemAdmin) return true;
+    return in_array($orgId, userIsOrgAdminOf($userId), true);
+};
+
+/* ====================================================================
+ * POST handlers — six edit endpoints (#707)
+ *
+ * Each handler:
+ *   1. Validates CSRF.
+ *   2. Calls $canActOnOrg($orgId) for the row-level gate. A forged POST
+ *      against an org the current user doesn't admin returns 403 even
+ *      if CSRF is valid.
+ *   3. Performs the action (INSERT / UPDATE / DELETE).
+ *   4. Writes an Activity Log row under org_admin.<verb>.
+ *   5. Surfaces success / error banner.
+ * ==================================================================== */
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!validateCsrf((string)($_POST['csrf_token'] ?? ''))) {
+        http_response_code(403);
+        echo 'Invalid CSRF token';
+        exit;
+    }
+    $action = (string)($_POST['action'] ?? '');
+    $orgId  = (int)($_POST['org_id'] ?? 0);
+
+    if (!$canActOnOrg($orgId)) {
+        http_response_code(403);
+        echo '<!DOCTYPE html><html><body style="font-family:sans-serif;padding:2rem;">';
+        echo '<h1>403 — Not authorised on this organisation</h1>';
+        echo '<p>You don\'t hold an admin or owner role on the target organisation. ';
+        echo 'This action was rejected at the server-side row-level check.</p>';
+        echo '<p><a href="/manage/my-organisations">Back to My Organisations</a></p>';
+        echo '</body></html>';
+        exit;
+    }
+
+    try {
+        switch ($action) {
+            case 'member_add': {
+                /* Add a user to the org by username or email. The form
+                   posts a free-text identifier; we resolve it to a
+                   tblUsers.Id so a curator can paste either form. */
+                $identifier = trim((string)($_POST['user_identifier'] ?? ''));
+                $role       = (string)($_POST['member_role'] ?? 'member');
+                if ($identifier === '') { $error = 'Username or email is required.'; break; }
+                if (!in_array($role, $MEMBER_ROLES, true)) { $error = 'Unknown member role.'; break; }
+
+                $stmt = $db->prepare(
+                    'SELECT Id FROM tblUsers WHERE Username = ? OR Email = ? LIMIT 1'
+                );
+                $stmt->bind_param('ss', $identifier, $identifier);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_assoc();
+                $stmt->close();
+                if (!$row) { $error = "User '{$identifier}' not found."; break; }
+                $targetUserId = (int)$row['Id'];
+
+                $stmt = $db->prepare(
+                    'INSERT INTO tblOrganisationMembers (UserId, OrgId, Role)
+                     VALUES (?, ?, ?)
+                     ON DUPLICATE KEY UPDATE Role = VALUES(Role)'
+                );
+                $stmt->bind_param('iis', $targetUserId, $orgId, $role);
+                $stmt->execute();
+                $stmt->close();
+                logActivity('org_admin.member_add', 'organisation', (string)$orgId, [
+                    'user_id'    => $targetUserId,
+                    'identifier' => $identifier,
+                    'role'       => $role,
+                ]);
+                $success = "Added {$identifier} as {$role}.";
+                break;
+            }
+
+            case 'member_role_change': {
+                $targetUserId = (int)($_POST['user_id'] ?? 0);
+                $role         = (string)($_POST['member_role'] ?? 'member');
+                if ($targetUserId <= 0) { $error = 'Invalid user.'; break; }
+                if (!in_array($role, $MEMBER_ROLES, true)) { $error = 'Unknown member role.'; break; }
+
+                $stmt = $db->prepare('UPDATE tblOrganisationMembers SET Role = ? WHERE OrgId = ? AND UserId = ?');
+                $stmt->bind_param('sii', $role, $orgId, $targetUserId);
+                $stmt->execute();
+                $stmt->close();
+                logActivity('org_admin.member_role_change', 'organisation', (string)$orgId, [
+                    'user_id' => $targetUserId,
+                    'role'    => $role,
+                ]);
+                $success = 'Member role updated.';
+                break;
+            }
+
+            case 'member_remove': {
+                $targetUserId = (int)($_POST['user_id'] ?? 0);
+                if ($targetUserId <= 0) { $error = 'Invalid user.'; break; }
+                /* Self-removal guard — an admin must never lock themselves
+                   out of the org by accident. They have to ask a sibling
+                   admin / owner / system admin to remove them. */
+                if ($targetUserId === $userId && !$systemAdmin) {
+                    $error = 'You cannot remove yourself from an organisation. Ask a co-admin or system admin to remove you.';
+                    break;
+                }
+                $stmt = $db->prepare('DELETE FROM tblOrganisationMembers WHERE OrgId = ? AND UserId = ?');
+                $stmt->bind_param('ii', $orgId, $targetUserId);
+                $stmt->execute();
+                $stmt->close();
+                logActivity('org_admin.member_remove', 'organisation', (string)$orgId, [
+                    'user_id' => $targetUserId,
+                ]);
+                $success = 'Member removed.';
+                break;
+            }
+
+            case 'licence_add': {
+                $licenceType   = (string)($_POST['licence_type']    ?? '');
+                $licenceNumber = trim((string)($_POST['licence_number'] ?? ''));
+                $expiresAt     = trim((string)($_POST['expires_at']  ?? '')) ?: null;
+                $isActive      = !empty($_POST['is_active']) ? 1 : 0;
+                $notes         = trim((string)($_POST['notes']       ?? '')) ?: null;
+                if (!in_array($licenceType, $LICENCE_TYPES, true)) { $error = 'Unknown licence type.'; break; }
+
+                $stmt = $db->prepare(
+                    'INSERT INTO tblOrganisationLicences
+                        (OrganisationId, LicenceType, LicenceNumber, IsActive, ExpiresAt, Notes)
+                     VALUES (?, ?, ?, ?, ?, ?)
+                     ON DUPLICATE KEY UPDATE
+                        LicenceNumber = VALUES(LicenceNumber),
+                        IsActive      = VALUES(IsActive),
+                        ExpiresAt     = VALUES(ExpiresAt),
+                        Notes         = VALUES(Notes)'
+                );
+                $stmt->bind_param('ississ',
+                    $orgId, $licenceType, $licenceNumber, $isActive, $expiresAt, $notes);
+                $stmt->execute();
+                $stmt->close();
+                logActivity('org_admin.licence_add', 'organisation', (string)$orgId, [
+                    'licence_type'   => $licenceType,
+                    'licence_number' => $licenceNumber,
+                    'is_active'      => (bool)$isActive,
+                ]);
+                $success = "Licence '{$licenceType}' saved.";
+                break;
+            }
+
+            case 'licence_change': {
+                $licenceId     = (int)($_POST['licence_id'] ?? 0);
+                $licenceNumber = trim((string)($_POST['licence_number'] ?? ''));
+                $expiresAt     = trim((string)($_POST['expires_at']  ?? '')) ?: null;
+                $isActive      = !empty($_POST['is_active']) ? 1 : 0;
+                $notes         = trim((string)($_POST['notes']       ?? '')) ?: null;
+                if ($licenceId <= 0) { $error = 'Invalid licence row.'; break; }
+
+                /* Belt-and-braces: confirm the licence row actually
+                   belongs to the org we already authorised on. Stops a
+                   crafted POST that mixes a licence_id from one org with
+                   an org_id the user CAN admin. */
+                $stmt = $db->prepare(
+                    'SELECT 1 FROM tblOrganisationLicences WHERE Id = ? AND OrganisationId = ?'
+                );
+                $stmt->bind_param('ii', $licenceId, $orgId);
+                $stmt->execute();
+                $owns = $stmt->get_result()->fetch_row() !== null;
+                $stmt->close();
+                if (!$owns) { $error = 'Licence row does not belong to that organisation.'; break; }
+
+                $stmt = $db->prepare(
+                    'UPDATE tblOrganisationLicences
+                        SET LicenceNumber = ?, IsActive = ?, ExpiresAt = ?, Notes = ?
+                      WHERE Id = ?'
+                );
+                $stmt->bind_param('sissi', $licenceNumber, $isActive, $expiresAt, $notes, $licenceId);
+                $stmt->execute();
+                $stmt->close();
+                logActivity('org_admin.licence_change', 'organisation', (string)$orgId, [
+                    'licence_id'   => $licenceId,
+                    'licence_number' => $licenceNumber,
+                    'is_active'    => (bool)$isActive,
+                ]);
+                $success = 'Licence updated.';
+                break;
+            }
+
+            case 'licence_remove': {
+                $licenceId = (int)($_POST['licence_id'] ?? 0);
+                if ($licenceId <= 0) { $error = 'Invalid licence row.'; break; }
+
+                /* Same belt-and-braces check as licence_change. */
+                $stmt = $db->prepare(
+                    'SELECT 1 FROM tblOrganisationLicences WHERE Id = ? AND OrganisationId = ?'
+                );
+                $stmt->bind_param('ii', $licenceId, $orgId);
+                $stmt->execute();
+                $owns = $stmt->get_result()->fetch_row() !== null;
+                $stmt->close();
+                if (!$owns) { $error = 'Licence row does not belong to that organisation.'; break; }
+
+                $stmt = $db->prepare('DELETE FROM tblOrganisationLicences WHERE Id = ?');
+                $stmt->bind_param('i', $licenceId);
+                $stmt->execute();
+                $stmt->close();
+                logActivity('org_admin.licence_remove', 'organisation', (string)$orgId, [
+                    'licence_id' => $licenceId,
+                ]);
+                $success = 'Licence removed.';
+                break;
+            }
+
+            default:
+                $error = 'Unknown action.';
+        }
+    } catch (\Throwable $e) {
+        error_log('[manage/my-organisations.php] ' . $e->getMessage());
+        if (function_exists('logActivityError')) {
+            logActivityError('admin.my_organisations.save', 'organisation',
+                (string)$orgId, $e, ['action' => $action]);
+        }
+        $where = $e->getFile() ? (' (' . basename($e->getFile()) . ':' . $e->getLine() . ')') : '';
+        $error = $error ?: 'Database error: ' . $e->getMessage() . $where;
+    }
+}
 
 try {
     if ($systemAdmin) {
@@ -115,7 +350,7 @@ foreach ($orgs as $o) {
     $orgId = (int)$o['Id'];
     try {
         $stmt = $db->prepare(
-            'SELECT u.Username, u.DisplayName, u.Role AS SystemRole,
+            'SELECT u.Id AS UserId, u.Username, u.DisplayName, u.Role AS SystemRole,
                     m.Role AS OrgRole, m.JoinedAt
                FROM tblOrganisationMembers m
                JOIN tblUsers u ON u.Id = m.UserId
@@ -132,7 +367,7 @@ foreach ($orgs as $o) {
 
     try {
         $stmt = $db->prepare(
-            'SELECT LicenceType, LicenceNumber, IsActive, ExpiresAt, Notes
+            'SELECT Id, LicenceType, LicenceNumber, IsActive, ExpiresAt, Notes
                FROM tblOrganisationLicences
               WHERE OrganisationId = ?
               ORDER BY LicenceType ASC'
@@ -149,6 +384,7 @@ foreach ($orgs as $o) {
 }
 
 render:
+$csrf = csrfToken();
 ?>
 <!DOCTYPE html>
 <html lang="en" data-bs-theme="dark">
@@ -170,11 +406,15 @@ render:
         <i class="bi bi-building me-2"></i>My Organisations
     </h1>
     <p class="text-muted small">
-        Organisations where you hold an admin or owner role. Read-only for now —
-        the member-management + licence-edit endpoints land in the next PR
-        (#707 follow-up). System administrators see every organisation here
-        because they can manage any of them.
+        Organisations where you hold an admin or owner role. You can add or remove members, change their org-role, and edit licence rows here. System administrators see every organisation because they can manage any of them.
     </p>
+
+    <?php if ($success): ?>
+        <div class="alert alert-success py-2 small"><?= htmlspecialchars($success) ?></div>
+    <?php endif; ?>
+    <?php if ($error): ?>
+        <div class="alert alert-danger py-2 small"><?= htmlspecialchars($error) ?></div>
+    <?php endif; ?>
 
     <?php if (empty($orgs)): ?>
         <div class="alert alert-info">
@@ -218,14 +458,14 @@ render:
 
                 <h3 class="h6 mt-3 mb-2">Members (<?= count($orgMembers[$orgId] ?? []) ?>)</h3>
                 <?php if (empty($orgMembers[$orgId])): ?>
-                    <p class="text-muted small mb-0">No members yet.</p>
+                    <p class="text-muted small">No members yet — use the Add member form below.</p>
                 <?php else: ?>
                     <div class="table-responsive">
-                        <table class="table table-sm table-dark mb-0 small">
+                        <table class="table table-sm table-dark mb-2 small align-middle">
                             <thead><tr>
                                 <th>Username</th><th>Display Name</th>
                                 <th>System role</th><th>Org role</th>
-                                <th>Joined</th>
+                                <th class="text-end">Actions</th>
                             </tr></thead>
                             <tbody>
                             <?php foreach ($orgMembers[$orgId] as $m): ?>
@@ -233,8 +473,34 @@ render:
                                     <td><?= htmlspecialchars((string)$m['Username']) ?></td>
                                     <td><?= htmlspecialchars((string)($m['DisplayName'] ?? '')) ?></td>
                                     <td><code><?= htmlspecialchars((string)($m['SystemRole'] ?? 'user')) ?></code></td>
-                                    <td><span class="badge bg-info text-dark"><?= htmlspecialchars((string)$m['OrgRole']) ?></span></td>
-                                    <td class="text-muted"><?= htmlspecialchars(substr((string)$m['JoinedAt'], 0, 10)) ?></td>
+                                    <td>
+                                        <form method="POST" class="d-inline-flex align-items-center gap-1">
+                                            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                                            <input type="hidden" name="action" value="member_role_change">
+                                            <input type="hidden" name="org_id"  value="<?= $orgId ?>">
+                                            <input type="hidden" name="user_id" value="<?= (int)($m['UserId'] ?? 0) ?>">
+                                            <select name="member_role" class="form-select form-select-sm py-0" style="width:auto;">
+                                                <?php foreach ($MEMBER_ROLES as $mr): ?>
+                                                    <option value="<?= $mr ?>" <?= $m['OrgRole'] === $mr ? 'selected' : '' ?>><?= $mr ?></option>
+                                                <?php endforeach; ?>
+                                            </select>
+                                            <button type="submit" class="btn btn-sm btn-outline-info py-0 px-2" title="Change role">
+                                                <i class="bi bi-check2"></i>
+                                            </button>
+                                        </form>
+                                    </td>
+                                    <td class="text-end">
+                                        <form method="POST" class="d-inline"
+                                              onsubmit="return confirm('Remove <?= htmlspecialchars($m['Username'], ENT_QUOTES) ?> from this organisation?');">
+                                            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                                            <input type="hidden" name="action" value="member_remove">
+                                            <input type="hidden" name="org_id"  value="<?= $orgId ?>">
+                                            <input type="hidden" name="user_id" value="<?= (int)($m['UserId'] ?? 0) ?>">
+                                            <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-2" title="Remove from organisation">
+                                                <i class="bi bi-x"></i>
+                                            </button>
+                                        </form>
+                                    </td>
                                 </tr>
                             <?php endforeach; ?>
                             </tbody>
@@ -242,34 +508,132 @@ render:
                     </div>
                 <?php endif; ?>
 
-                <?php if (!empty($orgLicences[$orgId])): ?>
-                    <h3 class="h6 mt-3 mb-2">Licences</h3>
-                    <ul class="small mb-0">
-                        <?php foreach ($orgLicences[$orgId] as $l): ?>
-                            <li>
-                                <code><?= htmlspecialchars((string)$l['LicenceType']) ?></code>
-                                <?php if ($l['LicenceNumber']): ?>
-                                    — <?= htmlspecialchars((string)$l['LicenceNumber']) ?>
-                                <?php endif; ?>
-                                <?php if (empty($l['IsActive'])): ?>
-                                    <span class="badge bg-secondary ms-1">inactive</span>
-                                <?php endif; ?>
-                                <?php if ($l['ExpiresAt']): ?>
-                                    <span class="text-muted ms-1">(expires <?= htmlspecialchars(substr((string)$l['ExpiresAt'], 0, 10)) ?>)</span>
-                                <?php endif; ?>
-                            </li>
-                        <?php endforeach; ?>
-                    </ul>
+                <!-- Add member form -->
+                <form method="POST" class="row g-2 align-items-end small mb-3">
+                    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                    <input type="hidden" name="action" value="member_add">
+                    <input type="hidden" name="org_id" value="<?= $orgId ?>">
+                    <div class="col-md-5">
+                        <label class="form-label small mb-0">Add member (username or email)</label>
+                        <input type="text" name="user_identifier" class="form-control form-control-sm"
+                               placeholder="username or email" required>
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label small mb-0">Role</label>
+                        <select name="member_role" class="form-select form-select-sm">
+                            <?php foreach ($MEMBER_ROLES as $mr): ?>
+                                <option value="<?= $mr ?>" <?= $mr === 'member' ? 'selected' : '' ?>><?= $mr ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+                    <div class="col-md-auto">
+                        <button type="submit" class="btn btn-sm btn-amber-solid">
+                            <i class="bi bi-plus-circle me-1"></i>Add member
+                        </button>
+                    </div>
+                </form>
+
+                <h3 class="h6 mt-3 mb-2">Licences</h3>
+                <?php if (empty($orgLicences[$orgId])): ?>
+                    <p class="text-muted small">No licences attached. Use the Add licence form below.</p>
+                <?php else: ?>
+                    <div class="table-responsive">
+                        <table class="table table-sm table-dark mb-2 small align-middle">
+                            <thead><tr>
+                                <th>Type</th><th>Number</th><th>Expires</th><th>Active</th><th>Notes</th>
+                                <th class="text-end">Actions</th>
+                            </tr></thead>
+                            <tbody>
+                            <?php foreach ($orgLicences[$orgId] as $l): ?>
+                                <tr>
+                                    <td><code><?= htmlspecialchars((string)$l['LicenceType']) ?></code></td>
+                                    <td>
+                                        <form method="POST" class="d-inline-flex align-items-center gap-1">
+                                            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                                            <input type="hidden" name="action" value="licence_change">
+                                            <input type="hidden" name="org_id"     value="<?= $orgId ?>">
+                                            <input type="hidden" name="licence_id" value="<?= (int)($l['Id'] ?? 0) ?>">
+                                            <input type="text" name="licence_number"
+                                                   class="form-control form-control-sm py-0"
+                                                   value="<?= htmlspecialchars((string)$l['LicenceNumber']) ?>"
+                                                   style="width: 10rem;">
+                                            <input type="date" name="expires_at"
+                                                   class="form-control form-control-sm py-0"
+                                                   value="<?= htmlspecialchars(substr((string)($l['ExpiresAt'] ?? ''), 0, 10)) ?>"
+                                                   style="width: 9rem;">
+                                            <div class="form-check form-check-inline mb-0">
+                                                <input class="form-check-input" type="checkbox" name="is_active" value="1"
+                                                       <?= !empty($l['IsActive']) ? 'checked' : '' ?>>
+                                                <label class="form-check-label small">active</label>
+                                            </div>
+                                            <input type="text" name="notes"
+                                                   class="form-control form-control-sm py-0"
+                                                   value="<?= htmlspecialchars((string)($l['Notes'] ?? '')) ?>"
+                                                   placeholder="notes" style="width: 11rem;">
+                                            <button type="submit" class="btn btn-sm btn-outline-info py-0 px-2" title="Save">
+                                                <i class="bi bi-check2"></i>
+                                            </button>
+                                        </form>
+                                    </td>
+                                    <td colspan="3"></td>
+                                    <td class="text-end">
+                                        <form method="POST" class="d-inline"
+                                              onsubmit="return confirm('Remove the <?= htmlspecialchars($l['LicenceType'], ENT_QUOTES) ?> licence row?');">
+                                            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                                            <input type="hidden" name="action" value="licence_remove">
+                                            <input type="hidden" name="org_id"     value="<?= $orgId ?>">
+                                            <input type="hidden" name="licence_id" value="<?= (int)($l['Id'] ?? 0) ?>">
+                                            <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-2" title="Remove licence">
+                                                <i class="bi bi-x"></i>
+                                            </button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                            </tbody>
+                        </table>
+                    </div>
                 <?php endif; ?>
+
+                <!-- Add licence form -->
+                <form method="POST" class="row g-2 align-items-end small">
+                    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                    <input type="hidden" name="action" value="licence_add">
+                    <input type="hidden" name="org_id" value="<?= $orgId ?>">
+                    <div class="col-md-2">
+                        <label class="form-label small mb-0">Type</label>
+                        <select name="licence_type" class="form-select form-select-sm" required>
+                            <option value="">— pick —</option>
+                            <?php foreach ($LICENCE_TYPES as $lt): ?>
+                                <option value="<?= $lt ?>"><?= $lt ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label small mb-0">Licence number</label>
+                        <input type="text" name="licence_number" class="form-control form-control-sm"
+                               placeholder="e.g. CCLI 1234567">
+                    </div>
+                    <div class="col-md-2">
+                        <label class="form-label small mb-0">Expires</label>
+                        <input type="date" name="expires_at" class="form-control form-control-sm">
+                    </div>
+                    <div class="col-md-1 form-check mb-2">
+                        <input class="form-check-input" type="checkbox" name="is_active" value="1" checked>
+                        <label class="form-check-label small">active</label>
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label small mb-0">Notes</label>
+                        <input type="text" name="notes" class="form-control form-control-sm" placeholder="optional">
+                    </div>
+                    <div class="col-md-auto">
+                        <button type="submit" class="btn btn-sm btn-amber-solid">
+                            <i class="bi bi-plus-circle me-1"></i>Add licence
+                        </button>
+                    </div>
+                </form>
             </div>
         <?php endforeach; ?>
-
-        <p class="text-muted small mt-4">
-            <i class="bi bi-info-circle me-1"></i>
-            Editing org members + licences from this page is on the
-            #707 follow-up. For now, ask a system administrator to make
-            changes via /manage/organisations, or wait for the next PR.
-        </p>
     <?php endif; ?>
 </div>
 


### PR DESCRIPTION
## Summary

Builds on the read-only foundation that landed in #725 (commit f4d4c2a). Adds the six POST endpoints + per-row forms + nav placement so org-admins can manage their own organisations end-to-end.

## What's in

### Six POST endpoints

| Action | Verb | What |
|---|---|---|
| \`member_add\` | \`org_admin.member_add\` | Resolve username/email → tblUsers.Id, INSERT (or upsert role) |
| \`member_role_change\` | \`org_admin.member_role_change\` | UPDATE Role on existing tblOrganisationMembers row |
| \`member_remove\` | \`org_admin.member_remove\` | DELETE row (self-removal guard for non-admins) |
| \`licence_add\` | \`org_admin.licence_add\` | INSERT into tblOrganisationLicences (upsert by OrgId+Type) |
| \`licence_change\` | \`org_admin.licence_change\` | UPDATE LicenceNumber/IsActive/ExpiresAt/Notes |
| \`licence_remove\` | \`org_admin.licence_remove\` | DELETE row |

### Defence in depth

Each handler:

1. \`validateCsrf()\` — first line.
2. \`\$canActOnOrg(\$orgId)\` — row-level gate. Returns true for system admins; otherwise verifies the orgId is in \`userIsOrgAdminOf(\$currentUserId)\`. Forged POST → 403 page even if CSRF is valid.
3. licence_change + licence_remove additionally re-verify the target licence_id belongs to the same orgId — stops a curator who admins org A from smuggling a licence_id from org B.
4. \`member_remove\` has a self-removal guard for non-admins — must ask a co-admin or system admin.
5. Activity Log captures every action under \`org_admin.*\` verbs.

### Forms

Each org card now renders edit-capable members + licences tables (inline role change / inline licence edit / per-row remove) plus add-member and add-licence forms below.

### Nav placement

New entry \`my-organisations\` in \`admin-links.php\` under the People group, gated by \`manage_own_organisation\` (open to every signed-in role). \`admin-nav.php\` applies a data-driven hide via \`userHasOwnOrganisation()\` so non-admin users only see the link when they actually hold an admin/owner row in tblOrganisationMembers. System admins see it unconditionally.

## Test plan

- [ ] Sign in as a user with admin/owner role on at least one org → \"My Organisations\" link appears in the sidebar; page renders the user's orgs.
- [ ] Sign in as a regular user with NO org-admin row → link is hidden; direct URL access returns 403 with a clear message.
- [ ] Sign in as system admin → link appears unconditionally; page lists every org.
- [ ] Add a member by username → row appears + Activity Log entry.
- [ ] Change a member's role → role updates + Activity Log entry.
- [ ] Remove a member → row disappears + Activity Log entry. Try removing yourself → blocked with helpful error.
- [ ] Add / change / remove a licence → row writes succeed + Activity Log entries.
- [ ] Forge a POST with an org_id you don't admin → 403.
- [ ] Forge a licence_change POST with an org_id you DO admin but a licence_id from another org → \"Licence row does not belong to that organisation\" error.

## Migrations

None — tblOrganisationMembers + tblOrganisationLicences already exist (via #640 migrations + the schema.sql additions in #722).

🤖 Generated with [Claude Code](https://claude.com/claude-code)