### PR TITLE
feat(ui): scroll-progress bar on every scrollable page (#751)

### DIFF
--- a/appWeb/public_html/js/modules/reading-progress.js
+++ b/appWeb/public_html/js/modules/reading-progress.js
@@ -1,12 +1,16 @@
 /**
- * iHymns — Reading Progress Indicator Module (#109)
+ * iHymns — Reading Progress Indicator Module (#109, #751)
  *
  * Copyright (c) 2026 iHymns. All rights reserved.
  *
  * PURPOSE:
- * Displays a thin, scroll-linked progress bar at the top of song pages
- * that fills from left to right as the user scrolls through lyrics.
- * Uses the songbook accent colour. Hidden on short songs that don't scroll.
+ * Displays a thin, scroll-linked progress bar at the top of any
+ * scrollable page. Originally song-only (#109); generalised in #751
+ * to fire on every page the router loads. The bar fills from left to
+ * right as the user scrolls, hidden on short pages that don't need
+ * scrolling. Songbook colour applies on song / songbook pages where
+ * the relevant `data-songbook-color` is present; everywhere else the
+ * bar uses the framework accent colour.
  */
 
 export class ReadingProgress {
@@ -27,22 +31,37 @@ export class ReadingProgress {
     init() {}
 
     /**
-     * Set up the progress indicator on a song page.
-     * Called by router after song page loads.
+     * Generic entry point: attach the progress bar to whatever page is
+     * currently rendered, regardless of which router page emitted it.
+     * Called by router.afterPageLoad() on every navigation. Safe to
+     * call when no scrollable content is present — short pages are
+     * detected via the documentElement.scrollHeight heuristic and the
+     * bar simply isn't created.
+     *
+     * Colour-source priority (set by createBar()):
+     *   1. data-songbook-color attribute on a `.page-song` /
+     *      `.page-songbook` ancestor — when the page has a clear
+     *      songbook context, we inherit its accent.
+     *   2. Legacy [data-songbook="…"] CSS rules for the original
+     *      hardcoded songbooks (CP/JP/MP/SDAH/CH/Misc).
+     *   3. CSS default (--bs-primary) — every other page.
      */
-    initSongPage() {
+    initOnAnyPage() {
         this.cleanup();
 
-        const songPage = document.querySelector('.page-song');
-        if (!songPage) return;
-
-        /* Check if the page actually scrolls */
+        /* Wait one frame so the freshly-injected page HTML has had
+           layout. scrollHeight is what we check; before layout it's
+           often equal to clientHeight and we'd false-negative. */
         requestAnimationFrame(() => {
             if (document.documentElement.scrollHeight <= window.innerHeight + 50) {
-                return; /* Song is short enough to not need scrolling */
+                return; /* Page doesn't scroll meaningfully — no bar needed. */
             }
 
-            this.createBar(songPage);
+            /* Prefer a song / songbook context for colour inheritance,
+               but the bar attaches even when neither is present. */
+            const ctx = document.querySelector('.page-song, .page-songbook');
+            this.createBar(ctx);
+
             this._scrollHandler = () => this.updateProgress();
             window.addEventListener('scroll', this._scrollHandler, { passive: true });
             this.updateProgress();
@@ -50,10 +69,22 @@ export class ReadingProgress {
     }
 
     /**
-     * Create the progress bar element.
-     * @param {HTMLElement} songPage The song page article element
+     * Backwards-compatible alias. The router still calls this on
+     * song-page navigation; new call sites should prefer
+     * initOnAnyPage(). (#751)
      */
-    createBar(songPage) {
+    initSongPage() {
+        this.initOnAnyPage();
+    }
+
+    /**
+     * Create the progress bar element.
+     * @param {HTMLElement|null} ctx Optional song/songbook context
+     *   element used to inherit the accent colour. When null (e.g. on
+     *   /home, /favorites, or any /manage/* page), the bar uses the
+     *   default --bs-primary CSS rule.
+     */
+    createBar(ctx) {
         this.bar = document.createElement('div');
         this.bar.className = 'reading-progress-bar';
         this.bar.setAttribute('role', 'progressbar');
@@ -62,23 +93,29 @@ export class ReadingProgress {
         this.bar.setAttribute('aria-valuemax', '100');
         this.bar.setAttribute('aria-valuenow', '0');
 
-        /* Apply songbook accent colour. Three sources, in priority order:
-           1) data-songbook-color on the article — the runtime colour
-              fetched by song.php from tblSongbooks.Colour. Works for
-              every songbook, including custom ones created via
+        /* Apply songbook accent colour when a context is present. Three
+           sources, in priority order:
+           1) data-songbook-color on the page-song / page-songbook
+              article — the runtime colour fetched by song.php /
+              songbook page from tblSongbooks.Colour. Works for every
+              songbook, including custom ones created via
               /manage/songbooks whose abbreviation isn't in the
               hardcoded --songbook-{ABBR} CSS variable set.
            2) data-songbook abbreviation, exposed via the
               [data-songbook="…"] CSS rules in app.css for the legacy
               built-in songbooks (CP/JP/MP/SDAH/CH/Misc).
-           3) The CSS default (--bs-primary). */
-        const songbook       = songPage.dataset.songbook;
-        const songbookColour = songPage.dataset.songbookColor;
-        if (songbookColour) {
-            this.bar.style.background = songbookColour;
-        }
-        if (songbook) {
-            this.bar.dataset.songbook = songbook;
+           3) The CSS default (--bs-primary) — applies on every other
+              page (#751: home, songbooks list, favourites, /manage/*,
+              etc.). */
+        if (ctx) {
+            const songbook       = ctx.dataset.songbook;
+            const songbookColour = ctx.dataset.songbookColor;
+            if (songbookColour) {
+                this.bar.style.background = songbookColour;
+            }
+            if (songbook) {
+                this.bar.dataset.songbook = songbook;
+            }
         }
 
         /* Insert directly under <body> rather than inside #page-content.

--- a/appWeb/public_html/js/modules/router.js
+++ b/appWeb/public_html/js/modules/router.js
@@ -428,6 +428,15 @@ export class Router {
            that already have handlers. */
         import('./offline-ui.js').then(m => m.bootOfflineUi()).catch(() => {});
 
+        /* Reading-progress bar on every scrollable page (#751). Was
+           song-only originally (#109); the module's short-page
+           short-circuit handles non-scrollable pages cleanly so
+           there's no need to gate per-page-type here. Songbook colour
+           still inherits from .page-song / .page-songbook when
+           present; everywhere else the CSS default (--bs-primary)
+           applies. */
+        this.app.readingProgress.initOnAnyPage();
+
         /* Initialise favourites state on song pages */
         if (page === 'song') {
             this.app.favorites.initSongPage();
@@ -437,7 +446,10 @@ export class Router {
             this.app.display.initSongPage();
             this.app.compare.initSongPage();
             this.app.transpose.initSongPage();
-            this.app.readingProgress.initSongPage();
+            /* readingProgress.initOnAnyPage() already ran at the top
+               of afterPageLoad — covers every page including song.
+               Removing the song-specific re-call avoids a redundant
+               cleanup-then-recreate cycle. (#751) */
 
             /* Audio button — hide if the browser can't actually play
                our MIDI-via-Tone.js pipeline (#602). The audio module

--- a/appWeb/public_html/manage/includes/admin-footer.php
+++ b/appWeb/public_html/manage/includes/admin-footer.php
@@ -92,3 +92,29 @@ if (!empty($GLOBALS['_adminLayoutOpen'])):
     bootBulkImportProgressWidget();
 </script>
 
+<?php
+    /* Reading-progress bar on every /manage/* page (#751). The public
+       site wires this through its router on every navigation;
+       /manage/* pages are full-page reloads, so we boot the module
+       once on DOMContentLoaded. The module is shared with the public
+       site (single source of truth) and the bar's mechanics are
+       identical: position:fixed at the top of the viewport, fills as
+       the user scrolls, hidden on short pages, defaults to
+       --bs-primary on admin pages where there's no songbook context. */
+    $_readingProgressPath = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'js' . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR . 'reading-progress.js';
+    $_readingProgressVersion = is_file($_readingProgressPath) ? (string)filemtime($_readingProgressPath) : '1';
+?>
+<script type="module">
+    import { ReadingProgress }
+        from '/js/modules/reading-progress.js?v=<?= htmlspecialchars($_readingProgressVersion, ENT_QUOTES) ?>';
+    /* Standalone instance — no parent app on /manage/* surfaces, so we
+       pass null. The module only reads `this.app` for hooks the admin
+       surface doesn't use. */
+    const rp = new ReadingProgress(null);
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', () => rp.initOnAnyPage());
+    } else {
+        rp.initOnAnyPage();
+    }
+</script>
+


### PR DESCRIPTION
## Summary

- Generalises the scroll-progress bar from song-pages-only (originally #109, restored by PR #749) to **every scrollable page** — public site (homepage, songbooks list, song list, song page, favourites, …) and admin /manage/* surfaces.
- Closes #751.

## Mechanics (unchanged from PR #749)

- \`position: fixed\` at the top of the viewport, with \`env(safe-area-inset-top)\` so it sits flush below an iOS Dynamic Island / notch in PWA mode.
- Fills left-to-right as the user scrolls.
- Hidden on short pages — \`scrollHeight ≤ viewport + 50\` short-circuit.
- Respects \`prefers-reduced-motion\` (instant width changes).
- Colour priority: \`data-songbook-color\` from \`.page-song\` / \`.page-songbook\` → built-in \`--songbook-{ABBR}-solid\` CSS rule for the legacy 6 abbreviations → \`--bs-primary\` (default for every other page including admin).

## Files

| File | Change |
| --- | --- |
| \`js/modules/reading-progress.js\` | Renamed entry point to \`initOnAnyPage()\`; \`initSongPage()\` is now a thin alias so any external caller still works. \`createBar(ctx)\` takes an optional context element — when null (no songbook on this page), the bar is created without the data-songbook attribute and the CSS default applies. Colour-context lookup now matches \`.page-song\` OR \`.page-songbook\`. |
| \`js/modules/router.js\` | \`afterPageLoad()\` calls \`readingProgress.initOnAnyPage()\` on every navigation, before the per-page-type branch. The redundant song-branch call is removed. |
| \`manage/includes/admin-footer.php\` | Adds a \`<script type=\"module\">\` block that constructs a standalone \`ReadingProgress\` instance and calls \`initOnAnyPage()\` on \`DOMContentLoaded\`. /manage/* surfaces are full-page reloads, so they need their own boot — the module is shared with the public site (single source of truth). |

CSS unchanged from PR #749 — same rules apply to the generalised case.

## Test plan

- [ ] **Public — homepage** — scroll. Expect: thin \`--bs-primary\` bar at top fills as you scroll.
- [ ] **Public — songbook list** — same. Bar fills.
- [ ] **Public — song page (SDAH)** — bar uses the SDAH gold colour (matches the screenshot).
- [ ] **Public — song page (custom songbook)** — bar uses the custom songbook's stored \`tblSongbooks.Colour\`.
- [ ] **Public — short page that doesn't scroll** — no bar appears.
- [ ] **Admin — /manage/dashboard** — scroll. Bar fills, default colour.
- [ ] **Admin — /manage/credit-people** (long table) — bar fills as the page scrolls.
- [ ] **Admin — /manage/setup-database** (long page) — bar fills.
- [ ] **Page transitions still work** — navigate /home → /song. Bar cleans up and re-creates per-page; no flicker / wrong-colour artefact.
- [ ] **Reduce-motion** — enable OS preference; width updates are instant.

## Refs

- Closes #751
- Built on PR #749 (#109's restoration after the #149 transform regression).
- Original feature: #109.

🤖 Generated with [Claude Code](https://claude.com/claude-code)