### PR TITLE
Admin polish + bug-fix batch (closes #811 #812 #813 #814 #815 #816 #817 #818 #819)

### DIFF
--- a/appWeb/.sql/migrate-recompute-songbook-songcount.php
+++ b/appWeb/.sql/migrate-recompute-songbook-songcount.php
@@ -7,6 +7,15 @@ declare(strict_types=1);
  *
  * Copyright (c) 2026 iHymns. All rights reserved.
  *
+ * STATUS: DEPRECATED ON THE DASHBOARD (#818) — superseded by the
+ * SongCount Triggers migration (#793 / migrate-songcount-triggers.php),
+ * which runs the same recompute as part of its installation. Listing
+ * both on /manage/setup-database meant the bulk runner recomputed
+ * twice on every Apply-All; the standalone card was dropped while
+ * leaving this script on disk for emergency CLI manual runs (e.g. if
+ * someone hand-edits tblSongs and needs to refresh the cache outside
+ * the trigger / save_song write paths).
+ *
  * PURPOSE:
  * tblSongbooks.SongCount is a cached aggregate that the home + the
  * /songbooks tile-grid use to gate render — `if songCount > 0`.
@@ -25,8 +34,9 @@ declare(strict_types=1);
  *
  * USAGE:
  *   CLI: php appWeb/.sql/migrate-recompute-songbook-songcount.php
- *   Web: /manage/setup-database → "Recompute Songbook SongCount (#791)"
- *        (entry point requires global_admin)
+ *   Web: removed from /manage/setup-database (#818) — run the
+ *        SongCount Triggers card to get the same recompute plus
+ *        the trigger installation.
  */
 
 if (PHP_SAPI === 'cli') {

--- a/appWeb/.sql/migrate-songcount-triggers.php
+++ b/appWeb/.sql/migrate-songcount-triggers.php
@@ -84,8 +84,42 @@ _migSCTrig_out('SongCount triggers migration starting (#793)…');
 
 $db = getDbMysqli();
 if (!$db) {
-    _migSCTrig_out('ERROR: could not connect to database.');
-    exit(1);
+    /* Throw rather than exit so the bulk runner records this as a real
+       failure (and its admin chrome still renders). exit() in a child
+       mid-bulk truncates the page — see #817. */
+    throw new \RuntimeException('Could not connect to database.');
+}
+
+/* Detect whether a mysqli error message indicates the host has denied
+   trigger creation (typically: SUPER required, binary-logging strict
+   mode, or shared-host policy). Three signals cover the common shapes:
+     - "you do not have the SUPER privilege"
+     - "TRIGGER command denied to user …"
+     - explicit "privilege" / "binary logging" hints. */
+function _migSCTrig_isDenied(string $err): bool
+{
+    return stripos($err, 'super') !== false
+        || stripos($err, 'denied') !== false
+        || stripos($err, 'privilege') !== false
+        || stripos($err, 'binary logging') !== false;
+}
+
+/* PHP 8.1+ defaults mysqli_report to throw mysqli_sql_exception on
+   failure, so $db->query() never returns false on error — it throws.
+   The pre-existing `if (!$db->query(...))` branch was unreachable.
+   This wrapper restores the run-and-classify pattern by catching the
+   exception and surfacing the original error message + denied flag. */
+function _migSCTrig_runQuery(\mysqli $db, string $sql): array
+{
+    try {
+        $ok = $db->query($sql);
+        if ($ok === false) {
+            return ['ok' => false, 'denied' => _migSCTrig_isDenied($db->error), 'err' => $db->error];
+        }
+        return ['ok' => true, 'denied' => false, 'err' => ''];
+    } catch (\mysqli_sql_exception $e) {
+        return ['ok' => false, 'denied' => _migSCTrig_isDenied($e->getMessage()), 'err' => $e->getMessage()];
+    }
 }
 
 /* =========================================================================
@@ -97,8 +131,15 @@ $triggerNames = [
     'trg_songs_songcount_au',
 ];
 foreach ($triggerNames as $name) {
-    if (!$db->query("DROP TRIGGER IF EXISTS {$name}")) {
-        _migSCTrig_out("WARN: DROP TRIGGER IF EXISTS {$name} failed: " . $db->error);
+    $r = _migSCTrig_runQuery($db, "DROP TRIGGER IF EXISTS {$name}");
+    if (!$r['ok']) {
+        _migSCTrig_out("WARN: DROP TRIGGER IF EXISTS {$name} failed: {$r['err']}");
+        if ($r['denied']) {
+            /* If the host denies DROP TRIGGER it will also deny CREATE
+               TRIGGER. Skip straight to the recompute fallback so the
+               operator gets a clean run instead of one error per name. */
+            break;
+        }
     }
 }
 
@@ -140,30 +181,46 @@ $triggersSql = [
 ];
 
 $triggersCreated = 0;
-$triggersFailed  = false;
+$triggersDenied  = false;
 foreach ($triggersSql as $name => $sql) {
-    if ($db->query($sql)) {
+    $r = _migSCTrig_runQuery($db, $sql);
+    if ($r['ok']) {
         _migSCTrig_out("[add ] {$name}.");
         $triggersCreated++;
-    } else {
-        $triggersFailed = true;
-        $err = $db->error;
-        _migSCTrig_out("WARN: CREATE TRIGGER {$name} failed: {$err}");
+        continue;
+    }
+    _migSCTrig_out("WARN: CREATE TRIGGER {$name} failed: {$r['err']}");
+    if ($r['denied']) {
         /* Most-common failure on shared hosts: SUPER privilege required
            pre-MySQL-8.0, or trigger creation explicitly denied by the
            hosting policy. Surface a clear hint so the operator knows
            the application-side recompute from PR #792 is the
-           remaining safety net. */
-        if (stripos($err, 'super') !== false || stripos($err, 'denied') !== false || stripos($err, 'privilege') !== false) {
-            _migSCTrig_out('       Hint: this MySQL host disallows CREATE TRIGGER without SUPER. Save_song from #791/PR #792 still keeps the cache correct for editor saves; bulk imports continue to recompute via their existing per-import path.');
-            break;
-        }
+           remaining safety net, then exit clean — failing the migration
+           would block `Apply all` for no benefit. */
+        $triggersDenied = true;
+        _migSCTrig_out('       Hint: this MySQL host disallows CREATE TRIGGER (typically: SUPER privilege, or shared-host policy).');
+        _migSCTrig_out('       Save_song from #791/PR #792 still keeps the cache correct for editor saves; bulk imports recompute via their per-import path. The migration is not failing — the triggers are an optimisation, not a requirement.');
+        break;
     }
+    /* Non-denial failure (e.g. syntax error, server error). Re-throw so
+       the bulk runner records the failure and stops — this would be a
+       genuine bug in the migration, not a host policy. */
+    throw new \RuntimeException("CREATE TRIGGER {$name} failed: {$r['err']}");
 }
 
-if ($triggersCreated === 0) {
+if ($triggersCreated === 0 && !$triggersDenied) {
     _migSCTrig_out('ERROR: no triggers could be created. Cache will rely on application-side recompute (PR #792) only.');
-    exit(1);
+    /* Use return rather than exit(1) so the bulk runner's page chrome
+       still renders (an exit() in a child mid-bulk truncates the
+       admin layout — see #817). The bulk runner doesn't see this as
+       a failure; the operator sees the WARN lines above. */
+    return;
+}
+if ($triggersDenied) {
+    _migSCTrig_out('');
+    _migSCTrig_out('SongCount triggers skipped on this host — using application-side recompute (PR #792) as the cache safety net.');
+    /* Still run the initial recompute below so the cache is clean
+       regardless of whether triggers were installed. */
 }
 
 /* =========================================================================

--- a/appWeb/public_html/css/admin.css
+++ b/appWeb/public_html/css/admin.css
@@ -174,6 +174,33 @@ body:has(.navbar-admin) {
     font-weight: 600;
 }
 
+/* Collapsible accordion group toggle (#819). Renders as an inline
+   button styled to match the old `admin-sidebar-group-label` so the
+   visual rhythm is preserved while adding click-to-toggle. The
+   chevron flips when the section opens. */
+.admin-sidebar-group-toggle,
+.admin-offcanvas-group-toggle {
+    letter-spacing: 0.04em;
+    text-decoration: none;
+    color: var(--text-secondary);
+}
+.admin-sidebar-group-toggle:hover,
+.admin-sidebar-group-toggle:focus,
+.admin-offcanvas-group-toggle:hover,
+.admin-offcanvas-group-toggle:focus {
+    color: var(--text-primary);
+    background-color: rgba(255, 255, 255, 0.03);
+    text-decoration: none;
+}
+.admin-sidebar-group-toggle .bi-chevron-down,
+.admin-offcanvas-group-toggle .bi-chevron-down {
+    transition: transform var(--transition-fast);
+}
+.admin-sidebar-group-toggle.collapsed .bi-chevron-down,
+.admin-offcanvas-group-toggle.collapsed .bi-chevron-down {
+    transform: rotate(-90deg);
+}
+
 .admin-sidebar-link {
     color: var(--text-secondary);
     text-decoration: none;

--- a/appWeb/public_html/css/app.css
+++ b/appWeb/public_html/css/app.css
@@ -36,7 +36,7 @@
 :root {
     /* --- Layout dimensions --- */
     --header-height: 56px;
-    --search-bar-height: 56px;
+    /* --search-bar-height removed (#812) — header search bar gone. */
     --footer-nav-height: 60px;
     --footer-info-height: 28px;
     --footer-total-height: calc(var(--footer-nav-height) + var(--footer-info-height));
@@ -466,26 +466,30 @@ body {
     border-radius: 50%;
 }
 
-/* Channel badge ("Alpha" / "Beta") responsive sizing (#580).
-   At wide widths we keep the full word; at < md we shrink to a
-   single letter so the right-edge cluster has room for every icon
-   (search, shuffle, theme, notifications, account) on phones. The
-   single-letter form preserves the colour cue so QA still spots
-   the channel at a glance. */
-.app-header .navbar-brand .badge.bg-warning,
-.navbar-admin .navbar-brand .badge.bg-warning {
+/* Channel badge ("Alpha" / "Beta") — uniform pill at every viewport (#812).
+   The full environment name MUST stay readable on every screen because
+   functionality and capabilities differ between channels. The previous
+   rule shrank the badge to a single letter (font-size:0 + ::first-letter)
+   on < 576px which looked clipped and obscured the cue. Fixed pill,
+   compact padding, uppercase text — readable everywhere. */
+.app-header .navbar-brand .badge.env-badge,
+.navbar-admin .navbar-brand .badge.env-badge {
+    font-size: 0.65rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 0.22em 0.55em;
+    line-height: 1.05;
+    border-radius: 999px;
     transition: padding 0.15s ease;
 }
-@media (max-width: 575.98px) {
-    .app-header .navbar-brand .badge.bg-warning,
-    .navbar-admin .navbar-brand .badge.bg-warning {
-        font-size: 0;            /* hide the long word */
-        padding: 0.18em 0.4em;
-        line-height: 1;
-    }
-    .app-header .navbar-brand .badge.bg-warning::first-letter,
-    .navbar-admin .navbar-brand .badge.bg-warning::first-letter {
-        font-size: 0.65rem;      /* show only the first letter */
+@media (max-width: 359.98px) {
+    /* Ultra-narrow viewports (< 360px) — tighten padding a touch but
+       keep the full word visible. No more single-letter trick. */
+    .app-header .navbar-brand .badge.env-badge,
+    .navbar-admin .navbar-brand .badge.env-badge {
+        padding: 0.2em 0.45em;
+        font-size: 0.6rem;
     }
 }
 
@@ -498,21 +502,9 @@ body {
     transform: scale(0.92);
 }
 
-/* Collapsible search bar */
-.header-search-bar {
-    max-height: 0;
-    overflow: hidden;
-    transition: max-height var(--transition-slow), opacity var(--transition-normal);
-    opacity: 0;
-    background: var(--header-bg);
-    border-top: 1px solid var(--card-border);
-}
-
-.header-search-bar.open {
-    max-height: var(--search-bar-height);
-    opacity: 1;
-    overflow: visible;
-}
+/* Collapsible header search bar removed (#812) — the bottom-drawer
+   Search entry navigates straight to /search; no need for a sliding
+   header bar duplicating the affordance. */
 
 /* ---------------------------------------------------------------------------
    Main Content Area
@@ -529,14 +521,9 @@ body.banner-visible .main-content {
     padding-top: calc(var(--header-height) + var(--install-banner-height) + env(safe-area-inset-top, 0px) + 8px);
 }
 
-/* Adjust when search bar is open */
-body.search-open .main-content {
-    padding-top: calc(var(--header-height) + var(--search-bar-height) + 8px);
-}
-
-body.banner-visible.search-open .main-content {
-    padding-top: calc(var(--header-height) + var(--install-banner-height) + var(--search-bar-height) + env(safe-area-inset-top, 0px) + 8px);
-}
+/* `.search-open` body class no longer applied (#812) — header search
+   bar + toggle were removed alongside the duplicate bottom-drawer
+   Search entry. The padding-shift rules went with them. */
 
 /* ---------------------------------------------------------------------------
    PWA Standalone Mode — Safe Area Insets
@@ -559,9 +546,7 @@ body.banner-visible.search-open .main-content {
         padding-bottom: calc(var(--footer-total-height) + env(safe-area-inset-bottom, 0px) + 8px);
     }
 
-    body.search-open .main-content {
-        padding-top: calc(var(--header-height) + var(--search-bar-height) + env(safe-area-inset-top, 0px) + 8px);
-    }
+    /* `.search-open` body class no longer applied (#812). */
 
     /* Footer — extend background into the bottom safe area (home indicator) */
     .app-footer {

--- a/appWeb/public_html/includes/entitlements.php
+++ b/appWeb/public_html/includes/entitlements.php
@@ -60,6 +60,15 @@ const ENTITLEMENTS = [
        grade outbound traffic from the server's IP. */
     'manage_configuration' => ['global_admin'],
 
+    /* In-app notifications admin — compose & broadcast. (#813)
+       Global Admin only: a broadcast targeting "all signed-in users"
+       can amount to mass messaging that's hard to revoke once
+       people have read it. Limit to operators who own platform
+       comms. The header bell + per-user list endpoints remain open
+       to every signed-in user; this is just for posting / managing
+       the feed. */
+    'manage_notifications' => ['global_admin'],
+
     /* Content moderation */
     'review_song_requests' => ['editor', 'admin', 'global_admin'],
 

--- a/appWeb/public_html/index.php
+++ b/appWeb/public_html/index.php
@@ -44,6 +44,67 @@ declare(strict_types=1);
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'debug_mode.php';
 enableDebugModeIfRequested();
 
+/* =========================================================================
+ * BOOTSTRAP SAFETY NET (#811)
+ *
+ * Catch any uncaught Throwable during request bootstrap and render a
+ * friendly fallback page instead of a blank screen. Triggers when the
+ * deployed code references schema (table / column) that the matching
+ * migrate-*.php hasn't been applied for yet — typically the brief
+ * window between a deploy landing and an admin running the migrations.
+ *
+ * Production: shows a generic "service starting" message.
+ * Alpha / Beta: includes the exception text + the exact admin path
+ *               to apply pending migrations.
+ *
+ * Register before any DB-touching require (config.php pulls APP_CONFIG
+ * but doesn't connect; SongData / channel_gate do).
+ * ========================================================================= */
+set_exception_handler(function (\Throwable $e): void {
+    error_log('[index.php bootstrap] uncaught ' . get_class($e) . ': ' . $e->getMessage()
+            . ' at ' . basename($e->getFile()) . ':' . $e->getLine());
+    if (!headers_sent()) {
+        http_response_code(503);
+        header('Content-Type: text/html; charset=UTF-8');
+        header('Retry-After: 30');
+    }
+    /* Best-effort: if we can detect Alpha/Beta from the server path, give
+       the admin a direct link to fix it. Production keeps the message
+       generic so a casual visitor isn't shown internals. */
+    $serverPath = (string)($_SERVER['SCRIPT_FILENAME'] ?? '');
+    $isPreProd  = str_contains($serverPath, 'public_html_dev')
+               || str_contains($serverPath, 'public_html_beta');
+    $detail = '';
+    if ($isPreProd) {
+        $detail = '<p class="muted">'
+                . htmlspecialchars(get_class($e) . ': ' . $e->getMessage())
+                . '</p><p>Admins: visit '
+                . '<a href="/manage/setup-database">/manage/setup-database</a> '
+                . 'and click <strong>Apply all pending migrations</strong>.</p>';
+    }
+    echo <<<HTML
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>iHymns — Service starting</title>
+<style>
+ body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;background:#1a1d21;color:#e8e6e3;
+      margin:0;padding:2rem;display:flex;min-height:100vh;align-items:center;justify-content:center}
+ main{max-width:480px;text-align:center}
+ h1{font-size:1.5rem;margin:0 0 .75rem}
+ p{line-height:1.5;margin:.5rem 0}
+ .muted{color:#888;font-size:.85rem;font-family:ui-monospace,monospace;text-align:left;
+        background:#0f1115;padding:.75rem;border-radius:6px;overflow-wrap:break-word}
+ a{color:#67aaff}
+</style></head>
+<body><main>
+ <h1>iHymns is starting up</h1>
+ <p>The service is initialising. Please retry in a moment.</p>
+ {$detail}
+</main></body></html>
+HTML;
+});
+
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'config.php';
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'infoAppVer.php';
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
@@ -272,8 +333,13 @@ try {
     else {
         $pageType = 'other';
     }
-} catch (\RuntimeException $e) {
-    /* If song data isn't available, use defaults — no fatal error */
+} catch (\Throwable $e) {
+    /* If song data isn't available, use defaults — no fatal error.
+       Widened from \RuntimeException → \Throwable (#811) so a fresh
+       deploy that lands new-schema code before its migrations have
+       run still renders the page; the metadata block falls back to
+       the static defaults rather than blanking the site. */
+    error_log('[index.php] OG/route detection failed: ' . $e->getMessage());
 }
 
 /* JSON-LD: WebSite schema with SearchAction (home page only) */

--- a/appWeb/public_html/index.php
+++ b/appWeb/public_html/index.php
@@ -646,7 +646,12 @@ if (!empty($breadcrumbItems)) {
                         <i class="fa-solid fa-music fa-lg" aria-hidden="true"></i>
                         <span class="fw-bold"><?= htmlspecialchars($app["Application"]["Name"]) ?></span>
                         <?php if ($app["Application"]["Version"]["Development"]["Status"]): ?>
-                            <span class="badge bg-warning text-dark ms-1 small"><?= htmlspecialchars($app["Application"]["Version"]["Development"]["Status"]) ?></span>
+                            <!-- Environment badge (#812) — must remain visible at every
+                                 viewport so functional differences between Alpha/Beta and
+                                 production stay obvious. Uses the dedicated `env-badge`
+                                 class (admin.css / app.css) for stable padding instead of
+                                 Bootstrap's `small` modifier which collapsed awkwardly. -->
+                            <span class="badge env-badge bg-warning text-dark ms-1"><?= htmlspecialchars($app["Application"]["Version"]["Development"]["Status"]) ?></span>
                         <?php endif; ?>
                     </button>
                     <ul class="dropdown-menu" aria-labelledby="logo-nav-btn">
@@ -693,15 +698,11 @@ if (!empty($breadcrumbItems)) {
 
                 <!-- Right-side header actions -->
                 <div class="d-flex align-items-center gap-2">
-                    <!-- Search toggle button -->
-                    <button type="button"
-                            class="btn btn-header-icon"
-                            id="header-search-toggle"
-                            aria-label="Toggle search"
-                            aria-expanded="false"
-                            aria-controls="header-search-bar">
-                        <i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
-                    </button>
+                    <!-- Search toggle button removed (#812) — the bottom
+                         footer-nav already exposes a "Search" entry that
+                         navigates to /search; one affordance is enough,
+                         and the saved real-estate matters most on mobile
+                         portrait. -->
 
                     <!-- Shuffle button — randomly pick a song -->
                     <button type="button"
@@ -860,35 +861,11 @@ if (!empty($breadcrumbItems)) {
             </div>
         </nav>
 
-        <!-- ============================================================
-             COLLAPSIBLE SEARCH BAR — Slides down below the header
-             when the search toggle is activated.
-             ============================================================ -->
-        <div id="header-search-bar" class="header-search-bar" aria-hidden="true">
-            <div class="container-fluid px-3 py-2">
-                <form id="search-form" role="search" aria-label="Search songs" autocomplete="off">
-                    <div class="input-group">
-                        <span class="input-group-text" aria-hidden="true">
-                            <i class="fa-solid fa-magnifying-glass"></i>
-                        </span>
-                        <input type="search"
-                               class="form-control"
-                               id="search-input"
-                               name="q"
-                               placeholder="Search songs, hymns, lyrics..."
-                               aria-label="Search songs"
-                               autocomplete="off"
-                               spellcheck="false">
-                        <button type="button"
-                                class="btn btn-outline-secondary d-none"
-                                id="search-clear-btn"
-                                aria-label="Clear search">
-                            <i class="fa-solid fa-xmark" aria-hidden="true"></i>
-                        </button>
-                    </div>
-                </form>
-            </div>
-        </div>
+        <!-- Collapsible header search bar removed (#812) alongside its
+             toggle button. The dedicated /search page reached via the
+             footer-nav handles the use case. The autocomplete + Fuse
+             index logic in js/modules/search.js degrades gracefully
+             when neither element is present. -->
     </header>
 
     <!-- ================================================================

--- a/appWeb/public_html/js/modules/notifications.js
+++ b/appWeb/public_html/js/modules/notifications.js
@@ -54,7 +54,10 @@ export class Notifications {
         const wrap = document.getElementById('header-notifications-dropdown');
         if (!wrap) return;
         if (this.app.userAuth?.isLoggedIn?.()) {
-            wrap.classList.remove('d-none');
+            /* Don't reveal the wrapper here — _renderBadge() owns that
+               decision and only shows the bell when there's at least one
+               unread notification (#812). Calling refresh() will
+               populate _items and trigger the visibility toggle. */
             this.refresh();
             this._startPolling();
         } else {
@@ -96,13 +99,23 @@ export class Notifications {
 
     _renderBadge() {
         const badge = document.getElementById('header-notifications-badge');
+        const wrap  = document.getElementById('header-notifications-dropdown');
         if (!badge) return;
         const unread = this._items.filter(n => !n.is_read).length;
         if (unread > 0) {
             badge.textContent = unread > 99 ? '99+' : String(unread);
             badge.classList.remove('d-none');
+            /* Reveal the bell only when there's at least one unread row
+               (#812). Avoids the bell crowding the header on every signed-in
+               page when nothing is pending — important on mobile portrait
+               where every header slot counts. */
+            wrap?.classList.remove('d-none');
         } else {
             badge.classList.add('d-none');
+            /* Mark-all-read or empty-feed → hide the wrapper too so the
+               header reclaims the slot. The next poll re-reveals it the
+               moment a fresh row arrives. */
+            wrap?.classList.add('d-none');
         }
     }
 

--- a/appWeb/public_html/manage/entitlements.php
+++ b/appWeb/public_html/manage/entitlements.php
@@ -76,7 +76,7 @@ $effective = effectiveEntitlements();
 $groups = [
     'Song data' => ['edit_songs', 'delete_songs', 'bulk_edit_songs', 'verify_songs'],
     'User management' => ['view_users', 'edit_users', 'change_user_roles', 'assign_global_admin', 'delete_users'],
-    'Database & operations' => ['view_admin_dashboard', 'view_analytics', 'run_db_install', 'run_db_migrate', 'run_db_backup', 'run_db_restore', 'drop_legacy_tables', 'manage_configuration'],
+    'Database & operations' => ['view_admin_dashboard', 'view_analytics', 'run_db_install', 'run_db_migrate', 'run_db_backup', 'run_db_restore', 'drop_legacy_tables', 'manage_configuration', 'manage_notifications'],
     'Content moderation' => ['review_song_requests'],
     'Content structure'  => ['manage_songbooks', 'manage_user_groups', 'manage_organisations', 'manage_credit_people', 'manage_languages', 'manage_tags'],
     'Channel access'     => ['access_alpha', 'access_beta'],
@@ -130,6 +130,7 @@ $ENTITLEMENT_LABELS = [
     'view_activity_log'         => ['View activity log',             'Open the audit-trail viewer (#535)'],
     'manage_entitlements'       => ['Manage entitlements',           'Edit this map itself — Global Admin only'],
     'manage_configuration'      => ['Manage system configuration',   'Email service, system flags — Global Admin only (#768)'],
+    'manage_notifications'      => ['Manage notifications',          'Compose & broadcast in-app notifications — Global Admin only (#813)'],
 ];
 
 $entLabel = static function (string $key) use ($ENTITLEMENT_LABELS): array {

--- a/appWeb/public_html/manage/includes/admin-links.php
+++ b/appWeb/public_html/manage/includes/admin-links.php
@@ -29,38 +29,56 @@ if (basename($_SERVER['SCRIPT_FILENAME'] ?? '') === basename(__FILE__)) {
     exit('Access denied.');
 }
 
+/* Sidebar group layout (#819). The Content group had grown to 12
+   items and dwarfed every other section — split into three more
+   meaningful groups (Songs / Catalogue / Access) and consolidated
+   Entitlements alongside the other gating concerns under Access.
+   The new groups render as collapsible accordion sections in
+   admin-sidebar.php and the mobile offcanvas. */
 $_adminLinks = [
-    /* id               href                       icon                 label                   entitlement                    group         */
-    ['dashboard',       '/manage/',                'bi-speedometer2',   'Dashboard',            null,                          ''           ],
-    ['editor',          '/manage/editor/',         'bi-pencil-square',  'Song Editor',          'edit_songs',                  'Content'    ],
-    ['requests',        '/manage/requests',        'bi-lightbulb',      'Song Requests',        'review_song_requests',        'Content'    ],
-    ['revisions',       '/manage/revisions',       'bi-clock-history',  'Revisions Audit',      'verify_songs',                'Content'    ],
-    ['missing-numbers', '/manage/missing-numbers', 'bi-binoculars',     'Missing Numbers',      'edit_songs',                  'Content'    ],
-    ['song-link-suggestions', '/manage/song-link-suggestions', 'bi-lightbulb', 'Song Link Suggestions', 'edit_songs',         'Content'    ],
-    ['songbooks',       '/manage/songbooks',       'bi-book',           'Songbooks',            'manage_songbooks',            'Content'    ],
-    ['songbook-series', '/manage/songbook-series', 'bi-collection',     'Songbook Series',      'manage_songbooks',            'Content'    ],
-    ['credit-people',   '/manage/credit-people',   'bi-person-badge',   'Credit People',        'manage_credit_people',        'Content'    ],
-    ['languages',       '/manage/languages',       'bi-translate',      'Languages',            'manage_languages',            'Content'    ],
-    ['tags',            '/manage/tags',            'bi-tags',           'Tags & Themes',        'manage_tags',                 'Content'    ],
-    ['restrictions',    '/manage/restrictions',    'bi-shield-lock',    'Content Restrictions', 'manage_content_restrictions', 'Content'    ],
-    ['tiers',           '/manage/tiers',           'bi-stars',          'Access Tiers',         'manage_access_tiers',         'Content'    ],
-    ['users',           '/manage/users',           'bi-people',         'Users',                'view_users',                  'People'     ],
-    ['groups',          '/manage/groups',          'bi-people-fill',    'User Groups',          'manage_user_groups',          'People'     ],
-    ['organisations',   '/manage/organisations',   'bi-building',       'Organisations',        'manage_organisations',        'People'     ],
+    /* id                    href                              icon                  label                    entitlement                    group         */
+    ['dashboard',            '/manage/',                       'bi-speedometer2',    'Dashboard',             null,                          ''           ],
+
+    /* Songs — per-row content surfaces (#819) */
+    ['editor',               '/manage/editor/',                'bi-pencil-square',   'Song Editor',           'edit_songs',                  'Songs'      ],
+    ['requests',             '/manage/requests',               'bi-lightbulb',       'Song Requests',         'review_song_requests',        'Songs'      ],
+    ['revisions',            '/manage/revisions',              'bi-clock-history',   'Revisions Audit',       'verify_songs',                'Songs'      ],
+    ['missing-numbers',      '/manage/missing-numbers',        'bi-binoculars',      'Missing Numbers',       'edit_songs',                  'Songs'      ],
+    ['song-link-suggestions','/manage/song-link-suggestions',  'bi-link-45deg',      'Song Link Suggestions', 'edit_songs',                  'Songs'      ],
+
+    /* Catalogue — collection / metadata surfaces (#819) */
+    ['songbooks',            '/manage/songbooks',              'bi-book',            'Songbooks',             'manage_songbooks',            'Catalogue'  ],
+    ['songbook-series',      '/manage/songbook-series',        'bi-collection',      'Songbook Series',       'manage_songbooks',            'Catalogue'  ],
+    ['credit-people',        '/manage/credit-people',          'bi-person-badge',    'Credit People',         'manage_credit_people',        'Catalogue'  ],
+    ['languages',            '/manage/languages',              'bi-translate',       'Languages',             'manage_languages',            'Catalogue'  ],
+    ['tags',                 '/manage/tags',                   'bi-tags',            'Tags & Themes',         'manage_tags',                 'Catalogue'  ],
+
+    /* Access — gating + permission surfaces (#819) */
+    ['restrictions',         '/manage/restrictions',           'bi-shield-lock',     'Content Restrictions',  'manage_content_restrictions', 'Access'     ],
+    ['tiers',                '/manage/tiers',                  'bi-stars',           'Access Tiers',          'manage_access_tiers',         'Access'     ],
+    ['entitlements',         '/manage/entitlements',           'bi-key',             'Entitlements',          'manage_entitlements',         'Access'     ],
+
+    /* People */
+    ['users',                '/manage/users',                  'bi-people',          'Users',                 'view_users',                  'People'     ],
+    ['groups',               '/manage/groups',                 'bi-people-fill',     'User Groups',           'manage_user_groups',          'People'     ],
+    ['organisations',        '/manage/organisations',          'bi-building',        'Organisations',         'manage_organisations',        'People'     ],
     /* My Organisations (#707) — the entitlement is open to every signed-in
        role; admin-nav.php applies a data-driven hide via
        userHasOwnOrganisation() so non-admins only see this link when they
        hold an admin/owner row in tblOrganisationMembers. */
-    ['my-organisations','/manage/my-organisations','bi-buildings',      'My Organisations',     'manage_own_organisation',     'People'     ],
-    ['entitlements',    '/manage/entitlements',    'bi-key',            'Entitlements',         'manage_entitlements',         'People'     ],
-    ['analytics',       '/manage/analytics',       'bi-graph-up',       'Analytics',            'view_analytics',              'Operations' ],
-    ['ccli-report',     '/manage/ccli-report',     'bi-receipt',        'CCLI Usage Report',    'view_ccli_report',            'Operations' ],
-    ['data-health',     '/manage/data-health',     'bi-activity',       'Data Health',          'drop_legacy_tables',          'Operations' ],
-    ['activity-log',    '/manage/activity-log',    'bi-journal-text',   'Activity Log',         'view_activity_log',           'Operations' ],
-    ['schema-audit',    '/manage/schema-audit',    'bi-clipboard2-data','Schema Audit',         'drop_legacy_tables',          'Operations' ],
-    ['setup-database',  '/manage/setup-database',  'bi-database-gear',  'Database Setup',       'run_db_install',              'Operations' ],
-    ['configuration',   '/manage/configuration',   'bi-sliders',        'Configuration',        'manage_configuration',        'Operations' ],
-    ['help',            '/manage/help',            'bi-life-preserver', 'Help / Guides',        null,                          'Help'       ],
+    ['my-organisations',     '/manage/my-organisations',       'bi-buildings',       'My Organisations',      'manage_own_organisation',     'People'     ],
+
+    /* Operations — reports, maintenance, infrastructure */
+    ['analytics',            '/manage/analytics',              'bi-graph-up',        'Analytics',             'view_analytics',              'Operations' ],
+    ['ccli-report',          '/manage/ccli-report',            'bi-receipt',         'CCLI Usage Report',     'view_ccli_report',            'Operations' ],
+    ['data-health',          '/manage/data-health',            'bi-activity',        'Data Health',           'drop_legacy_tables',          'Operations' ],
+    ['activity-log',         '/manage/activity-log',           'bi-journal-text',    'Activity Log',          'view_activity_log',           'Operations' ],
+    ['schema-audit',         '/manage/schema-audit',           'bi-clipboard2-data', 'Schema Audit',          'drop_legacy_tables',          'Operations' ],
+    ['setup-database',       '/manage/setup-database',         'bi-database-gear',   'Database Setup',        'run_db_install',              'Operations' ],
+    ['configuration',        '/manage/configuration',          'bi-sliders',         'Configuration',         'manage_configuration',        'Operations' ],
+    ['notifications',        '/manage/notifications',          'bi-bell',            'Notifications',         'manage_notifications',        'Operations' ],
+
+    ['help',                 '/manage/help',                   'bi-life-preserver',  'Help / Guides',         null,                          'Help'       ],
 ];
 
 /**

--- a/appWeb/public_html/manage/includes/admin-nav.php
+++ b/appWeb/public_html/manage/includes/admin-nav.php
@@ -102,7 +102,7 @@ $_avatarUrlLarge = userAvatarUrl($_userEmail, 64, $_userAvatarSvc);
                         id="admin-brand-btn">
                     <i class="bi bi-music-note-beamed fs-5" aria-hidden="true"></i>
                     <span class="fw-bold">iHymns</span>
-                    <span class="badge bg-warning text-dark ms-1 small">Admin</span>
+                    <span class="badge env-badge bg-warning text-dark ms-1">Admin</span>
                 </button>
                 <ul class="dropdown-menu" aria-labelledby="admin-brand-btn">
                     <li><a class="dropdown-item" href="/manage/">

--- a/appWeb/public_html/manage/includes/admin-nav.php
+++ b/appWeb/public_html/manage/includes/admin-nav.php
@@ -259,15 +259,71 @@ $_avatarUrlLarge = userAvatarUrl($_userEmail, 64, $_userAvatarSvc);
                 aria-label="Close"></button>
     </div>
     <div class="offcanvas-body p-0">
-        <nav class="list-group list-group-flush" aria-label="Admin sections">
-            <?php foreach ($_visibleAdminLinks as $l): ?>
-                <?php [$id, $href, $icon, $label, $entitlement] = $l; ?>
-                <a href="<?= htmlspecialchars($href) ?>"
-                   class="list-group-item list-group-item-action d-flex align-items-center gap-2<?= $_activePage === $id ? ' active' : '' ?>"
-                   <?= $_activePage === $id ? 'aria-current="page"' : '' ?>>
-                    <i class="bi <?= htmlspecialchars($icon) ?>" aria-hidden="true"></i>
-                    <span><?= htmlspecialchars($label) ?><?= entitlementLockChipHtml($entitlement) ?></span>
-                </a>
+        <?php
+            /* Mirror the desktop sidebar's accordion structure (#819) so
+               mobile gets the same compact, collapsible groups. Same
+               localStorage keys, same active-group force-expand
+               behaviour — the JS in admin-sidebar.php scopes itself
+               via [data-admin-accordion]. */
+            $_offGrouped = [];
+            foreach ($_visibleAdminLinks as $l) {
+                $_offGrouped[$l[5] ?? ''][] = $l;
+            }
+            $_offActiveGroup = '';
+            foreach ($_visibleAdminLinks as $l) {
+                if (($l[0] ?? null) === $_activePage) {
+                    $_offActiveGroup = (string)($l[5] ?? '');
+                    break;
+                }
+            }
+            $_offSlug = static function (string $g): string {
+                $slug = strtolower(preg_replace('/[^A-Za-z0-9]+/', '-', $g));
+                return 'admin-off-grp-' . trim($slug, '-');
+            };
+        ?>
+        <nav class="admin-offcanvas-nav" aria-label="Admin sections"
+             data-admin-accordion="offcanvas">
+            <?php foreach ($_offGrouped as $_grp => $_links): ?>
+                <?php if ($_grp === ''): ?>
+                    <?php foreach ($_links as $l): ?>
+                        <?php [$id, $href, $icon, $label, $entitlement] = $l; ?>
+                        <a href="<?= htmlspecialchars($href) ?>"
+                           class="list-group-item list-group-item-action d-flex align-items-center gap-2<?= $_activePage === $id ? ' active' : '' ?>"
+                           <?= $_activePage === $id ? 'aria-current="page"' : '' ?>>
+                            <i class="bi <?= htmlspecialchars($icon) ?>" aria-hidden="true"></i>
+                            <span><?= htmlspecialchars($label) ?><?= entitlementLockChipHtml($entitlement) ?></span>
+                        </a>
+                    <?php endforeach; ?>
+                    <?php continue; ?>
+                <?php endif; ?>
+                <?php
+                    $_isActiveOff = ($_grp === $_offActiveGroup);
+                    $_offId       = $_offSlug($_grp);
+                ?>
+                <div class="admin-offcanvas-group" data-group="<?= htmlspecialchars((string)$_grp) ?>">
+                    <button type="button"
+                            class="admin-offcanvas-group-toggle btn btn-link w-100 d-flex align-items-center justify-content-between text-uppercase small fw-semibold px-3 py-2<?= $_isActiveOff ? '' : ' collapsed' ?>"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#<?= htmlspecialchars($_offId) ?>"
+                            aria-expanded="<?= $_isActiveOff ? 'true' : 'false' ?>"
+                            aria-controls="<?= htmlspecialchars($_offId) ?>">
+                        <span class="text-muted"><?= htmlspecialchars((string)$_grp) ?></span>
+                        <i class="bi bi-chevron-down ms-2 small" aria-hidden="true"></i>
+                    </button>
+                    <div id="<?= htmlspecialchars($_offId) ?>"
+                         class="offcanvas-group-body collapse<?= $_isActiveOff ? ' show' : '' ?>"
+                         <?= $_isActiveOff ? 'data-active-forced="1"' : '' ?>>
+                        <?php foreach ($_links as $l): ?>
+                            <?php [$id, $href, $icon, $label, $entitlement] = $l; ?>
+                            <a href="<?= htmlspecialchars($href) ?>"
+                               class="list-group-item list-group-item-action d-flex align-items-center gap-2 ps-4<?= $_activePage === $id ? ' active' : '' ?>"
+                               <?= $_activePage === $id ? 'aria-current="page"' : '' ?>>
+                                <i class="bi <?= htmlspecialchars($icon) ?>" aria-hidden="true"></i>
+                                <span><?= htmlspecialchars($label) ?><?= entitlementLockChipHtml($entitlement) ?></span>
+                            </a>
+                        <?php endforeach; ?>
+                    </div>
+                </div>
             <?php endforeach; ?>
         </nav>
     </div>

--- a/appWeb/public_html/manage/includes/admin-sidebar.php
+++ b/appWeb/public_html/manage/includes/admin-sidebar.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * iHymns — Shared Admin Sidebar (#460)
+ * iHymns — Shared Admin Sidebar (#460, accordion-fied #819)
  *
  * Pinned-left navigation visible at lg+ viewports; hidden below lg
  * by the `d-none d-lg-flex` utility classes, where the hamburger
@@ -11,7 +11,11 @@ declare(strict_types=1);
  *
  * Iterates `visibleAdminLinks()` from admin-links.php so the
  * destinations, entitlement gates and active-state highlighting stay
- * in lock-step with the offcanvas.
+ * in lock-step with the offcanvas. Renders each group as a
+ * collapsible accordion section — only the group containing the
+ * active page is expanded by default; the rest stay tucked away to
+ * keep the long admin nav scannable. Per-group open/closed state
+ * persists in localStorage between navigations.
  *
  * Expects the caller (admin-nav.php) to have already:
  *   - required admin-links.php (so visibleAdminLinks() is defined)
@@ -29,30 +33,123 @@ $_sidebarLinks  = visibleAdminLinks($_sidebarRole);
 
 /* Collect into { groupHeading => [link, …] } while preserving the
    registry's declaration order so groups surface in a stable sequence
-   (top-level → Content → People → Operations). */
+   (Dashboard → Songs → Catalogue → Access → People → Operations → Help). */
 $_sidebarGrouped = [];
 foreach ($_sidebarLinks as $l) {
     $_sidebarGrouped[$l[5] ?? ''][] = $l;
 }
 
+/* Identify the group containing the active page so the accordion
+   renderer can force-expand it on initial render, regardless of any
+   stored localStorage preference. */
+$_sidebarActiveGroup = '';
+foreach ($_sidebarLinks as $l) {
+    if (($l[0] ?? null) === $_sidebarActive) {
+        $_sidebarActiveGroup = (string)($l[5] ?? '');
+        break;
+    }
+}
+
+/* Build a stable, slug-safe id for each group so
+   data-bs-target / aria-controls + JS persistence agree. */
+$_sidebarGroupSlug = static function (string $g): string {
+    $slug = strtolower(preg_replace('/[^A-Za-z0-9]+/', '-', $g));
+    return 'admin-nav-grp-' . trim($slug, '-');
+};
+
 ?>
 <aside class="admin-sidebar d-none d-lg-flex flex-column" aria-label="Admin sections">
-    <nav class="admin-sidebar-nav flex-grow-1" aria-label="Primary">
+    <nav class="admin-sidebar-nav flex-grow-1" aria-label="Primary"
+         data-admin-accordion="sidebar">
         <?php foreach ($_sidebarGrouped as $group => $links): ?>
-            <?php if ($group !== ''): ?>
-                <div class="admin-sidebar-group-label text-uppercase small text-muted px-3 pt-3 pb-1">
-                    <?= htmlspecialchars((string)$group) ?>
-                </div>
+            <?php if ($group === ''): ?>
+                <?php /* Top-level (Dashboard) — render flat, no accordion. */ ?>
+                <?php foreach ($links as $l): ?>
+                    <?php [$id, $href, $icon, $label, $entitlement] = $l; ?>
+                    <a href="<?= htmlspecialchars($href) ?>"
+                       class="admin-sidebar-link d-flex align-items-center gap-2 px-3 py-2<?= $_sidebarActive === $id ? ' active' : '' ?>"
+                       <?= $_sidebarActive === $id ? 'aria-current="page"' : '' ?>>
+                        <i class="bi <?= htmlspecialchars($icon) ?> fs-6" aria-hidden="true"></i>
+                        <span><?= htmlspecialchars($label) ?><?= entitlementLockChipHtml($entitlement) ?></span>
+                    </a>
+                <?php endforeach; ?>
+                <?php continue; ?>
             <?php endif; ?>
-            <?php foreach ($links as $l): ?>
-                <?php [$id, $href, $icon, $label, $entitlement] = $l; ?>
-                <a href="<?= htmlspecialchars($href) ?>"
-                   class="admin-sidebar-link d-flex align-items-center gap-2 px-3 py-2<?= $_sidebarActive === $id ? ' active' : '' ?>"
-                   <?= $_sidebarActive === $id ? 'aria-current="page"' : '' ?>>
-                    <i class="bi <?= htmlspecialchars($icon) ?> fs-6" aria-hidden="true"></i>
-                    <span><?= htmlspecialchars($label) ?><?= entitlementLockChipHtml($entitlement) ?></span>
-                </a>
-            <?php endforeach; ?>
+            <?php
+                $_isActiveGroup = ($group === $_sidebarActiveGroup);
+                $_groupId       = $_sidebarGroupSlug($group);
+            ?>
+            <div class="admin-sidebar-group" data-group="<?= htmlspecialchars((string)$group) ?>">
+                <button type="button"
+                        class="admin-sidebar-group-toggle btn btn-link w-100 d-flex align-items-center justify-content-between text-uppercase small fw-semibold px-3 pt-3 pb-1<?= $_isActiveGroup ? '' : ' collapsed' ?>"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#<?= htmlspecialchars($_groupId) ?>"
+                        aria-expanded="<?= $_isActiveGroup ? 'true' : 'false' ?>"
+                        aria-controls="<?= htmlspecialchars($_groupId) ?>">
+                    <span class="text-muted"><?= htmlspecialchars((string)$group) ?></span>
+                    <i class="bi bi-chevron-down ms-2 small admin-sidebar-group-chev" aria-hidden="true"></i>
+                </button>
+                <div id="<?= htmlspecialchars($_groupId) ?>"
+                     class="admin-sidebar-group-body collapse<?= $_isActiveGroup ? ' show' : '' ?>">
+                    <?php foreach ($links as $l): ?>
+                        <?php [$id, $href, $icon, $label, $entitlement] = $l; ?>
+                        <a href="<?= htmlspecialchars($href) ?>"
+                           class="admin-sidebar-link d-flex align-items-center gap-2 px-3 py-2<?= $_sidebarActive === $id ? ' active' : '' ?>"
+                           <?= $_sidebarActive === $id ? 'aria-current="page"' : '' ?>>
+                            <i class="bi <?= htmlspecialchars($icon) ?> fs-6" aria-hidden="true"></i>
+                            <span><?= htmlspecialchars($label) ?><?= entitlementLockChipHtml($entitlement) ?></span>
+                        </a>
+                    <?php endforeach; ?>
+                </div>
+            </div>
         <?php endforeach; ?>
     </nav>
 </aside>
+
+<script>
+/* Sidebar accordion persistence (#819). On any group toggle, store
+   the open/closed state under "ihymns-admin-nav-<group>". On every
+   page load, restore stored state EXCEPT for the active group which
+   is always forced open via PHP-rendered `.show` so the user can
+   see their position. Failure to access localStorage is silent —
+   defaults work without persistence. */
+(() => {
+    const KEY_PREFIX = 'ihymns-admin-nav-';
+
+    /* Apply stored open/closed to non-active groups on initial load. */
+    document.querySelectorAll('[data-admin-accordion] [data-group]').forEach((el) => {
+        const group = el.getAttribute('data-group') || '';
+        const body  = el.querySelector('.admin-sidebar-group-body, .offcanvas-group-body');
+        const btn   = el.querySelector('[data-bs-toggle="collapse"]');
+        if (!body || !btn) return;
+        /* Active group's `.show` is rendered server-side; don't fight it. */
+        if (body.classList.contains('show') && body.dataset.activeForced === '1') return;
+        try {
+            const stored = localStorage.getItem(KEY_PREFIX + group);
+            if (stored === 'open') {
+                body.classList.add('show');
+                btn.setAttribute('aria-expanded', 'true');
+                btn.classList.remove('collapsed');
+            } else if (stored === 'closed') {
+                body.classList.remove('show');
+                btn.setAttribute('aria-expanded', 'false');
+                btn.classList.add('collapsed');
+            }
+        } catch (_e) { /* localStorage blocked — accept defaults */ }
+    });
+
+    /* Persist on toggle. Bootstrap fires `shown.bs.collapse` /
+       `hidden.bs.collapse` on the collapse target. */
+    document.querySelectorAll('[data-admin-accordion] [data-group]').forEach((el) => {
+        const group = el.getAttribute('data-group') || '';
+        const body  = el.querySelector('.admin-sidebar-group-body, .offcanvas-group-body');
+        if (!body) return;
+        body.addEventListener('shown.bs.collapse', () => {
+            try { localStorage.setItem(KEY_PREFIX + group, 'open'); } catch (_e) {}
+        });
+        body.addEventListener('hidden.bs.collapse', () => {
+            try { localStorage.setItem(KEY_PREFIX + group, 'closed'); } catch (_e) {}
+        });
+    });
+})();
+</script>

--- a/appWeb/public_html/manage/notifications.php
+++ b/appWeb/public_html/manage/notifications.php
@@ -1,0 +1,602 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Admin: Notifications (#813)
+ *
+ * Global Admin only. Compose + broadcast in-app notifications and
+ * inspect / delete the resulting feed. Closes the gap left by #289:
+ * tblNotifications existed and the header bell consumed it, but
+ * there was no admin path to post a row — every notification came
+ * from automated system events (bulk-import job completion, etc.).
+ *
+ * Audience targeting:
+ *   - single user      (resolved by username / email / id)
+ *   - role             (every signed-in user with this role)
+ *   - all signed-in    (every active account)
+ *
+ * One row per recipient is inserted on broadcast. Activity-Log
+ * entries are written for every compose / delete so the audit
+ * trail can answer "who broadcast what to whom on which date."
+ *
+ * Plain-text body for v1 — sanitised via htmlspecialchars on render.
+ * Markdown / rich-text + scheduling / future-send are out of scope
+ * (tracked separately if needed).
+ */
+
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'config.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
+
+if (!isAuthenticated()) {
+    header('Location: /manage/login');
+    exit;
+}
+$currentUser = getCurrentUser();
+if (!$currentUser || !userHasEntitlement('manage_notifications', $currentUser['role'] ?? null)) {
+    http_response_code(403);
+    echo '<!DOCTYPE html><html><body><h1>403 — manage_notifications required</h1></body></html>';
+    exit;
+}
+$activePage = 'notifications';
+
+$db   = getDbMysqli();
+$csrf = csrfToken();
+
+/* ----------------------------------------------------------------------
+ * POST handlers — compose / delete
+ * ---------------------------------------------------------------------- */
+
+$flashSuccess = '';
+$flashError   = '';
+
+/* Broadcast batch size cap (#813). All-signed-in audiences fan out one
+   INSERT per recipient; bound the loop so a runaway broadcast can't
+   pin the DB. Operators with > 5,000 active users should split into
+   role-targeted broadcasts for now. */
+const NOTIFY_BROADCAST_MAX = 5000;
+
+if (($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'POST') {
+    if (!validateCsrf((string)($_POST['csrf_token'] ?? ''))) {
+        $flashError = 'CSRF token invalid — refresh the page and try again.';
+    } else {
+        $action = (string)($_POST['action'] ?? '');
+
+        if ($action === 'compose') {
+            $audience    = (string)($_POST['audience'] ?? '');
+            $userQuery   = trim((string)($_POST['target_user'] ?? ''));
+            $roleTarget  = (string)($_POST['target_role'] ?? '');
+            $title       = trim((string)($_POST['title']     ?? ''));
+            $body        = trim((string)($_POST['body']      ?? ''));
+            $actionUrl   = trim((string)($_POST['action_url'] ?? ''));
+            $type        = trim((string)($_POST['type']      ?? 'announcement'));
+
+            /* Validate */
+            $errs = [];
+            if ($title === '' || mb_strlen($title) > 255) {
+                $errs[] = 'Title is required and must be ≤ 255 characters.';
+            }
+            if ($body === '') {
+                $errs[] = 'Body is required.';
+            } elseif (mb_strlen($body) > 2000) {
+                $errs[] = 'Body must be ≤ 2000 characters (#813 v1).';
+            }
+            if ($actionUrl !== ''
+                && !preg_match('#^/[^/]#', $actionUrl)        // local /-rooted paths
+                && !preg_match('#^https://#i', $actionUrl)) { // or absolute https
+                $errs[] = 'Action URL must be a /-rooted local path or an https:// URL.';
+            }
+            if (!in_array($audience, ['user', 'role', 'all'], true)) {
+                $errs[] = 'Pick an audience.';
+            }
+            $allowedTypes = ['announcement', 'maintenance', 'release', 'info'];
+            if (!in_array($type, $allowedTypes, true)) {
+                $type = 'announcement';
+            }
+
+            /* Resolve recipients */
+            $recipients = [];
+            if (!$errs) {
+                if ($audience === 'user') {
+                    if ($userQuery === '') {
+                        $errs[] = 'Pick a target user.';
+                    } else {
+                        /* Match by username / email / id (case-insensitive) */
+                        $stmt = $db->prepare(
+                            'SELECT Id FROM tblUsers
+                              WHERE Username = ? OR Email = ? OR Id = ?
+                              LIMIT 1'
+                        );
+                        $idCandidate = ctype_digit($userQuery) ? (int)$userQuery : 0;
+                        $stmt->bind_param('ssi', $userQuery, $userQuery, $idCandidate);
+                        $stmt->execute();
+                        $row = $stmt->get_result()->fetch_assoc();
+                        $stmt->close();
+                        if (!$row) {
+                            $errs[] = 'No user matched "' . htmlspecialchars($userQuery) . '".';
+                        } else {
+                            $recipients = [(int)$row['Id']];
+                        }
+                    }
+                } elseif ($audience === 'role') {
+                    $allowedRoles = ['user', 'editor', 'admin', 'global_admin'];
+                    if (!in_array($roleTarget, $allowedRoles, true)) {
+                        $errs[] = 'Pick a target role.';
+                    } else {
+                        $stmt = $db->prepare(
+                            'SELECT Id FROM tblUsers
+                              WHERE Role = ? AND COALESCE(IsActive, 1) = 1
+                              LIMIT ' . (int)NOTIFY_BROADCAST_MAX
+                        );
+                        $stmt->bind_param('s', $roleTarget);
+                        $stmt->execute();
+                        $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+                        $stmt->close();
+                        $recipients = array_map(static fn($r) => (int)$r['Id'], $rows);
+                    }
+                } elseif ($audience === 'all') {
+                    $res = $db->query(
+                        'SELECT Id FROM tblUsers WHERE COALESCE(IsActive, 1) = 1 LIMIT ' . (int)NOTIFY_BROADCAST_MAX
+                    );
+                    if ($res) {
+                        $rows = $res->fetch_all(MYSQLI_ASSOC);
+                        $res->close();
+                        $recipients = array_map(static fn($r) => (int)$r['Id'], $rows);
+                    }
+                }
+                if (!$errs && empty($recipients)) {
+                    $errs[] = 'No active recipients matched the audience.';
+                }
+            }
+
+            if ($errs) {
+                $flashError = implode(' ', $errs);
+            } else {
+                /* Fan-out INSERT. Single prepared statement, re-execute per
+                   recipient. mysqli has no true multi-row prepared insert
+                   without dynamically generated SQL — at NOTIFY_BROADCAST_MAX
+                   = 5000 the loop is fast enough (~< 1s on a typical host)
+                   and stays auditable per-row. */
+                $stmt = $db->prepare(
+                    'INSERT INTO tblNotifications (UserId, Type, Title, Body, ActionUrl)
+                     VALUES (?, ?, ?, ?, ?)'
+                );
+                $actionUrlForBind = $actionUrl !== '' ? $actionUrl : null;
+                $count = 0;
+                foreach ($recipients as $uid) {
+                    $stmt->bind_param('issss', $uid, $type, $title, $body, $actionUrlForBind);
+                    if (@$stmt->execute()) $count++;
+                }
+                $stmt->close();
+
+                /* Activity-log entry — single line with audience metadata. */
+                try {
+                    $auditUid = (int)($currentUser['Id'] ?? $currentUser['id'] ?? 0);
+                    $auditDetails = json_encode([
+                        'audience'    => $audience,
+                        'target_role' => $audience === 'role' ? $roleTarget : null,
+                        'target_user' => $audience === 'user' ? $userQuery : null,
+                        'title'       => mb_substr($title, 0, 100),
+                        'recipients'  => $count,
+                        'type'        => $type,
+                    ], JSON_UNESCAPED_SLASHES);
+                    $stmt2 = $db->prepare(
+                        'INSERT INTO tblActivityLog (UserId, Action, EntityType, EntityId, Details, IpAddress)
+                         VALUES (?, ?, ?, ?, ?, ?)'
+                    );
+                    if ($stmt2) {
+                        $auditAction = 'notification.broadcast';
+                        $auditEntity = 'notification';
+                        $auditEnId   = '';
+                        $auditIp     = (string)($_SERVER['REMOTE_ADDR'] ?? '');
+                        $stmt2->bind_param('isssss', $auditUid, $auditAction, $auditEntity, $auditEnId, $auditDetails, $auditIp);
+                        @$stmt2->execute();
+                        $stmt2->close();
+                    }
+                } catch (\Throwable $_e) { /* audit failure must not block */ }
+
+                $flashSuccess = "Sent to {$count} recipient" . ($count === 1 ? '' : 's') . '.';
+                /* PRG so a refresh doesn't re-broadcast */
+                $_SESSION['notifications_flash'] = ['success' => $flashSuccess];
+                header('Location: /manage/notifications');
+                exit;
+            }
+        }
+
+        if ($action === 'delete') {
+            $id = (int)($_POST['id'] ?? 0);
+            if ($id > 0) {
+                $stmt = $db->prepare('DELETE FROM tblNotifications WHERE Id = ?');
+                $stmt->bind_param('i', $id);
+                $stmt->execute();
+                $stmt->close();
+                $_SESSION['notifications_flash'] = ['success' => 'Notification deleted.'];
+                header('Location: /manage/notifications');
+                exit;
+            }
+        }
+    }
+}
+
+/* PRG flash pull-and-clear */
+if (!empty($_SESSION['notifications_flash']['success'])) {
+    $flashSuccess = (string)$_SESSION['notifications_flash']['success'];
+    unset($_SESSION['notifications_flash']);
+}
+
+/* ----------------------------------------------------------------------
+ * Feed list (paginated). Filter by user / read state / type / date range.
+ * ---------------------------------------------------------------------- */
+
+$filter = [
+    'user'    => trim((string)($_GET['user'] ?? '')),
+    'type'    => trim((string)($_GET['type'] ?? '')),
+    'read'    => trim((string)($_GET['read'] ?? '')), /* '' | 'unread' | 'read' */
+    'since'   => trim((string)($_GET['since'] ?? '')),
+];
+$page    = max(1, (int)($_GET['page'] ?? 1));
+$perPage = 50;
+$offset  = ($page - 1) * $perPage;
+
+$where  = [];
+$params = [];
+$types  = '';
+
+if ($filter['user'] !== '') {
+    $where[] = '(u.Username LIKE ? OR u.Email LIKE ? OR n.UserId = ?)';
+    $like    = '%' . $filter['user'] . '%';
+    $idCand  = ctype_digit($filter['user']) ? (int)$filter['user'] : 0;
+    $params[] = $like; $params[] = $like; $params[] = $idCand;
+    $types   .= 'ssi';
+}
+if ($filter['type'] !== '') {
+    $where[] = 'n.Type = ?';
+    $params[] = $filter['type'];
+    $types   .= 's';
+}
+if ($filter['read'] === 'unread') {
+    $where[] = 'n.IsRead = 0';
+} elseif ($filter['read'] === 'read') {
+    $where[] = 'n.IsRead = 1';
+}
+if ($filter['since'] !== '' && preg_match('/^\d{4}-\d{2}-\d{2}$/', $filter['since'])) {
+    $where[] = 'n.CreatedAt >= ?';
+    $params[] = $filter['since'] . ' 00:00:00';
+    $types   .= 's';
+}
+
+$whereSql = $where ? ('WHERE ' . implode(' AND ', $where)) : '';
+
+$sql = "SELECT n.Id, n.UserId, n.Type, n.Title, n.Body, n.ActionUrl,
+               n.IsRead, n.CreatedAt,
+               u.Username AS username, u.Email AS email
+          FROM tblNotifications n
+          LEFT JOIN tblUsers u ON u.Id = n.UserId
+          {$whereSql}
+         ORDER BY n.CreatedAt DESC
+         LIMIT {$perPage} OFFSET {$offset}";
+
+$stmt = $db->prepare($sql);
+if ($params) {
+    $stmt->bind_param($types, ...$params);
+}
+$stmt->execute();
+$feed = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+$stmt->close();
+
+/* Total count for pagination control */
+$countSql = "SELECT COUNT(*) AS c
+               FROM tblNotifications n
+               LEFT JOIN tblUsers u ON u.Id = n.UserId
+               {$whereSql}";
+$cstmt = $db->prepare($countSql);
+if ($params) {
+    $cstmt->bind_param($types, ...$params);
+}
+$cstmt->execute();
+$totalRows = (int)$cstmt->get_result()->fetch_assoc()['c'];
+$cstmt->close();
+$totalPages = max(1, (int)ceil($totalRows / $perPage));
+
+/* Distinct types in the table for the filter dropdown — gives admins
+   a discoverable list of "what types exist" without hardcoding. */
+$typesRes = $db->query('SELECT DISTINCT Type FROM tblNotifications ORDER BY Type ASC');
+$existingTypes = [];
+if ($typesRes) {
+    while ($r = $typesRes->fetch_assoc()) {
+        if ($r['Type']) $existingTypes[] = (string)$r['Type'];
+    }
+    $typesRes->close();
+}
+
+require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-favicon.php';
+?>
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Notifications — iHymns Admin</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.2/font/bootstrap-icons.css">
+    <link rel="stylesheet" href="/css/app.css">
+    <link rel="stylesheet" href="/css/admin.css">
+</head>
+<body>
+<?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-nav.php'; ?>
+
+<main class="container-fluid py-4">
+    <div class="d-flex justify-content-between align-items-start mb-3 flex-wrap gap-2">
+        <div>
+            <h1 class="h3 mb-1">
+                <i class="bi bi-bell me-2"></i>Notifications
+                <?= entitlementLockChipHtml('manage_notifications') ?>
+            </h1>
+            <p class="text-secondary small mb-0">
+                Compose and broadcast in-app notifications. Targets a single
+                user, an entire role, or every signed-in user.
+                <span class="badge bg-danger text-light ms-1" style="font-size: 0.7rem; font-weight: 600;">
+                    <i class="bi bi-lock-fill me-1" aria-hidden="true"></i>Global Admin only
+                </span>
+            </p>
+        </div>
+        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#notify-compose-modal">
+            <i class="bi bi-pencil-square me-1"></i> Compose
+        </button>
+    </div>
+
+    <?php if ($flashSuccess !== ''): ?>
+        <div class="alert alert-success">
+            <i class="bi bi-check-circle me-1"></i><?= htmlspecialchars($flashSuccess) ?>
+        </div>
+    <?php endif; ?>
+    <?php if ($flashError !== ''): ?>
+        <div class="alert alert-danger">
+            <i class="bi bi-exclamation-triangle me-1"></i><?= htmlspecialchars($flashError) ?>
+        </div>
+    <?php endif; ?>
+
+    <!-- ===========================
+         FILTER RAIL
+         =========================== -->
+    <div class="card bg-dark border-secondary mb-3">
+        <div class="card-body">
+            <form method="get" class="row g-2 align-items-end">
+                <div class="col-md-3">
+                    <label class="form-label small">Recipient (username / email / id)</label>
+                    <input type="text" name="user" class="form-control form-control-sm"
+                           value="<?= htmlspecialchars($filter['user']) ?>" placeholder="any">
+                </div>
+                <div class="col-md-2">
+                    <label class="form-label small">Type</label>
+                    <select name="type" class="form-select form-select-sm">
+                        <option value="">All</option>
+                        <?php foreach ($existingTypes as $t): ?>
+                            <option value="<?= htmlspecialchars($t) ?>" <?= $filter['type'] === $t ? 'selected' : '' ?>>
+                                <?= htmlspecialchars($t) ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="col-md-2">
+                    <label class="form-label small">Read state</label>
+                    <select name="read" class="form-select form-select-sm">
+                        <option value="">All</option>
+                        <option value="unread" <?= $filter['read'] === 'unread' ? 'selected' : '' ?>>Unread</option>
+                        <option value="read"   <?= $filter['read'] === 'read'   ? 'selected' : '' ?>>Read</option>
+                    </select>
+                </div>
+                <div class="col-md-2">
+                    <label class="form-label small">Since</label>
+                    <input type="date" name="since" class="form-control form-control-sm"
+                           value="<?= htmlspecialchars($filter['since']) ?>">
+                </div>
+                <div class="col-md-3 d-flex gap-2">
+                    <button type="submit" class="btn btn-sm btn-outline-info">Apply</button>
+                    <a href="/manage/notifications" class="btn btn-sm btn-outline-secondary">Reset</a>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <!-- ===========================
+         FEED TABLE
+         =========================== -->
+    <div class="card bg-dark border-secondary">
+        <div class="card-header d-flex justify-content-between align-items-center">
+            <span class="small text-secondary">
+                <?= number_format($totalRows) ?> notification<?= $totalRows === 1 ? '' : 's' ?>
+                — page <?= $page ?> of <?= $totalPages ?>
+            </span>
+        </div>
+        <div class="table-responsive">
+            <table class="table table-dark table-sm table-hover mb-0">
+                <thead>
+                    <tr>
+                        <th>When</th>
+                        <th>Recipient</th>
+                        <th>Type</th>
+                        <th>Title / Body</th>
+                        <th class="text-center">Read</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php if (empty($feed)): ?>
+                        <tr><td colspan="6" class="text-center text-muted py-4">No notifications match this filter.</td></tr>
+                    <?php else: ?>
+                        <?php foreach ($feed as $n): ?>
+                            <tr>
+                                <td class="small text-muted text-nowrap"><?= htmlspecialchars((string)$n['CreatedAt']) ?></td>
+                                <td class="small">
+                                    <?php if ($n['username']): ?>
+                                        <span class="text-light"><?= htmlspecialchars((string)$n['username']) ?></span>
+                                        <div class="text-muted"><?= htmlspecialchars((string)($n['email'] ?? '')) ?></div>
+                                    <?php else: ?>
+                                        <span class="text-muted">user #<?= (int)$n['UserId'] ?> (deleted?)</span>
+                                    <?php endif; ?>
+                                </td>
+                                <td class="small">
+                                    <span class="badge bg-secondary"><?= htmlspecialchars((string)$n['Type']) ?></span>
+                                </td>
+                                <td>
+                                    <strong><?= htmlspecialchars((string)$n['Title']) ?></strong>
+                                    <div class="text-muted small text-truncate" style="max-width: 50ch">
+                                        <?= htmlspecialchars((string)$n['Body']) ?>
+                                    </div>
+                                    <?php if (!empty($n['ActionUrl'])): ?>
+                                        <a class="small" href="<?= htmlspecialchars((string)$n['ActionUrl']) ?>" target="_blank" rel="noopener">
+                                            <i class="bi bi-box-arrow-up-right me-1"></i><?= htmlspecialchars((string)$n['ActionUrl']) ?>
+                                        </a>
+                                    <?php endif; ?>
+                                </td>
+                                <td class="text-center">
+                                    <?php if ((int)$n['IsRead'] === 1): ?>
+                                        <i class="bi bi-check-circle-fill text-success" title="Read"></i>
+                                    <?php else: ?>
+                                        <i class="bi bi-circle text-warning" title="Unread"></i>
+                                    <?php endif; ?>
+                                </td>
+                                <td class="text-end">
+                                    <form method="post" class="d-inline" onsubmit="return confirm('Delete this notification? It will disappear from the recipient\'s bell.');">
+                                        <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                                        <input type="hidden" name="action"     value="delete">
+                                        <input type="hidden" name="id"         value="<?= (int)$n['Id'] ?>">
+                                        <button type="submit" class="btn btn-sm btn-outline-danger" title="Delete">
+                                            <i class="bi bi-trash"></i>
+                                        </button>
+                                    </form>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    <?php endif; ?>
+                </tbody>
+            </table>
+        </div>
+        <?php if ($totalPages > 1): ?>
+            <div class="card-footer d-flex justify-content-center gap-2">
+                <?php
+                    $qs = $_GET;
+                    $linkFor = static function (int $p) use ($qs): string {
+                        $qs['page'] = $p;
+                        return '?' . http_build_query($qs);
+                    };
+                ?>
+                <?php if ($page > 1): ?>
+                    <a class="btn btn-sm btn-outline-secondary" href="<?= htmlspecialchars($linkFor($page - 1)) ?>">&laquo; Prev</a>
+                <?php endif; ?>
+                <span class="align-self-center small text-muted">Page <?= $page ?> of <?= $totalPages ?></span>
+                <?php if ($page < $totalPages): ?>
+                    <a class="btn btn-sm btn-outline-secondary" href="<?= htmlspecialchars($linkFor($page + 1)) ?>">Next &raquo;</a>
+                <?php endif; ?>
+            </div>
+        <?php endif; ?>
+    </div>
+</main>
+
+<!-- ===========================
+     COMPOSE MODAL
+     =========================== -->
+<div class="modal fade" id="notify-compose-modal" tabindex="-1" aria-labelledby="notify-compose-label" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered modal-lg">
+        <div class="modal-content bg-dark border-secondary">
+            <form method="post">
+                <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                <input type="hidden" name="action"     value="compose">
+
+                <div class="modal-header">
+                    <h5 class="modal-title" id="notify-compose-label">
+                        <i class="bi bi-pencil-square me-2"></i>Compose notification
+                    </h5>
+                    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+
+                <div class="modal-body">
+                    <!-- Audience selector -->
+                    <fieldset class="mb-3">
+                        <legend class="small text-muted">Audience</legend>
+                        <div class="form-check">
+                            <input class="form-check-input" type="radio" name="audience" id="aud-user" value="user" checked>
+                            <label class="form-check-label" for="aud-user">A single user</label>
+                        </div>
+                        <div class="form-check">
+                            <input class="form-check-input" type="radio" name="audience" id="aud-role" value="role">
+                            <label class="form-check-label" for="aud-role">Every user with role</label>
+                        </div>
+                        <div class="form-check">
+                            <input class="form-check-input" type="radio" name="audience" id="aud-all" value="all">
+                            <label class="form-check-label" for="aud-all">All signed-in users <span class="text-warning small">(broadcast)</span></label>
+                        </div>
+                    </fieldset>
+
+                    <div class="row g-3 mb-3">
+                        <div class="col-md-6" data-aud="user">
+                            <label class="form-label small">Target user (username, email, or id)</label>
+                            <input type="text" name="target_user" class="form-control form-control-sm" placeholder="e.g. lance" autocomplete="off">
+                        </div>
+                        <div class="col-md-6 d-none" data-aud="role">
+                            <label class="form-label small">Target role</label>
+                            <select name="target_role" class="form-select form-select-sm">
+                                <option value="user">user</option>
+                                <option value="editor">editor</option>
+                                <option value="admin">admin</option>
+                                <option value="global_admin">global_admin</option>
+                            </select>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label small">Type tag</label>
+                            <select name="type" class="form-select form-select-sm">
+                                <option value="announcement">announcement</option>
+                                <option value="maintenance">maintenance</option>
+                                <option value="release">release</option>
+                                <option value="info">info</option>
+                            </select>
+                        </div>
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label small">Title <span class="text-danger">*</span></label>
+                        <input type="text" name="title" class="form-control" maxlength="255" required placeholder="Short, scannable headline">
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label small">Body <span class="text-danger">*</span></label>
+                        <textarea name="body" class="form-control" rows="5" maxlength="2000" required placeholder="Plain-text body. ≤ 2000 characters. No HTML."></textarea>
+                    </div>
+                    <div class="mb-1">
+                        <label class="form-label small">Action URL <span class="text-muted">(optional)</span></label>
+                        <input type="text" name="action_url" class="form-control form-control-sm" placeholder="/manage/some-page  or  https://…">
+                        <div class="form-text small">Local /-rooted path or absolute https://. Clicking the row in the bell sends the user here.</div>
+                    </div>
+                </div>
+
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="bi bi-send me-1"></i>Send notification
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<script>
+/* Compose modal — reveal the field row matching the chosen audience.
+   Pure DOM, no module — keeps the surface tiny. */
+(() => {
+    const radios = document.querySelectorAll('input[name="audience"]');
+    const apply  = () => {
+        const sel = document.querySelector('input[name="audience"]:checked')?.value || 'user';
+        document.querySelectorAll('[data-aud]').forEach((el) => {
+            el.classList.toggle('d-none', el.dataset.aud !== sel);
+        });
+    };
+    radios.forEach((r) => r.addEventListener('change', apply));
+    apply();
+})();
+</script>
+
+<?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>
+</body>
+</html>

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -225,8 +225,11 @@ $friendlyTitles = [
     'multi-language-tables'            => 'Multi-language Tables (#778 phase A)',
     'parent-songbooks'                 => 'Parent Songbooks (#782 phase A)',
     'song-links'                       => 'Cross-book Song Links (#807 / #808)',
-    'recompute-songbook-songcount'     => 'Recompute Songbook SongCount (#791)',
     'songcount-triggers'               => 'SongCount Triggers (#793)',
+    /* `recompute-songbook-songcount` no longer exposed via the dashboard
+       (#818) — the SongCount Triggers migration above includes its own
+       initial recompute. The CLI script stays on disk for emergency
+       manual runs. */
 ];
 
 /* Per-migration card content (#816). Single source of truth for the
@@ -579,8 +582,12 @@ if ($action !== '') {
         'multi-language-tables'    => 'migrate-multi-language-tables.php',
         'parent-songbooks'         => 'migrate-parent-songbooks.php',
         'song-links'               => 'migrate-song-links.php',
-        'recompute-songbook-songcount' => 'migrate-recompute-songbook-songcount.php',
-        'songcount-triggers'           => 'migrate-songcount-triggers.php',
+        /* recompute-songbook-songcount removed from the dashboard
+           manifest (#818) — the work is now part of the SongCount
+           Triggers migration's installation step. The script remains
+           on disk for emergency CLI manual runs:
+             php appWeb/.sql/migrate-recompute-songbook-songcount.php  */
+        'songcount-triggers'       => 'migrate-songcount-triggers.php',
         'cleanup'     => 'cleanup.php',
         'backup'      => 'backup.php',
         'restore'     => 'restore.php',
@@ -626,7 +633,12 @@ if ($action !== '') {
         'multi-language-tables',
         'parent-songbooks',
         'song-links',
-        'recompute-songbook-songcount',
+        /* `recompute-songbook-songcount` removed from the bulk run
+           (#818) — its work is now baked into the SongCount Triggers
+           migration's installation step (the trigger-creation script
+           runs an initial recompute regardless of whether triggers were
+           successfully installed). Listing it here too would just
+           recompute twice on every Apply-All run. */
         'songcount-triggers',
         /* When you add a new migrate-*.php under appWeb/.sql/, ALSO add
            its action key to:

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -178,6 +178,56 @@ if (isset($_GET['saved'])) {
 $action = $_GET['action'] ?? '';
 $actionOutput = '';
 $actionSuccess = false;
+
+/* User-friendly action titles for the status heading (#814). The
+   previous heading rendered `ucfirst($action)` which left the URL
+   slug visible (e.g. "Bulk-import-jobs Output"). This map mirrors
+   each card's title so the operator sees the same name on the
+   action page that they clicked on the dashboard. Add an entry
+   when a new action is registered in $scriptMap below. Falling
+   back to `ucfirst()` keeps unknown actions readable instead of
+   PHP-warning. */
+$friendlyTitles = [
+    /* Top-level operations */
+    'install'                          => 'Install Tables',
+    'migrate'                          => 'Migrate Song Data',
+    'users'                            => 'Migrate Users & Setlists',
+    'cleanup'                          => 'Cleanup Expired Tokens',
+    'backup'                           => 'Backup Database',
+    'restore'                          => 'Restore from Backup',
+    'drop-legacy'                      => 'Drop Legacy Tables',
+    'apply-all-migrations'             => 'Apply All Pending Migrations',
+    /* Per-migration cards (label = card title minus the legacy
+       alphabetic prefix; #816 standardised this on the issue
+       number as the primary identifier). */
+    'account-sync'                     => 'Account Sync & Shared Setlists',
+    'credits'                          => 'Credit Fields (#497)',
+    'songbook-meta'                    => 'Songbook Metadata (#502)',
+    'user-features-catchup'            => 'User Features Catch-Up (#517)',
+    'activity-log-expand'              => 'Activity Log Expansion (#535)',
+    'credit-people'                    => 'Credit People Registry (#545)',
+    'credit-people-flags'              => 'Credit People Flags (#584, #585)',
+    'song-artists'                     => 'Songs Artist credit (#587)',
+    'credit-people-slug'               => 'Credit People Slug + public page (#588)',
+    'user-avatar-service'              => 'Per-user Avatar Service (#616)',
+    'organisation-licences'            => 'Multiple Licence Types per Organisation (#640)',
+    'songbook-affiliations'            => 'Songbook Affiliations Registry (#670)',
+    'songbook-bibliographic'           => 'Songbook Bibliographic Metadata (#672)',
+    'songbook-language'                => 'Songbook Language Column (#673)',
+    'ietf-bcp47-language'              => 'IETF BCP 47 Language Tagging (#681)',
+    'bulk-import-jobs'                 => 'Bulk Import Jobs Tracking (#676)',
+    'backfill-legacy-songbook-languages' => 'Backfill Legacy Songbook Languages (#735)',
+    'user-preferred-languages'         => 'User Preferred Languages Column (#736)',
+    'iana-language-subtag-registry'    => 'IETF BCP 47 Reference Data (#738)',
+    'cldr-native-names'                => 'CLDR Native Names Overlay',
+    'tag-titlecase'                    => 'Tag Title-Case Backfill (#762)',
+    'tblsongs-number-nullable'         => 'tblSongs.Number Nullable (#783)',
+    'multi-language-tables'            => 'Multi-language Tables (#778 phase A)',
+    'parent-songbooks'                 => 'Parent Songbooks (#782 phase A)',
+    'song-links'                       => 'Cross-book Song Links (#807 / #808)',
+    'recompute-songbook-songcount'     => 'Recompute Songbook SongCount (#791)',
+    'songcount-triggers'               => 'SongCount Triggers (#793)',
+];
 /* Captured during bulk-run so the failure can be surfaced as a visible
    banner ABOVE the (potentially long, scrollable) output panel. (#720) */
 $bulkFirstFailStep    = null;
@@ -590,7 +640,14 @@ if ($hasCredentials && defined('DB_HOST')) {
              ============================================================ -->
         <p><a href="?" class="btn btn-outline-secondary btn-sm">&larr; Back to Dashboard</a></p>
         <h4 class="mb-2">
-            <?= htmlspecialchars(ucfirst($action)) ?> Output
+            <?php
+                /* User-friendly heading (#814) — fall back to ucfirst()
+                   only when an action key has no entry in the map (a
+                   fresh migration whose card was added but whose entry
+                   wasn't registered yet — defensive, not expected). */
+                $headingTitle = $friendlyTitles[$action] ?? ucfirst($action);
+            ?>
+            <?= htmlspecialchars($headingTitle) ?> &mdash; Output
             <?php if ($actionSuccess): ?>
                 <span class="badge bg-success ms-2">Complete</span>
             <?php else: ?>

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -542,6 +542,35 @@ $bulkFirstFailLine    = 0;
 $bulkTotalRan         = 0;
 $bulkTotalFailed      = 0;
 
+/* Page-render sentinel + emergency chrome closer (#817).
+   "Apply all" was reported as rendering "in its own raw HTML page,
+   not within the same UI structure" — the cause is a child migration
+   that calls `exit()` mid-bulk. exit() bypasses the try/catch in the
+   bulk loop AND the outer page render below, so the admin chrome
+   never closes and the user sees an unwrapped log.
+   Set the flag to true at the very end of the page (just before the
+   trailing exit) and a shutdown handler emits the chrome's closing
+   tags if we never reached it. The migration scripts themselves are
+   being audited to use `return` / `throw` instead of exit(); this is
+   the defence-in-depth for any straggler. */
+$pageRenderedCleanly = false;
+register_shutdown_function(function () use (&$pageRenderedCleanly): void {
+    if ($pageRenderedCleanly) return;
+    /* Drain whatever's still buffered so it precedes the chrome tags
+       we're about to emit. The chrome itself is intentionally a
+       compact emergency-closure — full sidebar / footer can't be
+       reconstructed from a shutdown handler reliably (no access to
+       the open-state $GLOBALS['_adminLayoutOpen']) but closing the
+       outer wrappers + body/html prevents the browser from leaving
+       the response visually open. */
+    while (ob_get_level() > 0) {
+        @ob_end_flush();
+    }
+    echo "\n<!-- emergency chrome closure (#817) — a child script "
+       . "exited or died mid-render before the page completed. -->\n";
+    echo "</div>\n</main>\n</div><!-- /.admin-layout -->\n</body>\n</html>\n";
+});
+
 if ($action !== '') {
     /* Signal to the included scripts that they're being run from the
      * dashboard, so they skip `header('Content-Type: text/plain')` which
@@ -1450,4 +1479,5 @@ if ($hasCredentials && defined('DB_HOST')) {
 </html>
 <?php
 /* Prevent any included script's exit() from showing raw output after our page */
+$pageRenderedCleanly = true;
 exit;

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -228,6 +228,308 @@ $friendlyTitles = [
     'recompute-songbook-songcount'     => 'Recompute Songbook SongCount (#791)',
     'songcount-triggers'               => 'SongCount Triggers (#793)',
 ];
+
+/* Per-migration card content (#816). Single source of truth for the
+   card grid render. Title is the same string the status heading
+   uses, identified by issue number rather than the legacy
+   alphabetic-suffix scheme (3a, 3b, … 3z, 3y2 — non-monotonic and
+   visually confusing). Cards render in $migrationOrder sequence so
+   the grid mirrors the deployment order the bulk runner uses. The
+   `extra_html` slot lets a card append controls beyond the single
+   "Run …" button — currently used by the IANA + CLDR live-refresh
+   side-button on the BCP 47 reference card. */
+$migrationCards = [
+    'account-sync' => [
+        'title'  => 'Account Sync &amp; Shared Setlists',
+        'body'   => 'Adds the <code>Settings</code> column to <code>tblUsers</code>'
+                  . ' (per-device prefs sync) and creates <code>tblSharedSetlists</code>,'
+                  . ' then imports any legacy share-link JSON files into the new table.'
+                  . ' Idempotent — safe to re-run.',
+        'button' => 'Run Account Sync Migration',
+    ],
+    'credits' => [
+        'title'  => 'Credit Fields (#497)',
+        'body'   => 'Adds <code>TuneName</code> and <code>Iswc</code> columns to'
+                  . ' <code>tblSongs</code>, and creates'
+                  . ' <code>tblSongArrangers</code>, <code>tblSongAdaptors</code>'
+                  . ' and <code>tblSongTranslators</code>. Idempotent — safe to re-run.',
+        'button' => 'Run Credit Fields Migration',
+    ],
+    'songbook-meta' => [
+        'title'  => 'Songbook Metadata (#502)',
+        'body'   => 'Adds <code>Colour</code> (catch-up — missed forward-migration on older'
+                  . ' databases), <code>IsOfficial</code>, <code>Publisher</code>,'
+                  . ' <code>PublicationYear</code>, <code>Copyright</code> and'
+                  . ' <code>Affiliation</code> columns to <code>tblSongbooks</code>,'
+                  . ' and flags existing non-Misc songbooks as official.'
+                  . ' Idempotent — safe to re-run.',
+        'button' => 'Run Songbook Metadata Migration',
+    ],
+    'user-features-catchup' => [
+        'title'  => 'User Features Catch-Up (#517)',
+        'body'   => 'Catches up three pieces of user-feature schema that landed in'
+                  . ' <code>schema.sql</code> without forward-migrations and were'
+                  . ' surfaced by the Schema Audit page: <code>tblUserGroups.AllowCardReorder</code>,'
+                  . ' <code>tblUserSetlists</code> table, and <code>tblSearchQueries</code>'
+                  . ' table. Idempotent — safe to re-run.',
+        'button' => 'Run User Features Catch-Up Migration',
+    ],
+    'activity-log-expand' => [
+        'title'  => 'Activity Log Expansion (#535)',
+        'body'   => 'Extends <code>tblActivityLog</code> with the columns required by the'
+                  . ' comprehensive instrumentation pass: <code>Result</code>,'
+                  . ' <code>UserAgent</code>, <code>RequestId</code>, <code>Method</code>,'
+                  . ' <code>DurationMs</code>, plus indexes on <code>Result</code> and'
+                  . ' <code>RequestId</code> for the common debug-query patterns.'
+                  . ' Idempotent — safe to re-run.',
+        'button' => 'Run Activity Log Expansion Migration',
+    ],
+    'credit-people' => [
+        'title'  => 'Credit People Registry (#545)',
+        'body'   => 'Creates the registry tables that back the new'
+                  . ' <code>/manage/credit-people</code> area: <code>tblCreditPeople</code>'
+                  . ' (canonical name plus optional birth/death + notes),'
+                  . ' <code>tblCreditPersonLinks</code> (multiple external reference URLs'
+                  . ' per person), and <code>tblCreditPersonIPI</code> (multiple IPI Name'
+                  . ' Numbers per person). The five song-credit tables are not modified —'
+                  . ' this is additive. Idempotent — safe to re-run.',
+        'button' => 'Run Credit People Registry Migration',
+    ],
+    'credit-people-flags' => [
+        'title'  => 'Credit People Flags (#584, #585)',
+        'body'   => 'Adds the <code>IsSpecialCase</code> and <code>IsGroup</code>'
+                  . ' classification flags to <code>tblCreditPeople</code> so the registry'
+                  . ' can distinguish special-case attributions (Anonymous, Traditional,'
+                  . ' Public Domain, Unknown) from real individuals, and groups / bands /'
+                  . ' collectives (Hillsong United, Bethel Music) from single people.'
+                  . ' Backfills the four obvious special-case names on first run.'
+                  . ' Idempotent — safe to re-run.',
+        'button' => 'Run Credit People Flags Migration',
+    ],
+    'song-artists' => [
+        'title'  => 'Songs Artist credit (#587)',
+        'body'   => 'Adds <code>tblSongArtists</code> — a sixth credit role parallel to the'
+                  . ' existing five (writers / composers / arrangers / adaptors /'
+                  . ' translators). Captures the recording / release artist of'
+                  . ' contemporary worship songs (e.g. <em>Hillsong Worship</em> for'
+                  . ' "What a Beautiful Name") and feeds the future ProPresenter export.'
+                  . ' Names auto-register in <code>tblCreditPeople</code> via the same'
+                  . ' INSERT-IGNORE pattern as the other roles. Idempotent — safe to re-run.',
+        'button' => 'Run Songs Artist Migration',
+    ],
+    'credit-people-slug' => [
+        'title'  => 'Credit People Slug + public page (#588)',
+        'body'   => 'Adds <code>tblCreditPeople.Slug</code> with a UNIQUE index, backfills'
+                  . ' it from each row\'s Name (collision-safe with numeric suffixes), and'
+                  . ' unlocks the public <code>/people/&lt;slug&gt;</code> landing page —'
+                  . ' bio, lifespan, external links, and a discography grouped by role'
+                  . ' across the six song-credit tables. Idempotent — safe to re-run.',
+        'button' => 'Run Credit People Slug Migration',
+    ],
+    'user-avatar-service' => [
+        'title'  => 'Per-user avatar service (#616)',
+        'body'   => 'Adds <code>tblUsers.AvatarService</code> so each signed-in user can'
+                  . ' override the project-level avatar resolver default — Gravatar,'
+                  . ' Libravatar, DiceBear identicon (no third-party request), or None.'
+                  . ' NULL on this column means "inherit project default", so existing'
+                  . ' users behave identically until they choose to opt in or out via'
+                  . ' Settings &gt; Profile &gt; Avatar source. Idempotent — safe to re-run.',
+        'button' => 'Run Per-user Avatar Service Migration',
+    ],
+    'organisation-licences' => [
+        'title'  => 'Multiple licence types per organisation (#640)',
+        'body'   => 'Adds <code>tblOrganisationLicences</code> — a join table so each'
+                  . ' organisation can hold any number of licences (e.g. CCLI for lyrics +'
+                  . ' MRL for musical notation). Backfills one row per org from the'
+                  . ' existing primary <code>LicenceType</code> column. The primary column'
+                  . ' is left in place for back-compat; tier resolution unions across both.'
+                  . ' Idempotent — safe to re-run.',
+        'button' => 'Run Multi-licence Migration',
+    ],
+    'songbook-affiliations' => [
+        'title'  => 'Songbook affiliations registry (#670)',
+        'body'   => 'Closes the &ldquo;Affiliation lookup table&rdquo; out-of-scope item from'
+                  . ' #502. Adds <code>tblSongbookAffiliations</code> as a controlled'
+                  . ' vocabulary (Name UNIQUE) so the songbook editor can typeahead-suggest'
+                  . ' existing values instead of letting small typing variations create'
+                  . ' duplicate entries. Backfills the registry from every distinct non-empty'
+                  . ' <code>Affiliation</code> already in <code>tblSongbooks</code>.'
+                  . ' Idempotent — safe to re-run.',
+        'button' => 'Run Songbook Affiliations Migration',
+    ],
+    'songbook-bibliographic' => [
+        'title'  => 'Songbook bibliographic metadata (#672)',
+        'body'   => 'Adds 13 nullable columns to <code>tblSongbooks</code> for canonical'
+                  . ' references to the wider bibliographic record: Website / Internet'
+                  . ' Archive / Wikipedia URLs, plus the authority identifiers WikiData,'
+                  . ' OCLC, OCN, LCP, ISBN, ARK, ISNI, VIAF, LCCN, and LC Class. All'
+                  . ' optional; no FKs. Idempotent — safe to re-run.',
+        'button' => 'Run Songbook Bibliographic Migration',
+    ],
+    'songbook-language' => [
+        'title'  => 'Songbook language column (#673)',
+        'body'   => 'Adds an optional <code>Language</code> column to <code>tblSongbooks</code>'
+                  . ' (ISO 639-1 code, NULLable) so a curator can tag a songbook with its'
+                  . ' predominant language. Mirrors <code>tblSongs.Language</code> without'
+                  . ' the NOT NULL or DEFAULT — empty selection saves as NULL. Idempotent —'
+                  . ' safe to re-run.',
+        'button' => 'Run Songbook Language Migration',
+    ],
+    'ietf-bcp47-language' => [
+        'title'  => 'IETF BCP 47 language tagging (#681)',
+        'body'   => 'Brings every <code>Language</code> column on songs, songbooks,'
+                  . ' translations and song-requests up to <code>VARCHAR(35)</code> so they'
+                  . ' can hold a full IETF BCP 47 tag (language[-script][-region], e.g.'
+                  . ' <code>pt-BR</code>, <code>zh-Hans-CN</code>, <code>sr-Latn</code>).'
+                  . ' Adds <code>tblScripts</code> (~28 ISO 15924 codes) and'
+                  . ' <code>tblRegions</code> (~255 ISO 3166-1 codes + six M.49 area'
+                  . ' groupings) for the composite picker\'s typeahead. Idempotent — safe'
+                  . ' to re-run.',
+        'button' => 'Run IETF BCP 47 Language Migration',
+    ],
+    'bulk-import-jobs' => [
+        'title'  => 'Bulk Import Jobs Tracking (#676)',
+        'body'   => 'Adds <code>tblBulkImportJobs</code> so the Song Editor\'s ZIP import'
+                  . ' can run asynchronously: the upload returns <code>{job_id}</code>'
+                  . ' immediately, the worker keeps processing in the freed PHP request,'
+                  . ' and the browser polls a status endpoint for live progress (% complete).'
+                  . ' Lets a curator navigate away while a long import runs; a notification'
+                  . ' fires on completion. Idempotent — safe to re-run.',
+        'button' => 'Run Bulk Import Jobs Migration',
+    ],
+    'backfill-legacy-songbook-languages' => [
+        'title'  => 'Backfill legacy songbook languages (#735)',
+        'body'   => 'Sets <code>Language=\'en\'</code> on the 5 legacy English songbooks'
+                  . ' (CP, JP, MP, SDAH, CH) where it isn\'t already set. Required by the'
+                  . ' language filter (#734 / #736) — the filter renders only when ≥2'
+                  . ' distinct primary subtags exist across songbooks UNION songs, so this'
+                  . ' baseline ensures the filter appears the moment any non-English'
+                  . ' songbook lands. Idempotent — re-running is safe; rows already set'
+                  . ' (e.g. <code>en-GB</code>, <code>en-US</code>) are not touched.',
+        'button' => 'Run Legacy Songbook Language Backfill',
+    ],
+    'user-preferred-languages' => [
+        'title'  => 'User preferred languages column (#736)',
+        'body'   => 'Adds <code>tblUsers.PreferredLanguagesJson</code> so a signed-in user'
+                  . ' can save their language-filter choice to their account and have it'
+                  . ' sync across devices. Stored as a JSON array of IETF BCP 47 primary'
+                  . ' subtags (e.g. <code>["en","es"]</code>); NULL or <code>[]</code>'
+                  . ' means "show all languages". Idempotent — safe to re-run.',
+        'button' => 'Run User Preferred Languages Migration',
+    ],
+    'iana-language-subtag-registry' => [
+        'title'  => 'IETF BCP 47 Reference Data (#738)',
+        'body'   => 'Imports the IANA Language Subtag Registry and CLDR English display'
+                  . ' names — every language (~8,000), script (~225), region (~305), and'
+                  . ' variant (~140) subtag the IETF BCP 47 standard recognises. Uses'
+                  . ' bundled snapshots in <code>appWeb/.sql/data/</code>; the picker'
+                  . ' autocomplete works completely offline once applied.'
+                  . '</p><p class="card-text text-secondary small">'
+                  . 'Schema work (idempotent): renames <code>tblScripts</code> →'
+                  . ' <code>tblLanguageScripts</code> for clarity, adds'
+                  . ' <code>tblLanguageVariants</code>, adds <code>tblLanguages.Scope</code>.'
+                  . ' Re-running picks up new rows from a refreshed snapshot without'
+                  . ' touching curator-flagged ones.',
+        'button' => 'Run IANA + CLDR Import',
+        /* The IANA + CLDR card has a paired live-refresh side button +
+           status line; rendered after the primary button, inside the
+           card body. */
+        'extra_html' => '<button type="button"'
+                      . ' class="btn btn-outline-warning btn-action ms-2 ' . ($hasCredentials ? '' : 'disabled') . '"'
+                      . ' data-action="refresh-iana-cldr">'
+                      . '<i class="bi bi-cloud-download me-1" aria-hidden="true"></i>'
+                      . 'Refresh from IANA + CLDR (live)</button>'
+                      . '<p class="card-text small text-muted mt-2 mb-0" data-iana-refresh-status>'
+                      . 'Live refresh fetches the latest IANA registry and CLDR JSON files,'
+                      . ' overwrites the bundled snapshots, then re-runs the import.</p>',
+    ],
+    'cldr-native-names' => [
+        'title'  => 'CLDR Native Names overlay',
+        'body'   => 'Backfills <code>tblLanguages.NativeName</code> with each language\'s'
+                  . ' self-name — the form a speaker would write in their own locale'
+                  . ' ("Deutsch", "日本語", "Tshivenḓa", "العربية"). Sourced from'
+                  . ' <code>appWeb/.sql/data/cldr-native-names.json</code> (~316 entries,'
+                  . ' generated from <code>cldr-localenames-full</code>; rebuild with'
+                  . ' <code>tools/fetch-cldr-native-names.sh</code>). Once applied, the'
+                  . ' IETF picker (#681 / #685) shows e.g. "German (Deutsch) — de" instead'
+                  . ' of just "German — de". Idempotent — re-running no-ops on rows whose'
+                  . ' <code>NativeName</code> already matches.',
+        'button' => 'Run CLDR Native Names Overlay',
+    ],
+    'tag-titlecase' => [
+        'title'  => 'Tag Title-Case Backfill (#762)',
+        'body'   => 'Walks <code>tblSongTags</code> and rewrites <code>Name</code> to Title'
+                  . ' Case for any row that isn\'t already canonical. The <code>bulk_tag</code>'
+                  . ' handler now Title-Cases on every upsert, so new tags land canonical'
+                  . ' from creation; this backfill resolves rows that pre-date #762\'s'
+                  . ' normalisation. Idempotent — re-runs no-op on canonical rows. Rare'
+                  . ' collisions (two rows whose canonical forms would clash) are logged'
+                  . ' and left untouched for resolution via the forthcoming /manage/tags'
+                  . ' merge UI.',
+        'button' => 'Run Tag Title-Case Backfill',
+    ],
+    'tblsongs-number-nullable' => [
+        'title'  => 'tblSongs.Number nullable (#783)',
+        'body'   => 'Aligns the schema with the post-#392 policy that lets songs in'
+                  . ' unofficial songbooks (Misc, custom collections) persist'
+                  . ' <code>Number</code> as <code>NULL</code>. Without this, the save_song'
+                  . ' handler\'s intentional NULL-bind raises mysqli error 1048 ("Column'
+                  . ' \'Number\' cannot be null") on every Misc save. Idempotent —'
+                  . ' INFORMATION_SCHEMA probe; skips when already nullable.',
+        'button' => 'Run tblSongs.Number Nullable Migration',
+    ],
+    'multi-language-tables' => [
+        'title'  => 'Multi-language tables (#778 phase A)',
+        'body'   => 'Creates <code>tblSongbookLanguages</code> + <code>tblSongLanguages</code>'
+                  . ' for the multi-language songbook / song work, and back-fills the legacy'
+                  . ' single-tag <code>Language</code> columns into them with'
+                  . ' <code>IsPrimary=1</code>. Read paths consuming the legacy columns'
+                  . ' continue to work unchanged. Phases B-E of #778 build the chip-list'
+                  . ' editors, display surfaces, filter union, and bulk-import auto-link'
+                  . ' on top. Idempotent.',
+        'button' => 'Run Multi-Language Tables Migration',
+    ],
+    'parent-songbooks' => [
+        'title'  => 'Parent Songbooks (#782 phase A)',
+        'body'   => 'Adds <code>tblSongbooks.ParentSongbookId</code> +'
+                  . ' <code>ParentRelationship</code> for hierarchical relationships'
+                  . ' (translations / editions / abridgements), plus'
+                  . ' <code>tblSongbookSeries</code> + <code>tblSongbookSeriesMembership</code>'
+                  . ' for peer-to-peer collections (Songs of Fellowship volumes, themed'
+                  . ' compilations). Both shapes coexist — a row can carry a parent FK AND'
+                  . ' series memberships. Schema only; phases B-E (admin picker, public'
+                  . ' display, helpers, bulk-import auto-link) are tracked in #782. Idempotent.',
+        'button' => 'Run Parent Songbooks Migration',
+    ],
+    'song-links' => [
+        'title'  => 'Cross-book Song Links (#807 / #808)',
+        'body'   => 'Creates <code>tblSongLinks</code> for the "this hymn appears in multiple'
+                  . ' songbooks" relationship (Amazing Grace as MP-031 / CH-376 / SDAH-108 /'
+                  . ' SoF-29 / JP-006), plus <code>tblSongLinkSuggestions</code> +'
+                  . ' <code>tblSongLinkSuggestionsDismissed</code> for the admin'
+                  . ' similar-titled-song candidate list (#808). Distinct from'
+                  . ' <code>tblSongTranslations</code> (different-language same hymn) and'
+                  . ' <code>tblSongbooks.ParentSongbookId</code> (translated / edition'
+                  . ' derivatives at the songbook level). Idempotent.',
+        'button' => 'Run Cross-book Song Links Migration',
+    ],
+    'songcount-triggers' => [
+        'title'  => 'SongCount Triggers (#793)',
+        'body'   => 'Installs three triggers (<code>AFTER INSERT / UPDATE / DELETE</code>)'
+                  . ' on <code>tblSongs</code> so <code>tblSongbooks.SongCount</code>'
+                  . ' auto-maintains without any application-side recompute. Lifts the'
+                  . ' cache-maintenance responsibility off every current and future write'
+                  . ' path. Also runs an initial recompute as part of installation.'
+                  . ' Idempotent. On hosts that disallow <code>CREATE TRIGGER</code> the'
+                  . ' migration logs a friendly skip cleanly (#815) — PR #792\'s app-side'
+                  . ' recompute remains the safety net.',
+        'button' => 'Run SongCount Triggers Migration',
+    ],
+    /* recompute-songbook-songcount card removed (#818) — its work is
+       now covered by the SongCount Triggers migration above, which
+       runs an initial recompute as part of its installation. The
+       underlying script remains on disk for emergency CLI runs. */
+];
 /* Captured during bulk-run so the failure can be surfaced as a visible
    banner ABOVE the (potentially long, scrollable) output panel. (#720) */
 $bulkFirstFailStep    = null;
@@ -768,574 +1070,49 @@ if ($hasCredentials && defined('DB_HOST')) {
                     </div>
                 </div>
             </div>
-            <div class="col-md-6">
-                <div class="card bg-dark border-secondary h-100">
-                    <div class="card-body">
-                        <h5 class="card-title">3a. Account Sync &amp; Shared Setlists</h5>
-                        <p class="card-text text-secondary small">
-                            Adds the <code>Settings</code> column to <code>tblUsers</code>
-                            (per-device prefs sync) and creates <code>tblSharedSetlists</code>,
-                            then imports any legacy share-link JSON files into the new table.
-                            Idempotent — safe to re-run.
-                        </p>
-                        <a href="?action=account-sync" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
-                            Run Account Sync Migration
-                        </a>
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-6">
-                <div class="card bg-dark border-secondary h-100">
-                    <div class="card-body">
-                        <h5 class="card-title">3b. Credit Fields (#497)</h5>
-                        <p class="card-text text-secondary small">
-                            Adds <code>TuneName</code> and <code>Iswc</code> columns to
-                            <code>tblSongs</code>, and creates
-                            <code>tblSongArrangers</code>, <code>tblSongAdaptors</code>
-                            and <code>tblSongTranslators</code>. Idempotent — safe to re-run.
-                        </p>
-                        <a href="?action=credits" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
-                            Run Credit Fields Migration
-                        </a>
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-6">
-                <div class="card bg-dark border-secondary h-100">
-                    <div class="card-body">
-                        <h5 class="card-title">3c. Songbook Metadata (#502)</h5>
-                        <p class="card-text text-secondary small">
-                            Adds <code>Colour</code> (catch-up — missed
-                            forward-migration on older databases),
-                            <code>IsOfficial</code>, <code>Publisher</code>,
-                            <code>PublicationYear</code>, <code>Copyright</code> and
-                            <code>Affiliation</code> columns to <code>tblSongbooks</code>,
-                            and flags existing non-Misc songbooks as official.
-                            Idempotent — safe to re-run.
-                        </p>
-                        <a href="?action=songbook-meta" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
-                            Run Songbook Metadata Migration
-                        </a>
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-6">
-                <div class="card bg-dark border-secondary h-100">
-                    <div class="card-body">
-                        <h5 class="card-title">3d. User Features Catch-Up (#517)</h5>
-                        <p class="card-text text-secondary small">
-                            Catches up three pieces of user-feature schema that
-                            landed in <code>schema.sql</code> without forward-
-                            migrations and were surfaced by the Schema Audit page:
-                            <code>tblUserGroups.AllowCardReorder</code>,
-                            <code>tblUserSetlists</code> table, and
-                            <code>tblSearchQueries</code> table.
-                            Idempotent — safe to re-run.
-                        </p>
-                        <a href="?action=user-features-catchup" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
-                            Run User Features Catch-Up Migration
-                        </a>
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-6">
-                <div class="card bg-dark border-secondary h-100">
-                    <div class="card-body">
-                        <h5 class="card-title">3e. Activity Log Expansion (#535)</h5>
-                        <p class="card-text text-secondary small">
-                            Extends <code>tblActivityLog</code> with the columns
-                            required by the comprehensive instrumentation
-                            pass: <code>Result</code>, <code>UserAgent</code>,
-                            <code>RequestId</code>, <code>Method</code>,
-                            <code>DurationMs</code>, plus indexes on
-                            <code>Result</code> and <code>RequestId</code>
-                            for the common debug-query patterns.
-                            Idempotent — safe to re-run.
-                        </p>
-                        <a href="?action=activity-log-expand" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
-                            Run Activity Log Expansion Migration
-                        </a>
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-6">
-                <div class="card bg-dark border-secondary h-100">
-                    <div class="card-body">
-                        <h5 class="card-title">3f. Credit People Registry (#545)</h5>
-                        <p class="card-text text-secondary small">
-                            Creates the registry tables that back the new
-                            <code>/manage/credit-people</code> area:
-                            <code>tblCreditPeople</code> (canonical name plus
-                            optional birth/death + notes),
-                            <code>tblCreditPersonLinks</code> (multiple external
-                            reference URLs per person), and
-                            <code>tblCreditPersonIPI</code> (multiple IPI Name
-                            Numbers per person). The five song-credit tables
-                            are not modified — this is additive.
-                            Idempotent — safe to re-run.
-                        </p>
-                        <a href="?action=credit-people" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
-                            Run Credit People Registry Migration
-                        </a>
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-6">
-                <div class="card bg-dark border-secondary h-100">
-                    <div class="card-body">
-                        <h5 class="card-title">3g. Credit People Flags (#584, #585)</h5>
-                        <p class="card-text text-secondary small">
-                            Adds the <code>IsSpecialCase</code> and <code>IsGroup</code>
-                            classification flags to <code>tblCreditPeople</code> so the
-                            registry can distinguish special-case attributions
-                            (Anonymous, Traditional, Public Domain, Unknown)
-                            from real individuals, and groups / bands /
-                            collectives (Hillsong United, Bethel Music) from
-                            single people. Backfills the four obvious special-case
-                            names on first run. Idempotent — safe to re-run.
-                        </p>
-                        <a href="?action=credit-people-flags" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
-                            Run Credit People Flags Migration
-                        </a>
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-6">
-                <div class="card bg-dark border-secondary h-100">
-                    <div class="card-body">
-                        <h5 class="card-title">3h. Songs Artist credit (#587)</h5>
-                        <p class="card-text text-secondary small">
-                            Adds <code>tblSongArtists</code> — a sixth credit role
-                            parallel to the existing five (writers / composers /
-                            arrangers / adaptors / translators). Captures the
-                            recording / release artist of contemporary worship
-                            songs (e.g. <em>Hillsong Worship</em> for "What a
-                            Beautiful Name") and feeds the future ProPresenter
-                            export. Names auto-register in <code>tblCreditPeople</code>
-                            via the same INSERT-IGNORE pattern as the other roles.
-                            Idempotent — safe to re-run.
-                        </p>
-                        <a href="?action=song-artists" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
-                            Run Songs Artist Migration
-                        </a>
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-6">
-                <div class="card bg-dark border-secondary h-100">
-                    <div class="card-body">
-                        <h5 class="card-title">3i. Credit People Slug + public page (#588)</h5>
-                        <p class="card-text text-secondary small">
-                            Adds <code>tblCreditPeople.Slug</code> with a UNIQUE
-                            index, backfills it from each row's Name (collision-safe
-                            with numeric suffixes), and unlocks the public
-                            <code>/people/&lt;slug&gt;</code> landing page —
-                            bio, lifespan, external links, and a discography
-                            grouped by role across the six song-credit tables.
-                            Idempotent — safe to re-run.
-                        </p>
-                        <a href="?action=credit-people-slug" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
-                            Run Credit People Slug Migration
-                        </a>
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-6">
-                <div class="card bg-dark border-secondary h-100">
-                    <div class="card-body">
-                        <h5 class="card-title">3j. Per-user avatar service (#616)</h5>
-                        <p class="card-text text-secondary small">
-                            Adds <code>tblUsers.AvatarService</code> so each
-                            signed-in user can override the project-level
-                            avatar resolver default — Gravatar, Libravatar,
-                            DiceBear identicon (no third-party request), or
-                            None. NULL on this column means "inherit project
-                            default", so existing users behave identically
-                            until they choose to opt in or out via Settings
-                            &gt; Profile &gt; Avatar source. Idempotent —
-                            safe to re-run.
-                        </p>
-                        <a href="?action=user-avatar-service" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
-                            Run Per-user Avatar Service Migration
-                        </a>
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-6">
-                <div class="card bg-dark border-secondary h-100">
-                    <div class="card-body">
-                        <h5 class="card-title">3k. Multiple licence types per organisation (#640)</h5>
-                        <p class="card-text text-secondary small">
-                            Adds <code>tblOrganisationLicences</code> — a join table
-                            so each organisation can hold any number of licences
-                            (e.g. CCLI for lyrics + MRL for musical notation).
-                            Backfills one row per org from the existing primary
-                            <code>LicenceType</code> column. The primary column
-                            is left in place for back-compat; tier resolution
-                            unions across both. Idempotent — safe to re-run.
-                        </p>
-                        <a href="?action=organisation-licences" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
-                            Run Multi-licence Migration
-                        </a>
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-6">
-                <div class="card bg-dark border-secondary h-100">
-                    <div class="card-body">
-                        <h5 class="card-title">3l. Songbook affiliations registry (#670)</h5>
-                        <p class="card-text text-secondary small">
-                            Closes the &ldquo;Affiliation lookup table&rdquo; out-of-scope
-                            item from #502. Adds <code>tblSongbookAffiliations</code> as
-                            a controlled vocabulary (Name UNIQUE) so the songbook editor
-                            can typeahead-suggest existing values instead of letting small
-                            typing variations create duplicate entries. Backfills the
-                            registry from every distinct non-empty <code>Affiliation</code>
-                            already in <code>tblSongbooks</code>. Idempotent — safe to re-run.
-                        </p>
-                        <a href="?action=songbook-affiliations" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
-                            Run Songbook Affiliations Migration
-                        </a>
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-6">
-                <div class="card bg-dark border-secondary h-100">
-                    <div class="card-body">
-                        <h5 class="card-title">3m. Songbook bibliographic metadata (#672)</h5>
-                        <p class="card-text text-secondary small">
-                            Adds 13 nullable columns to <code>tblSongbooks</code> for
-                            canonical references to the wider bibliographic record:
-                            Website / Internet Archive / Wikipedia URLs, plus the
-                            authority identifiers WikiData, OCLC, OCN, LCP, ISBN,
-                            ARK, ISNI, VIAF, LCCN, and LC Class. All optional;
-                            no FKs. Idempotent — safe to re-run.
-                        </p>
-                        <a href="?action=songbook-bibliographic" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
-                            Run Songbook Bibliographic Migration
-                        </a>
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-6">
-                <div class="card bg-dark border-secondary h-100">
-                    <div class="card-body">
-                        <h5 class="card-title">3n. Songbook language column (#673)</h5>
-                        <p class="card-text text-secondary small">
-                            Adds an optional <code>Language</code> column to
-                            <code>tblSongbooks</code> (ISO 639-1 code, NULLable) so a
-                            curator can tag a songbook with its predominant language.
-                            Mirrors <code>tblSongs.Language</code> without the NOT NULL
-                            or DEFAULT — empty selection saves as NULL. Idempotent —
-                            safe to re-run.
-                        </p>
-                        <a href="?action=songbook-language" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
-                            Run Songbook Language Migration
-                        </a>
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-6">
-                <div class="card bg-dark border-secondary h-100">
-                    <div class="card-body">
-                        <h5 class="card-title">3o. IETF BCP 47 language tagging (#681)</h5>
-                        <p class="card-text text-secondary small">
-                            Brings every <code>Language</code> column on songs,
-                            songbooks, translations and song-requests up to
-                            <code>VARCHAR(35)</code> so they can hold a full IETF
-                            BCP 47 tag (language[-script][-region], e.g.
-                            <code>pt-BR</code>, <code>zh-Hans-CN</code>,
-                            <code>sr-Latn</code>). Adds <code>tblScripts</code>
-                            (~28 ISO 15924 codes) and <code>tblRegions</code>
-                            (~255 ISO 3166-1 codes + six M.49 area groupings)
-                            for the composite picker's typeahead. Idempotent
-                            — safe to re-run.
-                        </p>
-                        <a href="?action=ietf-bcp47-language" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
-                            Run IETF BCP 47 Language Migration
-                        </a>
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-6">
-                <div class="card bg-dark border-secondary h-100">
-                    <div class="card-body">
-                        <h5 class="card-title">3p. Bulk import jobs tracking (#676)</h5>
-                        <p class="card-text text-secondary small">
-                            Adds <code>tblBulkImportJobs</code> so the Song Editor's
-                            ZIP import can run asynchronously: the upload returns
-                            <code>{job_id}</code> immediately, the worker keeps
-                            processing in the freed PHP request, and the browser
-                            polls a status endpoint for live progress (% complete).
-                            Lets a curator navigate away while a long import runs;
-                            a notification fires on completion. Idempotent —
-                            safe to re-run.
-                        </p>
-                        <a href="?action=bulk-import-jobs" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
-                            Run Bulk Import Jobs Migration
-                        </a>
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-6">
-                <div class="card bg-dark border-secondary h-100">
-                    <div class="card-body">
-                        <h5 class="card-title">3s. IETF BCP 47 reference data (#738)</h5>
-                        <p class="card-text text-secondary small">
-                            Imports the IANA Language Subtag Registry and CLDR
-                            English display names — every language (~8,000),
-                            script (~225), region (~305), and variant (~140)
-                            subtag the IETF BCP 47 standard recognises. Uses
-                            bundled snapshots in <code>appWeb/.sql/data/</code>;
-                            the picker autocomplete works completely offline
-                            once applied.
-                        </p>
-                        <p class="card-text text-secondary small">
-                            Schema work (idempotent): renames
-                            <code>tblScripts</code> →
-                            <code>tblLanguageScripts</code> for clarity, adds
-                            <code>tblLanguageVariants</code>, adds
-                            <code>tblLanguages.Scope</code>. Re-running picks
-                            up new rows from a refreshed snapshot without
-                            touching curator-flagged ones.
-                        </p>
-                        <div class="d-flex gap-2 flex-wrap">
-                            <a href="?action=iana-language-subtag-registry" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
-                                Run IANA + CLDR Import
+
+            <!-- ============================================================
+                 PER-MIGRATION CARDS (#816)
+
+                 Data-driven render: cards iterate $migrationOrder so the
+                 grid matches the deployment / dependency order the
+                 "Apply all" runner uses. Each card identifies itself by
+                 issue number — the legacy alphabetic-prefix scheme
+                 (3a, 3b, … 3z, 3y2) was non-monotonic and rotted on
+                 every addition.
+
+                 To add a new migration card, add an entry to
+                 $migrationCards above and append its action key to
+                 $migrationOrder. The bulk runner picks it up
+                 automatically; this loop renders it in the correct
+                 grid position with no further edits.
+                 ============================================================ -->
+            <?php foreach ($migrationOrder as $_migAction): ?>
+                <?php
+                    /* Skip if no card definition — keeps $migrationOrder
+                       able to track scripts that run via "Apply all"
+                       but don't need a per-card UI (e.g. the redundant
+                       recompute step removed in #818). */
+                    $_card = $migrationCards[$_migAction] ?? null;
+                    if (!$_card) continue;
+                ?>
+                <div class="col-md-6">
+                    <div class="card bg-dark border-secondary h-100">
+                        <div class="card-body">
+                            <h5 class="card-title"><?= $_card['title'] ?></h5>
+                            <p class="card-text text-secondary small"><?= $_card['body'] ?></p>
+                            <a href="?action=<?= htmlspecialchars($_migAction) ?>"
+                               class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
+                                <?= htmlspecialchars($_card['button']) ?>
                             </a>
-                            <button type="button"
-                                    class="btn btn-outline-warning btn-action <?= $hasCredentials ? '' : 'disabled' ?>"
-                                    data-action="refresh-iana-cldr">
-                                <i class="bi bi-cloud-download me-1" aria-hidden="true"></i>
-                                Refresh from IANA + CLDR (live)
-                            </button>
+                            <?php if (!empty($_card['extra_html'])): ?>
+                                <?= $_card['extra_html'] ?>
+                            <?php endif; ?>
                         </div>
-                        <p class="card-text small text-muted mt-2 mb-0" data-iana-refresh-status>
-                            Live refresh fetches the latest IANA registry and
-                            CLDR JSON files, overwrites the bundled snapshots,
-                            then re-runs the import.
-                        </p>
                     </div>
                 </div>
-            </div>
-            <div class="col-md-6">
-                <div class="card bg-dark border-secondary h-100">
-                    <div class="card-body">
-                        <h5 class="card-title">3z. SongCount triggers (#793)</h5>
-                        <p class="card-text text-secondary small">
-                            Installs three triggers
-                            (<code>AFTER INSERT / UPDATE / DELETE</code>) on
-                            <code>tblSongs</code> so
-                            <code>tblSongbooks.SongCount</code> auto-maintains
-                            without any application-side recompute. Lifts the
-                            cache-maintenance responsibility off every current
-                            and future write path. Also runs an initial
-                            recompute as part of installation so the standalone
-                            recompute card (3y.) becomes redundant after this
-                            one runs. Idempotent. On hosts that disallow
-                            <code>CREATE TRIGGER</code> the migration logs the
-                            failure cleanly — PR #792's app-side recompute
-                            remains the safety net.
-                        </p>
-                        <a href="?action=songcount-triggers" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
-                            Run SongCount Triggers Migration
-                        </a>
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-6">
-                <div class="card bg-dark border-secondary h-100">
-                    <div class="card-body">
-                        <h5 class="card-title">3y. Recompute Songbook SongCount (#791)</h5>
-                        <p class="card-text text-secondary small">
-                            Walks every <code>tblSongbooks</code> row and rewrites
-                            <code>SongCount</code> from a live
-                            <code>SELECT COUNT(*) FROM tblSongs WHERE SongbookAbbr = ?</code>.
-                            Fixes stale cache values left behind when songs were
-                            saved via the editor before #791's recompute fix
-                            landed — the symptom was Misc (or any songbook that
-                            received its first song via the editor) failing to
-                            appear on the home / songbooks pages because the
-                            tile-render gate is <code>songCount &gt; 0</code>.
-                            Idempotent — rows already correct skip silently.
-                        </p>
-                        <a href="?action=recompute-songbook-songcount" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
-                            Run Songbook SongCount Recompute
-                        </a>
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-6">
-                <div class="card bg-dark border-secondary h-100">
-                    <div class="card-body">
-                        <h5 class="card-title">3y2. Cross-book song links (#807 / #808)</h5>
-                        <p class="card-text text-secondary small">
-                            Creates <code>tblSongLinks</code> for the
-                            "this hymn appears in multiple songbooks"
-                            relationship (Amazing Grace as MP-031 / CH-376
-                            / SDAH-108 / SoF-29 / JP-006), plus
-                            <code>tblSongLinkSuggestions</code> +
-                            <code>tblSongLinkSuggestionsDismissed</code>
-                            for the admin similar-titled-song candidate
-                            list (#808). Distinct from
-                            <code>tblSongTranslations</code>
-                            (different-language same hymn) and
-                            <code>tblSongbooks.ParentSongbookId</code>
-                            (translated / edition derivatives at the
-                            songbook level). Idempotent.
-                        </p>
-                        <a href="?action=song-links" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
-                            Run Cross-book Song Links Migration
-                        </a>
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-6">
-                <div class="card bg-dark border-secondary h-100">
-                    <div class="card-body">
-                        <h5 class="card-title">3x. Parent Songbooks (#782 phase A)</h5>
-                        <p class="card-text text-secondary small">
-                            Adds <code>tblSongbooks.ParentSongbookId</code> +
-                            <code>ParentRelationship</code> for hierarchical
-                            relationships (translations / editions /
-                            abridgements), plus <code>tblSongbookSeries</code>
-                            + <code>tblSongbookSeriesMembership</code> for
-                            peer-to-peer collections (Songs of Fellowship
-                            volumes, themed compilations). Both shapes
-                            coexist — a row can carry a parent FK AND series
-                            memberships. Schema only; phases B-E (admin
-                            picker, public display, helpers, bulk-import
-                            auto-link) are tracked in #782. Idempotent.
-                        </p>
-                        <a href="?action=parent-songbooks" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
-                            Run Parent Songbooks Migration
-                        </a>
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-6">
-                <div class="card bg-dark border-secondary h-100">
-                    <div class="card-body">
-                        <h5 class="card-title">3w. Multi-language tables (#778 phase A)</h5>
-                        <p class="card-text text-secondary small">
-                            Creates <code>tblSongbookLanguages</code> +
-                            <code>tblSongLanguages</code> for the multi-language
-                            songbook / song work, and back-fills the legacy
-                            single-tag <code>Language</code> columns into them
-                            with <code>IsPrimary=1</code>. Read paths consuming
-                            the legacy columns continue to work unchanged.
-                            Phases B-E of #778 build the chip-list editors,
-                            display surfaces, filter union, and bulk-import
-                            auto-link on top. Idempotent.
-                        </p>
-                        <a href="?action=multi-language-tables" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
-                            Run Multi-Language Tables Migration
-                        </a>
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-6">
-                <div class="card bg-dark border-secondary h-100">
-                    <div class="card-body">
-                        <h5 class="card-title">3v. tblSongs.Number nullable (#783)</h5>
-                        <p class="card-text text-secondary small">
-                            Aligns the schema with the post-#392 policy that lets
-                            songs in unofficial songbooks (Misc, custom collections)
-                            persist <code>Number</code> as <code>NULL</code>. Without
-                            this, the save_song handler's intentional NULL-bind
-                            raises mysqli error 1048 (\"Column 'Number' cannot be
-                            null\") on every Misc save. Idempotent — INFORMATION_SCHEMA
-                            probe; skips when already nullable.
-                        </p>
-                        <a href="?action=tblsongs-number-nullable" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
-                            Run tblSongs.Number Nullable Migration
-                        </a>
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-6">
-                <div class="card bg-dark border-secondary h-100">
-                    <div class="card-body">
-                        <h5 class="card-title">3u. Tag Title-Case Backfill (#762)</h5>
-                        <p class="card-text text-secondary small">
-                            Walks <code>tblSongTags</code> and rewrites <code>Name</code>
-                            to Title Case for any row that isn't already canonical. The
-                            <code>bulk_tag</code> handler now Title-Cases on every
-                            upsert, so new tags land canonical from creation; this
-                            backfill resolves rows that pre-date #762's normalisation.
-                            Idempotent — re-runs no-op on canonical rows. Rare
-                            collisions (two rows whose canonical forms would clash)
-                            are logged and left untouched for resolution via the
-                            forthcoming /manage/tags merge UI.
-                        </p>
-                        <a href="?action=tag-titlecase" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
-                            Run Tag Title-Case Backfill
-                        </a>
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-6">
-                <div class="card bg-dark border-secondary h-100">
-                    <div class="card-body">
-                        <h5 class="card-title">3t. CLDR Native Names overlay</h5>
-                        <p class="card-text text-secondary small">
-                            Backfills <code>tblLanguages.NativeName</code> with each
-                            language's self-name — the form a speaker would write in
-                            their own locale ("Deutsch", "日本語", "Tshivenḓa", "العربية").
-                            Sourced from <code>appWeb/.sql/data/cldr-native-names.json</code>
-                            (~316 entries, generated from
-                            <code>cldr-localenames-full</code>; rebuild with
-                            <code>tools/fetch-cldr-native-names.sh</code>). Once applied,
-                            the IETF picker (#681 / #685) shows e.g. "German (Deutsch) — de"
-                            instead of just "German — de". Idempotent — re-running
-                            no-ops on rows whose <code>NativeName</code> already matches.
-                        </p>
-                        <a href="?action=cldr-native-names" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
-                            Run CLDR Native Names Overlay
-                        </a>
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-6">
-                <div class="card bg-dark border-secondary h-100">
-                    <div class="card-body">
-                        <h5 class="card-title">3r. User preferred languages column (#736)</h5>
-                        <p class="card-text text-secondary small">
-                            Adds <code>tblUsers.PreferredLanguagesJson</code> so a
-                            signed-in user can save their language-filter choice
-                            to their account and have it sync across devices.
-                            Stored as a JSON array of IETF BCP 47 primary
-                            subtags (e.g. <code>["en","es"]</code>); NULL or
-                            <code>[]</code> means "show all languages".
-                            Idempotent — safe to re-run.
-                        </p>
-                        <a href="?action=user-preferred-languages" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
-                            Run User Preferred Languages Migration
-                        </a>
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-6">
-                <div class="card bg-dark border-secondary h-100">
-                    <div class="card-body">
-                        <h5 class="card-title">3q. Backfill legacy songbook languages (#735)</h5>
-                        <p class="card-text text-secondary small">
-                            Sets <code>Language='en'</code> on the 5 legacy English
-                            songbooks (CP, JP, MP, SDAH, CH) where it isn't already
-                            set. Required by the language filter (#734 / #736) — the
-                            filter renders only when ≥2 distinct primary subtags
-                            exist across songbooks UNION songs, so this baseline
-                            ensures the filter appears the moment any non-English
-                            songbook lands. Idempotent — re-running is safe; rows
-                            already set (e.g. <code>en-GB</code>, <code>en-US</code>)
-                            are not touched.
-                        </p>
-                        <a href="?action=backfill-legacy-songbook-languages" class="btn btn-info btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
-                            Run Legacy Songbook Language Backfill
-                        </a>
-                    </div>
-                </div>
-            </div>
+            <?php endforeach; ?>
+
             <div class="col-md-6">
                 <div class="card bg-dark border-secondary h-100">
                     <div class="card-body">


### PR DESCRIPTION
## Summary

A nine-issue admin polish + bug-fix batch agreed in conversation. Bundled per the CLAUDE.md "one PR per piece of work, multiple commits inside it" rule — each commit is atomic and individually revertable, the issues are tracked separately for traceability.

## Issues addressed (commits in dependency order)

- **#815** — `fix(setup-database): SongCount triggers handle SUPER denial gracefully`
  PHP 8.1+ throws `mysqli_sql_exception` so the migration's existing fallback hint never ran; wrap CREATE TRIGGER in try/catch, classify denial keywords, exit clean with success-with-warning. PR #792's app-side recompute is the safety net on shared hosts.

- **#811** — `fix(public): graceful degradation when new-schema tables missing on first deploy`
  Widen the OG/route-detection catch from `\RuntimeException` to `\Throwable`; add a top-level `set_exception_handler` that emits a 503 + friendly "service starting" page (with admin pointer to /manage/setup-database on Alpha/Beta).

- **#812** — `fix(header): polish env badge, drop duplicate search button, hide bell when no unread`
  Replace the `font-size:0` ::first-letter trick with a stable `.env-badge` pill — Alpha/Beta/Admin all stay readable at every viewport. Remove the duplicate header search button + slide-down bar (the footer-nav Search entry covers it). Hide the notification bell wrapper when unread count = 0.

- **#814** — `fix(setup-database): show user-friendly card title in migration status heading`
  Add a `$friendlyTitles` map so clicking "3p. Bulk Import Jobs (#676)" no longer surfaces "Bulk-import-jobs Output" — the heading mirrors the card.

- **#816** — `refactor(setup-database): data-driven migration cards by issue number`
  Drop the alphabetic-suffix scheme (3a, 3b, … 3z, 3y2 — non-monotonic). Define a `$migrationCards` array; render with a foreach over `$migrationOrder` so the grid matches the bulk runner's deployment order. New migrations need only a card entry + one slug append.

- **#818** — `refactor(setup-database): drop redundant SongCount Recompute card`
  The SongCount Triggers migration already includes the same recompute. Drop from `$migrationOrder`, `$scriptMap`, `$friendlyTitles`. The standalone script stays on disk (deprecated header) for emergency CLI runs.

- **#817** — `fix(setup-database): apply-all-migrations renders within admin chrome`
  Defensive `register_shutdown_function` that emits emergency closing tags if a child migration `exit()`s mid-bulk. The migrate-songcount-triggers.php fix in #815 is the model for replacing exit() with `return` / `throw \RuntimeException`; mass-conversion across the other migrate-*.php files is deferred.

- **#819** — `refactor(admin): collapsible accordion sidebar + hamburger`
  Restructure the 24-item sidebar into seven semantically-tighter groups (Songs / Catalogue / Access / People / Operations / Help). Each group is a Bootstrap collapse — only the active page's group is expanded by default. localStorage persists per-group open/closed across navigations. Same accordion pattern applied to the mobile hamburger offcanvas.

- **#813** — `feat(admin): /manage/notifications page`
  Compose & broadcast tab covering single user / role / all signed-in audiences, capped at 5,000 fan-out per send. Filterable feed list + per-row delete. New `manage_notifications` entitlement (Global Admin only). Activity-log entry on every broadcast.

## Deferred (separate issue)

- **#820** — auto-hide migrations whose work is already applied (only show pending)
  Tracked as a follow-up; touches every migrate-*.php to add `is_pending()` probes. Standalone PR.

## Test plan

- [ ] `/manage/setup-database` — card titles use issue numbers, render in `$migrationOrder` sequence; status heading uses friendly title; SongCount triggers run cleanly on a host without SUPER (logs friendly skip + recompute fallback).
- [ ] `/manage/notifications` — compose to a single user → header bell appears on next poll for that user; broadcast to a role → all members of that role get the row; delete works; filters work.
- [ ] Header chrome — Alpha badge readable at 320px / 360px / 768px / 1280px; no header search button; notification bell hidden when zero unread, appears on a fresh post, hides again on mark-all-read.
- [ ] Sidebar — only the active page's group expanded on load; toggle a group, navigate, group state persists; same on mobile hamburger.
- [ ] Public site `/` — fresh deploy without migrations applied returns the 503 friendly page (Alpha/Beta) or generic startup page (production), not a blank screen.
- [ ] Apply-all migrations runs within full admin chrome even if a child step exits (verify against the SongCount triggers SUPER-denial path on a constrained DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
