### PR TITLE
fix(api,auth): surface real signup/login errors instead of 'Network error' (#803)

### DIFF
--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -50,6 +50,99 @@ enableDebugModeIfRequested();
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'config.php';
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'infoAppVer.php';
+
+/* =========================================================================
+ * GLOBAL JSON ERROR HANDLER (#803)
+ *
+ * Without this, an uncaught \Throwable anywhere in the dispatch below
+ * produced PHP's default HTML error page — every JSON client hit it
+ * and `res.json()` blew up, surfacing the misleading "Network error.
+ * Please try again." instead of the real cause. Registered as early as
+ * possible so even a fatal in the rest of the bootstrap (require_once
+ * etc.) gets a JSON response on action requests.
+ *
+ * Two registrations:
+ *   - set_exception_handler   — catches uncaught \Throwable
+ *   - register_shutdown_function — catches fatal errors (parse errors,
+ *                                    out-of-memory, …) that don't
+ *                                    surface as throwables
+ *
+ * Page (?page=…) requests still get an HTML fragment — the SPA injects
+ * the response into a <div>, so a JSON body would be useless. Action
+ * requests get JSON. Everything is logged to error_log with a request
+ * id correlation token.
+ *
+ * Body shape on Alpha/Beta — message + class to speed up debugging:
+ *   { "error": "Database error: ...", "request_id": "abc1234567",
+ *     "exception_class": "mysqli_sql_exception" }
+ * Body shape on production — generic message + request id only:
+ *   { "error": "Internal server error.", "request_id": "abc1234567" }
+ * ========================================================================= */
+(function () {
+    /* Generate a short request id once. Re-used by both handlers + by
+       any inner handler that wants to thread the same correlation id
+       through to its log lines. Stashed on $GLOBALS so the rest of the
+       request can read it without reaching back through this closure. */
+    $rid = bin2hex(random_bytes(5));
+    $GLOBALS['_ihymnsApiRequestId'] = $rid;
+
+    $isAction = isset($_GET['action']) && trim((string)$_GET['action']) !== '';
+    $devStatus = $GLOBALS['app']['Application']['Version']['Development']['Status'] ?? null;
+    $verbose = ($devStatus === 'Alpha' || $devStatus === 'Beta');
+
+    $emit = function (string $msg, string $class, ?string $where = null) use ($isAction, $verbose, $rid) {
+        /* Always log the full detail to error_log so production admins
+           can correlate via the request id even when the response is
+           generic. */
+        error_log(sprintf(
+            '[api uncaught rid=%s] %s: %s%s',
+            $rid, $class, $msg, $where ? " @ {$where}" : ''
+        ));
+        if (headers_sent()) return; /* nothing we can do — response already started */
+        http_response_code(500);
+        if ($isAction) {
+            header('Content-Type: application/json; charset=UTF-8');
+            header('X-Content-Type-Options: nosniff');
+            header('Cache-Control: no-cache, must-revalidate');
+            $body = ['error' => 'Internal server error.', 'request_id' => $rid];
+            if ($verbose) {
+                $body['error']           = $msg;
+                $body['exception_class'] = $class;
+                if ($where !== null) $body['where'] = $where;
+            }
+            echo json_encode($body, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        } else {
+            /* Page requests stay HTML so the SPA can render the chunk
+               into the page <div>. Same alpha/beta gating on what we
+               disclose. */
+            header('Content-Type: text/html; charset=UTF-8');
+            echo '<div class="alert alert-danger" role="alert">';
+            echo '<strong>Internal server error.</strong> ';
+            echo 'Reference: <code>' . htmlspecialchars($rid, ENT_QUOTES) . '</code>';
+            if ($verbose) {
+                echo '<br><small>' . htmlspecialchars($class . ': ' . $msg, ENT_QUOTES) . '</small>';
+            }
+            echo '</div>';
+        }
+    };
+
+    set_exception_handler(function (\Throwable $e) use ($emit) {
+        $emit($e->getMessage(), get_class($e),
+              basename($e->getFile()) . ':' . $e->getLine());
+    });
+
+    register_shutdown_function(function () use ($emit) {
+        $err = error_get_last();
+        /* Only trip on fatal-class errors — non-fatal warnings/notices
+           shouldn't write a 500. PHP fatals are E_ERROR, E_PARSE,
+           E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR. */
+        $fatalMask = E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR;
+        if (!$err || !($err['type'] & $fatalMask)) return;
+        $emit($err['message'], 'PHP fatal',
+              basename($err['file'] ?? '?') . ':' . ($err['line'] ?? 0));
+    });
+})();
+
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'SongData.php';
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'content_access.php';

--- a/appWeb/public_html/js/modules/user-auth.js
+++ b/appWeb/public_html/js/modules/user-auth.js
@@ -152,6 +152,82 @@ export class UserAuth {
      * ===================================================================== */
 
     /**
+     * Run a JSON POST against the auth API and resolve the response into
+     * either { ok: true, data } or { ok: false, error } where `error` is
+     * the most diagnostic string we can produce.
+     *
+     * Three failure shapes that previously all collapsed to the same
+     * misleading "Network error. Please try again." (#803):
+     *   1. fetch() rejects                  → real connectivity / CORS
+     *   2. fetch() succeeds but res.json()  → server returned non-JSON
+     *      throws (HTML error page, empty body) — surface status + a
+     *      snippet of the body so support has something actionable
+     *   3. res.ok === false                 → server returned JSON 4xx;
+     *      use data.error (existing behaviour) and fall back to status
+     *      text if data.error is missing
+     *
+     * `defaultMsg` is the friendly verb fallback for case 3 — caller
+     * passes "Registration failed." / "Login failed." etc.
+     *
+     * @param {string} url
+     * @param {object} body
+     * @param {string} defaultMsg
+     * @returns {Promise<{ ok: true, data: any } | { ok: false, error: string }>}
+     */
+    async _postJson(url, body, defaultMsg) {
+        let res;
+        try {
+            res = await fetch(url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest',
+                },
+                body: JSON.stringify(body),
+            });
+        } catch (err) {
+            /* Case 1 — fetch itself rejected. This is the only true
+               "couldn't reach the server" path. */
+            return { ok: false, error: 'Network error. Please check your connection and try again.' };
+        }
+
+        /* Try to parse the body as JSON. On parse failure (case 2) we
+           reach for the raw text so we can show the curator something
+           actionable — typically the start of a PHP error page or an
+           empty 502. */
+        let data = null;
+        let parseFailed = false;
+        try {
+            data = await res.json();
+        } catch {
+            parseFailed = true;
+        }
+
+        if (parseFailed) {
+            let snippet = '';
+            try { snippet = (await res.text()).slice(0, 200).trim(); } catch { /* ignore */ }
+            const detail = snippet ? ` Server said: "${snippet.replace(/\s+/g, ' ')}"` : '';
+            return {
+                ok:    false,
+                error: `Server returned an unreadable response (HTTP ${res.status} ${res.statusText}).${detail} `
+                     + 'This is a server bug — please report it.',
+            };
+        }
+
+        if (!res.ok) {
+            /* Case 3 — server replied with a JSON body but a non-2xx
+               status. data.error is the friendly message; data.request_id
+               (added by the global handler in api.php for 500s, #803)
+               is included verbatim so support can correlate the log. */
+            const friendly = (data && data.error) ? data.error : (defaultMsg + ` (HTTP ${res.status})`);
+            const rid      = data && data.request_id ? ` [ref ${data.request_id}]` : '';
+            return { ok: false, error: friendly + rid };
+        }
+
+        return { ok: true, data };
+    }
+
+    /**
      * Register a new account.
      * @param {string} username
      * @param {string} password
@@ -159,24 +235,14 @@ export class UserAuth {
      * @returns {Promise<{ success: boolean, error?: string }>}
      */
     async register(username, password, displayName) {
-        try {
-            const res = await fetch(`${this.app.config.apiUrl}?action=auth_register`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-Requested-With': 'XMLHttpRequest',
-                },
-                body: JSON.stringify({ username, password, display_name: displayName }),
-            });
-
-            const data = await res.json();
-            if (!res.ok) return { success: false, error: data.error || 'Registration failed.' };
-
-            this.saveCredentials(data.token, data.user);
-            return { success: true };
-        } catch {
-            return { success: false, error: 'Network error. Please try again.' };
-        }
+        const r = await this._postJson(
+            `${this.app.config.apiUrl}?action=auth_register`,
+            { username, password, display_name: displayName },
+            'Registration failed.'
+        );
+        if (!r.ok) return { success: false, error: r.error };
+        this.saveCredentials(r.data.token, r.data.user);
+        return { success: true };
     }
 
     /**
@@ -186,24 +252,14 @@ export class UserAuth {
      * @returns {Promise<{ success: boolean, error?: string }>}
      */
     async login(username, password) {
-        try {
-            const res = await fetch(`${this.app.config.apiUrl}?action=auth_login`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-Requested-With': 'XMLHttpRequest',
-                },
-                body: JSON.stringify({ username, password }),
-            });
-
-            const data = await res.json();
-            if (!res.ok) return { success: false, error: data.error || 'Login failed.' };
-
-            this.saveCredentials(data.token, data.user);
-            return { success: true };
-        } catch {
-            return { success: false, error: 'Network error. Please try again.' };
-        }
+        const r = await this._postJson(
+            `${this.app.config.apiUrl}?action=auth_login`,
+            { username, password },
+            'Login failed.'
+        );
+        if (!r.ok) return { success: false, error: r.error };
+        this.saveCredentials(r.data.token, r.data.user);
+        return { success: true };
     }
 
     /**


### PR DESCRIPTION
## Summary

A new user reported that creating an account on `dev.ihymns.app` fails with the unhelpful **"Network error. Please try again."** — even after they fix the obvious problem (a space in the username) and try again.

The wording is wrong. The network is fine. The real cause is masked because:

1. The server has **no global exception handler** in `api.php`. Any uncaught `\Throwable` produces PHP's default HTML error page.
2. The client's `register()` / `login()` calls `res.json()` on the response. The HTML body throws a parse error, the catch block fires, and the catch hard-codes \"Network error\".

This affects **every** `/api.php` endpoint, not just signup.

Closes **#803**.

## What's in this PR

### Server — `appWeb/public_html/api.php`

Top-of-file global handler registered as early as possible (right after `infoAppVer.php` so we know the deployment channel). Two pieces working together:

- `set_exception_handler` — catches uncaught `\Throwable`
- `register_shutdown_function` + `error_get_last()` — catches PHP fatals (parse errors, OOM, …) that don't surface as throwables

Each uncaught error is logged to `error_log` with a 10-char `request_id` correlation token. The HTTP response branches by request type:

- **Action requests** (`?action=…`) → JSON 500 with `error`, `request_id`. On Alpha/Beta the body also includes `exception_class` + the file:line `where` so devs can debug from the browser. Production gets a generic `\"Internal server error.\"` + `request_id` only.
- **Page requests** (`?page=…`) → HTML alert chunk (the SPA injects HTML responses) with the same env-gated detail policy.

### Client — `appWeb/public_html/js/modules/user-auth.js`

`register()` and `login()` now share a new `_postJson()` helper that distinguishes three failure modes that previously all collapsed to \"Network error\":

| Symptom | Old message | New message |
| --- | --- | --- |
| `fetch()` rejected (real connectivity / CORS) | \"Network error. Please try again.\" | \"Network error. Please check your connection and try again.\" |
| `res.json()` failed (server returned non-JSON) | \"Network error. Please try again.\" | \"Server returned an unreadable response (HTTP 500 Internal Server Error). Server said: \\\"<first 200 chars of body>\\\". This is a server bug — please report it.\" |
| `res.ok === false` with JSON body | (already used `data.error`) | Same, plus `[ref abc1234567]` appended when `request_id` is present |

## Why this is the right fix

I can't see server logs from the dev box, so I don't know which specific PHP error is firing inside `auth_register` on `dev.ihymns.app` right now. With this PR merged, the actual exception class + message + file:line will surface in the modal on the user's next attempt (via the Alpha/Beta verbose body). At that point the underlying root cause becomes a one-liner to fix.

Even more importantly, **every other API endpoint** picks up the same protection — no more silent \"Network error\" lies.

## Files

| File | Change |
| --- | --- |
| `appWeb/public_html/api.php` | New global handler closure (~90 LOC) registered before the rest of the bootstrap requires. |
| `appWeb/public_html/js/modules/user-auth.js` | New `_postJson()` helper (~70 LOC); `register()` / `login()` rewritten to use it. |

## Test plan

- [ ] Deploy to alpha. Hit the Create Account modal with the same inputs as the original report — expect the real PHP error message + `[ref ...]` token in the modal instead of \"Network error\".
- [ ] Same flow on Login — expect the same improved error treatment.
- [ ] Trigger a true network failure (kill DNS / disconnect WiFi) — expect \"Network error. Please check your connection and try again.\"
- [ ] In a `php -l` smoke test, hit `/api.php?action=throw_test` (you'd need to add a temporary throw in a case to verify) — expect a JSON 500 with `error` + `request_id` + `exception_class` (since alpha is verbose).
- [ ] Check `error_log` has the corresponding `[api uncaught rid=…]` line so the curator can correlate browser → log.
- [ ] On a production deployment (Status = NULL) — expect the JSON body to have the generic \"Internal server error.\" string only, not the exception class / message. (Verbose mode is gated by `Alpha`/`Beta` env detection from `infoAppVer.php`.)

## Refs

- Closes #803.
- The signup endpoint itself isn't changed — its actual server-side error will become visible to the user on next attempt and can be addressed in a follow-up issue once we see the message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)