### PR TITLE
fix(editor): tag-add no longer blocks saved Misc songs (#788)

### DIFF
--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -1884,17 +1884,16 @@ function addSongTag(song, tagName) {
     if (!song || !song.id || !tagName || !tagName.trim()) return;
     tagName = tagName.trim();
 
-    /* Block tag-add on songs that haven't been saved yet (#770).
-       Brand-new songs from Add carry a synthetic
-       `song-<ts>-<rand>` id and won't have a corresponding row in
-       tblSongs — the bulk_tag handler's INSERT into tblSongTagMap
-       would silently skip due to the foreign-key constraint, the
-       API would still respond {added: 0}, and the success toast
-       would mislead the curator into thinking it stuck. */
-    if (typeof song.id === 'string' && song.id.indexOf('song-') === 0) {
-        showToast('Save the song first, then add tags. (Tags need a saved song to attach to.)', 'warning');
-        return;
-    }
+    /* Pre-flight guard removed (#788). The earlier version refused
+       any song whose id started with "song-" on the assumption it
+       was a brand-new in-memory id from Add. That assumption is
+       wrong — songs in unofficial / Misc songbooks have a synthetic
+       `song-<ts>-<rand>` SongId as their CANONICAL persisted id
+       (#392 / PR #740), not a "this isn't saved yet" marker. The
+       server-side detection below (data.added === 0 → friendly
+       "Save the song first" toast) is the correct way to spot a
+       genuinely-unsaved song; the prefix check was just blocking
+       every saved Misc song from being tagged. */
 
     /* Optimistic update: append the chip locally so the UI feels
        snappy, then re-fetch on completion to pick up the real row


### PR DESCRIPTION
## Summary

- Removes the pre-flight \`song.id.startsWith('song-')\` guard from \`addSongTag\` that was wrongly refusing tag-add on **saved** Misc songs.
- The server-side detection (post-fetch \`data.added === 0\` branch from PR #771) is unchanged and is the correct way to handle the genuinely-unsaved case.
- Closes #788.

## Why the guard was wrong

PR #771 added the guard with this assumption: \"any song whose id starts with \`song-\` is a brand-new in-memory row from the Add button — refuse to tag it because the FK insert will fail.\"

That assumption breaks on the unofficial-songbook workflow shipped in #392 / PR #740. Songs in Misc / curated groupings don't have a per-songbook number; their **canonical persisted SongId IS** the synthetic \`song-<ts>-<rand>\` form. A saved Misc song looks identical to an unsaved one by ID alone — the guard couldn't tell them apart.

## Files

| File | Change |
| --- | --- |
| \`appWeb/public_html/manage/editor/editor.js\` | One block deleted from \`addSongTag\`. Comment block left in place so a future maintainer doesn't reintroduce it. |

## Test plan

- [ ] **Saved Misc song** (the user's reproduction case) — Tags tab → type \"Worship\" → press Enter. Expect: success toast, chip appears in Assigned tags.
- [ ] **Unsaved (just-added) song** — same flow. Expect: server's \`{added: 0}\` triggers the friendly \"Tag couldn't be applied. Save the song first…\" toast (post-fetch branch unchanged).
- [ ] **Saved official-songbook song** (e.g. SDAH-0042) — unchanged behaviour.
- [ ] No regression on the case-insensitive / Title-Case handling from PR #763.

## Refs

- Closes #788
- Reverts the over-eager part of PR #771 (closing #770) without losing its post-fetch detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)