### PR TITLE
fix: hide "0" suffix on single-component Verse/Chorus labels (#795)

### DIFF
--- a/appWeb/public_html/includes/pages/song.php
+++ b/appWeb/public_html/includes/pages/song.php
@@ -522,11 +522,15 @@ unset($_t);
                 $lines  = $component['lines'] ?? [];
 
                 /* Build a human-readable label for the component.
-                   "refrain" is an alias for "chorus" — display as Chorus. */
+                   "refrain" is an alias for "chorus" — display as Chorus.
+                   The editor stores `number: 0` as a sentinel for "this is the
+                   only one of its kind" (issue #795). Treat any non-positive
+                   or non-numeric value as "no number" so single-component songs
+                   render as plain "Verse" / "Chorus" rather than "Verse 0". */
                 $displayType = ($type === 'refrain') ? 'chorus' : $type;
                 $label = ucfirst($displayType);
-                if ($number !== null) {
-                    $label .= ' ' . $number;
+                if (is_numeric($number) && (int)$number > 0) {
+                    $label .= ' ' . (int)$number;
                 }
 
                 /* CSS class for styling different component types */

--- a/appWeb/public_html/js/utils/components.js
+++ b/appWeb/public_html/js/utils/components.js
@@ -65,6 +65,23 @@ function resolveType(type) {
 }
 
 /**
+ * Coerce a component number to a positive integer, or null.
+ *
+ * The editor stores `number: 0` (or null/empty) as a sentinel meaning
+ * "this is the only one of its kind" — see issue #795. Anything that is
+ * not a positive integer is therefore treated as "no number" and the
+ * caller suppresses the suffix.
+ *
+ * @param {*} n
+ * @returns {number|null}
+ */
+function positiveNumber(n) {
+    if (n == null || n === '') return null;
+    const parsed = parseInt(n, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+/**
  * Build a short tag for a component, e.g. "V1", "C", "B2", "PC1".
  * Aliases resolve to their canonical type (e.g. refrain → "C").
  *
@@ -73,7 +90,8 @@ function resolveType(type) {
  */
 export function shortTag(comp) {
     const meta = resolveType(comp.type) || { short: comp.type.charAt(0).toUpperCase() };
-    return meta.short + (comp.number != null ? comp.number : '');
+    const num = positiveNumber(comp.number);
+    return meta.short + (num != null ? num : '');
 }
 
 /**
@@ -86,7 +104,8 @@ export function shortTag(comp) {
 export function fullLabel(comp) {
     const meta = resolveType(comp.type);
     const label = meta ? meta.label : comp.type.charAt(0).toUpperCase() + comp.type.slice(1);
-    return comp.number != null ? `${label} ${comp.number}` : label;
+    const num = positiveNumber(comp.number);
+    return num != null ? `${label} ${num}` : label;
 }
 
 /**


### PR DESCRIPTION
Closes #795.

## Summary

Songs that have only one verse or only one chorus are stored with `number: 0` as a sentinel meaning "this is the only one of its kind". The editor itself already suppresses that 0, but two display surfaces still rendered the raw value, producing labels like **`VERSE 0`** and **`CHORUS 0`** in the UI (visible label *and* `aria-label`).

This PR makes both surfaces follow the editor's rule: only append the number when it is a positive integer.

## Changes

Two atomic commits, one per surface:

1. **`fix(song-view): hide "0" suffix on single-component verse/chorus labels`**
   `appWeb/public_html/includes/pages/song.php` — guard the suffix with `is_numeric($number) && (int)$number > 0`. Fixes the visible label and `aria-label` on the public song page (the surface in the reporter's screenshot).

2. **`fix(arrangement): hide "0" suffix in shortTag/fullLabel for single components`**
   `appWeb/public_html/js/utils/components.js` — extract a small `positiveNumber()` helper and use it from both `shortTag()` and `fullLabel()`. Fixes the arrangement-editor chips, tooltips, and aria-labels (these helpers are imported by `setlist.js`).

No data migration. The fix is purely on the render path — existing JSON keeps `number: 0`, but the UI now collapses it to plain `Verse` / `Chorus`.

## Verification

- PHP lint: `php -l appWeb/public_html/includes/pages/song.php` → no errors.
- JS syntax: `node --check appWeb/public_html/js/utils/components.js` → ok.
- Smoke-tested both label builders with `{number: 0}`, `{number: null}`, `{number: ''}`, `{number: 1}`, `{number: 2}`, `{type: 'refrain', number: 1}`, `{type: 'pre-chorus', number: 0}`. All produce the expected labels (`Verse`, `Verse 1`, `Chorus 1`, `Pre-Chorus`, etc.).

## Test plan

- [ ] Open a song with a single verse and a single chorus on the alpha deploy → labels read `Verse` and `Chorus` (no trailing `0`).
- [ ] Open a song with multiple verses → labels still read `Verse 1`, `Verse 2`, …
- [ ] Open the arrangement editor for a single-component song → pool chips show `V` / `C`, not `V0` / `C0`; tooltips read "Verse" / "Chorus".
- [ ] VoiceOver / NVDA on the song page → block is announced as "Verse", not "Verse 0".

---
_Generated by [Claude Code](https://claude.ai/code/session_015MP5vbbajHUyz2a2bDkzr1)_