### PR TITLE
fix(setup): bulk migration aborts with "mysqli object is already closed" (#745)

### DIFF
--- a/appWeb/.sql/migrate-credit-people-slug.php
+++ b/appWeb/.sql/migrate-credit-people-slug.php
@@ -228,4 +228,8 @@ if ($idxExists) {
 }
 
 _migCpSlug_out('Credit People slug migration finished.');
-$mysqli->close();
+/* Don't close $mysqli — it's the shared singleton from getDbMysqli().
+   The bulk migration runner in /manage/setup-database.php iterates many
+   migrations in one PHP request; closing here would invalidate the
+   handle for every subsequent migration that calls getDbMysqli(). PHP
+   closes the connection on script exit anyway. */

--- a/appWeb/.sql/migrate-organisation-licences.php
+++ b/appWeb/.sql/migrate-organisation-licences.php
@@ -188,4 +188,8 @@ if ($filled > 0) {
 }
 
 _migOrgLic_out('Multi-licence migration finished.');
-$mysqli->close();
+/* Don't close $mysqli — it's the shared singleton from getDbMysqli().
+   The bulk migration runner in /manage/setup-database.php iterates many
+   migrations in one PHP request; closing here would invalidate the
+   handle for every subsequent migration that calls getDbMysqli(). PHP
+   closes the connection on script exit anyway. */

--- a/appWeb/.sql/migrate-song-artists.php
+++ b/appWeb/.sql/migrate-song-artists.php
@@ -145,4 +145,8 @@ if (_migArtists_tableExists($mysqli, 'tblSongArtists')) {
 }
 
 _migArtists_out('Songs Artist credit migration finished.');
-$mysqli->close();
+/* Don't close $mysqli — it's the shared singleton from getDbMysqli().
+   The bulk migration runner in /manage/setup-database.php iterates many
+   migrations in one PHP request; closing here would invalidate the
+   handle for every subsequent migration that calls getDbMysqli(). PHP
+   closes the connection on script exit anyway. */

--- a/appWeb/.sql/migrate-user-avatar-service.php
+++ b/appWeb/.sql/migrate-user-avatar-service.php
@@ -133,4 +133,8 @@ if (_migAvatarSvc_columnExists($mysqli, 'tblUsers', 'AvatarService')) {
 }
 
 _migAvatarSvc_out('User avatar-service migration finished.');
-$mysqli->close();
+/* Don't close $mysqli — it's the shared singleton from getDbMysqli().
+   The bulk migration runner in /manage/setup-database.php iterates many
+   migrations in one PHP request; closing here would invalidate the
+   handle for every subsequent migration that calls getDbMysqli(). PHP
+   closes the connection on script exit anyway. */

--- a/appWeb/public_html/includes/db_mysql.php
+++ b/appWeb/public_html/includes/db_mysql.php
@@ -58,7 +58,21 @@ function getDbMysqli(): mysqli
     global $_mysqliConnection;
 
     if ($_mysqliConnection !== null) {
-        return $_mysqliConnection;
+        /* Verify the cached handle is still alive. The bulk migration
+           runner in /manage/setup-database.php iterates many migration
+           scripts in one PHP request, and it's easy for a script to
+           call $mysqli->close() on the singleton — every subsequent
+           caller would otherwise get back a closed handle and fail on
+           the first prepare(). Touching `thread_id` on a closed
+           connection throws under MYSQLI_REPORT_STRICT (set below);
+           catching that lets us null the cache and reconnect below
+           without a wasted MySQL ping round-trip. (#745) */
+        try {
+            $_ = $_mysqliConnection->thread_id;
+            return $_mysqliConnection;
+        } catch (\Throwable $_e) {
+            $_mysqliConnection = null;
+        }
     }
 
     /* Verify credentials are loaded */


### PR DESCRIPTION
## Summary

- Strips \`\$mysqli->close()\` from 4 migrations that share the \`getDbMysqli()\` singleton.
- Hardens \`getDbMysqli()\` so a closed cached handle is detected (no MySQL round-trip) and replaced transparently.
- Closes #745.

## Root cause

The bulk runner in \`/manage/setup-database.php\` requires each migration in the **same PHP request**. \`getDbMysqli()\` returns a cached singleton — once any migration calls \`->close()\` on it, every subsequent caller gets back the closed handle and fails on the first \`prepare()\`.

Audit of the 20 migrations in \`\$migrationOrder\` flagged 4 mishandling the singleton:

| Migration | Status |
| --- | --- |
| song-artists | Was closing the singleton — first to break the chain (caused #745's failure at step 9) |
| credit-people-slug | Same pattern — would have compounded |
| user-avatar-service | Same |
| organisation-licences | Same |

The 6 \"close\"-style migrations earlier in the order (account-sync, credits, songbook-meta, user-features-catchup, activity-log-expand, credit-people) all open their own \`new mysqli(...)\` connection and close that — they don't touch the singleton, so they're fine.

## Files

| File | Change |
| --- | --- |
| \`appWeb/.sql/migrate-song-artists.php\` | Removed trailing \`\$mysqli->close()\`. |
| \`appWeb/.sql/migrate-credit-people-slug.php\` | Same. |
| \`appWeb/.sql/migrate-user-avatar-service.php\` | Same. |
| \`appWeb/.sql/migrate-organisation-licences.php\` | Same. Each strip is replaced with a comment explaining why an explicit close is skipped, so a future maintainer doesn't add it back. |
| \`appWeb/public_html/includes/db_mysql.php\` | \`getDbMysqli()\` now touches \`\$conn->thread_id\` inside a try/catch on the cache-hit path — under \`MYSQLI_REPORT_STRICT\` accessing a property on a closed mysqli throws. On throw, the cache nulls and the function falls through to the existing reconnect path. Cheapest liveness check (no MySQL round-trip). Belt-and-braces against any future migration accidentally closing the singleton. |

## Test plan

- [ ] **Bulk run on a clean schema** — \`Apply All Pending Migrations\` runs the full 20-step chain to completion. Per-step output shows each migration's \`[SKIP]\` or \`[add]\` lines as expected.
- [ ] **Bulk run is idempotent** — re-clicking the button immediately after is a no-op for every step (each migration's INFORMATION_SCHEMA probes hit \`[skip]\`).
- [ ] **Singleton hardening** — manually call \`\$db = getDbMysqli(); \$db->close(); \$db = getDbMysqli();\` in a smoke script — the second call returns a fresh, alive connection.
- [ ] **Standalone runs still work** — clicking each per-card button (e.g. \`Run Song Artists Migration\`) still completes; the missing close doesn't leak (PHP closes on script exit).

## Refs

- Closes #745
- Related to PR #741 (CLDR NativeName overlay) and #742 (/manage/languages CRUD) — both add migrations that follow the singleton pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)