### PR TITLE
fix(editor): leave Song Number blank when adding a new song (#756)

### DIFF
--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -3318,11 +3318,19 @@ function addNewSong() {
     /* Generate a simple unique ID (timestamp + random suffix). */
     var newId = 'song-' + Date.now() + '-' + Math.random().toString(36).substring(2, 8);
 
-    /* Build the blank song object with all required fields. */
+    /* Build the blank song object with all required fields. The
+       Song Number starts as null rather than (songs.length + 1) —
+       the curator may be adding a song to an unofficial / Misc
+       songbook where there's no per-songbook number, or simply
+       hasn't picked a songbook yet. selectSong() coerces null →
+       empty string when populating the input, so the placeholder
+       'e.g. 42' shows in greyed form and the curator has to enter
+       a real value (which the validator then enforces only when
+       the chosen songbook is IsOfficial=1, per #392 / PR #740). */
     var newSong = {
         id: newId,
         title: 'New Song',
-        number: songData.songs.length + 1,
+        number: null,
         songbook: '',
         songbookName: '',
         language: 'en',


### PR DESCRIPTION
## Summary

- **Add → Song** now leaves the Song Number input empty (greyed-out \`e.g. 42\` placeholder) instead of pre-filling with \`songs.length + 1\`.
- The save validators (per #392 / PR #740) already enforce \"number required\" only on official songbooks, so the blank state behaves correctly across both unofficial (NULL OK) and official (validator catches missing) songbooks.
- Closes #756.

## Why

[appWeb/public_html/manage/editor/editor.js:3325](appWeb/public_html/manage/editor/editor.js#L3325) (before):

\`\`\`javascript
number: songData.songs.length + 1,
\`\`\`

On a 12,370-song corpus, every new song landed with \`number = 12371\`. Rendered as a real value, easy to miss, easy to save by accident, easy to collide with the next legitimate song someone tries to add to the same songbook. The \"e.g. 42\" placeholder defined on the input was being shadowed by this live value.

## Fix

\`number: null\`. Three flow-throughs verified:

1. **Display** — \`selectSong()\` calls \`setVal('edit-number', song.number || '')\` → null coerces to \`''\` → input renders empty → CSS placeholder \"e.g. 42\" shows greyed.
2. **Save (unofficial songbook)** — backend persists \`tblSongs.Number IS NULL\` per PR #740. Internal \`SongId\` is the cross-record link.
3. **Save (official songbook)** — frontend validator (\`validateSongData\` / \`validateSongsByIds\`) blocks the save with \`\"missing 'number' (required for official songbooks)\"\` toast, exactly as designed for #392.

## Test plan

- [ ] Click **Add** in the Song Editor. Expect: Song Number input is empty, placeholder \"e.g. 42\" is visible in greyed form.
- [ ] Pick songbook **Misc**, click Save. Expect: succeeds; row in \`tblSongs\` has \`Number IS NULL\`.
- [ ] Add another. Pick songbook **SDAH** (official), don't enter a number, click Save. Expect: validator blocks with the missing-number toast.
- [ ] Existing songs (saved before this change with their auto-incremented number) load and display unchanged.

## Refs

- Closes #756
- Related: #392 / PR #740 — \"unofficial songbooks: number is optional\". This bug undermined the validator-driven workflow that PR introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)