### PR TITLE
feat(admin): padlock indicators for restricted admin items (#758)

### DIFF
--- a/appWeb/public_html/css/app.css
+++ b/appWeb/public_html/css/app.css
@@ -2173,6 +2173,42 @@ body.reduce-motion .shortcuts-overlay {
 }
 
 /* ==========================================================================
+   ENTITLEMENT LOCK CHIPS (#758)
+   Small SVG-rendered padlock indicator next to admin-surface labels and
+   card titles. Colour communicates the role tier required to actually
+   click through:
+     red   = Global Admin only
+     yellow = Admin or Global Admin
+   Items visible to user/editor render no chip — the absence is itself
+   the cue. The HTML lives in entitlementLockChipHtml() in
+   includes/entitlements.php; markup is <i class="bi bi-lock-fill
+   lock-chip lock-chip-{tier}" title="…">.
+   ========================================================================== */
+
+.lock-chip {
+    font-size: 0.78em;
+    opacity: 0.9;
+    vertical-align: 0.05em;
+    margin-left: 0.4rem;
+    /* Don't let a tooltip-cursor crowd the link target on mobile. */
+    pointer-events: auto;
+}
+
+.lock-chip-global-admin { color: #ef4444; }
+.lock-chip-admin        { color: #f59e0b; }
+
+/* In high-contrast mode the chip needs a slightly bolder outline so
+   the colour difference reads at a glance. */
+[data-ihymns-theme="high-contrast"] .lock-chip-global-admin {
+    color: #ff5252;
+    text-shadow: 0 0 1px #000;
+}
+[data-ihymns-theme="high-contrast"] .lock-chip-admin {
+    color: #ffb020;
+    text-shadow: 0 0 1px #000;
+}
+
+/* ==========================================================================
    READING PROGRESS INDICATOR (#109)
    ========================================================================== */
 

--- a/appWeb/public_html/includes/entitlements.php
+++ b/appWeb/public_html/includes/entitlements.php
@@ -126,6 +126,59 @@ const ENTITLEMENTS = [
 $_ihymns_effective_entitlements = null;
 
 /**
+ * Return the most-restrictive role tier required by an entitlement,
+ * for use by the admin-surface padlock indicators (#758).
+ *
+ * Mapping:
+ *   - null / empty key → null   (no chip)
+ *   - user or editor in roles → null   (no chip — anyone can act)
+ *   - admin in roles → 'admin'   (yellow chip)
+ *   - only global_admin in roles → 'global_admin'   (red chip)
+ *
+ * Reads the effective map (defaults + admin overrides) so a curator
+ * who has tightened access via /manage/entitlements sees padlocks
+ * that match the live policy, not the hardcoded defaults.
+ *
+ * @param string|null $key Entitlement key (e.g. 'manage_songbooks')
+ * @return string|null     'admin' | 'global_admin' | null
+ */
+function entitlementHighestRole(?string $key): ?string
+{
+    if ($key === null || $key === '') return null;
+    $map = effectiveEntitlements();
+    $roles = $map[$key] ?? [];
+    if (empty($roles)) return null;
+    if (in_array('user', $roles, true) || in_array('editor', $roles, true)) {
+        return null;
+    }
+    if (in_array('admin', $roles, true)) {
+        return 'admin';
+    }
+    return 'global_admin';
+}
+
+/**
+ * Render the inline HTML for a padlock chip next to an entitlement-
+ * gated label / card title. Empty string when the entitlement is
+ * accessible to user/editor (no chip needed). Bootstrap Icons
+ * bi-lock-fill is SVG-rendered and accepts CSS colour overrides via
+ * the .lock-chip-{tier} class. (#758)
+ *
+ * @param string|null $key Entitlement key
+ * @return string          Inline HTML (already escaped) or ''
+ */
+function entitlementLockChipHtml(?string $key): string
+{
+    $tier = entitlementHighestRole($key);
+    if ($tier === null) return '';
+    $tierCls = $tier === 'global_admin' ? 'lock-chip-global-admin' : 'lock-chip-admin';
+    $label   = $tier === 'global_admin' ? 'Requires Global Admin' : 'Requires Admin';
+    return ' <i class="bi bi-lock-fill lock-chip ' . $tierCls . '"'
+         . ' aria-label="' . htmlspecialchars($label, ENT_QUOTES, 'UTF-8') . '"'
+         . ' title="' . htmlspecialchars($label, ENT_QUOTES, 'UTF-8') . '"></i>';
+}
+
+/**
  * Return the effective entitlement map, applying any admin overrides
  * saved under `tblAppSettings.SettingKey = 'entitlements_overrides'`.
  *

--- a/appWeb/public_html/manage/includes/admin-nav.php
+++ b/appWeb/public_html/manage/includes/admin-nav.php
@@ -261,12 +261,12 @@ $_avatarUrlLarge = userAvatarUrl($_userEmail, 64, $_userAvatarSvc);
     <div class="offcanvas-body p-0">
         <nav class="list-group list-group-flush" aria-label="Admin sections">
             <?php foreach ($_visibleAdminLinks as $l): ?>
-                <?php [$id, $href, $icon, $label] = $l; ?>
+                <?php [$id, $href, $icon, $label, $entitlement] = $l; ?>
                 <a href="<?= htmlspecialchars($href) ?>"
                    class="list-group-item list-group-item-action d-flex align-items-center gap-2<?= $_activePage === $id ? ' active' : '' ?>"
                    <?= $_activePage === $id ? 'aria-current="page"' : '' ?>>
                     <i class="bi <?= htmlspecialchars($icon) ?>" aria-hidden="true"></i>
-                    <span><?= htmlspecialchars($label) ?></span>
+                    <span><?= htmlspecialchars($label) ?><?= entitlementLockChipHtml($entitlement) ?></span>
                 </a>
             <?php endforeach; ?>
         </nav>

--- a/appWeb/public_html/manage/includes/admin-sidebar.php
+++ b/appWeb/public_html/manage/includes/admin-sidebar.php
@@ -45,12 +45,12 @@ foreach ($_sidebarLinks as $l) {
                 </div>
             <?php endif; ?>
             <?php foreach ($links as $l): ?>
-                <?php [$id, $href, $icon, $label] = $l; ?>
+                <?php [$id, $href, $icon, $label, $entitlement] = $l; ?>
                 <a href="<?= htmlspecialchars($href) ?>"
                    class="admin-sidebar-link d-flex align-items-center gap-2 px-3 py-2<?= $_sidebarActive === $id ? ' active' : '' ?>"
                    <?= $_sidebarActive === $id ? 'aria-current="page"' : '' ?>>
                     <i class="bi <?= htmlspecialchars($icon) ?> fs-6" aria-hidden="true"></i>
-                    <span><?= htmlspecialchars($label) ?></span>
+                    <span><?= htmlspecialchars($label) ?><?= entitlementLockChipHtml($entitlement) ?></span>
                 </a>
             <?php endforeach; ?>
         <?php endforeach; ?>

--- a/appWeb/public_html/manage/index.php
+++ b/appWeb/public_html/manage/index.php
@@ -296,7 +296,7 @@ $csrf = csrfToken();
             <?php foreach ($dashboardLayout['order'] as $cardId): ?>
                 <?php
                 if (!isset($dashboardById[$cardId])) continue;
-                [$id, , $href, $icon, $title, $sub, $sameTab] = $dashboardById[$cardId];
+                [$id, $entitlement, $href, $icon, $title, $sub, $sameTab] = $dashboardById[$cardId];
                 $isHidden = isset($hiddenSet[$id]);
                 $target = $sameTab ? '' : 'target="_blank" rel="noopener"';
                 ?>
@@ -306,7 +306,7 @@ $csrf = csrfToken();
                     <div class="card-admin position-relative">
                         <a href="<?= htmlspecialchars($href) ?>" class="quick-link" <?= $target ?>>
                             <i class="bi <?= htmlspecialchars($icon) ?> d-block mb-2" aria-hidden="true"></i>
-                            <strong><?= $title /* some titles contain &amp; entity */ ?></strong>
+                            <strong><?= $title /* some titles contain &amp; entity */ ?><?= entitlementLockChipHtml($entitlement) ?></strong>
                             <div class="small text-muted"><?= $sub /* same */ ?></div>
                         </a>
                     </div>

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -463,8 +463,15 @@ if ($hasCredentials && defined('DB_HOST')) {
 
 <div class="container-admin py-4">
 
-    <h1 class="mb-1">Database Setup</h1>
-    <p class="text-secondary mb-4">iHymns Admin &mdash; Installation, migration, and maintenance</p>
+    <h1 class="mb-1">
+        Database Setup<?= entitlementLockChipHtml('run_db_install') ?>
+    </h1>
+    <p class="text-secondary mb-4">
+        iHymns Admin &mdash; Installation, migration, and maintenance.
+        <span class="badge bg-danger text-light ms-2" style="font-size: 0.7rem; font-weight: 600;">
+            <i class="bi bi-lock-fill me-1" aria-hidden="true"></i>Global Admin only
+        </span>
+    </p>
 
     <?php if ($credSuccess !== ''): ?>
         <div class="alert alert-success"><?= htmlspecialchars($credSuccess) ?></div>


### PR DESCRIPTION
## Summary

Visual cue for admin-surface restrictions:

- 🔒 **red** = Global Admin only
- 🔒 **yellow** = Admin or Global Admin
- nothing = no restriction (any signed-in user)

Closes #758.

## Surfaces

| Where | Change |
| --- | --- |
| Pinned sidebar (\`admin-sidebar.php\`, lg+) | Chip after each link's label |
| Hamburger offcanvas (\`admin-nav.php\`, < lg) | Same |
| Dashboard tile grid (\`manage/index.php\`) | Chip after each card title |
| /manage/setup-database | Single page-header red chip + \"Global Admin only\" badge in subtitle (page-level gate, so per-card chips would be visual noise — every card is the same red) |

## Mechanics

\`entitlementHighestRole(\$key)\` returns \`'admin'\` / \`'global_admin'\` / \`null\` based on the **effective** map (defaults merged with admin overrides via /manage/entitlements). So a curator who tightens access via the entitlements editor sees padlocks that match the live policy, not the hardcoded defaults.

\`entitlementLockChipHtml(\$key)\` emits:

\`\`\`html
<i class=\"bi bi-lock-fill lock-chip lock-chip-{tier}\"
   aria-label=\"Requires Admin\" title=\"Requires Admin\"></i>
\`\`\`

Hover tooltip surfaces the requirement; \`aria-label\` carries it for screen readers.

## Files

| File | Change |
| --- | --- |
| \`appWeb/public_html/includes/entitlements.php\` | New \`entitlementHighestRole()\` + \`entitlementLockChipHtml()\` helpers. |
| \`appWeb/public_html/css/app.css\` | \`.lock-chip\` + \`.lock-chip-admin\` / \`.lock-chip-global-admin\` colours. High-contrast theme bumps saturation + adds a 1px text-shadow outline. |
| \`manage/includes/admin-sidebar.php\` | Destructures \`\$entitlement\` from the link tuple, renders the chip after the label. |
| \`manage/includes/admin-nav.php\` | Same in the offcanvas. |
| \`manage/index.php\` | Destructures \`\$entitlement\` from the card tuple (it was already in the array, just unused), renders the chip after each card's title. |
| \`manage/setup-database.php\` | Single page-header chip + subtitle badge. Per-card chips deliberately skipped — page-level gating already restricts every card uniformly. |

## Bootstrap Icons availability

\`bi-lock-fill\` is already loaded site-wide via the existing Bootstrap Icons CSS (the same icon family as \`bi-translate\`, \`bi-pencil-square\`, etc. in admin-links). No new asset to bundle.

## Test plan

- [ ] **Sidebar (lg+)** as a global_admin — every restricted row shows a coloured padlock; \`Dashboard\`, \`Help / Guides\` show none.
- [ ] **Sidebar** as an admin — items they can see (most non-global_admin entries) still show yellow padlocks; the global_admin-only ones don't appear at all per \`visibleAdminLinks()\`.
- [ ] **Hamburger offcanvas (< lg)** — same chips on mobile.
- [ ] **Dashboard tiles** — each restricted card title carries a coloured chip; \`Song Editor\` (editor + admin + global_admin) shows nothing because editor is in roles.
- [ ] **/manage/setup-database** — H1 carries the red chip; subtitle has the \"Global Admin only\" badge.
- [ ] **Hover** any chip — tooltip reads \"Requires Admin\" or \"Requires Global Admin\".
- [ ] **High-contrast theme** — chips remain visible (saturated red / amber, 1px outline).

## Refs

- Closes #758
- Same Bootstrap Icons family as the existing admin-links \`icon\` field.
- Honours admin overrides via the existing \`effectiveEntitlements()\` cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)