### PR TITLE
fix(admin): hoist tblSongbookSeries probe so series-membership saves actually persist

### DIFF
--- a/appWeb/public_html/manage/songbooks.php
+++ b/appWeb/public_html/manage/songbooks.php
@@ -502,6 +502,27 @@ $validateAbbr   = fn(string $abbr): ?string => validateSongbookAbbr($abbr);
 $validateColour = fn(string $c): ?string    => validateSongbookColour($c);
 $validateBcp47  = fn(string $tag): ?string  => validateSongbookBcp47($tag);
 
+/* Probe for the series schema BEFORE the POST handler so the
+   series-membership reconciliation block inside it can gate on
+   $hasSeriesSchema. Without this hoist the variable was first
+   defined ~1000 lines down (in the dashboard render section)
+   AFTER the POST handler had already returned, so every save
+   silently skipped its series block. The data-fetch (allSeries +
+   sbSeriesMap) stays down with the render where it's actually
+   consumed. */
+$hasSeriesSchema = false;
+try {
+    $probeSeries = $db->prepare(
+        "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE()
+            AND TABLE_NAME   = 'tblSongbookSeries'
+          LIMIT 1"
+    );
+    $probeSeries->execute();
+    $hasSeriesSchema = $probeSeries->get_result()->fetch_row() !== null;
+    $probeSeries->close();
+} catch (\Throwable $_e) { /* probe failure → series UI stays hidden */ }
+
 /* ----- POST actions ----- */
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!validateCsrf((string)($_POST['csrf_token'] ?? ''))) {
@@ -1506,21 +1527,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
  *       Schema-conditional: if tblSongbookSeries hasn't been migrated
  *       yet the section is silently absent and $allSeries / $sbSeriesMap
  *       stay empty.
+ *
+ *       $hasSeriesSchema is probed earlier in the file (just before
+ *       the POST handler) so the membership-reconciliation block
+ *       inside the POST path can gate on it. Don't re-probe here.
  * ----- */
-$hasSeriesSchema = false;
 $allSeries       = [];
 $sbSeriesMap     = []; /* SongbookId => [SeriesId, ...] */
-try {
-    $probe = $db->prepare(
-        "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
-          WHERE TABLE_SCHEMA = DATABASE()
-            AND TABLE_NAME   = 'tblSongbookSeries'
-          LIMIT 1"
-    );
-    $probe->execute();
-    $hasSeriesSchema = $probe->get_result()->fetch_row() !== null;
-    $probe->close();
-} catch (\Throwable $_e) { /* probe failure → series UI stays hidden */ }
 if ($hasSeriesSchema) {
     try {
         $res = $db->query('SELECT Id, Name, Slug FROM tblSongbookSeries ORDER BY Name ASC');


### PR DESCRIPTION
## Summary

Pre-existing bug discovered while editing songbooks.php — IDE flagged `$hasSeriesSchema` as undefined at lines 894 and 992 (inside the POST handler). Investigation confirmed: the variable was first defined ~1000 lines below the POST handler, so PHP coerced it to falsy and **silently skipped the series-membership reconciliation on every save**.

## Symptom

A curator who ticked or unticked series checkboxes in the songbook edit modal saw the modal close cleanly, but reopening it showed the same memberships as before — the POST discarded their changes. No error in the log because PHP's undefined-variable warnings are suppressed under the live site's error level.

## Fix

Hoist the boolean probe to right before the POST handler (~line 506). The data-fetch (`$allSeries` / `$sbSeriesMap`) stays down with the render where it's actually consumed — those don't need to exist during the POST, only the schema flag does.

```php
// Just before the POST handler:
$hasSeriesSchema = false;
try {
    $probeSeries = $db->prepare(
        "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
          WHERE TABLE_SCHEMA = DATABASE()
            AND TABLE_NAME   = 'tblSongbookSeries'
          LIMIT 1"
    );
    $probeSeries->execute();
    $hasSeriesSchema = $probeSeries->get_result()->fetch_row() !== null;
    $probeSeries->close();
} catch (\Throwable $_e) { /* series UI stays hidden */ }
```

Lower-down probe block deleted (just the duplicated `$hasSeriesSchema` setup; the data-fetch stays).

## Test plan

- [ ] Open Edit on any songbook → tick a series checkbox → Save → reopen Edit → checkbox is still ticked.
- [ ] Untick a previously-set series → Save → reopen → unticked.
- [ ] On a deployment without `tblSongbookSeries` (pre-#782 phase A): edit modal still loads; series UI stays hidden; POST still saves all other fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
