### PR TITLE
feat(transitions): direction-aware slide + scroll restoration (#752 v1)

### DIFF
--- a/appWeb/public_html/css/app.css
+++ b/appWeb/public_html/css/app.css
@@ -628,6 +628,56 @@ body.banner-visible.search-open .main-content {
     transform: translateY(0);
 }
 
+/* ------------------------------------------------------------------
+ * Per-type page transitions (#752)
+ *
+ * The base rules above describe the legacy "fade-with-translateY"
+ * effect — that's the default for both `fade` and `crossfade`. The
+ * `slide` variant overrides the transform to be horizontal and
+ * direction-aware: forward navigation slides the leaving page out
+ * to the left and the new page in from the right, mirroring iOS /
+ * Android navigation cues. Back navigation reverses both axes.
+ *
+ * Settings → Page transitions exposes the four options:
+ *   none      — no transition (handled in JS, .page-visible applied
+ *               immediately).
+ *   fade      — opacity fade with subtle vertical translate (legacy).
+ *   slide     — horizontal slide that follows nav direction.
+ *   crossfade — pure opacity, no translate (cleaner on data-heavy
+ *               pages where translateY can flicker).
+ * ------------------------------------------------------------------ */
+
+/* slide — forward (push from right). */
+body[data-page-transition="slide"][data-nav-direction="forward"] #page-content.page-leaving {
+    transform: translateX(-24px);
+}
+body[data-page-transition="slide"][data-nav-direction="forward"] #page-content.page-entering {
+    transform: translateX(24px);
+}
+
+/* slide — back (push from left). */
+body[data-page-transition="slide"][data-nav-direction="back"] #page-content.page-leaving {
+    transform: translateX(24px);
+}
+body[data-page-transition="slide"][data-nav-direction="back"] #page-content.page-entering {
+    transform: translateX(-24px);
+}
+
+/* slide — visible state always rests at zero offset. */
+body[data-page-transition="slide"] #page-content.page-visible {
+    transform: translateX(0);
+}
+
+/* crossfade — opacity-only, no translate. Less motion for
+   information-dense pages. */
+body[data-page-transition="crossfade"] #page-content.page-leaving,
+body[data-page-transition="crossfade"] #page-content.page-entering {
+    transform: none;
+}
+body[data-page-transition="crossfade"] #page-content.page-visible {
+    transform: none;
+}
+
 /* Staggered list items (#149) */
 .page-song .song-list-item,
 .page-songbook .song-list-item,

--- a/appWeb/public_html/js/modules/router.js
+++ b/appWeb/public_html/js/modules/router.js
@@ -41,6 +41,18 @@ export class Router {
 
         /** @type {AbortController|null} For cancelling in-flight AJAX requests */
         this.abortController = null;
+
+        /** @type {number} Monotonic counter stored in history.state so
+         *  we can detect navigation direction on popstate. Each forward
+         *  navigation pushes counter+1; back navigation lands on a
+         *  smaller counter, forward (re-)navigation on a larger one.
+         *  (#752) */
+        this._navCounter = 0;
+
+        /** @type {Map<string, number>} Per-path scroll positions.
+         *  Saved on navigation, restored on popstate when the user
+         *  goes back to a previously-seen page. (#752) */
+        this._scrollByPath = new Map();
     }
 
     /**
@@ -50,9 +62,41 @@ export class Router {
         /* Handle magic link login before any routing (#magic-link) */
         this._handleMagicLink();
 
-        /* Handle browser back/forward navigation */
-        window.addEventListener('popstate', () => {
-            this.handleCurrentRoute();
+        /* Seed the initial history entry with a navigation counter so
+           direction detection works from the first popstate. If we
+           don't seed, the very first back-navigation lands on a state
+           with no counter and the direction lookup falls through to
+           the "forward" default. (#752) */
+        if (!window.history.state || typeof window.history.state.counter !== 'number') {
+            window.history.replaceState(
+                { ...(window.history.state || {}), path: window.location.pathname, counter: this._navCounter },
+                '',
+                window.location.pathname + window.location.search
+            );
+        } else {
+            this._navCounter = window.history.state.counter;
+        }
+
+        /* Handle browser back/forward navigation. The popstate event's
+           target state carries the counter we set when navigate()
+           pushed it; comparing against our local counter tells us
+           which direction the user moved.
+
+           We save the OUTGOING path's scroll position before
+           handleCurrentRoute updates this.currentPath so a
+           back-then-forward cycle can restore the user to where they
+           were on each side. */
+        window.addEventListener('popstate', (e) => {
+            const newCounter = (e.state && typeof e.state.counter === 'number')
+                ? e.state.counter
+                : 0;
+            const direction = newCounter < this._navCounter ? 'back' : 'forward';
+            this._navCounter = newCounter;
+            document.body.dataset.navDirection = direction;
+            if (this.currentPath) {
+                this._scrollByPath.set(this.currentPath, window.scrollY || 0);
+            }
+            this.handleCurrentRoute({ isPopstate: true });
         });
     }
 
@@ -72,19 +116,29 @@ export class Router {
         /* Don't reload if already on this path */
         if (path === this.currentPath) return;
 
-        /* Push new state to browser history */
-        window.history.pushState({ path }, '', path);
+        /* Save current scroll position before leaving this page so
+           popstate-back can restore it. (#752) */
+        if (this.currentPath) {
+            this._scrollByPath.set(this.currentPath, window.scrollY || 0);
+        }
+
+        /* Push new state to browser history with an incremented
+           counter so popstate can detect direction. (#752) */
+        this._navCounter += 1;
+        window.history.pushState({ path, counter: this._navCounter }, '', path);
+        document.body.dataset.navDirection = 'forward';
 
         /* Load the page content */
-        await this.handleCurrentRoute();
+        await this.handleCurrentRoute({ isPopstate: false });
     }
 
     /**
      * Handle the current URL route — determine which page to load
      * and fetch its content from the API.
      */
-    async handleCurrentRoute() {
+    async handleCurrentRoute(opts = {}) {
         const path = window.location.pathname || '/';
+        const previousPath = this.currentPath;
         this.currentPath = path;
 
         /* Parse the route into an API request */
@@ -140,9 +194,28 @@ export class Router {
         /* Run post-load hooks (e.g., initialise favourites on song pages) */
         this.afterPageLoad(page, params);
 
-        /* Scroll to top on navigation */
+        /* Scroll handling. On popstate-back / forward to a previously-
+           seen path, restore the saved scroll position with a smooth
+           scroll. On forward navigation (or when no saved position
+           exists), jump to the top instantly. (#752) */
+        const saved = opts.isPopstate ? this._scrollByPath.get(path) : undefined;
         document.getElementById('main-content')?.scrollTo(0, 0);
-        window.scrollTo(0, 0);
+        if (typeof saved === 'number' && saved > 0) {
+            /* Two rAFs so the page-entering transform has a chance to
+               settle before we scroll — otherwise the browser scrolls
+               into a transformed coordinate system. */
+            requestAnimationFrame(() => {
+                requestAnimationFrame(() => {
+                    window.scrollTo({
+                        top: saved,
+                        left: 0,
+                        behavior: document.body.classList.contains('reduce-motion') ? 'auto' : 'smooth',
+                    });
+                });
+            });
+        } else {
+            window.scrollTo(0, 0);
+        }
     }
 
     /**

--- a/appWeb/public_html/js/modules/transitions.js
+++ b/appWeb/public_html/js/modules/transitions.js
@@ -32,10 +32,15 @@ export class Transitions {
     }
 
     /**
-     * Load the saved transition type from localStorage.
+     * Load the saved transition type from localStorage and stamp it
+     * onto <body> so CSS can branch on the active variant. The
+     * settings UI offers `none | fade | slide | crossfade`; per-type
+     * CSS lives in app.css under the
+     * `body[data-page-transition="…"]` selectors.
      */
     loadType() {
         this.type = localStorage.getItem(STORAGE_TRANSITION) || 'none';
+        document.body.dataset.pageTransition = this.type;
     }
 
     /**


### PR DESCRIPTION
## Summary

Three v1 transition upgrades from #752:

- **Per-type CSS variants** — Settings has offered \`fade / slide / crossfade / none\` for a while but the CSS only defined the legacy \"fade with translateY\" effect, so every option except \"none\" looked identical. \`<body data-page-transition>\` now drives distinct CSS rules per type.
- **Direction-aware slide** — Forward navigation slides the leaving page out left and the new page in from the right; back navigation reverses both axes. Mirrors iOS / Android navigation cues.
- **Smooth scroll restoration** — Back / forward to a previously-seen page restores the saved scroll position smoothly (or instantly under reduce-motion).

Out of scope for v1 (deferred per the issue body): View Transitions API, shared-element morphing, skeleton screens.

## Files

| File | Change |
| --- | --- |
| \`js/modules/transitions.js\` | \`loadType()\` stamps \`data-page-transition\` on \`<body>\` alongside the existing \`this.type\` assignment so per-type CSS variants pick up automatically. |
| \`js/modules/router.js\` | Adds \`_navCounter\` (mirrored into \`history.state\`) so popstate can detect direction. Stamps \`data-nav-direction=\"forward\"\| \"back\"\` on \`<body>\` on every navigation. Adds \`_scrollByPath: Map<string, number>\` populated on every navigate / popstate; restored on popstate with smooth scroll (instant under reduce-motion). |
| \`css/app.css\` | Per-type CSS rules:<br>• \`slide\` — horizontal translateX that follows nav direction.<br>• \`crossfade\` — opacity-only, no translate.<br>• \`fade\` — keeps the legacy translateY baseline (no override).<br>• \`none\` — instant (no CSS, already worked). |

## How direction tracking works

\`history.pushState\` carries a \`{ path, counter }\` state object. The counter increments on every \`navigate()\` call, so:

- Forward: counter+1 vs current → \`forward\`
- Back: smaller counter than current → \`back\`

Initial history entry is \`replaceState\`'d on init with the seed counter so the very first popstate already has direction info.

## How scroll restoration works

- On every \`navigate()\` (forward), the current path's \`scrollY\` is recorded in the \`Map\` before the URL changes.
- On every \`popstate\` (back / forward), the outgoing path's \`scrollY\` is recorded before \`handleCurrentRoute()\` updates \`currentPath\`.
- After the new page renders, we look up the new path's saved scroll. If found, we scroll there with \`behavior: 'smooth'\` (or instant under reduce-motion) after two rAFs — long enough for the \`page-entering\` transform to settle so we scroll into post-transition coordinates.

## Test plan

- [ ] **Default (none)** — Settings → Page transitions = \"None\". Navigation is instant; no slide, no fade.
- [ ] **fade** — switch to Fade. Navigation does the existing opacity + 8 px translateY (the previous baseline).
- [ ] **slide forward** — switch to Slide. Open a song from the homepage. Expect: homepage slides left out of view; song slides in from right.
- [ ] **slide back** — hit browser back. Expect: song slides right out of view; homepage slides in from left.
- [ ] **crossfade** — switch to Crossfade. Navigation is pure opacity, no translate.
- [ ] **scroll restoration** — open the songbook list, scroll halfway down, click a song, hit back. Expect: page restores to the saved mid-scroll position with a smooth animation.
- [ ] **scroll restoration under reduce-motion** — same flow with \`prefers-reduced-motion: reduce\`. Restoration is instant, not smooth.
- [ ] **forward-then-back-then-forward** — multi-step history walk. Expect: each path's scroll position is preserved on each visit.

## Refs

- Closes #752 (v1 ship list)
- Built on the existing transitions infrastructure (#149).

🤖 Generated with [Claude Code](https://claude.com/claude-code)