### PR TITLE
fix(setup-database): apply-all renders inside admin chrome (round 2 of #817)

### DIFF
--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -734,6 +734,12 @@ if ($action !== '') {
        The non-action path (the dashboard) keeps its own existing render
        block lower down. */
     header('Content-Type: text/html; charset=UTF-8');
+    /* Lock the Content-Type so even if a child migration's earlier
+       `header('Content-Type: text/plain')` had set it, the browser
+       trusts ours and doesn't fall back to plaintext rendering on
+       sniff. (#817 round 2 — was the suspected root cause of the
+       "raw HTML page" symptom.) */
+    header('X-Content-Type-Options: nosniff');
 
     /* Drain any default output buffer so our manual flush() actually
        reaches the browser. PHP defaults to one ambient buffer; we

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -740,12 +740,19 @@ if ($action !== '') {
        sniff. (#817 round 2 — was the suspected root cause of the
        "raw HTML page" symptom.) */
     header('X-Content-Type-Options: nosniff');
+    /* Disable caching of the apply-all response so a curator never sees
+       a stale "raw HTML" snapshot from a CDN / browser cache after the
+       chrome-render fix lands. Each apply-all run is unique anyway. */
+    header('Cache-Control: no-store, no-cache, must-revalidate');
+    header('Pragma: no-cache');
 
     /* Drain any default output buffer so our manual flush() actually
        reaches the browser. PHP defaults to one ambient buffer; we
-       want output to stream as soon as we echo. */
+       want output to stream as soon as we echo. The first echo below
+       triggers PHP to send the headers we just queued. */
     while (ob_get_level() > 0) {
-        @ob_end_flush();
+        @ob_end_clean();   /* discard any buffered content from before
+                              the action block, to be safe */
     }
     @ob_implicit_flush(true);
 
@@ -758,6 +765,8 @@ if ($action !== '') {
        runs. */
     ?>
 <!DOCTYPE html>
+<!-- IHYMNS_APPLY_ALL_CHROME_v3 — if you can see this comment in View Source,
+     the chrome-first render is reaching the browser. (#817 round 2) -->
 <html lang="en" data-bs-theme="dark">
 <head>
     <meta charset="UTF-8">


### PR DESCRIPTION
## Summary

Refs #817 — second-round fix after the user reported that "Apply All Migrations still only shows its output in a raw html page".

## What was wrong with round 1

The first attempt added a `register_shutdown_function` that emitted closing HTML tags (`</div></main>...</body></html>`) when the page didn't reach its clean-render flag. That helped only when the chrome had **already started** rendering. But for the bulk run, the action handler captured the run via `ob_start()` **before any chrome was rendered**. A child `exit()` inside that buffer auto-flushed the migration log to the browser without any chrome ever being opened. Result: a raw plain-text-looking page.

## The fix

Restructure the action path to be self-contained — chrome opens **inside** the action block, before the bulk run, with `Content-Type: text/html` + `X-Content-Type-Options: nosniff` committed first. Once the chrome bytes are on the wire:

- A child `header('Content-Type: text/plain')` becomes a silent no-op (PHP can't override sent headers).
- A child `exit()` leaves the chrome opening visible — the existing shutdown handler emits the closing tags into the already-open layout.

## Action path flow

1. Set `Content-Type: text/html` + `X-Content-Type-Options: nosniff`.
2. Drain the ambient `ob` buffer; `ob_implicit_flush(true)`.
3. Render chrome: DOCTYPE → admin-nav → `<div class="output-log">`. `ob_flush() + flush()`.
4. `ob_start()` captures the bulk run (preserves the failure-banner data the existing UX needs).
5. Bulk runner runs.
6. `ob_get_clean()` → echo captured output **inside** the open `<div class="output-log">`.
7. Render the bulk-failure banner **below** the panel (the data is only available post-run; the panel itself is the source of truth for diagnostics).
8. Close `<div>`s → `require admin-footer.php` → `</body></html>`.
9. `$pageRenderedCleanly = true; exit;`

The non-action dashboard path is unchanged. The legacy `<?php if ($action !== ''): … <?php else: ?>` wrapper around the dashboard cards has been removed (the action path now exits before reaching it).

## Test plan

- [ ] Click **Apply all pending migrations** on a healthy host: chrome (sidebar, top nav, Bootstrap-styled output panel) is visible throughout.
- [ ] Force a failing migration (e.g. revoke the schema's CREATE TABLE permission for one): chrome is still visible, the bulk-failure banner renders below the panel.
- [ ] Trigger a child `exit()` mid-bulk: chrome still visible, partial output renders inside `<div class="output-log">`, page closes via the shutdown handler.
- [ ] Per-card runs (Run X migration) — also use the same self-contained chrome render and remain inside the admin layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
