### PR TITLE
fix(auth): /manage logout now clears the ihymns_auth API token (#764)

### DIFF
--- a/appWeb/public_html/manage/includes/auth.php
+++ b/appWeb/public_html/manage/includes/auth.php
@@ -522,6 +522,52 @@ function logout(bool $logEvent = true): void
         logActivity('auth.logout', 'user', (string)$userId, [], 'success', $userId);
     }
 
+    /* Also invalidate any `ihymns_auth` API-token cookie that the
+       main-site sign-in flow set (#764). Without this, the
+       isAuthenticated() fallback in this same file calls
+       adoptApiTokenSession(), which reads the still-valid cookie,
+       looks up tblApiTokens, and re-seeds $_SESSION — so /manage/login
+       would adopt the token immediately after logout() destroys the
+       session and bounce the user straight back to /manage/.
+
+       Three things have to happen:
+         1. DELETE the row in tblApiTokens (otherwise the cookie value
+            keeps working on a future request that re-presents it).
+         2. Clear the cookie so the browser doesn't keep sending it.
+         3. Be tolerant: a missing tblApiTokens table or DB outage
+            must not block the rest of the logout. */
+    $tokenCookie = (string)($_COOKIE['ihymns_auth'] ?? '');
+    if ($tokenCookie !== '' && preg_match('/^[a-f0-9]{64}$/i', $tokenCookie)) {
+        try {
+            if (function_exists('getDbMysqli')) {
+                $db = getDbMysqli();
+                $stmt = $db->prepare('DELETE FROM tblApiTokens WHERE Token = ?');
+                if ($stmt) {
+                    $tokenHash = hash('sha256', $tokenCookie);
+                    $stmt->bind_param('s', $tokenHash);
+                    $stmt->execute();
+                    $stmt->close();
+                }
+            }
+        } catch (\Throwable $e) {
+            error_log('[manage logout] tblApiTokens delete failed: ' . $e->getMessage());
+        }
+    }
+    if (!empty($_COOKIE['ihymns_auth']) && !headers_sent()) {
+        $host  = preg_replace('/:\d+$/', '', (string)($_SERVER['HTTP_HOST'] ?? ''));
+        $https = !empty($_SERVER['HTTPS'])
+              || (($_SERVER['HTTP_X_FORWARDED_PROTO'] ?? '') === 'https');
+        setcookie('ihymns_auth', '', [
+            'expires'  => time() - 3600,
+            'path'     => '/',
+            'domain'   => $host,
+            'secure'   => $https,
+            'httponly' => true,
+            'samesite' => 'Lax',
+        ]);
+        unset($_COOKIE['ihymns_auth']);
+    }
+
     $_SESSION = [];
 
     if (ini_get('session.use_cookies')) {


### PR DESCRIPTION
## Summary

- \`/manage\` Log out now actually logs the user out. Previously the page reloaded and the session re-established immediately from the still-valid \`ihymns_auth\` API-token cookie set by the main-site sign-in flow.
- Closes #764.

## Root cause

\`/manage/logout.php\` calls \`logout()\` from \`/manage/includes/auth.php\`. That destroyed the PHP session and redirected to \`/manage/login\`. But \`/manage/login.php\`'s guard calls \`isAuthenticated()\`, which in the same file falls through to \`adoptApiTokenSession()\` — that helper reads the \`ihymns_auth\` cookie, looks it up in \`tblApiTokens\`, and re-seeds \`\$_SESSION\`. So the freshly-cleared session got re-established from the cookie before the user saw the login page, and the redirect chain bounced them back to \`/manage/\`.

The main-site \`auth_logout\` handler in \`api.php\` already does the right thing (DELETE from \`tblApiTokens\` + clear the cookie). \`/manage\` didn't.

## Files

| File | Change |
| --- | --- |
| \`appWeb/public_html/manage/includes/auth.php\` | \`logout()\` now also: (a) DELETEs the matching \`tblApiTokens\` row using \`sha256(\$_COOKIE['ihymns_auth'])\`, wrapped in try/catch so a missing table or DB outage doesn't block the rest of the logout; (b) clears the \`ihymns_auth\` cookie via \`setcookie\` with the same path / domain / SameSite=Lax / HttpOnly / Secure options as \`_authCookieOpts()\` in \`api.php\`. Both run BEFORE session destroy so the audit-log row still attributes correctly. The cookie value is format-checked against \`/^[a-f0-9]{64}\$/i\` first so a malformed cookie can't reach the prepare. |

## Test plan

- [ ] **Sign in to /manage**, click **Log out** in the user dropdown. Expect: lands on /manage/login and **stays there**, even on refresh.
- [ ] **Log out from /manage/editor** (the toolbar button). Expect: same.
- [ ] **DevTools cookie pane** after logout: \`ihymns_auth\` is gone.
- [ ] **\`tblApiTokens\` row** corresponding to that cookie is deleted.
- [ ] **Multi-device** — sign in on two browsers. Log out on one. Expect: only the logging-out browser's token is invalidated; the other browser stays signed in (deletion is keyed on the specific token hash, not the user id).
- [ ] **Main-site logout** still works (regression check).
- [ ] **Edge case** — logout when no \`ihymns_auth\` cookie is present (PHP-only session). Expect: same behaviour as today; no errors.

## Refs

- Closes #764
- Mirrors the cleanup logic that \`auth_logout\` in \`api.php\` already runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)