### PR TITLE
feat(api): credit-people + analytics + diagnostics — closes #719 PR 2 tail (PR 2d)

### DIFF
--- a/appWeb/public_html/api-docs.yaml
+++ b/appWeb/public_html/api-docs.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 
 info:
   title: iHymns API
-  version: "0.53.0"
+  version: "0.54.0"
   description: |
     The iHymns API provides programmatic access to the iHymns hymn and song
     database. It powers the iHymns Progressive Web App (PWA), enabling song
@@ -216,6 +216,29 @@ tags:
       `includes/organisation_validation.php` — every endpoint
       refuses cross-org POSTs at the server side regardless of how
       the caller mounted the request.
+  - name: Admin — Credit People
+    description: |
+      Credit-people CRUD parity (#719 PR 2d, #545). Catalogue-wide
+      management of the people credited on songs across
+      `tblSongWriters` / `tblSongComposers` / `tblSongArrangers` /
+      `tblSongAdaptors` / `tblSongTranslators`. Helpers (link-type
+      catalogue, IPI normaliser, flag-columns probe) live in
+      `includes/credit_people_helpers.php` and are shared with
+      `/manage/credit-people`.
+  - name: Admin — Analytics
+    description: |
+      Read-only analytics endpoints. Two of the three
+      `/manage/analytics` panels are already covered by
+      `popular_songs` (top_songs + top_books); this surface adds
+      the search-query reporting needed for parity.
+  - name: Admin — Diagnostics
+    description: |
+      Operational diagnostic read endpoints (#719 PR 2d). Mirror the
+      payloads `/manage/data-health`, `/manage/schema-audit`, and
+      `/manage/setup-database` render. Designed for tooling clients
+      (CI, monitoring, dashboards) — pure read paths with no
+      mutations. Schema-audit + migrations-status reuse the parser
+      / scanner / comparer in `includes/schema_audit.php`.
   - name: Admin — Revisions
     description: Review pending song revisions
   - name: Admin — Maintenance
@@ -5528,6 +5551,423 @@ paths:
         "404":
           description: Licence row does not belong to that organisation
 
+  # ===========================================================================
+  # ADMIN — CREDIT PEOPLE  (#719 PR 2d, #545)
+  # Catalogue-wide CRUD over the people credited on songs across the
+  # five song-credit tables + the tblCreditPeople registry.
+  # ===========================================================================
+
+  /api.php?action=admin_credit_person_add:
+    post:
+      operationId: adminCreditPersonAdd
+      tags: [Admin — Credit People]
+      summary: Add a registry entry (with optional links + IPI rows)
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_credit_person_add] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AdminCreditPersonInput"
+      responses:
+        "201":
+          description: Person added
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:   { type: boolean, example: true }
+                  id:   { type: integer }
+                  name: { type: string }
+        "400":
+          description: Validation error (missing name, name too long, bad birth/death date)
+        "403":
+          description: Admin access required
+        "409":
+          description: A person with that name is already registered
+
+  /api.php?action=admin_credit_person_update:
+    post:
+      operationId: adminCreditPersonUpdate
+      tags: [Admin — Credit People]
+      summary: Update biographical metadata + replace child rows
+      description: |
+        The Name column is NOT changed by this endpoint — renames have
+        their own endpoint (`admin_credit_person_rename`) because their
+        blast radius is cross-table. If the body's `name` field differs
+        from the stored name we reject with **400**.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_credit_person_update] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: "#/components/schemas/AdminCreditPersonInput"
+                - type: object
+                  required: [id]
+                  properties:
+                    id: { type: integer }
+      responses:
+        "200":
+          description: Person updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:             { type: boolean, example: true }
+                  id:             { type: integer }
+                  name:           { type: string }
+                  fields_changed:
+                    type: array
+                    items: { type: string }
+        "400":
+          description: Validation error or name field doesn't match (use rename instead)
+        "403":
+          description: Admin access required
+        "404":
+          description: Person not found
+
+  /api.php?action=admin_credit_person_rename:
+    post:
+      operationId: adminCreditPersonRename
+      tags: [Admin — Credit People]
+      summary: Rename a credit person — cascades across all 5 song-credit tables
+      description: |
+        Cascades the new name across `tblSongWriters` /
+        `tblSongComposers` / `tblSongArrangers` / `tblSongAdaptors` /
+        `tblSongTranslators` AND the registry row inside one
+        transaction. Refuses with **409** if the new name already
+        belongs to a different registry row (caller should use
+        `admin_credit_person_merge`).
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_credit_person_rename] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [id, new_name]
+              properties:
+                id:       { type: integer }
+                new_name: { type: string, maxLength: 255 }
+      responses:
+        "200":
+          description: Renamed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:                   { type: boolean, example: true }
+                  id:                   { type: integer }
+                  old_name:             { type: string }
+                  new_name:             { type: string }
+                  song_credit_renames:  { type: integer, description: Total rows updated across the 5 song-credit tables }
+        "400":
+          description: Missing fields, name too long, or new_name same as old
+        "403":
+          description: Admin access required
+        "404":
+          description: Person not found
+        "409":
+          description: Another registry row already uses that name (use merge)
+
+  /api.php?action=admin_credit_person_merge:
+    post:
+      operationId: adminCreditPersonMerge
+      tags: [Admin — Credit People]
+      summary: Collapse two registry entries into one
+      description: |
+        Re-points every song-credit row from the source name to the
+        target name across all five song-credit tables, migrates the
+        chosen child rows from source → target, then deletes the
+        source registry row. The FK ON DELETE CASCADE on
+        `tblCreditPersonLinks` / `tblCreditPersonIPI` drops any
+        child rows the caller chose not to migrate.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_credit_person_merge] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [source_id, target_id]
+              properties:
+                source_id:
+                  type: integer
+                  description: Registry row to absorb. Must be different from target_id.
+                target_id:
+                  type: integer
+                  description: Surviving registry row. The target's name + biographical fields are preserved.
+                keep_link_ids:
+                  type: array
+                  items: { type: integer }
+                  description: tblCreditPersonLinks.Id values from the source side to migrate. Anything not listed gets dropped via the cascade.
+                keep_ipi_ids:
+                  type: array
+                  items: { type: integer }
+                  description: tblCreditPersonIPI.Id values from the source side to migrate.
+      responses:
+        "200":
+          description: Merge completed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:                  { type: boolean, example: true }
+                  source_id:           { type: integer }
+                  target_id:           { type: integer }
+                  source_name:         { type: string }
+                  target_name:         { type: string }
+                  song_credit_renames: { type: integer }
+                  links_kept:          { type: integer }
+                  links_dropped:       { type: integer }
+                  ipi_kept:            { type: integer }
+                  ipi_dropped:         { type: integer }
+        "400":
+          description: Missing source_id / target_id, or they're equal
+        "403":
+          description: Admin access required
+        "404":
+          description: Source or target person not found
+
+  /api.php?action=admin_credit_person_delete:
+    post:
+      operationId: adminCreditPersonDelete
+      tags: [Admin — Credit People]
+      summary: Remove a registry row (force flag for in-use names)
+      description: |
+        Refuses with **422** + `usage_count` if any song-credit table
+        still cites the name AND `force` is not set. With `force=true`
+        the registry row is removed even when song credits still
+        reference the name — the credits stay; only the registry
+        row goes.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_credit_person_delete] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [id]
+              properties:
+                id:    { type: integer }
+                force:
+                  type: boolean
+                  default: false
+                  description: When true, deletes the registry row even if song credits still cite the name.
+      responses:
+        "200":
+          description: Person deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:           { type: boolean, example: true }
+                  id:           { type: integer }
+                  name:         { type: string }
+                  usage_count:  { type: integer }
+                  forced:       { type: boolean }
+        "400":
+          description: Missing id
+        "403":
+          description: Admin access required
+        "404":
+          description: Person not found
+        "422":
+          description: |
+            Refused — song credits still cite the name and `force` is
+            not set. Response includes `usage_count`, `name`, `hint`.
+
+  # ===========================================================================
+  # ADMIN — ANALYTICS  (#719 PR 2d)
+  # ===========================================================================
+
+  /api.php?action=admin_analytics_searches:
+    get:
+      operationId: adminAnalyticsSearches
+      tags: [Admin — Analytics]
+      summary: Top + zero-result search queries
+      description: |
+        Mirrors the search-query panel on `/manage/analytics`. Two
+        lists in one response: the most-frequent queries (`top`) and
+        the most-frequent zero-result queries (`zero`). Returns
+        **503** when `tblSearchQueries` doesn't exist yet (pre-#404
+        deployment).
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_analytics_searches] }
+        - name: range
+          in: query
+          required: false
+          schema: { type: integer, enum: [7, 30, 90], default: 30 }
+        - name: limit
+          in: query
+          required: false
+          schema: { type: integer, minimum: 1, maximum: 100, default: 15 }
+      responses:
+        "200":
+          description: Search-query analytics
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  range_days: { type: integer }
+                  since:      { type: string, format: date-time }
+                  top:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        query:     { type: string }
+                        hits:      { type: integer }
+                        top_count: { type: integer, description: Highest ResultCount seen for this query in the window }
+                  zero:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        query: { type: string }
+                        hits:  { type: integer }
+        "403":
+          description: Admin access required
+        "503":
+          description: tblSearchQueries not yet created — run /manage/setup-database
+
+  # ===========================================================================
+  # ADMIN — DIAGNOSTICS  (#719 PR 2d)
+  # Pure read endpoints designed for tooling clients (CI, monitoring,
+  # dashboards). Mirror the payloads /manage/data-health,
+  # /manage/schema-audit, and /manage/setup-database render.
+  # ===========================================================================
+
+  /api.php?action=admin_data_health:
+    get:
+      operationId: adminDataHealth
+      tags: [Admin — Diagnostics]
+      summary: Table-row counts + legacy-fallback state
+      description: |
+        Mirrors the `/manage/data-health` panel. Returns counts for
+        the canonical tables, the SongData JSON-fallback flag, the
+        share-directory file count vs DB row count, and whether the
+        legacy SQLite database is still on disk.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_data_health] }
+      responses:
+        "200":
+          description: Data-health snapshot
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminDataHealthResponse"
+        "403":
+          description: Admin access required
+        "503":
+          description: Database unreachable (response includes detail)
+
+  /api.php?action=admin_schema_audit:
+    get:
+      operationId: adminSchemaAudit
+      tags: [Admin — Diagnostics]
+      summary: schema.sql vs live DB drift report
+      description: |
+        Mirrors `/manage/schema-audit`. Compares schema.sql declarations
+        against `INFORMATION_SCHEMA.COLUMNS` and the migration
+        coverage discovered by walking every `migrate-*.php` under
+        `appWeb/.sql/`. Per-column status enum: `ok` | `missing` |
+        `uncovered` | `orphan`.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_schema_audit] }
+      responses:
+        "200":
+          description: Audit result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminSchemaAuditResponse"
+        "403":
+          description: Admin access required
+
+  /api.php?action=admin_migrations_status:
+    get:
+      operationId: adminMigrationsStatus
+      tags: [Admin — Diagnostics]
+      summary: Per-migration applied/partial/pending status
+      description: |
+        Walks every `migrate-*.php` under `appWeb/.sql/`, derives the
+        set of (table, column) declarations each one is responsible
+        for (literal ALTER, CREATE TABLE blocks, `@migration-adds`
+        doctags), and reports an `applied|partial|pending` status
+        per file by checking each declared column against the live
+        `INFORMATION_SCHEMA`. No central registry — state is derived
+        from the schema.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [admin_migrations_status] }
+      responses:
+        "200":
+          description: Status report
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminMigrationsStatusResponse"
+        "403":
+          description: Admin access required
+
   /api.php?action=admin_songbook_health:
     get:
       operationId: adminSongbookHealth
@@ -7282,6 +7722,198 @@ components:
         notes:
           type: string
           nullable: true
+
+    # -------------------------------------------------------------------------
+    # Credit-people write-input + diagnostics shapes (#719 PR 2d)
+    # -------------------------------------------------------------------------
+
+    CreditPersonLink:
+      type: object
+      description: |
+        One row of the per-person external-link sub-form. Unknown
+        `type` keys are silently coerced to `other` server-side —
+        keeps the API forward-compatible with future picker
+        categories.
+      required: [url]
+      properties:
+        type:
+          type: string
+          description: Link type key from CREDIT_PERSON_LINK_TYPE_CATALOGUE (e.g. `wikipedia`, `spotify`, `youtube`). Unknown keys → `other`.
+          default: other
+        url:
+          type: string
+        label:
+          type: string
+          nullable: true
+        sort_order:
+          type: integer
+          default: 0
+
+    CreditPersonIpi:
+      type: object
+      description: One row of the per-person IPI Name Number sub-form.
+      required: [number]
+      properties:
+        number:
+          type: string
+          description: IPI Name Number (CISAC).
+        name_used:
+          type: string
+          nullable: true
+          description: Name variant the IPI is registered under, if it differs from the canonical name.
+        notes:
+          type: string
+          nullable: true
+
+    AdminCreditPersonInput:
+      type: object
+      description: |
+        Shared input for `admin_credit_person_add` and the metadata
+        half of `admin_credit_person_update`. Add `id` (required)
+        for the latter via `allOf` composition.
+      required: [name]
+      properties:
+        name:
+          type: string
+          maxLength: 255
+        notes:
+          type: string
+          nullable: true
+        birth_place:
+          type: string
+          nullable: true
+        birth_date:
+          type: string
+          nullable: true
+          pattern: '^\d{4}-\d{2}-\d{2}$'
+          description: YYYY-MM-DD if supplied.
+        death_place:
+          type: string
+          nullable: true
+        death_date:
+          type: string
+          nullable: true
+          pattern: '^\d{4}-\d{2}-\d{2}$'
+        is_special_case:
+          type: boolean
+          default: false
+          description: Mutually exclusive with `is_group`. If both arrive, `is_special_case` wins.
+        is_group:
+          type: boolean
+          default: false
+        links:
+          type: array
+          items:
+            $ref: "#/components/schemas/CreditPersonLink"
+        ipi:
+          type: array
+          items:
+            $ref: "#/components/schemas/CreditPersonIpi"
+
+    AdminDataHealthResponse:
+      type: object
+      description: Snapshot returned by `admin_data_health`. Mirrors the panel `/manage/data-health` renders.
+      properties:
+        database_up:
+          type: boolean
+        table_counts:
+          type: object
+          description: |
+            Map of canonical table name → row count. `null` when the
+            table doesn't exist on this deployment (fresh install
+            before migrations).
+          additionalProperties:
+            type: integer
+            nullable: true
+        songs_json_fallback:
+          type: boolean
+          nullable: true
+          description: True when `SongData` is currently reading from songs.json instead of MySQL. `null` if the probe couldn't run.
+        songs_json_note:
+          type: string
+          nullable: true
+          description: Diagnostic note when the SongData probe threw (e.g. corrupt songs.json).
+        share_dir:
+          type: object
+          properties:
+            configured:        { type: boolean, description: True when APP_SETLIST_SHARE_DIR is defined. }
+            present:           { type: boolean, description: True when the directory actually exists on disk. }
+            file_count:        { type: integer, nullable: true }
+            unimported_count:  { type: integer, description: Files on disk that don't have a matching tblSharedSetlists row. }
+            unimported_ids:
+              type: array
+              items: { type: string }
+        legacy_sqlite:
+          type: object
+          properties:
+            present:    { type: boolean }
+            size_bytes: { type: integer }
+
+    AdminSchemaAuditRow:
+      type: object
+      properties:
+        col:
+          type: string
+          description: Column name.
+        status:
+          type: string
+          enum: [ok, missing, uncovered, orphan]
+          description: |
+            - `ok` — declared in schema.sql AND present in DB.
+            - `missing` — in schema.sql, not in DB, but a migration would add it.
+            - `uncovered` — in schema.sql, not in DB, no migration adds it (latent bomb).
+            - `orphan` — in DB, not in schema.sql.
+        migration:
+          type: string
+          nullable: true
+          description: Filename(s) of migrate-*.php that would add this column (set on `missing` rows only).
+
+    AdminSchemaAuditResponse:
+      type: object
+      description: Result of `admin_schema_audit`. Mirrors `/manage/schema-audit`.
+      properties:
+        summary:
+          type: object
+          properties:
+            ok:        { type: integer }
+            missing:   { type: integer }
+            uncovered: { type: integer }
+            orphan:    { type: integer }
+        by_table:
+          type: object
+          description: Map of table name → list of per-column audit rows.
+          additionalProperties:
+            type: array
+            items:
+              $ref: "#/components/schemas/AdminSchemaAuditRow"
+
+    AdminMigrationsStatusResponse:
+      type: object
+      description: Result of `admin_migrations_status`. Per-migration applied / partial / pending status derived from `INFORMATION_SCHEMA`.
+      properties:
+        summary:
+          type: object
+          properties:
+            pending: { type: integer }
+            partial: { type: integer }
+            applied: { type: integer }
+        migrations:
+          type: array
+          items:
+            type: object
+            properties:
+              file:
+                type: string
+                description: Migration script filename (basename only).
+              declared_columns:
+                type: integer
+                description: Total (table, column) pairs this migration is responsible for, derived from ALTER ADD COLUMN statements + CREATE TABLE blocks + `@migration-adds` doctags.
+              applied_columns:
+                type: integer
+                description: How many of those columns currently exist in INFORMATION_SCHEMA.COLUMNS.
+              status:
+                type: string
+                enum: [pending, partial, applied]
 
     # -------------------------------------------------------------------------
     # Generic response models

--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -63,6 +63,13 @@ require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 
 /* Shared organisation helpers (#719 PR 2c). ORG_MEMBER_ROLES +
    slugifyOrganisationName() + userCanActOnOrg() row-level gate. */
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'organisation_validation.php';
+/* Shared credit-people helpers (#719 PR 2d). Link-type catalogue +
+   normalisers + flag-columns probe. */
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'credit_people_helpers.php';
+/* Shared schema-audit helpers (#719 PR 2d). Parser + migration
+   scanner + comparer used by admin_schema_audit and
+   admin_migrations_status read endpoints. */
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'schema_audit.php';
 
 /* =========================================================================
  * CSRF DEFENCE POLICY (#293 / B15)
@@ -8463,6 +8470,1053 @@ if ($action !== null) {
                 ]);
                 error_log('[org_admin_licence_remove] ' . $e->getMessage());
                 sendJson(['error' => 'Could not remove licence.'], 500);
+            }
+            break;
+        }
+
+        /* =================================================================
+         * CREDIT PEOPLE — admin CRUD parity (#719 PR 2d)
+         *
+         * Mirrors /manage/credit-people.php POST handlers (#545). Every
+         * mutating endpoint runs inside $db->begin_transaction() so a
+         * partial failure (e.g. a child-row INSERT failing after the
+         * parent UPDATE landed) rolls back cleanly.
+         *
+         * Activity-log verb prefix is `api.admin.credit_person.*` —
+         * distinguishes API-driven changes from web-UI changes (which
+         * write `credit_person.*`) so /manage/activity-log shows both
+         * sides clearly.
+         *
+         * Validation rules (link-type allowlist, IPI shape) live in
+         * includes/credit_people_helpers.php — the same file
+         * /manage/credit-people uses.
+         * ================================================================= */
+
+        /* -----------------------------------------------------------------
+         * Admin: add a new credit-person registry row
+         * POST body: {
+         *   name (required), notes?, birth_place?, birth_date?,
+         *   death_place?, death_date?, is_special_case?, is_group?,
+         *   links?: [{type,url,label,sort_order}], ipi?: [{number,name_used,notes}]
+         * }
+         * Birth/death dates must be YYYY-MM-DD if supplied.
+         * ----------------------------------------------------------------- */
+        case 'admin_credit_person_add': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser || !in_array($authUser['Role'], ['admin', 'global_admin'])) {
+                sendJson(['error' => 'Admin access required.'], 403);
+                break;
+            }
+
+            $body = json_decode((string)file_get_contents('php://input'), true) ?: [];
+            $name        = trim((string)($body['name']         ?? ''));
+            $notesRaw    = trim((string)($body['notes']        ?? ''));
+            $birthPlace  = trim((string)($body['birth_place']  ?? '')) ?: null;
+            $birthDate   = trim((string)($body['birth_date']   ?? '')) ?: null;
+            $deathPlace  = trim((string)($body['death_place']  ?? '')) ?: null;
+            $deathDate   = trim((string)($body['death_date']   ?? '')) ?: null;
+            $notes       = $notesRaw !== '' ? $notesRaw : null;
+            $links       = normaliseCreditPersonLinks($body['links'] ?? null);
+            $ipi         = normaliseCreditPersonIpi($body['ipi']     ?? null);
+            $isSpecialCase = !empty($body['is_special_case']) ? 1 : 0;
+            $isGroup       = !empty($body['is_group'])        ? 1 : 0;
+            /* Mutually exclusive in the UI; if both arrive we prefer
+               special-case (more constraining). */
+            if ($isSpecialCase && $isGroup) { $isGroup = 0; }
+
+            if ($name === '')           { sendJson(['error' => 'Name is required.'], 400); break; }
+            if (mb_strlen($name) > 255) { sendJson(['error' => 'Name must be 255 characters or fewer.'], 400); break; }
+            if ($birthDate && !preg_match('/^\d{4}-\d{2}-\d{2}$/', $birthDate)) {
+                sendJson(['error' => 'birth_date must be YYYY-MM-DD.'], 400); break;
+            }
+            if ($deathDate && !preg_match('/^\d{4}-\d{2}-\d{2}$/', $deathDate)) {
+                sendJson(['error' => 'death_date must be YYYY-MM-DD.'], 400); break;
+            }
+
+            try {
+                $db = getDbMysqli();
+
+                $stmt = $db->prepare('SELECT Id FROM tblCreditPeople WHERE Name = ?');
+                $stmt->bind_param('s', $name);
+                $stmt->execute();
+                $exists = $stmt->get_result()->fetch_row() !== null;
+                $stmt->close();
+                if ($exists) {
+                    sendJson(['error' => "A person with the name '{$name}' is already registered."], 409);
+                    break;
+                }
+
+                $db->begin_transaction();
+                try {
+                    /* #630 — flag columns may not exist on a partly-
+                       migrated install. Skip them when absent. */
+                    $hasFlagsCols = creditPeopleFlagsColumnsExist($db);
+                    if ($hasFlagsCols) {
+                        $stmt = $db->prepare(
+                            'INSERT INTO tblCreditPeople
+                                (Name, Notes, BirthPlace, BirthDate, DeathPlace, DeathDate, IsSpecialCase, IsGroup)
+                             VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
+                        );
+                        $stmt->bind_param('ssssssii',
+                            $name, $notes, $birthPlace, $birthDate, $deathPlace, $deathDate,
+                            $isSpecialCase, $isGroup
+                        );
+                    } else {
+                        $stmt = $db->prepare(
+                            'INSERT INTO tblCreditPeople
+                                (Name, Notes, BirthPlace, BirthDate, DeathPlace, DeathDate)
+                             VALUES (?, ?, ?, ?, ?, ?)'
+                        );
+                        $stmt->bind_param('ssssss',
+                            $name, $notes, $birthPlace, $birthDate, $deathPlace, $deathDate
+                        );
+                    }
+                    $stmt->execute();
+                    $newId = (int)$db->insert_id;
+                    $stmt->close();
+
+                    if ($links) {
+                        $linkStmt = $db->prepare(
+                            'INSERT INTO tblCreditPersonLinks
+                                (CreditPersonId, LinkType, Url, Label, SortOrder)
+                             VALUES (?, ?, ?, ?, ?)'
+                        );
+                        foreach ($links as $l) {
+                            $linkStmt->bind_param('isssi',
+                                $newId, $l['type'], $l['url'], $l['label'], $l['sort_order']);
+                            $linkStmt->execute();
+                        }
+                        $linkStmt->close();
+                    }
+                    if ($ipi) {
+                        $ipiStmt = $db->prepare(
+                            'INSERT INTO tblCreditPersonIPI
+                                (CreditPersonId, IPINumber, NameUsed, Notes)
+                             VALUES (?, ?, ?, ?)'
+                        );
+                        foreach ($ipi as $r) {
+                            $ipiStmt->bind_param('isss',
+                                $newId, $r['number'], $r['name_used'], $r['notes']);
+                            $ipiStmt->execute();
+                        }
+                        $ipiStmt->close();
+                    }
+                    $db->commit();
+                } catch (\Throwable $txErr) {
+                    $db->rollback();
+                    throw $txErr;
+                }
+
+                logActivity('api.admin.credit_person.add', 'credit_person', (string)$newId, [
+                    'name'       => $name,
+                    'fields'     => array_filter([
+                        'birth_place' => $birthPlace,
+                        'birth_date'  => $birthDate,
+                        'death_place' => $deathPlace,
+                        'death_date'  => $deathDate,
+                        'notes'       => $notes,
+                    ], static fn($v) => $v !== null),
+                    'link_count' => count($links),
+                    'ipi_count'  => count($ipi),
+                ]);
+
+                sendJson([
+                    'ok'   => true,
+                    'id'   => $newId,
+                    'name' => $name,
+                ], 201);
+            } catch (\Throwable $e) {
+                logActivityError('api.admin.credit_person.add', 'credit_person', '', $e, ['name' => $name]);
+                error_log('[admin_credit_person_add] ' . $e->getMessage());
+                sendJson(['error' => 'Could not add person.'], 500);
+            }
+            break;
+        }
+
+        /* -----------------------------------------------------------------
+         * Admin: update an existing credit-person registry row
+         * POST body: { id (required), name, notes?, biographical
+         *              fields, is_special_case?, is_group?,
+         *              links?, ipi? }
+         * The Name column is NOT changed here — renames have their own
+         * endpoint because their blast radius is cross-table. If the
+         * body's name field differs from the stored name we reject
+         * with 400 and direct the caller to admin_credit_person_rename.
+         * ----------------------------------------------------------------- */
+        case 'admin_credit_person_update': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser || !in_array($authUser['Role'], ['admin', 'global_admin'])) {
+                sendJson(['error' => 'Admin access required.'], 403);
+                break;
+            }
+
+            $body = json_decode((string)file_get_contents('php://input'), true) ?: [];
+            $id          = (int)($body['id']           ?? 0);
+            $name        = trim((string)($body['name']         ?? ''));
+            $notesRaw    = trim((string)($body['notes']        ?? ''));
+            $birthPlace  = trim((string)($body['birth_place']  ?? '')) ?: null;
+            $birthDate   = trim((string)($body['birth_date']   ?? '')) ?: null;
+            $deathPlace  = trim((string)($body['death_place']  ?? '')) ?: null;
+            $deathDate   = trim((string)($body['death_date']   ?? '')) ?: null;
+            $notes       = $notesRaw !== '' ? $notesRaw : null;
+            $links       = normaliseCreditPersonLinks($body['links'] ?? null);
+            $ipi         = normaliseCreditPersonIpi($body['ipi']     ?? null);
+            $isSpecialCase = !empty($body['is_special_case']) ? 1 : 0;
+            $isGroup       = !empty($body['is_group'])        ? 1 : 0;
+            if ($isSpecialCase && $isGroup) { $isGroup = 0; }
+
+            if ($id <= 0)               { sendJson(['error' => 'Person id required.'], 400); break; }
+            if ($name === '')           { sendJson(['error' => 'Name is required.'], 400); break; }
+            if ($birthDate && !preg_match('/^\d{4}-\d{2}-\d{2}$/', $birthDate)) {
+                sendJson(['error' => 'birth_date must be YYYY-MM-DD.'], 400); break;
+            }
+            if ($deathDate && !preg_match('/^\d{4}-\d{2}-\d{2}$/', $deathDate)) {
+                sendJson(['error' => 'death_date must be YYYY-MM-DD.'], 400); break;
+            }
+
+            try {
+                $db = getDbMysqli();
+                $stmt = $db->prepare(
+                    'SELECT Name, Notes, BirthPlace, BirthDate, DeathPlace, DeathDate
+                       FROM tblCreditPeople WHERE Id = ?'
+                );
+                $stmt->bind_param('i', $id);
+                $stmt->execute();
+                $beforeRow = $stmt->get_result()->fetch_assoc() ?: null;
+                $stmt->close();
+                if ($beforeRow === null) {
+                    sendJson(['error' => 'Person not found.'], 404);
+                    break;
+                }
+                if ((string)$beforeRow['Name'] !== $name) {
+                    sendJson([
+                        'error' => 'Use admin_credit_person_rename to change a person\'s name — the change cascades to every song that cites them.',
+                    ], 400);
+                    break;
+                }
+
+                $db->begin_transaction();
+                try {
+                    if (creditPeopleFlagsColumnsExist($db)) {
+                        $stmt = $db->prepare(
+                            'UPDATE tblCreditPeople
+                                SET Notes = ?, BirthPlace = ?, BirthDate = ?,
+                                    DeathPlace = ?, DeathDate = ?,
+                                    IsSpecialCase = ?, IsGroup = ?
+                              WHERE Id = ?'
+                        );
+                        $stmt->bind_param('sssssiii',
+                            $notes, $birthPlace, $birthDate, $deathPlace, $deathDate,
+                            $isSpecialCase, $isGroup, $id);
+                    } else {
+                        $stmt = $db->prepare(
+                            'UPDATE tblCreditPeople
+                                SET Notes = ?, BirthPlace = ?, BirthDate = ?,
+                                    DeathPlace = ?, DeathDate = ?
+                              WHERE Id = ?'
+                        );
+                        $stmt->bind_param('sssssi',
+                            $notes, $birthPlace, $birthDate, $deathPlace, $deathDate, $id);
+                    }
+                    $stmt->execute();
+                    $stmt->close();
+
+                    /* Child rows: DELETE then INSERT — simpler than
+                       diffing and the per-person row counts are small
+                       (typically < 10 each). The child Ids change as a
+                       side effect, but no other table references them. */
+                    $del = $db->prepare('DELETE FROM tblCreditPersonLinks WHERE CreditPersonId = ?');
+                    $del->bind_param('i', $id);
+                    $del->execute();
+                    $del->close();
+                    if ($links) {
+                        $linkStmt = $db->prepare(
+                            'INSERT INTO tblCreditPersonLinks
+                                (CreditPersonId, LinkType, Url, Label, SortOrder)
+                             VALUES (?, ?, ?, ?, ?)'
+                        );
+                        foreach ($links as $l) {
+                            $linkStmt->bind_param('isssi',
+                                $id, $l['type'], $l['url'], $l['label'], $l['sort_order']);
+                            $linkStmt->execute();
+                        }
+                        $linkStmt->close();
+                    }
+
+                    $del = $db->prepare('DELETE FROM tblCreditPersonIPI WHERE CreditPersonId = ?');
+                    $del->bind_param('i', $id);
+                    $del->execute();
+                    $del->close();
+                    if ($ipi) {
+                        $ipiStmt = $db->prepare(
+                            'INSERT INTO tblCreditPersonIPI
+                                (CreditPersonId, IPINumber, NameUsed, Notes)
+                             VALUES (?, ?, ?, ?)'
+                        );
+                        foreach ($ipi as $r) {
+                            $ipiStmt->bind_param('isss',
+                                $id, $r['number'], $r['name_used'], $r['notes']);
+                            $ipiStmt->execute();
+                        }
+                        $ipiStmt->close();
+                    }
+                    $db->commit();
+                } catch (\Throwable $txErr) {
+                    $db->rollback();
+                    throw $txErr;
+                }
+
+                $afterRow = [
+                    'Notes'      => $notes,
+                    'BirthPlace' => $birthPlace,
+                    'BirthDate'  => $birthDate,
+                    'DeathPlace' => $deathPlace,
+                    'DeathDate'  => $deathDate,
+                ];
+                $changed = [];
+                foreach ($afterRow as $k => $v) {
+                    if ((string)($beforeRow[$k] ?? '') !== (string)($v ?? '')) {
+                        $changed[] = $k;
+                    }
+                }
+
+                logActivity('api.admin.credit_person.update', 'credit_person', (string)$id, [
+                    'name'       => $name,
+                    'fields'     => $changed,
+                    'before'     => array_intersect_key($beforeRow, array_flip($changed)),
+                    'after'      => array_intersect_key($afterRow,  array_flip($changed)),
+                    'link_count' => count($links),
+                    'ipi_count'  => count($ipi),
+                ]);
+
+                sendJson([
+                    'ok'             => true,
+                    'id'             => $id,
+                    'name'           => $name,
+                    'fields_changed' => $changed,
+                ]);
+            } catch (\Throwable $e) {
+                logActivityError('api.admin.credit_person.update', 'credit_person', (string)$id, $e);
+                error_log('[admin_credit_person_update] ' . $e->getMessage());
+                sendJson(['error' => 'Could not update person.'], 500);
+            }
+            break;
+        }
+
+        /* -----------------------------------------------------------------
+         * Admin: rename a credit-person — cascades across the five
+         * song-credit tables AND the registry row inside one transaction.
+         * POST body: { id, new_name }
+         * Refuses with 409 if the new name already belongs to a different
+         * registry row (caller should use admin_credit_person_merge).
+         * ----------------------------------------------------------------- */
+        case 'admin_credit_person_rename': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser || !in_array($authUser['Role'], ['admin', 'global_admin'])) {
+                sendJson(['error' => 'Admin access required.'], 403);
+                break;
+            }
+
+            $body    = json_decode((string)file_get_contents('php://input'), true) ?: [];
+            $id      = (int)($body['id']       ?? 0);
+            $newName = trim((string)($body['new_name'] ?? ''));
+
+            if ($id <= 0)                  { sendJson(['error' => 'Person id required.'], 400); break; }
+            if ($newName === '')           { sendJson(['error' => 'new_name is required.'], 400); break; }
+            if (mb_strlen($newName) > 255) { sendJson(['error' => 'new_name must be 255 characters or fewer.'], 400); break; }
+
+            try {
+                $db = getDbMysqli();
+                $stmt = $db->prepare('SELECT Name FROM tblCreditPeople WHERE Id = ?');
+                $stmt->bind_param('i', $id);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_row();
+                $stmt->close();
+                $oldName = (string)($row[0] ?? '');
+                if ($oldName === '')        { sendJson(['error' => 'Person not found.'], 404); break; }
+                if ($oldName === $newName)  { sendJson(['error' => 'new_name is the same as the current name.'], 400); break; }
+
+                $stmt = $db->prepare('SELECT Id FROM tblCreditPeople WHERE Name = ? AND Id <> ?');
+                $stmt->bind_param('si', $newName, $id);
+                $stmt->execute();
+                $clash = $stmt->get_result()->fetch_row() !== null;
+                $stmt->close();
+                if ($clash) {
+                    sendJson([
+                        'error' => "Another registry row already uses '{$newName}'. Use admin_credit_person_merge to combine them.",
+                    ], 409);
+                    break;
+                }
+
+                $db->begin_transaction();
+                $affected = [];
+                try {
+                    /* Cascade across the five song-credit tables. */
+                    $tables = [
+                        'tblSongWriters', 'tblSongComposers', 'tblSongArrangers',
+                        'tblSongAdaptors', 'tblSongTranslators',
+                    ];
+                    foreach ($tables as $tbl) {
+                        $stmt = $db->prepare("UPDATE {$tbl} SET Name = ? WHERE Name = ?");
+                        $stmt->bind_param('ss', $newName, $oldName);
+                        $stmt->execute();
+                        $affected[$tbl] = $stmt->affected_rows;
+                        $stmt->close();
+                    }
+                    $stmt = $db->prepare('UPDATE tblCreditPeople SET Name = ? WHERE Id = ?');
+                    $stmt->bind_param('si', $newName, $id);
+                    $stmt->execute();
+                    $stmt->close();
+                    $db->commit();
+                } catch (\Throwable $txErr) {
+                    $db->rollback();
+                    throw $txErr;
+                }
+
+                $totalRenamed = array_sum($affected);
+                logActivity('api.admin.credit_person.rename', 'credit_person', (string)$id, [
+                    'before'   => ['name' => $oldName],
+                    'after'    => ['name' => $newName],
+                    'affected' => [
+                        'writers'     => $affected['tblSongWriters'],
+                        'composers'   => $affected['tblSongComposers'],
+                        'arrangers'   => $affected['tblSongArrangers'],
+                        'adaptors'    => $affected['tblSongAdaptors'],
+                        'translators' => $affected['tblSongTranslators'],
+                    ],
+                ]);
+
+                sendJson([
+                    'ok'                  => true,
+                    'id'                  => $id,
+                    'old_name'            => $oldName,
+                    'new_name'            => $newName,
+                    'song_credit_renames' => $totalRenamed,
+                ]);
+            } catch (\Throwable $e) {
+                logActivityError('api.admin.credit_person.rename', 'credit_person', (string)$id, $e);
+                error_log('[admin_credit_person_rename] ' . $e->getMessage());
+                sendJson(['error' => 'Could not rename person.'], 500);
+            }
+            break;
+        }
+
+        /* -----------------------------------------------------------------
+         * Admin: merge two registry entries
+         * POST body: {
+         *   source_id, target_id,
+         *   keep_link_ids?: [int], keep_ipi_ids?: [int]
+         * }
+         * Re-points every song-credit row from source name → target name,
+         * migrates the chosen child rows from source → target, then
+         * deletes the source registry row (FK cascade drops any child
+         * rows the caller chose not to migrate).
+         * ----------------------------------------------------------------- */
+        case 'admin_credit_person_merge': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser || !in_array($authUser['Role'], ['admin', 'global_admin'])) {
+                sendJson(['error' => 'Admin access required.'], 403);
+                break;
+            }
+
+            $body      = json_decode((string)file_get_contents('php://input'), true) ?: [];
+            $sourceId  = (int)($body['source_id'] ?? 0);
+            $targetId  = (int)($body['target_id'] ?? 0);
+            $keepLinks = array_map('intval', (array)($body['keep_link_ids'] ?? []));
+            $keepIpi   = array_map('intval', (array)($body['keep_ipi_ids']  ?? []));
+
+            if ($sourceId <= 0 || $targetId <= 0) {
+                sendJson(['error' => 'source_id and target_id required.'], 400);
+                break;
+            }
+            if ($sourceId === $targetId) {
+                sendJson(['error' => 'Source and target must be different people.'], 400);
+                break;
+            }
+
+            try {
+                $db = getDbMysqli();
+                $stmt = $db->prepare('SELECT Id, Name FROM tblCreditPeople WHERE Id IN (?, ?)');
+                $stmt->bind_param('ii', $sourceId, $targetId);
+                $stmt->execute();
+                $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+                $stmt->close();
+                $byId = [];
+                foreach ($rows as $r) { $byId[(int)$r['Id']] = (string)$r['Name']; }
+                if (!isset($byId[$sourceId])) { sendJson(['error' => 'Source person not found.'], 404); break; }
+                if (!isset($byId[$targetId])) { sendJson(['error' => 'Target person not found.'], 404); break; }
+                $sourceName = $byId[$sourceId];
+                $targetName = $byId[$targetId];
+
+                $db->begin_transaction();
+                $affected     = [];
+                $linksKept    = 0;
+                $linksDropped = 0;
+                $ipiKept      = 0;
+                $ipiDropped   = 0;
+                try {
+                    /* Re-point song-credit rows: source → target across
+                       all five tables. */
+                    $tables = [
+                        'tblSongWriters', 'tblSongComposers', 'tblSongArrangers',
+                        'tblSongAdaptors', 'tblSongTranslators',
+                    ];
+                    foreach ($tables as $tbl) {
+                        $stmt = $db->prepare("UPDATE {$tbl} SET Name = ? WHERE Name = ?");
+                        $stmt->bind_param('ss', $targetName, $sourceName);
+                        $stmt->execute();
+                        $affected[$tbl] = $stmt->affected_rows;
+                        $stmt->close();
+                    }
+
+                    /* Migrate the chosen child rows from source → target.
+                       Anything not in keep_link_ids / keep_ipi_ids gets
+                       dropped via the cascade when the source row is
+                       deleted below. */
+                    $stmt = $db->prepare('SELECT Id FROM tblCreditPersonLinks WHERE CreditPersonId = ?');
+                    $stmt->bind_param('i', $sourceId);
+                    $stmt->execute();
+                    $sourceLinkIds = array_column($stmt->get_result()->fetch_all(MYSQLI_ASSOC), 'Id');
+                    $stmt->close();
+
+                    $stmt = $db->prepare('SELECT Id FROM tblCreditPersonIPI WHERE CreditPersonId = ?');
+                    $stmt->bind_param('i', $sourceId);
+                    $stmt->execute();
+                    $sourceIpiIds = array_column($stmt->get_result()->fetch_all(MYSQLI_ASSOC), 'Id');
+                    $stmt->close();
+
+                    if ($keepLinks && $sourceLinkIds) {
+                        $toMove = array_intersect($keepLinks, array_map('intval', $sourceLinkIds));
+                        if ($toMove) {
+                            $upd = $db->prepare(
+                                'UPDATE tblCreditPersonLinks SET CreditPersonId = ? WHERE Id = ? AND CreditPersonId = ?'
+                            );
+                            foreach ($toMove as $lid) {
+                                $upd->bind_param('iii', $targetId, $lid, $sourceId);
+                                $upd->execute();
+                                $linksKept += $upd->affected_rows;
+                            }
+                            $upd->close();
+                        }
+                    }
+                    $linksDropped = max(0, count($sourceLinkIds) - $linksKept);
+
+                    if ($keepIpi && $sourceIpiIds) {
+                        $toMove = array_intersect($keepIpi, array_map('intval', $sourceIpiIds));
+                        if ($toMove) {
+                            $upd = $db->prepare(
+                                'UPDATE tblCreditPersonIPI SET CreditPersonId = ? WHERE Id = ? AND CreditPersonId = ?'
+                            );
+                            foreach ($toMove as $iid) {
+                                $upd->bind_param('iii', $targetId, $iid, $sourceId);
+                                $upd->execute();
+                                $ipiKept += $upd->affected_rows;
+                            }
+                            $upd->close();
+                        }
+                    }
+                    $ipiDropped = max(0, count($sourceIpiIds) - $ipiKept);
+
+                    /* Drop the source registry row. Cascade removes
+                       any child rows we chose not to migrate. */
+                    $stmt = $db->prepare('DELETE FROM tblCreditPeople WHERE Id = ?');
+                    $stmt->bind_param('i', $sourceId);
+                    $stmt->execute();
+                    $stmt->close();
+
+                    $db->commit();
+                } catch (\Throwable $txErr) {
+                    $db->rollback();
+                    throw $txErr;
+                }
+
+                $totalRenamed = array_sum($affected);
+                logActivity('api.admin.credit_person.merge', 'credit_person', (string)$targetId, [
+                    'source'     => ['id' => $sourceId, 'name' => $sourceName],
+                    'target'     => ['id' => $targetId, 'name' => $targetName],
+                    'affected'   => [
+                        'writers'     => $affected['tblSongWriters'],
+                        'composers'   => $affected['tblSongComposers'],
+                        'arrangers'   => $affected['tblSongArrangers'],
+                        'adaptors'    => $affected['tblSongAdaptors'],
+                        'translators' => $affected['tblSongTranslators'],
+                    ],
+                    'child_rows' => [
+                        'links_kept'    => $linksKept,
+                        'links_dropped' => $linksDropped,
+                        'ipi_kept'      => $ipiKept,
+                        'ipi_dropped'   => $ipiDropped,
+                    ],
+                ]);
+
+                sendJson([
+                    'ok'                  => true,
+                    'source_id'           => $sourceId,
+                    'target_id'           => $targetId,
+                    'source_name'         => $sourceName,
+                    'target_name'         => $targetName,
+                    'song_credit_renames' => $totalRenamed,
+                    'links_kept'          => $linksKept,
+                    'links_dropped'       => $linksDropped,
+                    'ipi_kept'            => $ipiKept,
+                    'ipi_dropped'         => $ipiDropped,
+                ]);
+            } catch (\Throwable $e) {
+                logActivityError('api.admin.credit_person.merge', 'credit_person', (string)$targetId, $e, [
+                    'source_id' => $sourceId,
+                ]);
+                error_log('[admin_credit_person_merge] ' . $e->getMessage());
+                sendJson(['error' => 'Could not merge people.'], 500);
+            }
+            break;
+        }
+
+        /* -----------------------------------------------------------------
+         * Admin: delete a registry row
+         * POST body: { id, force? }
+         * Refuses with 422 + usage_count if any song-credit table still
+         * cites the name AND force is not set. With force=true the
+         * registry row is removed even if song credits still reference
+         * the name (the credits stay — only the registry row goes).
+         * ----------------------------------------------------------------- */
+        case 'admin_credit_person_delete': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser || !in_array($authUser['Role'], ['admin', 'global_admin'])) {
+                sendJson(['error' => 'Admin access required.'], 403);
+                break;
+            }
+
+            $body  = json_decode((string)file_get_contents('php://input'), true) ?: [];
+            $id    = (int)($body['id'] ?? 0);
+            $force = !empty($body['force']);
+            if ($id <= 0) {
+                sendJson(['error' => 'Person id required.'], 400);
+                break;
+            }
+
+            try {
+                $db = getDbMysqli();
+                $stmt = $db->prepare('SELECT Name FROM tblCreditPeople WHERE Id = ?');
+                $stmt->bind_param('i', $id);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_row();
+                $stmt->close();
+                $name = (string)($row[0] ?? '');
+                if ($name === '') {
+                    sendJson(['error' => 'Person not found.'], 404);
+                    break;
+                }
+
+                /* Single round-trip count across all five song-credit
+                   tables. */
+                $stmt = $db->prepare(
+                    "SELECT (
+                        (SELECT COUNT(*) FROM tblSongWriters     WHERE Name = ?) +
+                        (SELECT COUNT(*) FROM tblSongComposers   WHERE Name = ?) +
+                        (SELECT COUNT(*) FROM tblSongArrangers   WHERE Name = ?) +
+                        (SELECT COUNT(*) FROM tblSongAdaptors    WHERE Name = ?) +
+                        (SELECT COUNT(*) FROM tblSongTranslators WHERE Name = ?)
+                     ) AS total"
+                );
+                $stmt->bind_param('sssss', $name, $name, $name, $name, $name);
+                $stmt->execute();
+                $usage = (int)($stmt->get_result()->fetch_row()[0] ?? 0);
+                $stmt->close();
+
+                if ($usage > 0 && !$force) {
+                    sendJson([
+                        'error'        => "Cannot delete '{$name}': {$usage} song-credit row(s) still cite this name.",
+                        'usage_count'  => $usage,
+                        'name'         => $name,
+                        'hint'         => 'Pass force=true to delete the registry row anyway — the song credits stay.',
+                    ], 422);
+                    break;
+                }
+
+                $stmt = $db->prepare('DELETE FROM tblCreditPeople WHERE Id = ?');
+                $stmt->bind_param('i', $id);
+                $stmt->execute();
+                $stmt->close();
+
+                logActivity('api.admin.credit_person.delete', 'credit_person', (string)$id, [
+                    'name'        => $name,
+                    'had_credits' => $usage > 0,
+                    'force'       => $force,
+                ]);
+
+                sendJson([
+                    'ok'           => true,
+                    'id'           => $id,
+                    'name'         => $name,
+                    'usage_count'  => $usage,
+                    'forced'       => $force,
+                ]);
+            } catch (\Throwable $e) {
+                logActivityError('api.admin.credit_person.delete', 'credit_person', (string)$id, $e);
+                error_log('[admin_credit_person_delete] ' . $e->getMessage());
+                sendJson(['error' => 'Could not delete person.'], 500);
+            }
+            break;
+        }
+
+        /* =================================================================
+         * ADMIN ANALYTICS — search-query reporting (#719 PR 2d)
+         *
+         * Mirrors the Top search queries / Zero-result panels on
+         * /manage/analytics. The other two analytics verbs
+         * (`top_songs` / `top_books`) are already covered by the
+         * existing `popular_songs` endpoint; this fills the search-side
+         * gap.
+         * ================================================================= */
+
+        /* -----------------------------------------------------------------
+         * Admin: top + zero-result search queries
+         * GET ?action=admin_analytics_searches&range=7|30|90&limit=15
+         * Default range = 30 days, limit = 15.
+         * ----------------------------------------------------------------- */
+        case 'admin_analytics_searches': {
+            $authUser = getAuthenticatedUser();
+            if (!$authUser || !in_array($authUser['Role'], ['admin', 'global_admin'])) {
+                sendJson(['error' => 'Admin access required.'], 403);
+                break;
+            }
+
+            $range = (int)($_GET['range'] ?? 30);
+            if (!in_array($range, [7, 30, 90], true)) { $range = 30; }
+            $limit = (int)($_GET['limit'] ?? 15);
+            if ($limit < 1 || $limit > 100)           { $limit = 15; }
+            $since = (new DateTime("-{$range} days"))->format('Y-m-d H:i:s');
+
+            $top  = [];
+            $zero = [];
+            try {
+                $db = getDbMysqli();
+
+                $stmt = $db->prepare(
+                    'SELECT Query AS query, COUNT(*) AS hits, MAX(ResultCount) AS top_count
+                       FROM tblSearchQueries
+                      WHERE SearchedAt >= ? AND Query <> ""
+                      GROUP BY Query
+                      ORDER BY hits DESC
+                      LIMIT ?'
+                );
+                $stmt->bind_param('si', $since, $limit);
+                $stmt->execute();
+                $top = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+                $stmt->close();
+
+                $stmt = $db->prepare(
+                    'SELECT Query AS query, COUNT(*) AS hits
+                       FROM tblSearchQueries
+                      WHERE SearchedAt >= ? AND ResultCount = 0 AND Query <> ""
+                      GROUP BY Query
+                      ORDER BY hits DESC
+                      LIMIT ?'
+                );
+                $stmt->bind_param('si', $since, $limit);
+                $stmt->execute();
+                $zero = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+                $stmt->close();
+
+                /* Coerce numeric fields from string (mysqli_result default)
+                   so JSON consumers don't have to parseInt. */
+                foreach ($top as &$r) {
+                    $r['hits']      = (int)$r['hits'];
+                    $r['top_count'] = $r['top_count'] !== null ? (int)$r['top_count'] : 0;
+                }
+                unset($r);
+                foreach ($zero as &$r) { $r['hits'] = (int)$r['hits']; }
+                unset($r);
+            } catch (\Throwable $e) {
+                /* tblSearchQueries may not exist on a pre-#404 deploy.
+                   Surface as 503 so the caller knows it's a setup issue
+                   rather than malformed input. */
+                error_log('[admin_analytics_searches] ' . $e->getMessage());
+                sendJson([
+                    'error' => 'Search analytics not yet available — tblSearchQueries may not be created.',
+                    'note'  => 'Run /manage/setup-database to apply the search-query migration.',
+                ], 503);
+                break;
+            }
+
+            sendJson([
+                'range_days' => $range,
+                'since'      => $since,
+                'top'        => $top,
+                'zero'       => $zero,
+            ]);
+            break;
+        }
+
+        /* =================================================================
+         * READ-SIDE DIAGNOSTICS (#719 PR 2d)
+         *
+         * Three operational endpoints natives + tooling clients (CI,
+         * monitoring) probably want. All admin / global_admin gated.
+         * Pure read paths; no mutations.
+         * ================================================================= */
+
+        /* -----------------------------------------------------------------
+         * Admin: data-health snapshot
+         * GET ?action=admin_data_health
+         * Returns table-row counts for the canonical tables, plus the
+         * legacy-fallback state (songs.json fallback active? share JSON
+         * file count vs DB row count? legacy SQLite present?). Mirrors
+         * /manage/data-health's panel.
+         * ----------------------------------------------------------------- */
+        case 'admin_data_health': {
+            $authUser = getAuthenticatedUser();
+            if (!$authUser || !in_array($authUser['Role'], ['admin', 'global_admin'])) {
+                sendJson(['error' => 'Admin access required.'], 403);
+                break;
+            }
+
+            /* Same allowlist /manage/data-health uses. Hard-coded so a
+               future tweak to the canonical-table list lands once and
+               both surfaces pick it up by reading this constant. */
+            $healthTables = [
+                'tblSongs', 'tblSongbooks', 'tblUsers', 'tblUserSetlists',
+                'tblSharedSetlists', 'tblSongRequests', 'tblSongRevisions',
+                'tblUserGroups', 'tblOrganisations',
+            ];
+
+            try {
+                $db = getDbMysqli();
+            } catch (\Throwable $dbErr) {
+                sendJson([
+                    'error'         => 'Database unreachable.',
+                    'database_up'   => false,
+                    'detail'        => $dbErr->getMessage(),
+                ], 503);
+                break;
+            }
+
+            $tableCounts = [];
+            foreach ($healthTables as $tbl) {
+                try {
+                    /* Allowlist guard: $tbl came from the literal array
+                       above, but a belt-and-braces in_array check makes
+                       the safety provable at the query site without
+                       tracing control flow. */
+                    if (!in_array($tbl, $healthTables, true)) { continue; }
+                    $stmt = $db->prepare('SELECT COUNT(*) FROM `' . $tbl . '`');
+                    $stmt->execute();
+                    $row = $stmt->get_result()->fetch_row();
+                    $tableCounts[$tbl] = (int)($row[0] ?? 0);
+                    $stmt->close();
+                } catch (\Throwable $_e) {
+                    /* Table missing on a fresh deploy is expected;
+                       represent as null. */
+                    $tableCounts[$tbl] = null;
+                }
+            }
+
+            /* SongData JSON fallback probe — non-fatal on partly-loaded
+               configs. The probe runs the SongData constructor which
+               may throw when songs.json is corrupt; we surface the
+               exception text in `note` rather than failing the whole
+               response. */
+            $songDataJsonFallback = null;
+            $songDataNote         = null;
+            try {
+                if (class_exists('\\SongData')) {
+                    $probe = new \SongData();
+                    $songDataJsonFallback = $probe->isJsonFallback();
+                }
+            } catch (\Throwable $sdErr) {
+                $songDataNote = 'SongData probe failed: ' . $sdErr->getMessage();
+            }
+
+            /* Legacy share-directory + SQLite presence checks. Defined
+               constants come from config.php; treat absence as "not
+               configured" rather than a 500. */
+            $songsJsonPath = defined('APP_DATA_FILE')          ? APP_DATA_FILE          : '';
+            $shareDirPath  = defined('APP_SETLIST_SHARE_DIR')  ? APP_SETLIST_SHARE_DIR  : '';
+            $sqliteDbPath  = defined('APP_ROOT')
+                ? dirname(APP_ROOT) . DIRECTORY_SEPARATOR . 'data_share' . DIRECTORY_SEPARATOR . 'SQLite'
+                  . DIRECTORY_SEPARATOR . 'ihymns.db'
+                : '';
+
+            $shareFileCount      = null;
+            $unimportedShareIds  = [];
+            if ($shareDirPath && is_dir($shareDirPath)) {
+                $files = glob($shareDirPath . DIRECTORY_SEPARATOR . '*.json') ?: [];
+                $shareFileCount = count($files);
+                if ($shareFileCount > 0 && isset($tableCounts['tblSharedSetlists'])) {
+                    $idsOnDisk = array_filter(array_map(
+                        fn($f) => preg_match('/^[a-f0-9]{6,32}$/i', basename($f, '.json'))
+                                    ? basename($f, '.json') : null,
+                        $files
+                    ));
+                    try {
+                        $stmt = $db->prepare('SELECT ShareId FROM tblSharedSetlists');
+                        $stmt->execute();
+                        $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+                        $stmt->close();
+                        $inDb = array_fill_keys(array_column($rows, 'ShareId'), true);
+                        foreach ($idsOnDisk as $id) {
+                            if (!isset($inDb[$id])) $unimportedShareIds[] = $id;
+                        }
+                    } catch (\Throwable $_e) {
+                        /* tblSharedSetlists missing — leave unimported list empty. */
+                    }
+                }
+            }
+            $sqliteExists = $sqliteDbPath && file_exists($sqliteDbPath);
+            $sqliteSize   = $sqliteExists ? (int)@filesize($sqliteDbPath) : 0;
+
+            sendJson([
+                'database_up'           => true,
+                'table_counts'          => $tableCounts,
+                'songs_json_fallback'   => $songDataJsonFallback,
+                'songs_json_note'       => $songDataNote,
+                'share_dir' => [
+                    'configured'        => $shareDirPath !== '',
+                    'present'           => $shareDirPath !== '' && is_dir($shareDirPath),
+                    'file_count'        => $shareFileCount,
+                    'unimported_count'  => count($unimportedShareIds),
+                    'unimported_ids'    => $unimportedShareIds,
+                ],
+                'legacy_sqlite' => [
+                    'present'   => $sqliteExists,
+                    'size_bytes'=> $sqliteSize,
+                ],
+            ]);
+            break;
+        }
+
+        /* -----------------------------------------------------------------
+         * Admin: schema-audit JSON
+         * GET ?action=admin_schema_audit
+         * Mirrors /manage/schema-audit's diff payload — schema.sql vs
+         * live DB vs migration coverage. Returns the same {byTable, summary}
+         * shape the page consumes.
+         * ----------------------------------------------------------------- */
+        case 'admin_schema_audit': {
+            $authUser = getAuthenticatedUser();
+            if (!$authUser || !in_array($authUser['Role'], ['admin', 'global_admin'])) {
+                sendJson(['error' => 'Admin access required.'], 403);
+                break;
+            }
+
+            $schemaSrc = dirname(__DIR__, 1) . DIRECTORY_SEPARATOR . '.sql' . DIRECTORY_SEPARATOR . 'schema.sql';
+            $sqlDir    = dirname(__DIR__, 1) . DIRECTORY_SEPARATOR . '.sql';
+
+            try {
+                $db = getDbMysqli();
+                if (!is_readable($schemaSrc)) {
+                    throw new \RuntimeException('schema.sql not readable at ' . $schemaSrc);
+                }
+                $schemaSql  = (string)file_get_contents($schemaSrc);
+                $schemaCols = schemaAuditParseSchema($schemaSql);
+                if (!$schemaCols) {
+                    throw new \RuntimeException('Parsed zero tables from schema.sql — parser broken or file shape changed.');
+                }
+                $migrations = schemaAuditScanMigrations($sqlDir);
+                $dbCols     = schemaAuditReadDb($db);
+                $audit      = schemaAuditCompare($schemaCols, $dbCols, $migrations);
+
+                sendJson([
+                    'summary'  => $audit['summary'],
+                    'by_table' => $audit['byTable'],
+                ]);
+            } catch (\Throwable $e) {
+                error_log('[admin_schema_audit] ' . $e->getMessage());
+                sendJson(['error' => 'Schema audit failed: ' . $e->getMessage()], 500);
+            }
+            break;
+        }
+
+        /* -----------------------------------------------------------------
+         * Admin: migrations status
+         * GET ?action=admin_migrations_status
+         * Walks every migrate-*.php under appWeb/.sql/, matches each
+         * declared (table, column) against the live DB, and reports
+         * an applied|partial|pending status per migration. Designed
+         * for tooling clients (CI, monitoring) — derives state from
+         * the schema rather than maintaining a separate registry.
+         * ----------------------------------------------------------------- */
+        case 'admin_migrations_status': {
+            $authUser = getAuthenticatedUser();
+            if (!$authUser || !in_array($authUser['Role'], ['admin', 'global_admin'])) {
+                sendJson(['error' => 'Admin access required.'], 403);
+                break;
+            }
+
+            $sqlDir = dirname(__DIR__, 1) . DIRECTORY_SEPARATOR . '.sql';
+
+            try {
+                $db = getDbMysqli();
+                $migrations = schemaAuditScanMigrations($sqlDir);
+                $dbCols     = schemaAuditReadDb($db);
+
+                /* Invert: [tbl.col => [files...]] becomes [file => [(tbl,col), ...]]. */
+                $byFile = [];
+                foreach ($migrations as $key => $files) {
+                    [$tbl, $col] = explode('.', $key, 2);
+                    foreach ($files as $f) {
+                        $byFile[$f][] = ['table' => $tbl, 'column' => $col];
+                    }
+                }
+
+                $report = [];
+                foreach ($byFile as $file => $declared) {
+                    $applied = 0;
+                    foreach ($declared as $d) {
+                        if (in_array($d['column'], $dbCols[$d['table']] ?? [], true)) {
+                            $applied++;
+                        }
+                    }
+                    $total  = count($declared);
+                    $status = $applied === 0       ? 'pending'
+                            : ($applied === $total ? 'applied' : 'partial');
+                    $report[] = [
+                        'file'             => $file,
+                        'declared_columns' => $total,
+                        'applied_columns'  => $applied,
+                        'status'           => $status,
+                    ];
+                }
+
+                /* Stable sort: pending first, then partial, then applied;
+                   alphabetic within each group so the report reads as a
+                   "what to run next" punchlist. */
+                usort($report, function (array $a, array $b): int {
+                    $rank = ['pending' => 0, 'partial' => 1, 'applied' => 2];
+                    return $rank[$a['status']] <=> $rank[$b['status']]
+                         ?: strcmp($a['file'], $b['file']);
+                });
+
+                $summary = ['pending' => 0, 'partial' => 0, 'applied' => 0];
+                foreach ($report as $r) { $summary[$r['status']]++; }
+
+                sendJson([
+                    'summary'    => $summary,
+                    'migrations' => $report,
+                ]);
+            } catch (\Throwable $e) {
+                error_log('[admin_migrations_status] ' . $e->getMessage());
+                sendJson(['error' => 'Could not derive migrations status: ' . $e->getMessage()], 500);
             }
             break;
         }

--- a/appWeb/public_html/includes/credit_people_helpers.php
+++ b/appWeb/public_html/includes/credit_people_helpers.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Credit-people shared helpers (#719 PR 2d)
+ *
+ * Single source of truth for the bits both /manage/credit-people.php
+ * and the admin_credit_person_* API endpoints share:
+ *
+ *   - CREDIT_PERSON_LINK_TYPE_CATALOGUE — grouped catalogue of
+ *     link-type keys for the per-person external-link sub-form (#586).
+ *   - CREDIT_PERSON_LINK_TYPE_KEYS — flat lookup used by the validator.
+ *   - normaliseCreditPersonLinks() / normaliseCreditPersonIpi() —
+ *     drop empty rows, coerce unknown link types to 'other', normalise
+ *     the row shape into INSERT-ready arrays.
+ *   - creditPeopleFlagsColumnsExist() — cached check for the
+ *     IsSpecialCase / IsGroup columns from #584/#585. Lets the add /
+ *     update paths gracefully no-op the flag writes on a partly-
+ *     migrated install (#630).
+ *
+ * Direct access is blocked so this file can't be loaded as an
+ * arbitrary endpoint via an open Apache config.
+ */
+
+if (basename($_SERVER['SCRIPT_FILENAME'] ?? '') === basename(__FILE__)) {
+    http_response_code(403);
+    exit('Access denied.');
+}
+
+/**
+ * Curated link-type registry (#586).
+ *
+ * Adding a new provider: append it under its category. The picker
+ * UI (built from this catalogue via <optgroup>) and the
+ * normaliser's allowlist both update automatically. Legacy
+ * LinkType values stored in the DB before #586 (e.g. 'official',
+ * 'wikipedia') stay valid because they still appear under General.
+ */
+if (!defined('IHYMNS_CREDIT_LINK_CATALOGUE_DEFINED')) {
+    define('IHYMNS_CREDIT_LINK_CATALOGUE_DEFINED', true);
+    define('CREDIT_PERSON_LINK_TYPE_CATALOGUE', [
+        'General' => [
+            'official'      => 'Official website',
+            'wikipedia'     => 'Wikipedia',
+            'wikidata'      => 'Wikidata',
+            'musicbrainz'   => 'MusicBrainz',
+            'discogs'       => 'Discogs',
+            'imslp'         => 'IMSLP',
+            'hymnary'       => 'Hymnary',
+        ],
+        'Music streaming / stores' => [
+            'spotify'       => 'Spotify',
+            'apple_music'   => 'Apple Music',
+            'youtube_music' => 'YouTube Music',
+            'amazon_music'  => 'Amazon Music',
+            'tidal'         => 'Tidal',
+            'qobuz'         => 'Qobuz',
+            'pandora'       => 'Pandora',
+            'bandcamp'      => 'Bandcamp',
+            'soundcloud'    => 'SoundCloud',
+        ],
+        'Social media' => [
+            'facebook'      => 'Facebook',
+            'instagram'     => 'Instagram',
+            'twitter'       => 'Twitter / X',
+            'tiktok'        => 'TikTok',
+            'youtube'       => 'YouTube',
+            'snapchat'      => 'Snapchat',
+            'threads'       => 'Threads',
+            'mastodon'      => 'Mastodon',
+        ],
+        'Other' => [
+            'other'         => 'Other (free text)',
+        ],
+    ]);
+    /* Flat lookup used by the normaliser's allowlist + by the JS-side
+       serialiser when it needs to validate keys client-side. */
+    define('CREDIT_PERSON_LINK_TYPE_KEYS',
+        array_keys(array_merge(...array_values(CREDIT_PERSON_LINK_TYPE_CATALOGUE))));
+}
+
+/**
+ * Normalise the per-person external-link sub-form. Drops empty rows
+ * (no URL), coerces unknown types to 'other', and returns
+ * INSERT-ready row arrays.
+ *
+ * Accepts either the form-array shape from /manage/credit-people
+ * (`links[i][type|url|label]`) or the JSON shape from /api.php
+ * (`links[]: {type, url, label}`). The shape is identical once
+ * decoded, so one normaliser covers both surfaces.
+ *
+ * @param mixed $raw Form / JSON-decoded array; non-array → []
+ * @return list<array{type:string,url:string,label:?string,sort_order:int}>
+ */
+function normaliseCreditPersonLinks(mixed $raw): array
+{
+    if (!is_array($raw)) return [];
+    $out = [];
+    foreach ($raw as $i => $row) {
+        if (!is_array($row)) continue;
+        $url = trim((string)($row['url'] ?? ''));
+        if ($url === '') continue;
+        $type = trim((string)($row['type'] ?? 'other'));
+        /* Unknown types collapse to 'other' rather than 500ing —
+           keeps a forward-compatible UI where a future picker
+           category gets dropped to a sane bucket on older servers. */
+        if (!in_array($type, CREDIT_PERSON_LINK_TYPE_KEYS, true)) {
+            $type = 'other';
+        }
+        $out[] = [
+            'type'       => $type,
+            'url'        => $url,
+            'label'      => trim((string)($row['label'] ?? '')) ?: null,
+            'sort_order' => (int)($row['sort_order'] ?? $i),
+        ];
+    }
+    return $out;
+}
+
+/**
+ * Normalise the per-person IPI Name Number sub-form. Drops empty
+ * rows (no number) and returns INSERT-ready row arrays.
+ *
+ * @param mixed $raw Form / JSON-decoded array; non-array → []
+ * @return list<array{number:string,name_used:?string,notes:?string}>
+ */
+function normaliseCreditPersonIpi(mixed $raw): array
+{
+    if (!is_array($raw)) return [];
+    $out = [];
+    foreach ($raw as $row) {
+        if (!is_array($row)) continue;
+        $num = trim((string)($row['number'] ?? ''));
+        if ($num === '') continue;
+        $out[] = [
+            'number'    => $num,
+            'name_used' => trim((string)($row['name_used'] ?? '')) ?: null,
+            'notes'     => trim((string)($row['notes']     ?? '')) ?: null,
+        ];
+    }
+    return $out;
+}
+
+/**
+ * Cached check for the IsSpecialCase / IsGroup columns from
+ * #584/#585 (#630). Both ship together via
+ * migrate-credit-people-flags.php; detecting one is sufficient to
+ * assume both. Caches the result for the request lifetime via a
+ * static so the add / update paths don't pay the
+ * INFORMATION_SCHEMA round-trip twice.
+ */
+function creditPeopleFlagsColumnsExist(\mysqli $db): bool
+{
+    static $cached = null;
+    if ($cached !== null) return $cached;
+    try {
+        $stmt = $db->prepare(
+            "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+              WHERE TABLE_SCHEMA = DATABASE()
+                AND TABLE_NAME   = 'tblCreditPeople'
+                AND COLUMN_NAME  = 'IsSpecialCase' LIMIT 1"
+        );
+        $stmt->execute();
+        $cached = $stmt->get_result()->fetch_row() !== null;
+        $stmt->close();
+    } catch (\Throwable $_e) {
+        $cached = false;
+    }
+    return $cached;
+}

--- a/appWeb/public_html/includes/schema_audit.php
+++ b/appWeb/public_html/includes/schema_audit.php
@@ -1,0 +1,300 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Schema-audit shared helpers (#719 PR 2d, #518)
+ *
+ * The four parser / comparer / scanner functions used by
+ * /manage/schema-audit.php, lifted out so the new admin_schema_audit
+ * and admin_migrations_status API endpoints can call them without
+ * pulling the whole admin page into the include path.
+ *
+ * Each helper is pure — given the same inputs, returns the same
+ * outputs. No global state, no logging, no superglobal reads.
+ *
+ *   - schemaAuditParseSchema(string)       parses appWeb/.sql/schema.sql
+ *                                          → [tableName => [colName, …]]
+ *   - schemaAuditScanMigrations(string)    walks every migrate-*.php under
+ *                                          appWeb/.sql/ → [tblName.colName
+ *                                          => [migrationFile, …]]
+ *   - schemaAuditReadDb(\mysqli)           one INFORMATION_SCHEMA roundtrip
+ *                                          → [tableName => [colName, …]]
+ *   - schemaAuditCompare(...)              merges the three sources →
+ *                                          { byTable, summary }
+ *
+ * Direct access is blocked so this file can't be loaded as an
+ * arbitrary endpoint via an open Apache config.
+ */
+
+if (basename($_SERVER['SCRIPT_FILENAME'] ?? '') === basename(__FILE__)) {
+    http_response_code(403);
+    exit('Access denied.');
+}
+
+/**
+ * Parse `schema.sql` into a `[tableName => [columnName, ...]]` map.
+ *
+ * Doesn't try to be a full SQL parser — leans on the file's
+ * consistent shape: every table is `CREATE TABLE IF NOT EXISTS
+ * tblX (` … `) ENGINE=…;` with one column or constraint per line.
+ * Strips block comments before splitting at top-level commas so
+ * multi-line column declarations stay intact (#722 parser fix).
+ */
+function schemaAuditParseSchema(string $schemaSql): array
+{
+    $tables = [];
+
+    /* `s` flag so `.` matches newlines inside the parenthesised body. */
+    $matched = preg_match_all(
+        '/CREATE\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?\s+(tbl\w+)\s*\((.*?)\)\s*ENGINE\s*=/is',
+        $schemaSql,
+        $matches,
+        PREG_SET_ORDER
+    );
+    if ($matched === false || $matched === 0) {
+        return $tables;
+    }
+
+    foreach ($matches as $m) {
+        $tableName = $m[1];
+        $body      = $m[2];
+
+        /* Strip multi-line block comments first — otherwise lines
+           inside a /* … *\/ block (which themselves don't start with
+           /* on the current line) get read as phantom column
+           declarations. (#722) */
+        $body = preg_replace('/\/\*.*?\*\//s', '', $body);
+
+        /* Split into top-level segments at commas, ignoring commas
+           inside parentheses (so ENUM('success','failure','error')
+           stays in one segment, not three). Each segment is exactly
+           one column declaration OR one table-level constraint —
+           irrespective of how many lines it spans. */
+        $segments = [];
+        $depth = 0;
+        $buf   = '';
+        for ($i = 0, $n = strlen($body); $i < $n; $i++) {
+            $ch = $body[$i];
+            if ($ch === "'") {
+                $buf .= $ch;
+                $i++;
+                while ($i < $n) {
+                    $buf .= $body[$i];
+                    if ($body[$i] === "'" && (($i + 1) >= $n || $body[$i + 1] !== "'")) break;
+                    $i++;
+                }
+                continue;
+            }
+            if ($ch === '(') $depth++;
+            if ($ch === ')') $depth--;
+            if ($ch === ',' && $depth === 0) {
+                $segments[] = $buf;
+                $buf = '';
+                continue;
+            }
+            $buf .= $ch;
+        }
+        if (trim($buf) !== '') {
+            $segments[] = $buf;
+        }
+
+        $columns = [];
+        foreach ($segments as $segment) {
+            $segment = preg_replace('/--[^\n]*/', '', $segment);
+            $segment = trim(preg_replace('/\s+/', ' ', $segment));
+            if ($segment === '') continue;
+
+            /* Skip table-level constraints. */
+            if (preg_match(
+                '/^(PRIMARY\s+KEY|INDEX|UNIQUE|KEY|CONSTRAINT|FOREIGN\s+KEY|FULLTEXT|SPATIAL)\b/i',
+                $segment
+            )) {
+                continue;
+            }
+            /* Column declaration: starts with Name (optionally
+               backtick-quoted) followed by a type. */
+            if (preg_match('/^`?([A-Za-z_][A-Za-z0-9_]*)`?\s+/', $segment, $cm)) {
+                $columns[] = $cm[1];
+            }
+        }
+
+        $tables[$tableName] = $columns;
+    }
+
+    return $tables;
+}
+
+/**
+ * Scan every `migrate-*.php` in `appWeb/.sql/` for the columns each
+ * one adds, returning `[tblName.colName => [migrationFile, …]]`.
+ *
+ * Three signals merged:
+ *   1. Literal `ALTER TABLE tblX ADD COLUMN <Name>` strings.
+ *   2. `CREATE TABLE [IF NOT EXISTS] tblX (…)` blocks (parsed via
+ *      schemaAuditParseSchema()).
+ *   3. Docblock convention: `@migration-adds tblX.colName`. Used
+ *      when ALTERs are built dynamically and a literal regex can't
+ *      see the column name.
+ */
+function schemaAuditScanMigrations(string $sqlDir): array
+{
+    $coverage = [];
+    $files = glob($sqlDir . DIRECTORY_SEPARATOR . 'migrate-*.php') ?: [];
+
+    foreach ($files as $file) {
+        $contents = @file_get_contents($file);
+        if ($contents === false) {
+            continue;
+        }
+        $base = basename($file);
+
+        /* Signal 1 — literal ALTER … ADD COLUMN strings */
+        if (preg_match_all(
+            '/ALTER\s+TABLE\s+(tbl\w+)\s+ADD\s+COLUMN\s+`?([A-Za-z_][A-Za-z0-9_]*)`?/is',
+            $contents,
+            $matches,
+            PREG_SET_ORDER
+        )) {
+            foreach ($matches as $m) {
+                $coverage[$m[1] . '.' . $m[2]][] = $base;
+            }
+        }
+
+        /* Signal 2 — CREATE TABLE blocks inside the migration. */
+        $createTableCols = schemaAuditParseSchema($contents);
+        foreach ($createTableCols as $tbl => $cols) {
+            foreach ($cols as $col) {
+                $coverage[$tbl . '.' . $col][] = $base;
+            }
+        }
+
+        /* Signal 3 — @migration-adds doctag */
+        if (preg_match_all(
+            '/@migration-adds\s+(tbl\w+)\.([A-Za-z_][A-Za-z0-9_]*)/i',
+            $contents,
+            $matches,
+            PREG_SET_ORDER
+        )) {
+            foreach ($matches as $m) {
+                $coverage[$m[1] . '.' . $m[2]][] = $base;
+            }
+        }
+    }
+
+    /* De-dupe filenames per column. */
+    foreach ($coverage as $k => $files) {
+        $coverage[$k] = array_values(array_unique($files));
+    }
+
+    return $coverage;
+}
+
+/**
+ * Read every `tblXxx` column the live database currently has.
+ * One INFORMATION_SCHEMA roundtrip; cheap.
+ *
+ * @return array<string, string[]> tableName => [columnName, …]
+ */
+function schemaAuditReadDb(\mysqli $db): array
+{
+    $sql = "SELECT TABLE_NAME, COLUMN_NAME
+              FROM INFORMATION_SCHEMA.COLUMNS
+             WHERE TABLE_SCHEMA = DATABASE()
+               AND TABLE_NAME LIKE 'tbl%'
+             ORDER BY TABLE_NAME, ORDINAL_POSITION";
+    $tables = [];
+    $stmt = $db->prepare($sql);
+    $stmt->execute();
+    foreach ($stmt->get_result()->fetch_all(MYSQLI_ASSOC) as $row) {
+        $tables[$row['TABLE_NAME']][] = $row['COLUMN_NAME'];
+    }
+    $stmt->close();
+    return $tables;
+}
+
+/**
+ * Compare the three sources and return per-table rows + a summary
+ * count of each status across the whole database.
+ *
+ * Status enum:
+ *   - ok        : in code AND in DB
+ *   - missing   : in code, not in DB, but a migration would add it
+ *   - uncovered : in code, not in DB, no migration adds it (latent bomb)
+ *   - orphan    : in DB, not in code (column dropped from schema.sql)
+ *
+ * @return array{
+ *   byTable: array<string, list<array{col:string,status:string,migration:?string}>>,
+ *   summary: array{ok:int,missing:int,uncovered:int,orphan:int}
+ * }
+ */
+function schemaAuditCompare(array $schemaCols, array $dbCols, array $migrations): array
+{
+    $byTable = [];
+    $summary = ['ok' => 0, 'missing' => 0, 'uncovered' => 0, 'orphan' => 0];
+
+    foreach ($schemaCols as $tbl => $cols) {
+        $rows       = [];
+        $dbColsHere = $dbCols[$tbl] ?? [];
+
+        foreach ($cols as $col) {
+            $key   = $tbl . '.' . $col;
+            $inDb  = in_array($col, $dbColsHere, true);
+            $inMig = isset($migrations[$key]);
+
+            if ($inDb) {
+                $rows[] = ['col' => $col, 'status' => 'ok', 'migration' => null];
+                $summary['ok']++;
+            } elseif ($inMig) {
+                $rows[] = ['col' => $col, 'status' => 'missing', 'migration' => implode(', ', $migrations[$key])];
+                $summary['missing']++;
+            } else {
+                $rows[] = ['col' => $col, 'status' => 'uncovered', 'migration' => null];
+                $summary['uncovered']++;
+            }
+        }
+
+        /* Orphans = columns in DB but not in schema for this table */
+        foreach ($dbColsHere as $dbCol) {
+            if (!in_array($dbCol, $cols, true)) {
+                $rows[] = ['col' => $dbCol, 'status' => 'orphan', 'migration' => null];
+                $summary['orphan']++;
+            }
+        }
+
+        $byTable[$tbl] = $rows;
+    }
+
+    /* Tables in DB but not in schema.sql at all — every column orphan. */
+    foreach ($dbCols as $tbl => $cols) {
+        if (isset($schemaCols[$tbl])) {
+            continue;
+        }
+        $rows = [];
+        foreach ($cols as $col) {
+            $rows[] = ['col' => $col, 'status' => 'orphan', 'migration' => null];
+            $summary['orphan']++;
+        }
+        $byTable[$tbl] = $rows;
+    }
+
+    /* Stable sort: tables with any non-OK rows first, then alphabetically. */
+    uksort($byTable, function (string $a, string $b) use ($byTable) {
+        $aDirty = schemaAuditTableHasIssues($byTable[$a]) ? 0 : 1;
+        $bDirty = schemaAuditTableHasIssues($byTable[$b]) ? 0 : 1;
+        return $aDirty <=> $bDirty ?: strcmp($a, $b);
+    });
+
+    return ['byTable' => $byTable, 'summary' => $summary];
+}
+
+/** True if any row in the per-table list isn't `ok`. */
+function schemaAuditTableHasIssues(array $rows): bool
+{
+    foreach ($rows as $r) {
+        if ($r['status'] !== 'ok') {
+            return true;
+        }
+    }
+    return false;
+}

--- a/appWeb/public_html/manage/credit-people.php
+++ b/appWeb/public_html/manage/credit-people.php
@@ -42,6 +42,11 @@ declare(strict_types=1);
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'config.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
+/* Shared credit-people helpers (#719 PR 2d) — link-type catalogue +
+   normalisers + flag-columns-exist probe. Same helpers used by the
+   admin_credit_person_* API endpoints in /api.php so a tweak to the
+   link-type set or the row-shape rules lands on both surfaces. */
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'credit_people_helpers.php';
 
 if (!isAuthenticated()) {
     header('Location: /manage/login');
@@ -82,128 +87,26 @@ $logCreditPerson = static function (string $action, string $entityId, array $det
 };
 
 /* ----------------------------------------------------------------------
- * Helpers — link / IPI sub-form normalisation
+ * Helpers — link / IPI sub-form normalisation (#719 PR 2d)
  *
- * The Add and Update_person actions both accept arrays of links and
- * IPI numbers in the POST body, posted as `links[i][type|url|label]`
- * and `ipi[i][number|name_used|notes]`. Empty rows (no URL / no
- * IPI number) are silently dropped. Returns a clean array of
- * row-shaped arrays ready to INSERT.
+ * The link-type catalogue, the two normalisers, and the
+ * flag-columns-exist probe now live in
+ * /includes/credit_people_helpers.php. The closures kept here are
+ * thin wrappers so the existing call sites below ($normaliseLinks,
+ * $normaliseIpi, _cpFlagsColumnsExist) keep working unchanged.
  * ---------------------------------------------------------------------- */
-/**
- * Curated link-type registry (#586).
- *
- * Replaces the seven-item hard-coded set with a grouped catalogue of
- * well-known providers — Wikipedia, Wikidata, MusicBrainz, the
- * streaming services (Spotify / Apple Music / YouTube Music / …) and
- * the major social networks. The picker in the modal is built from
- * this array via <optgroup>; the server-side validator accepts any
- * key from the flat list. "Other" is always allowed and stays as the
- * free-text fallback.
- *
- * Adding a new provider: append it under its category. The picker
- * UI and the validator both update automatically. Legacy LinkType
- * values stored in the DB before #586 (e.g. 'wikipedia', 'official')
- * remain valid because they still appear in the catalogue under the
- * General category — no data migration needed.
- */
-$LINK_TYPE_CATALOGUE = [
-    'General' => [
-        'official'      => 'Official website',
-        'wikipedia'     => 'Wikipedia',
-        'wikidata'      => 'Wikidata',
-        'musicbrainz'   => 'MusicBrainz',
-        'discogs'       => 'Discogs',
-        'imslp'         => 'IMSLP',
-        'hymnary'       => 'Hymnary',
-    ],
-    'Music streaming / stores' => [
-        'spotify'       => 'Spotify',
-        'apple_music'   => 'Apple Music',
-        'youtube_music' => 'YouTube Music',
-        'amazon_music'  => 'Amazon Music',
-        'tidal'         => 'Tidal',
-        'qobuz'         => 'Qobuz',
-        'pandora'       => 'Pandora',
-        'bandcamp'      => 'Bandcamp',
-        'soundcloud'    => 'SoundCloud',
-    ],
-    'Social media' => [
-        'facebook'      => 'Facebook',
-        'instagram'     => 'Instagram',
-        'twitter'       => 'Twitter / X',
-        'tiktok'        => 'TikTok',
-        'youtube'       => 'YouTube',
-        'snapchat'      => 'Snapchat',
-        'threads'       => 'Threads',
-        'mastodon'      => 'Mastodon',
-    ],
-    'Other' => [
-        'other'         => 'Other (free text)',
-    ],
-];
-/* Flat lookup used by the validator + by the JS-side serialiser. */
-$LINK_TYPE_KEYS = array_keys(array_merge(...array_values($LINK_TYPE_CATALOGUE)));
+$LINK_TYPE_CATALOGUE = CREDIT_PERSON_LINK_TYPE_CATALOGUE;
+$LINK_TYPE_KEYS      = CREDIT_PERSON_LINK_TYPE_KEYS;
+$normaliseLinks      = static fn(mixed $raw): array => normaliseCreditPersonLinks($raw);
+$normaliseIpi        = static fn(mixed $raw): array => normaliseCreditPersonIpi($raw);
 
-/**
- * Cached check for the IsSpecialCase / IsGroup columns from #584/#585
- * (closes #630). Both columns ship together via migrate-credit-people-
- * flags.php, so detecting one is sufficient to assume both. The result
- * is cached for the request lifetime via a static so the add / update_
- * person paths don't pay the INFORMATION_SCHEMA round-trip twice.
- */
+/* Wrapper kept under the original snake_case private-prefix name so
+   existing call sites in this file keep working without further
+   touch-up. */
 function _cpFlagsColumnsExist(\mysqli $db): bool
 {
-    static $cached = null;
-    if ($cached !== null) return $cached;
-    $stmt = $db->prepare(
-        "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
-          WHERE TABLE_SCHEMA = DATABASE()
-            AND TABLE_NAME   = 'tblCreditPeople'
-            AND COLUMN_NAME  = 'IsSpecialCase' LIMIT 1"
-    );
-    $stmt->execute();
-    $cached = $stmt->get_result()->fetch_row() !== null;
-    $stmt->close();
-    return $cached;
+    return creditPeopleFlagsColumnsExist($db);
 }
-
-$normaliseLinks = static function (mixed $raw) use ($LINK_TYPE_KEYS): array {
-    if (!is_array($raw)) return [];
-    $out = [];
-    foreach ($raw as $i => $row) {
-        if (!is_array($row)) continue;
-        $url = trim((string)($row['url'] ?? ''));
-        if ($url === '') continue;
-        $type = trim((string)($row['type']  ?? 'other'));
-        /* Unknown types collapse to 'other' rather than 500ing —
-           keeps a forward-compatible UI where a future picker
-           category gets dropped to a sane bucket on older servers. */
-        if (!in_array($type, $LINK_TYPE_KEYS, true)) { $type = 'other'; }
-        $out[] = [
-            'type'       => $type,
-            'url'        => $url,
-            'label'      => trim((string)($row['label'] ?? '')) ?: null,
-            'sort_order' => (int)($row['sort_order'] ?? $i),
-        ];
-    }
-    return $out;
-};
-$normaliseIpi = static function (mixed $raw): array {
-    if (!is_array($raw)) return [];
-    $out = [];
-    foreach ($raw as $row) {
-        if (!is_array($row)) continue;
-        $num = trim((string)($row['number'] ?? ''));
-        if ($num === '') continue;
-        $out[] = [
-            'number'    => $num,
-            'name_used' => trim((string)($row['name_used'] ?? '')) ?: null,
-            'notes'     => trim((string)($row['notes']     ?? '')) ?: null,
-        ];
-    }
-    return $out;
-};
 
 /* ----------------------------------------------------------------------
  * GET endpoint — view_songs JSON

--- a/appWeb/public_html/manage/schema-audit.php
+++ b/appWeb/public_html/manage/schema-audit.php
@@ -32,300 +32,48 @@ declare(strict_types=1);
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
+/* Schema-audit parser / scanner / comparer extracted to a shared
+   include (#719 PR 2d) so the new admin_schema_audit and
+   admin_migrations_status API endpoints can call them. The
+   _schemaAudit_* wrappers below keep this file's existing call
+   sites working unchanged. */
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'schema_audit.php';
 
 requireGlobalAdmin();
 $currentUser = getCurrentUser();
 $activePage  = 'schema-audit';
 
 /* =========================================================================
- * AUDIT HELPERS
+ * AUDIT HELPERS — thin wrappers around the shared include.
  *
- * Self-contained inside this file for v1; if v2 grows run-buttons or
- * other admin pages need the same parsers, extract to includes/.
+ * Implementations live in /includes/schema_audit.php (#719 PR 2d).
+ * Wrappers kept under the original `_schemaAudit_*` names so existing
+ * call sites further down this file keep working unchanged.
  * ========================================================================= */
 
-/**
- * Parse `schema.sql` into a `[tableName => [columnName, ...]]` map.
- *
- * Doesn't try to be a full SQL parser — leans on the file's consistent
- * shape: every table is `CREATE TABLE IF NOT EXISTS tblX (` … `) ENGINE=…;`
- * with one column or constraint per line. Column lines start with the
- * column identifier; table-level constraint lines start with one of
- * PRIMARY KEY / INDEX / UNIQUE / KEY / FOREIGN / CONSTRAINT.
- */
 function _schemaAudit_parseSchema(string $schemaSql): array
 {
-    $tables = [];
-
-    /* `s` flag so `.` matches newlines inside the parenthesised body. */
-    $matched = preg_match_all(
-        '/CREATE\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?\s+(tbl\w+)\s*\((.*?)\)\s*ENGINE\s*=/is',
-        $schemaSql,
-        $matches,
-        PREG_SET_ORDER
-    );
-    if ($matched === false || $matched === 0) {
-        return $tables;
-    }
-
-    foreach ($matches as $m) {
-        $tableName = $m[1];
-        $body      = $m[2];
-
-        /* Strip multi-line block comments first — otherwise lines inside
-           a /* … *\/ block (which themselves don't start with /* on the
-           current line) get read as phantom column declarations. The
-           previous parser flagged "fill" + "catalogue" as uncovered
-           columns because they appeared at the start of body-comment
-           lines on tblSongbooks. (#722 parser fix) */
-        $body = preg_replace('/\/\*.*?\*\//s', '', $body);
-
-        /* Split into top-level segments at commas, ignoring commas
-           inside parentheses (so ENUM('success','failure','error') stays
-           in one segment, not three). Each segment is exactly one column
-           declaration OR one table-level constraint — irrespective of
-           how many lines it spans. The previous newline-based split read
-           the SECOND line of multi-line column declarations as a
-           phantom column (e.g. the "COMMENT '...'" continuation of
-           tblActivityLog.Result was flagged as a column called COMMENT). */
-        $segments = [];
-        $depth = 0;
-        $buf   = '';
-        for ($i = 0, $n = strlen($body); $i < $n; $i++) {
-            $ch = $body[$i];
-            if ($ch === "'" ) {
-                /* Skip over string literal — quotes can wrap commas. */
-                $buf .= $ch;
-                $i++;
-                while ($i < $n) {
-                    $buf .= $body[$i];
-                    if ($body[$i] === "'" && (($i + 1) >= $n || $body[$i + 1] !== "'")) break;
-                    $i++;
-                }
-                continue;
-            }
-            if ($ch === '(') $depth++;
-            if ($ch === ')') $depth--;
-            if ($ch === ',' && $depth === 0) {
-                $segments[] = $buf;
-                $buf = '';
-                continue;
-            }
-            $buf .= $ch;
-        }
-        if (trim($buf) !== '') {
-            $segments[] = $buf;
-        }
-
-        $columns = [];
-        foreach ($segments as $segment) {
-            /* Strip line comments + collapse whitespace so the leading
-               keyword check sees the segment cleanly. */
-            $segment = preg_replace('/--[^\n]*/', '', $segment);
-            $segment = trim(preg_replace('/\s+/', ' ', $segment));
-            if ($segment === '') continue;
-
-            /* Skip table-level constraints (PRIMARY KEY / INDEX / etc.). */
-            if (preg_match(
-                '/^(PRIMARY\s+KEY|INDEX|UNIQUE|KEY|CONSTRAINT|FOREIGN\s+KEY|FULLTEXT|SPATIAL)\b/i',
-                $segment
-            )) {
-                continue;
-            }
-            /* Column declaration: starts with Name (optionally backtick-quoted)
-               followed by a type. */
-            if (preg_match('/^`?([A-Za-z_][A-Za-z0-9_]*)`?\s+/', $segment, $cm)) {
-                $columns[] = $cm[1];
-            }
-        }
-
-        $tables[$tableName] = $columns;
-    }
-
-    return $tables;
+    return schemaAuditParseSchema($schemaSql);
 }
 
-/**
- * Scan every `migrate-*.php` in `appWeb/.sql/` for the columns each one
- * adds, returning `[tblName.colName => [migrationFile, …]]`.
- *
- * Three signals, merged:
- *
- *   1. Literal `ALTER TABLE tblXxx ADD COLUMN <Name>` strings — works
- *      for migrations like `migrate-songbook-meta.php` whose ALTERs
- *      are baked into a `$steps` array as full SQL strings. Multiline-
- *      aware so newline-broken ALTERs are still caught.
- *
- *   2. `CREATE TABLE [IF NOT EXISTS] tblXxx (…)` blocks — picks up
- *      migrations that introduce a brand-new table (e.g.
- *      `migrate-account-sync.php` Step 2 creates `tblSharedSetlists`).
- *      Every column inside the parens gets attributed to the migration.
- *
- *   3. Docblock convention: `@migration-adds tblXxx.colName` — for
- *      migrations like `migrate-account-sync.php` Step 1b that build
- *      their ALTER strings dynamically from a `[name, definition]`
- *      data structure (where the column name is a PHP variable
- *      interpolation and a literal regex can't see it). Each
- *      `@migration-adds` line declares one column the migration is
- *      responsible for. One line per column; multiple per file allowed.
- */
 function _schemaAudit_scanMigrations(string $sqlDir): array
 {
-    $coverage = [];
-    $files = glob($sqlDir . DIRECTORY_SEPARATOR . 'migrate-*.php') ?: [];
-
-    foreach ($files as $file) {
-        $contents = @file_get_contents($file);
-        if ($contents === false) {
-            continue;
-        }
-        $base = basename($file);
-
-        /* Signal 1 — literal ALTER … ADD COLUMN strings */
-        if (preg_match_all(
-            '/ALTER\s+TABLE\s+(tbl\w+)\s+ADD\s+COLUMN\s+`?([A-Za-z_][A-Za-z0-9_]*)`?/is',
-            $contents,
-            $matches,
-            PREG_SET_ORDER
-        )) {
-            foreach ($matches as $m) {
-                $coverage[$m[1] . '.' . $m[2]][] = $base;
-            }
-        }
-
-        /* Signal 2 — CREATE TABLE blocks inside the migration. Reuses
-           the same parser the schema-audit page applies to schema.sql,
-           since the column-line shape is identical. */
-        $createTableCols = _schemaAudit_parseSchema($contents);
-        foreach ($createTableCols as $tbl => $cols) {
-            foreach ($cols as $col) {
-                $coverage[$tbl . '.' . $col][] = $base;
-            }
-        }
-
-        /* Signal 3 — @migration-adds doctag */
-        if (preg_match_all(
-            '/@migration-adds\s+(tbl\w+)\.([A-Za-z_][A-Za-z0-9_]*)/i',
-            $contents,
-            $matches,
-            PREG_SET_ORDER
-        )) {
-            foreach ($matches as $m) {
-                $coverage[$m[1] . '.' . $m[2]][] = $base;
-            }
-        }
-    }
-
-    /* De-dupe filenames per column (a migration may carry the doctag
-       AND a literal ALTER for the same column — only credit it once). */
-    foreach ($coverage as $k => $files) {
-        $coverage[$k] = array_values(array_unique($files));
-    }
-
-    return $coverage;
+    return schemaAuditScanMigrations($sqlDir);
 }
 
-/**
- * Read every `tblXxx` column the live database currently has.
- * One INFORMATION_SCHEMA roundtrip; cheap.
- *
- * @return array<string, string[]> tableName => [columnName, …]
- */
 function _schemaAudit_readDb(\mysqli $db): array
 {
-    $sql = "SELECT TABLE_NAME, COLUMN_NAME
-              FROM INFORMATION_SCHEMA.COLUMNS
-             WHERE TABLE_SCHEMA = DATABASE()
-               AND TABLE_NAME LIKE 'tbl%'
-             ORDER BY TABLE_NAME, ORDINAL_POSITION";
-    $tables = [];
-    $stmt = $db->prepare($sql);
-    $stmt->execute();
-    foreach ($stmt->get_result()->fetch_all(MYSQLI_ASSOC) as $row) {
-        $tables[$row['TABLE_NAME']][] = $row['COLUMN_NAME'];
-    }
-    $stmt->close();
-    return $tables;
+    return schemaAuditReadDb($db);
 }
 
-/**
- * Compare the three sources and return per-table rows + a summary count
- * of each status across the whole database.
- *
- * @return array{
- *   byTable: array<string, array<int, array{col:string,status:string,migration:?string}>>,
- *   summary: array{ok:int,missing:int,uncovered:int,orphan:int}
- * }
- */
 function _schemaAudit_compare(array $schemaCols, array $dbCols, array $migrations): array
 {
-    $byTable = [];
-    $summary = ['ok' => 0, 'missing' => 0, 'uncovered' => 0, 'orphan' => 0];
-
-    /* Tables declared in schema.sql */
-    foreach ($schemaCols as $tbl => $cols) {
-        $rows       = [];
-        $dbColsHere = $dbCols[$tbl] ?? [];
-
-        foreach ($cols as $col) {
-            $key = $tbl . '.' . $col;
-            $inDb  = in_array($col, $dbColsHere, true);
-            $inMig = isset($migrations[$key]);
-
-            if ($inDb) {
-                $rows[] = ['col' => $col, 'status' => 'ok', 'migration' => null];
-                $summary['ok']++;
-            } elseif ($inMig) {
-                $rows[] = ['col' => $col, 'status' => 'missing', 'migration' => implode(', ', $migrations[$key])];
-                $summary['missing']++;
-            } else {
-                $rows[] = ['col' => $col, 'status' => 'uncovered', 'migration' => null];
-                $summary['uncovered']++;
-            }
-        }
-
-        /* Orphans = columns in DB but not in schema for this table */
-        foreach ($dbColsHere as $dbCol) {
-            if (!in_array($dbCol, $cols, true)) {
-                $rows[] = ['col' => $dbCol, 'status' => 'orphan', 'migration' => null];
-                $summary['orphan']++;
-            }
-        }
-
-        $byTable[$tbl] = $rows;
-    }
-
-    /* Tables in DB but not in schema.sql at all — every column is an orphan. */
-    foreach ($dbCols as $tbl => $cols) {
-        if (isset($schemaCols[$tbl])) {
-            continue;
-        }
-        $rows = [];
-        foreach ($cols as $col) {
-            $rows[] = ['col' => $col, 'status' => 'orphan', 'migration' => null];
-            $summary['orphan']++;
-        }
-        $byTable[$tbl] = $rows;
-    }
-
-    /* Stable sort: tables with any non-OK rows first, then alphabetically. */
-    uksort($byTable, function (string $a, string $b) use ($byTable) {
-        $aDirty = _schemaAudit_tableHasIssues($byTable[$a]) ? 0 : 1;
-        $bDirty = _schemaAudit_tableHasIssues($byTable[$b]) ? 0 : 1;
-        return $aDirty <=> $bDirty ?: strcmp($a, $b);
-    });
-
-    return ['byTable' => $byTable, 'summary' => $summary];
+    return schemaAuditCompare($schemaCols, $dbCols, $migrations);
 }
 
 function _schemaAudit_tableHasIssues(array $rows): bool
 {
-    foreach ($rows as $r) {
-        if ($r['status'] !== 'ok') {
-            return true;
-        }
-    }
-    return false;
+    return schemaAuditTableHasIssues($rows);
 }
 
 function _schemaAudit_statusBadge(string $status): string


### PR DESCRIPTION
## Summary

PR 2d of the multi-PR sequence laid out in the API parity audit (#727 / refs #719). **Closes the audit's gap list** — every admin write verb the web admin offers now has a public-API counterpart, plus the three operational read-side diagnostics flagged for tooling clients (CI, monitoring, dashboards).

9 new endpoints, full OpenAPI documentation:

### Credit People (5) — admin/global_admin only

| Endpoint | Behaviour |
|---|---|
| `admin_credit_person_add` | transactional add with optional links + IPI sub-rows. **409** on duplicate name. YYYY-MM-DD date validation. |
| `admin_credit_person_update` | metadata + child-row replace. Name field is **immutable** here — directs callers to the rename endpoint for a cross-table cascade. |
| `admin_credit_person_rename` | cascades the new name across all 5 song-credit tables (Writers/Composers/Arrangers/Adaptors/Translators) AND the registry row in **one transaction**. **409** on collision (caller should use merge). Returns per-table affected counts. |
| `admin_credit_person_merge` | re-points song credits source → target across 5 tables, migrates chosen `keep_link_ids[]` / `keep_ipi_ids[]` from source → target, deletes source registry row (FK cascade drops the rest). Returns kept/dropped counts. |
| `admin_credit_person_delete` | refuses with **422** + `usage_count` if song credits still cite the name. `force=true` overrides — credits stay, only the registry row goes (the audit-validated "drop a seed entry that was never adopted" use case). |

### Analytics (1) — admin/global_admin only

| Endpoint | Behaviour |
|---|---|
| `admin_analytics_searches` | top + zero-result query lists from `tblSearchQueries`. `range` (7/30/90 days) + `limit` query params. **503** when the table doesn't exist on this deploy (pre-#404). |

### Diagnostics (3 — read-only, admin/global_admin only)

| Endpoint | Behaviour |
|---|---|
| `admin_data_health` | table-row counts + songs.json fallback flag + share-dir file count vs DB import deltas + legacy SQLite presence. Mirrors `/manage/data-health`. **503** when the database itself is unreachable. |
| `admin_schema_audit` | schema.sql vs live DB drift report. Per-column status enum: `ok` / `missing` / `uncovered` / `orphan`. Mirrors `/manage/schema-audit`. |
| `admin_migrations_status` | derives `applied|partial|pending` per migrate-*.php by walking three signals (literal ALTER ADD COLUMN, CREATE TABLE blocks, `@migration-adds` doctags) and matching against `INFORMATION_SCHEMA.COLUMNS`. No central registry — state derived from the schema itself. |

## Architectural notes

- **Two new shared includes** — `includes/credit_people_helpers.php` (link-type catalogue + sub-form normalisers + flag-columns probe) and `includes/schema_audit.php` (parser + migration scanner + comparer). Both /manage pages now call thin wrappers around the shared functions; the API endpoints call them directly. A future tweak (e.g. a new link-type provider, a new audit signal) lands on every surface in one go.

- **The five song-credit tables** (Writers/Composers/Arrangers/Adaptors/Translators) are walked identically in `admin_credit_person_rename` and `admin_credit_person_merge` — same iteration order as the web admin. Returns per-table affected counts so callers can render an honest "renamed N rows across 5 tables" toast.

- **Merge ordering matters** — the source's song credits are re-pointed BEFORE the source registry row is dropped, so the FK ON DELETE CASCADE doesn't sweep rows we wanted to migrate. Same pattern as the web admin.

- **`admin_migrations_status` derives state without a registry** — every migrate-*.php script is already idempotent (each checks INFORMATION_SCHEMA before running), so the API can reverse-engineer "which migrations have actually applied" by checking whether each declared (table, column) pair exists in the live DB. This works because the migration scanner walks all three signals — literal ALTER ADD COLUMN, CREATE TABLE blocks, and `@migration-adds` doctags — that the schema-audit page already trusts.

- **OpenAPI** — bumped 0.53.0 → 0.54.0. Three new tags. Seven new schema components covering the input + diagnostic-response shapes.

## What's NOT in this PR

PR 2 (a-d) is now **complete**. The audit's remaining work:

- PR 3 — OpenAPI tail / final schema audit
- PR 4 — In-app docs (`/help` + `/manage/help`) refresh
- PR 5 — GitHub Wiki refresh

## Commits on this branch

- `95bc19c` refactor: extract credit-people + schema-audit helpers
- `7f1a4b8` feat(api): credit-people CRUD + analytics + diagnostics
- `4365b83` docs(openapi): document credit-people / analytics / diagnostics

## Test plan

- [ ] **Local lint** — `php -l` clean on `api.php`, both new includes, and both refactored /manage pages. ✅ verified.
- [ ] **OpenAPI** — YAML parses; 9 new paths present; 7 new schema components present; operationIds unique (151 → 161). ✅ verified.
- [ ] **Web admin smoke** — `/manage/credit-people` and `/manage/schema-audit` still load + work end-to-end (closures + thin wrappers preserved).
- [ ] **Credit-people API smoke** — curl all 5 endpoints; verify the transaction rollback path on a deliberately broken request, the 409 on dup name, the 422 on in-use delete, the cascade-during-rename row counts.
- [ ] **Merge** — pick two test registry entries, post `admin_credit_person_merge` with selective `keep_link_ids`, verify the source's links/IPI rows that weren't kept are dropped via the cascade.
- [ ] **Analytics** — `GET admin_analytics_searches?range=7&limit=20` returns top + zero arrays. Verify the **503** when `tblSearchQueries` is dropped.
- [ ] **Data health** — `GET admin_data_health` returns the same table counts the page shows. Confirm `share_dir.unimported_count` matches the page's "X share JSON files not yet imported" line.
- [ ] **Schema audit** — `GET admin_schema_audit` returns the same `summary` numbers the page banner shows.
- [ ] **Migrations status** — `GET admin_migrations_status` shows the per-file status. Run an unapplied migration via /manage/setup-database and confirm the status flips from `pending` → `applied` on the next call.

## Migrations

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)