### PR TITLE
feat(filter): language filter v2 — multi-select, per-song, settings UI, account sync (closes #734 #735 #736)

### DIFF
--- a/appWeb/.sql/migrate-backfill-legacy-songbook-languages.php
+++ b/appWeb/.sql/migrate-backfill-legacy-songbook-languages.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Backfill Language='en' on the 5 legacy English songbooks (#735)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * The original 5 songbooks (CP, JP, MP, SDAH, CH) were created
+ * before #673 added the Language column and currently carry
+ * Language = NULL. With the multilingual scrapes from #699 about
+ * to land (HA, NHA, HASD, HL, IA, plus 5 Slavic sites), it's time
+ * to retro-tag the legacy 5 with their actual primary language.
+ *
+ * Each of the 5 is English, so this migration sets:
+ *   tblSongbooks.Language = 'en'
+ *   WHERE Abbreviation IN ('CP','JP','MP','SDAH','CH')
+ *     AND (Language IS NULL OR Language = '')
+ *
+ * Why the second clause: a curator may have already set a more
+ * specific tag like 'en-GB' or 'en-US' on one of these. The
+ * migration MUST NOT overwrite that — re-running on a partly-
+ * tagged catalogue should be a no-op for the rows already done.
+ *
+ * Required by:
+ *   - #734 — language filter visibility scan
+ *   - #736 — language filter v2 (multi-select / per-song / settings)
+ *
+ * The filter renders only when ≥2 distinct primary subtags exist
+ * across songbooks UNION songs. Without this backfill, importing
+ * one Spanish hymnal yields {es} = 1 distinct subtag = filter
+ * suppressed. After this backfill, importing any non-English
+ * songbook yields {en, es, …} ≥ 2 = filter renders automatically.
+ *
+ * Idempotent — re-running is safe; the SET-WHERE-NULL guard means
+ * already-tagged rows are unaffected.
+ *
+ * USAGE:
+ *   CLI: php appWeb/.sql/migrate-backfill-legacy-songbook-languages.php
+ *   Web: /manage/setup-database → "Backfill Legacy Songbook Languages"
+ *        (entry point requires global_admin)
+ */
+
+if (PHP_SAPI === 'cli') {
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = true;
+} else {
+    if (!defined('IHYMNS_SETUP_DASHBOARD')) {
+        if (!function_exists('isAuthenticated')) {
+            require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+        }
+        if (!isAuthenticated()) {
+            http_response_code(401);
+            exit('Authentication required.');
+        }
+        $u = getCurrentUser();
+        if (!$u || $u['role'] !== 'global_admin') {
+            http_response_code(403);
+            exit('Global admin required.');
+        }
+    }
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = false;
+}
+
+function _migBackfillLang_out(string $line): void
+{
+    global $isCli;
+    echo $line . ($isCli ? "\n" : "<br>\n");
+    if ($isCli) {
+        flush();
+    }
+}
+
+function _migBackfillLang_tableExists(mysqli $db, string $table): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? LIMIT 1'
+    );
+    $stmt->bind_param('s', $table);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+function _migBackfillLang_columnExists(mysqli $db, string $table, string $column): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+          WHERE TABLE_SCHEMA = DATABASE()
+            AND TABLE_NAME   = ?
+            AND COLUMN_NAME  = ?
+          LIMIT 1'
+    );
+    $stmt->bind_param('ss', $table, $column);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+_migBackfillLang_out('Legacy songbook Language backfill starting…');
+
+$db = getDbMysqli();
+if (!$db) {
+    _migBackfillLang_out('ERROR: could not connect to database.');
+    exit(1);
+}
+
+/* Pre-flight: tblSongbooks AND its Language column must exist.
+   If Language doesn't exist, the songbook-language-column migration
+   (#673) hasn't been run yet — direct the operator to run it first
+   rather than auto-chaining. Keeps each migration one-liner-clear. */
+if (!_migBackfillLang_tableExists($db, 'tblSongbooks')) {
+    _migBackfillLang_out('ERROR: tblSongbooks not found. Run install.php first.');
+    exit(1);
+}
+if (!_migBackfillLang_columnExists($db, 'tblSongbooks', 'Language')) {
+    _migBackfillLang_out(
+        'ERROR: tblSongbooks.Language column missing. ' .
+        'Run migrate-songbook-language.php (#673) first, then re-run this.'
+    );
+    exit(1);
+}
+
+/* The 5 legacy songbooks. Hard-coded by Abbreviation because they
+   are the historical baseline we know are English. Any newer
+   songbook should be tagged at create time via the editor's
+   Language picker (#681). */
+$LEGACY_ABBRS = ['CP', 'JP', 'MP', 'SDAH', 'CH'];
+
+/* First report what's there so the operator sees the before-state. */
+$placeholders = implode(',', array_fill(0, count($LEGACY_ABBRS), '?'));
+$types        = str_repeat('s', count($LEGACY_ABBRS));
+
+$stmt = $db->prepare(
+    "SELECT Abbreviation, Language
+       FROM tblSongbooks
+      WHERE Abbreviation IN ($placeholders)
+      ORDER BY Abbreviation"
+);
+$stmt->bind_param($types, ...$LEGACY_ABBRS);
+$stmt->execute();
+$rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+$stmt->close();
+
+if (!$rows) {
+    _migBackfillLang_out(
+        '[skip] None of CP/JP/MP/SDAH/CH found in tblSongbooks. ' .
+        'Either this is a fresh install with no legacy data, or the ' .
+        'Abbreviation values have been renamed since #673.'
+    );
+    _migBackfillLang_out('Legacy songbook Language backfill finished.');
+    exit(0);
+}
+
+_migBackfillLang_out('Before:');
+foreach ($rows as $r) {
+    $label = $r['Language'] === null ? '(NULL)' : "'" . $r['Language'] . "'";
+    _migBackfillLang_out("  {$r['Abbreviation']}  Language=$label");
+}
+
+/* Targeted UPDATE — only rows still NULL or empty get retagged.
+   Already-set values (e.g. 'en-GB' set by a curator) are preserved. */
+$stmt = $db->prepare(
+    "UPDATE tblSongbooks
+        SET Language = 'en'
+      WHERE Abbreviation IN ($placeholders)
+        AND (Language IS NULL OR Language = '')"
+);
+$stmt->bind_param($types, ...$LEGACY_ABBRS);
+$stmt->execute();
+$updated = $stmt->affected_rows;
+$stmt->close();
+
+if ($updated === 0) {
+    _migBackfillLang_out("[skip] All 5 legacy songbooks already have a Language set. Nothing to backfill.");
+} else {
+    _migBackfillLang_out("[ok  ] Set Language='en' on {$updated} legacy songbook(s).");
+}
+
+/* Show the after-state so the operator can verify. */
+$stmt = $db->prepare(
+    "SELECT Abbreviation, Language
+       FROM tblSongbooks
+      WHERE Abbreviation IN ($placeholders)
+      ORDER BY Abbreviation"
+);
+$stmt->bind_param($types, ...$LEGACY_ABBRS);
+$stmt->execute();
+$rowsAfter = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+$stmt->close();
+_migBackfillLang_out('After:');
+foreach ($rowsAfter as $r) {
+    $label = $r['Language'] === null ? '(NULL)' : "'" . $r['Language'] . "'";
+    _migBackfillLang_out("  {$r['Abbreviation']}  Language=$label");
+}
+
+_migBackfillLang_out('Legacy songbook Language backfill finished.');

--- a/appWeb/.sql/migrate-user-preferred-languages.php
+++ b/appWeb/.sql/migrate-user-preferred-languages.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — User preferred-languages column migration (#736)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Adds an optional PreferredLanguagesJson TEXT NULL column to
+ * tblUsers so a signed-in user can save their language-filter
+ * choice to their account and have it sync across devices via the
+ * existing user_preferences flow.
+ *
+ * Column shape: a JSON array of IETF BCP 47 PRIMARY subtags
+ * (lowercase 2–3 letters). e.g.:
+ *   ["en"]              — show only English-tagged + untagged content
+ *   ["en", "es"]        — show English + Spanish + untagged
+ *   ["en", "es", "pt"]  — show English + Spanish + Portuguese + untagged
+ *   NULL or "[]"        — no filter; show every language
+ *
+ * Why JSON-array: the old user_preferences key/value table could
+ * have stored the same data as a comma-list, but a typed JSON
+ * array is more explicit AND we can extend it later (e.g. add
+ * { "show_only": [...], "hide": [...] }) without a column rename.
+ *
+ * Why "primary subtag only": per spec the filter operates on the
+ * first component of the BCP 47 tag (`en` matches `en`, `en-GB`,
+ * `en-US`). Storing only primary subtags here keeps the saved
+ * data canonical and the comparison cheap.
+ *
+ * @migration-adds tblUsers.PreferredLanguagesJson
+ *
+ * Idempotent — re-running is safe.
+ *
+ * USAGE:
+ *   CLI: php appWeb/.sql/migrate-user-preferred-languages.php
+ *   Web: /manage/setup-database → "User Preferred Languages Migration"
+ *        (entry point requires global_admin)
+ */
+
+if (PHP_SAPI === 'cli') {
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = true;
+} else {
+    if (!defined('IHYMNS_SETUP_DASHBOARD')) {
+        if (!function_exists('isAuthenticated')) {
+            require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+        }
+        if (!isAuthenticated()) {
+            http_response_code(401);
+            exit('Authentication required.');
+        }
+        $u = getCurrentUser();
+        if (!$u || $u['role'] !== 'global_admin') {
+            http_response_code(403);
+            exit('Global admin required.');
+        }
+    }
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = false;
+}
+
+function _migUserPrefLang_out(string $line): void
+{
+    global $isCli;
+    echo $line . ($isCli ? "\n" : "<br>\n");
+    if ($isCli) {
+        flush();
+    }
+}
+
+function _migUserPrefLang_columnExists(mysqli $db, string $table, string $column): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+          WHERE TABLE_SCHEMA = DATABASE()
+            AND TABLE_NAME   = ?
+            AND COLUMN_NAME  = ?
+          LIMIT 1'
+    );
+    $stmt->bind_param('ss', $table, $column);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+function _migUserPrefLang_tableExists(mysqli $db, string $table): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? LIMIT 1'
+    );
+    $stmt->bind_param('s', $table);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+_migUserPrefLang_out('User PreferredLanguagesJson column migration starting…');
+
+$db = getDbMysqli();
+if (!$db) {
+    _migUserPrefLang_out('ERROR: could not connect to database.');
+    exit(1);
+}
+
+if (!_migUserPrefLang_tableExists($db, 'tblUsers')) {
+    _migUserPrefLang_out('ERROR: tblUsers not found. Run install.php first.');
+    exit(1);
+}
+
+if (_migUserPrefLang_columnExists($db, 'tblUsers', 'PreferredLanguagesJson')) {
+    _migUserPrefLang_out('[skip] tblUsers.PreferredLanguagesJson already present.');
+} else {
+    $sql = "ALTER TABLE tblUsers
+            ADD COLUMN PreferredLanguagesJson TEXT NULL DEFAULT NULL
+            COMMENT 'JSON array of IETF BCP 47 primary subtags the user wants to see (e.g. [\"en\",\"es\"]). NULL or [] = all languages.'";
+    if (!$db->query($sql)) {
+        _migUserPrefLang_out('ERROR: adding PreferredLanguagesJson failed: ' . $db->error);
+        exit(1);
+    }
+    _migUserPrefLang_out('[add ] tblUsers.PreferredLanguagesJson.');
+}
+
+_migUserPrefLang_out('User PreferredLanguagesJson column migration finished.');

--- a/appWeb/public_html/api-docs.yaml
+++ b/appWeb/public_html/api-docs.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 
 info:
   title: iHymns API
-  version: "0.55.0"
+  version: "0.56.0"
   description: |
     The iHymns API provides programmatic access to the iHymns hymn and song
     database. It powers the iHymns Progressive Web App (PWA), enabling song
@@ -3431,6 +3431,110 @@ paths:
                   preferences:
                     type: object
                     additionalProperties: { type: string }
+
+  # ===========================================================================
+  # USER PREFERRED LANGUAGES  (#736)
+  #
+  # Per-account persistence of the language-filter selection so a
+  # signed-in user's choice syncs across devices. Anonymous users
+  # keep using localStorage on the SPA side (the SPA also passes the
+  # choice via `X-Preferred-Languages` on every fetch so the server
+  # filter applies to anonymous requests too).
+  # ===========================================================================
+
+  /api.php?action=user_preferred_languages:
+    get:
+      operationId: getUserPreferredLanguages
+      tags: [Preferences]
+      summary: Get the authenticated user's saved language-filter subtag list
+      description: |
+        Returns the user's saved primary language subtags, or `[]` if
+        no filter has been set. On a pre-#736 deployment (the
+        `tblUsers.PreferredLanguagesJson` column is absent), the
+        response includes `migration_needed: true` and an empty list
+        so the client can render the picker without a filter applied.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [user_preferred_languages] }
+      responses:
+        "200":
+          description: Saved subtag list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  subtags:
+                    type: array
+                    items:
+                      type: string
+                      pattern: '^[a-z]{2,3}$'
+                    example: ["en", "es"]
+                  migration_needed:
+                    type: boolean
+                    description: Present and true on pre-#736 deployments only.
+        "401":
+          description: Not authenticated
+
+  /api.php?action=user_preferred_languages_save:
+    post:
+      operationId: saveUserPreferredLanguages
+      tags: [Preferences]
+      summary: Save the authenticated user's language-filter subtag list
+      description: |
+        Server-side normalisation: invalid subtags are dropped, the
+        list is lowercased, primary-subtag-only, deduplicated, and
+        sorted (`parsePreferredLanguageSubtags` in
+        `includes/language_filter.php`). An empty array clears the
+        filter — the column is set to `NULL` to distinguish "no
+        filter set" from "filter set to empty set" (which would
+        mean "show nothing").
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema: { type: string, enum: [user_preferred_languages_save] }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [subtags]
+              properties:
+                subtags:
+                  type: array
+                  items:
+                    type: string
+                    description: Any BCP 47 tag — only the primary subtag is kept after normalisation.
+                  example: ["en", "es-MX", "pt-BR"]
+      responses:
+        "200":
+          description: Saved (canonical normalised list returned)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:      { type: boolean, example: true }
+                  subtags:
+                    type: array
+                    items: { type: string }
+                    example: ["en", "es", "pt"]
+        "400":
+          description: subtags must be an array
+        "401":
+          description: Not authenticated
+        "503":
+          description: |
+            Migration not yet applied on this deployment — response
+            includes `migration_needed: true`.
 
   # ===========================================================================
   # SETLISTS — SCHEDULING (#398)

--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -70,6 +70,12 @@ require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 
    scanner + comparer used by admin_schema_audit and
    admin_migrations_status read endpoints. */
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'schema_audit.php';
+/* Language filter helper (#736). Resolves the active preferred-
+   language subtag list for the current request (via ?lang= query
+   param, X-Preferred-Languages header, or tblUsers.PreferredLanguagesJson)
+   and provides applyLanguageFilterSql() / makeLanguageFilterPredicate()
+   helpers for endpoints to filter song / songbook results. */
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'language_filter.php';
 
 /* =========================================================================
  * CSRF DEFENCE POLICY (#293 / B15)
@@ -322,6 +328,15 @@ if ($action !== null) {
 
             $results = $songData->searchSongs($query, $bookId, $limit);
 
+            /* Language filter (#736). Apply the active preferred-subtag
+               set in-memory so search results respect the user's
+               saved preference / current dropdown selection. Untagged
+               songs always pass. */
+            $_langPred = makeLanguageFilterPredicate(
+                resolvePreferredLanguagesForRequest(getAuthenticatedUser())
+            );
+            $results = array_values(array_filter($results, $_langPred));
+
             /* Fire-and-forget search-query logging (#404). Silently no-ops
                if the table is missing (fresh installs before the schema
                ALTER has been applied). */
@@ -409,14 +424,18 @@ if ($action !== null) {
             break;
 
         /* -----------------------------------------------------------------
-         * Get all songbooks
+         * Get all songbooks (filtered by user's preferred languages, #736)
          * ----------------------------------------------------------------- */
         case 'songbooks':
-            sendJson(['songbooks' => $songData->getSongbooks()]);
+            $_books = $songData->getSongbooks();
+            $_langPred = makeLanguageFilterPredicate(
+                resolvePreferredLanguagesForRequest(getAuthenticatedUser())
+            );
+            sendJson(['songbooks' => array_values(array_filter($_books, $_langPred))]);
             break;
 
         /* -----------------------------------------------------------------
-         * Get songs list (with optional songbook filter)
+         * Get songs list (with optional songbook filter, language filter #736)
          * Parameters: songbook (optional)
          * ----------------------------------------------------------------- */
         case 'songs':
@@ -426,6 +445,10 @@ if ($action !== null) {
             }
 
             $songs = $songData->getSongs($bookId);
+            $_langPred = makeLanguageFilterPredicate(
+                resolvePreferredLanguagesForRequest(getAuthenticatedUser())
+            );
+            $songs = array_values(array_filter($songs, $_langPred));
             sendJson([
                 'songs' => array_map('songToSummary', $songs),
                 'total' => count($songs),
@@ -3612,17 +3635,25 @@ if ($action !== null) {
                    title + songbook metadata the home-page renderer needs.
                    Songs that have been deleted since they were viewed
                    drop out of the list naturally (#546). */
+                /* Language filter (#736). s.Language pulled into the
+                   SELECT so the in-memory predicate can read it
+                   without a second round-trip. The filter is
+                   applied AFTER the LIMIT here, so the visible
+                   set may be < limit when the catalogue spans
+                   languages the user has filtered out — that's an
+                   acceptable trade-off for a "popular" list. */
                 $stmt = $db->prepare(
                     'SELECT h.SongId        AS songId,
                             s.Title         AS title,
                             s.Number        AS number,
                             s.SongbookAbbr  AS songbook,
                             s.SongbookName  AS songbookName,
+                            s.Language      AS language,
                             COUNT(*)        AS views
                      FROM tblSongHistory h
                      JOIN tblSongs s ON s.SongId = h.SongId
                      WHERE h.ViewedAt > DATE_SUB(NOW(), INTERVAL ? DAY)
-                     GROUP BY h.SongId, s.Title, s.Number, s.SongbookAbbr, s.SongbookName
+                     GROUP BY h.SongId, s.Title, s.Number, s.SongbookAbbr, s.SongbookName, s.Language
                      ORDER BY views DESC
                      LIMIT ?'
                 );
@@ -3635,6 +3666,11 @@ if ($action !== null) {
                     $ps['views'] = (int)$ps['views'];
                 }
                 unset($ps);
+
+                $_langPred = makeLanguageFilterPredicate(
+                    resolvePreferredLanguagesForRequest(getAuthenticatedUser())
+                );
+                $songs = array_values(array_filter($songs, $_langPred));
 
                 sendJson(['songs' => $songs, 'period' => $period]);
             } catch (\Throwable $e) {
@@ -3678,11 +3714,12 @@ if ($action !== null) {
                             s.Number        AS number,
                             s.SongbookAbbr  AS songbook,
                             s.SongbookName  AS songbookName,
+                            s.Language      AS language,
                             MAX(h.ViewedAt) AS viewedAt
                      FROM tblSongHistory h
                      JOIN tblSongs s ON s.SongId = h.SongId
                      WHERE h.UserId = ?
-                     GROUP BY h.SongId, s.Title, s.Number, s.SongbookAbbr, s.SongbookName
+                     GROUP BY h.SongId, s.Title, s.Number, s.SongbookAbbr, s.SongbookName, s.Language
                      ORDER BY MAX(h.ViewedAt) DESC
                      LIMIT 50'
                 );
@@ -3691,6 +3728,12 @@ if ($action !== null) {
                 $stmt->execute();
                 $history = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
                 $stmt->close();
+                /* Language filter (#736) — apply in-memory after the
+                   LIMIT, same trade-off as popular_songs. */
+                $_langPred = makeLanguageFilterPredicate(
+                    resolvePreferredLanguagesForRequest($authUser)
+                );
+                $history = array_values(array_filter($history, $_langPred));
                 sendJson(['history' => $history]);
             } catch (\Throwable $e) {
                 error_log('[api/song_history] ' . $e->getMessage());
@@ -3948,6 +3991,148 @@ if ($action !== null) {
             $stmt->close();
 
             sendJson(['ok' => true]);
+            break;
+
+        /* =================================================================
+         * USER PREFERRED LANGUAGES (#736)
+         *
+         * Per-account persistence of the language-filter selection so a
+         * signed-in user's choice syncs across devices. Anonymous users
+         * keep using localStorage on the SPA side; the SPA can also pass
+         * the choice via the X-Preferred-Languages header on every fetch
+         * to get the same server-side filter as authenticated users
+         * (see resolvePreferredLanguagesForRequest() in language_filter.php).
+         * ================================================================= */
+
+        /* -----------------------------------------------------------------
+         * Get the authenticated user's saved preferred-language subtags
+         * Requires: Bearer token
+         *
+         * Response: { subtags: ["en","es"] }   (empty array = no filter)
+         * ----------------------------------------------------------------- */
+        case 'user_preferred_languages':
+            $authUser = getAuthenticatedUser();
+            if (!$authUser) {
+                sendJson(['error' => 'Not authenticated.'], 401);
+                break;
+            }
+
+            try {
+                $db = getDbMysqli();
+                /* Probe the column so a pre-#736 deployment returns
+                   an empty list rather than 500ing the request. */
+                $probe = $db->prepare(
+                    "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+                      WHERE TABLE_SCHEMA = DATABASE()
+                        AND TABLE_NAME   = 'tblUsers'
+                        AND COLUMN_NAME  = 'PreferredLanguagesJson' LIMIT 1"
+                );
+                $probe->execute();
+                $hasCol = $probe->get_result()->fetch_row() !== null;
+                $probe->close();
+                if (!$hasCol) {
+                    sendJson([
+                        'subtags'          => [],
+                        'migration_needed' => true,
+                    ]);
+                    break;
+                }
+
+                $stmt = $db->prepare(
+                    'SELECT PreferredLanguagesJson FROM tblUsers WHERE Id = ?'
+                );
+                $authUserId = (int)$authUser['Id'];
+                $stmt->bind_param('i', $authUserId);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_row();
+                $stmt->close();
+                $raw = $row[0] ?? null;
+                $subtags = [];
+                if ($raw) {
+                    $decoded = json_decode($raw, true);
+                    if (is_array($decoded)) {
+                        $subtags = parsePreferredLanguageSubtags(
+                            implode(',', array_map('strval', $decoded))
+                        );
+                    }
+                }
+                sendJson(['subtags' => $subtags]);
+            } catch (\Throwable $e) {
+                error_log('[user_preferred_languages] ' . $e->getMessage());
+                sendJson(['error' => 'Could not load preferred languages.'], 500);
+            }
+            break;
+
+        /* -----------------------------------------------------------------
+         * Save the authenticated user's preferred-language subtags
+         * POST body: { "subtags": ["en","es"] }   (empty array = no filter)
+         * Requires: Bearer token
+         *
+         * Server-side normalisation: invalid subtags are dropped, the
+         * list is lowercased, primary-subtag-only, and deduplicated
+         * (parsePreferredLanguageSubtags). Empty array clears the
+         * filter (returns the saved value as []).
+         * ----------------------------------------------------------------- */
+        case 'user_preferred_languages_save':
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser) {
+                sendJson(['error' => 'Not authenticated.'], 401);
+                break;
+            }
+
+            $body = json_decode((string)file_get_contents('php://input'), true) ?: [];
+            $rawList = $body['subtags'] ?? [];
+            if (!is_array($rawList)) {
+                sendJson(['error' => 'subtags must be an array.'], 400);
+                break;
+            }
+
+            /* Run through the canonical parser so the saved value is
+               always a clean primary-subtag list. Invalid entries
+               are dropped silently. */
+            $clean = parsePreferredLanguageSubtags(
+                implode(',', array_map('strval', $rawList))
+            );
+
+            try {
+                $db = getDbMysqli();
+                $probe = $db->prepare(
+                    "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+                      WHERE TABLE_SCHEMA = DATABASE()
+                        AND TABLE_NAME   = 'tblUsers'
+                        AND COLUMN_NAME  = 'PreferredLanguagesJson' LIMIT 1"
+                );
+                $probe->execute();
+                $hasCol = $probe->get_result()->fetch_row() !== null;
+                $probe->close();
+                if (!$hasCol) {
+                    sendJson([
+                        'error'            => 'Migration not yet applied on this deployment.',
+                        'migration_needed' => true,
+                    ], 503);
+                    break;
+                }
+
+                /* Empty array → store NULL so the column reads as
+                   "no filter set" rather than "filter set to empty
+                   set" (which would mean "show nothing"). */
+                $store = empty($clean) ? null : json_encode(array_values($clean));
+                $stmt = $db->prepare(
+                    'UPDATE tblUsers SET PreferredLanguagesJson = ?, UpdatedAt = NOW() WHERE Id = ?'
+                );
+                $authUserId = (int)$authUser['Id'];
+                $stmt->bind_param('si', $store, $authUserId);
+                $stmt->execute();
+                $stmt->close();
+                sendJson(['ok' => true, 'subtags' => $clean]);
+            } catch (\Throwable $e) {
+                error_log('[user_preferred_languages_save] ' . $e->getMessage());
+                sendJson(['error' => 'Could not save preferred languages.'], 500);
+            }
             break;
 
         /* =================================================================

--- a/appWeb/public_html/includes/language_filter.php
+++ b/appWeb/public_html/includes/language_filter.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Server-side language-filter helper (#736)
+ *
+ * Single source of truth for the "show only songbooks/songs in
+ * these primary subtags + always-show untagged" rule, applied
+ * server-side at SELECT time so:
+ *
+ *   1. Native clients (Apple, Android, FireOS) get the same
+ *      filter behaviour as the SPA without re-implementing it.
+ *   2. Excluded rows aren't shipped over the wire just to be
+ *      hidden client-side — bandwidth + page-render savings on
+ *      large catalogues.
+ *   3. Pagination counts (limit / offset / total) are correct
+ *      relative to the visible set rather than the underlying
+ *      one.
+ *
+ * The filter operates on the PRIMARY subtag (the first 2-3
+ * letters of the BCP 47 tag) so picking "en" matches `en`,
+ * `en-GB`, `en-US`. Untagged rows (Language IS NULL OR '')
+ * always pass the filter regardless of the requested set.
+ *
+ * Resolution order for an incoming request:
+ *
+ *   1. Explicit `?lang=en,es,pt` query param — highest priority,
+ *      so the SPA can override the user's saved preference per-
+ *      request (e.g. for the Search page's "show all languages"
+ *      escape hatch).
+ *   2. `X-Preferred-Languages: en,es,pt` request header — the
+ *      SPA sends this from localStorage on every fetch so
+ *      anonymous users get persistent filtering across page
+ *      navigations.
+ *   3. `tblUsers.PreferredLanguagesJson` — for an authenticated
+ *      user, fall back to the saved-on-account list.
+ *   4. Empty set — no filter applied; show every language.
+ *
+ * Direct access is blocked so this file can't be loaded as an
+ * arbitrary endpoint via an open Apache config.
+ */
+
+if (basename($_SERVER['SCRIPT_FILENAME'] ?? '') === basename(__FILE__)) {
+    http_response_code(403);
+    exit('Access denied.');
+}
+
+/**
+ * Parse a comma-separated list of language hints into a
+ * canonical set of lowercase primary subtags. Invalid tokens
+ * are silently dropped — a curator typing `en, es, garbage` gets
+ * `["en", "es"]` rather than a 400.
+ *
+ * @param string|null $rawCsv Comma-list (e.g. "en,es,pt").
+ * @return list<string> Sorted, deduplicated, lowercase primary subtags.
+ */
+function parsePreferredLanguageSubtags(?string $rawCsv): array
+{
+    if ($rawCsv === null || trim($rawCsv) === '') {
+        return [];
+    }
+    $out = [];
+    foreach (explode(',', $rawCsv) as $tok) {
+        $tok = trim($tok);
+        if ($tok === '') continue;
+        /* Take only the first component before a hyphen — `en-GB`
+           collapses to `en`, `zh-Hans-CN` collapses to `zh`. */
+        $primary = strtolower(explode('-', $tok, 2)[0]);
+        if (preg_match('/^[a-z]{2,3}$/', $primary)) {
+            $out[$primary] = true;
+        }
+    }
+    $list = array_keys($out);
+    sort($list);
+    return $list;
+}
+
+/**
+ * Resolve the active set of preferred-language subtags for the
+ * current request. Walks the four-level priority chain (see
+ * file docblock). Returns `[]` when no filter should apply.
+ *
+ * @param array|null $authUser The authenticated user array (from
+ *                             getAuthenticatedUser()), or null
+ *                             for anonymous requests.
+ * @return list<string> Subtag list to filter by, or `[]` for no filter.
+ */
+function resolvePreferredLanguagesForRequest(?array $authUser): array
+{
+    /* 1. Explicit ?lang= query param wins. Empty string means
+       "show all" — the curator has actively cleared their saved
+       preference for this request. We distinguish the two by
+       isset() rather than a falsey check on the string value. */
+    if (isset($_GET['lang'])) {
+        return parsePreferredLanguageSubtags((string)$_GET['lang']);
+    }
+
+    /* 2. X-Preferred-Languages request header — the SPA sends this
+       from localStorage on every fetch so anonymous users get
+       per-device persistence without per-request URL parameters. */
+    $hdr = $_SERVER['HTTP_X_PREFERRED_LANGUAGES'] ?? '';
+    if ($hdr !== '') {
+        return parsePreferredLanguageSubtags($hdr);
+    }
+
+    /* 3. Authenticated user's saved preference. Probe the column
+       so a pre-#736 deployment doesn't 500 on the SELECT. */
+    if ($authUser && !empty($authUser['Id'])) {
+        try {
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'db_mysql.php';
+            $db = getDbMysqli();
+            $probe = $db->prepare(
+                "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+                  WHERE TABLE_SCHEMA = DATABASE()
+                    AND TABLE_NAME   = 'tblUsers'
+                    AND COLUMN_NAME  = 'PreferredLanguagesJson' LIMIT 1"
+            );
+            $probe->execute();
+            $hasCol = $probe->get_result()->fetch_row() !== null;
+            $probe->close();
+            if ($hasCol) {
+                $stmt = $db->prepare(
+                    'SELECT PreferredLanguagesJson FROM tblUsers WHERE Id = ?'
+                );
+                $userId = (int)$authUser['Id'];
+                $stmt->bind_param('i', $userId);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_row();
+                $stmt->close();
+                $raw = $row[0] ?? null;
+                if ($raw) {
+                    $decoded = json_decode($raw, true);
+                    if (is_array($decoded)) {
+                        return parsePreferredLanguageSubtags(
+                            implode(',', array_map('strval', $decoded))
+                        );
+                    }
+                }
+            }
+        } catch (\Throwable $_e) {
+            /* Best-effort — DB read failure falls through to
+               "no filter" rather than 500ing the request. */
+        }
+    }
+
+    return [];
+}
+
+/**
+ * Build a SQL WHERE-clause fragment + bind-param pair to apply
+ * the language filter at SELECT time.
+ *
+ * The fragment looks like:
+ *   AND (
+ *       <colExpr> IS NULL OR <colExpr> = ''
+ *    OR LOWER(SUBSTRING_INDEX(<colExpr>, '-', 1)) IN (?, ?, …)
+ *   )
+ *
+ * Untagged rows (NULL / empty) always pass — matches the spec.
+ * Empty subtag list returns `[" AND 1=1", '', []]` so callers can
+ * blindly concatenate without checking emptiness.
+ *
+ * @param string       $colExpr SQL column expression (e.g. `s.Language`,
+ *                              `Language`, or a coalesce expression).
+ * @param list<string> $subtags From resolvePreferredLanguagesForRequest().
+ * @return array{0:string,1:string,2:list<string>} [whereSql, paramTypes, paramValues]
+ */
+function applyLanguageFilterSql(string $colExpr, array $subtags): array
+{
+    if (empty($subtags)) {
+        return [' AND 1=1', '', []];
+    }
+    $placeholders = implode(',', array_fill(0, count($subtags), '?'));
+    $where = " AND ("
+           .   "$colExpr IS NULL OR $colExpr = '' "
+           .   "OR LOWER(SUBSTRING_INDEX($colExpr, '-', 1)) IN ($placeholders)"
+           . ")";
+    $types = str_repeat('s', count($subtags));
+    return [$where, $types, array_values($subtags)];
+}
+
+/**
+ * Convenience: return the filter for in-memory (PHP-array) row
+ * filtering, used by code paths that don't want to push the
+ * filter into SQL (e.g. the songbooks list which is small + cached).
+ *
+ * @param list<string> $subtags From resolvePreferredLanguagesForRequest().
+ * @return callable(array): bool Predicate; true → keep the row.
+ */
+function makeLanguageFilterPredicate(array $subtags): callable
+{
+    if (empty($subtags)) {
+        return static fn(array $_row): bool => true;
+    }
+    $set = array_flip($subtags);
+    return static function (array $row) use ($set): bool {
+        $tag = (string)($row['language'] ?? $row['Language'] ?? '');
+        if ($tag === '') return true;                   // untagged → always show
+        $primary = strtolower(explode('-', $tag, 2)[0]);
+        return isset($set[$primary]);
+    };
+}

--- a/appWeb/public_html/includes/pages/help.php
+++ b/appWeb/public_html/includes/pages/help.php
@@ -185,18 +185,35 @@ declare(strict_types=1);
             <div id="help-language-filter" class="accordion-collapse collapse" data-bs-parent="#help-accordion">
                 <div class="accordion-body">
                     <p>
-                        The home-page tile grid groups songbooks by language — English, Portuguese, Mandarin,
-                        and so on (#679). The <strong>language filter</strong> at the top lets you hide languages
-                        you don't need so the grid only shows what you can use.
+                        Pick one or more languages to <strong>show</strong> across the catalogue —
+                        the rest are hidden. Untagged songbooks and untagged songs are always
+                        shown, regardless of what you've selected.
                     </p>
+                    <h3 class="h6">Where to set it</h3>
                     <ul>
-                        <li>Tap the language pill at the top of the home page.</li>
-                        <li>Tick / un-tick the languages you want to show.</li>
-                        <li>The grid updates immediately. Your choice is remembered locally per device.</li>
+                        <li><strong>Ad-hoc:</strong> the chip group at the top of the home page and <em>Songbooks</em> page.</li>
+                        <li><strong>Persistent:</strong> the <em>Language Preferences</em> section on the <a href="/settings" data-navigate="settings">Settings</a> page.</li>
                     </ul>
+                    <h3 class="h6">What it filters</h3>
+                    <ul>
+                        <li><strong>Songbook tiles</strong> on the home grid + <em>Songbooks</em> page.</li>
+                        <li><strong>Search results</strong> — songs in unselected languages don't appear.</li>
+                        <li><strong>Song lists</strong> inside a songbook detail page.</li>
+                        <li><strong>Popular songs</strong> + <strong>recently viewed</strong> blocks on the home page.</li>
+                    </ul>
+                    <h3 class="h6">Sync across devices</h3>
+                    <p>
+                        If you're <a href="/login" data-navigate="login">signed in</a>, your
+                        choice saves to your account and follows you to every device — the
+                        web app, the iOS / iPadOS / tvOS / Android / Fire OS native apps.
+                        Anonymous users get per-device persistence via local storage.
+                    </p>
                     <p class="small text-muted mb-0">
-                        Songbooks without a language tag (e.g. mixed-language collections) always show, regardless
-                        of the filter — the filter is additive, not exclusive.
+                        Matching uses the primary language subtag — picking <code>en</code>
+                        matches <code>en</code>, <code>en-GB</code>, <code>en-US</code>, etc.
+                        The filter only appears when the catalogue spans at least two
+                        distinct languages — until then, it stays hidden because there's
+                        nothing to filter.
                     </p>
                 </div>
             </div>

--- a/appWeb/public_html/includes/pages/settings.php
+++ b/appWeb/public_html/includes/pages/settings.php
@@ -443,6 +443,41 @@ declare(strict_types=1);
     </div>
 
     <!-- ============================================================
+         LANGUAGE PREFERENCES SECTION (#736)
+         ============================================================ -->
+    <div class="card card-settings mb-3">
+        <div class="card-body">
+            <h2 class="h6 mb-3">
+                <i class="fa-solid fa-language me-2" aria-hidden="true"></i>
+                Language Preferences
+            </h2>
+
+            <p class="small text-muted mb-3">
+                Choose which languages you want to see across songbooks
+                and song listings. Songbooks and songs without a
+                language tag always remain visible.
+                <?php if (!empty($currentUser)): ?>
+                Your selection saves to your account and syncs across
+                devices.
+                <?php else: ?>
+                <a href="/login" data-navigate="login">Sign in</a> to
+                sync your selection across devices.
+                <?php endif; ?>
+            </p>
+
+            <div data-settings-language-filter
+                 aria-label="Show only these languages"
+                 class="mb-2">
+                <!-- Populated client-side by /js/modules/settings-language-filter.js -->
+                <p class="small text-muted">
+                    <i class="fa-solid fa-spinner fa-spin me-1" aria-hidden="true"></i>
+                    Loading available languages…
+                </p>
+            </div>
+        </div>
+    </div>
+
+    <!-- ============================================================
          ACCESSIBILITY SECTION
          ============================================================ -->
     <div class="card card-settings mb-3">

--- a/appWeb/public_html/includes/partials/songbook-language-filter.php
+++ b/appWeb/public_html/includes/partials/songbook-language-filter.php
@@ -112,24 +112,36 @@ if (count($languageOptions) <= 1) {
     return;
 }
 ?>
-<div class="songbook-language-filter mb-3 d-flex align-items-center gap-2"
+<div class="songbook-language-filter mb-3"
      data-songbook-language-filter
-     aria-label="Filter songbooks by language">
-    <label class="form-label small mb-0 me-1" for="songbook-language-filter-select">
-        <i class="bi bi-translate me-1" aria-hidden="true"></i>
-        Filter by language:
-    </label>
-    <select class="form-select form-select-sm js-songbook-language-filter"
-            id="songbook-language-filter-select"
-            style="max-width: 14rem;">
-        <option value="">All languages</option>
-        <?php foreach ($languageOptions as $sub => $label): ?>
-            <option value="<?= htmlspecialchars($sub, ENT_QUOTES, 'UTF-8') ?>">
-                <?= htmlspecialchars($label, ENT_QUOTES, 'UTF-8') ?>
-            </option>
-        <?php endforeach; ?>
-    </select>
+     aria-label="Filter songbooks and songs by language">
+    <div class="d-flex align-items-center flex-wrap gap-2 mb-1">
+        <span class="form-label small mb-0 me-1">
+            <i class="bi bi-translate me-1" aria-hidden="true"></i>
+            Show languages:
+        </span>
+        <div class="btn-group btn-group-sm flex-wrap" role="group" aria-label="Language filter options">
+            <input type="checkbox" class="btn-check js-songbook-language-filter-all"
+                   id="songbook-language-filter-all" autocomplete="off" checked>
+            <label class="btn btn-outline-info" for="songbook-language-filter-all">All</label>
+            <?php foreach ($languageOptions as $sub => $label): ?>
+                <?php $id = 'songbook-language-filter-' . htmlspecialchars($sub, ENT_QUOTES, 'UTF-8'); ?>
+                <input type="checkbox" class="btn-check js-songbook-language-filter-option"
+                       id="<?= $id ?>"
+                       value="<?= htmlspecialchars($sub, ENT_QUOTES, 'UTF-8') ?>"
+                       autocomplete="off">
+                <label class="btn btn-outline-info" for="<?= $id ?>">
+                    <?= htmlspecialchars($label, ENT_QUOTES, 'UTF-8') ?>
+                </label>
+            <?php endforeach; ?>
+        </div>
+    </div>
     <small class="text-muted">
-        Songbooks without a language set always remain visible.
+        Songbooks and songs without a language set always remain visible.
+        <?php if (!empty($currentUser)): ?>
+        Your selection is saved to your account and syncs across devices.
+        <?php else: ?>
+        Sign in to save your selection across devices.
+        <?php endif; ?>
     </small>
 </div>

--- a/appWeb/public_html/includes/partials/songbook-language-filter.php
+++ b/appWeb/public_html/includes/partials/songbook-language-filter.php
@@ -42,32 +42,72 @@ if (!isset($songbooks) || !is_array($songbooks)) {
     $songbooks = [];
 }
 
-/* Build the de-duplicated language list. Each tblSongbooks row's
-   Language is a full BCP 47 tag (`pt-BR`, `zh-Hans-CN`, …); the
-   filter operates on the language subtag (the first component
-   before the hyphen) so "pt" matches both "pt-BR" and "pt-PT". The
-   keys of the map are the lowercase subtags, the values are the
-   display labels (uppercase code so the dropdown reads cleanly). */
+/* Build the de-duplicated language list. Each row's Language is a
+   full BCP 47 tag (`pt-BR`, `zh-Hans-CN`, …); the filter operates on
+   the primary subtag (the first component before the hyphen) so
+   "pt" matches both "pt-BR" and "pt-PT". The keys of the map are
+   the lowercase subtags, the values are the display labels
+   (uppercase code so the dropdown reads cleanly). */
 $languageOptions = [];
+
+/* Source 1 — songbook-level Language (the original #679 set). */
 foreach ($songbooks as $book) {
     $tag = (string)($book['language'] ?? '');
     if ($tag === '') continue;
     if (!preg_match('/^([a-z]{2,3})/i', $tag, $m)) continue;
     $sub = strtolower($m[1]);
-    /* Display label: ISO code uppercased + (optionally) the friendly
-       language name from the same row's data. We don't have the
-       resolved name here so we just show the code; the JS module
-       can later swap it for a friendly label fetched from
-       /api?action=languages if the host page wants that. */
     if (!isset($languageOptions[$sub])) {
         $languageOptions[$sub] = strtoupper($m[1]);
     }
 }
+
+/* Source 2 — song-level Language (#734). A song carries its own
+   Language independent of its songbook (e.g. a Spanish translation
+   of an English-primary songbook), so the catalogue can be
+   multilingual even when every tblSongbooks row is in one language.
+   Best-effort: probe column existence first so a pre-#673 deployment
+   doesn't 500 on the SELECT. Cheap because the SELECT pulls only
+   distinct primary subtags via SUBSTRING_INDEX. */
+try {
+    require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'db_mysql.php';
+    $db = getDbMysqli();
+    $probe = $db->prepare(
+        "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+          WHERE TABLE_SCHEMA = DATABASE()
+            AND TABLE_NAME   = 'tblSongs'
+            AND COLUMN_NAME  = 'Language' LIMIT 1"
+    );
+    $probe->execute();
+    $hasSongLangCol = $probe->get_result()->fetch_row() !== null;
+    $probe->close();
+    if ($hasSongLangCol) {
+        $stmt = $db->prepare(
+            "SELECT DISTINCT LOWER(SUBSTRING_INDEX(Language, '-', 1)) AS sub
+               FROM tblSongs
+              WHERE Language IS NOT NULL AND Language <> ''"
+        );
+        $stmt->execute();
+        $res = $stmt->get_result();
+        while ($row = $res->fetch_row()) {
+            $sub = (string)$row[0];
+            if (!preg_match('/^[a-z]{2,3}$/', $sub)) continue;
+            if (!isset($languageOptions[$sub])) {
+                $languageOptions[$sub] = strtoupper($sub);
+            }
+        }
+        $stmt->close();
+    }
+} catch (\Throwable $_e) {
+    /* Best-effort. If the DB read fails (pre-migration deployment,
+       missing tblSongs, etc.) just fall back to the songbook-only
+       set computed above. */
+}
+
 ksort($languageOptions);
 
-/* Don't render the filter at all if every songbook is in the same
-   language (or none have a Language set). The filter is only useful
-   when the catalogue actually spans multiple languages. */
+/* Don't render the filter at all if every songbook+song is in the
+   same language (or none have a Language set). The filter is only
+   useful when the catalogue actually spans multiple languages. */
 if (count($languageOptions) <= 1) {
     return;
 }

--- a/appWeb/public_html/js/modules/router.js
+++ b/appWeb/public_html/js/modules/router.js
@@ -538,6 +538,23 @@ export class Router {
                 .catch(err => console.error('[Router] songbook-language-filter init failed:', err));
         }
 
+        /* Settings page — language preferences picker (#736). The
+           settings page hosts a duplicate of the language filter UI
+           inside the Language Preferences section, so the user can
+           adjust their preference from a non-grid context. The
+           module is idempotent. */
+        if (page === 'settings') {
+            import('./settings-language-filter.js')
+                .then(m => m.bootSettingsLanguageFilter())
+                .catch(err => console.error('[Router] settings-language-filter init failed:', err));
+            /* Also boot the songbook-filter module so the global
+               fetch-header patch + saved subtag list propagation
+               applies even when the home grid isn't on screen. */
+            import('./songbook-language-filter.js')
+                .then(m => m.bootSongbookLanguageFilter())
+                .catch(() => { /* non-critical */ });
+        }
+
         /* Persistent bulk-import progress widget (#676). Booted on
            every SPA navigation so a curator who started an import
            on /manage/editor and switched to the public app still

--- a/appWeb/public_html/js/modules/settings-language-filter.js
+++ b/appWeb/public_html/js/modules/settings-language-filter.js
@@ -1,0 +1,165 @@
+/**
+ * Settings page — Language preferences section (#736)
+ *
+ * Populates the [data-settings-language-filter] container on the
+ * /settings page with a checkbox group of every language in the
+ * catalogue, wired to the same persistence layer as the home-grid
+ * filter (localStorage + /api?action=user_preferred_languages_save).
+ *
+ * Reuses bootSongbookLanguageFilter()'s persistence + sync by
+ * delegating to the same filter wrapper markup pattern. The
+ * settings page just renders the picker into a different host
+ * element so the user can adjust their preference from a
+ * non-grid context.
+ */
+
+const STORAGE_KEY = 'songbook-language-filter';
+
+function loadSavedSubtags() {
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) return [];
+        const parsed = JSON.parse(raw);
+        return Array.isArray(parsed)
+            ? parsed.filter(s => typeof s === 'string' && /^[a-z]{2,3}$/.test(s))
+            : [];
+    } catch (_e) { return []; }
+}
+
+function saveSubtags(subtags) {
+    try {
+        if (subtags.length === 0) localStorage.removeItem(STORAGE_KEY);
+        else                       localStorage.setItem(STORAGE_KEY, JSON.stringify(subtags));
+    } catch (_e) { /* private mode */ }
+}
+
+function saveToAccount(subtags) {
+    let token = null;
+    try { token = localStorage.getItem('ihymns_auth_token'); } catch (_e) {}
+    if (!token) return Promise.resolve();
+    return fetch('/api?action=user_preferred_languages_save', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer ' + token,
+            'X-Requested-With': 'XMLHttpRequest',
+        },
+        body: JSON.stringify({ subtags }),
+    }).catch(() => { /* best-effort */ });
+}
+
+/**
+ * Build the picker UI inside the host element.
+ * Available subtags come from /api?action=songbooks (each row's
+ * `language` field) — this is the same set the home grid filter
+ * shows, so the two stay in lock-step.
+ */
+async function buildPicker(host) {
+    /* Discover available languages from songbook + song catalogue.
+       /api?action=languages would ALSO work but it returns every
+       known ISO code; we only want what the catalogue actually has. */
+    let books = [];
+    try {
+        const resp = await fetch('/api?action=songbooks');
+        if (resp.ok) {
+            const j = await resp.json();
+            books = Array.isArray(j.songbooks) ? j.songbooks : [];
+        }
+    } catch (_e) { /* offline → empty picker */ }
+
+    const subtagSet = new Set();
+    for (const b of books) {
+        const tag = (b.language || '').toLowerCase();
+        if (!tag) continue;
+        const m = tag.match(/^([a-z]{2,3})/);
+        if (m) subtagSet.add(m[1]);
+    }
+    const available = Array.from(subtagSet).sort();
+
+    if (available.length === 0) {
+        host.innerHTML = '<p class="small text-muted mb-0">' +
+            'No language tags exist on any songbook yet. The filter ' +
+            'will appear here once the catalogue spans multiple ' +
+            'languages.</p>';
+        return;
+    }
+
+    const saved = loadSavedSubtags();
+    const initialAll = saved.length === 0;
+    const set = new Set(saved);
+
+    /* Render the chip group. */
+    const html = [];
+    html.push('<div class="btn-group btn-group-sm flex-wrap" role="group">');
+    html.push(
+        '<input type="checkbox" class="btn-check" id="settings-lang-all" autocomplete="off"' +
+        (initialAll ? ' checked' : '') + '>' +
+        '<label class="btn btn-outline-info" for="settings-lang-all">All</label>'
+    );
+    for (const sub of available) {
+        const id = 'settings-lang-' + sub;
+        const checked = !initialAll && set.has(sub);
+        html.push(
+            `<input type="checkbox" class="btn-check js-settings-lang-opt" ` +
+            `id="${id}" value="${sub}" autocomplete="off"` +
+            (checked ? ' checked' : '') + '>' +
+            `<label class="btn btn-outline-info" for="${id}">${sub.toUpperCase()}</label>`
+        );
+    }
+    html.push('</div>');
+    host.innerHTML = html.join('');
+
+    const all  = host.querySelector('#settings-lang-all');
+    const opts = Array.from(host.querySelectorAll('.js-settings-lang-opt'));
+
+    function readUi() {
+        if (all.checked) return [];
+        return opts.filter(cb => cb.checked).map(cb => cb.value).sort();
+    }
+
+    function commit() {
+        const subtags = readUi();
+        saveSubtags(subtags);
+        window.__iHymnsPreferredLanguages = subtags.join(',');
+        saveToAccount(subtags);
+        /* Notify other modules on the page that the filter changed
+           so the songbook grid (if visible) re-applies. */
+        document.dispatchEvent(new CustomEvent('ihymns:language-filter-changed', {
+            detail: { subtags },
+        }));
+    }
+
+    all.addEventListener('change', () => {
+        if (all.checked) {
+            opts.forEach(cb => { cb.checked = false; });
+        } else {
+            all.checked = true;            // never allow zero selected
+        }
+        commit();
+    });
+    opts.forEach(cb => {
+        cb.addEventListener('change', () => {
+            if (cb.checked) {
+                all.checked = false;
+            } else if (opts.every(o => !o.checked)) {
+                all.checked = true;        // last opt unticked → fall back to "All"
+            }
+            commit();
+        });
+    });
+}
+
+/**
+ * Boot the settings-page language picker. Idempotent.
+ */
+export function bootSettingsLanguageFilter(root) {
+    const scope = root || document;
+    const host = scope.querySelector('[data-settings-language-filter]');
+    if (!host || host.dataset.langFilterBooted === '1') return;
+    host.dataset.langFilterBooted = '1';
+    buildPicker(host).catch(err => {
+        console.warn('[settings-language-filter] boot failed', err);
+        host.innerHTML = '<p class="small text-danger mb-0">' +
+            'Could not load the language picker.</p>';
+    });
+}

--- a/appWeb/public_html/js/modules/songbook-language-filter.js
+++ b/appWeb/public_html/js/modules/songbook-language-filter.js
@@ -1,30 +1,33 @@
 /**
- * Songbook language filter (#679)
+ * Songbook + song language filter (#679, extended in #736)
  *
- * Wires the <select class="js-songbook-language-filter"> rendered by
- * the /includes/partials/songbook-language-filter.php partial to a
- * pure client-side hide/show pass over the songbook tiles on the
- * surrounding page.
+ * Wires the multi-select chip group rendered by the
+ * /includes/partials/songbook-language-filter.php partial to:
  *
- * Rules:
- *   - "All languages" (value="") → every tile visible.
- *   - Specific subtag picked     → tiles whose data-songbook-language
- *     starts with that subtag stay visible. Tiles WITHOUT a
- *     data-songbook-language attribute (i.e. songbooks with no
- *     Language set) ALWAYS stay visible — the absence is treated as
- *     "multi-lingual / not specified" so a curated grouping that
- *     mixes languages doesn't disappear when the user filters.
+ *   1. A pure client-side hide/show pass over the songbook tiles
+ *      currently rendered on the surrounding page.
+ *   2. The X-Preferred-Languages request header on every fetch
+ *      (set globally so subsequent SPA navigations + native-API
+ *      consumers all see the same filter state).
+ *   3. The /api?action=user_preferred_languages_save endpoint when
+ *      the user is signed in, so the choice persists to the
+ *      account and syncs across devices.
+ *
+ * Filter rules (per spec):
+ *   - "All" checked → no filter; every tile + every song visible.
+ *   - One or more languages checked → show tiles whose
+ *     data-songbook-language starts with any of the selected
+ *     primary subtags. Tiles WITHOUT a data-songbook-language
+ *     attribute (i.e. songbooks with no Language set) ALWAYS
+ *     stay visible — the absence is treated as
+ *     "multi-lingual / not specified".
  *
  * Persistence:
- *   - The user's choice is stored in localStorage under
- *     'songbook-language-filter' so a return visit restores it.
- *
- * Accessibility:
- *   - Filtered-out tiles are hidden via display:none AND aria-hidden
- *     so a screen reader skips them.
- *   - The filter <select> is keyboard-reachable (rendered as a normal
- *     form control) and operates on `change`, so a curator using
- *     keyboard navigation gets the same UX as one with a mouse.
+ *   - localStorage key 'songbook-language-filter' for the
+ *     anonymous case (and as a fast-restore on every page load
+ *     before the auth check resolves).
+ *   - Account preference via /api?action=user_preferred_languages_save
+ *     for signed-in users.
  *
  * The module is idempotent: bootSongbookLanguageFilter() can be
  * called multiple times (e.g. once on first page load + once after
@@ -32,6 +35,96 @@
  */
 
 const STORAGE_KEY = 'songbook-language-filter';
+
+/**
+ * Read the saved preferred-language subtag list from localStorage.
+ * Stored as a JSON array of lowercase primary subtags.
+ * Returns [] on any error (including "private browsing mode").
+ */
+function loadSavedSubtags() {
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) return [];
+        const parsed = JSON.parse(raw);
+        if (!Array.isArray(parsed)) return [];
+        return parsed.filter(s => typeof s === 'string' && /^[a-z]{2,3}$/.test(s));
+    } catch (_e) {
+        return [];
+    }
+}
+
+function saveSubtags(subtags) {
+    try {
+        if (subtags.length === 0) {
+            localStorage.removeItem(STORAGE_KEY);
+        } else {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(subtags));
+        }
+    } catch (_e) { /* private mode — best effort */ }
+}
+
+/**
+ * Tell the global fetch wrapper to send X-Preferred-Languages on
+ * every request. Falls back to a per-fetch override using a
+ * Symbol-keyed property on window so anything that uses native
+ * fetch picks up the header without the SPA having to touch every
+ * call site.
+ */
+function applyHeaderToFetch(subtags) {
+    /* The SPA's fetch wrapper (if any) reads window.__iHymnsPreferredLanguages
+       and prepends it as a request header. If no wrapper exists,
+       we monkey-patch fetch globally to add the header — once. */
+    window.__iHymnsPreferredLanguages = subtags.join(',');
+
+    if (window.__iHymnsLangFilterFetchPatched) return;
+    window.__iHymnsLangFilterFetchPatched = true;
+
+    const origFetch = window.fetch;
+    window.fetch = function (input, init) {
+        const csv = window.__iHymnsPreferredLanguages || '';
+        if (csv === '') return origFetch(input, init);
+
+        /* Only attach the header for same-origin requests — never
+           leak the user's language preference to a third-party
+           CDN or analytics endpoint. */
+        let url = '';
+        try {
+            url = typeof input === 'string' ? input : input.url;
+        } catch (_e) {}
+        const sameOrigin = !url.startsWith('http')
+            || url.startsWith(window.location.origin);
+        if (!sameOrigin) return origFetch(input, init);
+
+        const next = init ? { ...init } : {};
+        next.headers = new Headers(next.headers || {});
+        next.headers.set('X-Preferred-Languages', csv);
+        return origFetch(input, next);
+    };
+}
+
+/**
+ * For signed-in users, persist the chosen subtag list to the
+ * account so it syncs across devices. Best-effort: a network
+ * failure or 401 (token expired) silently falls back to
+ * localStorage-only.
+ */
+function saveSubtagsToAccount(subtags) {
+    /* SPA stores the bearer token under 'ihymns_auth_token' (per
+       PWA Features wiki page). Skip the call if it's absent. */
+    let token = null;
+    try { token = localStorage.getItem('ihymns_auth_token'); } catch (_e) {}
+    if (!token) return;
+
+    fetch('/api?action=user_preferred_languages_save', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer ' + token,
+            'X-Requested-With': 'XMLHttpRequest',
+        },
+        body: JSON.stringify({ subtags }),
+    }).catch(() => { /* best-effort */ });
+}
 
 /* Find every tile on the page that corresponds to a songbook. The
    home.php compact tiles use `.card-songbook` directly on the inner
@@ -41,9 +134,6 @@ const STORAGE_KEY = 'songbook-language-filter';
    container — `.col` for home, `.col-12.col-sm-6.col-md-4.col-lg-3`
    for /songbooks — by walking up to the nearest column. */
 function findTileColumn(tile) {
-    /* Bootstrap col classes start with `col` or `col-`. Walk up until
-       we hit a parent that's a grid column, or fall through to the
-       tile itself (degrades to hiding just the inner card). */
     let node = tile;
     while (node && node.parentElement) {
         node = node.parentElement;
@@ -55,17 +145,30 @@ function findTileColumn(tile) {
     return tile;
 }
 
-function applyFilter(rootEl, subtag) {
-    const tiles = rootEl.querySelectorAll('[data-songbook-id]');
-    tiles.forEach(tile => {
+/**
+ * Apply the filter to every tile / row currently in the DOM that
+ * carries a data-songbook-language or data-song-language attribute.
+ *
+ * Spec:
+ *   - subtags == [] → show everything
+ *   - subtags non-empty → show rows whose primary subtag is in the
+ *     set, plus rows that have no language attribute at all
+ *     (untagged → always shown)
+ */
+function applyFilter(rootEl, subtags) {
+    const set = new Set(subtags.map(s => s.toLowerCase()));
+
+    /* Songbook tiles. */
+    rootEl.querySelectorAll('[data-songbook-id]').forEach(tile => {
         const tileLang = (tile.dataset.songbookLanguage || '').toLowerCase();
         const col = findTileColumn(tile);
         if (!col) return;
 
         const shouldShow = (() => {
-            if (!subtag) return true;                      // "All languages"
-            if (!tileLang) return true;                    // un-tagged → always shown
-            return tileLang.startsWith(subtag.toLowerCase());
+            if (set.size === 0) return true;
+            if (!tileLang) return true;
+            const primary = tileLang.split('-', 1)[0];
+            return set.has(primary);
         })();
 
         if (shouldShow) {
@@ -74,6 +177,24 @@ function applyFilter(rootEl, subtag) {
         } else {
             col.style.display = 'none';
             col.setAttribute('aria-hidden', 'true');
+        }
+    });
+
+    /* Song rows (when present — search results, song lists, etc.) */
+    rootEl.querySelectorAll('[data-song-language]').forEach(row => {
+        const rowLang = (row.dataset.songLanguage || '').toLowerCase();
+        const shouldShow = (() => {
+            if (set.size === 0) return true;
+            if (!rowLang) return true;
+            const primary = rowLang.split('-', 1)[0];
+            return set.has(primary);
+        })();
+        if (shouldShow) {
+            row.style.removeProperty('display');
+            row.removeAttribute('aria-hidden');
+        } else {
+            row.style.display = 'none';
+            row.setAttribute('aria-hidden', 'true');
         }
     });
 }
@@ -86,36 +207,107 @@ function applyFilter(rootEl, subtag) {
  */
 export function bootSongbookLanguageFilter(root) {
     const scope = root || document;
-    const filter = scope.querySelector('.js-songbook-language-filter');
-    if (!filter || filter.dataset.songbookFilterBooted === '1') return;
-    filter.dataset.songbookFilterBooted = '1';
+    const wrapper = scope.querySelector('[data-songbook-language-filter]');
+    if (!wrapper || wrapper.dataset.songbookFilterBooted === '1') {
+        /* Even when the wrapper isn't on this page, restore the
+           saved subtag list to the global header so cross-page
+           navigations still apply the filter to song listings
+           rendered by the SPA after this point. */
+        const savedHeaderOnly = loadSavedSubtags();
+        applyHeaderToFetch(savedHeaderOnly);
+        return;
+    }
+    wrapper.dataset.songbookFilterBooted = '1';
 
-    /* The filter element is rendered above the tile grid. Both surfaces
-       use document.body as the natural search scope for tiles — the
-       grid sits on the same page as the filter. */
-    const applyToPage = (subtag) => applyFilter(scope, subtag);
+    const allCheckbox      = wrapper.querySelector('.js-songbook-language-filter-all');
+    const optionCheckboxes = Array.from(wrapper.querySelectorAll('.js-songbook-language-filter-option'));
+    if (!allCheckbox || optionCheckboxes.length === 0) return;
 
-    /* Restore saved choice. localStorage may be unavailable in private
-       browsing modes; treat read errors as "no saved state". */
-    let saved = '';
-    try { saved = localStorage.getItem(STORAGE_KEY) || ''; } catch (_e) {}
-
-    /* If the saved value is no longer in the dropdown (the curator
-       removed every songbook in that language), fall back to "All". */
-    const optionExists = Array.from(filter.options).some(o => o.value === saved);
-    if (!optionExists) saved = '';
-
-    if (saved) {
-        filter.value = saved;
-        applyToPage(saved);
+    /* Sync UI state from saved subtag list. */
+    function syncUiFromSubtags(subtags) {
+        if (subtags.length === 0) {
+            allCheckbox.checked = true;
+            optionCheckboxes.forEach(cb => { cb.checked = false; });
+        } else {
+            allCheckbox.checked = false;
+            const set = new Set(subtags);
+            optionCheckboxes.forEach(cb => { cb.checked = set.has(cb.value); });
+        }
     }
 
-    filter.addEventListener('change', () => {
-        const v = filter.value;
-        try {
-            if (v) localStorage.setItem(STORAGE_KEY, v);
-            else   localStorage.removeItem(STORAGE_KEY);
-        } catch (_e) { /* private mode — best effort */ }
-        applyToPage(v);
+    /* Read current subtag list from UI state. */
+    function readSubtagsFromUi() {
+        if (allCheckbox.checked) return [];
+        return optionCheckboxes
+            .filter(cb => cb.checked)
+            .map(cb => cb.value)
+            .sort();
+    }
+
+    /* Restore on first boot. Try the saved value first; if it
+       references a language no longer in the catalogue, the
+       missing checkboxes simply won't toggle on (the rest still
+       apply). */
+    const initial = loadSavedSubtags();
+    syncUiFromSubtags(initial);
+    applyFilter(scope, initial);
+    applyHeaderToFetch(initial);
+
+    /* Wire change handlers. */
+    function commit() {
+        const subtags = readSubtagsFromUi();
+        saveSubtags(subtags);
+        applyFilter(scope, subtags);
+        applyHeaderToFetch(subtags);
+        saveSubtagsToAccount(subtags);
+    }
+
+    allCheckbox.addEventListener('change', () => {
+        if (allCheckbox.checked) {
+            optionCheckboxes.forEach(cb => { cb.checked = false; });
+        } else {
+            /* Can't have nothing selected — re-tick "All" so a
+               click on a checked "All" doesn't leave the user in
+               a "show nothing" state. */
+            allCheckbox.checked = true;
+        }
+        commit();
     });
+    optionCheckboxes.forEach(cb => {
+        cb.addEventListener('change', () => {
+            if (cb.checked) {
+                /* Selecting a specific language clears "All". */
+                allCheckbox.checked = false;
+            } else if (optionCheckboxes.every(o => !o.checked)) {
+                /* If the user just un-ticked the last specific
+                   language, fall back to "All" rather than
+                   leaving them with no selection. */
+                allCheckbox.checked = true;
+            }
+            commit();
+        });
+    });
+
+    /* For signed-in users, fetch the account-saved value once
+       on boot — it overrides localStorage if newer. Best-effort:
+       failures fall back to localStorage. */
+    let token = null;
+    try { token = localStorage.getItem('ihymns_auth_token'); } catch (_e) {}
+    if (token) {
+        fetch('/api?action=user_preferred_languages', {
+            headers: { 'Authorization': 'Bearer ' + token, 'X-Requested-With': 'XMLHttpRequest' },
+        })
+            .then(r => r.ok ? r.json() : null)
+            .then(j => {
+                if (!j || !Array.isArray(j.subtags)) return;
+                const remote = j.subtags.filter(s => /^[a-z]{2,3}$/.test(s));
+                /* Adopt the remote list — it's the canonical
+                   "across all my devices" view. */
+                saveSubtags(remote);
+                syncUiFromSubtags(remote);
+                applyFilter(scope, remote);
+                applyHeaderToFetch(remote);
+            })
+            .catch(() => { /* ignore — local state stands */ });
+    }
 }

--- a/appWeb/public_html/manage/help.php
+++ b/appWeb/public_html/manage/help.php
@@ -628,7 +628,7 @@ foreach ($sections as $s) {
                         <strong>Gotcha:</strong> Deleting a songbook does <em>not</em> delete its songs unless you use Cascade delete. The standard UI refuses if any song still references its abbreviation; reassign or delete those songs first.
                     </div>
                     <div class="gotcha small">
-                        <strong>Tip:</strong> The home-page tile grid (#678) shows official hymnals first, with a language filter (#679) that hides languages on demand. The <strong>Misc</strong> pseudo-songbook is always pinned to the bottom of the grid (#717) regardless of <code>DisplayOrder</code> — it's a catch-all and should never out-rank a curated hymnal. Songbooks without a Language field always show — useful for catch-all collections you don't want to risk filtering away.
+                        <strong>Tip:</strong> The home-page tile grid (#678) shows official hymnals first, with a language filter (#679 / #736 v2) that lets users pick which languages to <em>show</em> across both songbook tiles AND individual song listings (search, popular, recently-viewed). Multi-select is supported; signed-in users get the choice persisted to their account and synced across devices. The <strong>Misc</strong> pseudo-songbook is always pinned to the bottom of the grid (#717) regardless of <code>DisplayOrder</code> — it's a catch-all and should never out-rank a curated hymnal. Songbooks AND songs without a Language field always show, regardless of the filter — useful for catch-all collections.
                     </div>
                 </section>
 

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -219,6 +219,7 @@ if ($action !== '') {
         'ietf-bcp47-language'    => 'migrate-ietf-bcp47-language.php',
         'bulk-import-jobs'       => 'migrate-bulk-import-jobs.php',
         'backfill-legacy-songbook-languages' => 'migrate-backfill-legacy-songbook-languages.php',
+        'user-preferred-languages' => 'migrate-user-preferred-languages.php',
         'cleanup'     => 'cleanup.php',
         'backup'      => 'backup.php',
         'restore'     => 'restore.php',
@@ -256,6 +257,7 @@ if ($action !== '') {
         'ietf-bcp47-language',
         'bulk-import-jobs',
         'backfill-legacy-songbook-languages',
+        'user-preferred-languages',
         /* When you add a new migrate-*.php under appWeb/.sql/, ALSO add
            its action key to:
              1. $scriptMap above (action key → file)
@@ -989,6 +991,25 @@ if ($hasCredentials && defined('DB_HOST')) {
                         </p>
                         <a href="?action=bulk-import-jobs" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
                             Run Bulk Import Jobs Migration
+                        </a>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="card bg-dark border-secondary h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">3r. User preferred languages column (#736)</h5>
+                        <p class="card-text text-secondary small">
+                            Adds <code>tblUsers.PreferredLanguagesJson</code> so a
+                            signed-in user can save their language-filter choice
+                            to their account and have it sync across devices.
+                            Stored as a JSON array of IETF BCP 47 primary
+                            subtags (e.g. <code>["en","es"]</code>); NULL or
+                            <code>[]</code> means "show all languages".
+                            Idempotent — safe to re-run.
+                        </p>
+                        <a href="?action=user-preferred-languages" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
+                            Run User Preferred Languages Migration
                         </a>
                     </div>
                 </div>

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -218,6 +218,7 @@ if ($action !== '') {
         'songbook-language'      => 'migrate-songbook-language.php',
         'ietf-bcp47-language'    => 'migrate-ietf-bcp47-language.php',
         'bulk-import-jobs'       => 'migrate-bulk-import-jobs.php',
+        'backfill-legacy-songbook-languages' => 'migrate-backfill-legacy-songbook-languages.php',
         'cleanup'     => 'cleanup.php',
         'backup'      => 'backup.php',
         'restore'     => 'restore.php',
@@ -254,6 +255,7 @@ if ($action !== '') {
         'songbook-language',
         'ietf-bcp47-language',
         'bulk-import-jobs',
+        'backfill-legacy-songbook-languages',
         /* When you add a new migrate-*.php under appWeb/.sql/, ALSO add
            its action key to:
              1. $scriptMap above (action key → file)
@@ -987,6 +989,27 @@ if ($hasCredentials && defined('DB_HOST')) {
                         </p>
                         <a href="?action=bulk-import-jobs" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
                             Run Bulk Import Jobs Migration
+                        </a>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="card bg-dark border-secondary h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">3q. Backfill legacy songbook languages (#735)</h5>
+                        <p class="card-text text-secondary small">
+                            Sets <code>Language='en'</code> on the 5 legacy English
+                            songbooks (CP, JP, MP, SDAH, CH) where it isn't already
+                            set. Required by the language filter (#734 / #736) — the
+                            filter renders only when ≥2 distinct primary subtags
+                            exist across songbooks UNION songs, so this baseline
+                            ensures the filter appears the moment any non-English
+                            songbook lands. Idempotent — re-running is safe; rows
+                            already set (e.g. <code>en-GB</code>, <code>en-US</code>)
+                            are not touched.
+                        </p>
+                        <a href="?action=backfill-legacy-songbook-languages" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
+                            Run Legacy Songbook Language Backfill
                         </a>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary

Brings the language filter up to its full spec across three issues:

| # | Title | What it does |
|---|---|---|
| **#734** | Filter scan also looks at song-level Language | Filter renders when ≥2 distinct primary subtags exist across `tblSongbooks.Language` UNION `tblSongs.Language` (was: songbook-only). |
| **#735** | Backfill Language='en' on the 5 legacy songbooks | Idempotent migration — sets `Language='en'` on CP/JP/MP/SDAH/CH where currently NULL. Preserves `en-GB`/`en-US` if a curator already set them. |
| **#736** | Language filter v2 — multi-select, per-song, settings UI, account sync, server-side | The big one. See sections below. |

3 commits, one per issue, batch PR per the standard workflow.

## #736 — full v2 surface

### Schema

- New `tblUsers.PreferredLanguagesJson TEXT NULL` — JSON array of canonical primary subtags (e.g. `["en","es"]`). NULL or `[]` = no filter.
- Migration `migrate-user-preferred-languages.php`, idempotent, wired into `setup-database` (script map, migration order, new "3r" card).

### Server-side helper — `includes/language_filter.php`

| Helper | Purpose |
|---|---|
| `parsePreferredLanguageSubtags(?string)` | CSV → canonical sorted/dedup primary-subtag list. Invalid tokens dropped. |
| `resolvePreferredLanguagesForRequest(?array)` | 4-level priority chain: `?lang=` → `X-Preferred-Languages` header → `tblUsers.PreferredLanguagesJson` → empty (no filter). |
| `applyLanguageFilterSql(string, array)` | SQL fragment + bind-param pair for SELECT-time filtering. |
| `makeLanguageFilterPredicate(array)` | In-memory predicate; `language` or `Language` field, primary-subtag match, untagged always passes. |

### API endpoints

**Filter applied to** (in-memory predicate after the SELECT — untagged rows always pass):

- `?action=search` — search results
- `?action=songs` — full corpus song list
- `?action=songbooks` — songbook tile list (server-side now too, so native clients stay in lock-step with the SPA)
- `?action=popular_songs` — home-page block
- `?action=song_history` — recently-viewed block

**Deferred** (noted as follow-up in #736): `related_songs` (multi-stage SELECT, would need each stage updated), `favorites` (returns SongIds; would need a JOIN to `tblSongs`).

**New endpoints:**

- `GET ?action=user_preferred_languages` → `{ subtags: ["en","es"] }`. On pre-#736 deploys, returns `migration_needed: true` + `[]`.
- `POST ?action=user_preferred_languages_save` body `{ subtags: [...] }` — server-side normalisation via `parsePreferredLanguageSubtags()`. Empty list stores `NULL` so "no filter" is distinct from "filter to empty set" (which would mean "show nothing").

### Frontend

- **Partial rewrite**: `includes/partials/songbook-language-filter.php` — single `<select>` replaced with a Bootstrap btn-check chip group ("All" + one chip per language actually present in the catalogue, computed via the #734 union).
- **JS rewrite**: `js/modules/songbook-language-filter.js`:
  - Multi-select state machine — "All" master + per-language chips, mutually exclusive UX.
  - localStorage persistence (`songbook-language-filter` key, JSON array).
  - Account-side sync via `user_preferred_languages_save` when a bearer token is present.
  - **Global fetch monkey-patch** sets `X-Preferred-Languages: en,es,…` on every same-origin fetch — so server-side filter applies even on SPA-navigated pages where the filter wrapper isn't rendered. Same-origin guard prevents header leaking to third-party CDNs/analytics.
  - Filter applies to BOTH `[data-songbook-id]` tiles AND `[data-song-language]` song rows.
- **New module**: `js/modules/settings-language-filter.js` — populates the new "Language Preferences" section on `/settings`. Reuses the same persistence layer.
- **Router wiring**: settings page boots both modules so the global header patch applies even when the home grid isn't on screen.

### Settings page

New "Language Preferences" card on `/settings` (sits above Accessibility). Footer copy adapts to signed-in vs anonymous so users know whether the choice will sync.

### OpenAPI

- Spec version `0.55.0` → `0.56.0`.
- Two new endpoints documented under the **Preferences** tag.

### Docs

- `/help` — Language Filter section rewritten for v2 (multi-select / per-song / settings UI / account-vs-device sync).
- `/manage/help` — songbooks Tip block updated to reference v2.

## Architectural notes

- **Show-only semantics, not hide.** Pick `en` → see English-tagged + untagged. Untagged is the always-visible escape hatch so a curated multilingual collection (e.g. *Misc*) never disappears.
- **Primary subtag matching.** Picking `en` matches `en`, `en-GB`, `en-US`. The saved list is normalised to primary subtags only so the comparison is cheap (Set.has).
- **Suppress rule preserved.** The filter chip group still only renders when ≥2 distinct primary subtags exist anywhere — discoverable on a multilingual catalogue, invisible on a uniform one. The #734 scan extension means "anywhere" now includes per-song Language too.
- **In-memory filter, not SQL.** For this PR, song-listing endpoints filter results in PHP after the SELECT. SQL-side filtering is a future optimisation (note in #736 follow-up). Current performance is fine for all listed endpoints (≤~100 rows except `?action=songs` which is ~3600 rows but only rarely called).
- **`X-Preferred-Languages` header is the SPA-anonymous bridge.** Anonymous users have a localStorage list but no account; the global fetch patch propagates that list to the server on every request so server-side filtering still works without authentication.

## Test plan

- [ ] **Lint** — every touched PHP/JS/YAML file lints clean. ✅ verified.
- [ ] **Apply migrations** in dev: run `migrate-user-preferred-languages.php` + `migrate-backfill-legacy-songbook-languages.php` via `/manage/setup-database`. Confirm `tblUsers.PreferredLanguagesJson` exists and the 5 legacy songbooks have `Language='en'`.
- [ ] **#734 visibility** — load `/` with only English songbooks (post-#735 backfill) → no filter rendered. Bulk-import one Spanish songbook → filter appears next reload.
- [ ] **Multi-select** — pick "Spanish" only → English tiles hidden. Pick "Spanish + Portuguese" → only those + untagged shown.
- [ ] **Untagged always shown** — confirm Misc (untagged) stays visible regardless of selection.
- [ ] **Settings UI** — `/settings` Language Preferences chips reflect the same state as the home grid; changing one updates the other on next page load.
- [ ] **Account sync** — sign in on browser A, pick `["es"]`, sign in on browser B, confirm `["es"]` appears in the chip group on next page load.
- [ ] **API** — `GET /api?action=user_preferred_languages` returns the saved list. `POST /api?action=user_preferred_languages_save` with `{"subtags":["en","es-MX","garbage"]}` returns `{"ok":true,"subtags":["en","es"]}` (canonicalised).
- [ ] **`X-Preferred-Languages`** — anonymous user picks `["es"]` in the chip group; subsequent `/api?action=search&q=...` requests include `X-Preferred-Languages: es` and return only Spanish-tagged + untagged results.
- [ ] **Pre-migration safety** — drop `tblUsers.PreferredLanguagesJson` and `GET /api?action=user_preferred_languages` returns `{"subtags":[],"migration_needed":true}`.

## Migrations

- `migrate-user-preferred-languages.php` (#736)
- `migrate-backfill-legacy-songbook-languages.php` (#735)

Both idempotent; both wired into the bulk-runner so "Apply All Pending Migrations" picks them up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)