### PR TITLE
fix: stale SongCount hides newly-populated songbook tiles (Misc) (#791)

### DIFF
--- a/appWeb/.sql/migrate-recompute-songbook-songcount.php
+++ b/appWeb/.sql/migrate-recompute-songbook-songcount.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Recompute tblSongbooks.SongCount from live tblSongs (#791)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * tblSongbooks.SongCount is a cached aggregate that the home + the
+ * /songbooks tile-grid use to gate render — `if songCount > 0`.
+ * Several write paths (bulk_import_zip, the legacy bulk `save`
+ * action, /manage/songbooks edit / drag-drop) keep it in step, but
+ * the per-song save_song handler hadn't until #791 / PR closing
+ * this issue. Catalogues with editor-saved songs in newly-created
+ * songbooks (notably Misc) ended up with SongCount stuck at 0 even
+ * after rows landed in tblSongs — and the tile never appeared.
+ *
+ * This one-shot migration walks every tblSongbooks row and rewrites
+ * SongCount from a live `SELECT COUNT(*) FROM tblSongs WHERE
+ * SongbookAbbr = ?`. Idempotent: a row whose cached value already
+ * matches the live count is a no-op. Reports before/after for any
+ * row that drifted.
+ *
+ * USAGE:
+ *   CLI: php appWeb/.sql/migrate-recompute-songbook-songcount.php
+ *   Web: /manage/setup-database → "Recompute Songbook SongCount (#791)"
+ *        (entry point requires global_admin)
+ */
+
+if (PHP_SAPI === 'cli') {
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = true;
+} else {
+    if (!defined('IHYMNS_SETUP_DASHBOARD')) {
+        if (!function_exists('isAuthenticated')) {
+            require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+        }
+        if (!isAuthenticated()) {
+            http_response_code(401);
+            exit('Authentication required.');
+        }
+        $u = getCurrentUser();
+        if (!$u || $u['role'] !== 'global_admin') {
+            http_response_code(403);
+            exit('Global admin required.');
+        }
+    }
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = false;
+}
+
+function _migRecountSb_out(string $line): void
+{
+    global $isCli;
+    echo $line . ($isCli ? "\n" : "<br>\n");
+    if ($isCli) flush();
+}
+
+_migRecountSb_out('Songbook SongCount recompute starting (#791)…');
+
+$db = getDbMysqli();
+if (!$db) {
+    _migRecountSb_out('ERROR: could not connect to database.');
+    exit(1);
+}
+
+/* Pull every (Abbreviation, cached SongCount) pair, plus the live
+   COUNT(*) from tblSongs, in one query. The LEFT JOIN keeps rows
+   with zero matching songs (so an empty songbook with cached
+   SongCount=N gets corrected to 0). */
+$res = $db->query(
+    "SELECT b.Id, b.Abbreviation, b.SongCount AS cached,
+            COALESCE(s.live_count, 0) AS live
+       FROM tblSongbooks b
+       LEFT JOIN (
+            SELECT SongbookAbbr, COUNT(*) AS live_count
+              FROM tblSongs
+             GROUP BY SongbookAbbr
+       ) s ON s.SongbookAbbr = b.Abbreviation
+      ORDER BY b.Abbreviation"
+);
+if (!$res) {
+    _migRecountSb_out('ERROR: SELECT failed: ' . $db->error);
+    exit(1);
+}
+
+$rows = $res->fetch_all(MYSQLI_ASSOC);
+$res->close();
+
+$updateStmt = $db->prepare('UPDATE tblSongbooks SET SongCount = ? WHERE Id = ?');
+$drifted = 0;
+$correct = 0;
+$totalLive = 0;
+
+foreach ($rows as $r) {
+    $cached = (int)$r['cached'];
+    $live   = (int)$r['live'];
+    $totalLive += $live;
+    if ($cached === $live) {
+        $correct++;
+        continue;
+    }
+    $id = (int)$r['Id'];
+    $updateStmt->bind_param('ii', $live, $id);
+    $updateStmt->execute();
+    $delta = $live - $cached;
+    $sign  = $delta > 0 ? '+' : '';
+    _migRecountSb_out(sprintf(
+        '  [fix] %-12s cached=%d  live=%d  (%s%d)',
+        $r['Abbreviation'], $cached, $live, $sign, $delta
+    ));
+    $drifted++;
+}
+$updateStmt->close();
+
+_migRecountSb_out("");
+_migRecountSb_out("Summary: {$correct} songbook(s) already correct, {$drifted} re-counted; {$totalLive} song row(s) total across the catalogue.");
+_migRecountSb_out('Songbook SongCount recompute finished (#791).');

--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -822,6 +822,56 @@ switch ($action) {
                 $rev->close();
             } catch (\Throwable $_e) { /* revisions are best-effort */ }
 
+            /* Refresh tblSongbooks.SongCount for every songbook this
+               save touched (#791). The home + /songbooks tiles gate
+               render on `songCount > 0`, and SongCount is a cached
+               column — without this recompute, a brand-new song
+               saved to Misc / any not-yet-populated songbook lands
+               in tblSongs but the songbook tile never appears
+               because the cache stays at 0.
+
+               Two paths recompute:
+                 - The current row's SongbookAbbr (always).
+                 - The PREVIOUS row's SongbookAbbr if it differs
+                   (song moved between books — old book shrinks,
+                   new book grows). previousData is the JSON dump
+                   of the row before this save.
+
+               Wrapped in try/catch so a SongCount recompute failure
+               (e.g. transient deadlock) doesn't roll back the song
+               save itself — the cache will self-heal on the next
+               recompute pass. */
+            try {
+                $cnt = $db->prepare(
+                    'UPDATE tblSongbooks
+                        SET SongCount = (SELECT COUNT(*) FROM tblSongs WHERE SongbookAbbr = ?)
+                      WHERE Abbreviation = ?'
+                );
+                $cnt->bind_param('ss', $songbookAbbr, $songbookAbbr);
+                $cnt->execute();
+                $cnt->close();
+
+                /* If the row moved songbooks, the OLD book also needs
+                   its count refreshed so its tile shrinks (or hides
+                   entirely if this was its last song). */
+                if ($previousData !== null) {
+                    $prev = json_decode($previousData, true);
+                    $prevAbbr = is_array($prev) ? (string)($prev['SongbookAbbr'] ?? '') : '';
+                    if ($prevAbbr !== '' && $prevAbbr !== $songbookAbbr) {
+                        $cnt = $db->prepare(
+                            'UPDATE tblSongbooks
+                                SET SongCount = (SELECT COUNT(*) FROM tblSongs WHERE SongbookAbbr = ?)
+                              WHERE Abbreviation = ?'
+                        );
+                        $cnt->bind_param('ss', $prevAbbr, $prevAbbr);
+                        $cnt->execute();
+                        $cnt->close();
+                    }
+                }
+            } catch (\Throwable $_e) {
+                error_log('[editor save_song] SongCount recompute failed: ' . $_e->getMessage());
+            }
+
             /* Activity log (#535) — high-level "song.create" / "song.edit"
                row with a cross-link to the revisions row above so a
                timeline reader can drill into the full before/after diff

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -226,6 +226,7 @@ if ($action !== '') {
         'tblsongs-number-nullable' => 'migrate-tblsongs-number-nullable.php',
         'multi-language-tables'    => 'migrate-multi-language-tables.php',
         'parent-songbooks'         => 'migrate-parent-songbooks.php',
+        'recompute-songbook-songcount' => 'migrate-recompute-songbook-songcount.php',
         'cleanup'     => 'cleanup.php',
         'backup'      => 'backup.php',
         'restore'     => 'restore.php',
@@ -270,6 +271,7 @@ if ($action !== '') {
         'tblsongs-number-nullable',
         'multi-language-tables',
         'parent-songbooks',
+        'recompute-songbook-songcount',
         /* When you add a new migrate-*.php under appWeb/.sql/, ALSO add
            its action key to:
              1. $scriptMap above (action key → file)
@@ -1052,6 +1054,28 @@ if ($hasCredentials && defined('DB_HOST')) {
                             CLDR JSON files, overwrites the bundled snapshots,
                             then re-runs the import.
                         </p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="card bg-dark border-secondary h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">3y. Recompute Songbook SongCount (#791)</h5>
+                        <p class="card-text text-secondary small">
+                            Walks every <code>tblSongbooks</code> row and rewrites
+                            <code>SongCount</code> from a live
+                            <code>SELECT COUNT(*) FROM tblSongs WHERE SongbookAbbr = ?</code>.
+                            Fixes stale cache values left behind when songs were
+                            saved via the editor before #791's recompute fix
+                            landed — the symptom was Misc (or any songbook that
+                            received its first song via the editor) failing to
+                            appear on the home / songbooks pages because the
+                            tile-render gate is <code>songCount &gt; 0</code>.
+                            Idempotent — rows already correct skip silently.
+                        </p>
+                        <a href="?action=recompute-songbook-songcount" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
+                            Run Songbook SongCount Recompute
+                        </a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary

- The **Miscellaneous** songbook (and any songbook that received its first song via the editor) wasn't rendering on /home or /songbooks even after a song was saved into it.
- Root cause: \`tblSongbooks.SongCount\` is a cached column that the tile-render gate checks (\`> 0\`); \`save_song\` never updated it.
- Closes #791.

## Two-part fix

| Part | Where |
| --- | --- |
| **save_song recompute** | \`appWeb/public_html/manage/editor/api.php\`. After the UPSERT lands, runs \`UPDATE tblSongbooks SET SongCount = (SELECT COUNT(*) FROM tblSongs WHERE SongbookAbbr = ?) WHERE Abbreviation = ?\` for the current row's songbook. If the row moved between songbooks (\`previousData['SongbookAbbr']\` differs), the old songbook is recomputed too. Wrapped in try/catch — a recompute failure won't roll back the song save itself. |
| **One-shot recompute migration** | \`appWeb/.sql/migrate-recompute-songbook-songcount.php\` — walks every \`tblSongbooks\` row, derives a live \`COUNT(*)\` from \`tblSongs\` grouped by \`SongbookAbbr\`, and UPDATEs only where the cached value drifted. Idempotent — re-runs on a healthy catalogue are no-ops. Wired into \`/manage/setup-database\` (action key \`recompute-songbook-songcount\`, new \"3y.\" card). |

## Once this lands

Run the \"3y. Recompute Songbook SongCount\" migration once on the live DB — it'll fix the Misc tile (and any other drifted songbook) immediately. From that point on \`save_song\` keeps the cache honest automatically.

## Why a cache rather than a live aggregate

The home + songbooks pages already pull \`getSongbooks()\` once, and adding a per-songbook \`(SELECT COUNT(*) … GROUP BY)\` to that read is a real cost on a multi-thousand-song catalogue. The cache approach is the right shape; the bug was specifically that one write path forgot to maintain it.

## Test plan

- [ ] Run the migration via \`/manage/setup-database → Run Songbook SongCount Recompute\`. Expect: \`[fix] Misc … (+1)\` line if Misc has 1 song; other songbooks reported as already correct.
- [ ] /home + /songbooks: Misc tile now visible.
- [ ] Add another song to Misc via the editor; tile's \"N songs\" count increments without needing a manual recompute.
- [ ] Move a song from CIS to Misc via the editor; CIS count decrements, Misc count increments.
- [ ] Re-run the migration: \"0 re-counted\".

## Refs

- Closes #791
- The render gate itself stays in \`includes/pages/home.php:133\` + \`includes/pages/songbooks.php:45\` — \`if (\$book['songCount'] > 0)\`. Intentional (\"don't show empty tiles\").

🤖 Generated with [Claude Code](https://claude.com/claude-code)