### PR TITLE
feat(tags): case-insensitive matching, Title-Case storage + backfill (#762)

### DIFF
--- a/appWeb/.sql/migrate-tag-titlecase.php
+++ b/appWeb/.sql/migrate-tag-titlecase.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Tag display-form normalisation (#762)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * tblSongTags.Name is utf8mb4_unicode_ci with a UNIQUE index, so the
+ * database already prevents "Worship" + "worship" co-existing as two
+ * rows. But the row's stored Name is whatever the FIRST caller wrote
+ * — and that's what every subsequent reader sees in dropdowns and
+ * chips. Catalogues whose first writer typed lowercase end up with
+ * lowercase tags forever (until #762's bulk_tag normalisation
+ * canonicalises them on the next upsert).
+ *
+ * This one-shot migration walks tblSongTags and rewrites Name to
+ * Title Case for any row that doesn't already match. Idempotent:
+ * skip rows whose Name is already canonical.
+ *
+ * Title Case is computed via mb_convert_case(MB_CASE_TITLE_SIMPLE)
+ * — same rule the bulk_tag normaliser applies. Whitespace runs are
+ * collapsed to a single space first so a row stored as "Holy   Week"
+ * lands as "Holy Week".
+ *
+ * USAGE:
+ *   CLI: php appWeb/.sql/migrate-tag-titlecase.php
+ *   Web: /manage/setup-database → "Tag Title-Case Backfill"
+ *        (entry point requires global_admin)
+ */
+
+if (PHP_SAPI === 'cli') {
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = true;
+} else {
+    if (!defined('IHYMNS_SETUP_DASHBOARD')) {
+        if (!function_exists('isAuthenticated')) {
+            require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+        }
+        if (!isAuthenticated()) {
+            http_response_code(401);
+            exit('Authentication required.');
+        }
+        $u = getCurrentUser();
+        if (!$u || $u['role'] !== 'global_admin') {
+            http_response_code(403);
+            exit('Global admin required.');
+        }
+    }
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = false;
+}
+
+function _migTagTitle_out(string $line): void
+{
+    global $isCli;
+    echo $line . ($isCli ? "\n" : "<br>\n");
+    if ($isCli) {
+        flush();
+    }
+}
+
+function _migTagTitle_tableExists(mysqli $db, string $table): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? LIMIT 1'
+    );
+    $stmt->bind_param('s', $table);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+_migTagTitle_out('Tag Title-Case backfill starting…');
+
+$db = getDbMysqli();
+if (!$db) {
+    _migTagTitle_out('ERROR: could not connect to database.');
+    exit(1);
+}
+
+if (!_migTagTitle_tableExists($db, 'tblSongTags')) {
+    _migTagTitle_out('[skip] tblSongTags not found — nothing to normalise.');
+    _migTagTitle_out('Tag Title-Case backfill finished.');
+    exit(0);
+}
+
+/* Walk every row, compute canonical form, UPDATE only when different.
+   ~thousands of rows max — single-pass is fine. */
+$res = $db->query('SELECT Id, Name FROM tblSongTags ORDER BY Id ASC');
+if (!$res) {
+    _migTagTitle_out('ERROR: SELECT failed: ' . $db->error);
+    exit(1);
+}
+
+$update = $db->prepare('UPDATE tblSongTags SET Name = ? WHERE Id = ?');
+$updated = 0;
+$skipped = 0;
+$collisions = 0;
+
+while ($row = $res->fetch_assoc()) {
+    $id   = (int)$row['Id'];
+    $name = (string)$row['Name'];
+    /* Same normalisation as the bulk_tag handler: trim, collapse
+       whitespace, Title Case. */
+    $clean = trim($name);
+    $clean = preg_replace('/\s+/u', ' ', (string)$clean);
+    $titled = mb_convert_case((string)$clean, MB_CASE_TITLE_SIMPLE, 'UTF-8');
+    $titled = mb_substr($titled, 0, 50);
+
+    if ($titled === $name) {
+        $skipped++;
+        continue;
+    }
+
+    /* Catch the rare case where two rows would collide on the
+       canonical form (e.g. "Worship" + " worship "). The unique-
+       index would reject the second UPDATE; we log it and leave the
+       data alone for the curator to resolve via the (forthcoming)
+       /manage/tags merge UI. */
+    try {
+        $update->bind_param('si', $titled, $id);
+        $update->execute();
+        if ($db->affected_rows > 0) {
+            $updated++;
+        } else {
+            $skipped++;
+        }
+    } catch (\Throwable $e) {
+        $collisions++;
+        _migTagTitle_out("[warn] Id={$id} '{$name}' → '{$titled}' collides with an existing row — left as-is. " .
+                         'Resolve via /manage/tags merge once that ships.');
+    }
+}
+$res->close();
+$update->close();
+
+_migTagTitle_out("[ok  ] {$updated} row(s) renamed to Title Case.");
+_migTagTitle_out("[note] {$skipped} row(s) already canonical.");
+if ($collisions > 0) {
+    _migTagTitle_out("[note] {$collisions} row(s) collide with another row's canonical form — left untouched (resolve via merge UI).");
+}
+
+_migTagTitle_out('Tag Title-Case backfill finished.');

--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -1008,12 +1008,23 @@ switch ($action) {
         }));
         $addTags = is_array($payload['add'] ?? null) ? $payload['add'] : [];
         $remTags = is_array($payload['remove'] ?? null) ? $payload['remove'] : [];
+        /* Tag normalisation (#762):
+           - trim
+           - collapse internal whitespace runs to single spaces
+           - cap at 50 chars (matches tblSongTags.Name VARCHAR(50))
+           - Title-Case so 'worship' / 'WORSHIP' / 'Worship' all resolve
+             to the same canonical 'Worship' row, both for matching
+             (case-insensitive in DB collation, but defensive on PHP
+             side too) and for storage / display. */
         $normaliseTag = function ($name) {
             $trimmed = trim((string)$name);
-            return $trimmed === '' ? null : mb_substr($trimmed, 0, 50);
+            $trimmed = preg_replace('/\s+/u', ' ', $trimmed);
+            if ($trimmed === null || $trimmed === '') return null;
+            $titled = mb_convert_case($trimmed, MB_CASE_TITLE_SIMPLE, 'UTF-8');
+            return mb_substr($titled, 0, 50);
         };
-        $addTags = array_values(array_filter(array_map($normaliseTag, $addTags)));
-        $remTags = array_values(array_filter(array_map($normaliseTag, $remTags)));
+        $addTags = array_values(array_unique(array_filter(array_map($normaliseTag, $addTags))));
+        $remTags = array_values(array_unique(array_filter(array_map($normaliseTag, $remTags))));
 
         if (empty($songIds) || (empty($addTags) && empty($remTags))) {
             http_response_code(400);
@@ -1028,7 +1039,13 @@ switch ($action) {
             $db->begin_transaction();
 
             /* Resolve / create tag rows for each ADD name. Keep a map of
-               Name -> Id so we can insert mapping rows. */
+               Name -> Id so we can insert mapping rows. The
+               ON DUPLICATE KEY clause now also pulls the existing
+               row's Name up to the new (Title-Cased) form via
+               VALUES(Name) — so a curator who lands on an existing
+               row whose stored Name is non-canonical (e.g. "worship"
+               from before #762) re-canonicalises it on the next
+               upsert without a separate backfill round-trip. */
             $addIds = [];
             foreach ($addTags as $name) {
                 $slug = strtolower(preg_replace('/[^a-z0-9]+/i', '-', $name));
@@ -1036,7 +1053,7 @@ switch ($action) {
                 if ($slug === '') { continue; }
                 $stmt = $db->prepare(
                     'INSERT INTO tblSongTags (Name, Slug) VALUES (?, ?) ' .
-                    'ON DUPLICATE KEY UPDATE Id = LAST_INSERT_ID(Id)'
+                    'ON DUPLICATE KEY UPDATE Id = LAST_INSERT_ID(Id), Name = VALUES(Name)'
                 );
                 $stmt->bind_param('ss', $name, $slug);
                 $stmt->execute();
@@ -1062,7 +1079,12 @@ switch ($action) {
 
             /* Remove mapping rows. Resolve tag Ids by Name first (only
                delete if the tag exists — names that don't match anything
-               are silently ignored). */
+               are silently ignored). The Name comparison runs through
+               the column's utf8mb4_unicode_ci collation so a curator
+               removing 'worship' still hits the canonical 'Worship'
+               row (the input here is already Title-Cased by
+               $normaliseTag, but case-folded matching is the right
+               default for any future caller). */
             if (!empty($remTags) && !empty($songIds)) {
                 $remIds = [];
                 $nameStmt = $db->prepare('SELECT Id FROM tblSongTags WHERE Name = ? LIMIT 1');

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -222,6 +222,7 @@ if ($action !== '') {
         'user-preferred-languages' => 'migrate-user-preferred-languages.php',
         'iana-language-subtag-registry' => 'migrate-iana-language-subtag-registry.php',
         'cldr-native-names' => 'migrate-cldr-native-names.php',
+        'tag-titlecase'     => 'migrate-tag-titlecase.php',
         'cleanup'     => 'cleanup.php',
         'backup'      => 'backup.php',
         'restore'     => 'restore.php',
@@ -262,6 +263,7 @@ if ($action !== '') {
         'user-preferred-languages',
         'iana-language-subtag-registry',
         'cldr-native-names',
+        'tag-titlecase',
         /* When you add a new migrate-*.php under appWeb/.sql/, ALSO add
            its action key to:
              1. $scriptMap above (action key → file)
@@ -1044,6 +1046,27 @@ if ($hasCredentials && defined('DB_HOST')) {
                             CLDR JSON files, overwrites the bundled snapshots,
                             then re-runs the import.
                         </p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="card bg-dark border-secondary h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">3u. Tag Title-Case Backfill (#762)</h5>
+                        <p class="card-text text-secondary small">
+                            Walks <code>tblSongTags</code> and rewrites <code>Name</code>
+                            to Title Case for any row that isn't already canonical. The
+                            <code>bulk_tag</code> handler now Title-Cases on every
+                            upsert, so new tags land canonical from creation; this
+                            backfill resolves rows that pre-date #762's normalisation.
+                            Idempotent — re-runs no-op on canonical rows. Rare
+                            collisions (two rows whose canonical forms would clash)
+                            are logged and left untouched for resolution via the
+                            forthcoming /manage/tags merge UI.
+                        </p>
+                        <a href="?action=tag-titlecase" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
+                            Run Tag Title-Case Backfill
+                        </a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary

- **Typed input is normalised to Title Case** before insert/upsert in \`bulk_tag\` — \"easter\", \"EASTER\", \"Easter\" all resolve to a single canonical \`Easter\` row.
- **Existing non-canonical rows self-correct** on the next upsert via \`ON DUPLICATE KEY UPDATE Id = LAST_INSERT_ID(Id), Name = VALUES(Name)\`.
- **One-shot backfill migration** rewrites pre-#762 rows in bulk so the catalogue lands canonical without waiting for organic re-saves.
- Closes #762.

## Why

\`tblSongTags.Name\` is \`utf8mb4_unicode_ci\` with a \`UNIQUE\` index — the DB already prevents \"Worship\" and \"worship\" from co-existing as two rows. The bug was that the stored \`Name\` was whatever the **first writer** used, and every subsequent reader saw that exact form in dropdowns and chips. A catalogue whose first writer typed lowercase ended up with lowercase tags everywhere.

## Files

| File | Change |
| --- | --- |
| \`appWeb/public_html/manage/editor/api.php\` | \`\$normaliseTag\` closure: trim → collapse whitespace runs → \`mb_convert_case(MB_CASE_TITLE_SIMPLE)\` → 50-char cap. \`array_unique\` on the resulting list so a request that included \"Worship\" AND \"worship\" doesn't fire two upserts. ON DUPLICATE clause now updates \`Name = VALUES(Name)\` so existing rows self-correct. |
| \`appWeb/.sql/migrate-tag-titlecase.php\` (new) | One-shot backfill. Walks every row, computes canonical form, UPDATEs only when different. Idempotent. Rare canonical-form collisions (e.g. two rows whose canonical forms would clash on the unique index) are logged with \`[warn]\` and left untouched for resolution via the forthcoming \`/manage/tags\` merge UI. |
| \`appWeb/public_html/manage/setup-database.php\` | New action key \`tag-titlecase\` in \`\$scriptMap\` + \`\$migrationOrder\`; new card \"3u. Tag Title-Case Backfill\" with the standard \`Run\` button. |

Display is automatic — every read path returns whatever \`tblSongTags.Name\` holds, so once rows are canonical, chips / dropdowns / \`/tag/<slug>\` headings show Title Case without any frontend changes.

## Test plan

- [ ] **Type a tag in mixed case** — open the Song Editor, add \"Worship\" to a song. Expect: stored \`Name\` = \`Worship\`.
- [ ] **Type a different case variant** — add \"WORSHIP\" to another song. Expect: same row Id reused; toast \"Added tag 'Worship'\" (Title Case form). DB still has one row.
- [ ] **Backfill** — set up a tag like \"easter\" via direct DB insert (or run an old build). Run \`/manage/setup-database → Run Tag Title-Case Backfill\`. Expect: row's Name becomes \"Easter\"; chip everywhere updates on next render.
- [ ] **Backfill idempotent** — click again. Expect: \"0 row(s) renamed; N row(s) already canonical.\"
- [ ] **Collision** — manually create two rows whose canonical forms collide (e.g. \"Holy week\" + \" holy   week \"). Run backfill. Expect: \`[warn]\` line for the second row, neither rewritten, no exception aborts the migration. Resolution deferred to merge UI.

## Refs

- Closes #762
- Sets up the merge UI follow-up (\`/manage/tags\` admin CRUD) referenced in the migration's \`[warn]\` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)