### PR TITLE
feat(songs): cross-book counterparts + similar-title suggestions (#807, #808)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [unreleased] — alpha
+
+- feat(songs): **cross-book counterparts** (#807) — new `tblSongLinks` join table + editor sidebar section + public song-page "Also appears in" dropdown + `api.php?action=song_links` endpoint. Lets curators declare that two-or-more `tblSongs` rows in different songbooks are the same hymn (e.g. Amazing Grace as MP-031 / CH-376 / SDAH-108 / SoF-29 / JP-006). Distinct from `tblSongTranslations` (different language) and `tblSongbooks.ParentSongbookId` (translated / edition derivatives at songbook level).
+- feat(admin): **song link suggestions** (#808) — new `/manage/song-link-suggestions` page lists pre-computed similar-titled-song candidates with Link / Dismiss / Open-in-editor actions. Builder script at `tools/build-song-link-suggestions.php` computes pairwise title + first-line + author similarity, writing into `tblSongLinkSuggestions`. Inline 5-suggestion panel in the editor sidebar surfaces candidates for the open song.
+
 ## [0.10.x] — 2026-04-18 (alpha)
 
 - feat: **auth** — magic-link (email + 6-digit code) is now the primary sign-in path; cross-subdomain `HttpOnly` cookie + 30-day sliding expiry; HttpOnly cookie ITP-resistant persistence

--- a/appWeb/.sql/migrate-song-links.php
+++ b/appWeb/.sql/migrate-song-links.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Cross-book song links schema (#807)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Models "this hymn appears in multiple songbooks at unrelated
+ * numbers" — e.g. Amazing Grace as MP-031 / CH-376 / SDAH-108 /
+ * SoF-29 / JP-006. Distinct from:
+ *
+ *   - tblSongTranslations (#352)  — different-language version
+ *                                   of the same hymn, with a
+ *                                   Translator credit.
+ *   - tblSongbooks.ParentSongbookId (#782) — songbook-level
+ *                                   parent (translation /
+ *                                   edition / abridgement);
+ *                                   only deep-links to the
+ *                                   same hymn number in the
+ *                                   parent.
+ *
+ * Cross-book counterparts are SAME-HYMN, often SAME-LANGUAGE,
+ * different-songbook, unrelated-number. Two or more rows share
+ * a GroupId and the public song page surfaces them as an "Also
+ * appears in" dropdown.
+ *
+ * Modelling as a shared-group join (rather than per-pair edges)
+ * gives transitive closure for free — adding a fourth member is
+ * one INSERT, not three pair rows. UNIQUE on SongId enforces
+ * "one song belongs to at most one group".
+ *
+ * Idempotent — INFORMATION_SCHEMA-probed; re-runs are no-ops.
+ *
+ * USAGE:
+ *   CLI: php appWeb/.sql/migrate-song-links.php
+ *   Web: /manage/setup-database → "Cross-book song links (#807)"
+ *        (entry point requires global_admin)
+ */
+
+if (PHP_SAPI === 'cli') {
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = true;
+} else {
+    if (!defined('IHYMNS_SETUP_DASHBOARD')) {
+        if (!function_exists('isAuthenticated')) {
+            require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+        }
+        if (!isAuthenticated()) {
+            http_response_code(401);
+            exit('Authentication required.');
+        }
+        $u = getCurrentUser();
+        if (!$u || $u['role'] !== 'global_admin') {
+            http_response_code(403);
+            exit('Global admin required.');
+        }
+    }
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = false;
+}
+
+function _migSongLinks_out(string $line): void
+{
+    global $isCli;
+    echo $line . ($isCli ? "\n" : "<br>\n");
+    if ($isCli) flush();
+}
+
+function _migSongLinks_tableExists(mysqli $db, string $table): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? LIMIT 1'
+    );
+    $stmt->bind_param('s', $table);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+_migSongLinks_out('Cross-book song links migration starting (#807)…');
+
+$db = getDbMysqli();
+if (!$db) {
+    _migSongLinks_out('ERROR: could not connect to database.');
+    exit(1);
+}
+
+if (!_migSongLinks_tableExists($db, 'tblSongs')) {
+    _migSongLinks_out('ERROR: tblSongs not found. Run install.php first.');
+    exit(1);
+}
+
+/* =========================================================================
+ * Step 1 — tblSongLinks (the cross-book counterpart join table)
+ *
+ * GroupId is the equivalence-class key. UNIQUE on SongId means a
+ * song can only belong to one group at a time — preventing the
+ * "MP-031 is in group 7 AND group 12" inconsistency. To merge two
+ * groups, run a single UPDATE rewriting one GroupId to the other.
+ * ========================================================================= */
+if (_migSongLinks_tableExists($db, 'tblSongLinks')) {
+    _migSongLinks_out('[skip] tblSongLinks already exists.');
+} else {
+    $sql = "CREATE TABLE tblSongLinks (
+        Id           INT UNSIGNED  AUTO_INCREMENT PRIMARY KEY,
+        GroupId      INT UNSIGNED  NOT NULL
+                     COMMENT 'All songs sharing a GroupId are the same hymn (cross-book counterparts).',
+        SongId       VARCHAR(20)   NOT NULL,
+        Note         VARCHAR(255)  NOT NULL DEFAULT ''
+                     COMMENT 'Optional curator-set annotation, e.g. \"uses 1990 Wesley revision text\"',
+        Verified     TINYINT(1)    NOT NULL DEFAULT 0,
+        CreatedBy    INT UNSIGNED  NULL DEFAULT NULL
+                     COMMENT 'tblUsers.Id of the curator who linked this row, if signed in',
+        CreatedAt    TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE KEY uk_song (SongId),
+        KEY idx_GroupId (GroupId),
+        CONSTRAINT fk_SongLinks_Song FOREIGN KEY (SongId)
+            REFERENCES tblSongs(SongId)
+            ON DELETE CASCADE ON UPDATE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
+    if (!$db->query($sql)) {
+        _migSongLinks_out('ERROR: create tblSongLinks failed: ' . $db->error);
+        exit(1);
+    }
+    _migSongLinks_out('[add ] tblSongLinks.');
+}
+
+/* =========================================================================
+ * Step 2 — tblSongLinkSuggestions (#808 — paired-with-this-issue
+ *                                  candidate list)
+ *
+ * Pre-computed pairwise similarity scores for any two songs that
+ * MIGHT be the same hymn. The /manage/song-link-suggestions admin
+ * page reads from this table; the build job (tools/build-song-link-
+ * suggestions.php) writes to it. Storing here rather than computing
+ * on every page render is the only way the list stays interactive
+ * for a 12k-row catalogue.
+ *
+ * Convention: SongIdA < SongIdB lexicographically — the build script
+ * canonicalises so we never store both (A,B) and (B,A).
+ * ========================================================================= */
+if (_migSongLinks_tableExists($db, 'tblSongLinkSuggestions')) {
+    _migSongLinks_out('[skip] tblSongLinkSuggestions already exists.');
+} else {
+    $sql = "CREATE TABLE tblSongLinkSuggestions (
+        Id              INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+        SongIdA         VARCHAR(20)  NOT NULL COMMENT 'Always lexicographically <= SongIdB',
+        SongIdB         VARCHAR(20)  NOT NULL,
+        Score           DECIMAL(4,3) NOT NULL COMMENT 'Composite similarity, 0.000–1.000',
+        TitleScore      DECIMAL(4,3) NOT NULL DEFAULT 0.000,
+        LyricsScore     DECIMAL(4,3) NOT NULL DEFAULT 0.000,
+        AuthorsScore    DECIMAL(4,3) NOT NULL DEFAULT 0.000,
+        ComputedAt      TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE KEY uk_pair (SongIdA, SongIdB),
+        KEY idx_Score (Score),
+        KEY idx_SongA (SongIdA),
+        KEY idx_SongB (SongIdB),
+        CONSTRAINT fk_SongLinkSugg_A FOREIGN KEY (SongIdA)
+            REFERENCES tblSongs(SongId) ON DELETE CASCADE ON UPDATE CASCADE,
+        CONSTRAINT fk_SongLinkSugg_B FOREIGN KEY (SongIdB)
+            REFERENCES tblSongs(SongId) ON DELETE CASCADE ON UPDATE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
+    if (!$db->query($sql)) {
+        _migSongLinks_out('ERROR: create tblSongLinkSuggestions failed: ' . $db->error);
+        exit(1);
+    }
+    _migSongLinks_out('[add ] tblSongLinkSuggestions.');
+}
+
+/* =========================================================================
+ * Step 3 — tblSongLinkSuggestionsDismissed
+ *
+ * Curator-rejected pairs. The build script consults this table and
+ * skips any pair that's already been dismissed, so the suggestion
+ * list doesn't keep proposing pairs the curator has already said no
+ * to. Reasons are free-text and optional.
+ * ========================================================================= */
+if (_migSongLinks_tableExists($db, 'tblSongLinkSuggestionsDismissed')) {
+    _migSongLinks_out('[skip] tblSongLinkSuggestionsDismissed already exists.');
+} else {
+    $sql = "CREATE TABLE tblSongLinkSuggestionsDismissed (
+        Id              INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+        SongIdA         VARCHAR(20)  NOT NULL COMMENT 'Always lexicographically <= SongIdB',
+        SongIdB         VARCHAR(20)  NOT NULL,
+        DismissedBy     INT UNSIGNED NULL DEFAULT NULL,
+        DismissedAt     TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        Reason          VARCHAR(255) NOT NULL DEFAULT '',
+        UNIQUE KEY uk_pair (SongIdA, SongIdB),
+        KEY idx_SongA (SongIdA),
+        KEY idx_SongB (SongIdB)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
+    if (!$db->query($sql)) {
+        _migSongLinks_out('ERROR: create tblSongLinkSuggestionsDismissed failed: ' . $db->error);
+        exit(1);
+    }
+    _migSongLinks_out('[add ] tblSongLinkSuggestionsDismissed.');
+}
+
+/* =========================================================================
+ * Final probe
+ * ========================================================================= */
+$res = $db->query('SELECT COUNT(*) FROM tblSongLinks');
+$linkCount = $res ? (int)$res->fetch_row()[0] : 0;
+if ($res) $res->close();
+$res = $db->query('SELECT COUNT(DISTINCT GroupId) FROM tblSongLinks');
+$groupCount = $res ? (int)$res->fetch_row()[0] : 0;
+if ($res) $res->close();
+$res = $db->query('SELECT COUNT(*) FROM tblSongLinkSuggestions');
+$suggCount = $res ? (int)$res->fetch_row()[0] : 0;
+if ($res) $res->close();
+$res = $db->query('SELECT COUNT(*) FROM tblSongLinkSuggestionsDismissed');
+$dismCount = $res ? (int)$res->fetch_row()[0] : 0;
+if ($res) $res->close();
+
+_migSongLinks_out("Catalogue carries {$linkCount} cross-book link row(s) "
+                . "in {$groupCount} group(s); "
+                . "{$suggCount} pending suggestion(s); "
+                . "{$dismCount} dismissed pair(s).");
+_migSongLinks_out('Cross-book song links migration finished (#807 / #808).');

--- a/appWeb/.sql/schema.sql
+++ b/appWeb/.sql/schema.sql
@@ -1419,6 +1419,78 @@ ALTER TABLE tblSongs MODIFY Number INT UNSIGNED NULL DEFAULT NULL;
 -- Zero out any existing Misc song numbers (historic placeholders).
 UPDATE tblSongs SET Number = NULL WHERE SongbookAbbr = 'Misc' AND Number IS NOT NULL;
 
+-- ----------------------------------------------------------------------------
+-- tblSongLinks (#807) — cross-book counterparts.
+-- All rows sharing a GroupId represent the same hymn in different songbooks
+-- (Amazing Grace as MP-031 / CH-376 / SDAH-108 / SoF-29 / JP-006). Distinct
+-- from tblSongTranslations (different-language same hymn) and from
+-- tblSongbooks.ParentSongbookId (which only handles translated / edition
+-- derivatives at the songbook level, requiring matching hymn numbers).
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS tblSongLinks (
+    Id           INT UNSIGNED  AUTO_INCREMENT PRIMARY KEY,
+    GroupId      INT UNSIGNED  NOT NULL
+                 COMMENT 'All songs sharing a GroupId are the same hymn (cross-book counterparts).',
+    SongId       VARCHAR(20)   NOT NULL,
+    Note         VARCHAR(255)  NOT NULL DEFAULT ''
+                 COMMENT 'Optional curator-set annotation, e.g. "uses 1990 Wesley revision text"',
+    Verified     TINYINT(1)    NOT NULL DEFAULT 0,
+    CreatedBy    INT UNSIGNED  NULL DEFAULT NULL
+                 COMMENT 'tblUsers.Id of the curator who linked this row, if signed in',
+    CreatedAt    TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uk_song (SongId),
+    KEY idx_GroupId (GroupId),
+    CONSTRAINT fk_SongLinks_Song
+        FOREIGN KEY (SongId) REFERENCES tblSongs(SongId)
+        ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+-- ----------------------------------------------------------------------------
+-- tblSongLinkSuggestions (#808) — pre-computed pairwise similarity scores.
+-- Populated by tools/build-song-link-suggestions.php; consumed by the
+-- /manage/song-link-suggestions admin page. Pairs are stored canonically
+-- with SongIdA < SongIdB so each unordered pair has at most one row.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS tblSongLinkSuggestions (
+    Id              INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    SongIdA         VARCHAR(20)  NOT NULL COMMENT 'Always lexicographically <= SongIdB',
+    SongIdB         VARCHAR(20)  NOT NULL,
+    Score           DECIMAL(4,3) NOT NULL COMMENT 'Composite similarity, 0.000-1.000',
+    TitleScore      DECIMAL(4,3) NOT NULL DEFAULT 0.000,
+    LyricsScore     DECIMAL(4,3) NOT NULL DEFAULT 0.000,
+    AuthorsScore    DECIMAL(4,3) NOT NULL DEFAULT 0.000,
+    ComputedAt      TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uk_pair (SongIdA, SongIdB),
+    KEY idx_Score (Score),
+    KEY idx_SongA (SongIdA),
+    KEY idx_SongB (SongIdB),
+    CONSTRAINT fk_SongLinkSugg_A FOREIGN KEY (SongIdA)
+        REFERENCES tblSongs(SongId) ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT fk_SongLinkSugg_B FOREIGN KEY (SongIdB)
+        REFERENCES tblSongs(SongId) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+-- ----------------------------------------------------------------------------
+-- tblSongLinkSuggestionsDismissed (#808) — curator-rejected pairs.
+-- The build job consults this table and skips dismissed pairs so the
+-- suggestion list doesn't keep proposing pairs the curator has already
+-- said no to.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS tblSongLinkSuggestionsDismissed (
+    Id              INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    SongIdA         VARCHAR(20)  NOT NULL COMMENT 'Always lexicographically <= SongIdB',
+    SongIdB         VARCHAR(20)  NOT NULL,
+    DismissedBy     INT UNSIGNED NULL DEFAULT NULL,
+    DismissedAt     TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    Reason          VARCHAR(255) NOT NULL DEFAULT '',
+    UNIQUE KEY uk_pair (SongIdA, SongIdB),
+    KEY idx_SongA (SongIdA),
+    KEY idx_SongB (SongIdB)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
 -- Search-query log for analytics (#404). Captures every search so we can
 -- surface top queries + zero-result queries in the admin dashboard.
 CREATE TABLE IF NOT EXISTS tblSearchQueries (

--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -517,6 +517,81 @@ if ($action !== null) {
             break;
 
         /* -----------------------------------------------------------------
+         * Cross-book counterparts for one song (#807)
+         * Returns every other tblSongs row that shares this song's
+         * tblSongLinks.GroupId — same hymn in a different songbook.
+         * Distinct from translations (different language) and from the
+         * songbook-level parent link (#782 phase D).
+         * Parameters: id (required) — canonical SongId, e.g. CP-0001
+         * ----------------------------------------------------------------- */
+        case 'song_links':
+            $songId = isset($_GET['id']) ? trim($_GET['id']) : '';
+            if ($songId === '') {
+                sendJson(['error' => 'Song ID is required.'], 400);
+                break;
+            }
+            try {
+                $db = getDbMysqli();
+
+                /* Probe for the table — deployments that haven't run the
+                   migration get a clean empty list rather than a 500. */
+                $probe = $db->query(
+                    "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+                      WHERE TABLE_SCHEMA = DATABASE()
+                        AND TABLE_NAME   = 'tblSongLinks' LIMIT 1"
+                );
+                $hasTable = $probe && $probe->fetch_row() !== null;
+                if ($probe) $probe->close();
+                if (!$hasTable) {
+                    sendJson(['groupId' => 0, 'songs' => []]);
+                    break;
+                }
+
+                $stmt = $db->prepare(
+                    'SELECT GroupId FROM tblSongLinks WHERE SongId = ? LIMIT 1'
+                );
+                $stmt->bind_param('s', $songId);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_assoc();
+                $stmt->close();
+                $groupId = $row ? (int)$row['GroupId'] : 0;
+
+                $songs = [];
+                if ($groupId > 0) {
+                    $stmt = $db->prepare(
+                        'SELECT s.SongId       AS id,
+                                s.Title        AS title,
+                                s.Number       AS number,
+                                s.SongbookAbbr AS songbook,
+                                sb.Name        AS songbookName,
+                                s.Language     AS language,
+                                l.Note         AS note,
+                                l.Verified     AS verified
+                           FROM tblSongLinks l
+                           JOIN tblSongs s      ON s.SongId = l.SongId
+                           JOIN tblSongbooks sb ON sb.Abbreviation = s.SongbookAbbr
+                          WHERE l.GroupId = ?
+                            AND l.SongId  <> ?
+                          ORDER BY s.SongbookAbbr ASC, s.Number ASC'
+                    );
+                    $stmt->bind_param('is', $groupId, $songId);
+                    $stmt->execute();
+                    $songs = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+                    $stmt->close();
+                    foreach ($songs as &$s) {
+                        $s['number']   = ($s['number'] === null) ? null : (int)$s['number'];
+                        $s['verified'] = (bool)$s['verified'];
+                    }
+                    unset($s);
+                }
+                sendJson(['groupId' => $groupId, 'songs' => $songs]);
+            } catch (\Throwable $e) {
+                error_log('[api] song_links failed: ' . $e->getMessage());
+                sendJson(['error' => 'Failed to load cross-book counterparts.'], 500);
+            }
+            break;
+
+        /* -----------------------------------------------------------------
          * Get all songbooks (filtered by user's preferred languages, #736)
          * ----------------------------------------------------------------- */
         case 'songbooks':

--- a/appWeb/public_html/includes/pages/song.php
+++ b/appWeb/public_html/includes/pages/song.php
@@ -184,6 +184,67 @@ foreach ($translations as &$_t) {
 }
 unset($_t);
 
+/* ===================================================================
+ * Cross-book counterparts (#807) — same hymn appearing in different
+ * songbooks at unrelated numbers.
+ *
+ * Distinct from the translations list above (different language)
+ * and from the songbook-level parent link (#782 phase D, which only
+ * fires when the parent songbook carries the same hymn number).
+ *
+ * Probes for tblSongLinks first so deployments that haven't run the
+ * migration silently skip the panel rather than 500ing.
+ * =================================================================== */
+$songLinks = [];
+try {
+    if (!isset($translationsDb)) {
+        require_once __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'db_mysql.php';
+        $translationsDb = getDbMysqli();
+    }
+    $probe = $translationsDb->query(
+        "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE()
+            AND TABLE_NAME   = 'tblSongLinks' LIMIT 1"
+    );
+    $hasLinksTable = $probe && $probe->fetch_row() !== null;
+    if ($probe) $probe->close();
+
+    if ($hasLinksTable) {
+        $sid = (string)($song['id'] ?? '');
+        $stmt = $translationsDb->prepare(
+            'SELECT s.SongId       AS song_id,
+                    s.Title        AS title,
+                    s.Number       AS number,
+                    s.SongbookAbbr AS songbook,
+                    sb.Name        AS songbook_name,
+                    s.Language     AS language
+               FROM tblSongLinks self
+               JOIN tblSongLinks other ON other.GroupId = self.GroupId
+                                     AND other.SongId <> self.SongId
+               JOIN tblSongs s         ON s.SongId = other.SongId
+               JOIN tblSongbooks sb    ON sb.Abbreviation = s.SongbookAbbr
+              WHERE self.SongId = ?
+              ORDER BY s.SongbookAbbr ASC, s.Number ASC'
+        );
+        if ($stmt !== false) {
+            $stmt->bind_param('s', $sid);
+            $stmt->execute();
+            $res = $stmt->get_result();
+            while ($row = $res->fetch_assoc()) {
+                $row['number'] = ($row['number'] === null || $row['number'] === '' || (int)$row['number'] <= 0)
+                    ? null
+                    : (int)$row['number'];
+                $songLinks[] = $row;
+            }
+            $stmt->close();
+        }
+    }
+} catch (\Throwable $_e) {
+    /* Table missing or DB hiccup — hide the panel rather than block
+       the page render. The panel is decorative; the song still loads. */
+    $songLinks = [];
+}
+
 ?>
 
 <!-- ================================================================
@@ -404,6 +465,49 @@ unset($_t);
                                         <?php if (!empty($t['verified'])): ?>
                                             <i class="fa-solid fa-circle-check text-success ms-1 small"
                                                title="Verified translation" aria-hidden="true"></i>
+                                        <?php endif; ?>
+                                    </a>
+                                </li>
+                            <?php endforeach; ?>
+                        </ul>
+                    </div>
+                </div>
+            <?php endif; ?>
+
+            <!-- ============================================================
+                 Cross-book counterparts (#807) — "Also appears in" dropdown.
+                 Shown when this song shares a tblSongLinks.GroupId with one
+                 or more other songs (same hymn, different songbook, often
+                 same language). Sits beside the translations dropdown so
+                 the two are visually parallel but semantically distinct.
+                 ============================================================ -->
+            <?php if (!empty($songLinks)): ?>
+                <div class="song-cross-book-links mb-3">
+                    <div class="dropdown">
+                        <button type="button"
+                                class="btn btn-sm btn-outline-secondary dropdown-toggle"
+                                data-bs-toggle="dropdown"
+                                aria-expanded="false"
+                                aria-label="Also appears in other songbooks">
+                            <i class="fa-solid fa-link me-1" aria-hidden="true"></i>
+                            Also appears in
+                            <?php if (count($songLinks) === 1): ?>
+                                <?= htmlspecialchars($songLinks[0]['songbook']) ?>
+                            <?php else: ?>
+                                <?= count($songLinks) ?> songbooks
+                            <?php endif; ?>
+                        </button>
+                        <ul class="dropdown-menu">
+                            <?php foreach ($songLinks as $sl): ?>
+                                <li>
+                                    <a class="dropdown-item"
+                                       href="/song/<?= htmlspecialchars($sl['song_id']) ?>"
+                                       data-navigate="song"
+                                       data-song-id="<?= htmlspecialchars($sl['song_id']) ?>">
+                                        <span class="badge bg-body-secondary me-2"><?= htmlspecialchars($sl['songbook']) ?></span>
+                                        <span class="fw-semibold"><?= htmlspecialchars($sl['songbook_name']) ?></span>
+                                        <?php if ($sl['number'] !== null): ?>
+                                            <small class="text-muted ms-1">— hymn #<?= (int)$sl['number'] ?></small>
                                         <?php endif; ?>
                                     </a>
                                 </li>

--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -580,6 +580,452 @@ switch ($action) {
         break;
 
     /* -----------------------------------------------------------------
+     * GET_SONG_LINKS — Cross-book counterparts for one song (#807)
+     *
+     * Returns every other tblSongs row that shares this song's
+     * tblSongLinks.GroupId — i.e. every counterpart appearance of
+     * the same hymn in a different songbook. Distinct from
+     * get_translations (different-language same hymn) and from the
+     * songbook-level parent link (#782 phase D).
+     * ----------------------------------------------------------------- */
+    case 'get_song_links':
+        $songId = isset($_GET['id']) ? trim($_GET['id']) : '';
+        if ($songId === '') {
+            http_response_code(400);
+            echo json_encode(['error' => 'Song ID is required.']);
+            break;
+        }
+        try {
+            $db = getDbMysqli();
+            /* Two-step: find this song's GroupId (if any), then list
+               every OTHER member of that group. Returning the GroupId
+               itself lets the editor UI distinguish "no group yet" from
+               "in a group but I'm the only member" — both render as an
+               empty list, but the second case shouldn't happen and is
+               worth surfacing if it does. */
+            $stmt = $db->prepare('SELECT GroupId FROM tblSongLinks WHERE SongId = ? LIMIT 1');
+            $stmt->bind_param('s', $songId);
+            $stmt->execute();
+            $row = $stmt->get_result()->fetch_assoc();
+            $stmt->close();
+            $groupId = $row ? (int)$row['GroupId'] : 0;
+
+            $links = [];
+            if ($groupId > 0) {
+                $stmt = $db->prepare(
+                    'SELECT l.Id          AS id,
+                            l.SongId      AS songId,
+                            l.Note        AS note,
+                            l.Verified    AS verified,
+                            s.Title       AS title,
+                            s.Number      AS number,
+                            s.SongbookAbbr AS songbook,
+                            sb.Name       AS songbookName,
+                            s.Language    AS language
+                       FROM tblSongLinks l
+                       JOIN tblSongs s      ON s.SongId = l.SongId
+                       JOIN tblSongbooks sb ON sb.Abbreviation = s.SongbookAbbr
+                      WHERE l.GroupId = ?
+                        AND l.SongId  <> ?
+                      ORDER BY s.SongbookAbbr ASC, s.Number ASC'
+                );
+                $stmt->bind_param('is', $groupId, $songId);
+                $stmt->execute();
+                $links = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+                $stmt->close();
+                foreach ($links as &$ln) {
+                    $ln['id']       = (int)$ln['id'];
+                    $ln['verified'] = (bool)$ln['verified'];
+                    $ln['number']   = ($ln['number'] === null) ? null : (int)$ln['number'];
+                }
+                unset($ln);
+            }
+            echo json_encode([
+                'groupId' => $groupId,
+                'links'   => $links,
+            ]);
+        } catch (\Throwable $e) {
+            error_log('[iHymns Editor] get_song_links failed: ' . $e->getMessage());
+            http_response_code(500);
+            echo json_encode(['error' => 'Failed to load song links.']);
+        }
+        break;
+
+    /* -----------------------------------------------------------------
+     * ADD_SONG_LINK — Link two songs as cross-book counterparts (#807)
+     *
+     * Body: { sourceSongId, targetSongId, note? }
+     *
+     * Behaviour:
+     *   - If neither song is in a group, mint a new GroupId and add
+     *     both rows under it.
+     *   - If exactly one song is in a group, add the other to it.
+     *   - If both songs are already in the SAME group, no-op.
+     *   - If the two songs are in DIFFERENT groups, refuse — curator
+     *     must explicitly merge or unlink first (prevents accidental
+     *     loss of a multi-member group).
+     * ----------------------------------------------------------------- */
+    case 'add_song_link':
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            http_response_code(405);
+            echo json_encode(['error' => 'POST method required.']);
+            break;
+        }
+        $body = json_decode(file_get_contents('php://input'), true);
+        $srcId = trim((string)($body['sourceSongId'] ?? ''));
+        $tgtId = trim((string)($body['targetSongId'] ?? ''));
+        $note  = trim((string)($body['note'] ?? ''));
+        if ($srcId === '' || $tgtId === '') {
+            http_response_code(400);
+            echo json_encode(['error' => 'sourceSongId and targetSongId are required.']);
+            break;
+        }
+        if ($srcId === $tgtId) {
+            http_response_code(400);
+            echo json_encode(['error' => 'A song cannot be linked to itself.']);
+            break;
+        }
+
+        try {
+            $db = getDbMysqli();
+
+            /* Validate both songs exist before we mutate anything —
+               cheaper than catching an FK violation after a partial
+               INSERT. */
+            $probe = $db->prepare(
+                'SELECT SongId FROM tblSongs WHERE SongId IN (?, ?)'
+            );
+            $probe->bind_param('ss', $srcId, $tgtId);
+            $probe->execute();
+            $found = [];
+            $res = $probe->get_result();
+            while ($r = $res->fetch_assoc()) $found[] = $r['SongId'];
+            $probe->close();
+            if (count($found) < 2) {
+                http_response_code(404);
+                echo json_encode(['error' => 'One or both songs were not found.']);
+                break;
+            }
+
+            /* Look up each side's existing group, if any. */
+            $lookup = $db->prepare(
+                'SELECT SongId, GroupId FROM tblSongLinks WHERE SongId IN (?, ?)'
+            );
+            $lookup->bind_param('ss', $srcId, $tgtId);
+            $lookup->execute();
+            $existing = [];
+            $res = $lookup->get_result();
+            while ($r = $res->fetch_assoc()) $existing[$r['SongId']] = (int)$r['GroupId'];
+            $lookup->close();
+
+            $srcGroup = $existing[$srcId] ?? 0;
+            $tgtGroup = $existing[$tgtId] ?? 0;
+
+            $createdBy = isset($currentUser['id']) ? (int)$currentUser['id'] : null;
+
+            if ($srcGroup > 0 && $tgtGroup > 0) {
+                if ($srcGroup === $tgtGroup) {
+                    /* Already linked — refresh the note on the target row
+                       so the curator sees their annotation persisted, but
+                       don't error. */
+                    if ($note !== '') {
+                        $upd = $db->prepare(
+                            'UPDATE tblSongLinks SET Note = ? WHERE SongId = ?'
+                        );
+                        $upd->bind_param('ss', $note, $tgtId);
+                        $upd->execute();
+                        $upd->close();
+                    }
+                    echo json_encode(['success' => true, 'groupId' => $srcGroup, 'noop' => true]);
+                    break;
+                }
+                /* Two different groups — refuse. The curator can unlink
+                   one side first, or we can add a separate "merge groups"
+                   admin action later. */
+                http_response_code(409);
+                echo json_encode([
+                    'error' => 'Both songs are already in different counterpart groups. Unlink one before linking, or use the merge tool.',
+                ]);
+                break;
+            }
+
+            if ($srcGroup === 0 && $tgtGroup === 0) {
+                /* Neither in a group — mint a new GroupId.
+                   MAX(GroupId)+1 is fine here: tblSongLinks is small,
+                   curator-edited, and AUTO_INCREMENT on GroupId would
+                   complicate the merge-groups operation. */
+                $r = $db->query('SELECT COALESCE(MAX(GroupId), 0) + 1 AS NextId FROM tblSongLinks');
+                $newGroup = $r ? (int)$r->fetch_assoc()['NextId'] : 1;
+                if ($r) $r->close();
+
+                $ins = $db->prepare(
+                    'INSERT INTO tblSongLinks (GroupId, SongId, Note, CreatedBy)
+                     VALUES (?, ?, ?, ?), (?, ?, ?, ?)'
+                );
+                $emptyNote = '';
+                $ins->bind_param(
+                    'issiisis',
+                    $newGroup, $srcId, $emptyNote, $createdBy,
+                    $newGroup, $tgtId, $note,      $createdBy
+                );
+                $ins->execute();
+                $ins->close();
+                echo json_encode(['success' => true, 'groupId' => $newGroup, 'created' => true]);
+                break;
+            }
+
+            /* Exactly one side already in a group — extend it. */
+            $joinGroup = $srcGroup > 0 ? $srcGroup : $tgtGroup;
+            $newSongId = $srcGroup > 0 ? $tgtId    : $srcId;
+            $ins = $db->prepare(
+                'INSERT INTO tblSongLinks (GroupId, SongId, Note, CreatedBy)
+                 VALUES (?, ?, ?, ?)'
+            );
+            $ins->bind_param('issi', $joinGroup, $newSongId, $note, $createdBy);
+            $ins->execute();
+            $ins->close();
+            echo json_encode(['success' => true, 'groupId' => $joinGroup, 'extended' => true]);
+        } catch (\Throwable $e) {
+            error_log('[iHymns Editor] add_song_link failed: ' . $e->getMessage());
+            http_response_code(500);
+            echo json_encode(['error' => 'Failed to add song link.']);
+        }
+        break;
+
+    /* -----------------------------------------------------------------
+     * REMOVE_SONG_LINK — Drop one song from its group (#807)
+     *
+     * Body: { id?: int, songId?: string }  (either identifier works)
+     *
+     * If removing leaves the group with only one remaining member, the
+     * remaining row is also dropped — a singleton group is meaningless
+     * and would otherwise show up as "no counterparts" forever while
+     * still occupying a UNIQUE slot.
+     * ----------------------------------------------------------------- */
+    case 'remove_song_link':
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            http_response_code(405);
+            echo json_encode(['error' => 'POST method required.']);
+            break;
+        }
+        $body     = json_decode(file_get_contents('php://input'), true);
+        $removeId = (int)($body['id'] ?? 0);
+        $songId   = trim((string)($body['songId'] ?? ''));
+        if ($removeId <= 0 && $songId === '') {
+            http_response_code(400);
+            echo json_encode(['error' => 'id or songId is required.']);
+            break;
+        }
+
+        try {
+            $db = getDbMysqli();
+
+            /* Resolve the row + its GroupId before deleting so we can
+               clean up an orphaned singleton in the same transaction. */
+            if ($removeId > 0) {
+                $stmt = $db->prepare('SELECT Id, GroupId FROM tblSongLinks WHERE Id = ?');
+                $stmt->bind_param('i', $removeId);
+            } else {
+                $stmt = $db->prepare('SELECT Id, GroupId FROM tblSongLinks WHERE SongId = ?');
+                $stmt->bind_param('s', $songId);
+            }
+            $stmt->execute();
+            $row = $stmt->get_result()->fetch_assoc();
+            $stmt->close();
+            if (!$row) {
+                /* Already gone — return success rather than 404 so a
+                   double-click on the remove button doesn't surface a
+                   spurious error. */
+                echo json_encode(['success' => true, 'deleted' => 0]);
+                break;
+            }
+
+            $groupId = (int)$row['GroupId'];
+
+            $del = $db->prepare('DELETE FROM tblSongLinks WHERE Id = ?');
+            $del->bind_param('i', $row['Id']);
+            $del->execute();
+            $deleted = $del->affected_rows;
+            $del->close();
+
+            /* If the group now has fewer than two members, drop the
+               remainder. A singleton group is meaningless. */
+            $r = $db->prepare('SELECT COUNT(*) AS n FROM tblSongLinks WHERE GroupId = ?');
+            $r->bind_param('i', $groupId);
+            $r->execute();
+            $remaining = (int)$r->get_result()->fetch_assoc()['n'];
+            $r->close();
+            if ($remaining < 2) {
+                $cleanup = $db->prepare('DELETE FROM tblSongLinks WHERE GroupId = ?');
+                $cleanup->bind_param('i', $groupId);
+                $cleanup->execute();
+                $cleanup->close();
+            }
+
+            echo json_encode(['success' => true, 'deleted' => $deleted]);
+        } catch (\Throwable $e) {
+            error_log('[iHymns Editor] remove_song_link failed: ' . $e->getMessage());
+            http_response_code(500);
+            echo json_encode(['error' => 'Failed to remove song link.']);
+        }
+        break;
+
+    /* -----------------------------------------------------------------
+     * SUGGEST_SONG_LINKS — Top similar-title pairs for one song (#808)
+     *
+     * Returns up to 5 highest-scoring pending suggestions involving
+     * the open song, used by the editor sidebar's inline
+     * "Suggested counterparts" panel. Same data the
+     * /manage/song-link-suggestions admin page lists, scoped to a
+     * single song.
+     * ----------------------------------------------------------------- */
+    case 'suggest_song_links':
+        $songId = isset($_GET['id']) ? trim($_GET['id']) : '';
+        if ($songId === '') {
+            http_response_code(400);
+            echo json_encode(['error' => 'Song ID is required.']);
+            break;
+        }
+        try {
+            $db = getDbMysqli();
+
+            /* Probe the suggestion table — it might not exist yet on
+               deployments that haven't run the migration. Returning an
+               empty list (rather than 500ing) keeps the editor working
+               while the migration's still pending. */
+            $probe = $db->query(
+                "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+                  WHERE TABLE_SCHEMA = DATABASE()
+                    AND TABLE_NAME   = 'tblSongLinkSuggestions' LIMIT 1"
+            );
+            $hasTable = $probe && $probe->fetch_row() !== null;
+            if ($probe) $probe->close();
+            if (!$hasTable) {
+                echo json_encode(['suggestions' => [], 'tableMissing' => true]);
+                break;
+            }
+
+            $stmt = $db->prepare(
+                'SELECT s.Id        AS id,
+                        s.SongIdA   AS songIdA,
+                        s.SongIdB   AS songIdB,
+                        s.Score     AS score,
+                        s.TitleScore AS titleScore,
+                        s.LyricsScore AS lyricsScore,
+                        a.Title     AS titleA,
+                        a.Number    AS numberA,
+                        a.SongbookAbbr AS songbookA,
+                        b.Title     AS titleB,
+                        b.Number    AS numberB,
+                        b.SongbookAbbr AS songbookB
+                   FROM tblSongLinkSuggestions s
+                   JOIN tblSongs a ON a.SongId = s.SongIdA
+                   JOIN tblSongs b ON b.SongId = s.SongIdB
+                  WHERE (s.SongIdA = ? OR s.SongIdB = ?)
+                    AND NOT EXISTS (
+                        SELECT 1 FROM tblSongLinkSuggestionsDismissed d
+                         WHERE d.SongIdA = s.SongIdA AND d.SongIdB = s.SongIdB
+                    )
+                    /* Skip pairs where both songs are already in the
+                       same counterpart group — they\'re already linked. */
+                    AND NOT EXISTS (
+                        SELECT 1
+                          FROM tblSongLinks la
+                          JOIN tblSongLinks lb ON la.GroupId = lb.GroupId
+                         WHERE la.SongId = s.SongIdA AND lb.SongId = s.SongIdB
+                    )
+                  ORDER BY s.Score DESC
+                  LIMIT 5'
+            );
+            $stmt->bind_param('ss', $songId, $songId);
+            $stmt->execute();
+            $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+            $stmt->close();
+
+            /* Normalise the response so the "other side" is always in
+               a single `other` field, regardless of which slot the
+               current song was found in. */
+            $suggestions = [];
+            foreach ($rows as $r) {
+                $isA = ($r['songIdA'] === $songId);
+                $suggestions[] = [
+                    'id'          => (int)$r['id'],
+                    'score'       => (float)$r['score'],
+                    'titleScore'  => (float)$r['titleScore'],
+                    'lyricsScore' => (float)$r['lyricsScore'],
+                    'other' => [
+                        'songId'   => $isA ? $r['songIdB']  : $r['songIdA'],
+                        'title'    => $isA ? $r['titleB']   : $r['titleA'],
+                        'number'   => $isA ? $r['numberB']  : $r['numberA'],
+                        'songbook' => $isA ? $r['songbookB']: $r['songbookA'],
+                    ],
+                ];
+            }
+            echo json_encode(['suggestions' => $suggestions]);
+        } catch (\Throwable $e) {
+            error_log('[iHymns Editor] suggest_song_links failed: ' . $e->getMessage());
+            http_response_code(500);
+            echo json_encode(['error' => 'Failed to load suggestions.']);
+        }
+        break;
+
+    /* -----------------------------------------------------------------
+     * DISMISS_SONG_LINK_SUGGESTION — Curator says "no, different hymns" (#808)
+     *
+     * Body: { songIdA, songIdB, reason? }  (canonical order enforced
+     *       server-side so callers needn't pre-sort)
+     * ----------------------------------------------------------------- */
+    case 'dismiss_song_link_suggestion':
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            http_response_code(405);
+            echo json_encode(['error' => 'POST method required.']);
+            break;
+        }
+        $body = json_decode(file_get_contents('php://input'), true);
+        $a    = trim((string)($body['songIdA'] ?? ''));
+        $b    = trim((string)($body['songIdB'] ?? ''));
+        $reason = trim((string)($body['reason'] ?? ''));
+        if ($a === '' || $b === '' || $a === $b) {
+            http_response_code(400);
+            echo json_encode(['error' => 'songIdA and songIdB are required and must differ.']);
+            break;
+        }
+        /* Canonicalise: SongIdA < SongIdB lexicographically, matching
+           the build-script invariant. */
+        if ($a > $b) { [$a, $b] = [$b, $a]; }
+
+        try {
+            $db = getDbMysqli();
+            $dismissedBy = isset($currentUser['id']) ? (int)$currentUser['id'] : null;
+            $stmt = $db->prepare(
+                'INSERT INTO tblSongLinkSuggestionsDismissed (SongIdA, SongIdB, DismissedBy, Reason)
+                 VALUES (?, ?, ?, ?)
+                 ON DUPLICATE KEY UPDATE Reason = VALUES(Reason),
+                                         DismissedBy = VALUES(DismissedBy),
+                                         DismissedAt = CURRENT_TIMESTAMP'
+            );
+            $stmt->bind_param('ssis', $a, $b, $dismissedBy, $reason);
+            $stmt->execute();
+            $stmt->close();
+
+            /* Drop the matching pending suggestion so it disappears
+               from every consumer immediately. */
+            $del = $db->prepare(
+                'DELETE FROM tblSongLinkSuggestions WHERE SongIdA = ? AND SongIdB = ?'
+            );
+            $del->bind_param('ss', $a, $b);
+            $del->execute();
+            $del->close();
+
+            echo json_encode(['success' => true]);
+        } catch (\Throwable $e) {
+            error_log('[iHymns Editor] dismiss_song_link_suggestion failed: ' . $e->getMessage());
+            http_response_code(500);
+            echo json_encode(['error' => 'Failed to dismiss suggestion.']);
+        }
+        break;
+
+    /* -----------------------------------------------------------------
      * SAVE_SONG — Write a single song's data (#394)
      *
      * UPSERT of one song + its child rows (writers/composers/components)
@@ -1942,7 +2388,7 @@ switch ($action) {
      * ----------------------------------------------------------------- */
     default:
         http_response_code(400);
-        echo json_encode(['error' => 'Unknown action. Use: load, save, save_song, save_song_tags, tag_search, credit_search, bulk_tag, list_revisions, restore_revision, get_translations, add_translation, remove_translation, bulk_import_zip, bulk_import_status']);
+        echo json_encode(['error' => 'Unknown action. Use: load, save, save_song, save_song_tags, tag_search, credit_search, bulk_tag, list_revisions, restore_revision, get_translations, add_translation, remove_translation, get_song_links, add_song_link, remove_song_link, suggest_song_links, dismiss_song_link_suggestion, bulk_import_zip, bulk_import_status']);
         break;
 }
 

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -594,6 +594,13 @@ function selectSong(songId) {
     /* Render the translations (cross-song link) panel (#352). */
     renderTranslations(song);
 
+    /* Render cross-book counterparts (#807) and pull suggestions
+       for the open song (#808). Both are async — the panels show
+       a loading hint until their fetch resolves, and a switched
+       song mid-flight cancels via the currentSongId guard inside
+       each callback. */
+    renderSongLinks(song);
+
     /* Fetch + render this song's tags (#496). Async — the chip list
        shows "Loading…" until the fetch resolves; failures keep the
        list empty rather than blocking the whole editor. */
@@ -2209,6 +2216,366 @@ function initTranslationControls() {
     });
 }
 
+/* ============================================================================
+ * Cross-book counterparts (#807) — same hymn in different songbooks.
+ *
+ * Differs from the Translations panel in two ways:
+ *   1. Counterparts are typically same-language, different-songbook.
+ *   2. Persistence is server-side immediate (POST /api?action=add_song_link)
+ *      rather than batched into the song's save payload — the relationship
+ *      is independent of the song's other metadata, so deferring to save
+ *      would break the "linked songs appear on each other's page" promise
+ *      until the second song was also saved.
+ * ============================================================================ */
+
+/* Latest fetch result kept in-memory so render-only re-runs don't refetch. */
+var songLinksCache = { songId: null, links: [] };
+
+/**
+ * fetchSongLinks(songId, cb)
+ * --------------------------
+ * Reads the current cross-book counterparts for one song from
+ * /api?action=get_song_links and invokes cb({groupId, links}).
+ */
+function fetchSongLinks(songId, cb) {
+    fetch('api.php?action=get_song_links&id=' + encodeURIComponent(songId))
+        .then(function (r) { return r.json(); })
+        .then(function (data) {
+            if (data && data.error) { cb({ groupId: 0, links: [] }); return; }
+            cb({
+                groupId: data.groupId || 0,
+                links:   Array.isArray(data.links) ? data.links : [],
+            });
+        })
+        .catch(function () { cb({ groupId: 0, links: [] }); });
+}
+
+/**
+ * renderSongLinks(song)
+ * ---------------------
+ * Populates #song-links-container with one row per cross-book counterpart.
+ * The dataset is loaded asynchronously; while the fetch is in flight the
+ * container shows a small loading message.
+ *
+ * @param {Object} song - The currently-open song.
+ */
+function renderSongLinks(song) {
+    var container = document.getElementById('song-links-container');
+    if (!container) return;
+
+    /* Songs that haven't been persisted yet (synthetic ID prefix
+       "song-") have no FK target in tblSongs, so the API would 404
+       any link attempt. Surface that explicitly rather than letting
+       the user click Link and watch it fail. */
+    var unsaved = (typeof song.id === 'string' && song.id.indexOf('song-') === 0);
+    if (unsaved) {
+        container.innerHTML = '';
+        var hint = document.createElement('span');
+        hint.className = 'text-muted small';
+        hint.textContent = 'Save the song first, then add counterparts.';
+        container.appendChild(hint);
+        var datalist0 = document.getElementById('song-link-song-list');
+        if (datalist0) datalist0.innerHTML = '';
+        var sugBox = document.getElementById('song-link-suggestions');
+        if (sugBox) sugBox.style.display = 'none';
+        return;
+    }
+
+    container.innerHTML = '';
+    var loading = document.createElement('span');
+    loading.className = 'text-muted small';
+    loading.textContent = 'Loading cross-book counterparts…';
+    container.appendChild(loading);
+
+    /* Populate the datalist eagerly — the user might start typing
+       before the fetch returns. */
+    var datalist = document.getElementById('song-link-song-list');
+    if (datalist) {
+        datalist.innerHTML = '';
+        songData.songs.forEach(function (s) {
+            if (s.id === song.id) return;
+            var opt = document.createElement('option');
+            opt.value = s.id;
+            opt.textContent = s.title + ' (' + (s.songbook || '?') + ')';
+            datalist.appendChild(opt);
+        });
+    }
+
+    fetchSongLinks(song.id, function (data) {
+        /* Guard against an out-of-order fetch: the user may have
+           switched songs while the network call was in flight. */
+        if (currentSongId !== song.id) return;
+
+        songLinksCache = { songId: song.id, links: data.links };
+        container.innerHTML = '';
+
+        if (!data.links.length) {
+            var empty = document.createElement('span');
+            empty.className = 'text-muted small';
+            empty.textContent = 'No cross-book counterparts linked yet.';
+            container.appendChild(empty);
+        } else {
+            data.links.forEach(function (ln) {
+                var row = document.createElement('div');
+                row.className = 'd-flex align-items-center gap-2 mb-1';
+
+                var badge = document.createElement('span');
+                badge.className = 'badge bg-secondary';
+                badge.textContent = ln.songbook || '?';
+
+                var info = document.createElement('span');
+                info.className = 'flex-grow-1 small';
+                var strong = document.createElement('strong');
+                strong.textContent = ln.songId;
+                info.appendChild(strong);
+                var suffix = ' — ' + (ln.title || '(unknown)');
+                if (ln.number !== null && ln.number !== undefined) {
+                    suffix += ' (#' + ln.number + ')';
+                }
+                info.appendChild(document.createTextNode(suffix));
+
+                var removeBtn = document.createElement('button');
+                removeBtn.type = 'button';
+                removeBtn.className = 'btn btn-sm btn-outline-danger';
+                removeBtn.title = 'Unlink this counterpart';
+                removeBtn.innerHTML = '<i class="bi bi-x-lg"></i>';
+                removeBtn.addEventListener('click', function () {
+                    removeSongLink(song.id, ln.songId);
+                });
+
+                row.appendChild(badge);
+                row.appendChild(info);
+                row.appendChild(removeBtn);
+                container.appendChild(row);
+            });
+        }
+
+        /* Suggestions panel refresh runs alongside the link list. */
+        renderSongLinkSuggestions(song);
+    });
+}
+
+/**
+ * addSongLinkClickHandler()
+ * -------------------------
+ * Wired to the "Link" button below the counterparts list. POSTs to
+ * /api?action=add_song_link, then re-renders both the list and the
+ * suggestions panel on success.
+ */
+function addSongLinkClickHandler() {
+    if (!currentSongId) {
+        showToast('Select a song first.', 'warning');
+        return;
+    }
+    var input = document.getElementById('add-song-link-songid');
+    var targetId = (input.value || '').trim();
+    if (!targetId) {
+        showToast('Enter a target Song ID.', 'warning');
+        return;
+    }
+    if (targetId === currentSongId) {
+        showToast('A song cannot be a counterpart of itself.', 'warning');
+        return;
+    }
+    var targetSong = songData.songs.find(function (s) { return s.id === targetId; });
+    if (!targetSong) {
+        showToast('Song "' + targetId + '" not found in the database.', 'danger');
+        return;
+    }
+
+    fetch('api.php?action=add_song_link', {
+        method:  'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body:    JSON.stringify({ sourceSongId: currentSongId, targetSongId: targetId }),
+    })
+        .then(function (r) { return r.json().then(function (j) { return { status: r.status, body: j }; }); })
+        .then(function (resp) {
+            if (resp.status >= 400 || (resp.body && resp.body.error)) {
+                showToast(resp.body && resp.body.error
+                    ? resp.body.error
+                    : 'Failed to add counterpart link.', 'danger');
+                return;
+            }
+            input.value = '';
+            var song = songData.songs.find(function (s) { return s.id === currentSongId; });
+            if (song) renderSongLinks(song);
+            showToast('Cross-book counterpart linked.', 'success');
+        })
+        .catch(function () {
+            showToast('Network error while linking counterpart.', 'danger');
+        });
+}
+
+/**
+ * removeSongLink(currentId, targetSongId)
+ * ---------------------------------------
+ * Drops the link for `targetSongId` from the current group. The server
+ * also drops the remaining row if removing leaves a singleton group.
+ */
+function removeSongLink(currentId, targetSongId) {
+    fetch('api.php?action=remove_song_link', {
+        method:  'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body:    JSON.stringify({ songId: targetSongId }),
+    })
+        .then(function (r) { return r.json(); })
+        .then(function (data) {
+            if (data && data.error) {
+                showToast(data.error, 'danger');
+                return;
+            }
+            var song = songData.songs.find(function (s) { return s.id === currentId; });
+            if (song) renderSongLinks(song);
+            showToast('Cross-book counterpart unlinked.', 'success');
+        })
+        .catch(function () {
+            showToast('Network error while unlinking counterpart.', 'danger');
+        });
+}
+
+/**
+ * renderSongLinkSuggestions(song)
+ * -------------------------------
+ * Populates #song-link-suggestions with up to 5 high-similarity pairs
+ * involving the open song. Hidden when no suggestions are available.
+ *
+ * Server-side endpoint also returns `tableMissing: true` when the
+ * suggestion table doesn't exist yet (migration not applied) — in
+ * that case we silently keep the panel hidden.
+ */
+function renderSongLinkSuggestions(song) {
+    var box   = document.getElementById('song-link-suggestions');
+    var list  = document.getElementById('song-link-suggestions-list');
+    if (!box || !list) return;
+
+    fetch('api.php?action=suggest_song_links&id=' + encodeURIComponent(song.id))
+        .then(function (r) { return r.json(); })
+        .then(function (data) {
+            if (currentSongId !== song.id) return;
+            var suggestions = (data && Array.isArray(data.suggestions)) ? data.suggestions : [];
+            if (!suggestions.length) {
+                box.style.display = 'none';
+                list.innerHTML = '';
+                return;
+            }
+            list.innerHTML = '';
+            suggestions.forEach(function (sg) {
+                var row = document.createElement('div');
+                row.className = 'd-flex align-items-center gap-2 mb-1 small';
+
+                var scoreBadge = document.createElement('span');
+                scoreBadge.className = 'badge bg-info-subtle text-info-emphasis';
+                scoreBadge.textContent = Math.round(sg.score * 100) + '%';
+                scoreBadge.title = 'Title score ' + Math.round(sg.titleScore * 100)
+                                 + '% · lyrics score ' + Math.round(sg.lyricsScore * 100) + '%';
+
+                var info = document.createElement('span');
+                info.className = 'flex-grow-1';
+                var idChip = document.createElement('strong');
+                idChip.textContent = sg.other.songId;
+                info.appendChild(idChip);
+                var label = ' — ' + (sg.other.title || '(untitled)');
+                if (sg.other.number !== null && sg.other.number !== undefined) {
+                    label += ' (' + (sg.other.songbook || '?') + ' #' + sg.other.number + ')';
+                } else if (sg.other.songbook) {
+                    label += ' (' + sg.other.songbook + ')';
+                }
+                info.appendChild(document.createTextNode(label));
+
+                var linkBtn = document.createElement('button');
+                linkBtn.type = 'button';
+                linkBtn.className = 'btn btn-sm btn-outline-success';
+                linkBtn.title = 'Link as the same hymn';
+                linkBtn.innerHTML = '<i class="bi bi-link-45deg"></i>';
+                linkBtn.addEventListener('click', function () {
+                    fetch('api.php?action=add_song_link', {
+                        method:  'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body:    JSON.stringify({
+                            sourceSongId: song.id,
+                            targetSongId: sg.other.songId,
+                        }),
+                    })
+                        .then(function (r) { return r.json().then(function (j) { return { status: r.status, body: j }; }); })
+                        .then(function (resp) {
+                            if (resp.status >= 400 || (resp.body && resp.body.error)) {
+                                showToast(resp.body && resp.body.error
+                                    ? resp.body.error
+                                    : 'Failed to link from suggestion.', 'danger');
+                                return;
+                            }
+                            showToast('Linked as same hymn.', 'success');
+                            renderSongLinks(song);
+                        })
+                        .catch(function () {
+                            showToast('Network error.', 'danger');
+                        });
+                });
+
+                var dismissBtn = document.createElement('button');
+                dismissBtn.type = 'button';
+                dismissBtn.className = 'btn btn-sm btn-outline-secondary';
+                dismissBtn.title = 'Dismiss — different hymns';
+                dismissBtn.innerHTML = '<i class="bi bi-x-lg"></i>';
+                dismissBtn.addEventListener('click', function () {
+                    fetch('api.php?action=dismiss_song_link_suggestion', {
+                        method:  'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body:    JSON.stringify({
+                            songIdA: song.id,
+                            songIdB: sg.other.songId,
+                        }),
+                    })
+                        .then(function (r) { return r.json(); })
+                        .then(function (data) {
+                            if (data && data.error) {
+                                showToast(data.error, 'danger');
+                                return;
+                            }
+                            showToast('Suggestion dismissed.', 'info');
+                            renderSongLinkSuggestions(song);
+                        })
+                        .catch(function () {
+                            showToast('Network error.', 'danger');
+                        });
+                });
+
+                row.appendChild(scoreBadge);
+                row.appendChild(info);
+                row.appendChild(linkBtn);
+                row.appendChild(dismissBtn);
+                list.appendChild(row);
+            });
+            box.style.display = '';
+        })
+        .catch(function () {
+            box.style.display = 'none';
+        });
+}
+
+/**
+ * initSongLinksControls()
+ * -----------------------
+ * Wires the "Link" button. Idempotent: safe to call from init().
+ */
+function initSongLinksControls() {
+    var addBtn = document.getElementById('add-song-link-btn');
+    if (!addBtn) return;
+    addBtn.addEventListener('click', addSongLinkClickHandler);
+
+    /* Enter on the input field also triggers Link — matches the
+       interaction model on the Translations input. */
+    var input = document.getElementById('add-song-link-songid');
+    if (input) {
+        input.addEventListener('keydown', function (e) {
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                addSongLinkClickHandler();
+            }
+        });
+    }
+}
+
 /**
  * createDynamicInputRow(value, onChange, onRemove)
  * ------------------------------------------------
@@ -3606,6 +3973,9 @@ function init() {
 
     /* Bind translation controls (#352). */
     initTranslationControls();
+
+    /* Bind cross-book counterparts controls (#807). */
+    initSongLinksControls();
 
     /* Structure tab is display:none until its Bootstrap tab is opened,
        so scrollHeight reads 0 on any component textarea fitted while

--- a/appWeb/public_html/manage/editor/index.php
+++ b/appWeb/public_html/manage/editor/index.php
@@ -1012,6 +1012,47 @@ $currentUser = getCurrentUser();
                             </div>
                         </div>
 
+                        <!-- Cross-book counterparts (#807) — same hymn in different songbooks.
+                             Distinct from Translations: counterparts are typically the same
+                             language, different songbook, unrelated number — e.g. Amazing Grace
+                             as MP-031 and CH-376 and SDAH-108. -->
+                        <div class="mb-4">
+                            <label class="form-label">
+                                <i class="bi bi-link-45deg me-1"></i>Cross-book counterparts
+                            </label>
+                            <div class="form-text mb-2" style="color: var(--ih-text-muted); font-size: 0.75rem;">
+                                Link this song to its appearances in other songbooks (same hymn,
+                                different number). Use Translations for other-language versions.
+                            </div>
+
+                            <!-- Dynamic list of counterpart rows, rendered by editor.js. -->
+                            <div id="song-links-container">
+                                <span class="text-muted small">Save the song first, then add counterparts.</span>
+                            </div>
+
+                            <!-- Add Counterpart form -->
+                            <div class="input-group input-group-sm mt-2">
+                                <input type="text" class="form-control" id="add-song-link-songid"
+                                       placeholder="Target Song ID (e.g. CH-0376)" list="song-link-song-list">
+                                <datalist id="song-link-song-list"></datalist>
+                                <button type="button" class="btn btn-outline-primary" id="add-song-link-btn">
+                                    <i class="bi bi-plus-lg me-1"></i>Link
+                                </button>
+                            </div>
+
+                            <!-- Suggested counterparts (#808) — top similar-titled candidates.
+                                 Hidden until at least one suggestion exists for the open song. -->
+                            <div id="song-link-suggestions" class="mt-3" style="display:none;">
+                                <div class="form-text mb-2" style="color: var(--ih-text-muted); font-size: 0.75rem;">
+                                    <i class="bi bi-lightbulb me-1"></i>
+                                    Suggested counterparts — similar titles in other songbooks:
+                                </div>
+                                <div id="song-link-suggestions-list">
+                                    <!-- Rendered by editor.js -->
+                                </div>
+                            </div>
+                        </div>
+
                         <!-- Copyright Text — free-text copyright notice -->
                         <div class="mb-3">
                             <label for="edit-copyright" class="form-label">

--- a/appWeb/public_html/manage/includes/admin-links.php
+++ b/appWeb/public_html/manage/includes/admin-links.php
@@ -36,6 +36,7 @@ $_adminLinks = [
     ['requests',        '/manage/requests',        'bi-lightbulb',      'Song Requests',        'review_song_requests',        'Content'    ],
     ['revisions',       '/manage/revisions',       'bi-clock-history',  'Revisions Audit',      'verify_songs',                'Content'    ],
     ['missing-numbers', '/manage/missing-numbers', 'bi-binoculars',     'Missing Numbers',      'edit_songs',                  'Content'    ],
+    ['song-link-suggestions', '/manage/song-link-suggestions', 'bi-lightbulb', 'Song Link Suggestions', 'edit_songs',         'Content'    ],
     ['songbooks',       '/manage/songbooks',       'bi-book',           'Songbooks',            'manage_songbooks',            'Content'    ],
     ['songbook-series', '/manage/songbook-series', 'bi-collection',     'Songbook Series',      'manage_songbooks',            'Content'    ],
     ['credit-people',   '/manage/credit-people',   'bi-person-badge',   'Credit People',        'manage_credit_people',        'Content'    ],

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -226,6 +226,7 @@ if ($action !== '') {
         'tblsongs-number-nullable' => 'migrate-tblsongs-number-nullable.php',
         'multi-language-tables'    => 'migrate-multi-language-tables.php',
         'parent-songbooks'         => 'migrate-parent-songbooks.php',
+        'song-links'               => 'migrate-song-links.php',
         'recompute-songbook-songcount' => 'migrate-recompute-songbook-songcount.php',
         'songcount-triggers'           => 'migrate-songcount-triggers.php',
         'cleanup'     => 'cleanup.php',
@@ -272,6 +273,7 @@ if ($action !== '') {
         'tblsongs-number-nullable',
         'multi-language-tables',
         'parent-songbooks',
+        'song-links',
         'recompute-songbook-songcount',
         'songcount-triggers',
         /* When you add a new migrate-*.php under appWeb/.sql/, ALSO add
@@ -1102,6 +1104,31 @@ if ($hasCredentials && defined('DB_HOST')) {
                         </p>
                         <a href="?action=recompute-songbook-songcount" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
                             Run Songbook SongCount Recompute
+                        </a>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="card bg-dark border-secondary h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">3y2. Cross-book song links (#807 / #808)</h5>
+                        <p class="card-text text-secondary small">
+                            Creates <code>tblSongLinks</code> for the
+                            "this hymn appears in multiple songbooks"
+                            relationship (Amazing Grace as MP-031 / CH-376
+                            / SDAH-108 / SoF-29 / JP-006), plus
+                            <code>tblSongLinkSuggestions</code> +
+                            <code>tblSongLinkSuggestionsDismissed</code>
+                            for the admin similar-titled-song candidate
+                            list (#808). Distinct from
+                            <code>tblSongTranslations</code>
+                            (different-language same hymn) and
+                            <code>tblSongbooks.ParentSongbookId</code>
+                            (translated / edition derivatives at the
+                            songbook level). Idempotent.
+                        </p>
+                        <a href="?action=song-links" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
+                            Run Cross-book Song Links Migration
                         </a>
                     </div>
                 </div>

--- a/appWeb/public_html/manage/song-link-suggestions.php
+++ b/appWeb/public_html/manage/song-link-suggestions.php
@@ -1,0 +1,410 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Admin: Cross-book song link suggestions (#808)
+ *
+ * Lists pre-computed pairwise similarity candidates so a curator
+ * can one-click link them as the same hymn (writing into
+ * tblSongLinks) or dismiss them (writing into
+ * tblSongLinkSuggestionsDismissed). The producer side of the
+ * pipeline is tools/build-song-link-suggestions.php — this page
+ * only consumes that table.
+ *
+ * Entitlement: edit_songs (curators who can fix song metadata
+ * are the same set who should triage candidate links).
+ */
+
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'config.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
+
+requireAuth();
+$currentUser = getCurrentUser();
+if (!userHasEntitlement('edit_songs', $currentUser['role'] ?? null)) {
+    http_response_code(403);
+    exit('Access denied — song-link suggestions require the edit_songs entitlement.');
+}
+
+$activePage = 'song-link-suggestions';
+
+$flash = '';
+$error = '';
+
+$db = null;
+try {
+    $db = getDbMysqli();
+} catch (\Throwable $e) {
+    error_log('[song-link-suggestions] getDbMysqli failed: ' . $e->getMessage());
+    $error = 'Database is currently unreachable. ' . $e->getMessage();
+}
+
+/* Quick probe — if the migration hasn't been applied yet, we surface
+   a hint instead of crashing on the SELECT below. */
+$tablesPresent = false;
+if ($db) {
+    $probe = $db->query(
+        "SELECT COUNT(*) AS n FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE()
+            AND TABLE_NAME IN ('tblSongLinks','tblSongLinkSuggestions','tblSongLinkSuggestionsDismissed')"
+    );
+    if ($probe) {
+        $row = $probe->fetch_assoc();
+        $tablesPresent = ((int)($row['n'] ?? 0)) === 3;
+        $probe->close();
+    }
+}
+
+/* ---- POST handlers ---- */
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!validateCsrf((string)($_POST['csrf_token'] ?? ''))) {
+        http_response_code(403);
+        exit('Invalid CSRF token');
+    }
+    $postAction = (string)($_POST['action'] ?? '');
+    if ($postAction === 'rebuild') {
+        /* Run the builder script in-process. The script writes to
+           stdout via _bsls_out(), which we capture and surface as a
+           flash so the curator sees what was rebuilt. */
+        ob_start();
+        try {
+            require dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'tools' . DIRECTORY_SEPARATOR . 'build-song-link-suggestions.php';
+            $output = ob_get_clean();
+            $flash = 'Rebuilt suggestion list. ' . strip_tags(str_replace('<br>', ' · ', $output));
+        } catch (\Throwable $e) {
+            ob_end_clean();
+            $error = 'Rebuild failed: ' . $e->getMessage();
+        }
+    } elseif ($postAction === 'link' && $tablesPresent) {
+        /* The Link button ultimately POSTs to the editor's
+           add_song_link endpoint — we replicate the minimum logic
+           here to keep the page self-contained, since the editor API
+           insists on editor+ role and this surface is already gated
+           by edit_songs. */
+        $a = trim((string)($_POST['songIdA'] ?? ''));
+        $b = trim((string)($_POST['songIdB'] ?? ''));
+        if ($a !== '' && $b !== '' && $a !== $b) {
+            try {
+                $createdBy = (int)($currentUser['id'] ?? 0) ?: null;
+                /* Find any existing groups for either side. */
+                $stmt = $db->prepare('SELECT SongId, GroupId FROM tblSongLinks WHERE SongId IN (?, ?)');
+                $stmt->bind_param('ss', $a, $b);
+                $stmt->execute();
+                $existing = [];
+                $res = $stmt->get_result();
+                while ($r = $res->fetch_assoc()) $existing[$r['SongId']] = (int)$r['GroupId'];
+                $stmt->close();
+
+                $aG = $existing[$a] ?? 0;
+                $bG = $existing[$b] ?? 0;
+                if ($aG > 0 && $bG > 0 && $aG !== $bG) {
+                    $error = 'Both songs are already in different counterpart groups. Unlink one in the editor first.';
+                } elseif ($aG > 0 && $bG > 0) {
+                    $flash = 'Already linked.';
+                } else {
+                    if ($aG === 0 && $bG === 0) {
+                        $r = $db->query('SELECT COALESCE(MAX(GroupId), 0) + 1 AS NextId FROM tblSongLinks');
+                        $newGroup = $r ? (int)$r->fetch_assoc()['NextId'] : 1;
+                        if ($r) $r->close();
+                        $emptyNote = '';
+                        $ins = $db->prepare(
+                            'INSERT INTO tblSongLinks (GroupId, SongId, Note, CreatedBy)
+                             VALUES (?, ?, ?, ?), (?, ?, ?, ?)'
+                        );
+                        $ins->bind_param(
+                            'issiisis',
+                            $newGroup, $a, $emptyNote, $createdBy,
+                            $newGroup, $b, $emptyNote, $createdBy
+                        );
+                        $ins->execute();
+                        $ins->close();
+                        $flash = 'Linked as same hymn (new group).';
+                    } else {
+                        $joinGroup = $aG > 0 ? $aG : $bG;
+                        $newSong   = $aG > 0 ? $b  : $a;
+                        $emptyNote = '';
+                        $ins = $db->prepare(
+                            'INSERT INTO tblSongLinks (GroupId, SongId, Note, CreatedBy)
+                             VALUES (?, ?, ?, ?)'
+                        );
+                        $ins->bind_param('issi', $joinGroup, $newSong, $emptyNote, $createdBy);
+                        $ins->execute();
+                        $ins->close();
+                        $flash = 'Linked as same hymn (joined existing group).';
+                    }
+                    /* Drop the suggestion now that it's resolved. */
+                    /* Canonical order matches the build-script invariant. */
+                    $idA = $a; $idB = $b;
+                    if ($idA > $idB) { [$idA, $idB] = [$idB, $idA]; }
+                    $del = $db->prepare(
+                        'DELETE FROM tblSongLinkSuggestions WHERE SongIdA = ? AND SongIdB = ?'
+                    );
+                    $del->bind_param('ss', $idA, $idB);
+                    $del->execute();
+                    $del->close();
+                }
+            } catch (\Throwable $e) {
+                $error = 'Failed to link: ' . $e->getMessage();
+            }
+        }
+    } elseif ($postAction === 'dismiss' && $tablesPresent) {
+        $a = trim((string)($_POST['songIdA'] ?? ''));
+        $b = trim((string)($_POST['songIdB'] ?? ''));
+        $reason = trim((string)($_POST['reason'] ?? ''));
+        if ($a !== '' && $b !== '' && $a !== $b) {
+            if ($a > $b) { [$a, $b] = [$b, $a]; }
+            try {
+                $by = (int)($currentUser['id'] ?? 0) ?: null;
+                $stmt = $db->prepare(
+                    'INSERT INTO tblSongLinkSuggestionsDismissed (SongIdA, SongIdB, DismissedBy, Reason)
+                     VALUES (?, ?, ?, ?)
+                     ON DUPLICATE KEY UPDATE Reason = VALUES(Reason),
+                                             DismissedBy = VALUES(DismissedBy),
+                                             DismissedAt = CURRENT_TIMESTAMP'
+                );
+                $stmt->bind_param('ssis', $a, $b, $by, $reason);
+                $stmt->execute();
+                $stmt->close();
+                $del = $db->prepare(
+                    'DELETE FROM tblSongLinkSuggestions WHERE SongIdA = ? AND SongIdB = ?'
+                );
+                $del->bind_param('ss', $a, $b);
+                $del->execute();
+                $del->close();
+                $flash = 'Suggestion dismissed.';
+            } catch (\Throwable $e) {
+                $error = 'Failed to dismiss: ' . $e->getMessage();
+            }
+        }
+    }
+    /* PRG so refresh doesn't re-submit. */
+    $qs = ['flash' => $flash, 'error' => $error];
+    header('Location: /manage/song-link-suggestions?' . http_build_query(array_filter($qs)));
+    exit;
+}
+
+if (!empty($_GET['flash'])) $flash = (string)$_GET['flash'];
+if (!empty($_GET['error'])) $error = (string)$_GET['error'];
+
+/* ---- Read pending suggestions ---- */
+$page    = max(1, (int)($_GET['page'] ?? 1));
+$perPage = 30;
+$offset  = ($page - 1) * $perPage;
+
+$rows = [];
+$totalRows = 0;
+if ($db && $tablesPresent && !$error) {
+    try {
+        $cnt = $db->query(
+            'SELECT COUNT(*) AS n FROM tblSongLinkSuggestions s
+             WHERE NOT EXISTS (
+                 SELECT 1 FROM tblSongLinkSuggestionsDismissed d
+                  WHERE d.SongIdA = s.SongIdA AND d.SongIdB = s.SongIdB
+             )'
+        );
+        if ($cnt) {
+            $totalRows = (int)$cnt->fetch_assoc()['n'];
+            $cnt->close();
+        }
+
+        $stmt = $db->prepare(
+            'SELECT s.SongIdA, s.SongIdB, s.Score, s.TitleScore, s.LyricsScore, s.AuthorsScore,
+                    a.Title AS TitleA, a.Number AS NumberA, a.SongbookAbbr AS SongbookA, a.Language AS LangA,
+                    b.Title AS TitleB, b.Number AS NumberB, b.SongbookAbbr AS SongbookB, b.Language AS LangB,
+                    sa.Name AS SongbookNameA,
+                    sb.Name AS SongbookNameB
+               FROM tblSongLinkSuggestions s
+               JOIN tblSongs     a  ON a.SongId = s.SongIdA
+               JOIN tblSongs     b  ON b.SongId = s.SongIdB
+               JOIN tblSongbooks sa ON sa.Abbreviation = a.SongbookAbbr
+               JOIN tblSongbooks sb ON sb.Abbreviation = b.SongbookAbbr
+              WHERE NOT EXISTS (
+                  SELECT 1 FROM tblSongLinkSuggestionsDismissed d
+                   WHERE d.SongIdA = s.SongIdA AND d.SongIdB = s.SongIdB
+              )
+              ORDER BY s.Score DESC, s.SongIdA ASC
+              LIMIT ? OFFSET ?'
+        );
+        $stmt->bind_param('ii', $perPage, $offset);
+        $stmt->execute();
+        $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+        $stmt->close();
+    } catch (\Throwable $e) {
+        $error = 'Failed to load suggestions: ' . $e->getMessage();
+    }
+}
+
+$totalPages = max(1, (int)ceil($totalRows / $perPage));
+$csrf = csrfToken();
+
+?>
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Song Link Suggestions — iHymns Admin</title>
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-libs.php'; ?>
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-favicon.php'; ?>
+</head>
+<body>
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-nav.php'; ?>
+
+    <div class="container-admin py-4">
+        <h1 class="h4 mb-1">
+            <i class="bi bi-lightbulb me-2" aria-hidden="true"></i>
+            Cross-book Song Link Suggestions
+        </h1>
+        <p class="text-secondary small mb-4">
+            Pairs of songs flagged by the similarity engine as likely the
+            same hymn appearing in different songbooks. Confirm each pair
+            with <strong>Link</strong> (extends or creates a counterpart
+            group) or <strong>Dismiss</strong> (marks the pair as a
+            different-hymn false positive — never reappears). Tracked in
+            #807 / #808.
+        </p>
+
+        <?php if ($flash !== ''): ?>
+            <div class="alert alert-success small"><?= htmlspecialchars($flash) ?></div>
+        <?php endif; ?>
+        <?php if ($error !== ''): ?>
+            <div class="alert alert-danger small"><?= htmlspecialchars($error) ?></div>
+        <?php endif; ?>
+
+        <?php if (!$tablesPresent): ?>
+            <div class="alert alert-warning small">
+                <strong>Migration not applied.</strong> Run
+                <code>migrate-song-links.php</code> from the
+                <a href="/manage/setup-database">Database Setup</a>
+                page first — the suggestions table doesn't exist yet.
+            </div>
+        <?php else: ?>
+            <div class="row g-3 mb-4">
+                <div class="col-sm-4">
+                    <div class="card-admin">
+                        <div class="text-muted text-uppercase small">Pending suggestions</div>
+                        <div class="h4 mb-0"><?= number_format($totalRows) ?></div>
+                    </div>
+                </div>
+                <div class="col-sm-8">
+                    <form method="post" class="d-inline">
+                        <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                        <input type="hidden" name="action" value="rebuild">
+                        <button type="submit" class="btn btn-outline-primary">
+                            <i class="bi bi-arrow-clockwise me-1"></i>
+                            Rebuild suggestion list
+                        </button>
+                        <span class="text-muted small ms-2">
+                            Re-runs the similarity engine across the whole catalogue.
+                            Existing dismissals are preserved.
+                        </span>
+                    </form>
+                </div>
+            </div>
+
+            <?php if (empty($rows)): ?>
+                <div class="alert alert-info small mb-0">
+                    No pending suggestions. Either the catalogue has no
+                    near-duplicate-titled songs across songbooks, or the
+                    suggestion table hasn't been built yet — click
+                    <strong>Rebuild</strong> above to generate it.
+                </div>
+            <?php else: ?>
+                <div class="table-responsive">
+                    <table class="table table-sm align-middle">
+                        <thead>
+                            <tr>
+                                <th scope="col">Score</th>
+                                <th scope="col">Song A</th>
+                                <th scope="col">Song B</th>
+                                <th scope="col" class="text-end">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php foreach ($rows as $r): ?>
+                                <tr>
+                                    <td>
+                                        <span class="badge bg-info-subtle text-info-emphasis"
+                                              title="Title <?= round($r['TitleScore'] * 100) ?>% · lyrics <?= round($r['LyricsScore'] * 100) ?>% · authors <?= round($r['AuthorsScore'] * 100) ?>%">
+                                            <?= round($r['Score'] * 100) ?>%
+                                        </span>
+                                    </td>
+                                    <td>
+                                        <div class="small">
+                                            <span class="badge bg-body-secondary me-1"><?= htmlspecialchars($r['SongbookA']) ?></span>
+                                            <strong><?= htmlspecialchars($r['SongIdA']) ?></strong>
+                                            <?php if ($r['NumberA'] !== null): ?>
+                                                <span class="text-muted">#<?= (int)$r['NumberA'] ?></span>
+                                            <?php endif; ?>
+                                        </div>
+                                        <div><?= htmlspecialchars($r['TitleA']) ?></div>
+                                        <div class="text-muted small"><?= htmlspecialchars($r['SongbookNameA']) ?></div>
+                                    </td>
+                                    <td>
+                                        <div class="small">
+                                            <span class="badge bg-body-secondary me-1"><?= htmlspecialchars($r['SongbookB']) ?></span>
+                                            <strong><?= htmlspecialchars($r['SongIdB']) ?></strong>
+                                            <?php if ($r['NumberB'] !== null): ?>
+                                                <span class="text-muted">#<?= (int)$r['NumberB'] ?></span>
+                                            <?php endif; ?>
+                                        </div>
+                                        <div><?= htmlspecialchars($r['TitleB']) ?></div>
+                                        <div class="text-muted small"><?= htmlspecialchars($r['SongbookNameB']) ?></div>
+                                    </td>
+                                    <td class="text-end">
+                                        <form method="post" class="d-inline">
+                                            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                                            <input type="hidden" name="action"  value="link">
+                                            <input type="hidden" name="songIdA" value="<?= htmlspecialchars($r['SongIdA']) ?>">
+                                            <input type="hidden" name="songIdB" value="<?= htmlspecialchars($r['SongIdB']) ?>">
+                                            <button type="submit" class="btn btn-sm btn-outline-success" title="Link as same hymn">
+                                                <i class="bi bi-link-45deg me-1"></i>Link
+                                            </button>
+                                        </form>
+                                        <form method="post" class="d-inline">
+                                            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                                            <input type="hidden" name="action"  value="dismiss">
+                                            <input type="hidden" name="songIdA" value="<?= htmlspecialchars($r['SongIdA']) ?>">
+                                            <input type="hidden" name="songIdB" value="<?= htmlspecialchars($r['SongIdB']) ?>">
+                                            <button type="submit" class="btn btn-sm btn-outline-secondary" title="Dismiss — different hymns">
+                                                <i class="bi bi-x-lg me-1"></i>Dismiss
+                                            </button>
+                                        </form>
+                                        <a class="btn btn-sm btn-outline-primary"
+                                           href="/manage/editor/?id=<?= htmlspecialchars(urlencode($r['SongIdA'])) ?>"
+                                           target="_blank" rel="noopener"
+                                           title="Open Song A in editor">
+                                            <i class="bi bi-pencil-square"></i>
+                                        </a>
+                                        <a class="btn btn-sm btn-outline-primary"
+                                           href="/manage/editor/?id=<?= htmlspecialchars(urlencode($r['SongIdB'])) ?>"
+                                           target="_blank" rel="noopener"
+                                           title="Open Song B in editor">
+                                            <i class="bi bi-pencil-square"></i>
+                                        </a>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                </div>
+
+                <?php if ($totalPages > 1): ?>
+                    <nav aria-label="Suggestion pagination">
+                        <ul class="pagination pagination-sm">
+                            <?php for ($p = 1; $p <= $totalPages; $p++): ?>
+                                <li class="page-item <?= $p === $page ? 'active' : '' ?>">
+                                    <a class="page-link" href="?page=<?= $p ?>"><?= $p ?></a>
+                                </li>
+                            <?php endfor; ?>
+                        </ul>
+                    </nav>
+                <?php endif; ?>
+            <?php endif; ?>
+        <?php endif; ?>
+    </div>
+
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>
+</body>
+</html>

--- a/tools/build-song-link-suggestions.php
+++ b/tools/build-song-link-suggestions.php
@@ -1,0 +1,276 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Similar-titled-song suggestion builder (#808)
+ *
+ * Walks tblSongs and computes pairwise title / first-lyric / author
+ * similarity scores, writing the high-scoring candidates into
+ * tblSongLinkSuggestions. The /manage/song-link-suggestions admin
+ * page (and the inline suggestions panel inside the editor) reads
+ * straight from that table — this script is the producer side of
+ * that pipeline.
+ *
+ * Pairs are pruned early to keep the cost manageable on a 12k-row
+ * catalogue:
+ *   - Same language only (cross-language similarity is too noisy
+ *     for a heuristic pass).
+ *   - Same first letter of normalised title (collapses the corpus
+ *     into ~26 buckets — a typical bucket holds ~500 rows, so the
+ *     pairwise cost is ~125k pair comparisons per bucket, far
+ *     under the naive 76M for the whole catalogue).
+ *   - Already-linked pairs (same tblSongLinks.GroupId) are skipped.
+ *   - Already-dismissed pairs (tblSongLinkSuggestionsDismissed)
+ *     are skipped.
+ *
+ * Idempotent — every run TRUNCATEs and rebuilds tblSongLinkSuggestions.
+ *
+ * USAGE:
+ *   php tools/build-song-link-suggestions.php           # default 0.80 threshold
+ *   php tools/build-song-link-suggestions.php 0.75      # custom threshold
+ *
+ *   Web entry: /manage/song-link-suggestions?action=rebuild
+ */
+
+if (PHP_SAPI === 'cli') {
+    require_once __DIR__ . '/../appWeb/public_html/includes/db_mysql.php';
+    $isCli = true;
+} else {
+    /* Web callers must have already set up auth before requiring this file. */
+    require_once __DIR__ . '/../appWeb/public_html/includes/db_mysql.php';
+    $isCli = false;
+}
+
+function _bsls_out(string $line): void
+{
+    global $isCli;
+    echo $line . ($isCli ? "\n" : "<br>\n");
+    if ($isCli) flush();
+}
+
+/**
+ * Lower-cases, strips diacritics, drops leading articles + punctuation,
+ * collapses whitespace. Used for both title comparison and first-line
+ * comparison.
+ */
+function _bsls_normalise(string $s): string
+{
+    $s = mb_strtolower($s, 'UTF-8');
+    /* Strip diacritics by transliterating to ASCII. iconv() is
+       deliberately wrapped: on hosts where TRANSLIT isn't available
+       we fall back to the original string rather than blanking. */
+    $ascii = @iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $s);
+    if ($ascii !== false) $s = $ascii;
+    /* Drop leading articles. */
+    $s = preg_replace('/^(the|a|an|o|el|la|le|les|der|die|das)\s+/u', '', $s) ?? $s;
+    /* Strip punctuation, collapse whitespace. */
+    $s = preg_replace('/[^\p{L}\p{N}\s]/u', ' ', $s) ?? $s;
+    $s = preg_replace('/\s+/u', ' ', $s) ?? $s;
+    return trim($s);
+}
+
+/**
+ * 1 - levenshtein(a,b) / max(|a|,|b|).
+ * PHP's levenshtein() caps at 255 chars; truncate longer inputs to
+ * keep the function defined. First-line comparison can hit that
+ * limit on long opening verses, so the truncation is the realistic
+ * shape.
+ */
+function _bsls_similarity(string $a, string $b): float
+{
+    if ($a === '' && $b === '') return 0.0;
+    $a = mb_substr($a, 0, 255);
+    $b = mb_substr($b, 0, 255);
+    $max = max(strlen($a), strlen($b));
+    if ($max === 0) return 0.0;
+    $d = levenshtein($a, $b);
+    return 1.0 - ($d / $max);
+}
+
+/**
+ * Jaccard overlap on the lowercase token set of two pipe-joined
+ * author strings. Used as a small (15%) signal — songs with shared
+ * writer/composer names get a bump; differing authors get a penalty.
+ */
+function _bsls_authors_jaccard(string $a, string $b): float
+{
+    $tokA = array_filter(array_map('trim', explode('|', mb_strtolower($a, 'UTF-8'))));
+    $tokB = array_filter(array_map('trim', explode('|', mb_strtolower($b, 'UTF-8'))));
+    if (!$tokA && !$tokB) return 0.0;
+    $setA = array_flip($tokA);
+    $setB = array_flip($tokB);
+    $inter = count(array_intersect_key($setA, $setB));
+    $union = count($setA) + count($setB) - $inter;
+    return $union > 0 ? ($inter / $union) : 0.0;
+}
+
+/* =========================================================================
+ * Main
+ * ========================================================================= */
+
+$threshold = 0.80;
+if ($isCli && isset($argv[1]) && is_numeric($argv[1])) {
+    $threshold = max(0.0, min(1.0, (float)$argv[1]));
+}
+
+_bsls_out("Building song-link suggestions (threshold {$threshold})…");
+
+$db = getDbMysqli();
+if (!$db) {
+    _bsls_out('ERROR: could not connect to database.');
+    exit(1);
+}
+
+/* Probe the dependent tables — bail with a clear message rather than
+   500ing if the migration hasn't run yet. */
+$probe = $db->query(
+    "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
+      WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME IN ('tblSongLinks','tblSongLinkSuggestions','tblSongLinkSuggestionsDismissed')"
+);
+$present = [];
+while ($probe && ($row = $probe->fetch_row())) $present[] = $row[0];
+if ($probe) $probe->close();
+if (count($present) < 3) {
+    _bsls_out('ERROR: required tables missing — run migrate-song-links.php first. Found: ' . implode(', ', $present));
+    exit(1);
+}
+
+/* Truncate the suggestion table — every run is a full rebuild. The
+   dismissed-pair table is preserved across rebuilds (intentional —
+   a curator's "no, different hymns" verdict is permanent). */
+$db->query('TRUNCATE TABLE tblSongLinkSuggestions');
+
+/* Pull every song's title + first lyric line + writer/composer
+   list. The first-line snippet comes from tblSongComponents — we
+   take the first row's first non-empty paragraph. */
+$res = $db->query(
+    "SELECT s.SongId,
+            s.Title,
+            s.Language,
+            s.SongbookAbbr,
+            COALESCE(GROUP_CONCAT(DISTINCT w.Name SEPARATOR '|'), '') AS Writers,
+            COALESCE(GROUP_CONCAT(DISTINCT c.Name SEPARATOR '|'), '') AS Composers,
+            (SELECT cmp.Body
+               FROM tblSongComponents cmp
+              WHERE cmp.SongId = s.SongId
+              ORDER BY cmp.SortOrder ASC LIMIT 1) AS FirstComponentBody
+       FROM tblSongs s
+       LEFT JOIN tblSongWriters   w ON w.SongId = s.SongId
+       LEFT JOIN tblSongComposers c ON c.SongId = s.SongId
+      GROUP BY s.SongId"
+);
+if (!$res) {
+    _bsls_out('ERROR: failed to read tblSongs: ' . $db->error);
+    exit(1);
+}
+
+/* Group rows into language-bucket × first-letter-of-title-bucket
+   bags. The pairwise pass walks each bag, not the whole corpus. */
+$bags = [];
+$total = 0;
+while ($row = $res->fetch_assoc()) {
+    $title = (string)$row['Title'];
+    $normTitle = _bsls_normalise($title);
+    if ($normTitle === '') continue;
+    $firstLine = '';
+    $body = (string)($row['FirstComponentBody'] ?? '');
+    if ($body !== '') {
+        /* First non-empty line of the first component. */
+        foreach (preg_split('/\r?\n/', $body) ?: [] as $ln) {
+            $ln = trim($ln);
+            if ($ln !== '') { $firstLine = $ln; break; }
+        }
+    }
+    $bagKey = (string)$row['Language'] . '|' . mb_substr($normTitle, 0, 1, 'UTF-8');
+    if (!isset($bags[$bagKey])) $bags[$bagKey] = [];
+    $bags[$bagKey][] = [
+        'songId'        => (string)$row['SongId'],
+        'normTitle'     => $normTitle,
+        'normFirstLine' => _bsls_normalise($firstLine),
+        'authors'       => trim((string)$row['Writers'] . '|' . (string)$row['Composers'], '|'),
+        'songbook'      => (string)$row['SongbookAbbr'],
+    ];
+    $total++;
+}
+$res->close();
+_bsls_out("Loaded {$total} song(s) into " . count($bags) . ' bucket(s).');
+
+/* Pre-load dismissed pairs into a hash for O(1) skip. */
+$dismissed = [];
+$res = $db->query('SELECT SongIdA, SongIdB FROM tblSongLinkSuggestionsDismissed');
+while ($res && ($row = $res->fetch_row())) {
+    $dismissed[$row[0] . '|' . $row[1]] = true;
+}
+if ($res) $res->close();
+
+/* Pre-load existing same-group pairs so we don't propose pairs that
+   are already linked. We build a map songId -> groupId, then any
+   two songs with the same group id get skipped. */
+$groupOf = [];
+$res = $db->query('SELECT SongId, GroupId FROM tblSongLinks');
+while ($res && ($row = $res->fetch_row())) {
+    $groupOf[$row[0]] = (int)$row[1];
+}
+if ($res) $res->close();
+
+/* Pairwise pass per bag. */
+$inserted = 0;
+$insStmt = $db->prepare(
+    'INSERT INTO tblSongLinkSuggestions
+        (SongIdA, SongIdB, Score, TitleScore, LyricsScore, AuthorsScore)
+     VALUES (?, ?, ?, ?, ?, ?)
+     ON DUPLICATE KEY UPDATE Score=VALUES(Score), TitleScore=VALUES(TitleScore),
+         LyricsScore=VALUES(LyricsScore), AuthorsScore=VALUES(AuthorsScore),
+         ComputedAt=CURRENT_TIMESTAMP'
+);
+
+foreach ($bags as $bag) {
+    $n = count($bag);
+    for ($i = 0; $i < $n; $i++) {
+        for ($j = $i + 1; $j < $n; $j++) {
+            $a = $bag[$i];
+            $b = $bag[$j];
+            /* Same songbook isn't interesting — we want CROSS-book
+               counterparts. (Two rows in the same songbook with
+               near-identical titles is a curation duplicate, not
+               a counterpart relationship.) */
+            if ($a['songbook'] === $b['songbook']) continue;
+
+            /* Already linked into the same group — skip. */
+            if (isset($groupOf[$a['songId']], $groupOf[$b['songId']])
+                && $groupOf[$a['songId']] === $groupOf[$b['songId']]) continue;
+
+            /* Canonical order. */
+            $idA = $a['songId'];
+            $idB = $b['songId'];
+            if ($idA > $idB) {
+                [$idA, $idB] = [$idB, $idA];
+                [$a, $b]     = [$b, $a];
+            }
+            if (isset($dismissed[$idA . '|' . $idB])) continue;
+
+            /* Cheap pre-filter: if normalised titles differ in length
+               by >5 chars they're almost certainly different hymns;
+               skip the levenshtein() to save cycles. */
+            if (abs(strlen($a['normTitle']) - strlen($b['normTitle'])) > 5) continue;
+
+            $titleScore   = _bsls_similarity($a['normTitle'], $b['normTitle']);
+            if ($titleScore < 0.6) continue;   /* short-circuit on hopeless titles */
+            $lyricsScore  = _bsls_similarity($a['normFirstLine'], $b['normFirstLine']);
+            $authorsScore = _bsls_authors_jaccard($a['authors'], $b['authors']);
+
+            $score = (0.50 * $titleScore) + (0.35 * $lyricsScore) + (0.15 * $authorsScore);
+            if ($score < $threshold) continue;
+
+            $insStmt->bind_param('ssdddd', $idA, $idB, $score, $titleScore, $lyricsScore, $authorsScore);
+            $insStmt->execute();
+            $inserted++;
+        }
+    }
+}
+$insStmt->close();
+
+_bsls_out("Inserted {$inserted} suggestion(s) at score >= {$threshold}.");
+_bsls_out('Done.');


### PR DESCRIPTION
## Summary

Adds the third song-relationship axis the catalogue's been missing.
We already have:

1. **`tblSongTranslations`** — different-language version of the same hymn.
2. **`tblSongbooks.ParentSongbookId` + Series tables** — songbook-level
   grouping (translated derivatives, edition chains, peer series volumes).

Neither covers **the same hymn appearing in independent songbooks at
unrelated numbers** — Amazing Grace as `MP-031` / `CH-376` / `SDAH-108`
/ `SoF-29` / `JP-006`. This PR closes that gap, plus ships the
admin-side discovery workflow that makes it usable on a 12k-row
catalogue.

## Issues closed

- Closes #807 — cross-book counterpart linkage.
- Closes #808 — similar-title-suggestion admin surface + builder.

## Two commits

1. **`feat(songs): cross-book counterparts (#807)`** — schema
   migration, editor API, editor sidebar UI, public song-page
   dropdown, public API endpoint.
2. **`feat(admin): similar-titled-song suggestions (#808)`** —
   builder script, admin triage page, inline editor suggestions
   panel, admin-links registration, CHANGELOG.

## Schema

Three new tables (idempotent migration `appWeb/.sql/migrate-song-links.php`):

| Table | Role |
|---|---|
| `tblSongLinks` | Many-to-many `(GroupId, SongId)` — songs sharing a `GroupId` are the same hymn. UNIQUE on `SongId` enforces "one song belongs to at most one group". Note + Verified + CreatedBy on each row. |
| `tblSongLinkSuggestions` | Pre-computed pairwise similarity scores (`Score`, `TitleScore`, `LyricsScore`, `AuthorsScore`). Pairs canonicalised so `SongIdA < SongIdB`. |
| `tblSongLinkSuggestionsDismissed` | Curator-rejected pairs — the build script consults this to skip pairs the curator has already said no to. |

All three documented in `appWeb/.sql/schema.sql`, INFORMATION_SCHEMA-
probed in the migration, wired into setup-database `$scriptMap` +
`$migrationOrder` + a dashboard card.

## Surfaces

| Surface | What changed |
|---|---|
| `/manage/editor/` | New "Cross-book counterparts" section in the right-hand panel; inline 5-suggestion panel below it. |
| `/manage/editor/api.php` | `get_song_links`, `add_song_link`, `remove_song_link`, `suggest_song_links`, `dismiss_song_link_suggestion`. |
| `/manage/song-link-suggestions` (NEW) | Triage page listing pending candidates with Link / Dismiss / Open-in-editor actions + Rebuild button. Entitlement: `edit_songs`. |
| `/song/<id>` | New "Also appears in N songbook(s)" dropdown beside the existing translations dropdown. |
| `api.php?action=song_links&id=<SongId>` | Public endpoint returning the group's other members. |
| `tools/build-song-link-suggestions.php` | Pairwise similarity builder — runs over the full catalogue. CLI threshold override; usable in-process from the admin page's Rebuild handler. |

## Similarity algorithm

Composite weighted score, each signal in `[0, 1]`:

- 50% — normalised title Levenshtein (lowercase, strip diacritics,
  drop leading articles "The/A/An/El/La/…", strip punctuation).
- 35% — normalised first lyric line Levenshtein.
- 15% — Jaccard on writer + composer name tokens.

Pairs bucketed by `(language × first-letter-of-normalised-title)` so
the pairwise pass is sub-quadratic on the full catalogue.
Same-songbook pairs are skipped (those are curation duplicates, not
counterparts). Threshold defaults to `0.80`; CLI override:
`php tools/build-song-link-suggestions.php 0.75`.

## Test plan

- [ ] Apply migration: visit `/manage/setup-database` → "3y2.
      Cross-book song links (#807 / #808)" → click Run. Confirm the
      three tables exist (`SHOW TABLES LIKE 'tblSongLink%'`).
- [ ] Open `/manage/editor/` for a known hymn (e.g. `MP-031`
      Amazing Grace). Cross-book counterparts section appears
      empty. Type `CH-376` (or whichever AGn appearance) into the
      input, click Link. Confirm the row appears in the list and
      the toast confirms.
- [ ] Open `/song/MP-031` on the public side. Confirm "Also appears
      in 1 songbook" dropdown renders with `CH` chip → `CH-376`
      link. Click through; the reciprocal page shows MP.
- [ ] In the editor, click the X on the linked row. Both rows are
      removed (singleton-cleanup); reload the public page —
      dropdown disappears.
- [ ] Run `php tools/build-song-link-suggestions.php` (or use the
      Rebuild button on `/manage/song-link-suggestions`). Confirm
      the page populates with candidate pairs. Click Link on one;
      it disappears from the list. Click Dismiss on another; same.
- [ ] Editor sidebar: open a song that has a pending suggestion.
      Confirm the inline "Suggested counterparts" panel renders
      with a one-click Link button (drops the suggestion + adds the
      link in a single round-trip).
- [ ] Verify `api.php?action=song_links&id=<id>` returns the
      expected `{groupId, songs: [...]}` JSON, with songbook
      abbreviation, name, and number for each member.
- [ ] Probe failure mode: drop a fresh DB without running the
      migration → admin page surfaces "Migration not applied"
      hint, public song page silently hides the dropdown,
      `api.php?action=song_links` returns `{groupId: 0, songs: []}`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HFDKt61T2VbX8gcHDyciNk)_