### PR TITLE
feat(pwa): pull-down-to-refresh gesture (closes #822)

### DIFF
--- a/appWeb/public_html/css/app.css
+++ b/appWeb/public_html/css/app.css
@@ -3037,3 +3037,61 @@ body.offline-unsupported .btn-save-offline,
 body.offline-unsupported .offline-only {
     display: none !important;
 }
+
+/* ---------------------------------------------------------------------------
+   Pull-to-refresh indicator (#822)
+
+   Native-app-style pull-down circle that appears when the user drags from
+   the top of the page. The module sets translateY inline based on pull
+   distance; this CSS provides the resting position (off-screen above the
+   viewport) and the visual chrome of the circle + arrow + spinner.
+   --------------------------------------------------------------------------- */
+.pull-to-refresh-indicator {
+    position: fixed;
+    top: calc(env(safe-area-inset-top, 0px) - 56px);  /* off-screen by default */
+    left: 50%;
+    transform: translateX(-50%);  /* centred horizontally; JS adds translateY */
+    z-index: 1100;                /* above header (1030) + footer */
+    pointer-events: none;
+    transition: transform 0.18s ease-out;
+    will-change: transform;
+}
+@media (prefers-reduced-motion: reduce) {
+    .pull-to-refresh-indicator {
+        transition: none;
+    }
+}
+.pull-to-refresh-indicator .ptr-circle {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background: var(--surface-card, #1e293b);
+    border: 1px solid var(--card-border, rgba(255,255,255,0.1));
+    box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-secondary, #94a3b8);
+    transition: color 0.15s ease, transform 0.18s ease-out;
+}
+/* Past threshold — flip arrow + tint accent so the user sees the
+   "release to refresh" state distinctly. */
+.pull-to-refresh-indicator.is-armed .ptr-circle {
+    color: var(--accent-solid, #6366f1);
+    transform: rotate(180deg);
+}
+.pull-to-refresh-indicator.is-spinning .ptr-circle {
+    color: var(--accent-solid, #6366f1);
+    transform: none;  /* override is-armed rotate while spinning */
+}
+.pull-to-refresh-indicator .ptr-arrow {
+    font-size: 0.95rem;
+    transition: transform 0.18s ease-out;
+}
+.pull-to-refresh-indicator .ptr-spinner {
+    /* Bootstrap spinner-border-sm provides the spin animation; we
+       just need to size + colour it to match the arrow it replaces. */
+    width: 1rem;
+    height: 1rem;
+    border-width: 0.15em;
+}

--- a/appWeb/public_html/js/app.js
+++ b/appWeb/public_html/js/app.js
@@ -44,6 +44,7 @@ import { OfflineIndicator } from './modules/offline-indicator.js';
 import { StorageBridge } from './modules/storage-bridge.js';
 import { SubdomainSync } from './modules/subdomain-sync.js';
 import { Gestures } from './modules/gestures.js';
+import { PullToRefresh } from './modules/pull-to-refresh.js';
 import { Analytics } from './modules/analytics.js';
 import { Notifications } from './modules/notifications.js';
 import { escapeHtml } from './utils/html.js';
@@ -317,6 +318,35 @@ class iHymnsApp {
             /* Touch gesture navigation (#143) */
             this.gestures = new Gestures(this);
             this.gestures.init();
+
+            /* Pull-down-to-refresh gesture (#822) — restores the
+               native PWA pull-to-refresh that's lost when the app
+               runs in standalone mode (where the browser chrome
+               that owns the gesture is hidden). The default
+               handler refreshes the current route via the router;
+               page-specific modules can attach their own listeners
+               to refresh feature data (notifications, favourites,
+               etc.) before / alongside the route refresh. */
+            this.pullToRefresh = new PullToRefresh(this);
+            this.pullToRefresh.init();
+            document.addEventListener('ihymns:refresh-requested', async () => {
+                try {
+                    /* Re-poll auxiliary data first so the bell / footer
+                       counts update even if the route refresh below
+                       fails (e.g. offline). Best-effort — caller
+                       handles its own errors. */
+                    this.notifications?.refresh?.();
+                    /* Reload the current page's HTML + after-load hooks. */
+                    if (this.router) await this.router.refresh();
+                } catch (err) {
+                    console.warn('[iHymns] pull-to-refresh handler failed:', err);
+                } finally {
+                    /* Always signal completion so the indicator clears
+                       even on error. The 5s safety timeout in the
+                       module is a last-resort fallback. */
+                    document.dispatchEvent(new Event('ihymns:refresh-complete'));
+                }
+            });
 
             /* Unified analytics tracking */
             this.analytics = new Analytics(this);

--- a/appWeb/public_html/js/modules/pull-to-refresh.js
+++ b/appWeb/public_html/js/modules/pull-to-refresh.js
@@ -1,0 +1,254 @@
+/**
+ * iHymns — Pull-to-Refresh Gesture (#822)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Native-app-style pull-down-to-refresh gesture for the installed
+ * PWA. Standalone PWAs hide the browser chrome that would otherwise
+ * provide pull-to-refresh natively, leaving users with no equivalent
+ * on a phone-installed iHymns. This module restores the gesture.
+ *
+ * Behaviour:
+ *   - Engages only at scrollTop === 0 — mid-page scrolls are
+ *     untouched.
+ *   - Pull distance > REFRESH_THRESHOLD with a release fires the
+ *     refresh; below threshold snaps back.
+ *   - Indicator grows + spinner appears during pull, animates back
+ *     to home on release / completion.
+ *   - Dispatches `ihymns:refresh-requested`. Each page's controller
+ *     listens, re-fetches its data, then dispatches
+ *     `ihymns:refresh-complete` (the module clears its UI). A
+ *     SAFETY_TIMEOUT_MS clears the spinner if no completion event
+ *     arrives — never leaves the user stuck.
+ *   - Disabled at /manage/* surfaces (full-page reload PHP).
+ *   - Honours `prefers-reduced-motion` by skipping the animation
+ *     transitions but keeping the gesture functional.
+ *
+ * Pointer Events (not touch / mouse separately) so the same code
+ * path covers touch + mouse-drag in a desktop browser tab — useful
+ * for development without needing a phone.
+ */
+
+const REFRESH_THRESHOLD     = 70;     /* px — pull distance to commit */
+const MAX_PULL              = 130;    /* px — visual cap on indicator translation */
+const RESISTANCE            = 0.55;   /* fractional drag-translation ratio */
+const SAFETY_TIMEOUT_MS     = 5000;   /* dismiss spinner even if no completion event */
+const SCROLL_TOP_TOLERANCE  = 1;      /* px — allow tiny scroll for soft-keyboard cases */
+
+export class PullToRefresh {
+    /** @param {object} app Reference to the main iHymnsApp instance */
+    constructor(app) {
+        this.app = app;
+
+        /** Active pull state */
+        this._startY    = null;
+        this._lastY     = null;
+        this._pulling   = false;     /* user is past the engagement check */
+        this._refreshing = false;    /* refresh fired, waiting for completion */
+        this._safetyTimer = null;
+
+        /** Indicator DOM (lazy-created) */
+        this._indicator = null;
+
+        this._onPointerDown = this._onPointerDown.bind(this);
+        this._onPointerMove = this._onPointerMove.bind(this);
+        this._onPointerUp   = this._onPointerUp.bind(this);
+        this._onRefreshComplete = this._onRefreshComplete.bind(this);
+    }
+
+    init() {
+        /* Skip on admin / editor surfaces. /manage/* is full-page-reload
+           PHP so the browser refresh button works fine; no point adding
+           a gesture that competes with it. */
+        if (this._isAdminSurface()) return;
+
+        /* Pointer Events cover both touch + mouse. Wide-fallback to touch
+           events if the runtime lacks pointer support (very old iOS, but
+           we set passive: false so we can preventDefault selectively). */
+        if (window.PointerEvent) {
+            document.addEventListener('pointerdown', this._onPointerDown, { passive: true });
+            document.addEventListener('pointermove', this._onPointerMove, { passive: false });
+            document.addEventListener('pointerup',   this._onPointerUp,   { passive: true });
+            document.addEventListener('pointercancel', this._onPointerUp, { passive: true });
+        } else {
+            /* Older browsers — use touch events directly. */
+            document.addEventListener('touchstart', (e) => this._onPointerDown(e.touches[0]), { passive: true });
+            document.addEventListener('touchmove',  (e) => this._onPointerMove(this._wrapTouch(e)), { passive: false });
+            document.addEventListener('touchend',   () => this._onPointerUp(),   { passive: true });
+            document.addEventListener('touchcancel',() => this._onPointerUp(),   { passive: true });
+        }
+
+        /* Page handlers signal completion via this event so we know
+           when to dismiss the spinner. The 5s safety timeout fires
+           if a handler forgets / errors / hangs. */
+        document.addEventListener('ihymns:refresh-complete', this._onRefreshComplete);
+    }
+
+    _isAdminSurface() {
+        const p = window.location.pathname || '';
+        return p.startsWith('/manage/') || p.startsWith('/manage');
+    }
+
+    /* Touch event → pointer-event-shaped facade so the move handler
+       can call preventDefault on the underlying touch event. */
+    _wrapTouch(e) {
+        const t = e.touches[0];
+        return {
+            clientY: t.clientY,
+            preventDefault: () => e.preventDefault(),
+        };
+    }
+
+    _onPointerDown(p) {
+        if (this._refreshing) return;
+        const y = p?.clientY;
+        if (typeof y !== 'number') return;
+        const top = this._scrollContainerTop();
+        /* Only engage at top of page. If we're mid-scroll, every native
+           scroll gesture must work normally. */
+        if (top > SCROLL_TOP_TOLERANCE) return;
+        this._startY = y;
+        this._lastY  = y;
+        this._pulling = false;
+    }
+
+    _onPointerMove(p) {
+        if (this._refreshing) return;
+        if (this._startY === null) return;
+        const y = p?.clientY;
+        if (typeof y !== 'number') return;
+
+        const delta = y - this._startY;
+        /* Negative delta = pulling up; not our gesture. Clear and bail. */
+        if (delta <= 0) {
+            this._reset();
+            return;
+        }
+
+        /* If the page has scrolled (e.g. user touched while not at top
+           and the OS started scrolling), stop the gesture — let scroll
+           win. */
+        if (this._scrollContainerTop() > SCROLL_TOP_TOLERANCE) {
+            this._reset();
+            return;
+        }
+
+        /* Engage. Apply resistance so the visual movement decelerates
+           past the threshold (matches native iOS feel). */
+        this._pulling = true;
+        const translate = Math.min(delta * RESISTANCE, MAX_PULL);
+        this._showIndicator(translate, translate >= REFRESH_THRESHOLD);
+
+        /* Once engaged, suppress the underlying scroll/drag so the
+           browser doesn't simultaneously fire its own pull-to-refresh
+           (Chrome on Android still tries even in standalone). */
+        if (typeof p.preventDefault === 'function') {
+            try { p.preventDefault(); } catch (_e) { /* ignore */ }
+        }
+
+        this._lastY = y;
+    }
+
+    _onPointerUp() {
+        if (this._refreshing) return;
+        if (!this._pulling) {
+            this._reset();
+            return;
+        }
+        const delta = (this._lastY ?? this._startY) - this._startY;
+        const translate = Math.min(delta * RESISTANCE, MAX_PULL);
+        if (translate >= REFRESH_THRESHOLD) {
+            this._fireRefresh();
+        } else {
+            this._dismissIndicator();
+            this._reset();
+        }
+    }
+
+    _scrollContainerTop() {
+        return (document.scrollingElement || document.documentElement).scrollTop || 0;
+    }
+
+    /* ---------- Refresh lifecycle ---------- */
+
+    _fireRefresh() {
+        this._refreshing = true;
+        this._showIndicator(REFRESH_THRESHOLD, true, /* spinning */ true);
+
+        document.dispatchEvent(new CustomEvent('ihymns:refresh-requested'));
+
+        /* Safety timeout — if no handler completes (or all handlers
+           silently fail), un-stuck the UI. */
+        this._safetyTimer = setTimeout(() => {
+            this._onRefreshComplete();
+        }, SAFETY_TIMEOUT_MS);
+
+        this._reset(/* keepIndicator */ true);
+    }
+
+    _onRefreshComplete() {
+        if (!this._refreshing) return;
+        this._refreshing = false;
+        if (this._safetyTimer) {
+            clearTimeout(this._safetyTimer);
+            this._safetyTimer = null;
+        }
+        this._dismissIndicator();
+    }
+
+    _reset(keepIndicator = false) {
+        this._startY  = null;
+        this._lastY   = null;
+        this._pulling = false;
+        if (!keepIndicator) {
+            this._dismissIndicator();
+        }
+    }
+
+    /* ---------- Indicator UI ---------- */
+
+    _ensureIndicator() {
+        if (this._indicator) return this._indicator;
+        const wrap = document.createElement('div');
+        wrap.id = 'pull-to-refresh-indicator';
+        wrap.className = 'pull-to-refresh-indicator';
+        wrap.setAttribute('role', 'status');
+        wrap.setAttribute('aria-live', 'polite');
+        wrap.setAttribute('aria-hidden', 'true');
+        wrap.innerHTML =
+            '<div class="ptr-circle">' +
+              '<i class="fa-solid fa-arrow-down ptr-arrow" aria-hidden="true"></i>' +
+              '<span class="ptr-spinner spinner-border spinner-border-sm" aria-hidden="true"></span>' +
+            '</div>';
+        document.body.appendChild(wrap);
+        this._indicator = wrap;
+        return wrap;
+    }
+
+    _showIndicator(translatePx, atOrPastThreshold, spinning = false) {
+        const el = this._ensureIndicator();
+        el.style.transform = `translateY(${translatePx}px)`;
+        el.classList.toggle('is-armed',     atOrPastThreshold && !spinning);
+        el.classList.toggle('is-spinning',  spinning);
+        el.setAttribute('aria-hidden', 'false');
+        if (spinning) {
+            el.querySelector('.ptr-arrow')?.classList.add('d-none');
+            el.querySelector('.ptr-spinner')?.classList.remove('d-none');
+            el.setAttribute('aria-label', 'Refreshing');
+        } else {
+            el.querySelector('.ptr-arrow')?.classList.remove('d-none');
+            el.querySelector('.ptr-spinner')?.classList.add('d-none');
+            el.setAttribute('aria-label', atOrPastThreshold ? 'Release to refresh' : 'Pull to refresh');
+        }
+    }
+
+    _dismissIndicator() {
+        const el = this._indicator;
+        if (!el) return;
+        /* Animate back to home; CSS transition handles the easing. */
+        el.style.transform = '';
+        el.classList.remove('is-armed', 'is-spinning');
+        el.setAttribute('aria-hidden', 'true');
+    }
+}

--- a/appWeb/public_html/js/modules/router.js
+++ b/appWeb/public_html/js/modules/router.js
@@ -101,6 +101,17 @@ export class Router {
     }
 
     /**
+     * Re-load the current route's content. Used by the pull-to-refresh
+     * gesture (#822) — same as if the user navigated away and back,
+     * but without changing the URL. Re-fetches the page HTML and
+     * re-runs the after-load hooks so any cached page state (favourites
+     * counts, song-of-the-day, etc.) refreshes.
+     */
+    async refresh() {
+        await this.handleCurrentRoute({ isPopstate: false, isRefresh: true });
+    }
+
+    /**
      * Navigate to a new URL path.
      * Pushes the new state to the browser history and loads the page.
      *


### PR DESCRIPTION
## Summary

Closes #822 — restores the native-app pull-down-to-refresh gesture inside the installed PWA.

## Why

Standalone PWAs (iHymns once installed) **hide the browser chrome** that owns the OS-level pull-to-refresh. Installed-app users had no equivalent: no toolbar refresh button, no menu refresh action, no gesture. They had to leave the app and come back to get fresh data.

This adds an in-app gesture that mirrors what every other native app does.

## What's in it

**New module: [`js/modules/pull-to-refresh.js`](appWeb/public_html/js/modules/pull-to-refresh.js)**

- Pointer Events (with a touch-events fallback for very old iOS) so the same code path covers touch + mouse-drag — useful for testing in a desktop tab.
- Engages only at `scrollTop === 0`. Mid-page scrolls fall through to the browser's native handling.
- Resistance (0.55), max-pull cap (130 px), threshold (70 px) chosen to match the iOS feel.
- Visual: a 40 px pill pinned top-centre, slides down with the pull, flips arrow → spinner past the threshold and tints accent. Honours `prefers-reduced-motion` (transitions skipped, gesture preserved).
- Disabled on `/manage/*` (full-page-reload PHP — browser refresh covers it).

**Wiring**

- [`app.js`](appWeb/public_html/js/app.js) imports + initialises after the existing `Gestures` module.
- [`router.js`](appWeb/public_html/js/modules/router.js) gains a `refresh()` method that re-runs the current route's load path without changing the URL.
- A central `ihymns:refresh-requested` handler in `app.js` calls `notifications.refresh()` then `router.refresh()`, then dispatches `ihymns:refresh-complete` to clear the spinner. A 5 s safety timeout in the module clears it even if a handler hangs.

**CSS in [`app.css`](appWeb/public_html/css/app.css)**

- `.pull-to-refresh-indicator` resting position off-screen above the viewport, slides in via JS-set `translateY`.
- `.is-armed` flips the arrow (180°) + tints accent for the "release to refresh" state.
- `.is-spinning` swaps the arrow for a small Bootstrap spinner.

## Test plan

- [ ] Installed PWA on iOS / Android: pull down at top of `/`, indicator appears, releases past threshold → spinner + page reload; releases below → snaps back.
- [ ] Browser tab desktop: same behaviour using mouse drag from top.
- [ ] Mid-page scroll: native scroll wins, indicator never appears.
- [ ] Pull at top while already mid-refresh: gesture is no-op until completion.
- [ ] `/manage/*` pages: gesture is inactive (admin chrome handles its own reload).
- [ ] Reduced-motion: indicator still appears + works, but skips the easing animation.
- [ ] Hung refresh handler: 5 s safety timeout clears the spinner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
