### PR TITLE
fix(ci): auto-delete merged-PR head branches (#750)

### DIFF
--- a/.github/workflows/auto-merge-alpha.yml
+++ b/.github/workflows/auto-merge-alpha.yml
@@ -57,11 +57,16 @@ jobs:
     # Skip drafts — auto-merge cannot be enabled on draft PRs.
     if: github.event.pull_request.draft == false
     steps:
-      - name: Enable auto-merge (squash)
+      - name: Enable auto-merge (squash, delete branch on merge)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
-        run: gh pr merge --auto --squash "$PR_URL"
+        # --delete-branch is explicit: gh's --auto path doesn't propagate
+        # the repo-level delete_branch_on_merge setting through to the
+        # GraphQL enablePullRequestAutoMerge mutation. Without this flag
+        # every auto-merged PR's head branch sticks around after merge,
+        # which is exactly the regression behind #750.
+        run: gh pr merge --auto --squash --delete-branch "$PR_URL"
 
       # ---------------------------------------------------------------------
       # Bridge GitHub's GITHUB_TOKEN anti-recursion rule (#551).

--- a/tools/prune-merged-branches.sh
+++ b/tools/prune-merged-branches.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+#
+# Prune remote branches whose corresponding PR has already been merged.
+#
+# Background: from PR ~#737 onwards, auto-merge-alpha.yml stopped
+# deleting head branches because `gh pr merge --auto --squash` doesn't
+# propagate the repo-level delete_branch_on_merge setting (#750). The
+# fix in that PR adds --delete-branch so future merges clean up after
+# themselves; this script clears the existing backlog of merged-but-
+# undeleted branches.
+#
+# What it does:
+#   1. Lists every remote branch under refs/heads/.
+#   2. For each, asks GitHub whether a merged PR exists with that
+#      branch as its head ref.
+#   3. If yes, deletes the remote branch.
+#
+# What it never deletes:
+#   - main / alpha / beta — explicitly skipped, also blocked by the
+#     "Keep core branches" ruleset on the repo.
+#   - Branches whose PR is open or closed-without-merge.
+#   - Branches with no PR.
+#
+# Usage:
+#   tools/prune-merged-branches.sh             # dry-run (default)
+#   tools/prune-merged-branches.sh --apply     # actually delete
+#
+# Requires: gh CLI authenticated against MWBMPartners/iHymns.
+
+set -uo pipefail
+
+REPO="${REPO:-MWBMPartners/iHymns}"
+APPLY=0
+if [[ "${1:-}" == "--apply" ]]; then
+    APPLY=1
+fi
+
+PROTECTED=("main" "alpha" "beta")
+is_protected() {
+    local b="$1"
+    for p in "${PROTECTED[@]}"; do
+        [[ "$b" == "$p" ]] && return 0
+    done
+    return 1
+}
+
+# Fetch the live remote branch list. `git ls-remote --heads` is the
+# authoritative source; output shape is `<sha>\trefs/heads/<branch>`.
+# We read line-by-line into an array via a portable while-read loop
+# rather than `mapfile`, since macOS still ships bash 3.2 by default.
+echo "[info] Fetching remote branch list…" >&2
+BRANCHES=()
+while IFS= read -r line; do
+    [[ -n "$line" ]] && BRANCHES+=("$line")
+done < <(git ls-remote --heads "https://github.com/${REPO}.git" \
+    | awk '{sub(/^refs\/heads\//,"",$2); print $2}' | sort)
+
+echo "[info] ${#BRANCHES[@]} remote branch(es)." >&2
+echo "[info] Mode: $([[ $APPLY -eq 1 ]] && echo APPLY || echo DRY-RUN)" >&2
+echo >&2
+
+deleted=0
+skipped_protected=0
+skipped_no_pr=0
+skipped_open=0
+errors=0
+
+for b in "${BRANCHES[@]}"; do
+    if is_protected "$b"; then
+        skipped_protected=$((skipped_protected + 1))
+        continue
+    fi
+
+    # Lookup the PR (if any) that has this branch as head. We accept
+    # the most recent matching PR — if a branch has multiple closed
+    # PRs against it, the latest state wins.
+    state=$(gh pr list --repo "$REPO" --state all --head "$b" \
+        --json state,mergedAt --jq 'sort_by(.mergedAt) | last | .state // ""' 2>/dev/null)
+
+    case "$state" in
+        MERGED)
+            if [[ $APPLY -eq 1 ]]; then
+                if gh api -X DELETE "repos/${REPO}/git/refs/heads/${b}" >/dev/null 2>&1; then
+                    printf "[del]  %s\n" "$b"
+                    deleted=$((deleted + 1))
+                else
+                    printf "[err]  %s — DELETE failed\n" "$b"
+                    errors=$((errors + 1))
+                fi
+            else
+                printf "[plan] %s — merged PR, would delete\n" "$b"
+                deleted=$((deleted + 1))
+            fi
+            ;;
+        OPEN)
+            skipped_open=$((skipped_open + 1))
+            ;;
+        CLOSED|"")
+            # CLOSED-without-merge: leave alone — the curator might
+            # be planning to reopen / cherry-pick. Empty state means
+            # no PR ever existed against this branch (e.g. a draft
+            # branch with no PR yet).
+            skipped_no_pr=$((skipped_no_pr + 1))
+            ;;
+    esac
+done
+
+echo >&2
+echo "[done] Summary:" >&2
+echo "  $deleted branch(es) $([[ $APPLY -eq 1 ]] && echo deleted || echo would be deleted)" >&2
+echo "  $skipped_protected protected branch(es) skipped (main/alpha/beta)" >&2
+echo "  $skipped_open branch(es) with open PR — left alone" >&2
+echo "  $skipped_no_pr branch(es) with no merged PR — left alone" >&2
+if [[ $errors -gt 0 ]]; then
+    echo "  $errors delete error(s) — see [err] lines above" >&2
+fi
+
+if [[ $APPLY -eq 0 ]]; then
+    echo >&2
+    echo "[hint] Re-run with --apply to actually delete." >&2
+fi


### PR DESCRIPTION
## Summary

- Adds \`--delete-branch\` to the auto-merge workflow's \`gh pr merge --auto --squash\` invocation. Future auto-merged PRs will delete their head branch on success.
- Ships \`tools/prune-merged-branches.sh\` — one-shot cleanup script for the existing backlog. **Already applied as part of resolving #750: 43 merged-but-undeleted \`claude/*\` branches removed**, with \`main\` / \`alpha\` / \`beta\` and the only open-PR branch (this one) untouched.
- Closes #750.

## Why

\`delete_branch_on_merge\` is \`true\` at the repo level, the rulesets only protect \`main\` / \`alpha\` / \`beta\`, and direct \`gh api -X DELETE refs/heads/<x>\` succeeds without permission errors — yet 40+ \`claude/*\` branches from the past two weeks of merged PRs were still on the remote. Root cause is in \`auto-merge-alpha.yml\`:

\`\`\`yaml
gh pr merge --auto --squash \"\$PR_URL\"
\`\`\`

The \`--auto\` path queues the merge for \"when status checks pass\" via the GraphQL \`enablePullRequestAutoMerge\` mutation. That mutation has its own \`deleteBranchOnMerge\` parameter and does **not** automatically inherit the repo-level setting. Without \`--delete-branch\` the head branch survives every auto-merge.

## Files

| File | Change |
| --- | --- |
| \`.github/workflows/auto-merge-alpha.yml\` | One-line: add \`--delete-branch\` to the \`gh pr merge\` invocation, with a comment explaining why it can't be inferred from the repo setting. |
| \`tools/prune-merged-branches.sh\` (new) | Cleanup script. Lists every remote branch, asks \`gh pr list --state all --head <branch>\` for each, deletes when the latest matching PR is \`MERGED\`. Skips \`main\` / \`alpha\` / \`beta\`, leaves open-PR / closed-without-merge / no-PR branches alone. Dry-run by default; \`--apply\` actually deletes. Portable bash 3.2+ (no \`mapfile\` since macOS ships 3.2). |

## Cleanup applied

Before opening this PR I ran \`tools/prune-merged-branches.sh --apply\` against the remote. The summary:

\`\`\`
[done] Summary:
  43 branch(es) deleted
  3 protected branch(es) skipped (main/alpha/beta)
  1 branch(es) with open PR — left alone   ← this PR's branch
  0 branch(es) with no merged PR — left alone
\`\`\`

The 43 deletions included every branch in the user's recent \"Yours\" list — \`claude/feat-cldr-native-names-overlay\`, \`claude/fix-734-735-736-language-filter-v2\`, etc. — back through to mid-April PRs. Their content was already on alpha (squash-merged), so no work was lost.

## Test plan

- [ ] **Future auto-merge** — open a trivial PR against alpha, let CI pass + auto-merge fire. Expect: head branch is gone within seconds of the merge commit landing.
- [ ] **Cleanup script dry-run** — \`bash tools/prune-merged-branches.sh\` lists \`[plan]\` lines for any merged-but-undeleted branches without modifying anything.
- [ ] **Cleanup script apply** — \`bash tools/prune-merged-branches.sh --apply\` actually deletes them.
- [ ] **Protected refs untouched** — at no point does the script touch \`main\`, \`alpha\`, or \`beta\`.

## Refs

- Closes #750
- Related to PR #737's discovery: \`claude/fix-734-735-736-language-filter-v2\` looked unmerged because its individual commits were squashed; the branch sat stale because of this same auto-delete bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)