### PR TITLE
fix(admin): parent-songbook picker uses 'Name (ABBR)' format like rest of site

### DIFF
--- a/appWeb/public_html/manage/songbooks.php
+++ b/appWeb/public_html/manage/songbooks.php
@@ -2799,10 +2799,12 @@ $csrf = csrfToken();
 
             /* #782 phase B — pre-fill the parent picker. Hidden id +
                relationship come from the row payload; the visible search
-               input shows "ABBR — Name" so the curator sees what's bound
-               without re-typing. The boot script below scopes the
-               typeahead to the row currently being edited (exclude_id) so
-               descendants of this row never appear as candidates. */
+               input shows "Name (ABBR)" so the curator sees what's bound
+               in the same shape used elsewhere on the site (canonical
+               full-name-then-abbr pattern). The boot script below scopes
+               the typeahead to the row currently being edited
+               (exclude_id) so descendants of this row never appear as
+               candidates. */
             (function () {
                 const idInput  = document.getElementById('edit-parent-id');
                 const txtInput = document.getElementById('edit-parent-search');
@@ -2811,7 +2813,7 @@ $csrf = csrfToken();
                 if (txtInput) {
                     const a = (row.parent_abbreviation || '').toString();
                     const n = (row.parent_name        || '').toString();
-                    txtInput.value = a ? (n ? (a + ' — ' + n) : a) : '';
+                    txtInput.value = n ? (a ? (n + ' (' + a + ')') : n) : a;
                 }
                 if (relSel)   relSel.value   = row.parent_relationship || '';
                 /* Stash the row id so the typeahead can pass exclude_id
@@ -3220,13 +3222,17 @@ $csrf = csrfToken();
                 .then(data => {
                     const list = Array.isArray(data.suggestions) ? data.suggestions : [];
                     labelToId = new Map();
+                    /* Format suggestions as "Full Name (ABBR)" — same shape used
+                       elsewhere on the site for songbook references. (was the
+                       reverse "ABBR — Full Name" which the user reported as
+                       inconsistent with the rest of the UI.) */
                     dl.innerHTML = list.map(s => {
                         const a   = (s.abbreviation || '').replace(/"/g, '&quot;');
                         const n   = (s.name         || '').replace(/"/g, '&quot;');
                         const cc  = (typeof s.childCount === 'number') ? s.childCount : 0;
-                        const lbl = a + (n ? ' — ' + n : '');
+                        const lbl = n ? (a ? (n + ' (' + a + ')') : n) : a;
                         labelToId.set(lbl, String(s.id));
-                        const tail = cc > 0 ? ' (' + cc + ' child' + (cc === 1 ? '' : 'ren') + ')' : '';
+                        const tail = cc > 0 ? ' — ' + cc + ' child' + (cc === 1 ? '' : 'ren') : '';
                         return '<option value="' + lbl + '" label="' + lbl + tail + '"></option>';
                     }).join('');
                 })


### PR DESCRIPTION
## Summary

The Parent songbook typeahead in the `/manage/songbooks` edit modal rendered suggestions as `CIS — Christ in Song` and pre-filled the input the same way. Every other songbook reference on the site uses the `Christ in Song (CIS)` shape (full name first, abbreviation in parens) — see [`js/constants.js::songbookLabel()`](appWeb/public_html/js/constants.js#L78). User flagged the inconsistency.

## Fix

Two call-sites in [`manage/songbooks.php`](appWeb/public_html/manage/songbooks.php) flipped to the canonical shape:

| | Before | After |
|---|---|---|
| Pre-fill on edit-modal open (line ~2814) | `a + ' — ' + n` → "CIS — Christ in Song" | `n + ' (' + a + ')'` → "Christ in Song (CIS)" |
| Typeahead dropdown render (line ~3227) | same as above | same as above |

The `labelToId` map keys move to the new shape so exact-match selection still binds the hidden `parent_songbook_id`. Child-count tail in the dropdown's `<option label>` switches from `(1 child)` to `— 1 child` — the parens were clashing with the new `(ABBR)` suffix.

Falls back to abbr-only when the row has no Name (defensive, mirrors the public `songbookLabel` helper).

## Test plan

- [ ] Open Edit on a songbook that has a parent set → input shows "Christ in Song (CIS)".
- [ ] Open Edit on a songbook with no parent + click in Parent field → dropdown shows "Christ in Song (CIS) — 5 children", "Mission Praise (MP) — 3 children", etc.
- [ ] Select an option → hidden `parent_songbook_id` populates → save → reopen modal shows the new parent in the same shape.
- [ ] Clear button still wipes both fields + relationship select.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
