### PR TITLE
feat(api): admin songbook CRUD — closes largest #719 audit gap (PR 2a)

### DIFF
--- a/appWeb/public_html/api-docs.yaml
+++ b/appWeb/public_html/api-docs.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 
 info:
   title: iHymns API
-  version: "0.50.0"
+  version: "0.51.0"
   description: |
     The iHymns API provides programmatic access to the iHymns hymn and song
     database. It powers the iHymns Progressive Web App (PWA), enabling song
@@ -167,6 +167,14 @@ tags:
     description: Administrative endpoints for user, group, and content management
   - name: Admin — Restrictions
     description: Content-restriction rule engine (tier / org / platform / licence)
+  - name: Admin — Songbooks
+    description: |
+      Songbook curation surface (#719 PR 2a). CRUD parity with
+      `/manage/songbooks` so native clients (iOS / iPadOS / tvOS / Android
+      / FireOS) can manage hymnals without a webview. Validation is
+      shared with the web admin via `includes/songbook_validation.php`,
+      so a tweak to the abbreviation / colour / IETF BCP 47 grammar
+      lands on both surfaces in one go.
   - name: Admin — Revisions
     description: Review pending song revisions
   - name: Admin — Maintenance
@@ -4002,6 +4010,349 @@ paths:
         "200":
           description: Deleted
 
+  # ===========================================================================
+  # ADMIN — SONGBOOKS  (#719 PR 2a)
+  # CRUD parity with /manage/songbooks for native clients. Validation
+  # rules live in includes/songbook_validation.php and are shared with
+  # the web admin so abbreviation / colour / IETF BCP 47 grammar tweaks
+  # land on both surfaces in one go.
+  # ===========================================================================
+
+  /api.php?action=admin_songbook_create:
+    post:
+      operationId: adminSongbookCreate
+      tags: [Admin — Songbooks]
+      summary: Create a songbook
+      description: |
+        Mirrors the `create` POST on /manage/songbooks. Empty `colour`
+        triggers the auto-pick palette (#677); the resolved colour is
+        echoed back so the caller can render the badge immediately.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_songbook_create] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SongbookWriteInput"
+      responses:
+        "201":
+          description: Songbook created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:           { type: boolean, example: true }
+                  id:           { type: integer, description: New tblSongbooks.Id, example: 42 }
+                  abbreviation: { type: string,  example: CP }
+                  colour:       { type: string,  description: Resolved hex (auto-picked when blank), example: "#3B82F6" }
+        "400":
+          description: Validation error (abbreviation grammar, colour shape, BCP 47 tag, missing name)
+        "403":
+          description: Admin access required
+        "409":
+          description: Abbreviation already in use
+
+  /api.php?action=admin_songbook_update:
+    post:
+      operationId: adminSongbookUpdate
+      tags: [Admin — Songbooks]
+      summary: Update an existing songbook
+      description: |
+        Update name / colour / display_order / metadata, and optionally
+        rename the abbreviation. When `new_abbreviation` is set and
+        `rename_song_refs` is true, the call also updates every
+        `tblSongs.SongbookAbbr` that referenced the old key — atomic
+        within a single transaction.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_songbook_update] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: "#/components/schemas/SongbookWriteInput"
+                - type: object
+                  required: [id]
+                  properties:
+                    id:
+                      type: integer
+                      description: tblSongbooks.Id of the row to update
+                    new_abbreviation:
+                      type: string
+                      description: New ASCII-alphanumeric abbreviation. Omit to keep the existing key.
+                    rename_song_refs:
+                      type: boolean
+                      default: false
+                      description: When renaming, also UPDATE tblSongs.SongbookAbbr to the new value.
+      responses:
+        "200":
+          description: Songbook updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:             { type: boolean, example: true }
+                  id:             { type: integer }
+                  abbreviation:   { type: string }
+                  fields_changed:
+                    type: array
+                    items: { type: string }
+                    description: Names of columns that actually changed value (Activity-Log diff key set).
+                  songs_renamed:  { type: boolean }
+        "400":
+          description: Validation error (missing id, missing name, bad colour, bad BCP 47 tag, bad new abbreviation)
+        "403":
+          description: Admin access required
+        "404":
+          description: Songbook id not found
+        "409":
+          description: Target new_abbreviation is already in use by another row
+
+  /api.php?action=admin_songbook_delete:
+    post:
+      operationId: adminSongbookDelete
+      tags: [Admin — Songbooks]
+      summary: Delete an empty songbook
+      description: |
+        Refuses if any song still references the abbreviation. Use
+        `admin_songbook_delete_cascade` for the destructive path.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_songbook_delete] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [id]
+              properties:
+                id: { type: integer, description: tblSongbooks.Id }
+      responses:
+        "200":
+          description: Songbook deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:           { type: boolean, example: true }
+                  id:           { type: integer }
+                  abbreviation: { type: string }
+        "400":
+          description: Songbook id required
+        "403":
+          description: Admin access required
+        "404":
+          description: Songbook id not found
+        "422":
+          description: |
+            Refused — songs still reference the abbreviation. Response
+            includes `song_count` and `abbreviation` so the caller can
+            render an honest "reassign N songs first" prompt.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:        { type: string }
+                  song_count:   { type: integer }
+                  abbreviation: { type: string }
+                  hint:         { type: string }
+
+  /api.php?action=admin_songbook_delete_cascade:
+    post:
+      operationId: adminSongbookDeleteCascade
+      tags: [Admin — Songbooks]
+      summary: Cascade-delete a songbook + every song + every credit / tag / chord / translation
+      description: |
+        Destructive. Removes every song carrying this abbreviation
+        plus every credit / tag / chord / translation / artist row
+        that referenced those songs (via `ON DELETE CASCADE` FKs in
+        tblSongs's child tables). The songbook row itself is then
+        removed last. Server-side typed-confirmation gate mirrors the
+        web admin defence-in-depth check (#706).
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_songbook_delete_cascade] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [id, confirm_abbreviation]
+              properties:
+                id:
+                  type: integer
+                  description: tblSongbooks.Id of the row to delete
+                confirm_abbreviation:
+                  type: string
+                  description: Must equal the songbook's `Abbreviation` exactly. Defence-in-depth gate.
+      responses:
+        "200":
+          description: Cascade delete completed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:           { type: boolean, example: true }
+                  id:           { type: integer }
+                  abbreviation: { type: string }
+                  song_count:   { type: integer, description: Number of songs deleted as a side effect }
+        "400":
+          description: Missing id or confirm_abbreviation does not match
+        "403":
+          description: Admin / global_admin role required
+        "404":
+          description: Songbook id not found
+
+  /api.php?action=admin_songbooks_reorder:
+    post:
+      operationId: adminSongbooksReorder
+      tags: [Admin — Songbooks]
+      summary: Bulk-update DisplayOrder across the songbook list
+      description: |
+        Single transaction; one Activity-Log row for the whole bulk
+        operation rather than one per row.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_songbooks_reorder] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [display_order]
+              properties:
+                display_order:
+                  type: object
+                  description: |
+                    Map of `tblSongbooks.Id` (string) → integer order.
+                    Empty map is a 400.
+                  additionalProperties:
+                    type: integer
+                  example:
+                    "1": 0
+                    "2": 10
+                    "3": 20
+      responses:
+        "200":
+          description: Order saved
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:    { type: boolean, example: true }
+                  count: { type: integer, description: Number of rows updated }
+        "400":
+          description: Empty or malformed display_order map
+        "403":
+          description: Admin access required
+
+  /api.php?action=admin_songbooks_auto_colour_fill:
+    post:
+      operationId: adminSongbooksAutoColourFill
+      tags: [Admin — Songbooks]
+      summary: Auto-pick a palette colour for every songbook missing a #RRGGBB value
+      description: |
+        Walks `tblSongbooks`. Rows whose `Colour` is NULL, blank, or
+        not a `#RRGGBB` hex receive a freshly-picked palette colour
+        (see `manage/includes/songbook-palette.php`). Rows with a
+        valid hex are left alone. Idempotent.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_songbooks_auto_colour_fill] }
+      responses:
+        "200":
+          description: Auto-fill applied
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:      { type: boolean, example: true }
+                  changed: { type: integer, description: Rows whose colour was assigned }
+                  mode:    { type: string,  enum: [fill] }
+        "403":
+          description: Admin / global_admin role required
+
+  /api.php?action=admin_songbooks_auto_colour_reassign:
+    post:
+      operationId: adminSongbooksAutoColourReassign
+      tags: [Admin — Songbooks]
+      summary: Reassign a fresh palette colour to every songbook (destructive)
+      description: |
+        Overwrites every `Colour`. Server-side typed-confirmation gate
+        mirrors the web admin's defence-in-depth check.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_songbooks_auto_colour_reassign] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [confirm_phrase]
+              properties:
+                confirm_phrase:
+                  type: string
+                  enum: ["REASSIGN ALL"]
+                  description: Must equal the literal phrase `REASSIGN ALL`. Defence-in-depth gate.
+      responses:
+        "200":
+          description: Colours reassigned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:      { type: boolean, example: true }
+                  changed: { type: integer, description: Rows whose colour was replaced }
+                  mode:    { type: string,  enum: [reassign] }
+        "400":
+          description: confirm_phrase does not match
+        "403":
+          description: Admin / global_admin role required
+
   /api.php?action=admin_pending_revisions:
     get:
       operationId: adminPendingRevisions
@@ -5057,6 +5408,129 @@ components:
           nullable: true
           description: Library of Congress Classification (#672)
           example: M2117
+
+    SongbookWriteInput:
+      type: object
+      description: |
+        Input shape for `admin_songbook_create` and the metadata half
+        of `admin_songbook_update` (#719 PR 2a). Snake_case JSON keys
+        map onto the same column set the web admin writes; validators
+        live in `includes/songbook_validation.php` and are shared with
+        `/manage/songbooks` so a tweak to the grammar lands on both
+        surfaces in one go.
+
+        - `abbreviation`: required on create, ignored on update (use
+          `new_abbreviation` for renames).
+        - `colour`: optional. Empty triggers the auto-pick palette
+          (#677); the resolved hex is echoed back on the response.
+        - `language`: optional IETF BCP 47 tag (#681). Format:
+          `lang[-Script][-Region]`, max 35 chars.
+        - All bibliographic identifier fields are nullable; an empty
+          string normalises to NULL on the server.
+      required: [abbreviation, name]
+      properties:
+        abbreviation:
+          type: string
+          maxLength: 10
+          pattern: "^[A-Za-z0-9]+$"
+          description: ASCII-alphanumeric natural key. Used by tblSongs.SongbookAbbr.
+          example: CP
+        name:
+          type: string
+          example: Christian Praise
+        display_order:
+          type: integer
+          default: 0
+          description: Sort key used by the songbook list UI.
+        colour:
+          type: string
+          pattern: "^#[0-9A-Fa-f]{6}$"
+          nullable: true
+          description: 7-char `#RRGGBB` hex. Empty/missing triggers the auto-pick palette (#677).
+          example: "#3B82F6"
+        is_official:
+          type: boolean
+          default: false
+          description: Recognised as an official Adventist publication (#502 / #670).
+        publisher:
+          type: string
+          nullable: true
+          example: Pacific Press Publishing Association
+        publication_year:
+          type: string
+          nullable: true
+          description: Year of publication. Stored as VARCHAR so non-numeric strings (e.g. "1985 / 2002 reprint") survive.
+          example: "1985"
+        copyright:
+          type: string
+          nullable: true
+          example: "© 1985 Review and Herald"
+        affiliation:
+          type: string
+          nullable: true
+          description: |
+            Issuing organisation. Free-text; the API also INSERT-IGNOREs
+            the value into `tblSongbookAffiliations` so the typeahead
+            surfaces it on the next save (#670).
+        language:
+          type: string
+          nullable: true
+          maxLength: 35
+          pattern: "^[a-z]{2,3}(-[A-Z][a-z]{3})?(-[A-Z]{2}|-[0-9]{3})?$"
+          description: IETF BCP 47 tag (#681). lang[-Script][-Region].
+          example: en-GB
+        website_url:
+          type: string
+          nullable: true
+          description: Official website (#672)
+        internet_archive_url:
+          type: string
+          nullable: true
+          description: Internet Archive landing page (#672)
+        wikipedia_url:
+          type: string
+          nullable: true
+          description: Wikipedia article URL (#672)
+        wikidata_id:
+          type: string
+          nullable: true
+          description: Wikidata QID (#672)
+        oclc_number:
+          type: string
+          nullable: true
+          description: OCLC WorldCat record number (#672)
+        ocn_number:
+          type: string
+          nullable: true
+          description: OCLC OCN identifier (#672)
+        lcp_number:
+          type: string
+          nullable: true
+          description: Library of Congress Permalink number (#672)
+        isbn:
+          type: string
+          nullable: true
+          description: ISBN-10 or ISBN-13 (#672)
+        ark_id:
+          type: string
+          nullable: true
+          description: Archival Resource Key (ARK) (#672)
+        isni_id:
+          type: string
+          nullable: true
+          description: International Standard Name Identifier (#672)
+        viaf_id:
+          type: string
+          nullable: true
+          description: Virtual International Authority File ID (#672)
+        lccn:
+          type: string
+          nullable: true
+          description: Library of Congress Control Number (#672)
+        lc_class:
+          type: string
+          nullable: true
+          description: Library of Congress Classification (#672)
 
     Stats:
       type: object

--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -56,6 +56,10 @@ require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'entitlements.php';
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'card_layout.php';
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'activity_log.php';
+/* Shared songbook validators (#719 PR 2a). Same rules used by
+   /manage/songbooks.php so a tweak to abbrev / colour / IETF-tag
+   grammar lands on the web admin and the API surface in one go. */
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'songbook_validation.php';
 
 /* =========================================================================
  * CSRF DEFENCE POLICY (#293 / B15)
@@ -5742,6 +5746,791 @@ if ($action !== null) {
                 sendJson(['error' => 'Could not mark as read.'], 500);
             }
             break;
+
+        /* =================================================================
+         * SONGBOOKS — admin CRUD parity (#719 PR 2a)
+         *
+         * Mirrors the web-admin POST handlers in /manage/songbooks.php so
+         * native clients (Apple, Android, FireOS) can perform songbook
+         * curation without a webview. Field names are JSON-body snake_case
+         * to match the rest of /api.php; the underlying SQL writes the
+         * same column set as the web admin.
+         *
+         * Auth: admin / global_admin role only — same gate that grants the
+         * `manage_songbooks` entitlement (see includes/entitlements.php).
+         *
+         * Activity-log verb prefix is `api.admin.songbook.*` so a curator
+         * scanning /manage/activity-log can tell API-driven changes apart
+         * from web-UI changes (which still log under `songbook.*`).
+         *
+         * Validation lives in includes/songbook_validation.php — the same
+         * file the web admin uses. One source of truth for abbreviation,
+         * colour, and IETF BCP 47 language-tag rules.
+         * ================================================================= */
+
+        /* -----------------------------------------------------------------
+         * Admin: create a songbook
+         * POST body: {
+         *   abbreviation, name, display_order?, colour?,
+         *   is_official?, publisher?, publication_year?,
+         *   copyright?, affiliation?, language?,
+         *   website_url?, internet_archive_url?, wikipedia_url?,
+         *   wikidata_id?, oclc_number?, ocn_number?, lcp_number?,
+         *   isbn?, ark_id?, isni_id?, viaf_id?, lccn?, lc_class?
+         * }
+         * Empty colour triggers the auto-pick palette (#677). Conflict on
+         * duplicate abbreviation returns 409. Returns 201 + new id +
+         * resolved colour so the caller can render the badge immediately.
+         * ----------------------------------------------------------------- */
+        case 'admin_songbook_create': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser || !in_array($authUser['Role'], ['admin', 'global_admin'])) {
+                sendJson(['error' => 'Admin access required.'], 403);
+                break;
+            }
+
+            $body = json_decode((string)file_get_contents('php://input'), true) ?: [];
+
+            $abbr     = trim((string)($body['abbreviation']  ?? ''));
+            $name     = trim((string)($body['name']          ?? ''));
+            $colour   = trim((string)($body['colour']        ?? ''));
+            $order    = (int)($body['display_order']         ?? 0);
+            $isOfficial = !empty($body['is_official']) ? 1 : 0;
+            $publisher  = trim((string)($body['publisher']        ?? '')) ?: null;
+            $pubYear    = trim((string)($body['publication_year'] ?? '')) ?: null;
+            $copyright  = trim((string)($body['copyright']        ?? '')) ?: null;
+            $affiliation= trim((string)($body['affiliation']      ?? '')) ?: null;
+
+            /* Optional language tag (#673 / #681). Cap to column width
+               (35 chars) before validating so a crafted-long tag can't
+               smuggle past the regex via mid-string truncation. */
+            $language   = trim((string)($body['language']         ?? '')) ?: null;
+            if ($language !== null) {
+                $language = mb_substr($language, 0, 35);
+                if ($e = validateSongbookBcp47($language)) {
+                    sendJson(['error' => $e], 400);
+                    break;
+                }
+            }
+
+            $websiteUrl   = trim((string)($body['website_url']         ?? '')) ?: null;
+            $iaUrl        = trim((string)($body['internet_archive_url']?? '')) ?: null;
+            $wikipediaUrl = trim((string)($body['wikipedia_url']       ?? '')) ?: null;
+            $wikidataId   = trim((string)($body['wikidata_id']         ?? '')) ?: null;
+            $oclcNumber   = trim((string)($body['oclc_number']         ?? '')) ?: null;
+            $ocnNumber    = trim((string)($body['ocn_number']          ?? '')) ?: null;
+            $lcpNumber    = trim((string)($body['lcp_number']          ?? '')) ?: null;
+            $isbn         = trim((string)($body['isbn']                ?? '')) ?: null;
+            $arkId        = trim((string)($body['ark_id']              ?? '')) ?: null;
+            $isniId       = trim((string)($body['isni_id']             ?? '')) ?: null;
+            $viafId       = trim((string)($body['viaf_id']             ?? '')) ?: null;
+            $lccn         = trim((string)($body['lccn']                ?? '')) ?: null;
+            $lcClass      = trim((string)($body['lc_class']            ?? '')) ?: null;
+
+            if ($e = validateSongbookAbbr($abbr)) {
+                sendJson(['error' => $e], 400);
+                break;
+            }
+            if ($name === '') {
+                sendJson(['error' => 'Name is required.'], 400);
+                break;
+            }
+            if ($e = validateSongbookColour($colour)) {
+                sendJson(['error' => $e], 400);
+                break;
+            }
+
+            try {
+                $db = getDbMysqli();
+
+                /* Auto-colour fallback (#677) — palette helper lives in
+                   the manage tree because that's where the seed colours
+                   are documented. Lazy-loaded so the read paths above
+                   don't pay the include cost. */
+                if ($colour === '') {
+                    require_once __DIR__ . DIRECTORY_SEPARATOR . 'manage' . DIRECTORY_SEPARATOR
+                               . 'includes'  . DIRECTORY_SEPARATOR . 'songbook-palette.php';
+                    $colour = pickAutoSongbookColour($db, $abbr);
+                }
+
+                $stmt = $db->prepare('SELECT Id FROM tblSongbooks WHERE Abbreviation = ?');
+                $stmt->bind_param('s', $abbr);
+                $stmt->execute();
+                $exists = $stmt->get_result()->fetch_row() !== null;
+                $stmt->close();
+                if ($exists) {
+                    sendJson(['error' => 'Abbreviation already exists.'], 409);
+                    break;
+                }
+
+                $stmt = $db->prepare(
+                    'INSERT INTO tblSongbooks
+                        (Abbreviation, Name, DisplayOrder, Colour,
+                         IsOfficial, Publisher, PublicationYear, Copyright, Affiliation,
+                         Language,
+                         WebsiteUrl, InternetArchiveUrl, WikipediaUrl, WikidataId,
+                         OclcNumber, OcnNumber, LcpNumber, Isbn, ArkId, IsniId,
+                         ViafId, Lccn, LcClass)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?,
+                             ?,
+                             ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+                );
+                /* 23-char type string mirrors the web admin save (#694
+                   regression check): ssis (Abbr,Name,Order,Colour) +
+                   isssss (IsOfficial,Publisher,Year,Copyright,Affiliation)
+                   + s (Language) + 13s (bibliographic identifiers). */
+                $orderInt = (int)($order ?: 0);
+                $stmt->bind_param(
+                    'ssisissssssssssssssssss',
+                    $abbr, $name, $orderInt, $colour,
+                    $isOfficial, $publisher, $pubYear, $copyright, $affiliation,
+                    $language,
+                    $websiteUrl, $iaUrl, $wikipediaUrl, $wikidataId,
+                    $oclcNumber, $ocnNumber, $lcpNumber, $isbn, $arkId, $isniId,
+                    $viafId, $lccn, $lcClass
+                );
+                $stmt->execute();
+                $newId = (int)$db->insert_id;
+                $stmt->close();
+
+                logActivity('api.admin.songbook.create', 'songbook', (string)$newId, [
+                    'abbreviation'    => $abbr,
+                    'name'            => $name,
+                    'display_order'   => $orderInt,
+                    'colour'          => $colour,
+                    'is_official'     => (bool)$isOfficial,
+                    'publisher'       => $publisher,
+                    'publication_year'=> $pubYear,
+                    'copyright'       => $copyright,
+                    'affiliation'     => $affiliation,
+                    'language'        => $language,
+                    'bibliographic'   => array_filter([
+                        'website_url'           => $websiteUrl,
+                        'internet_archive_url'  => $iaUrl,
+                        'wikipedia_url'         => $wikipediaUrl,
+                        'wikidata_id'           => $wikidataId,
+                        'oclc_number'           => $oclcNumber,
+                        'ocn_number'            => $ocnNumber,
+                        'lcp_number'            => $lcpNumber,
+                        'isbn'                  => $isbn,
+                        'ark_id'                => $arkId,
+                        'isni_id'               => $isniId,
+                        'viaf_id'               => $viafId,
+                        'lccn'                  => $lccn,
+                        'lc_class'              => $lcClass,
+                    ], fn($v) => $v !== null && $v !== ''),
+                ]);
+
+                /* Self-populate affiliation registry (#670). */
+                registerSongbookAffiliation($db, $affiliation);
+
+                sendJson([
+                    'ok'           => true,
+                    'id'           => $newId,
+                    'abbreviation' => $abbr,
+                    'colour'       => $colour,
+                ], 201);
+            } catch (\Throwable $e) {
+                logActivityError('api.admin.songbook.create', 'songbook', '', $e, [
+                    'abbreviation' => $abbr,
+                ]);
+                error_log('[admin_songbook_create] ' . $e->getMessage());
+                sendJson(['error' => 'Could not create songbook.'], 500);
+            }
+            break;
+        }
+
+        /* -----------------------------------------------------------------
+         * Admin: update a songbook
+         * POST body: {
+         *   id (required),
+         *   name, colour, display_order,
+         *   new_abbreviation? (rename — opt-in),
+         *   rename_song_refs? (cascade abbr to tblSongs.SongbookAbbr),
+         *   …same metadata fields as create
+         * }
+         * Returns 200 + ok + list of changed fields. The before/after rows
+         * are written to the activity log so the timeline reader sees
+         * exactly what the call mutated.
+         * ----------------------------------------------------------------- */
+        case 'admin_songbook_update': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser || !in_array($authUser['Role'], ['admin', 'global_admin'])) {
+                sendJson(['error' => 'Admin access required.'], 403);
+                break;
+            }
+
+            $body = json_decode((string)file_get_contents('php://input'), true) ?: [];
+
+            $id          = (int)($body['id'] ?? 0);
+            if ($id <= 0) {
+                sendJson(['error' => 'Songbook id required.'], 400);
+                break;
+            }
+            $name        = trim((string)($body['name']         ?? ''));
+            $colour      = trim((string)($body['colour']       ?? ''));
+            $order       = (int)($body['display_order']        ?? 0);
+            $newAbbr     = trim((string)($body['new_abbreviation'] ?? ''));
+            $alsoRename  = !empty($body['rename_song_refs']);
+            $isOfficial  = !empty($body['is_official']) ? 1 : 0;
+            $publisher   = trim((string)($body['publisher']        ?? '')) ?: null;
+            $pubYear     = trim((string)($body['publication_year'] ?? '')) ?: null;
+            $copyright   = trim((string)($body['copyright']        ?? '')) ?: null;
+            $affiliation = trim((string)($body['affiliation']      ?? '')) ?: null;
+
+            $language    = trim((string)($body['language']         ?? '')) ?: null;
+            if ($language !== null) {
+                $language = mb_substr($language, 0, 35);
+                if ($e = validateSongbookBcp47($language)) {
+                    sendJson(['error' => $e], 400);
+                    break;
+                }
+            }
+
+            $websiteUrl   = trim((string)($body['website_url']         ?? '')) ?: null;
+            $iaUrl        = trim((string)($body['internet_archive_url']?? '')) ?: null;
+            $wikipediaUrl = trim((string)($body['wikipedia_url']       ?? '')) ?: null;
+            $wikidataId   = trim((string)($body['wikidata_id']         ?? '')) ?: null;
+            $oclcNumber   = trim((string)($body['oclc_number']         ?? '')) ?: null;
+            $ocnNumber    = trim((string)($body['ocn_number']          ?? '')) ?: null;
+            $lcpNumber    = trim((string)($body['lcp_number']          ?? '')) ?: null;
+            $isbn         = trim((string)($body['isbn']                ?? '')) ?: null;
+            $arkId        = trim((string)($body['ark_id']              ?? '')) ?: null;
+            $isniId       = trim((string)($body['isni_id']             ?? '')) ?: null;
+            $viafId       = trim((string)($body['viaf_id']             ?? '')) ?: null;
+            $lccn         = trim((string)($body['lccn']                ?? '')) ?: null;
+            $lcClass      = trim((string)($body['lc_class']            ?? '')) ?: null;
+
+            if ($name === '') {
+                sendJson(['error' => 'Name is required.'], 400);
+                break;
+            }
+            if ($e = validateSongbookColour($colour)) {
+                sendJson(['error' => $e], 400);
+                break;
+            }
+
+            try {
+                $db = getDbMysqli();
+
+                /* Capture the full before-row for diff-aware audit logs (#535).
+                   Match the web admin's SELECT shape exactly so the diff key set
+                   stays consistent across both surfaces. */
+                $existing = $db->prepare(
+                    'SELECT Abbreviation, Name, DisplayOrder, Colour, IsOfficial,
+                            Publisher, PublicationYear, Copyright, Affiliation,
+                            Language,
+                            WebsiteUrl, InternetArchiveUrl, WikipediaUrl, WikidataId,
+                            OclcNumber, OcnNumber, LcpNumber, Isbn, ArkId, IsniId,
+                            ViafId, Lccn, LcClass
+                       FROM tblSongbooks WHERE Id = ?'
+                );
+                $existing->bind_param('i', $id);
+                $existing->execute();
+                $beforeRow = $existing->get_result()->fetch_assoc() ?: null;
+                $existing->close();
+                $oldAbbr = $beforeRow ? (string)$beforeRow['Abbreviation'] : '';
+                if ($oldAbbr === '') {
+                    sendJson(['error' => 'Songbook not found.'], 404);
+                    break;
+                }
+
+                $abbrChanged = $newAbbr !== '' && $newAbbr !== $oldAbbr;
+                if ($abbrChanged) {
+                    if ($e = validateSongbookAbbr($newAbbr)) {
+                        sendJson(['error' => $e], 400);
+                        break;
+                    }
+                    $dup = $db->prepare('SELECT Id FROM tblSongbooks WHERE Abbreviation = ? AND Id <> ?');
+                    $dup->bind_param('si', $newAbbr, $id);
+                    $dup->execute();
+                    $dupExists = $dup->get_result()->fetch_row() !== null;
+                    $dup->close();
+                    if ($dupExists) {
+                        sendJson(['error' => 'That abbreviation is already taken.'], 409);
+                        break;
+                    }
+                }
+
+                $db->begin_transaction();
+                try {
+                    $stmt = $db->prepare(
+                        'UPDATE tblSongbooks
+                            SET Name = ?, Colour = ?, DisplayOrder = ?,
+                                IsOfficial = ?, Publisher = ?,
+                                PublicationYear = ?, Copyright = ?, Affiliation = ?,
+                                Language = ?,
+                                WebsiteUrl = ?, InternetArchiveUrl = ?,
+                                WikipediaUrl = ?, WikidataId = ?,
+                                OclcNumber = ?, OcnNumber = ?, LcpNumber = ?,
+                                Isbn = ?, ArkId = ?, IsniId = ?,
+                                ViafId = ?, Lccn = ?, LcClass = ?
+                          WHERE Id = ?'
+                    );
+                    /* 23-char type string: ssi (Name,Colour,Order)
+                       + issss (IsOfficial,Publisher,Year,Copyright,Affiliation)
+                       + s (Language) + 13s (bibliographic) + i (Id). */
+                    $orderInt = (int)($order ?: 0);
+                    $stmt->bind_param(
+                        'ssiissssssssssssssssssi',
+                        $name, $colour, $orderInt,
+                        $isOfficial, $publisher, $pubYear, $copyright, $affiliation,
+                        $language,
+                        $websiteUrl, $iaUrl, $wikipediaUrl, $wikidataId,
+                        $oclcNumber, $ocnNumber, $lcpNumber, $isbn, $arkId, $isniId,
+                        $viafId, $lccn, $lcClass,
+                        $id
+                    );
+                    $stmt->execute();
+                    $stmt->close();
+
+                    if ($abbrChanged) {
+                        $stmt = $db->prepare('UPDATE tblSongbooks SET Abbreviation = ? WHERE Id = ?');
+                        $stmt->bind_param('si', $newAbbr, $id);
+                        $stmt->execute();
+                        $stmt->close();
+                        if ($alsoRename) {
+                            $stmt = $db->prepare('UPDATE tblSongs SET SongbookAbbr = ? WHERE SongbookAbbr = ?');
+                            $stmt->bind_param('ss', $newAbbr, $oldAbbr);
+                            $stmt->execute();
+                            $stmt->close();
+                        }
+                    }
+                    $db->commit();
+                } catch (\Throwable $txErr) {
+                    $db->rollback();
+                    throw $txErr;
+                }
+
+                /* Audit (#535) — narrow the row to the actually-changed
+                   fields so the timeline reader doesn't have to skim
+                   identical before/after pairs. */
+                $afterRow = [
+                    'Abbreviation'      => $abbrChanged ? $newAbbr : $oldAbbr,
+                    'Name'              => $name,
+                    'DisplayOrder'      => (int)($order ?: 0),
+                    'Colour'            => $colour,
+                    'IsOfficial'        => $isOfficial,
+                    'Publisher'         => $publisher,
+                    'PublicationYear'   => $pubYear,
+                    'Copyright'         => $copyright,
+                    'Affiliation'       => $affiliation,
+                    'Language'          => $language,
+                    'WebsiteUrl'        => $websiteUrl,
+                    'InternetArchiveUrl'=> $iaUrl,
+                    'WikipediaUrl'      => $wikipediaUrl,
+                    'WikidataId'        => $wikidataId,
+                    'OclcNumber'        => $oclcNumber,
+                    'OcnNumber'         => $ocnNumber,
+                    'LcpNumber'         => $lcpNumber,
+                    'Isbn'              => $isbn,
+                    'ArkId'             => $arkId,
+                    'IsniId'            => $isniId,
+                    'ViafId'            => $viafId,
+                    'Lccn'              => $lccn,
+                    'LcClass'           => $lcClass,
+                ];
+                $changed = [];
+                foreach ($afterRow as $k => $v) {
+                    if (!array_key_exists($k, $beforeRow ?? [])) continue;
+                    if ((string)$beforeRow[$k] !== (string)$v) $changed[] = $k;
+                }
+                logActivity('api.admin.songbook.edit', 'songbook', (string)$id, [
+                    'fields'             => $changed,
+                    'before'             => array_intersect_key($beforeRow, array_flip($changed)),
+                    'after'              => array_intersect_key($afterRow,  array_flip($changed)),
+                    'songs_renamed_too'  => $alsoRename && $abbrChanged,
+                ]);
+
+                if (in_array('Affiliation', $changed, true)) {
+                    registerSongbookAffiliation($db, $affiliation);
+                }
+
+                sendJson([
+                    'ok'             => true,
+                    'id'             => $id,
+                    'abbreviation'   => $abbrChanged ? $newAbbr : $oldAbbr,
+                    'fields_changed' => $changed,
+                    'songs_renamed'  => $alsoRename && $abbrChanged,
+                ]);
+            } catch (\Throwable $e) {
+                logActivityError('api.admin.songbook.edit', 'songbook', (string)$id, $e);
+                error_log('[admin_songbook_update] ' . $e->getMessage());
+                sendJson(['error' => 'Could not update songbook.'], 500);
+            }
+            break;
+        }
+
+        /* -----------------------------------------------------------------
+         * Admin: delete an empty songbook
+         * POST body: { id }
+         * Refuses if any song still references the abbreviation — the
+         * caller must reassign or use admin_songbook_delete_cascade.
+         * Returns 422 (cannot delete) when the dependency check fails so
+         * native UIs can distinguish "wrong id" (404) from "not safe yet".
+         * ----------------------------------------------------------------- */
+        case 'admin_songbook_delete': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser || !in_array($authUser['Role'], ['admin', 'global_admin'])) {
+                sendJson(['error' => 'Admin access required.'], 403);
+                break;
+            }
+
+            $body = json_decode((string)file_get_contents('php://input'), true) ?: [];
+            $id   = (int)($body['id'] ?? 0);
+            if ($id <= 0) {
+                sendJson(['error' => 'Songbook id required.'], 400);
+                break;
+            }
+
+            try {
+                $db = getDbMysqli();
+
+                $stmt = $db->prepare('SELECT Abbreviation FROM tblSongbooks WHERE Id = ?');
+                $stmt->bind_param('i', $id);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_row();
+                $stmt->close();
+                $abbr = (string)($row[0] ?? '');
+                if ($abbr === '') {
+                    sendJson(['error' => 'Songbook not found.'], 404);
+                    break;
+                }
+
+                $stmt = $db->prepare('SELECT COUNT(*) FROM tblSongs WHERE SongbookAbbr = ?');
+                $stmt->bind_param('s', $abbr);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_row();
+                $stmt->close();
+                $songCount = (int)($row[0] ?? 0);
+                if ($songCount > 0) {
+                    sendJson([
+                        'error'        => "Cannot delete '{$abbr}': {$songCount} song(s) still reference it.",
+                        'song_count'   => $songCount,
+                        'abbreviation' => $abbr,
+                        'hint'         => 'Reassign the songs OR call admin_songbook_delete_cascade.',
+                    ], 422);
+                    break;
+                }
+
+                $stmt = $db->prepare('DELETE FROM tblSongbooks WHERE Id = ?');
+                $stmt->bind_param('i', $id);
+                $stmt->execute();
+                $stmt->close();
+
+                logActivity('api.admin.songbook.delete', 'songbook', (string)$id, [
+                    'abbreviation' => $abbr,
+                ]);
+
+                sendJson([
+                    'ok'           => true,
+                    'id'           => $id,
+                    'abbreviation' => $abbr,
+                ]);
+            } catch (\Throwable $e) {
+                logActivityError('api.admin.songbook.delete', 'songbook', (string)$id, $e);
+                error_log('[admin_songbook_delete] ' . $e->getMessage());
+                sendJson(['error' => 'Could not delete songbook.'], 500);
+            }
+            break;
+        }
+
+        /* -----------------------------------------------------------------
+         * Admin: cascade delete (songbook + every song + every credit /
+         * tag / chord / translation that referenced those songs)
+         * POST body: { id, confirm_abbreviation }
+         * Server-side typed-confirmation gate mirrors the web admin
+         * defence-in-depth check (#706). Admin / global_admin only.
+         * Returns 200 + song_count so the caller can render an honest
+         * "deleted N songs" toast.
+         * ----------------------------------------------------------------- */
+        case 'admin_songbook_delete_cascade': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser || !in_array($authUser['Role'], ['admin', 'global_admin'])) {
+                sendJson(['error' => 'Admin access required.'], 403);
+                break;
+            }
+
+            $body = json_decode((string)file_get_contents('php://input'), true) ?: [];
+            $id   = (int)($body['id'] ?? 0);
+            if ($id <= 0) {
+                sendJson(['error' => 'Songbook id required.'], 400);
+                break;
+            }
+            $typed = trim((string)($body['confirm_abbreviation'] ?? ''));
+
+            try {
+                $db = getDbMysqli();
+
+                $stmt = $db->prepare('SELECT Abbreviation FROM tblSongbooks WHERE Id = ?');
+                $stmt->bind_param('i', $id);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_row();
+                $stmt->close();
+                $abbr = (string)($row[0] ?? '');
+                if ($abbr === '') {
+                    sendJson(['error' => 'Songbook not found.'], 404);
+                    break;
+                }
+                if ($typed !== $abbr) {
+                    sendJson([
+                        'error' => "Cascade delete cancelled — confirm_abbreviation must equal the songbook abbreviation '{$abbr}' exactly.",
+                    ], 400);
+                    break;
+                }
+
+                $stmt = $db->prepare('SELECT COUNT(*) FROM tblSongs WHERE SongbookAbbr = ?');
+                $stmt->bind_param('s', $abbr);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_row();
+                $stmt->close();
+                $songCount = (int)($row[0] ?? 0);
+
+                $db->begin_transaction();
+                try {
+                    /* DELETE the songs — cascades to every credit / tag /
+                       chord / translation / artist / request-resolved
+                       reference / etc. via the FK ON DELETE CASCADE rules.
+                       The FK on SongbookAbbr is ON DELETE RESTRICT so we
+                       MUST delete the songs first; then the songbook row
+                       goes cleanly. */
+                    $stmt = $db->prepare('DELETE FROM tblSongs WHERE SongbookAbbr = ?');
+                    $stmt->bind_param('s', $abbr);
+                    $stmt->execute();
+                    $stmt->close();
+
+                    $stmt = $db->prepare('DELETE FROM tblSongbooks WHERE Id = ?');
+                    $stmt->bind_param('i', $id);
+                    $stmt->execute();
+                    $stmt->close();
+
+                    $db->commit();
+                } catch (\Throwable $txErr) {
+                    $db->rollback();
+                    throw $txErr;
+                }
+
+                logActivity('api.admin.songbook.delete_cascade', 'songbook', (string)$id, [
+                    'abbreviation' => $abbr,
+                    'song_count'   => $songCount,
+                ]);
+
+                sendJson([
+                    'ok'           => true,
+                    'id'           => $id,
+                    'abbreviation' => $abbr,
+                    'song_count'   => $songCount,
+                ]);
+            } catch (\Throwable $e) {
+                logActivityError('api.admin.songbook.delete_cascade', 'songbook', (string)$id, $e);
+                error_log('[admin_songbook_delete_cascade] ' . $e->getMessage());
+                sendJson(['error' => 'Could not cascade-delete songbook.'], 500);
+            }
+            break;
+        }
+
+        /* -----------------------------------------------------------------
+         * Admin: bulk reorder
+         * POST body: { display_order: { "<id>": <int>, ... } }
+         * Single transaction; one activity-log row for the bulk op.
+         * ----------------------------------------------------------------- */
+        case 'admin_songbooks_reorder': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser || !in_array($authUser['Role'], ['admin', 'global_admin'])) {
+                sendJson(['error' => 'Admin access required.'], 403);
+                break;
+            }
+
+            $body   = json_decode((string)file_get_contents('php://input'), true) ?: [];
+            $orders = $body['display_order'] ?? null;
+            if (!is_array($orders) || empty($orders)) {
+                sendJson(['error' => 'display_order map (id => order) required.'], 400);
+                break;
+            }
+
+            try {
+                $db = getDbMysqli();
+                $db->begin_transaction();
+                $count = 0;
+                try {
+                    $stmt = $db->prepare('UPDATE tblSongbooks SET DisplayOrder = ? WHERE Id = ?');
+                    foreach ($orders as $rowId => $value) {
+                        $valueInt = (int)$value;
+                        $idInt    = (int)$rowId;
+                        if ($idInt <= 0) continue;
+                        $stmt->bind_param('ii', $valueInt, $idInt);
+                        $stmt->execute();
+                        $count++;
+                    }
+                    $stmt->close();
+                    $db->commit();
+                } catch (\Throwable $txErr) {
+                    $db->rollback();
+                    throw $txErr;
+                }
+
+                logActivity('api.admin.songbook.reorder', 'songbook', '', [
+                    'count' => $count,
+                    'order' => array_map(fn($v) => (int)$v, (array)$orders),
+                ]);
+
+                sendJson(['ok' => true, 'count' => $count]);
+            } catch (\Throwable $e) {
+                logActivityError('api.admin.songbook.reorder', 'songbook', '', $e);
+                error_log('[admin_songbooks_reorder] ' . $e->getMessage());
+                sendJson(['error' => 'Could not reorder songbooks.'], 500);
+            }
+            break;
+        }
+
+        /* -----------------------------------------------------------------
+         * Admin: auto-colour fill (NULL/blank colours only)
+         * POST body: {}
+         * Walks tblSongbooks; rows without a valid #RRGGBB get a
+         * freshly-picked palette colour. Existing values left alone.
+         * Admin / global_admin only.
+         * ----------------------------------------------------------------- */
+        case 'admin_songbooks_auto_colour_fill': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser || !in_array($authUser['Role'], ['admin', 'global_admin'])) {
+                sendJson(['error' => 'Admin access required.'], 403);
+                break;
+            }
+
+            try {
+                $db = getDbMysqli();
+                require_once __DIR__ . DIRECTORY_SEPARATOR . 'manage' . DIRECTORY_SEPARATOR
+                           . 'includes'  . DIRECTORY_SEPARATOR . 'songbook-palette.php';
+
+                $stmt = $db->prepare('SELECT Id, Abbreviation, Colour FROM tblSongbooks ORDER BY Id');
+                $stmt->execute();
+                $books = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+                $stmt->close();
+
+                $db->begin_transaction();
+                $changed = 0;
+                try {
+                    $up = $db->prepare('UPDATE tblSongbooks SET Colour = ? WHERE Id = ?');
+                    foreach ($books as $b) {
+                        $existing = trim((string)($b['Colour'] ?? ''));
+                        if (preg_match('/^#[0-9A-Fa-f]{6}$/', $existing)) continue;
+                        $newColour = pickAutoSongbookColour($db, (string)$b['Abbreviation']);
+                        $bookId    = (int)$b['Id'];
+                        $up->bind_param('si', $newColour, $bookId);
+                        $up->execute();
+                        $changed++;
+                    }
+                    $up->close();
+                    $db->commit();
+                } catch (\Throwable $txErr) {
+                    $db->rollback();
+                    throw $txErr;
+                }
+
+                logActivity('api.admin.songbook.auto_colour_fill', 'songbook', '', [
+                    'count' => $changed,
+                    'mode'  => 'fill',
+                ]);
+
+                sendJson(['ok' => true, 'changed' => $changed, 'mode' => 'fill']);
+            } catch (\Throwable $e) {
+                logActivityError('api.admin.songbook.auto_colour_fill', 'songbook', '', $e);
+                error_log('[admin_songbooks_auto_colour_fill] ' . $e->getMessage());
+                sendJson(['error' => 'Could not auto-fill colours.'], 500);
+            }
+            break;
+        }
+
+        /* -----------------------------------------------------------------
+         * Admin: auto-colour reassign (every row gets a fresh colour)
+         * POST body: { confirm_phrase: "REASSIGN ALL" }
+         * Destructive — overwrites every Colour. Server-side phrase gate
+         * mirrors the web admin's defence-in-depth check. Admin /
+         * global_admin only.
+         * ----------------------------------------------------------------- */
+        case 'admin_songbooks_auto_colour_reassign': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser || !in_array($authUser['Role'], ['admin', 'global_admin'])) {
+                sendJson(['error' => 'Admin access required.'], 403);
+                break;
+            }
+
+            $body  = json_decode((string)file_get_contents('php://input'), true) ?: [];
+            $typed = trim((string)($body['confirm_phrase'] ?? ''));
+            if ($typed !== 'REASSIGN ALL') {
+                sendJson(['error' => 'Reassign-all needs confirm_phrase="REASSIGN ALL".'], 400);
+                break;
+            }
+
+            try {
+                $db = getDbMysqli();
+                require_once __DIR__ . DIRECTORY_SEPARATOR . 'manage' . DIRECTORY_SEPARATOR
+                           . 'includes'  . DIRECTORY_SEPARATOR . 'songbook-palette.php';
+
+                $stmt = $db->prepare('SELECT Id, Abbreviation FROM tblSongbooks ORDER BY Id');
+                $stmt->execute();
+                $books = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+                $stmt->close();
+
+                $db->begin_transaction();
+                $changed = 0;
+                try {
+                    $up = $db->prepare('UPDATE tblSongbooks SET Colour = ? WHERE Id = ?');
+                    foreach ($books as $b) {
+                        $newColour = pickAutoSongbookColour($db, (string)$b['Abbreviation']);
+                        $bookId    = (int)$b['Id'];
+                        $up->bind_param('si', $newColour, $bookId);
+                        $up->execute();
+                        $changed++;
+                    }
+                    $up->close();
+                    $db->commit();
+                } catch (\Throwable $txErr) {
+                    $db->rollback();
+                    throw $txErr;
+                }
+
+                logActivity('api.admin.songbook.auto_colour_reassign', 'songbook', '', [
+                    'count' => $changed,
+                    'mode'  => 'reassign',
+                ]);
+
+                sendJson(['ok' => true, 'changed' => $changed, 'mode' => 'reassign']);
+            } catch (\Throwable $e) {
+                logActivityError('api.admin.songbook.auto_colour_reassign', 'songbook', '', $e);
+                error_log('[admin_songbooks_auto_colour_reassign] ' . $e->getMessage());
+                sendJson(['error' => 'Could not reassign colours.'], 500);
+            }
+            break;
+        }
 
         /* -----------------------------------------------------------------
          * Unknown action

--- a/appWeb/public_html/includes/songbook_validation.php
+++ b/appWeb/public_html/includes/songbook_validation.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Songbook input validators (#719 PR 2a)
+ *
+ * Single source of truth for songbook field validation. Used by:
+ *
+ *   - /manage/songbooks.php   (web admin: create + update handlers)
+ *   - /api.php                (admin_songbook_* CRUD endpoints)
+ *
+ * Each validator returns NULL on a valid input or a human-readable
+ * error string on failure. Callers compose the result with their own
+ * error-display strategy (banner on the web admin, JSON envelope
+ * + 400 on the API).
+ *
+ * Length caps mirror the column widths in `appWeb/.sql/schema.sql`
+ * for tblSongbooks. Pattern checks mirror the established
+ * conventions: ASCII-alphanumeric abbreviation, #RRGGBB colour,
+ * IETF BCP 47 language subtag form per #681.
+ *
+ * Direct access is blocked so this file can't be loaded as an
+ * arbitrary endpoint via an open Apache config.
+ */
+
+if (basename($_SERVER['SCRIPT_FILENAME'] ?? '') === basename(__FILE__)) {
+    http_response_code(403);
+    exit('Access denied.');
+}
+
+/**
+ * Validate a songbook abbreviation. The natural key on tblSongs
+ * (every song carries SongbookAbbr); renaming has cascade implications
+ * which is why the form is opt-in. Caller decides whether the value
+ * is a NEW abbreviation (validate against existing rows) or simply
+ * a valid shape — that part stays in the call site since the SQL
+ * varies by surface.
+ *
+ * @param string $abbr Raw abbreviation as typed.
+ * @return string|null Error message or null if valid.
+ */
+function validateSongbookAbbr(string $abbr): ?string
+{
+    $abbr = trim($abbr);
+    if ($abbr === '') {
+        return 'Abbreviation is required.';
+    }
+    if (strlen($abbr) > 10) {
+        return 'Abbreviation must be 10 characters or fewer.';
+    }
+    if (!preg_match('/^[A-Za-z0-9]+$/', $abbr)) {
+        return 'Abbreviation must be letters/numbers only (no spaces or punctuation).';
+    }
+    return null;
+}
+
+/**
+ * Validate a songbook hex colour. Empty is OK — the auto-pick
+ * fallback (#677) chooses a palette tone at render. A non-empty
+ * value must be the canonical 7-char `#RRGGBB` form; 3-char
+ * shorthand and alpha variants are intentionally rejected so the
+ * downstream renderers can assume one shape.
+ *
+ * @param string $c Raw colour as typed (or '').
+ * @return string|null Error message or null if valid.
+ */
+function validateSongbookColour(string $c): ?string
+{
+    if ($c === '') {
+        return null;
+    }
+    if (!preg_match('/^#[0-9A-Fa-f]{6}$/', $c)) {
+        return 'Colour must be a #RRGGBB hex value (or blank).';
+    }
+    return null;
+}
+
+/**
+ * Validate an IETF BCP 47 language tag (#681). Empty is fine
+ * (NULL = "not specified" for songbooks). Otherwise must match the
+ * v1 grammar: lowercase 2-3 letter language, optional 4-letter
+ * Title Case script, optional 2-letter UPPER region or 3-digit
+ * numeric area code. Variants / extensions / private-use are out
+ * of scope for v1 per the issue brief.
+ *
+ * Returns null if valid (empty or matching), an error message
+ * string otherwise. Caller is responsible for calling mb_substr to
+ * cap to the column width regardless — the regex doesn't bound
+ * length on its own.
+ *
+ * @param string $tag Raw tag as typed (or '').
+ * @return string|null Error message or null if valid.
+ */
+function validateSongbookBcp47(string $tag): ?string
+{
+    if ($tag === '') {
+        return null;
+    }
+    if (strlen($tag) > 35) {
+        return 'Language tag must be 35 characters or fewer.';
+    }
+    if (!preg_match('/^[a-z]{2,3}(-[A-Z][a-z]{3})?(-[A-Z]{2}|-[0-9]{3})?$/', $tag)) {
+        return 'Language tag must be a valid IETF BCP 47 form (e.g. en, pt-BR, zh-Hans-CN).';
+    }
+    return null;
+}
+
+/**
+ * Best-effort affiliation registry sync (#670). INSERT IGNORE the
+ * supplied affiliation name into tblSongbookAffiliations so the
+ * typeahead surfaces it on the next save. Silent no-op when:
+ *
+ *   - $name is null or empty after trim
+ *   - tblSongbookAffiliations doesn't exist (pre-migration deployment)
+ *
+ * Same behaviour the closure in songbooks.php had previously — extracted
+ * here so the API CRUD endpoints can run the same registry sync without
+ * duplicating the logic.
+ *
+ * @param mysqli   $db  Database handle.
+ * @param ?string  $name Raw affiliation name; null/empty is a no-op.
+ */
+function registerSongbookAffiliation(\mysqli $db, ?string $name): void
+{
+    if ($name === null) {
+        return;
+    }
+    $trimmed = trim($name);
+    if ($trimmed === '') {
+        return;
+    }
+    /* Cap to the column width so a crafted input can't crash the
+       INSERT. mb_substr is unicode-safe for languages whose glyphs
+       are multi-byte. */
+    $trimmed = mb_substr($trimmed, 0, 120);
+    try {
+        $stmt = $db->prepare('INSERT IGNORE INTO tblSongbookAffiliations (Name) VALUES (?)');
+        $stmt->bind_param('s', $trimmed);
+        $stmt->execute();
+        $stmt->close();
+    } catch (\Throwable $e) {
+        /* Most likely cause: the migration hasn't been run yet so the
+           table doesn't exist. Best-effort sync; the parent operation
+           is unaffected. */
+        error_log('[songbook_validation] affiliation registry sync skipped: ' . $e->getMessage());
+    }
+}

--- a/appWeb/public_html/manage/songbooks.php
+++ b/appWeb/public_html/manage/songbooks.php
@@ -18,6 +18,10 @@ declare(strict_types=1);
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'songbook-palette.php';
+/* Shared validators (#719 PR 2a) — same rules used by the admin_songbook_*
+   API endpoints in /api.php. Single source of truth so a tweak to the
+   abbrev / colour / IETF-tag grammar lands on both surfaces in one go. */
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'songbook_validation.php';
 
 if (!isAuthenticated()) {
     header('Location: /manage/login');
@@ -258,77 +262,18 @@ if (($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'GET'
     exit;
 }
 
-/**
- * INSERT IGNORE the supplied affiliation name into the registry so
- * the typeahead surfaces it on the next save (#670). Silent no-op
- * when the table doesn't exist (pre-migration deployments) so the
- * songbook save path can't be broken by a half-applied schema. The
- * tblCreditPeople sync in the editor's save_song path uses the same
- * "best-effort registry sync" pattern (#545).
- *
- * @param ?string $name Affiliation name as typed; null/empty = no-op.
- */
+/* Local closures over $db that wrap the shared helpers in
+   includes/songbook_validation.php. The shared helpers are plain
+   functions (no captured state); these wrappers exist solely so the
+   call sites below can keep their existing `$registerAffiliation(...)`
+   / `$validateAbbr(...)` syntax without re-piping $db through every
+   call. (#719 PR 2a) */
 $registerAffiliation = function (?string $name) use ($db): void {
-    if ($name === null) return;
-    $trimmed = trim($name);
-    if ($trimmed === '') return;
-    /* Cap to the column width so a crafted form post can't crash
-       the INSERT. mb_substr is unicode-safe for languages whose
-       glyphs are multi-byte (e.g. denomination names in Cyrillic). */
-    $trimmed = mb_substr($trimmed, 0, 120);
-    try {
-        $stmt = $db->prepare('INSERT IGNORE INTO tblSongbookAffiliations (Name) VALUES (?)');
-        $stmt->bind_param('s', $trimmed);
-        $stmt->execute();
-        $stmt->close();
-    } catch (\Throwable $e) {
-        /* Most likely cause: the migration hasn't been run yet so the
-           table doesn't exist. The save itself is unaffected — this is
-           best-effort registry sync. */
-        error_log('[songbooks] registry sync skipped: ' . $e->getMessage());
-    }
+    registerSongbookAffiliation($db, $name);
 };
-
-/* Helpers */
-$validateAbbr = function (string $abbr): ?string {
-    $abbr = trim($abbr);
-    if ($abbr === '') return 'Abbreviation is required.';
-    if (strlen($abbr) > 10) return 'Abbreviation must be 10 characters or fewer.';
-    if (!preg_match('/^[A-Za-z0-9]+$/', $abbr)) return 'Abbreviation must be letters/numbers only (no spaces or punctuation).';
-    return null;
-};
-$validateColour = function (string $c): ?string {
-    if ($c === '') return null;
-    return preg_match('/^#[0-9A-Fa-f]{6}$/', $c) ? null : 'Colour must be a #RRGGBB hex value (or blank).';
-};
-
-/**
- * Validate an IETF BCP 47 language tag (#681). Empty is fine
- * (NULL = "not specified" for songbooks). Otherwise must match
- * the v1 grammar: lowercase 2-3 letter language, optional 4-letter
- * Title Case script, optional 2-letter UPPER region or 3-digit
- * numeric area code. Variants / extensions / private-use are out
- * of scope for v1 per the issue brief.
- *
- * Returns null if valid (empty or matching), an error message
- * string otherwise. Caller is responsible for calling mb_substr
- * to cap to the column width regardless — the regex doesn't bound
- * length on its own.
- */
-$validateBcp47 = function (string $tag): ?string {
-    if ($tag === '') return null;
-    if (strlen($tag) > 35) {
-        return 'Language tag must be 35 characters or fewer.';
-    }
-    /* The full grammar of BCP 47 is much richer; this regex covers
-       the in-scope subset (#681). Anything beyond is rejected so a
-       tampered POST can't smuggle private-use subtags into a column
-       the rest of the system assumes is well-formed. */
-    if (!preg_match('/^[a-z]{2,3}(-[A-Z][a-z]{3})?(-[A-Z]{2}|-[0-9]{3})?$/', $tag)) {
-        return 'Language tag must be a valid IETF BCP 47 form (e.g. en, pt-BR, zh-Hans-CN).';
-    }
-    return null;
-};
+$validateAbbr   = fn(string $abbr): ?string => validateSongbookAbbr($abbr);
+$validateColour = fn(string $c): ?string    => validateSongbookColour($c);
+$validateBcp47  = fn(string $tag): ?string  => validateSongbookBcp47($tag);
 
 /* ----- POST actions ----- */
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {


### PR DESCRIPTION
## Summary

PR 2a of the multi-PR sequence laid out in the API parity audit (#727 / refs #719). Closes the **largest single domain-shaped gap** from that audit: songbooks went from 0% API coverage (7 admin verbs missing) to 100%.

Native clients (Apple, Android, FireOS) can now create / update / delete / reorder / auto-colour songbooks via `/api?action=admin_songbook_*` rather than a webview onto `/manage/songbooks`.

7 new endpoints, all POST + JSON body, admin/global_admin gated, full OpenAPI documentation:

| Endpoint | Behaviour |
|---|---|
| `admin_songbook_create` | mirrors web admin `create`; auto-colour fallback (#677) when blank; affiliation registry sync (#670). Returns **201** + id + resolved colour. |
| `admin_songbook_update` | mirrors web admin `update`; optional rename (incl. `rename_song_refs` cascade to `tblSongs.SongbookAbbr`); per-row diff in audit log. |
| `admin_songbook_delete` | refuses with **422** + `song_count` if rows still reference. |
| `admin_songbook_delete_cascade` | typed-confirm (`confirm_abbreviation` must equal abbr) — mirrors web admin defence-in-depth (#706). Cascades via FK `ON DELETE CASCADE` chain. |
| `admin_songbooks_reorder` | bulk `display_order` map; single transaction; one Activity-Log row. |
| `admin_songbooks_auto_colour_fill` | idempotent — only NULL/blank/non-hex rows get a colour. |
| `admin_songbooks_auto_colour_reassign` | typed-confirm (`confirm_phrase` must equal `REASSIGN ALL`); destructive overwrite. |

## Architectural notes

- **Single source of truth for validation** — the abbreviation / colour / IETF BCP 47 grammar / affiliation-registry helpers are extracted out of the `/manage/songbooks.php` closures into `appWeb/public_html/includes/songbook_validation.php`. The web admin now calls thin fn-wrappers around the shared functions; the new API endpoints call the same functions directly. A future tweak to any rule lands on both surfaces in one go.

- **Activity-log verb prefix** — every API-driven change writes under `api.admin.songbook.*` (web UI still writes `songbook.*`). The `/manage/activity-log` viewer can surface both, but a curator can tell which surface drove a change. Catch-all `logActivityError` calls so failures show up under the same prefix.

- **Status codes follow REST** — 400 (validation), 401, 403, 404, 405, 409 (duplicate abbr), 422 (cannot delete because songs still reference). Native UIs can render the right toast without parsing the error string.

- **OpenAPI** — bumped 0.50.0 → 0.51.0. New `Admin — Songbooks` tag. New `SongbookWriteInput` schema component, re-used for `update` via `allOf`.

## What's NOT in this PR (per audit's recommended sequence)

- PR 2b — Users + Groups + Tiers API CRUD (15 endpoints) — admin core
- PR 2c — Organisations + my-organisations API CRUD (11 endpoints)
- PR 2d — Credit People + analytics + read-side admin endpoints (9 endpoints)
- PR 3 — OpenAPI refresh tail (any further admin-core endpoints)
- PR 4 — In-app docs (`/help` + `/manage/help`)
- PR 5 — Wiki refresh

## Commits on this branch

- `e5b80ee` refactor(songbooks): extract validators to shared include
- `3d78a51` feat(api): admin songbook CRUD endpoints + OpenAPI

## Test plan

- [ ] **Local lint** — `php -l` clean on `api.php`, `songbook_validation.php`, `manage/songbooks.php`. ✅ verified.
- [ ] **OpenAPI** — `python3 -c "import yaml; yaml.safe_load(open('appWeb/public_html/api-docs.yaml'))"` parses; 7 new paths present; `SongbookWriteInput` schema present; operationIds unique. ✅ verified.
- [ ] **Web admin smoke** — `/manage/songbooks` create + update + delete still work end-to-end (validators behaviour preserved by the wrapper closures).
- [ ] **API smoke** — curl each endpoint with a Bearer token + `X-Requested-With: XMLHttpRequest`; verify the auth gate, the 400/403/404/409/422 paths, and the success path.
- [ ] **Activity log** — every endpoint writes a `api.admin.songbook.*` row on success and on caught error; web admin still writes its `songbook.*` rows.
- [ ] **Cascade delete** — pick a tiny throwaway songbook, run `admin_songbook_delete_cascade`, confirm song count + that every credit / tag / chord / translation row is gone.

## Migrations

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)