### PR TITLE
fix: treat NULL/''/'0'/0 as unnumbered everywhere; hide badge + title-as-breadcrumb on unnumbered songs (#797)

### DIFF
--- a/appWeb/public_html/includes/SongData.php
+++ b/appWeb/public_html/includes/SongData.php
@@ -82,6 +82,30 @@ function toTitleCase(string $str): string
     return implode(' ', $words);
 }
 
+/**
+ * Normalise a tblSongs.Number value coming back from the database to the
+ * canonical "unnumbered" representation (#797).
+ *
+ * The column is nullable and NULL is the canonical sentinel for "this
+ * song has no songbook position" (#392). However:
+ *   - mysqli + assoc fetch hands NULL back as PHP null, which a naive
+ *     `(int)$row['number']` round-trips to 0 — masking the NULL and
+ *     causing the rest of the app to render "0" everywhere;
+ *   - some legacy rows / payloads carry an empty string or '0'.
+ *
+ * Treat null, '', '0' and any non-positive integer as null. Any positive
+ * integer is preserved as int.
+ *
+ * @param mixed $value
+ * @return int|null
+ */
+function normaliseSongNumber($value): ?int
+{
+    if ($value === null || $value === '') return null;
+    $n = (int)$value;
+    return $n > 0 ? $n : null;
+}
+
 class SongData
 {
     /** MySQLi connection (null when using JSON fallback) */
@@ -481,7 +505,7 @@ class SongData
 
         $songs = [];
         while ($row = $result->fetch_assoc()) {
-            $row['number'] = (int)$row['number'];
+            $row['number'] = normaliseSongNumber($row['number']);
             $row['verified'] = (bool)$row['verified'];
             $row['lyricsPublicDomain'] = (bool)$row['lyricsPublicDomain'];
             $row['musicPublicDomain'] = (bool)$row['musicPublicDomain'];
@@ -744,7 +768,7 @@ class SongData
 
         while ($row = $result->fetch_assoc()) {
             unset($row['relevance']);
-            $row['number'] = (int)$row['number'];
+            $row['number'] = normaliseSongNumber($row['number']);
             $row['verified'] = (bool)$row['verified'];
             $row['lyricsPublicDomain'] = (bool)$row['lyricsPublicDomain'];
             $row['musicPublicDomain'] = (bool)$row['musicPublicDomain'];
@@ -897,7 +921,7 @@ class SongData
 
         $songs = [];
         while ($row = $result->fetch_assoc()) {
-            $row['number'] = (int)$row['number'];
+            $row['number'] = normaliseSongNumber($row['number']);
             $row['verified'] = (bool)$row['verified'];
             $row['lyricsPublicDomain'] = (bool)$row['lyricsPublicDomain'];
             $row['musicPublicDomain'] = (bool)$row['musicPublicDomain'];
@@ -1097,7 +1121,7 @@ class SongData
             return null;
         }
 
-        $row['number'] = (int)$row['number'];
+        $row['number'] = normaliseSongNumber($row['number']);
         $row['verified'] = (bool)$row['verified'];
         $row['lyricsPublicDomain'] = (bool)$row['lyricsPublicDomain'];
         $row['musicPublicDomain'] = (bool)$row['musicPublicDomain'];
@@ -1651,7 +1675,7 @@ class SongData
 
         $songs = [];
         while ($row = $result->fetch_assoc()) {
-            $row['number'] = (int)$row['number'];
+            $row['number'] = normaliseSongNumber($row['number']);
             $row['verified'] = (bool)$row['verified'];
             $row['lyricsPublicDomain'] = (bool)$row['lyricsPublicDomain'];
             $row['musicPublicDomain'] = (bool)$row['musicPublicDomain'];

--- a/appWeb/public_html/includes/pages/song.php
+++ b/appWeb/public_html/includes/pages/song.php
@@ -31,9 +31,15 @@ if ($song === null) {
     return;
 }
 
-/* Extract metadata for convenience — Number is null for Misc songs (#392) */
+/* Extract metadata for convenience — Number is NULL for Misc songs and
+   for any custom-songbook entry that wasn't given a position (#392, #797).
+   Treat null, '', '0' and 0 as equivalent — the canonical "unnumbered"
+   value is NULL, but legacy rows and JS payloads sometimes carry 0 or '0'
+   and the rest of the page must treat them the same way. */
 $rawSongNumber = $song['number'] ?? null;
-$songNumber    = ($rawSongNumber === null || $rawSongNumber === '') ? null : (int)$rawSongNumber;
+$songNumber    = ($rawSongNumber === null || $rawSongNumber === '' || (int)$rawSongNumber <= 0)
+    ? null
+    : (int)$rawSongNumber;
 $songTitle   = toTitleCase($song['title'] ?? 'Untitled');
 $songbook    = $song['songbook'] ?? '';
 $bookName    = $song['songbookName'] ?? '';
@@ -155,7 +161,7 @@ unset($_t);
 <!-- ================================================================
      SONG PAGE — Full lyrics and metadata
      ================================================================ -->
-<article class="page-song" aria-label="<?= htmlspecialchars($songTitle) ?>" data-song-id="<?= htmlspecialchars($song['id']) ?>" data-songbook="<?= htmlspecialchars($songbook) ?>"<?php if ($songbookColour !== ''): ?> data-songbook-color="<?= htmlspecialchars($songbookColour) ?>"<?php endif; ?> data-song-number="<?= (int)$songNumber ?>"<?php if (!empty($song['capo'])): ?> data-capo="<?= (int)$song['capo'] ?>"<?php endif; ?><?php if (!empty($song['key'])): ?> data-key="<?= htmlspecialchars($song['key']) ?>"<?php endif; ?>>
+<article class="page-song" aria-label="<?= htmlspecialchars($songTitle) ?>" data-song-id="<?= htmlspecialchars($song['id']) ?>" data-songbook="<?= htmlspecialchars($songbook) ?>"<?php if ($songbookColour !== ''): ?> data-songbook-color="<?= htmlspecialchars($songbookColour) ?>"<?php endif; ?><?php if ($songNumber !== null): ?> data-song-number="<?= (int)$songNumber ?>"<?php endif; ?><?php if (!empty($song['capo'])): ?> data-capo="<?= (int)$song['capo'] ?>"<?php endif; ?><?php if (!empty($song['key'])): ?> data-key="<?= htmlspecialchars($song['key']) ?>"<?php endif; ?>>
 
     <!-- Breadcrumb navigation with schema.org markup (#151) -->
     <nav aria-label="Breadcrumb" class="mb-3">
@@ -176,7 +182,11 @@ unset($_t);
                 <meta itemprop="position" content="2">
             </li>
             <li class="breadcrumb-item active" aria-current="page" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
-                <span itemprop="name">#<?= $songNumber ?></span>
+                <?php /* Unnumbered songs (Misc, custom collections without a
+                         position) fall back to the song title so the final
+                         crumb is meaningful (#797) — "#0" was the bug we
+                         saw in alpha. */ ?>
+                <span itemprop="name"><?= $songNumber !== null ? '#' . (int)$songNumber : htmlspecialchars($songTitle) ?></span>
                 <meta itemprop="position" content="3">
             </li>
         </ol>
@@ -185,12 +195,17 @@ unset($_t);
     <!-- Song header card -->
     <div class="card card-song-header mb-4">
         <div class="card-body">
-            <!-- Song number and title -->
+            <!-- Song number and title — the coloured badge is rendered only
+                 for songs that actually have a songbook position. Unnumbered
+                 songs (Misc, custom collections without a position) drop the
+                 badge entirely so the title sits flush left (#797). -->
             <div class="d-flex align-items-start gap-3 mb-3">
+                <?php if ($songNumber !== null): ?>
                 <span class="song-number-badge-lg" data-songbook="<?= htmlspecialchars($songbook) ?>"
-                      aria-label="<?= $songNumber === null ? 'Unnumbered song' : 'Song number ' . (int)$songNumber ?>">
-                    <?= $songNumber === null ? '' : (int)$songNumber ?>
+                      aria-label="Song number <?= (int)$songNumber ?>">
+                    <?= (int)$songNumber ?>
                 </span>
+                <?php endif; ?>
                 <div class="flex-grow-1">
                     <h1 class="h4 mb-1"><?= htmlspecialchars($songTitle) ?><?php if (!empty($song['verified'])): ?><span class="verified-badge" title="Verified lyrics" aria-label="Verified lyrics"><svg viewBox="0 0 24 24" fill="none" aria-hidden="true"><circle cx="12" cy="12" r="10" fill="currentColor" opacity="0.15"/><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="1.5" fill="none"/><path d="M7.5 12.5L10.5 15.5L16.5 9" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg></span><?php endif; ?></h1>
                     <p class="text-muted mb-0">

--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -1303,8 +1303,14 @@ switch ($action) {
                components alone (safer than wiping them on a partial). */
             if (isset($restorePayload['Title'])) {
                 $title = (string)$restorePayload['Title'];
-                $number = isset($restorePayload['Number']) && $restorePayload['Number'] !== null
-                    ? (int)$restorePayload['Number'] : null;
+                /* Same NULL/''/'0'/0 normalisation as save_song (#797).
+                   A revision row whose stored Number is 0 (legacy data
+                   from before the convention was enforced) restores to
+                   NULL — round-tripping the 0 would defeat the fix. */
+                $rawRestoreNumber = $restorePayload['Number'] ?? null;
+                $number = ($rawRestoreNumber === null || $rawRestoreNumber === '' || (int)$rawRestoreNumber <= 0)
+                    ? null
+                    : (int)$rawRestoreNumber;
                 $verified = (int)($restorePayload['Verified']           ?? 0);
                 $lyricsPD = (int)($restorePayload['LyricsPublicDomain'] ?? 0);
                 $musicPD  = (int)($restorePayload['MusicPublicDomain']  ?? 0);
@@ -2115,7 +2121,16 @@ function _bulkImport_saveSong(\mysqli $db, array $song): array
 {
     $songId       = (string)$song['id'];
     $title        = (string)$song['title'];
-    $number       = isset($song['number']) ? (int)$song['number'] : null;
+    /* Same NULL/''/'0'/0 normalisation as the editor save paths (#797).
+       The TXT bulk-import parser usually produces a positive integer
+       (the file's leading "## NN" marker drives the SongId format), but
+       a future caller could legitimately pass a song with no songbook
+       position. Fold any non-positive / empty value to NULL so the
+       column carries the canonical sentinel. */
+    $rawNumber    = $song['number'] ?? null;
+    $number       = ($rawNumber === null || $rawNumber === '' || (int)$rawNumber <= 0)
+        ? null
+        : (int)$rawNumber;
     $songbookAbbr = (string)$song['songbook'];
     $songbookName = (string)$song['songbookName'];
     /* IETF BCP 47 sanitise (#681). Bulk-import builds the song dict


### PR DESCRIPTION
Closes #797.

## Summary

Songs without a position in their songbook (Misc and a few custom-collection stragglers) were rendering as `#0` in the breadcrumb and `0` inside the songbook-coloured badge on the song page. The schema already migrated those rows to `Number = NULL` (`.sql/schema.sql:1420`, per #392) — but the round-trip leaked `0` back through the PHP hydration layer, so the page never saw a clean null.

This PR establishes a single rule everywhere: **`NULL`, `''`, `'0'` and `0` all mean "this song has no songbook position", and the canonical stored value is `NULL`.**

## Changes (three atomic commits)

1. **`fix(songdata): preserve NULL tblSongs.Number through hydration`**
   `appWeb/public_html/includes/SongData.php` — five hydration sites did `$row['number'] = (int)$row['number']`, which casts a SQL NULL to PHP `0`. Add a `normaliseSongNumber()` helper that folds the four sentinels to null and use it at every site. Root cause for the bug visible on the page.

2. **`fix(song-view): hide badge + use title in breadcrumb for unnumbered songs`**
   `appWeb/public_html/includes/pages/song.php`:
   - Compute `$songNumber` with the same four-sentinel rule.
   - Final breadcrumb crumb falls back to the song title when unnumbered (was `#0`, now e.g. `Ons Is Almal Hier Tesaam`).
   - Drop the entire `<span class="song-number-badge-lg">` for unnumbered songs so the coloured box is gone, not just blank — the title sits flush left.
   - Omit `data-song-number` when there's no number, rather than emitting a misleading `data-song-number="0"`.

3. **`fix(editor-api): normalise 0/'0'/empty Number to NULL on restore + bulk-import`**
   `appWeb/public_html/manage/editor/api.php` — the two main save paths (`save_song`, bulk save) already normalise correctly per #392, but the **restore-from-revision** and **TXT bulk-import** paths still cast straight to int, so a 0 in the input round-tripped to a 0 in the column. Both paths now apply the same fold.

## Verification

- PHP lint on all three files: clean.
- Smoke-test of `normaliseSongNumber()` covers `null`, `''`, `'0'`, `0`, `'1'`, `1`, `42`, `'00042'`, `-1`, `'abc'` — only positive integers pass through, everything else → null.

## Test plan

- [ ] Open `Ons Is Almal Hier Tesaam` (Misc) on alpha — breadcrumb reads `Songbooks / Miscellaneous / Ons Is Almal Hier Tesaam`; no coloured box next to the title.
- [ ] Open any numbered Carol Praise / JP / SDAH song — breadcrumb still shows `#1`; coloured badge still shows `1`.
- [ ] Save a new song with the Number field left blank → DB stores `NULL`.
- [ ] Restore a revision whose stored Number is 0 → DB stores `NULL`, page renders unnumbered.
- [ ] Bulk-import a TXT with a header that lacks a number → DB stores `NULL`.
- [ ] VoiceOver on the song page → no "song number 0" announcement; just the title.

---
_Generated by [Claude Code](https://claude.ai/code/session_015MP5vbbajHUyz2a2bDkzr1)_