### PR TITLE
fix(editor): only require song Number for official songbooks (#392)

### DIFF
--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -263,10 +263,17 @@ switch ($action) {
             $stmtSongbook = $db->prepare(
                 "INSERT INTO tblSongbooks (Abbreviation, Name, SongCount) VALUES (?, ?, ?)"
             );
+            /* Build an IsOfficial lookup keyed by abbreviation so the
+               per-song INSERT below can null out Number for any song
+               whose songbook is unofficial (Misc and any custom
+               collection). #392. The payload's `isOfficial` is sourced
+               from SongData::getSongbooks() and is always boolean. */
+            $officialByAbbr = [];
             foreach ($data['songbooks'] as $book) {
                 $abbr  = $book['id'];
                 $name  = $book['name'];
                 $count = (int)($book['songCount'] ?? 0);
+                $officialByAbbr[$abbr] = !empty($book['isOfficial']);
                 $stmtSongbook->bind_param('ssi', $abbr, $name, $count);
                 $stmtSongbook->execute();
             }
@@ -304,10 +311,13 @@ switch ($action) {
                 $songId       = $song['id'];
                 $songbookAbbr = $song['songbook'];
 
-                /* Misc songs (and anything without a meaningful number)
-                   persist Number as NULL (#392). */
-                $rawNumber = $song['number'] ?? null;
-                $number    = ($songbookAbbr === 'Misc' || $rawNumber === null || $rawNumber === '' || (int)$rawNumber <= 0)
+                /* Songs in non-official songbooks (Misc, custom
+                   collections) persist Number as NULL — and so does
+                   anything missing/zero/negative. The internal SongId
+                   ties the record together. #392. */
+                $rawNumber  = $song['number'] ?? null;
+                $isOfficial = !empty($officialByAbbr[$songbookAbbr]);
+                $number     = (!$isOfficial || $rawNumber === null || $rawNumber === '' || (int)$rawNumber <= 0)
                     ? null
                     : (int)$rawNumber;
 
@@ -575,9 +585,29 @@ switch ($action) {
         $songId       = (string)$song['id'];
         $songbookAbbr = (string)($song['songbook'] ?? '');
 
-        /* Misc (or any missing value) persists Number as NULL (#392). */
+        /* Probe tblSongbooks for IsOfficial so songs in unofficial
+           songbooks (Misc, custom collections) can persist Number as
+           NULL while songs in official songbooks keep the per-songbook
+           number. The probe happens here (outside the transaction
+           below) because the songbook row is read-only context. #392. */
+        $isOfficialSongbook = false;
+        if ($songbookAbbr !== '') {
+            $probe = getDbMysqli()->prepare(
+                'SELECT IsOfficial FROM tblSongbooks WHERE Abbreviation = ? LIMIT 1'
+            );
+            $probe->bind_param('s', $songbookAbbr);
+            $probe->execute();
+            $row = $probe->get_result()->fetch_assoc();
+            $probe->close();
+            $isOfficialSongbook = (bool)($row['IsOfficial'] ?? false);
+        }
+
+        /* Songs in non-official songbooks (Misc, custom collections)
+           persist Number as NULL — and so does anything missing or
+           non-positive. The internal SongId is the cross-record link
+           in that case. #392. */
         $rawNumber = $song['number'] ?? null;
-        $number    = ($songbookAbbr === 'Misc' || $rawNumber === null || $rawNumber === '' || (int)$rawNumber <= 0)
+        $number    = (!$isOfficialSongbook || $rawNumber === null || $rawNumber === '' || (int)$rawNumber <= 0)
             ? null
             : (int)$rawNumber;
 

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -453,6 +453,43 @@ function getSelectedSongbookFilter() {
 }
 
 /**
+ * updateNumberLabelRequiredness(abbr)
+ * -----------------------------------
+ * Toggles the red `*` and the "Optional — this songbook is unofficial"
+ * hint next to the Song Number input based on whether the songbook
+ * `abbr` carries IsOfficial=1 in songData.songbooks. Required for
+ * official songbooks (SDAH, ACH, …); optional for unofficial ones
+ * (Misc, custom collections). #392.
+ *
+ * @param {string} abbr Songbook abbreviation (or empty string).
+ */
+function updateNumberLabelRequiredness(abbr) {
+    var star  = document.getElementById('edit-number-required');
+    var hint  = document.getElementById('edit-number-hint');
+    var input = document.getElementById('edit-number');
+    if (!star || !hint || !input) return;
+
+    /* No songbook selected: hide both — there's nothing to require yet. */
+    var trimmed = (abbr || '').trim();
+    if (trimmed === '') {
+        star.hidden = true;
+        hint.hidden = true;
+        input.removeAttribute('aria-required');
+        return;
+    }
+
+    var sb = (songData.songbooks || []).find(function (s) { return s.id === trimmed; });
+    var isOfficial = !!(sb && sb.isOfficial);
+    star.hidden = !isOfficial;
+    hint.hidden = isOfficial;
+    if (isOfficial) {
+        input.setAttribute('aria-required', 'true');
+    } else {
+        input.removeAttribute('aria-required');
+    }
+}
+
+/**
  * populateSongbookFilterDropdown()
  * --------------------------------
  * Fills the songbook filter <select> (and the metadata songbook dropdown)
@@ -517,6 +554,9 @@ function selectSong(songId) {
     setVal('edit-title', song.title || '');
     setVal('edit-number', song.number || '');
     setVal('edit-songbook', song.songbook || '');
+    /* Show/hide the red `*` next to "Song Number" based on the loaded
+       song's songbook IsOfficial flag (#392). */
+    updateNumberLabelRequiredness(song.songbook || '');
     setVal('edit-ccli', song.ccli || '');
     setVal('edit-iswc', song.iswc || '');            /* #497 */
     setVal('edit-tune-name', song.tuneName || '');   /* #497 */
@@ -620,6 +660,11 @@ function bindMetadataListeners() {
                 if (field.key === 'songbook') {
                     var sb = songData.songbooks.find(function (s) { return s.id === el.value; });
                     song.songbookName = sb ? sb.name : el.value;
+                    /* Re-evaluate the Song Number `*` requirement (#392).
+                       Switching from an official songbook to an unofficial
+                       one (or vice-versa) should immediately update the
+                       label so the user sees the rule applied to them. */
+                    updateNumberLabelRequiredness(el.value);
                 }
 
                 /* Mark this song as modified. */
@@ -2315,6 +2360,17 @@ function validateSongData() {
     /* Accumulator for error messages. */
     var errors = [];
 
+    /* IsOfficial lookup by songbook abbreviation. Songs in non-
+       official songbooks (Misc, custom collections, etc.) don't
+       have a meaningful per-songbook number — the internal Song ID
+       (`song-<ts>-<rand>`) is the cross-record link instead. Per
+       #392 / #738 follow-up: number is required ONLY when the
+       songbook is flagged IsOfficial=1. */
+    var officialByAbbr = (songData.songbooks || []).reduce(function (map, b) {
+        if (b && typeof b.id === 'string') map[b.id] = !!b.isOfficial;
+        return map;
+    }, Object.create(null));
+
     /* Iterate over every song. */
     songData.songs.forEach(function (song, i) {
         /* Build a label for this song to make errors identifiable. */
@@ -2330,14 +2386,18 @@ function validateSongData() {
             errors.push(label + ': missing or empty "title".');
         }
 
-        /* number is required (can be string or number, but must exist). */
-        if (song.number == null || String(song.number).trim() === '') {
-            errors.push(label + ': missing "number".');
-        }
-
         /* songbook is required. */
         if (!song.songbook || typeof song.songbook !== 'string' || song.songbook.trim() === '') {
             errors.push(label + ': missing or empty "songbook".');
+        }
+
+        /* number is required only when the song's songbook is flagged
+           IsOfficial=1. Unofficial songbooks (Misc and any other
+           custom collection) keep number as nullable since their
+           songs typically aren't numbered in the source. (#392) */
+        var isOfficial = !!officialByAbbr[(song.songbook || '').trim()];
+        if (isOfficial && (song.number == null || String(song.number).trim() === '')) {
+            errors.push(label + ': missing "number" (required for official songbooks).');
         }
 
         /* components must be a non-empty array. */
@@ -2364,6 +2424,12 @@ function validateSongData() {
 function validateSongsByIds(ids) {
     var wanted = new Set(ids);
     var errors = [];
+    /* Same IsOfficial map as validateSongData() — number is required
+       only when the song's songbook is flagged IsOfficial=1. (#392) */
+    var officialByAbbr = (songData.songbooks || []).reduce(function (map, b) {
+        if (b && typeof b.id === 'string') map[b.id] = !!b.isOfficial;
+        return map;
+    }, Object.create(null));
     (songData.songs || []).forEach(function (song, i) {
         if (!wanted.has(song.id)) return;
         var label = 'Song ' + (song.id || '[' + i + ']') +
@@ -2374,11 +2440,12 @@ function validateSongsByIds(ids) {
         if (!song.title || typeof song.title !== 'string' || song.title.trim() === '') {
             errors.push(label + ': missing or empty "title".');
         }
-        if (song.number == null || String(song.number).trim() === '') {
-            errors.push(label + ': missing "number".');
-        }
         if (!song.songbook || typeof song.songbook !== 'string' || song.songbook.trim() === '') {
             errors.push(label + ': missing or empty "songbook".');
+        }
+        var isOfficial = !!officialByAbbr[(song.songbook || '').trim()];
+        if (isOfficial && (song.number == null || String(song.number).trim() === '')) {
+            errors.push(label + ': missing "number" (required for official songbooks).');
         }
         if (!Array.isArray(song.components) || song.components.length === 0) {
             errors.push(label + ': must have at least one component.');
@@ -3111,6 +3178,9 @@ function clearEditForm() {
     setVal('edit-title', '');
     setVal('edit-number', '');
     setVal('edit-songbook', '');
+    /* Reset the Song Number `*` indicator now that no songbook is
+       selected (#392). */
+    updateNumberLabelRequiredness('');
     setVal('edit-ccli', '');
     setVal('edit-iswc', '');           /* #497 */
     setVal('edit-tune-name', '');      /* #497 */

--- a/appWeb/public_html/manage/editor/index.php
+++ b/appWeb/public_html/manage/editor/index.php
@@ -537,7 +537,9 @@ $currentUser = getCurrentUser();
                              own full-width line. -->
                         <div class="row g-2 mb-3">
                             <div class="col-md-2">
-                                <label for="edit-number" class="form-label">Song Number</label>
+                                <label for="edit-number" class="form-label">
+                                    Song Number<span id="edit-number-required" class="text-danger ms-1" hidden aria-hidden="true">*</span>
+                                </label>
                                 <input
                                     type="number"
                                     class="form-control"
@@ -546,6 +548,13 @@ $currentUser = getCurrentUser();
                                     min="1"
                                     max="9999"
                                 >
+                                <!-- Toggled by editor.js when the selected songbook
+                                     is unofficial (Misc, custom collections); songs
+                                     in those songbooks don't have a per-songbook
+                                     number and the internal Song ID is the link. #392 -->
+                                <div id="edit-number-hint" class="form-text" hidden>
+                                    Optional — this songbook is unofficial.
+                                </div>
                             </div>
                             <div class="col-md-5">
                                 <label for="edit-songbook" class="form-label">Songbook</label>


### PR DESCRIPTION
## Summary

- Songs in **unofficial songbooks** (Misc, custom collections — anything flagged `IsOfficial=0` in `tblSongbooks`) no longer require a per-songbook number. The internal `SongId` is the cross-record link.
- Songs in **official songbooks** still require a number — the `*` is shown next to the Song Number label and the existing validators reject empty values.
- Generalises a hardcoded `'Misc'` check that the original #392 backend work left in place, and brings the frontend validators into line with that policy.

## Why

Trying to add an Afrikaans song ("Ons Is Almal Hier Tesaam") to **Misc** without a song number surfaced as `Song song-1777649765838-r5kpll (Ons Is Almal Hier Tesaam): missing 'number'.` That was a frontend validator the backend partial-fix missed, and the backend itself was scoped to `'Misc'` literally — so any future unofficial collection (e.g. a curator-created custom songbook) would have re-introduced the same block.

## Changes

| File | Change |
| --- | --- |
| `appWeb/public_html/manage/editor/editor.js` | `validateSongData()` and `validateSongsByIds()` now skip the "number required" check when the song's songbook isn't `IsOfficial=1`. New `updateNumberLabelRequiredness()` helper wired into `selectSong()`, the songbook-change handler, and `clearEditForm()` keeps the `*` and `aria-required` state in sync as the curator switches songbooks. |
| `appWeb/public_html/manage/editor/api.php` | Bulk `save` action builds an `IsOfficial` lookup from the request payload (`SongData::getSongbooks()` already exposes `isOfficial` as a boolean) and uses it to NULL-out `Number` per song. Single-song `save_song` probes `tblSongbooks` for the same flag. Both paths persist `Number` as `NULL` for unofficial songbooks. |
| `appWeb/public_html/manage/editor/index.php` | Adds a `*` indicator (`#edit-number-required`) and a hidden hint (`#edit-number-hint` — "Optional — this songbook is unofficial") next to the Song Number input. Toggled by the JS helper above. |

## Test plan

- [ ] **Save unofficial-songbook song with no number** — add a new song to **Misc**, leave Song Number blank, click Save. Expect: success toast; row in `tblSongs` with `Number = NULL` and `SongId = song-<ts>-<rand>`.
- [ ] **Save unofficial-songbook song with a number** — same flow but enter `42`. Expect: persists `Number = 42` (the rule is permissive, not forcing NULL).
- [ ] **Save official-songbook song without a number** — pick e.g. **SDAH**, leave Song Number blank, click Save. Expect: validator blocks the save with `"missing 'number' (required for official songbooks)"`.
- [ ] **UI cue toggles live** — open an existing SDAH song; the `*` is visible. Switch the songbook dropdown to **Misc**; the `*` hides and the muted "Optional — this songbook is unofficial" hint appears. Switch back; `*` returns.
- [ ] **Bulk save round-trip** — export the corpus JSON, re-import via the bulk Save action. Expect: Misc songs round-trip with `Number IS NULL`; official-songbook songs keep their integer Number.

## Refs

- Closes #392
- Builds on backend partial fix in commit 33f10a3 (which scoped the rule to literal `'Misc'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)