### PR TITLE
polish(admin/public): dashboard padlock corner + tile language badge restyle (#785)

### DIFF
--- a/appWeb/public_html/css/app.css
+++ b/appWeb/public_html/css/app.css
@@ -2197,6 +2197,21 @@ body.reduce-motion .shortcuts-overlay {
 .lock-chip-global-admin { color: #ef4444; }
 .lock-chip-admin        { color: #f59e0b; }
 
+/* Corner placement for the dashboard tile / setup-database card variant
+   (#785). The inline-after-label form (above) is still used by the
+   admin sidebar + offcanvas; the corner form sits absolute in the
+   top-right of a position:relative parent. Slightly larger so it
+   reads at a glance without crowding the card heading. */
+.lock-chip-corner {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    margin-left: 0;
+    font-size: 1rem;
+    line-height: 1;
+    z-index: 2;
+}
+
 /* In high-contrast mode the chip needs a slightly bolder outline so
    the colour difference reads at a glance. */
 [data-ihymns-theme="high-contrast"] .lock-chip-global-admin {
@@ -2987,24 +3002,38 @@ body.reduce-motion .related-songs-chevron {
    button rendered) the badge stays in the top-right too — visually
    consistent across surfaces. */
 .songbook-tile-language-badge {
+    /* Match the download-cloud button's chrome (#785). The download
+       button uses Bootstrap's btn-sm + btn-outline-secondary — same
+       padding, border-radius, border colour and weight. The two
+       controls now read as a matched pair in the tile's top-right
+       cluster instead of one being a tiny pill and the other a full
+       button. */
     position: absolute;
     top: 0.45rem;
     right: 2.5rem;
     z-index: 2;
-    /* Compact pill so a 2-letter code reads at a glance without
-       crowding neighbouring elements. */
-    padding: 0.1rem 0.4rem;
+    /* Bootstrap btn-sm dimensions: padding 0.25rem 0.5rem; line-height 1.5;
+       font-size 0.875rem. We keep the font slightly tighter (0.7rem) so a
+       2-letter ISO code stays compact, but the box is identical to the
+       sibling btn-outline-secondary download icon so they line up. */
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 2rem;
+    height: 1.75rem;
+    padding: 0 0.5rem;
     border-radius: 0.25rem;
-    font-size: 0.65rem;
+    font-size: 0.7rem;
     font-weight: 700;
     letter-spacing: 0.04em;
     text-transform: uppercase;
-    background: var(--surface-elevated);
-    color: var(--text-secondary);
-    /* Subtle border so the badge stays visible when it overlaps a
-       light section of a coloured songbook icon background. */
-    border: 1px solid var(--card-border);
     line-height: 1;
+    /* Match btn-outline-secondary: transparent background, the same
+       border colour family, secondary text. Hover doesn't change
+       (this badge isn't clickable; it's purely informational). */
+    background: transparent;
+    color: var(--text-secondary);
+    border: 1px solid var(--card-border);
 }
 /* On the /songbooks full-cards surface there's no download button,
    so the badge can hug the top-right corner. The card has

--- a/appWeb/public_html/manage/index.php
+++ b/appWeb/public_html/manage/index.php
@@ -304,9 +304,25 @@ $csrf = csrfToken();
                      data-card-id="<?= htmlspecialchars($id) ?>"
                      data-hidden="<?= $isHidden ? '1' : '0' ?>">
                     <div class="card-admin position-relative">
+                        <?php
+                            /* Padlock chip moved to the top-right corner of the
+                               card (#785) — was inline next to the title and
+                               crowded the heading. The .lock-chip-corner class
+                               keeps the same red/yellow tier colours but
+                               position:absolutes the chip so it doesn't push
+                               anything around. */
+                            $tier = entitlementHighestRole($entitlement);
+                            if ($tier !== null):
+                                $tierCls   = $tier === 'global_admin' ? 'lock-chip-global-admin' : 'lock-chip-admin';
+                                $tierLabel = $tier === 'global_admin' ? 'Requires Global Admin' : 'Requires Admin';
+                        ?>
+                            <i class="bi bi-lock-fill lock-chip lock-chip-corner <?= $tierCls ?>"
+                               aria-label="<?= htmlspecialchars($tierLabel, ENT_QUOTES, 'UTF-8') ?>"
+                               title="<?= htmlspecialchars($tierLabel, ENT_QUOTES, 'UTF-8') ?>"></i>
+                        <?php endif; ?>
                         <a href="<?= htmlspecialchars($href) ?>" class="quick-link" <?= $target ?>>
                             <i class="bi <?= htmlspecialchars($icon) ?> d-block mb-2" aria-hidden="true"></i>
-                            <strong><?= $title /* some titles contain &amp; entity */ ?><?= entitlementLockChipHtml($entitlement) ?></strong>
+                            <strong><?= $title /* some titles contain &amp; entity */ ?></strong>
                             <div class="small text-muted"><?= $sub /* same */ ?></div>
                         </a>
                     </div>


### PR DESCRIPTION
## Summary

Two small visual fixes:

1. **Dashboard padlock** moved from inline-after-title to top-right corner of each restricted card. Same red/yellow tier colours from PR #761; card title no longer crowded.
2. **Songbook tile language badge** restyled to match the sibling download-cloud button's chrome (transparent background, same border, same height) so the two controls in the tile's top-right cluster read as a matched pair.

Closes #785.

## Files

| File | Change |
| --- | --- |
| \`appWeb/public_html/manage/index.php\` | Dashboard card grid now branches on \`entitlementHighestRole(\$entitlement)\` to render an \`.lock-chip-corner\` glyph BEFORE the \`<a class=\"quick-link\">\` when the card is restricted. Card title and subtitle return to their pre-PR-#761 layout. |
| \`appWeb/public_html/css/app.css\` | New \`.lock-chip-corner\` class extends \`.lock-chip\` with \`position:absolute; top:0.5rem; right:0.5rem\` — colour rules unchanged. \`.songbook-tile-language-badge\` rebuilt to match Bootstrap \`btn-sm btn-outline-secondary\` dimensions (\`min-width:2rem; height:1.75rem; padding:0 0.5rem\`); transparent background, same border colour as the download button. |

## Why ISO text instead of a flag emoji

The user asked whether we should consider flag emoji. I'm keeping ISO text for v1: flags map **countries**, not languages — \"English\" → 🇬🇧 vs 🇺🇸 vs 🇦🇺 vs 🇨🇦 picks one community over another, and the same shape repeats for Spanish (🇪🇸 vs 🇲🇽 vs 🇦🇷 …). The visual-coherence win the user wanted is the chip-shape match; the text is the right semantic. A future flag variant could be a follow-up if you want — would need a per-language → preferred-flag lookup, which is its own design conversation.

## Test plan

- [ ] **Dashboard** — open /manage/ as a global_admin. Expect: red padlock in the top-right corner of every global_admin-only card; yellow on admin-only cards; no padlock on Song Editor / Help / etc.
- [ ] **As an admin** — yellow padlocks visible; global_admin-only cards filtered out by \`visibleAdminLinks\` already.
- [ ] **Card title** is no longer pushed by the chip — sits flush in the centre of the card.
- [ ] **Songbook tile language badge** on /home and /songbooks looks like a sibling of the download-cloud button (same height, border, transparent fill).
- [ ] No regression on the existing sidebar/offcanvas \`.lock-chip\` (inline-after-label form) — those still render as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)