### PR TITLE
feat(songbooks): family helpers + import auto-link manifest (#782 phase E)

### DIFF
--- a/.importers/scrapers/ChristInSong.app.py
+++ b/.importers/scrapers/ChristInSong.app.py
@@ -592,6 +592,114 @@ def scrape_hymnal(key, output_dir, force, refrain_override=None, pad_width=3):
 # Optional: bundle output into a zip
 # ---------------------------------------------------------------------------
 
+def write_family_manifest(output_dir, attempted_keys, failed_keys, parent_key="english"):
+    """
+    Emit `_family-manifest.json` at the top of the output dir describing
+    the parent/child relationships among the hymnals just scraped.
+
+    The admin's `/manage/songbooks` page accepts this file via an "Apply
+    family manifest" upload (#782 phase E) and uses it to bulk-set the
+    `ParentSongbookId` + `ParentRelationship` columns on the imported
+    songbooks — so a curator who scrapes + bulk-imports the Christ in
+    Song catalogue doesn't have to hand-link 22 vernaculars to CIS one
+    at a time afterwards.
+
+    Manifest schema (versioned for future-proofing):
+
+        {
+            "schema_version": 1,
+            "scraper":         "ChristInSong.app.py",
+            "scraper_version": "1.0",
+            "generated_at":    "<ISO-8601 UTC>",
+            "families": [
+                {
+                    "parent": {
+                        "abbreviation": "CIS",
+                        "name":         "Christ in Song",
+                        "language":     "en"
+                    },
+                    "children": [
+                        {"abbreviation": "HA", "name": "Himnario Adventista",
+                         "language": "es", "relationship": "translation"},
+                        ...
+                    ]
+                }
+            ]
+        }
+
+    Args:
+        output_dir:       Where to write the manifest (same root that
+                          holds the per-hymnal folders).
+        attempted_keys:   Hymnal keys passed through the run (input arg).
+        failed_keys:      Subset that errored out — excluded from
+                          `children` so we don't link a non-existent
+                          songbook.
+        parent_key:       HYMNALS key to treat as the parent. Defaults
+                          to 'english' (the CIS canonical edition);
+                          exposed for future flexibility.
+
+    Returns:
+        Tuple `(manifest_path, child_count)`. child_count is the number
+        of vernacular hymnals that landed in the `children` list — zero
+        means nothing to write (parent only / parent failed) and the
+        manifest is skipped.
+    """
+    if parent_key not in HYMNALS:
+        return (None, 0)
+    if parent_key in failed_keys:
+        # Parent itself failed — there's nothing to attach children to.
+        return (None, 0)
+    if parent_key not in attempted_keys:
+        # Run was scoped to a subset that didn't include the parent —
+        # children would dangle. Skip the manifest; the curator can
+        # link by hand via /manage/songbooks if they want.
+        return (None, 0)
+
+    parent_info = HYMNALS[parent_key]
+    children = []
+    for k in attempted_keys:
+        if k == parent_key or k in failed_keys:
+            continue
+        info = HYMNALS.get(k)
+        if not info:
+            continue
+        children.append({
+            "abbreviation": info["abbrev"],
+            "name":         info["title"],
+            "language":     info.get("lang", ""),
+            # Every CIS vernacular is a translation of the English original
+            # by definition. Future scrapers (Mission Praise editions, …)
+            # can vary the relationship per child.
+            "relationship": "translation",
+        })
+
+    if not children:
+        return (None, 0)
+
+    from datetime import datetime, timezone
+    manifest = {
+        "schema_version": 1,
+        "scraper":         "ChristInSong.app.py",
+        "scraper_version": "1.0",
+        "generated_at":    datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "families": [
+            {
+                "parent": {
+                    "abbreviation": parent_info["abbrev"],
+                    "name":         parent_info["title"],
+                    "language":     parent_info.get("lang", ""),
+                },
+                "children": children,
+            },
+        ],
+    }
+    manifest_path = os.path.join(output_dir, "_family-manifest.json")
+    with open(manifest_path, "w", encoding="utf-8", newline="\n") as f:
+        json.dump(manifest, f, ensure_ascii=False, indent=2, sort_keys=False)
+        f.write("\n")
+    return (manifest_path, len(children))
+
+
 def zip_output(output_dir, zip_path):
     """
     Bundle every .txt file under `output_dir` into a single zip file.
@@ -730,6 +838,12 @@ notes:
         "--list", action="store_true",
         help="Print the hymnal manifest and exit."
     )
+    ap.add_argument(
+        "--no-manifest", action="store_true",
+        help="Skip writing _family-manifest.json (the file the admin "
+             "uses to bulk-link vernacular hymnals to CIS via "
+             "/manage/songbooks → 'Apply family manifest')."
+    )
     args = ap.parse_args()
 
     if args.list:
@@ -790,6 +904,25 @@ notes:
     if failed_keys:
         print(f"  Failed hymnals: {', '.join(failed_keys)}")
     print(f"{'='*60}")
+
+    # Family manifest (#782 phase E). Lists every successful vernacular
+    # under the English CIS parent so the admin's "Apply family manifest"
+    # uploader can bulk-link them post-import. Skipped when the parent
+    # itself wasn't part of the run, when the parent failed, or when
+    # --no-manifest is passed.
+    if not args.no_manifest:
+        manifest_path, child_count = write_family_manifest(
+            output_dir, keys, failed_keys
+        )
+        if manifest_path:
+            print(f"\nFamily manifest → {manifest_path}")
+            print(f"  {child_count} vernacular hymnal(s) listed under CIS.")
+            print( "  Upload this file via /manage/songbooks → "
+                   "'Apply family manifest' to bulk-link them.")
+        else:
+            print( "\nFamily manifest skipped — parent CIS was not part "
+                   "of this run (or failed). Use --hymnal english,… to "
+                   "include it.")
 
     # Optional zip bundle.
     if args.zip_path:

--- a/appWeb/public_html/includes/SongData.php
+++ b/appWeb/public_html/includes/SongData.php
@@ -647,6 +647,351 @@ class SongData
     }
 
     /* =====================================================================
+     * PARENT/SERIES PROGRAMMATIC HELPERS (#782 phase E)
+     *
+     * Public surface so other parts of the codebase (custom report
+     * generators, future projection-software exporters, the analytics
+     * module, etc.) can ask the questions the public song page + tile
+     * already render answers to, without re-implementing the joins.
+     * ===================================================================== */
+
+    /**
+     * Return the full hierarchical family of a songbook — its single
+     * parent (or null), every direct child, and every sibling (other
+     * children of the same parent, excluding the row itself). Hops are
+     * bounded at 64 in each direction so a pathological cycle in the
+     * data — already prevented by phase B's _wouldCreateParentCycle
+     * guard — couldn't blow up the walk anyway.
+     *
+     * Empty `parent` + `children` + `siblings` arrays for songbooks that
+     * have no relations declared. Pre-migration deployments (no
+     * ParentSongbookId column) get the same empty shape.
+     *
+     * Result shape:
+     *   [
+     *     'self'     => ['id' => 'CIS', 'name' => 'Christ in Song'],
+     *     'parent'   => null | ['id' => 'CIS', 'name' => '…',
+     *                            'relationship' => 'translation'|'edition'|'abridgement'],
+     *     'children' => [
+     *        ['id' => 'HA', 'name' => 'Himnario Adventista',
+     *         'relationship' => 'translation', 'language' => 'es'],
+     *        …
+     *     ],
+     *     'siblings' => [ ...same shape as children... ],
+     *   ]
+     *
+     * @param string $abbr Songbook abbreviation
+     * @return array Family shape (always returns a populated array; missing rows ⇒ self => null)
+     */
+    public function getSongbookFamily(string $abbr): array
+    {
+        $abbr = strtoupper(trim($abbr));
+        $empty = [
+            'self'     => null,
+            'parent'   => null,
+            'children' => [],
+            'siblings' => [],
+        ];
+        if ($abbr === '') return $empty;
+
+        if ($this->jsonMode) {
+            /* JSON-mode catalogues don't ship parent/series metadata
+               (the JSON shape predates phase A) — return the trivial
+               family. */
+            $book = $this->getSongbook($abbr);
+            return $book ? array_merge($empty, ['self' => ['id' => $book['id'], 'name' => $book['name']]]) : $empty;
+        }
+
+        if ($this->_songbookParentSelect() === '') return $empty;
+
+        try {
+            /* 1) self + own parent (if any). */
+            $stmt = $this->db->prepare(
+                'SELECT b.Id, b.Abbreviation, b.Name,
+                        b.ParentSongbookId, b.ParentRelationship,
+                        p.Abbreviation AS parentAbbr, p.Name AS parentName
+                   FROM tblSongbooks b
+                   LEFT JOIN tblSongbooks p ON p.Id = b.ParentSongbookId
+                  WHERE b.Abbreviation = ?'
+            );
+            $stmt->bind_param('s', $abbr);
+            $stmt->execute();
+            $self = $stmt->get_result()->fetch_assoc();
+            $stmt->close();
+            if (!$self) return $empty;
+
+            $selfId = (int)$self['Id'];
+            $out = [
+                'self' => [
+                    'id'   => (string)$self['Abbreviation'],
+                    'name' => (string)$self['Name'],
+                ],
+                'parent'   => null,
+                'children' => [],
+                'siblings' => [],
+            ];
+            $parentId = isset($self['ParentSongbookId']) ? (int)$self['ParentSongbookId'] : 0;
+            if ($parentId > 0) {
+                $out['parent'] = [
+                    'id'           => (string)($self['parentAbbr'] ?? ''),
+                    'name'         => (string)($self['parentName'] ?? ''),
+                    'relationship' => (string)($self['ParentRelationship'] ?? ''),
+                ];
+            }
+
+            /* 2) Direct children (rows whose ParentSongbookId === selfId).
+                  Pulled with the optional Language column so callers
+                  rendering a list can show "Spanish" / "Tswana" inline. */
+            $langTail = $this->_songbookLanguageSelect() === '' ? '' : ', b.Language AS language';
+            $stmt = $this->db->prepare(
+                "SELECT b.Abbreviation AS id, b.Name AS name,
+                        b.ParentRelationship AS relationship
+                        {$langTail}
+                   FROM tblSongbooks b
+                  WHERE b.ParentSongbookId = ?
+                  ORDER BY b.Name ASC"
+            );
+            $stmt->bind_param('i', $selfId);
+            $stmt->execute();
+            $res = $stmt->get_result();
+            while ($r = $res->fetch_assoc()) {
+                $out['children'][] = [
+                    'id'           => (string)$r['id'],
+                    'name'         => (string)$r['name'],
+                    'relationship' => (string)($r['relationship'] ?? ''),
+                    'language'     => (string)($r['language']     ?? ''),
+                ];
+            }
+            $stmt->close();
+
+            /* 3) Siblings (other children of the same parent, excluding
+                  self). Skipped when this row has no parent. */
+            if ($parentId > 0) {
+                $stmt = $this->db->prepare(
+                    "SELECT b.Abbreviation AS id, b.Name AS name,
+                            b.ParentRelationship AS relationship
+                            {$langTail}
+                       FROM tblSongbooks b
+                      WHERE b.ParentSongbookId = ?
+                        AND b.Id <> ?
+                      ORDER BY b.Name ASC"
+                );
+                $stmt->bind_param('ii', $parentId, $selfId);
+                $stmt->execute();
+                $res = $stmt->get_result();
+                while ($r = $res->fetch_assoc()) {
+                    $out['siblings'][] = [
+                        'id'           => (string)$r['id'],
+                        'name'         => (string)$r['name'],
+                        'relationship' => (string)($r['relationship'] ?? ''),
+                        'language'     => (string)($r['language']     ?? ''),
+                    ];
+                }
+                $stmt->close();
+            }
+
+            return $out;
+        } catch (\Throwable $e) {
+            error_log('[SongData::getSongbookFamily] ' . $e->getMessage());
+            return $empty;
+        }
+    }
+
+    /**
+     * Return every songbook in a series, ordered by membership SortOrder
+     * then Name. Looked up by either the series id (int) or its slug
+     * (string). Empty list when the series doesn't exist or the schema
+     * isn't live yet.
+     *
+     * Result shape per row:
+     *   ['id' => 'SoF1', 'name' => 'Songs of Fellowship vol 1',
+     *    'sortOrder' => 10, 'note' => 'first volume',
+     *    'language' => 'en']  // language only when the column is live
+     *
+     * @param int|string $seriesIdOrSlug
+     * @return array<int, array<string, int|string>>
+     */
+    public function getSongbooksInSeries($seriesIdOrSlug): array
+    {
+        if ($this->jsonMode) return []; /* JSON catalogues don't carry series */
+
+        /* Schema probe — same gate as _songbookSeriesMap(). */
+        try {
+            $probe = $this->db->prepare(
+                "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+                  WHERE TABLE_SCHEMA = DATABASE()
+                    AND TABLE_NAME   = 'tblSongbookSeries'
+                  LIMIT 1"
+            );
+            $probe->execute();
+            $present = $probe->get_result()->fetch_row() !== null;
+            $probe->close();
+            if (!$present) return [];
+        } catch (\Throwable $_e) {
+            return [];
+        }
+
+        $langTail = $this->_songbookLanguageSelect() === '' ? '' : ', b.Language AS language';
+        try {
+            if (is_int($seriesIdOrSlug)) {
+                $sql = "SELECT b.Abbreviation AS id, b.Name AS name,
+                               m.SortOrder    AS sortOrder,
+                               m.Note         AS note
+                               {$langTail}
+                          FROM tblSongbookSeriesMembership m
+                          JOIN tblSongbooks b ON b.Id = m.SongbookId
+                         WHERE m.SeriesId = ?
+                         ORDER BY m.SortOrder ASC, b.Name ASC";
+                $stmt = $this->db->prepare($sql);
+                $sid  = (int)$seriesIdOrSlug;
+                $stmt->bind_param('i', $sid);
+            } else {
+                $sql = "SELECT b.Abbreviation AS id, b.Name AS name,
+                               m.SortOrder    AS sortOrder,
+                               m.Note         AS note
+                               {$langTail}
+                          FROM tblSongbookSeriesMembership m
+                          JOIN tblSongbooks       b ON b.Id = m.SongbookId
+                          JOIN tblSongbookSeries  s ON s.Id = m.SeriesId
+                         WHERE s.Slug = ?
+                         ORDER BY m.SortOrder ASC, b.Name ASC";
+                $stmt = $this->db->prepare($sql);
+                $slug = (string)$seriesIdOrSlug;
+                $stmt->bind_param('s', $slug);
+            }
+            $stmt->execute();
+            $res = $stmt->get_result();
+            $out = [];
+            while ($r = $res->fetch_assoc()) {
+                $row = [
+                    'id'        => (string)$r['id'],
+                    'name'      => (string)$r['name'],
+                    'sortOrder' => (int)$r['sortOrder'],
+                    'note'      => (string)($r['note'] ?? ''),
+                ];
+                if (array_key_exists('language', $r)) {
+                    $row['language'] = (string)($r['language'] ?? '');
+                }
+                $out[] = $row;
+            }
+            $stmt->close();
+            return $out;
+        } catch (\Throwable $e) {
+            error_log('[SongData::getSongbooksInSeries] ' . $e->getMessage());
+            return [];
+        }
+    }
+
+    /**
+     * Given a SongId (e.g. 'HA-0042'), return the same hymn-number's
+     * row in every related songbook — parent + every child of the
+     * parent (i.e. every sibling translation/edition/abridgement) —
+     * keyed by relationship for easy rendering.
+     *
+     * Result shape:
+     *   [
+     *     'parent'   => ['id' => 'CIS-0042', 'songbook' => 'CIS',
+     *                    'name' => 'Christ in Song', 'language' => 'en',
+     *                    'relationship' => 'translation'],
+     *     'siblings' => [
+     *        ['id' => 'KMK-0042', 'songbook' => 'KMK', 'name' => 'Keresete Mo Kopelong',
+     *         'language' => 'tn', 'relationship' => 'translation'],
+     *        …
+     *     ],
+     *   ]
+     *
+     * Empty when:
+     *   - the song's number is null (Misc / unnumbered),
+     *   - the songbook has no parent,
+     *   - no related songbook carries the same number.
+     *
+     * Cheap: one INFORMATION_SCHEMA probe (cached), one row fetch,
+     * one family walk, one IN(…) query for the same-number row in
+     * each related songbook. ~3 queries total.
+     */
+    public function getSongCounterparts(string $songId): array
+    {
+        $empty = ['parent' => null, 'siblings' => []];
+        $songId = trim($songId);
+        if ($songId === '') return $empty;
+        if ($this->jsonMode) return $empty;
+        if ($this->_songbookParentSelect() === '') return $empty;
+
+        try {
+            /* Step 1 — pull the source song's (SongbookAbbr, Number).
+               Cheap, no joins. */
+            $stmt = $this->db->prepare(
+                'SELECT SongbookAbbr, Number FROM tblSongs WHERE SongId = ? LIMIT 1'
+            );
+            $stmt->bind_param('s', $songId);
+            $stmt->execute();
+            $row = $stmt->get_result()->fetch_assoc();
+            $stmt->close();
+            if (!$row) return $empty;
+
+            $abbr   = (string)$row['SongbookAbbr'];
+            $number = $row['Number'] !== null ? (int)$row['Number'] : 0;
+            if ($number <= 0) return $empty;
+
+            /* Step 2 — walk the family. Re-uses the helper above so the
+               relationship-aware language tail comes for free. */
+            $family = $this->getSongbookFamily($abbr);
+
+            /* Step 3 — assemble the candidate-row list of related songbook
+               abbreviations (parent + siblings). Children of the current
+               songbook aren't included — counterpart semantics here are
+               "this hymn elsewhere in the same family", and a child of
+               the current row would be a translation OF this row, which
+               is the inward-translations relationship already covered
+               by tblSongTranslations elsewhere on the song page (#281). */
+            $candidates = [];
+            $relationshipByAbbr = [];
+            if ($family['parent']) {
+                $candidates[] = $family['parent']['id'];
+                $relationshipByAbbr[$family['parent']['id']] = $family['parent']['relationship'];
+            }
+            foreach ($family['siblings'] as $s) {
+                $candidates[] = $s['id'];
+                $relationshipByAbbr[$s['id']] = $s['relationship'];
+            }
+            if (!$candidates) return $empty;
+
+            $ph   = implode(',', array_fill(0, count($candidates), '?'));
+            $sql  = "SELECT s.SongId, s.SongbookAbbr, b.Name AS bookName,
+                            b.Language AS bookLanguage
+                       FROM tblSongs s
+                       JOIN tblSongbooks b ON b.Abbreviation = s.SongbookAbbr
+                      WHERE s.Number = ? AND s.SongbookAbbr IN ($ph)";
+            $stmt = $this->db->prepare($sql);
+            $types = 'i' . str_repeat('s', count($candidates));
+            $args  = array_merge([$number], $candidates);
+            $stmt->bind_param($types, ...$args);
+            $stmt->execute();
+            $res = $stmt->get_result();
+            $out = $empty;
+            while ($r = $res->fetch_assoc()) {
+                $entry = [
+                    'id'           => (string)$r['SongId'],
+                    'songbook'     => (string)$r['SongbookAbbr'],
+                    'name'         => (string)$r['bookName'],
+                    'language'     => (string)($r['bookLanguage'] ?? ''),
+                    'relationship' => (string)($relationshipByAbbr[$r['SongbookAbbr']] ?? ''),
+                ];
+                if ($family['parent'] && $r['SongbookAbbr'] === $family['parent']['id']) {
+                    $out['parent'] = $entry;
+                } else {
+                    $out['siblings'][] = $entry;
+                }
+            }
+            $stmt->close();
+            return $out;
+        } catch (\Throwable $e) {
+            error_log('[SongData::getSongCounterparts] ' . $e->getMessage());
+            return $empty;
+        }
+    }
+
+    /* =====================================================================
      * SONG RETRIEVAL METHODS
      * ===================================================================== */
 

--- a/appWeb/public_html/manage/songbooks.php
+++ b/appWeb/public_html/manage/songbooks.php
@@ -37,6 +37,10 @@ $activePage = 'songbooks';
 
 $error   = '';
 $success = '';
+/* #782 phase E — populated by the `family_manifest` POST action below.
+   When non-null the page renders the plan table at the bottom of the
+   admin surface so the curator can review before a confirmed re-submit. */
+$manifestPreview = null;
 $db      = getDbMysqli();
 
 /* ---- GET ?action=pick_colour&abbr=XX (#772) -----------------------------
@@ -1231,6 +1235,245 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 break;
             }
 
+            case 'family_manifest': {
+                /* #782 phase E — apply / preview a family-manifest JSON
+                   file (the one ChristInSong.app.py emits as
+                   `_family-manifest.json` after a scrape). Two modes
+                   gated by `confirm`:
+                     - confirm absent → preview-only; build the plan
+                       and stash it on $manifestPreview for the page
+                       render to display the table. No DB writes.
+                     - confirm = '1'  → preview AND apply: walk the
+                       same plan and run the parent-link UPDATE for
+                       each row tagged 'will_link' / 'will_relink'.
+                   Re-uploadable: skipped rows ("already correct",
+                   "child missing", etc.) are surfaced in the result
+                   so a curator can fix the catalogue and re-upload. */
+                if (!in_array(($currentUser['role'] ?? ''), ['admin', 'global_admin'], true)) {
+                    $error = 'Admin role required to apply a family manifest.';
+                    break;
+                }
+                /* Local schema probe — the `update` case has its own
+                   $hasParentCols scoped to that case, and we don't want
+                   to lift it out just for one extra consumer. Same
+                   INFORMATION_SCHEMA query, instance-cached costs are
+                   negligible on the rare admin-only manifest path. */
+                $hasParentCols = false;
+                try {
+                    $probe = $db->prepare(
+                        "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+                          WHERE TABLE_SCHEMA = DATABASE()
+                            AND TABLE_NAME   = 'tblSongbooks'
+                            AND COLUMN_NAME  = 'ParentSongbookId'
+                          LIMIT 1"
+                    );
+                    $probe->execute();
+                    $hasParentCols = $probe->get_result()->fetch_row() !== null;
+                    $probe->close();
+                } catch (\Throwable $_e) { /* fall through to false */ }
+                if (!$hasParentCols) {
+                    $error = 'Parent-songbook schema (#782 phase A) is not installed yet — run /manage/setup-database first.';
+                    break;
+                }
+                $upload = $_FILES['manifest'] ?? null;
+                if (!is_array($upload) || ($upload['error'] ?? UPLOAD_ERR_NO_FILE) !== UPLOAD_ERR_OK) {
+                    $error = 'No manifest file received (or upload failed). Pick a JSON file and try again.';
+                    break;
+                }
+                if (($upload['size'] ?? 0) > 1024 * 1024) {
+                    /* Real manifests are tiny (a few KB). 1 MB is a
+                       generous cap that stops a runaway file from
+                       chewing memory in json_decode. */
+                    $error = 'Manifest file is too large (>1 MB). Are you sure this is a family manifest?';
+                    break;
+                }
+                $raw = file_get_contents($upload['tmp_name']);
+                if ($raw === false || $raw === '') {
+                    $error = 'Could not read the uploaded manifest file.';
+                    break;
+                }
+                $manifest = json_decode($raw, true);
+                if (!is_array($manifest)) {
+                    $error = 'Manifest is not valid JSON.';
+                    break;
+                }
+                if ((int)($manifest['schema_version'] ?? 0) !== 1) {
+                    $error = 'Unsupported manifest schema_version (this admin only knows version 1).';
+                    break;
+                }
+                $families = $manifest['families'] ?? [];
+                if (!is_array($families) || !$families) {
+                    $error = 'Manifest has no `families` entries to process.';
+                    break;
+                }
+
+                /* Pull every (Id, Abbreviation, ParentSongbookId) once so
+                   the plan loop is in-memory only. Catalogues are small
+                   enough that this beats one round-trip per child. */
+                $books = [];
+                $stmt  = $db->prepare(
+                    'SELECT Id, Abbreviation, ParentSongbookId, ParentRelationship
+                       FROM tblSongbooks'
+                );
+                $stmt->execute();
+                $res = $stmt->get_result();
+                while ($brow = $res->fetch_assoc()) {
+                    $books[strtoupper((string)$brow['Abbreviation'])] = [
+                        'id'           => (int)$brow['Id'],
+                        'parentId'     => isset($brow['ParentSongbookId']) ? (int)$brow['ParentSongbookId'] : 0,
+                        'relationship' => (string)($brow['ParentRelationship'] ?? ''),
+                    ];
+                }
+                $stmt->close();
+
+                /* Build the plan: one row per child across every family.
+                   Action codes:
+                     'will_link'    — child has no parent yet → set parent
+                     'will_relink'  — child has a parent that doesn't match the manifest → flagged but ONLY applied with `relink_existing=1`
+                     'already_ok'   — child already points at the right parent with the right relationship → skipped
+                     'parent_miss'  — manifest's parent.abbreviation isn't in the catalogue → cannot link, log + skip
+                     'child_miss'   — manifest's child isn't in the catalogue → log + skip
+                     'self'         — manifest claims child === parent → log + skip (defensive) */
+                $plan = [];
+                $relinkExisting = !empty($_POST['relink_existing']);
+                foreach ($families as $fam) {
+                    $parent = $fam['parent']  ?? null;
+                    $kids   = $fam['children'] ?? [];
+                    if (!is_array($parent) || !is_array($kids)) continue;
+                    $parentAbbr = strtoupper(trim((string)($parent['abbreviation'] ?? '')));
+                    if ($parentAbbr === '' || !isset($books[$parentAbbr])) {
+                        foreach ((array)$kids as $kid) {
+                            if (!is_array($kid)) continue;
+                            $plan[] = [
+                                'child'        => strtoupper((string)($kid['abbreviation'] ?? '')),
+                                'parent'       => $parentAbbr,
+                                'relationship' => (string)($kid['relationship'] ?? ''),
+                                'action'       => 'parent_miss',
+                                'note'         => "Parent `{$parentAbbr}` is not in the catalogue.",
+                            ];
+                        }
+                        continue;
+                    }
+                    $parentId = $books[$parentAbbr]['id'];
+                    foreach ($kids as $kid) {
+                        if (!is_array($kid)) continue;
+                        $childAbbr = strtoupper(trim((string)($kid['abbreviation'] ?? '')));
+                        $rel       = (string)($kid['relationship'] ?? 'translation');
+                        if (!in_array($rel, ['translation','edition','abridgement'], true)) {
+                            $rel = 'translation';
+                        }
+                        if ($childAbbr === '') continue;
+                        if ($childAbbr === $parentAbbr) {
+                            $plan[] = ['child' => $childAbbr, 'parent' => $parentAbbr,
+                                       'relationship' => $rel, 'action' => 'self',
+                                       'note' => 'Manifest lists the parent as its own child — skipped.'];
+                            continue;
+                        }
+                        if (!isset($books[$childAbbr])) {
+                            $plan[] = ['child' => $childAbbr, 'parent' => $parentAbbr,
+                                       'relationship' => $rel, 'action' => 'child_miss',
+                                       'note' => "Child `{$childAbbr}` is not in the catalogue (was it imported?)."];
+                            continue;
+                        }
+                        $current = $books[$childAbbr];
+                        if ($current['parentId'] === 0) {
+                            $plan[] = ['child' => $childAbbr, 'parent' => $parentAbbr,
+                                       'relationship' => $rel, 'action' => 'will_link',
+                                       'note' => ''];
+                        } elseif ($current['parentId'] === $parentId
+                                  && $current['relationship'] === $rel) {
+                            $plan[] = ['child' => $childAbbr, 'parent' => $parentAbbr,
+                                       'relationship' => $rel, 'action' => 'already_ok',
+                                       'note' => 'Already linked to this parent with this relationship.'];
+                        } else {
+                            $plan[] = ['child' => $childAbbr, 'parent' => $parentAbbr,
+                                       'relationship' => $rel, 'action' => 'will_relink',
+                                       'note' => 'Currently links to a different parent / relationship. '
+                                                . 'Tick "Relink existing" to overwrite.'];
+                        }
+                    }
+                }
+
+                /* Apply step (only when confirm=1). For will_relink rows
+                   we additionally require relink_existing — keeps the
+                   destructive overwrite behind a second tick so a hasty
+                   double-click doesn't silently rewire half the catalogue. */
+                $applied = 0;
+                $skipped = 0;
+                $confirm = !empty($_POST['confirm']);
+                if ($confirm) {
+                    $db->begin_transaction();
+                    try {
+                        $up = $db->prepare(
+                            'UPDATE tblSongbooks
+                                SET ParentSongbookId = ?, ParentRelationship = ?
+                              WHERE Abbreviation = ?'
+                        );
+                        foreach ($plan as &$p) {
+                            $shouldApply = ($p['action'] === 'will_link')
+                                || ($p['action'] === 'will_relink' && $relinkExisting);
+                            if (!$shouldApply) {
+                                if (in_array($p['action'], ['will_link', 'will_relink'], true)) {
+                                    $skipped++;
+                                }
+                                continue;
+                            }
+                            $parentAbbr  = $p['parent'];
+                            $parentId    = $books[$parentAbbr]['id'];
+                            $rel         = $p['relationship'];
+                            $childAbbr   = $p['child'];
+                            /* The UPDATE filters on Abbreviation rather
+                               than Id so the SQL stays readable; types
+                               are 'i' (parent id), 's' (relationship enum),
+                               's' (child abbreviation). */
+                            $up->bind_param('iss', $parentId, $rel, $childAbbr);
+                            $up->execute();
+                            $applied++;
+                            $p['action'] = $p['action'] === 'will_relink' ? 'relinked' : 'linked';
+                        }
+                        unset($p);
+                        $up->close();
+                        $db->commit();
+                        if (function_exists('logActivity')) {
+                            logActivity('songbook.family_manifest_apply', 'songbook', '', [
+                                'scraper'        => (string)($manifest['scraper'] ?? ''),
+                                'applied'        => $applied,
+                                'skipped'        => $skipped,
+                                'plan_size'      => count($plan),
+                                'relink_existing'=> $relinkExisting,
+                            ]);
+                        }
+                        $success = "Applied {$applied} parent link(s) from the manifest"
+                                 . ($skipped > 0 ? "; {$skipped} link(s) skipped (see table for why)." : '.');
+                    } catch (\Throwable $e) {
+                        $db->rollback();
+                        throw $e;
+                    }
+                } else {
+                    $countByAction = array_count_values(array_column($plan, 'action'));
+                    $success = 'Manifest parsed — preview below. Tick "Confirm" + re-submit to apply '
+                             . (int)($countByAction['will_link'] ?? 0) . ' new link(s)'
+                             . (isset($countByAction['will_relink']) ? ' (or also tick "Relink existing" to overwrite '
+                                . (int)$countByAction['will_relink'] . ' diverging row(s))' : '')
+                             . '.';
+                }
+
+                /* Stash for the page-template render block lower down. */
+                $manifestPreview = [
+                    'plan'            => $plan,
+                    'applied'         => $applied,
+                    'skipped'         => $skipped,
+                    'confirmed'       => $confirm,
+                    'relink_existing' => $relinkExisting,
+                    'meta'            => [
+                        'scraper'         => (string)($manifest['scraper']         ?? ''),
+                        'scraper_version' => (string)($manifest['scraper_version'] ?? ''),
+                        'generated_at'    => (string)($manifest['generated_at']    ?? ''),
+                    ],
+                ];
+                break;
+            }
+
             default:
                 $error = 'Unknown action.';
         }
@@ -1758,6 +2001,135 @@ $csrf = csrfToken();
                     </button>
                 </form>
             </div>
+        </div>
+        <?php endif; ?>
+
+        <?php if (in_array(($currentUser['role'] ?? ''), ['admin', 'global_admin'], true)): ?>
+        <!-- Family-manifest uploader (#782 phase E). Admin / global_admin
+             only. Curators upload the JSON file written by a scraper
+             (e.g. .importers/scrapers/ChristInSong.app.py emits
+             `_family-manifest.json` at the top of .SourceSongData/) to
+             bulk-link vernacular hymnals to their canonical parent
+             without hand-editing 22 rows on the songbooks list above.
+
+             Two-step flow: upload + click "Preview plan" → review the
+             plan table that renders below → tick "Confirm" + re-upload
+             the same file to actually apply. The destructive overwrite
+             ("Relink existing") sits behind a second tick so a hasty
+             double-click can't silently rewire a row that already
+             pointed at a different parent. -->
+        <div class="card-admin p-3 mb-4">
+            <h2 class="h6 mb-2"><i class="bi bi-diagram-3 me-2"></i>Apply family manifest</h2>
+            <p class="small text-muted mb-3">
+                Upload a JSON file produced by a scraper (e.g. <code>_family-manifest.json</code>
+                from <code>ChristInSong.app.py</code>) to bulk-link vernacular / edition / abridgement
+                rows to their canonical parent songbook. Preview-only by default — tick
+                <strong>Confirm</strong> below the preview to apply.
+            </p>
+            <form method="POST" enctype="multipart/form-data">
+                <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                <input type="hidden" name="action"     value="family_manifest">
+                <div class="row g-2 align-items-end">
+                    <div class="col-sm-6">
+                        <label class="form-label small">Manifest file (JSON, ≤ 1 MB)</label>
+                        <input type="file" name="manifest"
+                               class="form-control form-control-sm"
+                               accept="application/json,.json" required>
+                    </div>
+                    <div class="col-sm-3 d-flex align-items-end gap-2">
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox"
+                                   name="confirm" value="1" id="manifest-confirm">
+                            <label class="form-check-label small" for="manifest-confirm">
+                                Confirm — apply the plan
+                            </label>
+                        </div>
+                    </div>
+                    <div class="col-sm-3 d-flex align-items-end gap-2">
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox"
+                                   name="relink_existing" value="1" id="manifest-relink">
+                            <label class="form-check-label small" for="manifest-relink">
+                                Relink existing
+                                <small class="text-muted d-block">overwrite rows that already point elsewhere</small>
+                            </label>
+                        </div>
+                    </div>
+                </div>
+                <button type="submit" class="btn btn-amber btn-sm mt-3">
+                    <i class="bi bi-eye me-1"></i>Preview / Apply
+                </button>
+            </form>
+
+            <?php if ($manifestPreview !== null): ?>
+                <hr class="my-3">
+                <?php
+                    $meta = $manifestPreview['meta'];
+                    $countByAction = array_count_values(array_column($manifestPreview['plan'], 'action'));
+                    /* Action label + Bootstrap badge class lookup —
+                       pre-computed so the table loop stays compact. */
+                    $actionMeta = [
+                        'will_link'   => ['Will link',          'bg-info'],
+                        'will_relink' => ['Would relink',       'bg-warning text-dark'],
+                        'already_ok'  => ['Already correct',    'bg-success'],
+                        'parent_miss' => ['Parent missing',     'bg-secondary'],
+                        'child_miss'  => ['Child missing',      'bg-secondary'],
+                        'self'        => ['Self-parent',        'bg-danger'],
+                        'linked'      => ['Linked',             'bg-success'],
+                        'relinked'    => ['Relinked',           'bg-success'],
+                    ];
+                ?>
+                <div class="small text-muted mb-2">
+                    Manifest from
+                    <code><?= htmlspecialchars($meta['scraper'] ?: 'unknown') ?></code>
+                    <?php if ($meta['scraper_version']): ?>
+                        v<?= htmlspecialchars($meta['scraper_version']) ?>
+                    <?php endif; ?>
+                    <?php if ($meta['generated_at']): ?>
+                        · generated <?= htmlspecialchars($meta['generated_at']) ?>
+                    <?php endif; ?>
+                    · <?= count($manifestPreview['plan']) ?> row(s).
+                </div>
+                <table class="table table-sm align-middle mb-0">
+                    <thead>
+                        <tr class="text-muted small">
+                            <th>Child</th>
+                            <th>Parent</th>
+                            <th>Relationship</th>
+                            <th>Action</th>
+                            <th>Note</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($manifestPreview['plan'] as $p):
+                            [$lbl, $cls] = $actionMeta[$p['action']] ?? [$p['action'], 'bg-secondary'];
+                        ?>
+                            <tr>
+                                <td><code><?= htmlspecialchars($p['child']) ?></code></td>
+                                <td><code><?= htmlspecialchars($p['parent']) ?></code></td>
+                                <td><small><?= htmlspecialchars($p['relationship']) ?></small></td>
+                                <td><span class="badge <?= htmlspecialchars($cls) ?>"><?= htmlspecialchars($lbl) ?></span></td>
+                                <td><small class="text-muted"><?= htmlspecialchars($p['note']) ?></small></td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+                <?php if (!$manifestPreview['confirmed']): ?>
+                    <p class="small text-muted mt-3 mb-0">
+                        Re-upload the same file with <strong>Confirm</strong> ticked to apply
+                        <?= (int)($countByAction['will_link'] ?? 0) ?> new link(s)<?php
+                        if (!empty($countByAction['will_relink'])):
+                            ?> (or also tick <strong>Relink existing</strong> to overwrite
+                            <?= (int)$countByAction['will_relink'] ?> diverging row(s))<?php
+                        endif; ?>.
+                    </p>
+                <?php else: ?>
+                    <p class="small text-muted mt-3 mb-0">
+                        Applied <?= (int)$manifestPreview['applied'] ?>;
+                        skipped <?= (int)$manifestPreview['skipped'] ?> writable row(s).
+                    </p>
+                <?php endif; ?>
+            <?php endif; ?>
         </div>
         <?php endif; ?>
 


### PR DESCRIPTION
## Summary

Phase E — the **final piece** of the Parent Songbooks work. Closes out #782 by giving callers a clean programmatic surface for family / series queries AND automating the curator-side ergonomics of bulk-linking 22+ vernacular hymnals to their canonical parent after a scrape + bulk-import.

Closes **#782 phase E** (and with it, the whole #782).

## What's in this PR

### `SongData` — three new public helpers

- **`getSongbookFamily(string $abbr): array`** — returns `{ self, parent, children, siblings }` walking the `ParentSongbookId` FK in both directions. Pre-migration safe via the cached `_songbookParentSelect` probe.

- **`getSongbooksInSeries(int|string $idOrSlug): array`** — returns the songbooks that belong to a series, ordered by `SortOrder` then `Name`. Accepts either the int id or the URL-safe slug — handy for `/series/<slug>` public pages when those land.

- **`getSongCounterparts(string $songId): array`** — given a `SongId`, returns the same hymn-number's row in the parent songbook + every sibling translation/edition. Three queries total (probe + family walk + IN-list); empty for unnumbered songs, songbooks with no parent, or rows where no related songbook carries the same number.

### `ChristInSong.app.py` — manifest emission

After a successful scrape the script writes `_family-manifest.json` at the top of the output directory listing every vernacular hymnal as a translation child of the English CIS parent. Schema is versioned (`schema_version: 1`) and shaped so future scrapers (Mission Praise editions, Songs of Fellowship volumes-as-series) can write multi-family manifests on the same contract:

```json
{
  \"schema_version\": 1,
  \"scraper\": \"ChristInSong.app.py\",
  \"scraper_version\": \"1.0\",
  \"generated_at\": \"2026-05-02T...Z\",
  \"families\": [
    {
      \"parent\": { \"abbreviation\": \"CIS\", \"name\": \"Christ in Song\", \"language\": \"en\" },
      \"children\": [
        { \"abbreviation\": \"HA\", \"name\": \"Himnario Adventista\", \"language\": \"es\", \"relationship\": \"translation\" },
        ...
      ]
    }
  ]
}
```

`--no-manifest` opts out. The manifest is skipped when CIS itself wasn't part of the run or failed (children would dangle).

### `/manage/songbooks` — Apply family manifest uploader

Admin / global_admin only. Curators upload the JSON above; the page parses + matches every `(parent, child)` pair against `tblSongbooks` and renders a preview table:

- **`will_link`** — child has no parent → set parent
- **`will_relink`** — child links elsewhere → only applied with a second \"Relink existing\" tick (destructive overwrite gate)
- **`already_ok`** — already correct → skipped
- **`parent_miss`** / **`child_miss`** — referenced row not in the catalogue → logged + skipped
- **`self`** — manifest claims child === parent → defensive skip

Two-step flow (preview → confirm + re-upload) keeps the destructive bits behind explicit ticks. Apply step runs in one transaction; success emits a `songbook.family_manifest_apply` activity-log row with the applied / skipped counts.

## Pre-migration safety

Every schema-touching path is gated by `INFORMATION_SCHEMA` probes for `ParentSongbookId` / `tblSongbookSeries`. A deployment that hasn't run `migrate-parent-songbooks.php` (#782 phase A) sees the helpers return empty shapes and the admin uploader rejects with a friendly \"schema not installed\" error.

## Files

| File | Change |
| --- | --- |
| `appWeb/public_html/includes/SongData.php` | Three new public methods (~345 LOC). |
| `appWeb/public_html/manage/songbooks.php` | New `family_manifest` POST action + uploader card + preview table. |
| `.importers/scrapers/ChristInSong.app.py` | New `write_family_manifest()` + `--no-manifest` flag + call wired into `main()`. |

## Test plan

### Programmatic helpers

- [ ] On a populated DB with at least one parent-child relationship, call `\$songData->getSongbookFamily('CIS')` from a test harness or `php -r`. Expect `self`, `parent` (null for the canonical row), `children` (every linked vernacular), `siblings` (empty for the parent).
- [ ] Same helper on a vernacular abbreviation (e.g. `HA`). Expect `parent` populated and `siblings` listing the other vernaculars.
- [ ] On an unrelated standalone songbook (e.g. `MP`). Expect empty `parent` / `children` / `siblings`.
- [ ] Pre-migration: drop `tblSongbooks.ParentSongbookId` on a scratch DB. Same calls return the empty shape, no errors.
- [ ] `getSongbooksInSeries('songs-of-fellowship')` returns volume rows ordered by `SortOrder`. Same call with the int id returns the same list.
- [ ] `getSongCounterparts('HA-0042')` returns `parent` (CIS-0042 if it exists) + `siblings` (KMK-0042, KP-0042, etc. for every CIS sibling that carries number 42). Empty for `HA-0000` (unnumbered) and for `MP-0042` (no parent).

### Scraper manifest emission

- [ ] Run `python3 .importers/scrapers/ChristInSong.app.py --hymnal english,tswana,sotho` (a small subset). Expect `_family-manifest.json` at the top of `.SourceSongData/` with KMK + KP under CIS.
- [ ] `--no-manifest` skips the file.
- [ ] Run `--hymnal tswana,sotho` (no parent). Expect a console note and no manifest written.

### Admin uploader

- [ ] As an admin, open `/manage/songbooks`. Expect a new \"Apply family manifest\" card between the Auto-colour panel and the Create form.
- [ ] Upload `_family-manifest.json` with **Confirm** unticked. Expect a preview table with one row per `(parent, child)`. Rows where the child has no parent yet get `will_link` (info badge); rows already pointing at the right parent get `already_ok` (success badge).
- [ ] Re-upload with **Confirm** ticked. Expect the `will_link` rows to flip to `linked` and the songbook's Parent column on the list above to update on next page load.
- [ ] Manually set one child to point at a different parent via the edit modal. Re-upload. Expect that row to surface as `will_relink` (warning badge) and skip on apply unless **Relink existing** is also ticked.
- [ ] Upload a manifest that references a non-existent parent. Expect `parent_miss` for every child + the apply step skipping all of them.
- [ ] Pre-migration check: drop `ParentSongbookId`, reload `/manage/songbooks`. Expect the uploader to render but to reject the upload with \"schema not installed — run /manage/setup-database\".

### Activity log

- [ ] Apply a manifest. Expect a `songbook.family_manifest_apply` row in `/manage/activity-log` with `applied`, `skipped`, `plan_size`, and `relink_existing` fields.

## Refs

- Closes #782 phase E. With this merged, **the whole #782 is done.**
- Builds on the full chain: PR #790 (schema) → #799 (hierarchical admin UI) → #800 (series CRUD + membership picker) → #801 (public surfaces). No further migrations needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)