### PR TITLE
fix(editor): surface save-song error to admins + log to ActivityLog (#759)

### DIFF
--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -840,9 +840,42 @@ switch ($action) {
             }
             http_response_code(500);
             error_log('[editor save_song] ' . $e->getMessage());
-            /* Do not expose DB internals to the client — the details are
-               in the server error log for admins to inspect. */
-            echo json_encode(['error' => 'Failed to save song. Check server logs for details.']);
+
+            /* Capture the failure in tblActivityLog as a Result='error'
+               row so curators reviewing the audit log see a record of
+               the failed save alongside successful ones (#759). The
+               helper is best-effort — a logging failure must not
+               compound the original error. */
+            if (function_exists('logActivityError')) {
+                $mysqliCode = ($e instanceof \mysqli_sql_exception) ? $e->getCode() : null;
+                logActivityError(
+                    'song.save_failed',
+                    'song',
+                    $songId,
+                    $e,
+                    [
+                        'action'        => $action,
+                        'songbook'      => $songbookAbbr,
+                        'mysqli_code'   => $mysqliCode,
+                    ]
+                );
+            }
+
+            /* Surface the underlying error to admin / global_admin
+               users so they can self-diagnose without server-shell
+               access. Lower-privilege users still see the generic
+               message — DB internals are not for general consumption.
+               (#759) */
+            $payload = ['error' => 'Failed to save song. Check server logs for details.'];
+            $role    = $currentUser['role'] ?? null;
+            if (in_array($role, ['admin', 'global_admin'], true)) {
+                $payload['error_detail'] = $e->getMessage();
+                $payload['error_class']  = get_class($e);
+                if ($e instanceof \mysqli_sql_exception) {
+                    $payload['mysqli_code'] = $e->getCode();
+                }
+            }
+            echo json_encode($payload);
         }
         break;
 

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -2989,8 +2989,24 @@ function autoSaveSongsPerSong(ids) {
                 body: JSON.stringify(song),
             }).then(function (res) {
                 return res.json().then(function (data) {
-                    if (res.ok && data.ok) saved.push(id);
-                    else failed.push({ id: id, error: data.error || ('HTTP ' + res.status) });
+                    if (res.ok && data.ok) {
+                        saved.push(id);
+                    } else {
+                        /* Compose a maximally-useful error string. The
+                           API ships error_detail (and optionally
+                           mysqli_code / error_class) for admin /
+                           global_admin users — surface those inline so
+                           the failure self-diagnoses without a server-
+                           shell trip. (#759) */
+                        var msg = data.error || ('HTTP ' + res.status);
+                        if (data.error_detail) {
+                            msg += ' — ' + data.error_detail;
+                            if (data.mysqli_code) {
+                                msg += ' [mysqli ' + data.mysqli_code + ']';
+                            }
+                        }
+                        failed.push({ id: id, error: msg });
+                    }
                 });
             }).catch(function (err) {
                 failed.push({ id: id, error: err.message });


### PR DESCRIPTION
## Summary

- The save-song catch now surfaces the underlying mysqli / PHP error in the toast for **admin / global_admin** users (lower-privilege users still see the generic \"Check server logs\" message).
- Failed saves now record a \`song.save_failed\` row in **tblActivityLog** with \`Result='error'\` so the audit trail captures them alongside successful \`song.create\` / \`song.edit\` rows.
- Diagnostic-only PR — does not fix the underlying root cause of the user's failing Misc save. The new diagnostics let the next attempt self-diagnose without a server-shell trip.
- Closes #759.

## Why

The toast was a dead end:

> Failed to save song-1777670376989-8u4wue: Failed to save song. Check server logs for details.

\`error_log\` had the real cause but the curator couldn't reach it. tblActivityLog had nothing. The next save attempt would repeat the same opaque failure.

## Files

| File | Change |
| --- | --- |
| \`appWeb/public_html/manage/editor/api.php\` | \`save_song\` catch now invokes \`logActivityError('song.save_failed', 'song', \$songId, \$e, [...])\` with the action, songbook, and (when applicable) mysqli error code. The JSON 500 response carries \`error_detail\` / \`error_class\` / \`mysqli_code\` only when the current user's role is \`admin\` or \`global_admin\`. |
| \`appWeb/public_html/manage/editor/editor.js\` | The \`save_song\` failure handler now appends \`error_detail\` (and \`mysqli_code\` if present) to the toast message so the verbose detail lands inline. |

## Behaviour change

| Scenario | Before | After |
| --- | --- | --- |
| Admin save fails | Generic \"Check server logs\" toast; no audit row. | Toast names the exception message + mysqli code; audit row \`song.save_failed\` (Result=error) records exception class / message / file / line / mysqli code. |
| Non-admin save fails | Same generic toast. | Generic toast unchanged (no DB internals leaked); audit row recorded. |
| Successful save | \"Saved N songs\" toast + \`song.create\` / \`song.edit\` audit row. | Unchanged. |

## Test plan

- [ ] **Reproduce the user's case** — Misc songbook, no number, language \`af-ZA\`, 2 artists, verse + chorus, translation link to MP-0729. Save. Expect: toast names the underlying cause (likely \"Column 'Number' cannot be null\" if the user's deployment pre-dates the nullable migration, or some other specific error). \`/manage/activity-log\` shows a fresh \`song.save_failed\` row with the same detail.
- [ ] **Generic surface for non-admins** — same flow as a non-admin user role. Expect: toast still says \"Check server logs\" without leaking internals; the audit row is still recorded.
- [ ] **Successful save still works** — happy path unchanged.

## Refs

- Closes #759
- The suspected root cause for the original failure (nullable-Number migration not applied) will get its own follow-up PR once the next save attempt's error_detail confirms the hypothesis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)