### PR TITLE
fix(ui): restore the scroll-progress bar on song pages

### DIFF
--- a/appWeb/public_html/css/app.css
+++ b/appWeb/public_html/css/app.css
@@ -568,10 +568,10 @@ body.banner-visible.search-open .main-content {
         padding-bottom: env(safe-area-inset-bottom, 0px);
     }
 
-    /* Reading progress bar — account for taller header in standalone mode (#350) */
-    .reading-progress-bar {
-        top: calc(var(--header-height, 56px) + env(safe-area-inset-top, 0px));
-    }
+    /* Reading progress bar — the base rule already uses
+       env(safe-area-inset-top) so the bar sits flush below the
+       Dynamic Island / camera area in standalone PWA mode. No
+       override needed here. (#350) */
 
     .compare-header {
         padding-top: max(0.75rem, env(safe-area-inset-top, 0px));
@@ -2127,28 +2127,38 @@ body.reduce-motion .shortcuts-overlay {
    ========================================================================== */
 
 .reading-progress-bar {
-    position: sticky;
-    top: var(--header-height, 56px);
+    /* position: fixed (not sticky) — sticky breaks under any
+       transformed ancestor, and #page-content has a transform on it
+       for the page-transition animation (#149). The JS module
+       inserts the bar directly under <body> for the same reason —
+       body has no transform, so the fixed positioning is reliable.
+       env(safe-area-inset-top) keeps the bar flush below a notch /
+       Dynamic Island / camera punch-hole when installed as a PWA;
+       outside standalone mode it defaults to 0. (#350) */
+    position: fixed;
+    top: env(safe-area-inset-top, 0px);
     left: 0;
     width: 0;
     height: 3px;
     background: var(--bs-primary, #6366f1);
-    z-index: 1020;
+    z-index: 1030;
     transition: width 80ms linear;
     border-radius: 0 2px 2px 0;
+    pointer-events: none;
 }
 
-/* Songbook-specific accent colours */
-.reading-progress-bar[data-songbook="CP"] { background: var(--songbook-CP, #6366f1); }
-.reading-progress-bar[data-songbook="JP"] { background: var(--songbook-JP, #ec4899); }
-.reading-progress-bar[data-songbook="MP"] { background: var(--songbook-MP, #f59e0b); }
-.reading-progress-bar[data-songbook="SDAH"] { background: var(--songbook-SDAH, #ef4444); }
-.reading-progress-bar[data-songbook="CH"] { background: var(--songbook-CH, #8b5cf6); }
-
-/* In presentation mode, stick to top of screen (no header) */
-body.presentation-active .reading-progress-bar {
-    top: 0;
-}
+/* Built-in-songbook accent colours. The runtime colour from
+   tblSongbooks.Colour wins via inline style set in
+   js/modules/reading-progress.js — these data-attribute selectors
+   are the legacy fallback for the original 5 abbreviations + Misc.
+   Custom songbooks created via /manage/songbooks rely on the inline
+   style and don't need a CSS rule here. */
+.reading-progress-bar[data-songbook="CP"]   { background: var(--songbook-CP-solid,   #6366f1); }
+.reading-progress-bar[data-songbook="JP"]   { background: var(--songbook-JP-solid,   #ec4899); }
+.reading-progress-bar[data-songbook="MP"]   { background: var(--songbook-MP-solid,   #14b8a6); }
+.reading-progress-bar[data-songbook="SDAH"] { background: var(--songbook-SDAH-solid, #f59e0b); }
+.reading-progress-bar[data-songbook="CH"]   { background: var(--songbook-CH-solid,   #ef4444); }
+.reading-progress-bar[data-songbook="Misc"] { background: var(--songbook-Misc-solid, #8b5cf6); }
 
 /* Respect reduce-motion */
 body.reduce-motion .reading-progress-bar {

--- a/appWeb/public_html/includes/pages/song.php
+++ b/appWeb/public_html/includes/pages/song.php
@@ -37,6 +37,19 @@ $songNumber    = ($rawSongNumber === null || $rawSongNumber === '') ? null : (in
 $songTitle   = toTitleCase($song['title'] ?? 'Untitled');
 $songbook    = $song['songbook'] ?? '';
 $bookName    = $song['songbookName'] ?? '';
+/* Songbook colour for the reading-progress bar (#109). Fetched here
+   instead of leaving it to a CSS variable lookup so custom songbooks
+   created via /manage/songbooks (whose abbreviation isn't in the
+   hardcoded --songbook-{ABBR} CSS-var set) still get their assigned
+   colour on the bar. Empty string means "let the bar fall back to
+   the default accent". */
+$songbookColour = '';
+if ($songbook !== '') {
+    $bookData = $songData->getSongbook($songbook);
+    if (is_array($bookData) && !empty($bookData['colour'])) {
+        $songbookColour = trim((string)$bookData['colour']);
+    }
+}
 $writers     = $song['writers']     ?? [];
 $composers   = $song['composers']   ?? [];
 $arrangers   = $song['arrangers']   ?? [];   /* #497 */
@@ -142,7 +155,7 @@ unset($_t);
 <!-- ================================================================
      SONG PAGE — Full lyrics and metadata
      ================================================================ -->
-<article class="page-song" aria-label="<?= htmlspecialchars($songTitle) ?>" data-song-id="<?= htmlspecialchars($song['id']) ?>" data-songbook="<?= htmlspecialchars($songbook) ?>" data-song-number="<?= (int)$songNumber ?>"<?php if (!empty($song['capo'])): ?> data-capo="<?= (int)$song['capo'] ?>"<?php endif; ?><?php if (!empty($song['key'])): ?> data-key="<?= htmlspecialchars($song['key']) ?>"<?php endif; ?>>
+<article class="page-song" aria-label="<?= htmlspecialchars($songTitle) ?>" data-song-id="<?= htmlspecialchars($song['id']) ?>" data-songbook="<?= htmlspecialchars($songbook) ?>"<?php if ($songbookColour !== ''): ?> data-songbook-color="<?= htmlspecialchars($songbookColour) ?>"<?php endif; ?> data-song-number="<?= (int)$songNumber ?>"<?php if (!empty($song['capo'])): ?> data-capo="<?= (int)$song['capo'] ?>"<?php endif; ?><?php if (!empty($song['key'])): ?> data-key="<?= htmlspecialchars($song['key']) ?>"<?php endif; ?>>
 
     <!-- Breadcrumb navigation with schema.org markup (#151) -->
     <nav aria-label="Breadcrumb" class="mb-3">

--- a/appWeb/public_html/js/modules/reading-progress.js
+++ b/appWeb/public_html/js/modules/reading-progress.js
@@ -62,17 +62,33 @@ export class ReadingProgress {
         this.bar.setAttribute('aria-valuemax', '100');
         this.bar.setAttribute('aria-valuenow', '0');
 
-        /* Apply songbook accent colour if available */
-        const songbook = songPage.dataset.songbook;
+        /* Apply songbook accent colour. Three sources, in priority order:
+           1) data-songbook-color on the article — the runtime colour
+              fetched by song.php from tblSongbooks.Colour. Works for
+              every songbook, including custom ones created via
+              /manage/songbooks whose abbreviation isn't in the
+              hardcoded --songbook-{ABBR} CSS variable set.
+           2) data-songbook abbreviation, exposed via the
+              [data-songbook="…"] CSS rules in app.css for the legacy
+              built-in songbooks (CP/JP/MP/SDAH/CH/Misc).
+           3) The CSS default (--bs-primary). */
+        const songbook       = songPage.dataset.songbook;
+        const songbookColour = songPage.dataset.songbookColor;
+        if (songbookColour) {
+            this.bar.style.background = songbookColour;
+        }
         if (songbook) {
             this.bar.dataset.songbook = songbook;
         }
 
-        /* Insert at the very top of the main content area */
-        const content = document.getElementById('page-content');
-        if (content) {
-            content.insertBefore(this.bar, content.firstChild);
-        }
+        /* Insert directly under <body> rather than inside #page-content.
+           #page-content has a transform on it for the page-transition
+           animation (#149), and a transformed ancestor establishes a
+           new containing block for position:sticky/fixed — sticking
+           the bar inside the transitioning page instead of to the
+           viewport. Body has no transform, so position:fixed pins
+           reliably to the top of the viewport. */
+        document.body.appendChild(this.bar);
     }
 
     /** Update the progress bar width based on scroll position */


### PR DESCRIPTION
## Summary

- Restores the thin coloured bar at the top of song pages that fills left-to-right as the user scrolls (#109). It was working on LIVE but vanished on alpha/beta — now back, with the songbook's runtime colour applied (matches the yellow/gold for SDAH in the user-supplied screenshot).
- Side-fix: the legacy CSS only knew about the five built-in songbooks. Custom songbooks created via /manage/songbooks now use their assigned \`tblSongbooks.Colour\` automatically.

## Why it broke

The bar was inserted as the first child of \`#page-content\` and positioned with \`position: sticky; top: var(--header-height)\`. Per the CSS spec, **a transformed ancestor establishes a new containing block for sticky/fixed descendants**. The page-transition animation work (#149) added a \`transform\` to \`#page-content\` for the slide-in/out effect — once that landed, the bar started sticking to the moving page instead of the viewport, effectively going invisible at the wrong scroll positions.

Confirmed by walking the CSS / JS / DOM:

- [css/app.css:612-628](appWeb/public_html/css/app.css#L612-L628) — \`#page-content\` has \`transition: opacity 0.25s ease, transform 0.25s ease\` and \`.page-leaving\` / \`.page-entering\` apply \`transform: translateY(...)\`.
- [js/modules/reading-progress.js:74](appWeb/public_html/js/modules/reading-progress.js#L74) (before) — bar inserted into \`#page-content\`.
- That's the spec collision.

## Fix

| File | Change |
| --- | --- |
| \`js/modules/reading-progress.js\` | Append the bar to \`<body>\` instead of \`#page-content\`. <body> has no transform → stable containing block. \`bar.remove()\` cleanup still works. JS also now reads \`data-songbook-color\` from the article and applies it as an inline \`background\` style. |
| \`css/app.css\` | Switched from \`position: sticky; top: var(--header-height)\` to \`position: fixed; top: env(safe-area-inset-top, 0px); left: 0\`. The safe-area inset handles iOS PWA installs with a notch / Dynamic Island automatically — outside standalone mode it's 0. Added \`pointer-events: none\` so the 3-pixel-high bar never steals a tap. Dropped the now-redundant \`@media (display-mode: standalone)\` override. The legacy \`[data-songbook=\"…\"]\` rules now reference \`--songbook-{ABBR}-solid\` (introduced by #688) so the bar gets a solid colour instead of a 135° gradient on 3 vertical pixels. |
| \`includes/pages/song.php\` | Fetches \`tblSongbooks.Colour\` for the current song's songbook via the existing \`SongData::getSongbook()\` helper and exposes it on the article as \`data-songbook-color=\"#hex\"\`. The JS reads it first; falls back to \`[data-songbook=\"…\"]\` CSS rules for built-ins, falls back to \`--bs-primary\`. |

The base mechanic (don't render on short songs, update on scroll, ARIA progressbar, respect \`prefers-reduced-motion\`) is unchanged.

## Test plan

- [ ] **Song with long lyrics on alpha/beta** — open any SDAH song. Expect: thin gold bar at the very top of the viewport. Scrolling fills it left-to-right; reaches 100% at the bottom.
- [ ] **Different songbook colour** — open a CH song. Expect: bar is the CH solid colour (red).
- [ ] **Custom songbook** — create a custom songbook in /manage/songbooks with a non-standard hex like \`#22c55e\`, add a song, open it. Expect: bar shows that exact green.
- [ ] **Short song** — open a 1-verse song that doesn't scroll. Expect: no bar (intentional — \`scrollHeight <= viewport+50\` short-circuit).
- [ ] **Page transition** — navigate from one song to another via the in-app router. Expect: bar cleans up, the new page's bar replaces it; no leftover bar from the previous song; no flicker / stick at the wrong y position.
- [ ] **iOS PWA installed (Dynamic Island / notch)** — open a song. Expect: bar sits flush below the safe-area inset, not under the OS status area.
- [ ] **Reduce-motion** — enable the OS preference. Expect: width changes are instant, no transition.

## Refs

- Closes the regression from #149.
- Original feature: #109 (\"Add scroll-linked reading progress indicator on song pages\").
- Songbook colour comes from the auto-colour work in #688.

🤖 Generated with [Claude Code](https://claude.com/claude-code)