### PR TITLE
feat(public): canonical-source link + series tile line (#782 phase D)

### DIFF
--- a/appWeb/public_html/includes/SongData.php
+++ b/appWeb/public_html/includes/SongData.php
@@ -272,20 +272,23 @@ class SongData
             return $books;
         }
 
-        $bibSelect  = $this->_songbookBibSelect();
-        $langSelect = $this->_songbookLanguageSelect();
+        $bibSelect    = $this->_songbookBibSelect();
+        $langSelect   = $this->_songbookLanguageSelect();
+        $parentSelect = $this->_songbookParentSelect();
+        $parentJoin   = $this->_songbookParentJoin();
         $stmt = $this->db->prepare(
-            "SELECT Abbreviation AS id, Name AS name, SongCount AS songCount,
-                    Colour AS colour,
-                    IsOfficial      AS isOfficial,
-                    Publisher       AS publisher,
-                    PublicationYear AS publicationYear,
-                    Copyright       AS copyright,
-                    Affiliation     AS affiliation
+            "SELECT b.Abbreviation AS id, b.Name AS name, b.SongCount AS songCount,
+                    b.Colour AS colour,
+                    b.IsOfficial      AS isOfficial,
+                    b.Publisher       AS publisher,
+                    b.PublicationYear AS publicationYear,
+                    b.Copyright       AS copyright,
+                    b.Affiliation     AS affiliation
                     {$langSelect}
                     {$bibSelect}
-             FROM tblSongbooks
-             ORDER BY Name ASC"
+                    {$parentSelect}
+             FROM tblSongbooks b{$parentJoin}
+             ORDER BY b.Name ASC"
         );
         $stmt->execute();
         $result = $stmt->get_result();
@@ -295,10 +298,55 @@ class SongData
             /* Cast to a strict bool so JSON consumers don't have to
                deal with 0/1 vs true/false ambiguity (#502). */
             $row['isOfficial'] = (bool)$row['isOfficial'];
-            $books[] = $row;
+            $books[] = $this->_normaliseSongbookParent($row);
         }
         $stmt->close();
+
+        /* Attach series memberships in one batch query (#782 phase D)
+           so the home/browse grids can render a "Part of: <Series>" line
+           without N+1 queries. */
+        if ($books) {
+            $seriesMap = $this->_songbookSeriesMap(null);
+            foreach ($books as &$_b) {
+                $_b['series'] = $seriesMap[(string)$_b['id']] ?? [];
+            }
+            unset($_b);
+        }
         return $books;
+    }
+
+    /**
+     * Normalise the parent-songbook fields on a fetched row into a
+     * single nested `parent` key (or null) — keeps consumers from
+     * having to know about the underlying column names. Called once
+     * per row in getSongbook / getSongbooks. Safe to call when the
+     * schema isn't live: the parent fields are simply absent.
+     *
+     * @param array<string,mixed> $row Fetched row (mutated)
+     * @return array<string,mixed>     The same row with `parent` added
+     */
+    private function _normaliseSongbookParent(array $row): array
+    {
+        $pid = $row['parentSongbookId'] ?? null;
+        if ($pid !== null && (int)$pid > 0) {
+            $row['parent'] = [
+                'id'           => (int)$pid,
+                'abbreviation' => (string)($row['parentAbbreviation'] ?? ''),
+                'name'         => (string)($row['parentName']         ?? ''),
+                'relationship' => (string)($row['parentRelationship'] ?? ''),
+            ];
+        } else {
+            $row['parent'] = null;
+        }
+        /* Strip the flat columns now that we've nested them — keeps
+           the public shape clean. */
+        unset(
+            $row['parentSongbookId'],
+            $row['parentRelationship'],
+            $row['parentAbbreviation'],
+            $row['parentName']
+        );
+        return $row;
     }
 
     /**
@@ -371,6 +419,181 @@ class SongData
     private ?string $_langSelectCache = null;
 
     /**
+     * Same shape as _songbookBibSelect() / _songbookLanguageSelect()
+     * but for the optional parent-songbook FK columns added in #782
+     * phase A. When the schema is live, returns a SELECT tail with
+     * `b.ParentSongbookId AS parentSongbookId,
+     *  b.ParentRelationship AS parentRelationship,
+     *  p.Abbreviation AS parentAbbreviation,
+     *  p.Name AS parentName`
+     * — assumes the caller's main table is aliased `b` and joins
+     * `LEFT JOIN tblSongbooks p ON p.Id = b.ParentSongbookId`. The
+     * join fragment is exposed as a separate accessor so callers can
+     * inject it into the FROM clause.
+     *
+     * Probe-once cache (one INFORMATION_SCHEMA round-trip per request)
+     * keeps getSongbook + getSongbooks cheap when both are called.
+     */
+    private function _songbookParentSelect(): string
+    {
+        if ($this->_parentSelectCache !== null) {
+            return $this->_parentSelectCache;
+        }
+        $hasParentCol = false;
+        try {
+            $probe = $this->db->prepare(
+                "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+                  WHERE TABLE_SCHEMA = DATABASE()
+                    AND TABLE_NAME   = 'tblSongbooks'
+                    AND COLUMN_NAME  = 'ParentSongbookId'
+                  LIMIT 1"
+            );
+            $probe->execute();
+            $hasParentCol = $probe->get_result()->fetch_row() !== null;
+            $probe->close();
+        } catch (\Throwable $_e) { /* probe failure → no parent tail */ }
+        $this->_parentSelectCache = $hasParentCol
+            ? ', b.ParentSongbookId   AS parentSongbookId,
+                 b.ParentRelationship AS parentRelationship,
+                 p.Abbreviation       AS parentAbbreviation,
+                 p.Name               AS parentName'
+            : '';
+        return $this->_parentSelectCache;
+    }
+    private ?string $_parentSelectCache = null;
+
+    /** LEFT JOIN fragment paired with _songbookParentSelect(). Empty
+        when the schema isn't live so the FROM clause stays valid. */
+    private function _songbookParentJoin(): string
+    {
+        return $this->_songbookParentSelect() === ''
+            ? ''
+            : ' LEFT JOIN tblSongbooks p ON p.Id = b.ParentSongbookId';
+    }
+
+    /**
+     * Pull `[abbr => [{id, name, slug}, ...]]` from the
+     * tblSongbookSeries / tblSongbookSeriesMembership tables for a
+     * subset (or all) of songbooks. Series counts in real catalogues
+     * stay small — issuing one query per page-load (vs N queries per
+     * songbook) keeps both /songbook/<abbr> and the home grid cheap.
+     *
+     * Schema-probed; pre-migration deployments get an empty map so
+     * the caller's tile / page renders cleanly without the row.
+     *
+     * @param string[]|null $abbrs Limit to these abbreviations; null = all
+     * @return array<string, array<int, array{id:int,name:string,slug:string}>>
+     */
+    private function _songbookSeriesMap(?array $abbrs = null): array
+    {
+        $hasSeriesSchema = false;
+        try {
+            $probe = $this->db->prepare(
+                "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+                  WHERE TABLE_SCHEMA = DATABASE()
+                    AND TABLE_NAME   = 'tblSongbookSeries'
+                  LIMIT 1"
+            );
+            $probe->execute();
+            $hasSeriesSchema = $probe->get_result()->fetch_row() !== null;
+            $probe->close();
+        } catch (\Throwable $_e) { /* fall through */ }
+        if (!$hasSeriesSchema) return [];
+
+        try {
+            if ($abbrs === null) {
+                $sql = 'SELECT b.Abbreviation AS abbr,
+                               s.Id           AS sid,
+                               s.Name         AS sname,
+                               s.Slug         AS sslug,
+                               m.SortOrder    AS sortOrder
+                          FROM tblSongbookSeriesMembership m
+                          JOIN tblSongbookSeries s ON s.Id = m.SeriesId
+                          JOIN tblSongbooks      b ON b.Id = m.SongbookId
+                         ORDER BY b.Abbreviation, m.SortOrder ASC, s.Name ASC';
+                $stmt = $this->db->prepare($sql);
+            } else {
+                $abbrs = array_values(array_filter(array_unique(array_map(
+                    static fn($a) => strtoupper(trim((string)$a)),
+                    $abbrs
+                ))));
+                if (!$abbrs) return [];
+                $ph  = implode(',', array_fill(0, count($abbrs), '?'));
+                $sql = "SELECT b.Abbreviation AS abbr,
+                               s.Id           AS sid,
+                               s.Name         AS sname,
+                               s.Slug         AS sslug,
+                               m.SortOrder    AS sortOrder
+                          FROM tblSongbookSeriesMembership m
+                          JOIN tblSongbookSeries s ON s.Id = m.SeriesId
+                          JOIN tblSongbooks      b ON b.Id = m.SongbookId
+                         WHERE b.Abbreviation IN ($ph)
+                         ORDER BY b.Abbreviation, m.SortOrder ASC, s.Name ASC";
+                $stmt  = $this->db->prepare($sql);
+                $types = str_repeat('s', count($abbrs));
+                $stmt->bind_param($types, ...$abbrs);
+            }
+            $stmt->execute();
+            $res = $stmt->get_result();
+            $out = [];
+            while ($row = $res->fetch_assoc()) {
+                $abbr = (string)$row['abbr'];
+                if (!isset($out[$abbr])) $out[$abbr] = [];
+                $out[$abbr][] = [
+                    'id'   => (int)$row['sid'],
+                    'name' => (string)$row['sname'],
+                    'slug' => (string)$row['sslug'],
+                ];
+            }
+            $stmt->close();
+            return $out;
+        } catch (\Throwable $e) {
+            error_log('[SongData::_songbookSeriesMap] ' . $e->getMessage());
+            return [];
+        }
+    }
+
+    /**
+     * Find a SongId by (songbook abbreviation, number) without
+     * re-fetching the full song row. Used by the song page to
+     * decide whether the parent songbook has a same-numbered
+     * counterpart worth deep-linking to (#782 phase D). Returns
+     * null when the songbook has no song at that number.
+     *
+     * Cheaper than getSongByNumber() — only a single SELECT against
+     * the indexed (SongbookAbbr, Number) pair.
+     */
+    public function findSongIdByNumber(string $abbr, int $number): ?string
+    {
+        if ($number <= 0) return null;
+        $abbr = strtoupper(trim($abbr));
+        if ($abbr === '') return null;
+        if ($this->jsonMode) {
+            foreach ($this->jsonData['songs'] ?? [] as $song) {
+                if (strtoupper((string)($song['songbook'] ?? '')) === $abbr
+                    && (int)($song['number'] ?? 0) === $number
+                ) {
+                    return (string)$song['id'];
+                }
+            }
+            return null;
+        }
+        try {
+            $stmt = $this->db->prepare(
+                'SELECT SongId FROM tblSongs WHERE SongbookAbbr = ? AND Number = ? LIMIT 1'
+            );
+            $stmt->bind_param('si', $abbr, $number);
+            $stmt->execute();
+            $row = $stmt->get_result()->fetch_assoc();
+            $stmt->close();
+            return $row ? (string)$row['SongId'] : null;
+        } catch (\Throwable $e) {
+            error_log('[SongData::findSongIdByNumber] ' . $e->getMessage());
+            return null;
+        }
+    }
+
+    /**
      * Get a single songbook by its abbreviation ID.
      *
      * @param string $id Songbook abbreviation (e.g., 'CP', 'MP')
@@ -385,20 +608,23 @@ class SongData
             }
             return null;
         }
-        $bibSelect  = $this->_songbookBibSelect();
-        $langSelect = $this->_songbookLanguageSelect();
+        $bibSelect    = $this->_songbookBibSelect();
+        $langSelect   = $this->_songbookLanguageSelect();
+        $parentSelect = $this->_songbookParentSelect();
+        $parentJoin   = $this->_songbookParentJoin();
         $stmt = $this->db->prepare(
-            "SELECT Abbreviation AS id, Name AS name, SongCount AS songCount,
-                    Colour AS colour,
-                    IsOfficial      AS isOfficial,
-                    Publisher       AS publisher,
-                    PublicationYear AS publicationYear,
-                    Copyright       AS copyright,
-                    Affiliation     AS affiliation
+            "SELECT b.Abbreviation AS id, b.Name AS name, b.SongCount AS songCount,
+                    b.Colour AS colour,
+                    b.IsOfficial      AS isOfficial,
+                    b.Publisher       AS publisher,
+                    b.PublicationYear AS publicationYear,
+                    b.Copyright       AS copyright,
+                    b.Affiliation     AS affiliation
                     {$langSelect}
                     {$bibSelect}
-             FROM tblSongbooks
-             WHERE Abbreviation = ?"
+                    {$parentSelect}
+             FROM tblSongbooks b{$parentJoin}
+             WHERE b.Abbreviation = ?"
         );
         $stmt->bind_param('s', $id);
         $stmt->execute();
@@ -411,6 +637,12 @@ class SongData
         }
         $row['songCount']  = (int)$row['songCount'];
         $row['isOfficial'] = (bool)$row['isOfficial'];
+        $row = $this->_normaliseSongbookParent($row);
+        /* #782 phase D — also attach series memberships. Single-songbook
+           variant of the bulk fetch on getSongbooks(); pre-migration
+           safe via the schema probe inside _songbookSeriesMap. */
+        $seriesMap     = $this->_songbookSeriesMap([$id]);
+        $row['series'] = $seriesMap[(string)$row['id']] ?? [];
         return $row;
     }
 

--- a/appWeb/public_html/includes/pages/home.php
+++ b/appWeb/public_html/includes/pages/home.php
@@ -179,6 +179,31 @@ $songbooks = $songData->getSongbooks();
                                 <p class="card-text text-muted small mt-2 mb-0">
                                     <?= number_format($book['songCount']) ?> songs
                                 </p>
+                                <?php
+                                /* #782 phase D — "Part of: <Series>" line.
+                                   Renders only when the songbook belongs to one
+                                   or more series (Songs of Fellowship volumes,
+                                   themed compilations). Multiple series are
+                                   joined with " · " — clean separator that
+                                   doesn't fight with commas inside series
+                                   names. The series links route to the
+                                   /series/<slug> page (phase D adds the page
+                                   itself in a future PR; until then the
+                                   anchors 404 — captured in the PR's known-
+                                   limits list). */
+                                $bookSeries = (array)($book['series'] ?? []);
+                                if ($bookSeries):
+                                    $names = array_map(
+                                        static fn(array $s): string => htmlspecialchars((string)($s['name'] ?? '')),
+                                        $bookSeries
+                                    );
+                                ?>
+                                <p class="card-text text-muted small mt-1 mb-0 songbook-tile-series"
+                                   title="Part of <?= count($bookSeries) ?> series">
+                                    <i class="fa-solid fa-layer-group me-1" aria-hidden="true"></i>
+                                    <span class="visually-hidden">Part of </span><?= implode(' · ', $names) ?>
+                                </p>
+                                <?php endif; ?>
                             </div>
                             <!-- Offline-download button (#453). Hidden by
                                  default; the offline-support check in

--- a/appWeb/public_html/includes/pages/song.php
+++ b/appWeb/public_html/includes/pages/song.php
@@ -50,10 +50,38 @@ $bookName    = $song['songbookName'] ?? '';
    colour on the bar. Empty string means "let the bar fall back to
    the default accent". */
 $songbookColour = '';
+$songbookParent = null;   /* #782 phase D — nested array shape: id, abbreviation, name, relationship */
 if ($songbook !== '') {
     $bookData = $songData->getSongbook($songbook);
-    if (is_array($bookData) && !empty($bookData['colour'])) {
-        $songbookColour = trim((string)$bookData['colour']);
+    if (is_array($bookData)) {
+        if (!empty($bookData['colour'])) {
+            $songbookColour = trim((string)$bookData['colour']);
+        }
+        if (!empty($bookData['parent']) && is_array($bookData['parent'])) {
+            $songbookParent = $bookData['parent'];
+        }
+    }
+}
+
+/* #782 phase D — if the songbook has a parent (translation / edition /
+   abridgement of a canonical source), try to deep-link to the parent's
+   same-numbered song. Falls back to the parent songbook's index when
+   the parent doesn't carry that number. Skipped silently on unnumbered
+   songs (the parent-link only makes sense at hymn-number granularity). */
+$parentSongLinkUrl  = '';
+$parentSongLinkType = ''; /* 'song' | 'songbook' | '' */
+if ($songbookParent !== null
+    && $songNumber !== null
+    && (string)($songbookParent['abbreviation'] ?? '') !== ''
+) {
+    $parentAbbr = (string)$songbookParent['abbreviation'];
+    $parentSid  = $songData->findSongIdByNumber($parentAbbr, $songNumber);
+    if ($parentSid !== null) {
+        $parentSongLinkUrl  = '/song/' . $parentSid;
+        $parentSongLinkType = 'song';
+    } else {
+        $parentSongLinkUrl  = '/songbook/' . $parentAbbr;
+        $parentSongLinkType = 'songbook';
     }
 }
 $writers     = $song['writers']     ?? [];
@@ -212,6 +240,48 @@ unset($_t);
                         <span class="badge bg-body-secondary"><?= htmlspecialchars($songbook) ?></span>
                         <?= htmlspecialchars($bookName) ?>
                     </p>
+                    <?php if ($songbookParent !== null && $parentSongLinkUrl !== ''):
+                        /* #782 phase D — canonical-source link. Renders only
+                           when the current songbook declares a parent AND we
+                           have an absolute number to deep-link with. The icon
+                           varies by ParentRelationship — translate / bookmark
+                           (edition) / scissors (abridgement) — matching the
+                           admin-side Parent column in /manage/songbooks. The
+                           prose stays neutral ("Original …") so the badge
+                           reads naturally regardless of relationship type. */
+                        $rel    = (string)($songbookParent['relationship'] ?? '');
+                        $relLbl = match ($rel) {
+                            'translation' => 'Translation of',
+                            'edition'     => 'Edition of',
+                            'abridgement' => 'Abridgement of',
+                            default       => 'Original',
+                        };
+                        $relIcn = match ($rel) {
+                            'translation' => 'fa-language',
+                            'edition'     => 'fa-bookmark',
+                            'abridgement' => 'fa-scissors',
+                            default       => 'fa-link',
+                        };
+                        $parentName = (string)($songbookParent['name']         ?? '');
+                        $parentAbbr = (string)($songbookParent['abbreviation'] ?? '');
+                    ?>
+                    <p class="small mt-2 mb-0">
+                        <a href="<?= htmlspecialchars($parentSongLinkUrl) ?>"
+                           class="text-decoration-none"
+                           data-navigate="<?= htmlspecialchars($parentSongLinkType) ?>"
+                           <?php if ($parentSongLinkType === 'song'): ?>data-song-id="<?= htmlspecialchars(basename($parentSongLinkUrl)) ?>"<?php endif; ?>
+                           <?php if ($parentSongLinkType === 'songbook'): ?>data-songbook-id="<?= htmlspecialchars($parentAbbr) ?>"<?php endif; ?>
+                           title="View this hymn in its canonical source">
+                            <i class="fa-solid <?= htmlspecialchars($relIcn) ?> me-1" aria-hidden="true"></i>
+                            <?= htmlspecialchars($relLbl) ?>
+                            <span class="badge bg-body-secondary ms-1"><?= htmlspecialchars($parentAbbr) ?></span>
+                            <?= htmlspecialchars($parentName) ?>
+                            <?php if ($parentSongLinkType === 'song'): ?>
+                                <span class="text-muted">— hymn #<?= (int)$songNumber ?></span>
+                            <?php endif; ?>
+                        </a>
+                    </p>
+                    <?php endif; ?>
                 </div>
             </div>
 

--- a/appWeb/public_html/includes/pages/songbooks.php
+++ b/appWeb/public_html/includes/pages/songbooks.php
@@ -82,6 +82,27 @@ $stats = $songData->getStats();
                                     <p class="text-muted small mb-0 mt-1">
                                         <?= number_format($book['songCount']) ?> songs
                                     </p>
+                                    <?php
+                                    /* #782 phase D — "Part of: <Series>" line.
+                                       Same shape as the home-grid tile in
+                                       includes/pages/home.php. Renders only
+                                       when the songbook is in at least one
+                                       series; multiple series joined with " · ".
+                                       Kept on its own row to avoid stretching
+                                       the songCount line on tight viewports. */
+                                    $bookSeries = (array)($book['series'] ?? []);
+                                    if ($bookSeries):
+                                        $names = array_map(
+                                            static fn(array $s): string => htmlspecialchars((string)($s['name'] ?? '')),
+                                            $bookSeries
+                                        );
+                                    ?>
+                                    <p class="text-muted small mb-0 mt-1 songbook-tile-series"
+                                       title="Part of <?= count($bookSeries) ?> series">
+                                        <i class="fa-solid fa-layer-group me-1" aria-hidden="true"></i>
+                                        <span class="visually-hidden">Part of </span><?= implode(' · ', $names) ?>
+                                    </p>
+                                    <?php endif; ?>
                                 </div>
                                 <!-- Arrow indicator -->
                                 <i class="fa-solid fa-chevron-right text-muted mt-1" aria-hidden="true"></i>


### PR DESCRIPTION
## Summary

Phase D of the Parent Songbooks work — wires the schema landed in PR #790 and the admin UIs from PRs #799 / #800 into the **public read surfaces**. No new mutations; this PR is read-only.

Closes **#782 phase D**.

## What's in this PR

### `SongData` additions

- **`_songbookParentSelect()` / `_songbookParentJoin()`** — probe-once helpers (mirror `_songbookBibSelect` / `_songbookLanguageSelect`). Conditionally extend the `SELECT` with the parent FK columns + a `LEFT JOIN tblSongbooks p ON p.Id = b.ParentSongbookId` for the parent's abbreviation + name.
- **`_normaliseSongbookParent()`** — collapses the four flat columns into a single nested `parent` key on the row payload (`{id, abbreviation, name, relationship}`) so consumers don't have to know about underlying schema.
- **`_songbookSeriesMap(?array $abbrs)`** — pulls every membership in **one** query keyed by abbreviation, so `getSongbooks()` fans out a "Part of" line for the home grid without N+1. Same helper handles the single-songbook case for `getSongbook()`.
- **`findSongIdByNumber(string $abbr, int $number): ?string`** — lightweight `(SongbookAbbr, Number) → SongId` lookup so the song-page badge can deep-link the parent songbook's same-numbered hymn without re-fetching the full row via `getSongByNumber`.

### Song page — canonical-source link

When the songbook for the current song declares a parent AND the current song is numbered, show a small line under the songbook badge:

> 🔤 **Translation of** `CIS` Christ in Song — hymn #42

The icon + label vary by relationship (`translation` / `edition` / `abridgement`). Link target:

- prefers `/song/<id>` when the parent has the same number,
- falls back to `/songbook/<abbr>` when it doesn't.

Unnumbered songs (Misc, custom collections without a position) skip the badge — same-number deep-link doesn't make sense without a number.

### Songbook tile — "Part of `<Series>`" line

Both the home-page grid (`includes/pages/home.php`) and the `/songbooks` browse page (`includes/pages/songbooks.php`) gain a one-line indicator under the song count:

> 🗂 Part of: Songs of Fellowship · Mission Praise

Multiple series joined with ` · ` — clean separator that doesn't fight with commas inside series names. `fa-layer-group` icon. Series public pages aren't wired yet (no `/series/<slug>` route exists) so the names render as plain text for now — that's a follow-up either inside #782 or a fresh issue.

## Pre-migration safety

Every schema-touching code path is gated by `INFORMATION_SCHEMA` probes:

- `_songbookParentSelect()` returns an empty SELECT tail when `ParentSongbookId` doesn't exist.
- `_songbookSeriesMap()` returns an empty map when `tblSongbookSeries` doesn't exist.

So the song page + tiles render unchanged on a deployment that hasn't run `migrate-parent-songbooks.php` (#782 phase A).

## Files

| File | Change |
| --- | --- |
| `appWeb/public_html/includes/SongData.php` | New helpers + `getSongbook` / `getSongbooks` extended to attach `parent` and `series` keys to every row. |
| `appWeb/public_html/includes/pages/song.php` | Resolves `$songbookParent`, calls `findSongIdByNumber` to pick a deep-link target, renders the badge in the header card. |
| `appWeb/public_html/includes/pages/home.php` | Tile gains the "Part of" line below song count. |
| `appWeb/public_html/includes/pages/songbooks.php` | Same line on the browse-grid tile. |

## Test plan

### Canonical-source link

- [ ] Pick a child songbook (e.g. set Spanish "Himnario Adventista" as a `translation` of English "Christ in Song" via `/manage/songbooks`). Open a numbered hymn in HA. Expect a "Translation of CIS Christ in Song — hymn #N" line under the songbook badge.
- [ ] Click the link. Expect `/song/CIS-<padded-number>` if CIS has that number, else `/songbook/CIS`.
- [ ] Edit HA + change the relationship to `edition`. Reload the same song page. Expect "Edition of …" + the bookmark icon.
- [ ] Open an **unnumbered** song in HA. Expect no parent badge.
- [ ] Open a song in CIS itself (the parent). Expect no parent badge — only children carry the link.

### Songbook tile

- [ ] Add a few songbooks to a series via `/manage/songbook-series`. Reload `/`. Expect "Part of: <names>" under the song count on every tile that's a member.
- [ ] Same on `/songbooks`.
- [ ] Add a songbook to two series. Expect both names joined with " · ".
- [ ] Remove a songbook from every series. Reload. Expect the line to disappear.

### Pre-migration regression

- [ ] On a scratch DB, drop `tblSongbookSeries`. Reload `/`. Expect the home grid to render without "Part of" lines, no PHP errors.
- [ ] Drop `tblSongbooks.ParentSongbookId`. Reload a song page. Expect no parent badge, no errors.

## Refs

- Closes #782 phase D. Phase E (programmatic helpers + bulk-import auto-link) is the only remaining piece.
- Builds on PR #790 (schema), PR #799 (hierarchical admin UI), PR #800 (series CRUD + membership picker). No further migrations needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)