### PR TITLE
fix(songbooks): edit/delete buttons broken on apostrophe-in-name songbooks (#774)

### DIFF
--- a/appWeb/public_html/manage/songbooks.php
+++ b/appWeb/public_html/manage/songbooks.php
@@ -1118,39 +1118,55 @@ $csrf = csrfToken();
                                 <?php endif; ?>
                             </td>
                             <td class="text-end">
+                                <?php
+                                    /* Build the row payload once, then escape for
+                                       HTML attribute embedding (#774). The earlier
+                                       form embedded raw json_encode() output inside
+                                       a single-quoted onclick attribute — apostrophes
+                                       in a Name (e.g. "Ogotera kw'ogotogia Nyasae"
+                                       for OKON; many Polynesian / French / Slavic
+                                       names contain them) terminated the attribute
+                                       early and the click handler became malformed
+                                       silently, so the modal never opened. The
+                                       htmlspecialchars(ENT_QUOTES) wrap encodes
+                                       the apostrophe as &#039; — the browser
+                                       unescapes on attribute read and the JSON
+                                       arrives intact. */
+                                    $editRowJson = json_encode([
+                                        'id'                  => (int)$r['Id'],
+                                        'abbreviation'        => $r['Abbreviation'],
+                                        'name'                => $r['Name'],
+                                        'colour'              => $r['Colour'],
+                                        'display_order'       => (int)$r['DisplayOrder'],
+                                        'song_count'          => (int)$r['ActualSongCount'],
+                                        'is_official'         => (int)$r['IsOfficial'] === 1,
+                                        'publisher'           => $r['Publisher']       ?? '',
+                                        'publication_year'    => $r['PublicationYear'] ?? '',
+                                        'copyright'           => $r['Copyright']       ?? '',
+                                        'affiliation'         => $r['Affiliation']     ?? '',
+                                        /* #673 — Language defaults to '' so the dropdown
+                                           picks "— Not specified —" when absent. */
+                                        'language'            => $r['Language']        ?? '',
+                                        /* #672 — fields default to '' so a row from a
+                                           pre-migration deployment renders cleanly
+                                           (the bibSelect probe above gates the SELECT). */
+                                        'website_url'         => $r['WebsiteUrl']         ?? '',
+                                        'internet_archive_url'=> $r['InternetArchiveUrl'] ?? '',
+                                        'wikipedia_url'       => $r['WikipediaUrl']       ?? '',
+                                        'wikidata_id'         => $r['WikidataId']         ?? '',
+                                        'oclc_number'         => $r['OclcNumber']         ?? '',
+                                        'ocn_number'          => $r['OcnNumber']          ?? '',
+                                        'lcp_number'          => $r['LcpNumber']          ?? '',
+                                        'isbn'                => $r['Isbn']               ?? '',
+                                        'ark_id'              => $r['ArkId']              ?? '',
+                                        'isni_id'             => $r['IsniId']             ?? '',
+                                        'viaf_id'             => $r['ViafId']             ?? '',
+                                        'lccn'                => $r['Lccn']               ?? '',
+                                        'lc_class'            => $r['LcClass']            ?? '',
+                                    ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+                                ?>
                                 <button type="button" class="btn btn-sm btn-outline-info"
-                                        onclick='openEditModal(<?= json_encode([
-                                            'id'                  => (int)$r['Id'],
-                                            'abbreviation'        => $r['Abbreviation'],
-                                            'name'                => $r['Name'],
-                                            'colour'              => $r['Colour'],
-                                            'display_order'       => (int)$r['DisplayOrder'],
-                                            'song_count'          => (int)$r['ActualSongCount'],
-                                            'is_official'         => (int)$r['IsOfficial'] === 1,
-                                            'publisher'           => $r['Publisher']       ?? '',
-                                            'publication_year'    => $r['PublicationYear'] ?? '',
-                                            'copyright'           => $r['Copyright']       ?? '',
-                                            'affiliation'         => $r['Affiliation']     ?? '',
-                                            /* #673 — Language defaults to '' so the dropdown
-                                               picks "— Not specified —" when absent. */
-                                            'language'            => $r['Language']        ?? '',
-                                            /* #672 — fields default to '' so a row from a
-                                               pre-migration deployment renders cleanly
-                                               (the bibSelect probe above gates the SELECT). */
-                                            'website_url'         => $r['WebsiteUrl']         ?? '',
-                                            'internet_archive_url'=> $r['InternetArchiveUrl'] ?? '',
-                                            'wikipedia_url'       => $r['WikipediaUrl']       ?? '',
-                                            'wikidata_id'         => $r['WikidataId']         ?? '',
-                                            'oclc_number'         => $r['OclcNumber']         ?? '',
-                                            'ocn_number'          => $r['OcnNumber']          ?? '',
-                                            'lcp_number'          => $r['LcpNumber']          ?? '',
-                                            'isbn'                => $r['Isbn']               ?? '',
-                                            'ark_id'              => $r['ArkId']              ?? '',
-                                            'isni_id'             => $r['IsniId']             ?? '',
-                                            'viaf_id'             => $r['ViafId']             ?? '',
-                                            'lccn'                => $r['Lccn']               ?? '',
-                                            'lc_class'            => $r['LcClass']            ?? '',
-                                        ]) ?>)'
+                                        onclick="openEditModal(<?= htmlspecialchars((string)$editRowJson, ENT_QUOTES, 'UTF-8') ?>)"
                                         title="Edit songbook">
                                     <i class="bi bi-pencil"></i>
                                 </button>
@@ -1162,19 +1178,29 @@ $csrf = csrfToken();
                                     $songCnt = (int)$r['ActualSongCount'];
                                     $isAdmin = in_array(($currentUser['role'] ?? ''), ['admin', 'global_admin'], true);
                                 ?>
+                                <?php
+                                    /* Same htmlspecialchars wrap as the Edit button
+                                       above — protects the inline JSON against
+                                       apostrophes / quotes in Abbreviation. (#774) */
+                                    $deleteRowJson = json_encode([
+                                        'id'           => (int)$r['Id'],
+                                        'abbreviation' => $r['Abbreviation'],
+                                    ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+                                    $cascadeRowJson = json_encode([
+                                        'id'           => (int)$r['Id'],
+                                        'abbreviation' => $r['Abbreviation'],
+                                        'song_count'   => $songCnt,
+                                    ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+                                ?>
                                 <?php if ($songCnt === 0): ?>
                                 <button type="button" class="btn btn-sm btn-outline-danger"
-                                        onclick='openDeleteModal(<?= json_encode(['id' => (int)$r['Id'], 'abbreviation' => $r['Abbreviation']]) ?>)'
+                                        onclick="openDeleteModal(<?= htmlspecialchars((string)$deleteRowJson, ENT_QUOTES, 'UTF-8') ?>)"
                                         title="Delete songbook (no songs reference it)">
                                     <i class="bi bi-trash"></i>
                                 </button>
                                 <?php elseif ($isAdmin): ?>
                                 <button type="button" class="btn btn-sm btn-outline-danger"
-                                        onclick='openCascadeDeleteModal(<?= json_encode([
-                                            'id' => (int)$r['Id'],
-                                            'abbreviation' => $r['Abbreviation'],
-                                            'song_count' => $songCnt,
-                                        ]) ?>)'
+                                        onclick="openCascadeDeleteModal(<?= htmlspecialchars((string)$cascadeRowJson, ENT_QUOTES, 'UTF-8') ?>)"
                                         title="Cascade-delete: songbook + <?= $songCnt ?> song(s) + every reference to them">
                                     <i class="bi bi-trash"></i>
                                 </button>


### PR DESCRIPTION
## Summary

- Clicking Edit / Delete on **OKON** (\"Ogotera kw'ogotogia Nyasae\") did nothing — no modal opened. Same on every songbook whose Name carries a single quote (Polynesian, French \"L'Église\", many Slavic spellings).
- Closes #774.

## Root cause

\`manage/songbooks.php\` embedded row data in inline \`onclick\` handlers:

\`\`\`php
onclick='openEditModal(<?= json_encode([...]) ?>)'
\`\`\`

The \`onclick\` is single-quoted, the \`json_encode\` output is echoed unescaped. JSON does **not** escape \`'\` (only \`\"\`) — so an apostrophe inside \`Name\` terminated the attribute early. The click handler ended up malformed; silent no-op.

Three call sites exhibited this: **Edit**, plain **Delete**, **Cascade Delete**. All fixed.

## Fix

Wrap each \`json_encode()\` output in \`htmlspecialchars(..., ENT_QUOTES, 'UTF-8')\` so apostrophes encode to \`&#039;\`. The browser unescapes on attribute read; the JSON arrives intact at \`openEditModal\` / \`openDeleteModal\` / \`openCascadeDeleteModal\`. Also switched the attribute delimiter to \`\"\` since \`htmlspecialchars\` now encodes \`\"\` to \`&quot;\` consistently.

Companion \`tiers.php\` uses \`JSON_HEX_APOS | JSON_HEX_QUOT\` for the same purpose — both approaches work; we picked \`htmlspecialchars(ENT_QUOTES)\` here because it also handles \`&\`, \`<\`, \`>\` consistently with the rest of the file's escaping conventions.

## Test plan

- [ ] **OKON Edit** — click the pencil. Expect: modal opens with the row's data populated.
- [ ] **OKON Delete** (zero songs) — click trash. Expect: confirmation modal opens.
- [ ] **Cascade Delete** on a populated apostrophe-name songbook — admin role required, modal opens with the typed-confirm field.
- [ ] **Other songbooks** (no apostrophe) — Edit / Delete / Cascade Delete unchanged.
- [ ] **No XSS regression** — attempt a Name like \`</td><script>alert(1)</script>\`. Expect: encoded as text in the JSON value, harmless on the JS side; click opens the modal with the literal text shown in the Name input.

## Refs

- Closes #774
- Long-standing bug; surfaced now because OKON's import made it visible against an alpha catalogue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)