### PR TITLE
fix(schema): make tblSongs.Number nullable to align with #392 policy (#783)

### DIFF
--- a/appWeb/.sql/migrate-tblsongs-number-nullable.php
+++ b/appWeb/.sql/migrate-tblsongs-number-nullable.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Make tblSongs.Number nullable (#783)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * tblSongs.Number was originally `INT UNSIGNED NOT NULL DEFAULT 0`
+ * because every songbook at the time (CP / JP / MP / SDAH / CH) had
+ * numbered rows. With Misc + every curated grouping that's flagged
+ * IsOfficial=0 (#392) + the multi-language work in flight (#778),
+ * songs in unofficial songbooks legitimately have NO per-songbook
+ * number — the internal SongId is the cross-record link instead.
+ *
+ * The save_song handler in /manage/editor/api.php has bound NULL on
+ * unofficial-songbook saves since PR #740, but the schema on existing
+ * deployments still says NOT NULL — so every Misc save 1048s with
+ * "Column 'Number' cannot be null". This migration aligns the
+ * schema with the post-#392 policy.
+ *
+ * Idempotent — INFORMATION_SCHEMA probe; skip if IS_NULLABLE='YES'.
+ * Existing rows with integer Numbers stay valid; the only behaviour
+ * change is that NULL becomes a permissible value.
+ *
+ * USAGE:
+ *   CLI: php appWeb/.sql/migrate-tblsongs-number-nullable.php
+ *   Web: /manage/setup-database → "Make tblSongs.Number nullable"
+ *        (entry point requires global_admin)
+ */
+
+if (PHP_SAPI === 'cli') {
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = true;
+} else {
+    if (!defined('IHYMNS_SETUP_DASHBOARD')) {
+        if (!function_exists('isAuthenticated')) {
+            require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+        }
+        if (!isAuthenticated()) {
+            http_response_code(401);
+            exit('Authentication required.');
+        }
+        $u = getCurrentUser();
+        if (!$u || $u['role'] !== 'global_admin') {
+            http_response_code(403);
+            exit('Global admin required.');
+        }
+    }
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = false;
+}
+
+function _migNumNull_out(string $line): void
+{
+    global $isCli;
+    echo $line . ($isCli ? "\n" : "<br>\n");
+    if ($isCli) flush();
+}
+
+_migNumNull_out('tblSongs.Number nullable migration starting…');
+
+$db = getDbMysqli();
+if (!$db) {
+    _migNumNull_out('ERROR: could not connect to database.');
+    exit(1);
+}
+
+/* Probe current state of the column. */
+$stmt = $db->prepare(
+    "SELECT IS_NULLABLE, COLUMN_DEFAULT, COLUMN_TYPE
+       FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME   = 'tblSongs'
+        AND COLUMN_NAME  = 'Number'
+      LIMIT 1"
+);
+$stmt->execute();
+$row = $stmt->get_result()->fetch_assoc();
+$stmt->close();
+
+if (!$row) {
+    _migNumNull_out('ERROR: tblSongs.Number not found. Run install.php first.');
+    exit(1);
+}
+
+if (($row['IS_NULLABLE'] ?? '') === 'YES') {
+    _migNumNull_out('[skip] tblSongs.Number is already nullable. Nothing to do.');
+    _migNumNull_out('tblSongs.Number nullable migration finished.');
+    exit(0);
+}
+
+_migNumNull_out(sprintf(
+    'Current shape: %s, IS_NULLABLE=%s, DEFAULT=%s.',
+    $row['COLUMN_TYPE'] ?? '?',
+    $row['IS_NULLABLE'] ?? '?',
+    $row['COLUMN_DEFAULT'] === null ? 'NULL' : ("'" . $row['COLUMN_DEFAULT'] . "'")
+));
+
+/* Apply the ALTER. We re-state the column type to match what's there
+   today (INT UNSIGNED) rather than picking a new type — the only
+   intent of this migration is to flip the nullability. The default
+   moves from 0 to NULL so a row created without an explicit Number
+   lands as NULL rather than 0 (which would otherwise look like a
+   "real" hymn #0 in any UI that doesn't special-case it). */
+$sql = 'ALTER TABLE tblSongs MODIFY COLUMN Number INT UNSIGNED NULL DEFAULT NULL';
+if (!$db->query($sql)) {
+    _migNumNull_out('ERROR: ALTER failed: ' . $db->error);
+    exit(1);
+}
+_migNumNull_out('[ok  ] tblSongs.Number → NULL DEFAULT NULL.');
+
+/* Verify the change took effect — defence against a silent failure
+   on a pre-MySQL-5.6 server or one with a strange SQL_MODE. */
+$stmt = $db->prepare(
+    "SELECT IS_NULLABLE FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME   = 'tblSongs'
+        AND COLUMN_NAME  = 'Number'
+      LIMIT 1"
+);
+$stmt->execute();
+$after = (string)($stmt->get_result()->fetch_row()[0] ?? '');
+$stmt->close();
+if ($after !== 'YES') {
+    _migNumNull_out("WARN: post-ALTER probe shows IS_NULLABLE='{$after}'. The migration ran but the change may not have applied. Check server SQL_MODE.");
+} else {
+    _migNumNull_out('[verify] confirmed nullable.');
+}
+
+_migNumNull_out('tblSongs.Number nullable migration finished.');

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -223,6 +223,7 @@ if ($action !== '') {
         'iana-language-subtag-registry' => 'migrate-iana-language-subtag-registry.php',
         'cldr-native-names' => 'migrate-cldr-native-names.php',
         'tag-titlecase'     => 'migrate-tag-titlecase.php',
+        'tblsongs-number-nullable' => 'migrate-tblsongs-number-nullable.php',
         'cleanup'     => 'cleanup.php',
         'backup'      => 'backup.php',
         'restore'     => 'restore.php',
@@ -264,6 +265,7 @@ if ($action !== '') {
         'iana-language-subtag-registry',
         'cldr-native-names',
         'tag-titlecase',
+        'tblsongs-number-nullable',
         /* When you add a new migrate-*.php under appWeb/.sql/, ALSO add
            its action key to:
              1. $scriptMap above (action key → file)
@@ -1046,6 +1048,25 @@ if ($hasCredentials && defined('DB_HOST')) {
                             CLDR JSON files, overwrites the bundled snapshots,
                             then re-runs the import.
                         </p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="card bg-dark border-secondary h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">3v. tblSongs.Number nullable (#783)</h5>
+                        <p class="card-text text-secondary small">
+                            Aligns the schema with the post-#392 policy that lets
+                            songs in unofficial songbooks (Misc, custom collections)
+                            persist <code>Number</code> as <code>NULL</code>. Without
+                            this, the save_song handler's intentional NULL-bind
+                            raises mysqli error 1048 (\"Column 'Number' cannot be
+                            null\") on every Misc save. Idempotent — INFORMATION_SCHEMA
+                            probe; skips when already nullable.
+                        </p>
+                        <a href="?action=tblsongs-number-nullable" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
+                            Run tblSongs.Number Nullable Migration
+                        </a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary

- **Schema fix.** \`tblSongs.Number\` was \`INT UNSIGNED NOT NULL DEFAULT 0\`, blocking the unofficial-songbook saves that PR #740 (closing #392) introduced. The save path bound \`NULL\` on every Misc save and got rejected with \`mysqli 1048 — Column 'Number' cannot be null\`.
- New idempotent migration flips the column to \`INT UNSIGNED NULL DEFAULT NULL\`. Wired into \`/manage/setup-database\`.
- Closes #783.

## Why this surfaced now

The diagnostic improvements from PR #760 (closing #759) just landed in production. Saving a Misc song now surfaces the underlying mysqli error in the toast, instead of the previous opaque \"Check server logs for details\". Once the toast read \`Column 'Number' cannot be null [mysqli 1048]\`, the schema mismatch was the obvious culprit.

The root cause has been quiet for a while — every PR that touched the Misc workflow (#392 / PR #740 / PR #757) assumed the column was nullable. On a fresh \`install.php\` deployment it would have been; on the user's deployment, the column is from the original schema where every songbook had numbered rows.

## Files

| File | Change |
| --- | --- |
| \`appWeb/.sql/migrate-tblsongs-number-nullable.php\` (new) | Idempotent INFORMATION_SCHEMA probe; runs \`ALTER TABLE tblSongs MODIFY COLUMN Number INT UNSIGNED NULL DEFAULT NULL\` only when the column is currently \`NOT NULL\`. Re-reads the column post-ALTER and warns if a non-standard \`SQL_MODE\` blocked the change. |
| \`appWeb/public_html/manage/setup-database.php\` | New action key \`tblsongs-number-nullable\` in \`\$scriptMap\` + \`\$migrationOrder\`. New card \"3v. tblSongs.Number nullable (#783)\" with the standard Run button. |

## Behaviour

- Existing rows with integer Numbers stay valid.
- New rows in unofficial songbooks (Misc, custom collections) land with \`Number IS NULL\` — the internal \`SongId\` is the cross-record link.
- New rows in official songbooks still require Number per the existing frontend validator (PR #740) — that policy is unchanged.
- \`Number\`'s default moves from \`0\` to \`NULL\` so a row created without an explicit value lands as NULL rather than 0 (which would otherwise look like a \"real\" hymn #0 in any UI that didn't special-case the zero).

## Test plan

- [ ] **Run the migration** via /manage/setup-database → \"Run tblSongs.Number Nullable Migration\". Expect: \`[ok ] tblSongs.Number → NULL DEFAULT NULL.\` followed by \`[verify] confirmed nullable.\`.
- [ ] **Re-run** — expect: \`[skip] tblSongs.Number is already nullable. Nothing to do.\`
- [ ] **Reproduce the original failing save**: Add a song to **Miscellaneous**, leave Song Number empty, language \`af-ZA\`, save. Expect: success toast; \`tblSongs.Number IS NULL\` for that row.
- [ ] **Official-songbook regression**: Add a song to **SDAH** without a Number. Expect: frontend validator blocks with the existing \"missing 'number' (required for official songbooks)\" message.
- [ ] **Existing songs**: every previously-saved row keeps its integer Number unchanged.

## Refs

- Closes #783
- Surfaced via #759 / PR #760 (diagnostic improvements that named the actual cause).
- Aligns the schema with the policy from #392 / PR #740.

🤖 Generated with [Claude Code](https://claude.com/claude-code)