### PR TITLE
feat(api): admin user / group / tier CRUD — admin core (PR 2b of #719)

### DIFF
--- a/appWeb/public_html/api-docs.yaml
+++ b/appWeb/public_html/api-docs.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 
 info:
   title: iHymns API
-  version: "0.51.0"
+  version: "0.52.0"
   description: |
     The iHymns API provides programmatic access to the iHymns hymn and song
     database. It powers the iHymns Progressive Web App (PWA), enabling song
@@ -175,6 +175,30 @@ tags:
       shared with the web admin via `includes/songbook_validation.php`,
       so a tweak to the abbreviation / colour / IETF BCP 47 grammar
       lands on both surfaces in one go.
+  - name: Admin — Users
+    description: |
+      User CRUD parity (#719 PR 2b). Mirrors `/manage/users` so native
+      clients can create / update / rename / role-change / activate /
+      reset-password / delete user accounts. Mutations route through
+      the helpers in `manage/includes/auth.php`, which write the
+      canonical activity-log rows under `user.create`,
+      `auth.role_change`, `auth.username_change`, `user.activate`,
+      `user.deactivate`. Hierarchy gates mirror the web admin: an
+      admin can never act on a peer or superior unless they're
+      `global_admin`, never promote above their own level, never
+      delete or deactivate their own account.
+  - name: Admin — Groups
+    description: |
+      User-group CRUD parity (#719 PR 2b). Mirrors `/manage/groups`.
+      Each user belongs to at most one group via `tblUsers.GroupId`;
+      the `admin_group_member_*` endpoints toggle that FK.
+  - name: Admin — Tiers
+    description: |
+      Access-tier CRUD parity (#719 PR 2b). Mirrors `/manage/tiers`.
+      Capability-column list (`TIER_CAPS`) lives in
+      `includes/access_tier_validation.php` so a new capability is a
+      one-line schema + const change — no surface-specific bind_param
+      edits needed.
   - name: Admin — Revisions
     description: Review pending song revisions
   - name: Admin — Maintenance
@@ -2153,6 +2177,623 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+
+  # ===========================================================================
+  # ADMIN — USERS  (#719 PR 2b)
+  # CRUD parity with /manage/users for native clients. The mutation
+  # routes through helpers in manage/includes/auth.php; activity-log
+  # rows land under the canonical `user.*` / `auth.*` verbs.
+  # ===========================================================================
+
+  /api.php?action=admin_user_create:
+    post:
+      operationId: adminUserCreate
+      tags: [Admin — Users]
+      summary: Create a user
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_user_create] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AdminUserCreateInput"
+      responses:
+        "201":
+          description: User created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:       { type: boolean, example: true }
+                  id:       { type: integer }
+                  username: { type: string }
+                  role:     { type: string }
+        "400":
+          description: Validation error (username too short, password too short, invalid role)
+        "403":
+          description: |
+            Admin access required, or hierarchy gate (cannot promote
+            above your own level; only `global_admin` can assign
+            `global_admin`).
+        "409":
+          description: Username already taken
+
+  /api.php?action=admin_user_update:
+    post:
+      operationId: adminUserUpdate
+      tags: [Admin — Users]
+      summary: Update a user's profile (display name + email)
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_user_update] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AdminUserProfileInput"
+      responses:
+        "200":
+          description: Profile updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:       { type: boolean, example: true }
+                  id:       { type: integer }
+                  username: { type: string }
+        "400":
+          description: Missing user_id or display_name
+        "403":
+          description: Admin access required, or hierarchy gate
+        "404":
+          description: User id not found
+
+  /api.php?action=admin_user_rename:
+    post:
+      operationId: adminUserRename
+      tags: [Admin — Users]
+      summary: Change a user's username
+      description: |
+        Username uniqueness check is case-insensitive
+        (utf8mb4_unicode_ci) but the curator's chosen casing is
+        preserved on disk. Cascades automatically — every FK to
+        `tblUsers.Id` is keyed by `Id`, not `Username`.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_user_rename] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [user_id, new_username]
+              properties:
+                user_id:      { type: integer }
+                new_username:
+                  type: string
+                  minLength: 3
+                  maxLength: 100
+                  pattern: "^[A-Za-z0-9_.\\-]+$"
+      responses:
+        "200":
+          description: User renamed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:           { type: boolean, example: true }
+                  id:           { type: integer }
+                  old_username: { type: string }
+                  new_username: { type: string }
+        "400":
+          description: Bad shape (length / charset)
+        "403":
+          description: Admin access required, or hierarchy gate
+        "404":
+          description: User id not found
+        "409":
+          description: Username already taken
+
+  /api.php?action=admin_user_role_change:
+    post:
+      operationId: adminUserRoleChange
+      tags: [Admin — Users]
+      summary: Change a user's role
+      description: |
+        Hierarchy gates enforced by `updateUserRole()` in
+        `manage/includes/auth.php`. Cannot promote above your own
+        level, cannot demote a peer or superior unless you're
+        `global_admin`, only `global_admin` can assign `global_admin`.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_user_role_change] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [user_id, new_role]
+              properties:
+                user_id: { type: integer }
+                new_role:
+                  type: string
+                  enum: [user, editor, admin, global_admin]
+      responses:
+        "200":
+          description: Role changed
+        "400":
+          description: Missing user_id or new_role
+        "403":
+          description: Hierarchy violation
+        "404":
+          description: User id not found
+
+  /api.php?action=admin_user_toggle_active:
+    post:
+      operationId: adminUserToggleActive
+      tags: [Admin — Users]
+      summary: Toggle a user's active state
+      description: |
+        Deactivation also drops every API token for the user
+        (defence-in-depth — they can't keep using a stolen token
+        after the suspension). Cannot deactivate yourself.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_user_toggle_active] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [user_id]
+              properties:
+                user_id: { type: integer }
+      responses:
+        "200":
+          description: Active state toggled
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:        { type: boolean, example: true }
+                  id:        { type: integer }
+                  is_active: { type: boolean }
+        "403":
+          description: Cannot deactivate self, or hierarchy gate
+        "404":
+          description: User id not found
+
+  /api.php?action=admin_user_password_reset:
+    post:
+      operationId: adminUserPasswordReset
+      tags: [Admin — Users]
+      summary: Reset a user's password
+      description: |
+        Self-reset is permitted (mirrors `/manage/users`). Otherwise
+        the target must be below the acting user's role level.
+        bcrypt cost-12 hashing is performed inside
+        `changeUserPassword()`; the plaintext never touches the
+        activity log.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_user_password_reset] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [user_id, new_password]
+              properties:
+                user_id:      { type: integer }
+                new_password:
+                  type: string
+                  format: password
+                  minLength: 8
+      responses:
+        "200":
+          description: Password reset
+        "400":
+          description: Password too short, or missing user_id
+        "403":
+          description: Hierarchy gate
+        "404":
+          description: User id not found
+
+  /api.php?action=admin_user_delete:
+    post:
+      operationId: adminUserDelete
+      tags: [Admin — Users]
+      summary: Permanently delete a user
+      description: |
+        Hard delete via `deleteUser()` in
+        `manage/includes/auth.php`. Cannot delete yourself; cannot
+        delete a peer or superior unless `global_admin`. FK cascades
+        clean up tokens, setlists, etc.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_user_delete] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [user_id]
+              properties:
+                user_id: { type: integer }
+      responses:
+        "200":
+          description: User deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:       { type: boolean, example: true }
+                  id:       { type: integer }
+                  username: { type: string }
+        "403":
+          description: Cannot delete self, or hierarchy gate
+        "404":
+          description: User id not found
+
+  # ===========================================================================
+  # ADMIN — GROUPS  (#719 PR 2b)
+  # ===========================================================================
+
+  /api.php?action=admin_group_create:
+    post:
+      operationId: adminGroupCreate
+      tags: [Admin — Groups]
+      summary: Create a user group
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_group_create] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AdminGroupWriteInput"
+      responses:
+        "201":
+          description: Group created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:   { type: boolean, example: true }
+                  id:   { type: integer }
+                  name: { type: string }
+        "400":
+          description: Missing name, or name too long
+        "403":
+          description: Admin access required
+        "409":
+          description: Group name already in use
+
+  /api.php?action=admin_group_update:
+    post:
+      operationId: adminGroupUpdate
+      tags: [Admin — Groups]
+      summary: Update a user group
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_group_update] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: "#/components/schemas/AdminGroupWriteInput"
+                - type: object
+                  required: [id]
+                  properties:
+                    id: { type: integer }
+      responses:
+        "200":
+          description: Group updated
+        "400":
+          description: Missing id or name
+        "403":
+          description: Admin access required
+        "404":
+          description: Group id not found
+        "409":
+          description: Another group already uses that name
+
+  /api.php?action=admin_group_delete:
+    post:
+      operationId: adminGroupDelete
+      tags: [Admin — Groups]
+      summary: Delete an empty user group
+      description: Refuses with 422 if any user is still a member.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_group_delete] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [id]
+              properties:
+                id: { type: integer }
+      responses:
+        "200":
+          description: Group deleted
+        "400":
+          description: Missing id
+        "403":
+          description: Admin access required
+        "404":
+          description: Group id not found
+        "422":
+          description: |
+            Refused — group still has members. Response includes
+            `member_count`, `name`, and `hint` so the caller can
+            render an honest "move users first" prompt.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:        { type: string }
+                  member_count: { type: integer }
+                  name:         { type: string }
+                  hint:         { type: string }
+
+  /api.php?action=admin_group_member_add:
+    post:
+      operationId: adminGroupMemberAdd
+      tags: [Admin — Groups]
+      summary: Move a user into a group (sets tblUsers.GroupId)
+      description: |
+        A user belongs to at most one group at a time, so calling
+        this also moves them out of whatever group they were in.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_group_member_add] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [group_id, user_id]
+              properties:
+                group_id: { type: integer }
+                user_id:  { type: integer }
+      responses:
+        "200":
+          description: Membership set
+        "400":
+          description: Missing group_id or user_id
+        "403":
+          description: Admin access required
+        "404":
+          description: Group or user not found
+
+  /api.php?action=admin_group_member_remove:
+    post:
+      operationId: adminGroupMemberRemove
+      tags: [Admin — Groups]
+      summary: Remove a user from their group (clears tblUsers.GroupId)
+      description: |
+        Drops the FK to NULL — a user belongs to at most one group,
+        so the previous group_id isn't required from the caller.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_group_member_remove] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [user_id]
+              properties:
+                user_id: { type: integer }
+      responses:
+        "200":
+          description: Membership cleared (or already absent)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:             { type: boolean, example: true }
+                  user_id:        { type: integer }
+                  previous_group:
+                    type: integer
+                    nullable: true
+                    description: The group_id the user was in before this call (null if they weren't in any).
+        "400":
+          description: Missing user_id
+        "403":
+          description: Admin access required
+        "404":
+          description: User id not found
+
+  # ===========================================================================
+  # ADMIN — TIERS  (#719 PR 2b)
+  # ===========================================================================
+
+  /api.php?action=admin_tier_create:
+    post:
+      operationId: adminTierCreate
+      tags: [Admin — Tiers]
+      summary: Create an access tier
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_tier_create] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AdminTierCreateInput"
+      responses:
+        "201":
+          description: Tier created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:   { type: boolean, example: true }
+                  id:   { type: integer }
+                  name: { type: string }
+        "400":
+          description: Validation error (name shape, level bounds, missing display_name)
+        "403":
+          description: Admin access required
+        "409":
+          description: Tier name already in use
+
+  /api.php?action=admin_tier_update:
+    post:
+      operationId: adminTierUpdate
+      tags: [Admin — Tiers]
+      summary: Update an access tier
+      description: |
+        Machine `name` is intentionally immutable — too many
+        `tblUsers.AccessTier` rows reference it for a casual
+        rename. Use a manual SQL migration if a rename is genuinely
+        needed.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_tier_update] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AdminTierUpdateInput"
+      responses:
+        "200":
+          description: Tier updated
+        "400":
+          description: Validation error
+        "403":
+          description: Admin access required
+        "404":
+          description: Tier id not found
+
+  /api.php?action=admin_tier_delete:
+    post:
+      operationId: adminTierDelete
+      tags: [Admin — Tiers]
+      summary: Delete an unused access tier
+      description: Refuses with 422 if any user is still on the tier.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_tier_delete] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [id]
+              properties:
+                id: { type: integer }
+      responses:
+        "200":
+          description: Tier deleted
+        "400":
+          description: Missing id
+        "403":
+          description: Admin access required
+        "404":
+          description: Tier id not found
+        "422":
+          description: |
+            Refused — users are still on this tier. Response includes
+            `user_count`, `name`, and `hint`.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:      { type: string }
+                  user_count: { type: integer }
+                  name:       { type: string }
+                  hint:       { type: string }
 
   /api.php?action=admin_activity_log:
     get:
@@ -5982,6 +6623,131 @@ components:
           type: string
           nullable: true
           description: Username of the actor
+
+    # -------------------------------------------------------------------------
+    # Admin write-input shapes (#719 PR 2b)
+    # -------------------------------------------------------------------------
+
+    AdminUserCreateInput:
+      type: object
+      description: |
+        Input for `admin_user_create`. The mutation routes through
+        `createUser()` in `manage/includes/auth.php`, which hashes
+        the password with bcrypt before insert and writes the
+        canonical `user.create` activity-log row.
+      required: [username, password]
+      properties:
+        username:
+          type: string
+          minLength: 3
+          maxLength: 100
+          description: Case preserved on disk; uniqueness check is case-insensitive (utf8mb4_unicode_ci).
+        password:
+          type: string
+          minLength: 8
+          format: password
+        display_name:
+          type: string
+          description: Defaults to `username` when blank.
+        role:
+          type: string
+          enum: [user, editor, admin, global_admin]
+          default: editor
+          description: |
+            Hierarchy gate: can never exceed the acting user's role
+            level; only `global_admin` can assign `global_admin`.
+        email:
+          type: string
+          format: email
+
+    AdminUserProfileInput:
+      type: object
+      description: Input for `admin_user_update` (display name + email only).
+      required: [user_id, display_name]
+      properties:
+        user_id:    { type: integer }
+        display_name: { type: string }
+        email:      { type: string, format: email }
+
+    AdminGroupWriteInput:
+      type: object
+      description: |
+        Input for `admin_group_create` and the metadata half of
+        `admin_group_update`. Add `id` (required) for the latter.
+      required: [name]
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        description:
+          type: string
+        access_alpha: { type: boolean, default: false }
+        access_beta:  { type: boolean, default: false }
+        access_rc:    { type: boolean, default: false }
+        access_rtw:   { type: boolean, default: false }
+
+    AdminTierCapabilities:
+      type: object
+      description: |
+        Capability flags keyed by exact `tblAccessTiers` column
+        name. Unknown keys are ignored; missing keys default to
+        false. The list mirrors `TIER_CAPS` in
+        `includes/access_tier_validation.php` so a new capability
+        is a one-line schema + const change.
+      properties:
+        CanViewLyrics:      { type: boolean, default: false }
+        CanViewCopyrighted: { type: boolean, default: false }
+        CanPlayAudio:       { type: boolean, default: false }
+        CanDownloadMidi:    { type: boolean, default: false }
+        CanDownloadPdf:     { type: boolean, default: false }
+        CanOfflineSave:     { type: boolean, default: false }
+        RequiresCcli:       { type: boolean, default: false }
+
+    AdminTierCreateInput:
+      type: object
+      description: Input for `admin_tier_create`.
+      required: [name, display_name, level]
+      properties:
+        name:
+          type: string
+          maxLength: 30
+          pattern: "^[A-Za-z0-9_-]+$"
+          description: Machine key. Letters / digits / hyphen / underscore. Case preserved.
+          example: mwbm-insiders
+        display_name:
+          type: string
+          example: MWBM Insiders
+        level:
+          type: integer
+          minimum: 0
+          maximum: 1000
+          description: Higher level = more permissions. Bounded so a typo can't elevate one tier above the rest.
+        description:
+          type: string
+        caps:
+          $ref: "#/components/schemas/AdminTierCapabilities"
+
+    AdminTierUpdateInput:
+      type: object
+      description: |
+        Input for `admin_tier_update`. The machine `name` is
+        intentionally immutable — too many `tblUsers.AccessTier`
+        rows reference it for a casual rename. Use a manual SQL
+        migration if a rename is genuinely needed.
+      required: [id, display_name, level]
+      properties:
+        id:
+          type: integer
+        display_name:
+          type: string
+        level:
+          type: integer
+          minimum: 0
+          maximum: 1000
+        description:
+          type: string
+        caps:
+          $ref: "#/components/schemas/AdminTierCapabilities"
 
     # -------------------------------------------------------------------------
     # Generic response models

--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -6532,6 +6532,1081 @@ if ($action !== null) {
             break;
         }
 
+        /* =================================================================
+         * USERS — admin CRUD parity (#719 PR 2b)
+         *
+         * Mirrors the web-admin POST handlers in /manage/users.php so
+         * native clients can perform user curation without a webview.
+         * The actual mutation goes through the helpers in
+         * manage/includes/auth.php (createUser / updateUserRole / etc.)
+         * — those helpers already write the canonical activity-log
+         * row (`user.create`, `auth.role_change`, ...). The endpoints
+         * here only add a parallel `api.admin.user.*` row on the catch
+         * path so failures surface under the API surface prefix in
+         * /manage/activity-log.
+         *
+         * Hierarchy gates mirror users.php exactly: an admin can't
+         * promote above their own level, can't act on a peer or
+         * superior unless they are global_admin, and can't act on
+         * themselves for the destructive verbs.
+         * ================================================================= */
+
+        /* -----------------------------------------------------------------
+         * Admin: create a user
+         * POST body: { username, password, display_name?, role?, email? }
+         * Defaults: role=editor, display_name=username, email=''.
+         * Returns 201 + new user id.
+         * ----------------------------------------------------------------- */
+        case 'admin_user_create': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser || !in_array($authUser['Role'], ['admin', 'global_admin'])) {
+                sendJson(['error' => 'Admin access required.'], 403);
+                break;
+            }
+
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'manage' . DIRECTORY_SEPARATOR
+                       . 'includes'  . DIRECTORY_SEPARATOR . 'auth.php';
+
+            $body        = json_decode((string)file_get_contents('php://input'), true) ?: [];
+            $username    = trim((string)($body['username']     ?? ''));
+            $password    = (string)($body['password']          ?? '');
+            $displayName = trim((string)($body['display_name'] ?? '')) ?: $username;
+            $role        = trim((string)($body['role']         ?? 'editor'));
+            $email       = trim((string)($body['email']        ?? ''));
+
+            if (mb_strlen($username) < 3) {
+                sendJson(['error' => 'Username must be at least 3 characters.'], 400);
+                break;
+            }
+            if (strlen($password) < 8) {
+                sendJson(['error' => 'Password must be at least 8 characters.'], 400);
+                break;
+            }
+            if (!in_array($role, allRoles(), true)) {
+                sendJson(['error' => 'Invalid role.'], 400);
+                break;
+            }
+            /* Hierarchy gate (mirrors users.php). Only global_admin can
+               assign global_admin; nobody can promote above their own
+               level. */
+            $actingRole = (string)$authUser['Role'];
+            if ($role === 'global_admin' && $actingRole !== 'global_admin') {
+                sendJson(['error' => 'Only Global Admin can assign the Global Admin role.'], 403);
+                break;
+            }
+            if (roleLevel($role) > roleLevel($actingRole)) {
+                sendJson(['error' => 'Cannot assign a role higher than your own.'], 403);
+                break;
+            }
+
+            try {
+                $newUserId = createUser($username, $password, $displayName, $role, $email);
+                sendJson([
+                    'ok'       => true,
+                    'id'       => (int)$newUserId,
+                    'username' => $username,
+                    'role'     => $role,
+                ], 201);
+            } catch (\RuntimeException $e) {
+                /* createUser throws on duplicate username — surface as
+                   409 Conflict so native UIs can render a sensible
+                   "username already taken" prompt. */
+                $status = stripos($e->getMessage(), 'already exists') !== false ? 409 : 400;
+                sendJson(['error' => $e->getMessage()], $status);
+            } catch (\Throwable $e) {
+                logActivityError('api.admin.user.create', 'user', '', $e, ['username' => $username]);
+                error_log('[admin_user_create] ' . $e->getMessage());
+                sendJson(['error' => 'Could not create user.'], 500);
+            }
+            break;
+        }
+
+        /* -----------------------------------------------------------------
+         * Admin: update a user's profile (display name + email)
+         * POST body: { user_id, display_name, email? }
+         * Hierarchy: an admin can edit themselves; otherwise the target
+         * must be strictly below the acting user's role level (or the
+         * acting user is global_admin).
+         * ----------------------------------------------------------------- */
+        case 'admin_user_update': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser || !in_array($authUser['Role'], ['admin', 'global_admin'])) {
+                sendJson(['error' => 'Admin access required.'], 403);
+                break;
+            }
+
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'manage' . DIRECTORY_SEPARATOR
+                       . 'includes'  . DIRECTORY_SEPARATOR . 'auth.php';
+
+            $body        = json_decode((string)file_get_contents('php://input'), true) ?: [];
+            $targetId    = (int)($body['user_id']      ?? 0);
+            $displayName = trim((string)($body['display_name'] ?? ''));
+            $email       = trim((string)($body['email']        ?? ''));
+
+            if ($targetId <= 0) {
+                sendJson(['error' => 'user_id required.'], 400);
+                break;
+            }
+            if ($displayName === '') {
+                sendJson(['error' => 'Display name cannot be empty.'], 400);
+                break;
+            }
+
+            $target = getUserById($targetId);
+            if (!$target) {
+                sendJson(['error' => 'User not found.'], 404);
+                break;
+            }
+            $actingId   = (int)$authUser['Id'];
+            $actingRole = (string)$authUser['Role'];
+            if (roleLevel((string)$target['role']) >= roleLevel($actingRole)
+                && $actingRole !== 'global_admin'
+                && $targetId !== $actingId) {
+                sendJson(['error' => 'Cannot edit a user at or above your role level.'], 403);
+                break;
+            }
+
+            try {
+                updateUserProfile($targetId, $displayName, $email);
+                sendJson(['ok' => true, 'id' => $targetId, 'username' => (string)$target['username']]);
+            } catch (\Throwable $e) {
+                logActivityError('api.admin.user.update', 'user', (string)$targetId, $e);
+                error_log('[admin_user_update] ' . $e->getMessage());
+                sendJson(['error' => 'Could not update profile.'], 500);
+            }
+            break;
+        }
+
+        /* -----------------------------------------------------------------
+         * Admin: rename a user (username change)
+         * POST body: { user_id, new_username }
+         * renameUser() returns false + error string on shape / dup
+         * conflicts; the API turns those into 400/409.
+         * ----------------------------------------------------------------- */
+        case 'admin_user_rename': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser || !in_array($authUser['Role'], ['admin', 'global_admin'])) {
+                sendJson(['error' => 'Admin access required.'], 403);
+                break;
+            }
+
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'manage' . DIRECTORY_SEPARATOR
+                       . 'includes'  . DIRECTORY_SEPARATOR . 'auth.php';
+
+            $body        = json_decode((string)file_get_contents('php://input'), true) ?: [];
+            $targetId    = (int)($body['user_id']      ?? 0);
+            $newUsername = trim((string)($body['new_username'] ?? ''));
+
+            if ($targetId <= 0) {
+                sendJson(['error' => 'user_id required.'], 400);
+                break;
+            }
+
+            $target = getUserById($targetId);
+            if (!$target) {
+                sendJson(['error' => 'User not found.'], 404);
+                break;
+            }
+            $actingId   = (int)$authUser['Id'];
+            $actingRole = (string)$authUser['Role'];
+            if (roleLevel((string)$target['role']) >= roleLevel($actingRole)
+                && $actingRole !== 'global_admin'
+                && $targetId !== $actingId) {
+                sendJson(['error' => 'Cannot rename a user at or above your role level.'], 403);
+                break;
+            }
+
+            try {
+                $renameError = null;
+                $ok = renameUser($targetId, $newUsername, $renameError);
+                if (!$ok) {
+                    /* renameUser sets $renameError to the user-friendly
+                       reason. "already" → conflict, anything else → 400. */
+                    $msg    = $renameError ?? 'Could not rename user.';
+                    $status = stripos($msg, 'already') !== false ? 409 : 400;
+                    sendJson(['error' => $msg], $status);
+                    break;
+                }
+                sendJson([
+                    'ok'           => true,
+                    'id'           => $targetId,
+                    'old_username' => (string)$target['username'],
+                    'new_username' => mb_strtolower(trim($newUsername)),
+                ]);
+            } catch (\Throwable $e) {
+                logActivityError('api.admin.user.rename', 'user', (string)$targetId, $e);
+                error_log('[admin_user_rename] ' . $e->getMessage());
+                sendJson(['error' => 'Could not rename user.'], 500);
+            }
+            break;
+        }
+
+        /* -----------------------------------------------------------------
+         * Admin: change a user's role
+         * POST body: { user_id, new_role }
+         * updateUserRole() throws on hierarchy violations — turned
+         * into 403 (when the message is about the role gate) or 400.
+         * ----------------------------------------------------------------- */
+        case 'admin_user_role_change': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser || !in_array($authUser['Role'], ['admin', 'global_admin'])) {
+                sendJson(['error' => 'Admin access required.'], 403);
+                break;
+            }
+
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'manage' . DIRECTORY_SEPARATOR
+                       . 'includes'  . DIRECTORY_SEPARATOR . 'auth.php';
+
+            $body     = json_decode((string)file_get_contents('php://input'), true) ?: [];
+            $targetId = (int)($body['user_id']  ?? 0);
+            $newRole  = trim((string)($body['new_role'] ?? ''));
+
+            if ($targetId <= 0 || $newRole === '') {
+                sendJson(['error' => 'user_id and new_role required.'], 400);
+                break;
+            }
+
+            try {
+                /* The helper takes the same shape getCurrentUser()
+                   produces — lowercase keys. Build that from the
+                   bearer-token user. */
+                $actingShape = [
+                    'id'   => (int)$authUser['Id'],
+                    'role' => (string)$authUser['Role'],
+                ];
+                updateUserRole($targetId, $newRole, $actingShape);
+                sendJson(['ok' => true, 'id' => $targetId, 'new_role' => $newRole]);
+            } catch (\RuntimeException $e) {
+                $msg = $e->getMessage();
+                $isHierarchy = (stripos($msg, 'cannot')      !== false)
+                            || (stripos($msg, 'only global') !== false);
+                $status = $isHierarchy ? 403 : (stripos($msg, 'not found') !== false ? 404 : 400);
+                sendJson(['error' => $msg], $status);
+            } catch (\Throwable $e) {
+                logActivityError('api.admin.user.role_change', 'user', (string)$targetId, $e);
+                error_log('[admin_user_role_change] ' . $e->getMessage());
+                sendJson(['error' => 'Could not change role.'], 500);
+            }
+            break;
+        }
+
+        /* -----------------------------------------------------------------
+         * Admin: toggle active state
+         * POST body: { user_id }
+         * Cannot deactivate self. Cannot act on a peer or superior
+         * unless global_admin.
+         * Returns 200 + ok + new is_active so the caller can render
+         * the toggled state without re-reading.
+         * ----------------------------------------------------------------- */
+        case 'admin_user_toggle_active': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser || !in_array($authUser['Role'], ['admin', 'global_admin'])) {
+                sendJson(['error' => 'Admin access required.'], 403);
+                break;
+            }
+
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'manage' . DIRECTORY_SEPARATOR
+                       . 'includes'  . DIRECTORY_SEPARATOR . 'auth.php';
+
+            $body     = json_decode((string)file_get_contents('php://input'), true) ?: [];
+            $targetId = (int)($body['user_id'] ?? 0);
+            if ($targetId <= 0) {
+                sendJson(['error' => 'user_id required.'], 400);
+                break;
+            }
+
+            $target = getUserById($targetId);
+            if (!$target) {
+                sendJson(['error' => 'User not found.'], 404);
+                break;
+            }
+            $actingId   = (int)$authUser['Id'];
+            $actingRole = (string)$authUser['Role'];
+            if ($targetId === $actingId) {
+                sendJson(['error' => 'Cannot deactivate your own account.'], 403);
+                break;
+            }
+            if (roleLevel((string)$target['role']) >= roleLevel($actingRole)
+                && $actingRole !== 'global_admin') {
+                sendJson(['error' => 'Cannot modify a user at or above your role level.'], 403);
+                break;
+            }
+
+            try {
+                $newState = !((bool)$target['is_active']);
+                setUserActive($targetId, $newState);
+                sendJson([
+                    'ok'        => true,
+                    'id'        => $targetId,
+                    'is_active' => $newState,
+                ]);
+            } catch (\Throwable $e) {
+                logActivityError('api.admin.user.toggle_active', 'user', (string)$targetId, $e);
+                error_log('[admin_user_toggle_active] ' . $e->getMessage());
+                sendJson(['error' => 'Could not update active state.'], 500);
+            }
+            break;
+        }
+
+        /* -----------------------------------------------------------------
+         * Admin: reset a user's password
+         * POST body: { user_id, new_password }
+         * Self-reset is permitted (mirrors users.php). Otherwise the
+         * target must be below the acting user's role level (or the
+         * acting user is global_admin).
+         * ----------------------------------------------------------------- */
+        case 'admin_user_password_reset': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser || !in_array($authUser['Role'], ['admin', 'global_admin'])) {
+                sendJson(['error' => 'Admin access required.'], 403);
+                break;
+            }
+
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'manage' . DIRECTORY_SEPARATOR
+                       . 'includes'  . DIRECTORY_SEPARATOR . 'auth.php';
+
+            $body        = json_decode((string)file_get_contents('php://input'), true) ?: [];
+            $targetId    = (int)($body['user_id']      ?? 0);
+            $newPassword = (string)($body['new_password'] ?? '');
+
+            if ($targetId <= 0) {
+                sendJson(['error' => 'user_id required.'], 400);
+                break;
+            }
+            if (strlen($newPassword) < 8) {
+                sendJson(['error' => 'Password must be at least 8 characters.'], 400);
+                break;
+            }
+
+            $target = getUserById($targetId);
+            if (!$target) {
+                sendJson(['error' => 'User not found.'], 404);
+                break;
+            }
+            $actingId   = (int)$authUser['Id'];
+            $actingRole = (string)$authUser['Role'];
+            if (roleLevel((string)$target['role']) >= roleLevel($actingRole)
+                && $actingRole !== 'global_admin'
+                && $targetId !== $actingId) {
+                sendJson(['error' => 'Cannot reset password for a user at or above your role level.'], 403);
+                break;
+            }
+
+            try {
+                changeUserPassword($targetId, $newPassword);
+                sendJson(['ok' => true, 'id' => $targetId, 'username' => (string)$target['username']]);
+            } catch (\Throwable $e) {
+                logActivityError('api.admin.user.password_reset', 'user', (string)$targetId, $e);
+                error_log('[admin_user_password_reset] ' . $e->getMessage());
+                sendJson(['error' => 'Could not reset password.'], 500);
+            }
+            break;
+        }
+
+        /* -----------------------------------------------------------------
+         * Admin: delete a user
+         * POST body: { user_id }
+         * Cannot delete self. Cannot delete a peer or superior unless
+         * global_admin. Hard delete via the helper — the helper handles
+         * audit + cascading FK semantics.
+         * ----------------------------------------------------------------- */
+        case 'admin_user_delete': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser || !in_array($authUser['Role'], ['admin', 'global_admin'])) {
+                sendJson(['error' => 'Admin access required.'], 403);
+                break;
+            }
+
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'manage' . DIRECTORY_SEPARATOR
+                       . 'includes'  . DIRECTORY_SEPARATOR . 'auth.php';
+
+            $body     = json_decode((string)file_get_contents('php://input'), true) ?: [];
+            $targetId = (int)($body['user_id'] ?? 0);
+            if ($targetId <= 0) {
+                sendJson(['error' => 'user_id required.'], 400);
+                break;
+            }
+
+            $target = getUserById($targetId);
+            if (!$target) {
+                sendJson(['error' => 'User not found.'], 404);
+                break;
+            }
+            $actingId   = (int)$authUser['Id'];
+            $actingRole = (string)$authUser['Role'];
+            if ($targetId === $actingId) {
+                sendJson(['error' => 'Cannot delete your own account.'], 403);
+                break;
+            }
+            if (roleLevel((string)$target['role']) >= roleLevel($actingRole)
+                && $actingRole !== 'global_admin') {
+                sendJson(['error' => 'Cannot delete a user at or above your role level.'], 403);
+                break;
+            }
+
+            try {
+                deleteUser($targetId);
+                sendJson(['ok' => true, 'id' => $targetId, 'username' => (string)$target['username']]);
+            } catch (\Throwable $e) {
+                logActivityError('api.admin.user.delete', 'user', (string)$targetId, $e);
+                error_log('[admin_user_delete] ' . $e->getMessage());
+                sendJson(['error' => 'Could not delete user.'], 500);
+            }
+            break;
+        }
+
+        /* =================================================================
+         * USER GROUPS — admin CRUD parity (#719 PR 2b)
+         *
+         * Mirrors /manage/groups.php. Group rows live in tblUserGroups;
+         * membership lives in tblUsers.GroupId (one group per user).
+         * ================================================================= */
+
+        /* -----------------------------------------------------------------
+         * Admin: create a user group
+         * POST body: {
+         *   name, description?,
+         *   access_alpha?, access_beta?, access_rc?, access_rtw?
+         * }
+         * Returns 201 + new group id.
+         * ----------------------------------------------------------------- */
+        case 'admin_group_create': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser || !in_array($authUser['Role'], ['admin', 'global_admin'])) {
+                sendJson(['error' => 'Admin access required.'], 403);
+                break;
+            }
+
+            $body = json_decode((string)file_get_contents('php://input'), true) ?: [];
+            $name = trim((string)($body['name']        ?? ''));
+            $desc = trim((string)($body['description'] ?? ''));
+            $aA   = !empty($body['access_alpha']) ? 1 : 0;
+            $aB   = !empty($body['access_beta'])  ? 1 : 0;
+            $aR   = !empty($body['access_rc'])    ? 1 : 0;
+            $aW   = !empty($body['access_rtw'])   ? 1 : 0;
+
+            if ($name === '') {
+                sendJson(['error' => 'Name is required.'], 400);
+                break;
+            }
+            if (strlen($name) > 100) {
+                sendJson(['error' => 'Name must be 100 characters or fewer.'], 400);
+                break;
+            }
+
+            try {
+                $db = getDbMysqli();
+                $stmt = $db->prepare('SELECT Id FROM tblUserGroups WHERE Name = ?');
+                $stmt->bind_param('s', $name);
+                $stmt->execute();
+                $exists = $stmt->get_result()->fetch_row() !== null;
+                $stmt->close();
+                if ($exists) {
+                    sendJson(['error' => 'A group with that name already exists.'], 409);
+                    break;
+                }
+
+                $stmt = $db->prepare(
+                    'INSERT INTO tblUserGroups (Name, Description, AccessAlpha, AccessBeta, AccessRc, AccessRtw)
+                     VALUES (?, ?, ?, ?, ?, ?)'
+                );
+                $stmt->bind_param('ssiiii', $name, $desc, $aA, $aB, $aR, $aW);
+                $stmt->execute();
+                $newId = (int)$db->insert_id;
+                $stmt->close();
+
+                logActivity('api.admin.group.create', 'group', (string)$newId, [
+                    'name'          => $name,
+                    'description'   => $desc,
+                    'access_alpha'  => (bool)$aA,
+                    'access_beta'   => (bool)$aB,
+                    'access_rc'     => (bool)$aR,
+                    'access_rtw'    => (bool)$aW,
+                ]);
+
+                sendJson(['ok' => true, 'id' => $newId, 'name' => $name], 201);
+            } catch (\Throwable $e) {
+                logActivityError('api.admin.group.create', 'group', '', $e, ['name' => $name]);
+                error_log('[admin_group_create] ' . $e->getMessage());
+                sendJson(['error' => 'Could not create group.'], 500);
+            }
+            break;
+        }
+
+        /* -----------------------------------------------------------------
+         * Admin: update a user group
+         * POST body: {
+         *   id, name, description?,
+         *   access_alpha?, access_beta?, access_rc?, access_rtw?
+         * }
+         * ----------------------------------------------------------------- */
+        case 'admin_group_update': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser || !in_array($authUser['Role'], ['admin', 'global_admin'])) {
+                sendJson(['error' => 'Admin access required.'], 403);
+                break;
+            }
+
+            $body = json_decode((string)file_get_contents('php://input'), true) ?: [];
+            $id   = (int)($body['id']   ?? 0);
+            $name = trim((string)($body['name']        ?? ''));
+            $desc = trim((string)($body['description'] ?? ''));
+            $aA   = !empty($body['access_alpha']) ? 1 : 0;
+            $aB   = !empty($body['access_beta'])  ? 1 : 0;
+            $aR   = !empty($body['access_rc'])    ? 1 : 0;
+            $aW   = !empty($body['access_rtw'])   ? 1 : 0;
+
+            if ($id <= 0) {
+                sendJson(['error' => 'Group id required.'], 400);
+                break;
+            }
+            if ($name === '') {
+                sendJson(['error' => 'Name is required.'], 400);
+                break;
+            }
+            if (strlen($name) > 100) {
+                sendJson(['error' => 'Name must be 100 characters or fewer.'], 400);
+                break;
+            }
+
+            try {
+                $db = getDbMysqli();
+                /* Confirm the row exists so we can return 404 cleanly
+                   instead of a successful no-op. */
+                $stmt = $db->prepare('SELECT Id FROM tblUserGroups WHERE Id = ?');
+                $stmt->bind_param('i', $id);
+                $stmt->execute();
+                $found = $stmt->get_result()->fetch_row() !== null;
+                $stmt->close();
+                if (!$found) {
+                    sendJson(['error' => 'Group not found.'], 404);
+                    break;
+                }
+
+                $stmt = $db->prepare('SELECT Id FROM tblUserGroups WHERE Name = ? AND Id <> ?');
+                $stmt->bind_param('si', $name, $id);
+                $stmt->execute();
+                $dup = $stmt->get_result()->fetch_row() !== null;
+                $stmt->close();
+                if ($dup) {
+                    sendJson(['error' => 'Another group already uses that name.'], 409);
+                    break;
+                }
+
+                $stmt = $db->prepare(
+                    'UPDATE tblUserGroups
+                        SET Name = ?, Description = ?,
+                            AccessAlpha = ?, AccessBeta = ?, AccessRc = ?, AccessRtw = ?
+                      WHERE Id = ?'
+                );
+                $stmt->bind_param('ssiiiii', $name, $desc, $aA, $aB, $aR, $aW, $id);
+                $stmt->execute();
+                $stmt->close();
+
+                logActivity('api.admin.group.update', 'group', (string)$id, [
+                    'name'          => $name,
+                    'description'   => $desc,
+                    'access_alpha'  => (bool)$aA,
+                    'access_beta'   => (bool)$aB,
+                    'access_rc'     => (bool)$aR,
+                    'access_rtw'    => (bool)$aW,
+                ]);
+
+                sendJson(['ok' => true, 'id' => $id, 'name' => $name]);
+            } catch (\Throwable $e) {
+                logActivityError('api.admin.group.update', 'group', (string)$id, $e);
+                error_log('[admin_group_update] ' . $e->getMessage());
+                sendJson(['error' => 'Could not update group.'], 500);
+            }
+            break;
+        }
+
+        /* -----------------------------------------------------------------
+         * Admin: delete a user group
+         * POST body: { id }
+         * Refuses with 422 if any user is still a member.
+         * ----------------------------------------------------------------- */
+        case 'admin_group_delete': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser || !in_array($authUser['Role'], ['admin', 'global_admin'])) {
+                sendJson(['error' => 'Admin access required.'], 403);
+                break;
+            }
+
+            $body = json_decode((string)file_get_contents('php://input'), true) ?: [];
+            $id   = (int)($body['id'] ?? 0);
+            if ($id <= 0) {
+                sendJson(['error' => 'Group id required.'], 400);
+                break;
+            }
+
+            try {
+                $db = getDbMysqli();
+                $stmt = $db->prepare('SELECT Name FROM tblUserGroups WHERE Id = ?');
+                $stmt->bind_param('i', $id);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_row();
+                $stmt->close();
+                $name = (string)($row[0] ?? '');
+                if ($name === '') {
+                    sendJson(['error' => 'Group not found.'], 404);
+                    break;
+                }
+
+                $stmt = $db->prepare('SELECT COUNT(*) FROM tblUsers WHERE GroupId = ?');
+                $stmt->bind_param('i', $id);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_row();
+                $stmt->close();
+                $members = (int)($row[0] ?? 0);
+                if ($members > 0) {
+                    sendJson([
+                        'error'        => "Cannot delete '{$name}': {$members} user(s) still belong to it.",
+                        'member_count' => $members,
+                        'name'         => $name,
+                        'hint'         => 'Move the members to another group (or remove them) first.',
+                    ], 422);
+                    break;
+                }
+
+                $stmt = $db->prepare('DELETE FROM tblUserGroups WHERE Id = ?');
+                $stmt->bind_param('i', $id);
+                $stmt->execute();
+                $stmt->close();
+
+                logActivity('api.admin.group.delete', 'group', (string)$id, ['name' => $name]);
+                sendJson(['ok' => true, 'id' => $id, 'name' => $name]);
+            } catch (\Throwable $e) {
+                logActivityError('api.admin.group.delete', 'group', (string)$id, $e);
+                error_log('[admin_group_delete] ' . $e->getMessage());
+                sendJson(['error' => 'Could not delete group.'], 500);
+            }
+            break;
+        }
+
+        /* -----------------------------------------------------------------
+         * Admin: add a user to a group (sets tblUsers.GroupId)
+         * POST body: { group_id, user_id }
+         * No-op-friendly: re-adding a user already in the same group
+         * is a 200 (UPDATE just touches UpdatedAt).
+         * ----------------------------------------------------------------- */
+        case 'admin_group_member_add': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser || !in_array($authUser['Role'], ['admin', 'global_admin'])) {
+                sendJson(['error' => 'Admin access required.'], 403);
+                break;
+            }
+
+            $body    = json_decode((string)file_get_contents('php://input'), true) ?: [];
+            $groupId = (int)($body['group_id'] ?? 0);
+            $userId  = (int)($body['user_id']  ?? 0);
+            if ($groupId <= 0 || $userId <= 0) {
+                sendJson(['error' => 'group_id and user_id required.'], 400);
+                break;
+            }
+
+            try {
+                $db = getDbMysqli();
+
+                /* Probe both rows so we can return the right 404. The
+                   web admin doesn't bother (typo → silent UPDATE 0
+                   rows), but a JSON API caller wants a definite
+                   answer. */
+                $stmt = $db->prepare('SELECT Id FROM tblUserGroups WHERE Id = ?');
+                $stmt->bind_param('i', $groupId);
+                $stmt->execute();
+                $hasGroup = $stmt->get_result()->fetch_row() !== null;
+                $stmt->close();
+                if (!$hasGroup) {
+                    sendJson(['error' => 'Group not found.'], 404);
+                    break;
+                }
+                $stmt = $db->prepare('SELECT Id FROM tblUsers WHERE Id = ?');
+                $stmt->bind_param('i', $userId);
+                $stmt->execute();
+                $hasUser = $stmt->get_result()->fetch_row() !== null;
+                $stmt->close();
+                if (!$hasUser) {
+                    sendJson(['error' => 'User not found.'], 404);
+                    break;
+                }
+
+                $stmt = $db->prepare('UPDATE tblUsers SET GroupId = ?, UpdatedAt = CURRENT_TIMESTAMP WHERE Id = ?');
+                $stmt->bind_param('ii', $groupId, $userId);
+                $stmt->execute();
+                $stmt->close();
+
+                logActivity('api.admin.group.member_add', 'group', (string)$groupId, [
+                    'user_id' => $userId,
+                ]);
+
+                sendJson(['ok' => true, 'group_id' => $groupId, 'user_id' => $userId]);
+            } catch (\Throwable $e) {
+                logActivityError('api.admin.group.member_add', 'group', (string)$groupId, $e, ['user_id' => $userId]);
+                error_log('[admin_group_member_add] ' . $e->getMessage());
+                sendJson(['error' => 'Could not add member to group.'], 500);
+            }
+            break;
+        }
+
+        /* -----------------------------------------------------------------
+         * Admin: remove a user from their group (sets GroupId = NULL)
+         * POST body: { user_id }
+         * group_id is intentionally NOT required — a user belongs to at
+         * most one group via tblUsers.GroupId, so dropping the FK is
+         * sufficient regardless of which group they were in.
+         * ----------------------------------------------------------------- */
+        case 'admin_group_member_remove': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser || !in_array($authUser['Role'], ['admin', 'global_admin'])) {
+                sendJson(['error' => 'Admin access required.'], 403);
+                break;
+            }
+
+            $body   = json_decode((string)file_get_contents('php://input'), true) ?: [];
+            $userId = (int)($body['user_id'] ?? 0);
+            if ($userId <= 0) {
+                sendJson(['error' => 'user_id required.'], 400);
+                break;
+            }
+
+            try {
+                $db = getDbMysqli();
+                $stmt = $db->prepare('SELECT GroupId FROM tblUsers WHERE Id = ?');
+                $stmt->bind_param('i', $userId);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_row();
+                $stmt->close();
+                if ($row === null) {
+                    sendJson(['error' => 'User not found.'], 404);
+                    break;
+                }
+                $oldGroupId = $row[0] !== null ? (int)$row[0] : null;
+
+                $stmt = $db->prepare('UPDATE tblUsers SET GroupId = NULL, UpdatedAt = CURRENT_TIMESTAMP WHERE Id = ?');
+                $stmt->bind_param('i', $userId);
+                $stmt->execute();
+                $stmt->close();
+
+                logActivity('api.admin.group.member_remove', 'group',
+                    $oldGroupId !== null ? (string)$oldGroupId : '', [
+                        'user_id'  => $userId,
+                    ]
+                );
+
+                sendJson([
+                    'ok'              => true,
+                    'user_id'         => $userId,
+                    'previous_group'  => $oldGroupId,
+                ]);
+            } catch (\Throwable $e) {
+                logActivityError('api.admin.group.member_remove', 'group', '', $e, ['user_id' => $userId]);
+                error_log('[admin_group_member_remove] ' . $e->getMessage());
+                sendJson(['error' => 'Could not remove member from group.'], 500);
+            }
+            break;
+        }
+
+        /* =================================================================
+         * ACCESS TIERS — admin CRUD parity (#719 PR 2b)
+         *
+         * Mirrors /manage/tiers.php. Capability-column list lives in
+         * includes/access_tier_validation.php (TIER_CAPS const) so a
+         * new capability is a one-line schema + const change — no
+         * surface-specific bind_param edits needed.
+         *
+         * Input shape: `caps` is a JSON object keyed by exact tblAccessTiers
+         * column name, value bool/int. Unknown keys are ignored; missing
+         * keys default to 0.
+         *
+         * Reserved tier names (public / free / ccli / premium / pro) cannot
+         * be deleted via the API — same hard refusal as /manage/tiers.php's
+         * implicit gate (the row lookup blocks delete on rows still
+         * referenced by users, but the API also rejects up-front).
+         * ================================================================= */
+
+        /* -----------------------------------------------------------------
+         * Admin: create an access tier
+         * POST body: {
+         *   name, display_name, level, description?, caps?: { ... }
+         * }
+         * ----------------------------------------------------------------- */
+        case 'admin_tier_create': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser || !in_array($authUser['Role'], ['admin', 'global_admin'])) {
+                sendJson(['error' => 'Admin access required.'], 403);
+                break;
+            }
+
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'access_tier_validation.php';
+
+            $body        = json_decode((string)file_get_contents('php://input'), true) ?: [];
+            $name        = trim((string)($body['name']         ?? ''));
+            $displayName = trim((string)($body['display_name'] ?? ''));
+            $level       = (int)($body['level']                ?? 0);
+            $description = trim((string)($body['description']  ?? ''));
+            $capsInput   = is_array($body['caps'] ?? null) ? $body['caps'] : [];
+
+            if ($e = validateTierName($name))   { sendJson(['error' => $e], 400); break; }
+            if ($displayName === '')            { sendJson(['error' => 'display_name is required.'], 400); break; }
+            if ($e = validateTierLevel($level)) { sendJson(['error' => $e], 400); break; }
+
+            try {
+                $db = getDbMysqli();
+                $stmt = $db->prepare('SELECT Id FROM tblAccessTiers WHERE Name = ?');
+                $stmt->bind_param('s', $name);
+                $stmt->execute();
+                $exists = $stmt->get_result()->fetch_row() !== null;
+                $stmt->close();
+                if ($exists) {
+                    sendJson(['error' => 'A tier with that name already exists.'], 409);
+                    break;
+                }
+
+                $caps = [];
+                foreach (array_keys(TIER_CAPS) as $col) {
+                    /* Accept the camelCase or PascalCase form clients
+                       might use; the canonical key is the exact column
+                       name. Default to 0 when unspecified. */
+                    $caps[$col] = !empty($capsInput[$col]) ? 1 : 0;
+                }
+
+                $cols         = array_merge(['Name','DisplayName','Level','Description'], array_keys(TIER_CAPS));
+                $placeholders = implode(', ', array_fill(0, count($cols), '?'));
+                $sql          = 'INSERT INTO tblAccessTiers (' . implode(',', $cols) . ') VALUES (' . $placeholders . ')';
+                /* Type string: Name(s) DisplayName(s) Level(i) Description(s) +
+                   each TIER_CAPS column as int. Built dynamically so a new
+                   capability column auto-extends the bind without an edit. */
+                $types  = 'ssis' . str_repeat('i', count(TIER_CAPS));
+                $values = array_merge([$name, $displayName, $level, $description], array_values($caps));
+                $stmt   = $db->prepare($sql);
+                $stmt->bind_param($types, ...$values);
+                $stmt->execute();
+                $newId = (int)$db->insert_id;
+                $stmt->close();
+
+                logActivity('api.admin.tier.create', 'access_tier', (string)$newId, [
+                    'name'         => $name,
+                    'display_name' => $displayName,
+                    'level'        => $level,
+                    'description'  => $description,
+                    'caps'         => $caps,
+                ]);
+
+                sendJson(['ok' => true, 'id' => $newId, 'name' => $name], 201);
+            } catch (\Throwable $e) {
+                logActivityError('api.admin.tier.create', 'access_tier', '', $e, ['name' => $name]);
+                error_log('[admin_tier_create] ' . $e->getMessage());
+                sendJson(['error' => 'Could not create tier.'], 500);
+            }
+            break;
+        }
+
+        /* -----------------------------------------------------------------
+         * Admin: update an access tier
+         * POST body: {
+         *   id, display_name, level, description?, caps?: { ... }
+         * }
+         * `name` (the machine key) is intentionally immutable — too
+         * many tblUsers.AccessTier rows reference it for a casual
+         * rename. Use a manual SQL migration if a rename is genuinely
+         * needed.
+         * ----------------------------------------------------------------- */
+        case 'admin_tier_update': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser || !in_array($authUser['Role'], ['admin', 'global_admin'])) {
+                sendJson(['error' => 'Admin access required.'], 403);
+                break;
+            }
+
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'access_tier_validation.php';
+
+            $body        = json_decode((string)file_get_contents('php://input'), true) ?: [];
+            $id          = (int)($body['id']                   ?? 0);
+            $displayName = trim((string)($body['display_name'] ?? ''));
+            $level       = (int)($body['level']                ?? 0);
+            $description = trim((string)($body['description']  ?? ''));
+            $capsInput   = is_array($body['caps'] ?? null) ? $body['caps'] : [];
+
+            if ($id <= 0)                       { sendJson(['error' => 'Tier id required.'], 400); break; }
+            if ($displayName === '')            { sendJson(['error' => 'display_name is required.'], 400); break; }
+            if ($e = validateTierLevel($level)) { sendJson(['error' => $e], 400); break; }
+
+            try {
+                $db = getDbMysqli();
+                $stmt = $db->prepare('SELECT Name FROM tblAccessTiers WHERE Id = ?');
+                $stmt->bind_param('i', $id);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_row();
+                $stmt->close();
+                $name = (string)($row[0] ?? '');
+                if ($name === '') {
+                    sendJson(['error' => 'Tier not found.'], 404);
+                    break;
+                }
+
+                $caps = [];
+                foreach (array_keys(TIER_CAPS) as $col) {
+                    $caps[$col] = !empty($capsInput[$col]) ? 1 : 0;
+                }
+
+                $sets = ['DisplayName = ?', 'Level = ?', 'Description = ?'];
+                $args = [$displayName, $level, $description];
+                foreach ($caps as $col => $val) {
+                    $sets[] = "$col = ?";
+                    $args[] = $val;
+                }
+                $args[] = $id;
+                /* Type string: DisplayName(s), Level(i), Description(s),
+                   each TIER_CAPS column as int, then Id(i). */
+                $types = 'sis' . str_repeat('i', count(TIER_CAPS)) . 'i';
+                $stmt  = $db->prepare(
+                    'UPDATE tblAccessTiers SET ' . implode(', ', $sets) . ' WHERE Id = ?'
+                );
+                $stmt->bind_param($types, ...$args);
+                $stmt->execute();
+                $stmt->close();
+
+                logActivity('api.admin.tier.update', 'access_tier', (string)$id, [
+                    'name'         => $name,
+                    'display_name' => $displayName,
+                    'level'        => $level,
+                    'description'  => $description,
+                    'caps'         => $caps,
+                ]);
+
+                sendJson(['ok' => true, 'id' => $id, 'name' => $name]);
+            } catch (\Throwable $e) {
+                logActivityError('api.admin.tier.update', 'access_tier', (string)$id, $e);
+                error_log('[admin_tier_update] ' . $e->getMessage());
+                sendJson(['error' => 'Could not update tier.'], 500);
+            }
+            break;
+        }
+
+        /* -----------------------------------------------------------------
+         * Admin: delete an access tier
+         * POST body: { id }
+         * Refuses with 422 if any user is still on this tier.
+         * ----------------------------------------------------------------- */
+        case 'admin_tier_delete': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser || !in_array($authUser['Role'], ['admin', 'global_admin'])) {
+                sendJson(['error' => 'Admin access required.'], 403);
+                break;
+            }
+
+            $body = json_decode((string)file_get_contents('php://input'), true) ?: [];
+            $id   = (int)($body['id'] ?? 0);
+            if ($id <= 0) {
+                sendJson(['error' => 'Tier id required.'], 400);
+                break;
+            }
+
+            try {
+                $db = getDbMysqli();
+                $stmt = $db->prepare('SELECT Name FROM tblAccessTiers WHERE Id = ?');
+                $stmt->bind_param('i', $id);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_row();
+                $stmt->close();
+                $name = (string)($row[0] ?? '');
+                if ($name === '') {
+                    sendJson(['error' => 'Tier not found.'], 404);
+                    break;
+                }
+
+                $stmt = $db->prepare('SELECT COUNT(*) FROM tblUsers WHERE AccessTier = ?');
+                $stmt->bind_param('s', $name);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_row();
+                $stmt->close();
+                $inUse = (int)($row[0] ?? 0);
+                if ($inUse > 0) {
+                    sendJson([
+                        'error'      => "Cannot delete '{$name}': {$inUse} user(s) are currently on this tier.",
+                        'user_count' => $inUse,
+                        'name'       => $name,
+                        'hint'       => 'Reassign affected users to another tier first.',
+                    ], 422);
+                    break;
+                }
+
+                $stmt = $db->prepare('DELETE FROM tblAccessTiers WHERE Id = ?');
+                $stmt->bind_param('i', $id);
+                $stmt->execute();
+                $stmt->close();
+
+                logActivity('api.admin.tier.delete', 'access_tier', (string)$id, ['name' => $name]);
+                sendJson(['ok' => true, 'id' => $id, 'name' => $name]);
+            } catch (\Throwable $e) {
+                logActivityError('api.admin.tier.delete', 'access_tier', (string)$id, $e);
+                error_log('[admin_tier_delete] ' . $e->getMessage());
+                sendJson(['error' => 'Could not delete tier.'], 500);
+            }
+            break;
+        }
+
         /* -----------------------------------------------------------------
          * Unknown action
          * ----------------------------------------------------------------- */

--- a/appWeb/public_html/includes/access_tier_validation.php
+++ b/appWeb/public_html/includes/access_tier_validation.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Access-tier shared validators (#719 PR 2b)
+ *
+ * Single source of truth for the `tblAccessTiers` capability column
+ * list and the tier-name grammar. Used by:
+ *
+ *   - /manage/tiers.php       (web admin: create + update handlers,
+ *                              capability table headers)
+ *   - /api.php                (admin_tier_* CRUD endpoints)
+ *
+ * Adding a new capability column on the schema is a one-line change
+ * to TIER_CAPS — both surfaces pick it up automatically (the dynamic
+ * SQL builders in tiers.php and the API endpoint walk
+ * `array_keys(TIER_CAPS)` to derive the column list).
+ *
+ * The label tuple `[short, long]` is used by tiers.php for the table
+ * column header + tooltip; the API surface ignores the labels and
+ * just consumes the column-name keys.
+ *
+ * Direct access is blocked so this file can't be loaded as an
+ * arbitrary endpoint via an open Apache config.
+ */
+
+if (basename($_SERVER['SCRIPT_FILENAME'] ?? '') === basename(__FILE__)) {
+    http_response_code(403);
+    exit('Access denied.');
+}
+
+/**
+ * Capability columns on tblAccessTiers, mapped to their UI labels.
+ *
+ * Keyed by exact column name (used as both the SQL identifier and
+ * the JSON-input form field via the `cap_<Column>` POST key on the
+ * web admin / `caps.<column>` JSON path on the API).
+ *
+ * Tuple shape: [short_label, full_description].
+ */
+if (!defined('IHYMNS_TIER_CAPS_DEFINED')) {
+    define('IHYMNS_TIER_CAPS_DEFINED', true);
+    define('TIER_CAPS', [
+        'CanViewLyrics'      => ['Lyrics',       'View song lyrics'],
+        'CanViewCopyrighted' => ['Copyrighted',  'View copyrighted songs'],
+        'CanPlayAudio'       => ['Audio',        'Play MIDI / audio in-app'],
+        'CanDownloadMidi'    => ['MIDI',         'Download MIDI files'],
+        'CanDownloadPdf'     => ['PDF',          'Download sheet-music PDFs'],
+        'CanOfflineSave'     => ['Offline',      'Save songs for offline use'],
+        'RequiresCcli'       => ['Needs CCLI',   'Tier requires a valid CCLI licence number'],
+    ]);
+}
+
+/**
+ * Validate a tier name. Permits the curator's chosen casing — the
+ * Username column on tblAccessTiers is utf8mb4_unicode_ci so the
+ * uniqueness check stays case-insensitive without us lowercasing.
+ *
+ * Letters / digits / hyphen / underscore (#639). 30-char cap.
+ *
+ * @param string $name Raw tier-name as typed.
+ * @return string|null Error message or null if valid.
+ */
+function validateTierName(string $name): ?string
+{
+    $name = trim($name);
+    if ($name === '') {
+        return 'Name is required.';
+    }
+    if (strlen($name) > 30) {
+        return 'Name must be 30 characters or fewer.';
+    }
+    if (!preg_match('/^[A-Za-z0-9_-]+$/', $name)) {
+        return 'Name must be letters, digits, hyphen or underscore.';
+    }
+    return null;
+}
+
+/**
+ * Validate the tier `Level` integer. The level governs how the
+ * tier_check / licence_check helpers compare two tiers — higher
+ * level = more permissions. Bounded to [0, 1000] to prevent a typo
+ * (e.g. an extra zero) from making one tier silently outrank
+ * everything else in the catalogue.
+ *
+ * @param int $level Raw level value.
+ * @return string|null Error message or null if valid.
+ */
+function validateTierLevel(int $level): ?string
+{
+    if ($level < 0 || $level > 1000) {
+        return 'Level must be between 0 and 1000.';
+    }
+    return null;
+}

--- a/appWeb/public_html/manage/tiers.php
+++ b/appWeb/public_html/manage/tiers.php
@@ -20,6 +20,11 @@ declare(strict_types=1);
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
+/* Shared tier-validation include (#719 PR 2b) — exports the TIER_CAPS
+   const + validateTierName() / validateTierLevel(). Same helpers used
+   by the new admin_tier_* API endpoints in /api.php so a tweak to the
+   capability set or the name grammar lands on both surfaces. */
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'access_tier_validation.php';
 
 if (!isAuthenticated()) {
     header('Location: /manage/login');
@@ -37,33 +42,10 @@ $error   = '';
 $success = '';
 $db      = getDbMysqli();
 
-/* Ordered list of capability columns — used for both the table header
-   and as the authoritative input/update list, so adding a new capability
-   on the schema is a one-line change here. */
-const TIER_CAPS = [
-    'CanViewLyrics'      => ['Lyrics',       'View song lyrics'],
-    'CanViewCopyrighted' => ['Copyrighted',  'View copyrighted songs'],
-    'CanPlayAudio'       => ['Audio',        'Play MIDI / audio in-app'],
-    'CanDownloadMidi'    => ['MIDI',         'Download MIDI files'],
-    'CanDownloadPdf'     => ['PDF',          'Download sheet-music PDFs'],
-    'CanOfflineSave'     => ['Offline',      'Save songs for offline use'],
-    'RequiresCcli'       => ['Needs CCLI',   'Tier requires a valid CCLI licence number'],
-];
-
-/* Name is the machine-key for a tier (e.g. 'public', 'free', 'mwbm-insiders').
-   Allow letters (both cases), digits, hyphen and underscore (#639). The
-   five reserved tiers stay lowercase because TIER_LEVELS / validTiers in
-   ccli_validator.php + api.php are still hand-rolled lowercase maps;
-   custom-named tiers above level 0 get their level from the row itself
-   (tblAccessTiers.Level), so mixed-case names like 'MWBMInsiders' work
-   correctly through the SELECT-by-Name path. */
-$validName = function (string $n): ?string {
-    $n = trim($n);
-    if ($n === '')                            return 'Name is required.';
-    if (strlen($n) > 30)                      return 'Name must be 30 characters or fewer.';
-    if (!preg_match('/^[A-Za-z0-9_-]+$/', $n)) return 'Name must be letters, digits, hyphen or underscore.';
-    return null;
-};
+/* TIER_CAPS const + validateTierName() / validateTierLevel() now
+   live in access_tier_validation.php (#719 PR 2b). Closure kept as a
+   thin wrapper so the existing call sites below continue to work. */
+$validName = fn(string $n): ?string => validateTierName($n);
 
 /* ----- POST actions ----- */
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {


### PR DESCRIPTION
## Summary

PR 2b of the multi-PR sequence laid out in the API parity audit (#727 / refs #719). Closes the **admin-core gap**: users, groups, and access tiers all went from 0–13% API coverage to 100%. Native clients (Apple, Android, FireOS) can now perform every admin verb the web admin offers across these three domains.

15 new endpoints, all POST + JSON body, admin/global_admin gated, full OpenAPI documentation:

### Users (7)

| Endpoint | Behaviour |
|---|---|
| `admin_user_create` | mirrors web admin `create`. **201** + id. Routes through `createUser()` so bcrypt hashing + canonical `user.create` audit row are unchanged. **409** on duplicate username. Hierarchy gate: only `global_admin` can assign `global_admin`; nobody can promote above their own level. |
| `admin_user_update` | profile (display name + email). |
| `admin_user_rename` | username change. **409** on conflict. Returns old/new pair. |
| `admin_user_role_change` | wraps `updateUserRole()` so all hierarchy + cross-tier rules are enforced once, in one place. |
| `admin_user_toggle_active` | returns the new `is_active` so the caller can render the toggled state without a re-read. Cannot deactivate self. Drops API tokens on deactivate (defence-in-depth). |
| `admin_user_password_reset` | self-reset permitted. Otherwise hierarchy gate. |
| `admin_user_delete` | cannot delete self; cannot delete a peer or superior unless `global_admin`. |

### Groups (5)

| Endpoint | Behaviour |
|---|---|
| `admin_group_create` | name (≤100), description, alpha/beta/RC/RTW flags. **409** on duplicate name. |
| `admin_group_update` | same fields; id required; **409** on rename collision. |
| `admin_group_delete` | **422** + `member_count` if users still belong. |
| `admin_group_member_add` | sets `tblUsers.GroupId`. A user belongs to at most one group, so this also moves them out of any prior group. |
| `admin_group_member_remove` | clears `tblUsers.GroupId` to NULL. Returns the previous_group so callers can show "moved out of <name>" feedback. |

### Tiers (3)

| Endpoint | Behaviour |
|---|---|
| `admin_tier_create` | name (≤30, `[A-Za-z0-9_-]+`), display_name, level (0–1000), description, caps. Capability columns walked from `TIER_CAPS` const. **409** on duplicate name. |
| `admin_tier_update` | machine `name` is **immutable** — too many `tblUsers.AccessTier` rows reference it. Use a manual SQL migration if rename is genuinely needed. |
| `admin_tier_delete` | **422** + `user_count` if users are still on the tier. |

## Architectural notes

- **Helpers reused, not duplicated** — every user mutation routes through `createUser` / `updateUserRole` / `setUserActive` / `changeUserPassword` / `updateUserProfile` / `renameUser` / `deleteUser` in `manage/includes/auth.php`. The activity-log rows the web admin already writes (`user.create`, `auth.role_change`, etc.) are unchanged. The API endpoints add a parallel `api.admin.user.*` log entry **only on the catch path** so failures surface under the API prefix without doubling success rows.

- **Single source of truth for tier validation** — `TIER_CAPS` const + `validateTierName` / `validateTierLevel` extracted out of the closures in `manage/tiers.php` into a new `includes/access_tier_validation.php`. Adding a new capability column on `tblAccessTiers` is now a one-line edit to `TIER_CAPS`, picked up automatically by both the web admin's dynamic SQL builder and the API endpoint's `bind_param` string.

- **Hierarchy gates mirror users.php exactly** — every endpoint that acts on a target user re-checks `roleLevel($target['role']) >= roleLevel($acting['role']) && $acting !== 'global_admin'`. Self-acting paths use `$targetId === $actingId` consistently. The two destructive verbs (`toggle_active`, `delete`) refuse on self regardless of role.

- **REST-ish status codes** — 400 (validation), 401 (no auth), 403 (wrong role + hierarchy), 404 (entity not found), 405 (wrong method), 409 (duplicate username / group name / tier name), 422 (cannot delete because dependents exist). Native UIs can render the right toast without parsing the error string.

- **OpenAPI** — bumped 0.51.0 → 0.52.0. Three new tags (`Admin — Users` / `Groups` / `Tiers`). Six new schema components (`AdminUserCreateInput`, `AdminUserProfileInput`, `AdminGroupWriteInput`, `AdminTierCapabilities`, `AdminTierCreateInput`, `AdminTierUpdateInput`). Existing `AdminUser` + `AdminGroup` read schemas left untouched.

## What's NOT in this PR (per audit's recommended sequence)

- PR 2c — Organisations + my-organisations API CRUD (11 endpoints)
- PR 2d — Credit People + analytics + read-side admin endpoints (9 endpoints)
- PR 3 — OpenAPI tail / schema audit
- PR 4 — In-app docs refresh
- PR 5 — Wiki refresh

## Commits on this branch

- `8a8f91e` refactor(tiers): extract TIER_CAPS const + validators to shared include
- `a1f25ad` feat(api): admin user / group / tier CRUD endpoints
- `35554ed` docs(openapi): document admin user / group / tier CRUD

## Test plan

- [ ] **Local lint** — `php -l` clean on `api.php`, `access_tier_validation.php`, `manage/tiers.php`. ✅ verified.
- [ ] **OpenAPI** — YAML parses; 15 new paths present; 6 new schema components present; operationIds unique. ✅ verified.
- [ ] **Web admin smoke** — `/manage/users`, `/manage/groups`, `/manage/tiers` all create / update / delete still work end-to-end (helpers + validators behaviour preserved).
- [ ] **API smoke (users)** — curl each endpoint with a Bearer token + `X-Requested-With: XMLHttpRequest`; verify the auth gate, the hierarchy refusals, the 400/403/404/409 paths, the success path. Confirm canonical activity-log rows still write (`user.create`, `auth.role_change`, etc.).
- [ ] **API smoke (groups)** — create + update + delete (incl. 422 with members), member_add and member_remove (incl. previous_group echo).
- [ ] **API smoke (tiers)** — create with caps map, update (including caps changes), delete (incl. 422 when users are on it). Verify `api.admin.tier.*` Activity-Log rows.
- [ ] **Self-deactivate refusal** — POST `admin_user_toggle_active` with your own user_id; expect 403 "Cannot deactivate your own account."
- [ ] **Self-delete refusal** — POST `admin_user_delete` with your own user_id; expect 403 "Cannot delete your own account."
- [ ] **Hierarchy refusal** — as `admin`, try to deactivate / delete / role_change a `global_admin` user; expect 403 "Cannot ... a user at or above your role level."

## Migrations

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)