### PR TITLE
feat(catalogue): alternative titles for songs + songbooks (closes #832)

### DIFF
--- a/appWeb/.sql/migrate-alternative-titles.php
+++ b/appWeb/.sql/migrate-alternative-titles.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Alternative Titles Migration (#832)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Two parallel join tables that let curators store multiple
+ * "also known as" titles per song and per songbook. Used for:
+ *
+ *   1. Internal search — a search for "Faith's Review and Expectation"
+ *      returns Amazing Grace (its original 1779 title); "Adventist
+ *      Hymnal" returns The Church Hymnal.
+ *   2. SEO / webpage metadata — surfaces alt titles via JSON-LD
+ *      `alternateName` on song + songbook pages so search engines
+ *      pick up the equivalents.
+ *
+ * Schema:
+ *   tblSongAlternativeTitles
+ *     SongId       FK → tblSongs(SongId)
+ *     Title        the alt title
+ *     Language     optional IETF BCP 47 tag for multilingual hymns
+ *                  (e.g. 'es' for "Sublime Gracia" alt of "Amazing Grace")
+ *     SortOrder    display order
+ *     Note         optional context ("original title", "first line", …)
+ *     CreatedAt
+ *     UNIQUE (SongId, Title)
+ *
+ *   tblSongbookAlternativeTitles
+ *     SongbookId   FK → tblSongbooks(Id)
+ *     Title
+ *     SortOrder
+ *     Note
+ *     CreatedAt
+ *     UNIQUE (SongbookId, Title)
+ *
+ * Idempotent — INFORMATION_SCHEMA probe; CREATE skips when present.
+ * No data backfill (alt titles are curator-entered, not derivable).
+ *
+ * USAGE:
+ *   CLI: php appWeb/.sql/migrate-alternative-titles.php
+ *   Web: /manage/setup-database → "Alternative Titles (#832)"
+ *        (entry point requires global_admin)
+ *
+ * @migration-adds tblSongAlternativeTitles
+ * @migration-adds tblSongbookAlternativeTitles
+ * @requires PHP 8.1+ with mysqli extension
+ */
+
+if (PHP_SAPI === 'cli') {
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = true;
+} else {
+    if (!defined('IHYMNS_SETUP_DASHBOARD')) {
+        if (!function_exists('isAuthenticated')) {
+            require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+        }
+        if (!isAuthenticated()) {
+            http_response_code(401);
+            exit('Authentication required.');
+        }
+        $u = getCurrentUser();
+        if (!$u || $u['role'] !== 'global_admin') {
+            http_response_code(403);
+            exit('Global admin required.');
+        }
+    }
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = false;
+}
+
+function _migAltTitles_out(string $line): void
+{
+    global $isCli;
+    echo $line . ($isCli ? "\n" : "<br>\n");
+    if ($isCli) flush();
+}
+
+function _migAltTitles_tableExists(\mysqli $db, string $table): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? LIMIT 1'
+    );
+    $stmt->bind_param('s', $table);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+_migAltTitles_out('Alternative Titles migration starting (#832)…');
+
+$mysqli = getDbMysqli();
+if (!$mysqli) {
+    throw new \RuntimeException('Could not connect to database.');
+}
+
+foreach (['tblSongs', 'tblSongbooks'] as $required) {
+    if (!_migAltTitles_tableExists($mysqli, $required)) {
+        _migAltTitles_out("ERROR: {$required} not found. Run install.php / migrate-json.php first.");
+        return;
+    }
+}
+
+/* ----------------------------------------------------------------------
+ * Step 1 — tblSongAlternativeTitles
+ * ---------------------------------------------------------------------- */
+if (_migAltTitles_tableExists($mysqli, 'tblSongAlternativeTitles')) {
+    _migAltTitles_out('[skip] tblSongAlternativeTitles already present.');
+} else {
+    $sql = "CREATE TABLE tblSongAlternativeTitles (
+        Id           INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+        SongId       VARCHAR(20)  NOT NULL,
+        Title        VARCHAR(255) NOT NULL,
+        Language     VARCHAR(35)  NULL,
+        SortOrder    INT UNSIGNED NOT NULL DEFAULT 0,
+        Note         VARCHAR(255) NULL,
+        CreatedAt    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+        INDEX idx_song   (SongId),
+        INDEX idx_title  (Title),
+        UNIQUE KEY uq_song_title (SongId, Title),
+
+        CONSTRAINT fk_alt_song
+            FOREIGN KEY (SongId) REFERENCES tblSongs(SongId) ON DELETE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
+    if (!$mysqli->query($sql)) {
+        throw new \RuntimeException('CREATE TABLE tblSongAlternativeTitles failed: ' . $mysqli->error);
+    }
+    _migAltTitles_out('[add ] tblSongAlternativeTitles.');
+}
+
+/* ----------------------------------------------------------------------
+ * Step 2 — tblSongbookAlternativeTitles
+ * ---------------------------------------------------------------------- */
+if (_migAltTitles_tableExists($mysqli, 'tblSongbookAlternativeTitles')) {
+    _migAltTitles_out('[skip] tblSongbookAlternativeTitles already present.');
+} else {
+    $sql = "CREATE TABLE tblSongbookAlternativeTitles (
+        Id           INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+        SongbookId   INT UNSIGNED NOT NULL,
+        Title        VARCHAR(255) NOT NULL,
+        SortOrder    INT UNSIGNED NOT NULL DEFAULT 0,
+        Note         VARCHAR(255) NULL,
+        CreatedAt    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+        INDEX idx_book   (SongbookId),
+        INDEX idx_title  (Title),
+        UNIQUE KEY uq_book_title (SongbookId, Title),
+
+        CONSTRAINT fk_alt_book
+            FOREIGN KEY (SongbookId) REFERENCES tblSongbooks(Id) ON DELETE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
+    if (!$mysqli->query($sql)) {
+        throw new \RuntimeException('CREATE TABLE tblSongbookAlternativeTitles failed: ' . $mysqli->error);
+    }
+    _migAltTitles_out('[add ] tblSongbookAlternativeTitles.');
+}
+
+_migAltTitles_out('Alternative Titles migration finished (#832).');

--- a/appWeb/public_html/includes/SongData.php
+++ b/appWeb/public_html/includes/SongData.php
@@ -302,15 +302,18 @@ class SongData
         }
         $stmt->close();
 
-        /* Attach series memberships in one batch query (#782 phase D)
-           so the home/browse grids can render a "Part of: <Series>" line
-           without N+1 queries. Compilers attached the same way (#831). */
+        /* Attach series memberships + compilers + alt names in one
+           batch query each (#782 phase D, #831, #832) so the home /
+           browse grids can render "Part of: <Series>", "Compiled by …"
+           and "Also known as …" lines without N+1 queries. */
         if ($books) {
             $seriesMap    = $this->_songbookSeriesMap(null);
             $compilersMap = $this->_songbookCompilersMap(null);
+            $altNamesMap  = $this->_songbookAltNamesMap(null);
             foreach ($books as &$_b) {
-                $_b['series']    = $seriesMap[(string)$_b['id']]    ?? [];
-                $_b['compilers'] = $compilersMap[(string)$_b['id']] ?? [];
+                $_b['series']           = $seriesMap[(string)$_b['id']]    ?? [];
+                $_b['compilers']        = $compilersMap[(string)$_b['id']] ?? [];
+                $_b['alternativeNames'] = $altNamesMap[(string)$_b['id']]  ?? [];
             }
             unset($_b);
         }
@@ -651,6 +654,144 @@ class SongData
     }
 
     /**
+     * Pull `[abbr => [{title, note}, ...]]` from
+     * tblSongbookAlternativeTitles. Schema-probed (#832).
+     * Pre-migration deployments get an empty map so the public
+     * "Also known as …" line and JSON-LD alternateName both
+     * gracefully no-op.
+     *
+     * @param string[]|null $abbrs Limit to these abbreviations; null = all
+     * @return array<string, array<int, array{title:string,note:string}>>
+     */
+    private function _songbookAltNamesMap(?array $abbrs = null): array
+    {
+        $hasSchema = false;
+        try {
+            $probe = $this->db->prepare(
+                "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+                  WHERE TABLE_SCHEMA = DATABASE()
+                    AND TABLE_NAME   = 'tblSongbookAlternativeTitles'
+                  LIMIT 1"
+            );
+            $probe->execute();
+            $hasSchema = $probe->get_result()->fetch_row() !== null;
+            $probe->close();
+        } catch (\Throwable $_e) { /* fall through */ }
+        if (!$hasSchema) return [];
+
+        try {
+            if ($abbrs === null) {
+                $sql = 'SELECT b.Abbreviation AS abbr,
+                               a.Title         AS title,
+                               a.Note          AS note,
+                               a.SortOrder     AS sortOrder
+                          FROM tblSongbookAlternativeTitles a
+                          JOIN tblSongbooks b ON b.Id = a.SongbookId
+                         ORDER BY b.Abbreviation, a.SortOrder ASC, a.Title ASC';
+                $stmt = $this->db->prepare($sql);
+            } else {
+                $abbrs = array_values(array_filter(array_unique(array_map(
+                    static fn($a) => strtoupper(trim((string)$a)),
+                    $abbrs
+                ))));
+                if (!$abbrs) return [];
+                $ph  = implode(',', array_fill(0, count($abbrs), '?'));
+                $sql = "SELECT b.Abbreviation AS abbr,
+                               a.Title         AS title,
+                               a.Note          AS note,
+                               a.SortOrder     AS sortOrder
+                          FROM tblSongbookAlternativeTitles a
+                          JOIN tblSongbooks b ON b.Id = a.SongbookId
+                         WHERE b.Abbreviation IN ($ph)
+                         ORDER BY b.Abbreviation, a.SortOrder ASC, a.Title ASC";
+                $stmt  = $this->db->prepare($sql);
+                $types = str_repeat('s', count($abbrs));
+                $stmt->bind_param($types, ...$abbrs);
+            }
+            $stmt->execute();
+            $res = $stmt->get_result();
+            $out = [];
+            while ($row = $res->fetch_assoc()) {
+                $abbr = (string)$row['abbr'];
+                if (!isset($out[$abbr])) $out[$abbr] = [];
+                $out[$abbr][] = [
+                    'title' => (string)$row['title'],
+                    'note'  => (string)($row['note'] ?? ''),
+                ];
+            }
+            $stmt->close();
+            return $out;
+        } catch (\Throwable $e) {
+            error_log('[SongData::_songbookAltNamesMap] ' . $e->getMessage());
+            return [];
+        }
+    }
+
+    /**
+     * Pull `[songId => [{title, note, language}, ...]]` from
+     * tblSongAlternativeTitles. Schema-probed (#832).
+     *
+     * @param string[]|null $songIds Limit to these SongIds; null = all
+     * @return array<string, array<int, array{title:string,note:string,language:string}>>
+     */
+    private function _songAltTitlesMap(?array $songIds = null): array
+    {
+        $hasSchema = false;
+        try {
+            $probe = $this->db->prepare(
+                "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+                  WHERE TABLE_SCHEMA = DATABASE()
+                    AND TABLE_NAME   = 'tblSongAlternativeTitles'
+                  LIMIT 1"
+            );
+            $probe->execute();
+            $hasSchema = $probe->get_result()->fetch_row() !== null;
+            $probe->close();
+        } catch (\Throwable $_e) { /* fall through */ }
+        if (!$hasSchema) return [];
+
+        try {
+            if ($songIds === null) {
+                $sql = 'SELECT SongId, Title, Note, Language, SortOrder
+                          FROM tblSongAlternativeTitles
+                         ORDER BY SongId, SortOrder ASC, Title ASC';
+                $stmt = $this->db->prepare($sql);
+            } else {
+                $songIds = array_values(array_filter(array_unique(array_map(
+                    static fn($s) => trim((string)$s),
+                    $songIds
+                ))));
+                if (!$songIds) return [];
+                $ph  = implode(',', array_fill(0, count($songIds), '?'));
+                $sql = "SELECT SongId, Title, Note, Language, SortOrder
+                          FROM tblSongAlternativeTitles
+                         WHERE SongId IN ($ph)
+                         ORDER BY SongId, SortOrder ASC, Title ASC";
+                $stmt  = $this->db->prepare($sql);
+                $types = str_repeat('s', count($songIds));
+                $stmt->bind_param($types, ...$songIds);
+            }
+            $stmt->execute();
+            $res = $stmt->get_result();
+            $out = [];
+            while ($row = $res->fetch_assoc()) {
+                $sid = (string)$row['SongId'];
+                if (!isset($out[$sid])) $out[$sid] = [];
+                $out[$sid][] = [
+                    'title'    => (string)$row['Title'],
+                    'note'     => (string)($row['Note'] ?? ''),
+                    'language' => (string)($row['Language'] ?? ''),
+                ];
+            }
+            $stmt->close();
+            return $out;
+        } catch (\Throwable $e) {
+            error_log('[SongData::_songAltTitlesMap] ' . $e->getMessage());
+            return [];
+        }
+    }
+
+    /**
      * Find a SongId by (songbook abbreviation, number) without
      * re-fetching the full song row. Used by the song page to
      * decide whether the parent songbook has a same-numbered
@@ -738,11 +879,14 @@ class SongData
         /* #782 phase D — also attach series memberships. Single-songbook
            variant of the bulk fetch on getSongbooks(); pre-migration
            safe via the schema probe inside _songbookSeriesMap.
-           #831 — compilers attached the same way. */
-        $seriesMap        = $this->_songbookSeriesMap([$id]);
-        $compilersMap     = $this->_songbookCompilersMap([$id]);
-        $row['series']    = $seriesMap[(string)$row['id']]    ?? [];
-        $row['compilers'] = $compilersMap[(string)$row['id']] ?? [];
+           #831 — compilers attached the same way.
+           #832 — alt names attached the same way. */
+        $seriesMap               = $this->_songbookSeriesMap([$id]);
+        $compilersMap            = $this->_songbookCompilersMap([$id]);
+        $altNamesMap             = $this->_songbookAltNamesMap([$id]);
+        $row['series']           = $seriesMap[(string)$row['id']]    ?? [];
+        $row['compilers']        = $compilersMap[(string)$row['id']] ?? [];
+        $row['alternativeNames'] = $altNamesMap[(string)$row['id']]  ?? [];
         return $row;
     }
 
@@ -1822,6 +1966,11 @@ class SongData
         if (!empty($translations)) {
             $row['translations'] = $translations;
         }
+
+        /* #832 — alt titles for this song. Empty array on a pre-
+           migration deployment via the schema probe in the helper. */
+        $altMap = $this->_songAltTitlesMap([$songId]);
+        $row['alternativeTitles'] = $altMap[$songId] ?? [];
 
         return $row;
     }

--- a/appWeb/public_html/includes/SongData.php
+++ b/appWeb/public_html/includes/SongData.php
@@ -1608,6 +1608,30 @@ class SongData
             $results = $this->_searchByWriterComposer($query, $songbookId, $limit);
         }
 
+        /* Alternative-title matches (#832) — also surface songs whose
+           tblSongAlternativeTitles row matches the query. Merges
+           de-duplicated into the existing result list AT THE TOP so
+           a curator-flagged alt match outranks a body-text fuzzy hit
+           (a search for "Faith's Review and Expectation" should put
+           Amazing Grace first, not buried below lyrics matches). */
+        $altHits = $this->_searchByAlternativeTitle($query, $songbookId, $limit);
+        if (!empty($altHits)) {
+            $seenAlt = [];
+            foreach ($results as $r) { $seenAlt[$r['id']] = true; }
+            $merged = [];
+            foreach ($altHits as $hit) {
+                if (!isset($seenAlt[$hit['id']])) {
+                    $merged[] = $hit;
+                    $seenAlt[$hit['id']] = true;
+                }
+            }
+            foreach ($results as $r) {
+                $merged[] = $r;
+            }
+            $results = $merged;
+            if ($limit > 0) $results = array_slice($results, 0, $limit);
+        }
+
         /* Scripture-reference tag matches (#397 follow-up) — if the query
            looked like a scripture reference, ALSO surface songs that have
            been tagged with the canonical book or full reference. Merges
@@ -1639,6 +1663,97 @@ class SongData
      * via /manage/editor/ (tags UI) and the hit merges into search
      * results for scripture-style queries.
      */
+
+    /**
+     * Search songs by alternative title (#832). Returns the same row
+     * shape as searchSongs() so the caller can merge results
+     * transparently. The match ranks "alt title contains the query"
+     * at the same level as a canonical title hit — alt titles ARE
+     * canonical-equivalents in MusicBrainz parlance, just less
+     * prominent. Each returned row also carries `matchedVia` =
+     * { alternativeTitle: "<the alt that matched>" } so the result
+     * UI can render a "(known as: …)" hint.
+     *
+     * Schema-probed; pre-migration deployments return an empty list.
+     */
+    private function _searchByAlternativeTitle(string $query, ?string $songbookId, int $limit): array
+    {
+        if ($this->jsonMode || !$this->db) return [];
+        $query = trim($query);
+        if ($query === '') return [];
+
+        /* Probe — bail cheaply when the schema isn't live. */
+        try {
+            $probe = $this->db->query(
+                "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+                  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tblSongAlternativeTitles' LIMIT 1"
+            );
+            $exists = $probe && $probe->fetch_row() !== null;
+            if ($probe) $probe->close();
+            if (!$exists) return [];
+        } catch (\Throwable $_e) {
+            return [];
+        }
+
+        try {
+            $like = '%' . $query . '%';
+            $sql  = 'SELECT s.SongId AS id, s.Number AS number, s.Title AS title,
+                            s.SongbookAbbr AS songbook, s.SongbookName AS songbookName,
+                            s.Language AS language, s.Copyright AS copyright, s.Ccli AS ccli,
+                            s.Verified AS verified, s.LyricsPublicDomain AS lyricsPublicDomain,
+                            s.MusicPublicDomain AS musicPublicDomain,
+                            s.HasAudio AS hasAudio, s.HasSheetMusic AS hasSheetMusic,
+                            a.Title AS matchedAltTitle
+                       FROM tblSongAlternativeTitles a
+                       JOIN tblSongs s ON s.SongId = a.SongId
+                      WHERE a.Title LIKE ?';
+            $params = [$like];
+            $types  = 's';
+            if ($songbookId !== null) {
+                $songbookId = strtoupper(trim($songbookId));
+                $sql .= ' AND s.SongbookAbbr = ?';
+                $params[] = $songbookId;
+                $types   .= 's';
+            }
+            $sql .= ' ORDER BY s.SongbookAbbr, s.Number';
+            if ($limit > 0) {
+                $sql .= ' LIMIT ?';
+                $params[] = $limit;
+                $types   .= 'i';
+            }
+
+            $stmt = $this->db->prepare($sql);
+            $stmt->bind_param($types, ...$params);
+            $stmt->execute();
+            $res = $stmt->get_result();
+
+            /* De-dup on SongId — a song with three alt-titles all matching
+               the query would otherwise appear three times in the merge. */
+            $hits = [];
+            while ($row = $res->fetch_assoc()) {
+                $sid = (string)$row['id'];
+                if (isset($hits[$sid])) continue;
+                $matchedAlt = (string)($row['matchedAltTitle'] ?? '');
+                unset($row['matchedAltTitle']);
+                $row['number'] = normaliseSongNumber($row['number']);
+                $row['verified'] = (bool)$row['verified'];
+                $row['lyricsPublicDomain'] = (bool)$row['lyricsPublicDomain'];
+                $row['musicPublicDomain'] = (bool)$row['musicPublicDomain'];
+                $row['hasAudio'] = (bool)$row['hasAudio'];
+                $row['hasSheetMusic'] = (bool)$row['hasSheetMusic'];
+                $row['matchedVia'] = ['alternativeTitle' => $matchedAlt];
+                $hits[$sid] = $row;
+            }
+            $stmt->close();
+            $hits = array_values($hits);
+            $this->_attachSearchResultCredits($hits);
+            return $hits;
+        } catch (\Throwable $e) {
+            error_log('[SongData::_searchByAlternativeTitle] ' . $e->getMessage());
+            return [];
+        }
+    }
+
     private function _searchByScriptureTag(string $scriptureRef, ?string $songbookId): array
     {
         if ($this->jsonMode || !$this->db) return [];

--- a/appWeb/public_html/includes/pages/song.php
+++ b/appWeb/public_html/includes/pages/song.php
@@ -297,6 +297,29 @@ try {
                 <?php endif; ?>
                 <div class="flex-grow-1">
                     <h1 class="h4 mb-1"><?= htmlspecialchars($songTitle) ?><?php if (!empty($song['verified'])): ?><span class="verified-badge" title="Verified lyrics" aria-label="Verified lyrics"><svg viewBox="0 0 24 24" fill="none" aria-hidden="true"><circle cx="12" cy="12" r="10" fill="currentColor" opacity="0.15"/><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="1.5" fill="none"/><path d="M7.5 12.5L10.5 15.5L16.5 9" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg></span><?php endif; ?></h1>
+                    <?php
+                        /* #832 — "Also known as …" line. Hidden when this
+                           song has no alt titles (or pre-migration). Per-row
+                           Note appears in muted parentheses; per-row Language
+                           tag appears as a small badge (e.g. "es") so a user
+                           can see which alt belongs to which language variant. */
+                        $altTitles = $song['alternativeTitles'] ?? [];
+                        if (!empty($altTitles)):
+                    ?>
+                        <p class="text-muted small mb-1">
+                            <span class="me-1">Also known as:</span>
+                            <?php foreach ($altTitles as $i => $a): ?>
+                                <?php if ($i > 0): ?>, <?php endif; ?>
+                                <em><?= htmlspecialchars($a['title']) ?></em>
+                                <?php if (!empty($a['language'])): ?>
+                                    <span class="badge bg-secondary text-light small"><?= htmlspecialchars($a['language']) ?></span>
+                                <?php endif; ?>
+                                <?php if (!empty($a['note'])): ?>
+                                    <span class="text-muted">(<?= htmlspecialchars($a['note']) ?>)</span>
+                                <?php endif; ?>
+                            <?php endforeach; ?>
+                        </p>
+                    <?php endif; ?>
                     <p class="text-muted mb-0">
                         <span class="badge bg-body-secondary"><?= htmlspecialchars($songbook) ?></span>
                         <?= htmlspecialchars($bookName) ?>

--- a/appWeb/public_html/includes/pages/songbook.php
+++ b/appWeb/public_html/includes/pages/songbook.php
@@ -92,6 +92,23 @@ if ($book === null) {
                     <?php endforeach; ?>
                 </p>
             <?php endif; ?>
+            <?php
+                /* #832 — "Also known as …" line. Hidden when this
+                   songbook has no alt names (or pre-migration). */
+                $altNames = $book['alternativeNames'] ?? [];
+                if (!empty($altNames)):
+            ?>
+                <p class="text-muted small mb-0 mt-1">
+                    <span class="me-1">Also known as:</span>
+                    <?php foreach ($altNames as $i => $a): ?>
+                        <?php if ($i > 0): ?>, <?php endif; ?>
+                        <em><?= htmlspecialchars($a['title']) ?></em>
+                        <?php if (!empty($a['note'])): ?>
+                            <span class="text-muted">(<?= htmlspecialchars($a['note']) ?>)</span>
+                        <?php endif; ?>
+                    <?php endforeach; ?>
+                </p>
+            <?php endif; ?>
         </div>
         <div class="d-flex gap-2">
             <!-- Number pad search for this songbook -->

--- a/appWeb/public_html/index.php
+++ b/appWeb/public_html/index.php
@@ -245,6 +245,20 @@ try {
                 'name'     => $ogSong['title'],
                 'inLanguage' => $locale,
             ];
+            /* #832 — alternateName for SEO. Search engines pick this up
+               so a query for the original title / common misspelling /
+               vernacular name still surfaces this song. Empty array on
+               pre-migration deployments — key omitted in that case so
+               the JSON-LD stays clean. */
+            if (!empty($ogSong['alternativeTitles'])) {
+                $musicComposition['alternateName'] = array_values(array_map(
+                    static fn(array $a): string => (string)($a['title'] ?? ''),
+                    array_filter(
+                        $ogSong['alternativeTitles'],
+                        static fn($a) => is_array($a) && !empty($a['title'])
+                    )
+                ));
+            }
             if (!empty($ogSong['composers'])) {
                 $musicComposition['composer'] = array_map(
                     fn($name) => ['@type' => 'Person', 'name' => $name],
@@ -283,6 +297,21 @@ try {
             $ogTitle = htmlspecialchars($ogBook['name']) . ' — ' . $app["Application"]["Name"];
             $ogDescription = 'Browse ' . number_format($ogBook['songCount'])
                            . ' songs from ' . $ogBook['name'] . ' on ' . $app["Application"]["Name"];
+            /* #832 — append "Also known as: …" to social previews when
+               alt names are present, so a Twitter/Facebook share card
+               surfaces vernacular names too. Capped at 3 alts to keep
+               the OG description from blowing past the ~200 char
+               threshold platforms truncate at. */
+            if (!empty($ogBook['alternativeNames'])) {
+                $altSlice = array_slice($ogBook['alternativeNames'], 0, 3);
+                $altText  = implode(', ', array_map(
+                    static fn(array $a): string => (string)($a['title'] ?? ''),
+                    $altSlice
+                ));
+                if ($altText !== '') {
+                    $ogDescription .= '. Also known as: ' . $altText;
+                }
+            }
             $ogImage = getCanonicalUrl('/og-image?songbook=' . urlencode($matches[1]));
             $ogImageAlt = $ogBook['name'] . ' songbook on ' . $app["Application"]["Name"];
 
@@ -292,6 +321,24 @@ try {
                 ['name' => 'Songbooks', 'url' => getCanonicalUrl('/songbooks')],
                 ['name' => $ogBook['name'], 'url' => $canonicalUrl],
             ];
+
+            /* JSON-LD: MusicAlbum (#832 — alternateName for SEO). */
+            $musicAlbum = [
+                '@context' => 'https://schema.org',
+                '@type'    => 'MusicAlbum',
+                'name'     => $ogBook['name'],
+                'numTracks' => (int)($ogBook['songCount'] ?? 0),
+            ];
+            if (!empty($ogBook['alternativeNames'])) {
+                $musicAlbum['alternateName'] = array_values(array_map(
+                    static fn(array $a): string => (string)($a['title'] ?? ''),
+                    array_filter(
+                        $ogBook['alternativeNames'],
+                        static fn($a) => is_array($a) && !empty($a['title'])
+                    )
+                ));
+            }
+            $jsonLdScripts[] = $musicAlbum;
         }
     }
     /* Shared setlist page: /setlist/shared/abc123 */

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -227,6 +227,7 @@ $friendlyTitles = [
     'song-links'                       => 'Cross-book Song Links (#807 / #808)',
     'songcount-triggers'               => 'SongCount Triggers (#793)',
     'songbook-compilers'               => 'Songbook Compilers (#831)',
+    'alternative-titles'               => 'Alternative Titles for Songs &amp; Songbooks (#832)',
     /* `recompute-songbook-songcount` no longer exposed via the dashboard
        (#818) — the SongCount Triggers migration above includes its own
        initial recompute. The CLI script stays on disk for emergency
@@ -540,6 +541,19 @@ $migrationCards = [
                   . ' Idempotent.',
         'button' => 'Run Songbook Compilers Migration',
     ],
+    'alternative-titles' => [
+        'title'  => 'Alternative Titles for Songs &amp; Songbooks (#832)',
+        'body'   => 'Adds <code>tblSongAlternativeTitles</code> +'
+                  . ' <code>tblSongbookAlternativeTitles</code> so curators can record'
+                  . ' multiple "also known as" titles per entity. Used for internal'
+                  . ' search (a query for "Faith\'s Review and Expectation" returns'
+                  . ' Amazing Grace; "Adventist Hymnal" returns The Church Hymnal) and'
+                  . ' surfaced via JSON-LD <code>alternateName</code> for SEO. Each'
+                  . ' alt carries optional Note + per-row Language tag (songs only;'
+                  . ' lets a Spanish alt of an English hymn be flagged'
+                  . ' <code>es</code>). Idempotent.',
+        'button' => 'Run Alternative Titles Migration',
+    ],
     /* recompute-songbook-songcount card removed (#818) — its work is
        now covered by the SongCount Triggers migration above, which
        runs an initial recompute as part of its installation. The
@@ -670,6 +684,7 @@ $migrationProbes = [
        reachable as a manual recompute. */
     'songcount-triggers'                 => static fn(\mysqli $db) => !_migProbe_triggerExists($db, 'trg_songs_songcount_ai'),
     'songbook-compilers'                 => static fn(\mysqli $db) => !_migProbe_tableExists($db, 'tblSongbookCompilers'),
+    'alternative-titles'                 => static fn(\mysqli $db) => !_migProbe_tableExists($db, 'tblSongAlternativeTitles'),
     /* Data-only backfills — applied state isn't cheap to detect
        reliably from schema alone. Default to "always show" so a
        curator can always re-run; re-runs are idempotent. */
@@ -859,6 +874,7 @@ if ($action !== '') {
              php appWeb/.sql/migrate-recompute-songbook-songcount.php  */
         'songcount-triggers'       => 'migrate-songcount-triggers.php',
         'songbook-compilers'       => 'migrate-songbook-compilers.php',
+        'alternative-titles'       => 'migrate-alternative-titles.php',
         'cleanup'     => 'cleanup.php',
         'backup'      => 'backup.php',
         'restore'     => 'restore.php',
@@ -912,6 +928,7 @@ if ($action !== '') {
            recompute twice on every Apply-All run. */
         'songcount-triggers',
         'songbook-compilers',
+        'alternative-titles',
         /* When you add a new migrate-*.php under appWeb/.sql/, ALSO add
            its action key to:
              1. $scriptMap above (action key → file)

--- a/appWeb/public_html/manage/songbooks.php
+++ b/appWeb/public_html/manage/songbooks.php
@@ -618,6 +618,21 @@ try {
     $probeComp->close();
 } catch (\Throwable $_e) { /* probe failure → compilers UI stays hidden */ }
 
+/* Probe for tblSongbookAlternativeTitles (#832). Same hoist
+   rationale as $hasSeriesSchema — POST handler needs the gate. */
+$hasAltNamesSchema = false;
+try {
+    $probeAlt = $db->prepare(
+        "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE()
+            AND TABLE_NAME   = 'tblSongbookAlternativeTitles'
+          LIMIT 1"
+    );
+    $probeAlt->execute();
+    $hasAltNamesSchema = $probeAlt->get_result()->fetch_row() !== null;
+    $probeAlt->close();
+} catch (\Throwable $_e) { /* probe failure → alt-names UI stays hidden */ }
+
 /* ----- POST actions ----- */
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!validateCsrf((string)($_POST['csrf_token'] ?? ''))) {
@@ -1112,6 +1127,58 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         }
                     }
 
+                    /* #832 — reconcile songbook alternative names. The edit
+                       modal posts parallel arrays:
+                         alt_name_titles[]  — the alt name string
+                         alt_name_notes[]   — optional per-row note
+                       Position N in each array is the same alt-name row;
+                       array index drives SortOrder. Empty / blank titles
+                       are dropped before insert.
+                       Schema-gated by $hasAltNamesSchema; pre-migration
+                       deployments skip this block silently. */
+                    $postedAltNames = [];
+                    if ($hasAltNamesSchema) {
+                        $rawT = $_POST['alt_name_titles'] ?? [];
+                        $rawN = $_POST['alt_name_notes']  ?? [];
+                        if (!is_array($rawT)) $rawT = [];
+                        if (!is_array($rawN)) $rawN = [];
+                        $altRows = [];
+                        $seen    = [];
+                        foreach ($rawT as $idx => $rawTitle) {
+                            $title = trim((string)$rawTitle);
+                            if ($title === '')              continue;
+                            $title = mb_substr($title, 0, 255);
+                            $key   = mb_strtolower($title);
+                            if (isset($seen[$key]))         continue;  /* de-dup case-insensitive */
+                            $seen[$key] = true;
+                            $note = trim((string)($rawN[$idx] ?? ''));
+                            $altRows[] = [
+                                'title' => $title,
+                                'note'  => ($note !== '' ? mb_substr($note, 0, 255) : null),
+                                'order' => count($altRows),
+                            ];
+                        }
+
+                        $stmt = $db->prepare('DELETE FROM tblSongbookAlternativeTitles WHERE SongbookId = ?');
+                        $stmt->bind_param('i', $id);
+                        $stmt->execute();
+                        $stmt->close();
+
+                        if ($altRows) {
+                            $stmt = $db->prepare(
+                                'INSERT INTO tblSongbookAlternativeTitles
+                                     (SongbookId, Title, SortOrder, Note)
+                                  VALUES (?, ?, ?, ?)'
+                            );
+                            foreach ($altRows as $a) {
+                                $stmt->bind_param('isis', $id, $a['title'], $a['order'], $a['note']);
+                                $stmt->execute();
+                                $postedAltNames[] = $a['title'];
+                            }
+                            $stmt->close();
+                        }
+                    }
+
                     $db->commit();
 
                     /* Audit (#535) — compute the changed-fields list
@@ -1165,6 +1232,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     }
                     if ($hasCompilersSchema) {
                         $auditExtras['compiler_person_ids'] = $postedCompilerSet;
+                    }
+                    if ($hasAltNamesSchema) {
+                        $auditExtras['alternative_names'] = $postedAltNames;
                     }
                     logActivity('songbook.edit', 'songbook', (string)$id, array_merge([
                         'fields'             => $changed,
@@ -1755,6 +1825,37 @@ if ($hasCompilersSchema) {
     }
 }
 
+/* ----- Alternative-names map (#832) -----------------------------------
+ *       SongbookId => [{title, sortOrder, note}, …] in SortOrder asc.
+ *       Same caching strategy as $sbSeriesMap — single batch fetch
+ *       per page-load. Schema-conditional via $hasAltNamesSchema.
+ * ----- */
+$sbAltNamesMap = [];
+if ($hasAltNamesSchema) {
+    try {
+        $res = $db->query(
+            'SELECT SongbookId, Title, SortOrder, Note
+               FROM tblSongbookAlternativeTitles
+              ORDER BY SongbookId ASC, SortOrder ASC, Title ASC'
+        );
+        if ($res) {
+            while ($arow = $res->fetch_assoc()) {
+                $sb = (int)$arow['SongbookId'];
+                if (!isset($sbAltNamesMap[$sb])) $sbAltNamesMap[$sb] = [];
+                $sbAltNamesMap[$sb][] = [
+                    'title'      => (string)$arow['Title'],
+                    'sort_order' => (int)$arow['SortOrder'],
+                    'note'       => (string)($arow['Note'] ?? ''),
+                ];
+            }
+            $res->close();
+        }
+    } catch (\Throwable $e) {
+        error_log('[manage/songbooks.php alt-names fetch] ' . $e->getMessage());
+        $sbAltNamesMap = [];
+    }
+}
+
 /* ----- Active languages for the songbook editor's optional
  *       Language dropdown (#673). Sourced from tblLanguages so the
  *       admin doesn't have to hard-code ISO codes. We pull this
@@ -2111,6 +2212,10 @@ $csrf = csrfToken();
                                            person_slug, note. Empty list pre-migration or for
                                            songbooks with no compilers. */
                                         'compilers'             => $sbCompilersMap[(int)$r['Id']] ?? [],
+                                        /* #832 — alternative names attached to this songbook,
+                                           in SortOrder. Each item carries title + note. Empty
+                                           list pre-migration or for songbooks with no alts. */
+                                        'alternative_names'     => $sbAltNamesMap[(int)$r['Id']] ?? [],
                                     ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
                                 ?>
                                 <button type="button" class="btn btn-sm btn-outline-info"
@@ -2796,6 +2901,40 @@ $csrf = csrfToken();
                         </div>
                         <?php endif; ?>
 
+                        <?php if ($hasAltNamesSchema): ?>
+                        <!-- #832 — Alternative songbook names. Multi-row chip list:
+                             each row pairs an alt-title with an optional Note
+                             ("vernacular", "older form", "transliteration", …).
+                             Reorder via drag handle persists via array index ⇒
+                             SortOrder on save. -->
+                        <div class="mb-3" id="edit-alt-names-block">
+                            <label class="form-label">Alternative names <span class="text-muted small">(optional)</span></label>
+                            <div class="form-text small mb-2">
+                                "Also known as …" — vernacular names, older spellings,
+                                or originals. Searched alongside the canonical name and
+                                emitted as JSON-LD <code>alternateName</code> for SEO.
+                            </div>
+                            <div id="edit-alt-names-rows" class="vstack gap-2 mb-2"></div>
+                            <div class="row g-2 align-items-end">
+                                <div class="col-md-9">
+                                    <input type="text"
+                                           class="form-control form-control-sm"
+                                           id="edit-alt-name-add-input"
+                                           placeholder="Type an alternative name and press Enter"
+                                           maxlength="255"
+                                           autocomplete="off">
+                                </div>
+                                <div class="col-md-3">
+                                    <button type="button"
+                                            class="btn btn-sm btn-outline-info w-100"
+                                            id="edit-alt-name-add-btn">
+                                        <i class="bi bi-plus-lg me-1" aria-hidden="true"></i>Add
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                        <?php endif; ?>
+
                         <!-- #672 — collapsible "Online links" + "Authority identifiers".
                              Closed by default so the modal still opens at the same height
                              curators are used to. <details> is native HTML5; no JS needed
@@ -3128,6 +3267,26 @@ $csrf = csrfToken();
                 /* Clear the add-search field too so reopening the modal
                    doesn't leave a stale half-typed name behind. */
                 const addInput = document.getElementById('edit-compiler-add-search');
+                if (addInput) addInput.value = '';
+            })();
+
+            /* #832 — populate the alternative-names list from
+               row.alternative_names. Container only exists when the
+               schema probe says yes; clear + repopulate on every
+               open so opening row B after row A doesn't carry A's
+               alts over. */
+            (function () {
+                const container = document.getElementById('edit-alt-names-rows');
+                if (!container) return;
+                container.innerHTML = '';
+                const alts = Array.isArray(row.alternative_names) ? row.alternative_names : [];
+                alts.forEach(a => {
+                    container.appendChild(window._iHymnsBuildAltNameRow({
+                        title: a.title || '',
+                        note:  a.note  || '',
+                    }));
+                });
+                const addInput = document.getElementById('edit-alt-name-add-input');
                 if (addInput) addInput.value = '';
             })();
 
@@ -3705,6 +3864,81 @@ $csrf = csrfToken();
                 .replace(/>/g, '&gt;')
                 .replace(/"/g, '&quot;')
                 .replace(/'/g, '&#39;');
+        }
+    })();
+    </script>
+
+    <!-- Alternative-names chip-list editor (#832). Pure-text picker —
+         no FK, no typeahead — just type-and-Enter to add. Each row
+         carries hidden alt_name_titles[] / alt_name_notes[] inputs,
+         a Note input, and a remove button. -->
+    <script>
+    (function () {
+        const addInput = document.getElementById('edit-alt-name-add-input');
+        const addBtn   = document.getElementById('edit-alt-name-add-btn');
+        const rowsEl   = document.getElementById('edit-alt-names-rows');
+        if (!addInput || !rowsEl) return;  /* schema not live → block absent */
+
+        const commitAdd = () => {
+            const v = addInput.value.trim();
+            if (v === '') return;
+            /* Skip if already added (case-insensitive). UNIQUE
+               (SongbookId, Title) on the table would catch it but a
+               soft client-side guard is friendlier. */
+            const existing = Array.from(rowsEl.querySelectorAll('input[name="alt_name_titles[]"]'))
+                .map(i => (i.value || '').toLowerCase());
+            if (existing.includes(v.toLowerCase())) {
+                addInput.classList.add('is-invalid');
+                setTimeout(() => addInput.classList.remove('is-invalid'), 1500);
+                return;
+            }
+            rowsEl.appendChild(window._iHymnsBuildAltNameRow({
+                title: v,
+                note:  '',
+            }));
+            addInput.value = '';
+        };
+        if (addBtn) addBtn.addEventListener('click', commitAdd);
+        addInput.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                commitAdd();
+            }
+        });
+
+        /* Shared row-builder, also used by openEditModal() above to
+           rebuild the list on modal-open. */
+        window._iHymnsBuildAltNameRow = function (data) {
+            const card = document.createElement('div');
+            card.className = 'card bg-dark border-secondary';
+            const t  = String(data.title || '');
+            const nt = String(data.note  || '');
+            card.innerHTML =
+                '<div class="card-body py-2">' +
+                  '<div class="d-flex align-items-center gap-2">' +
+                    '<i class="bi bi-grip-vertical text-muted" aria-hidden="true"></i>' +
+                    '<div class="flex-grow-1">' +
+                      '<input type="text" class="form-control form-control-sm fw-semibold" ' +
+                              'name="alt_name_titles[]" maxlength="255" required value="' + escapeHtml(t) + '">' +
+                      '<input type="text" class="form-control form-control-sm mt-1" ' +
+                              'name="alt_name_notes[]" placeholder="Optional note (e.g. \'older spelling\')" ' +
+                              'maxlength="255" value="' + escapeHtml(nt) + '">' +
+                    '</div>' +
+                    '<button type="button" class="btn btn-sm btn-outline-danger" ' +
+                            'data-action="remove-alt-name" title="Remove this alt name">' +
+                      '<i class="bi bi-x-lg"></i>' +
+                    '</button>' +
+                  '</div>' +
+                '</div>';
+            card.querySelector('[data-action=remove-alt-name]')
+                .addEventListener('click', () => card.remove());
+            return card;
+        };
+
+        function escapeHtml(s) {
+            return String(s)
+                .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
         }
     })();
     </script>


### PR DESCRIPTION
## Summary

First instalment of #832. Adds alternative-title support across the catalogue:

- **Songbooks** — fully wired end-to-end: schema, admin chip-list editor, public "Also known as …" line, JSON-LD `alternateName`, OG description.
- **Songs** — schema + read-side + public + server search. **Song-editor admin UI is deferred to a follow-up issue** (the editor at `/manage/editor/` is a complex 3000-line file — a focused follow-up PR will land the chip-list editor there). Curators can add song alt titles via SQL or via the bulk-import path until that ships.
- **Internal search** — server-side `searchSongs` merges `tblSongAlternativeTitles` matches at the top of the result list. A query for "Faith's Review and Expectation" now surfaces *Amazing Grace*. Deferred: client-side Fuse.js index inclusion (separate commit so this PR stays focused).
- **SEO** — JSON-LD `alternateName` array on both `/song/<id>` (`MusicComposition`) and `/songbook/<abbr>` (`MusicAlbum`) pages. OG description on `/songbook/<abbr>` appends "Also known as: …" (capped at 3 alts to stay under platform truncation thresholds).

## Schema (one migration, two tables)

```sql
tblSongAlternativeTitles
  SongId       FK → tblSongs(SongId)        ON DELETE CASCADE
  Title        the alt title (VARCHAR 255)
  Language     optional IETF BCP 47 tag for multilingual hymns
  SortOrder
  Note         optional ("original title", "first line", …)
  UNIQUE (SongId, Title)
  INDEX idx_title  -- supports the search LIKE query

tblSongbookAlternativeTitles
  SongbookId   FK → tblSongbooks(Id)        ON DELETE CASCADE
  Title
  SortOrder
  Note
  UNIQUE (SongbookId, Title)
  INDEX idx_title
```

Idempotent. Registered across `$scriptMap`, `$migrationOrder`, `$migrationCards`, `$migrationProbes`, `$friendlyTitles` so the auto-hide system (#820) treats it like every other migration.

## Admin — songbook side

`/manage/songbooks` edit modal gains an **Alternative names** section:
- Vstack of card-rows (drag-handle + title input + per-row note input + remove button).
- Type-and-Enter add (or click "Add" button). Case-insensitive dedup.
- POST handler reconciles via the same DELETE-then-INSERT pattern used for series memberships + #831 compilers; array index → `SortOrder`. Audit-log entry includes the new `alternative_names` list.
- Schema-probed (`$hasAltNamesSchema`); pre-migration deployments load with the section silently absent.

## Data

- **`SongData::_songbookAltNamesMap()`** — same shape + caching as the existing `_songbookSeriesMap()`.
- **`SongData::_songAltTitlesMap()`** — keyed by SongId.
- `getSongbook()`/`getSongbooks()` attach a `alternativeNames` array.
- `_fetchSongRow()` (single-song path) attaches a `alternativeTitles` array.

## Public

- **`/song/<id>`**: "Also known as: *<alt>*" line below the canonical title, before the songbook chip strip. Per-row Note in muted parens; per-row Language tag as a small badge.
- **`/songbook/<abbr>`**: same shape under the song count.
- **JSON-LD**:
  - `MusicComposition.alternateName` on song pages.
  - `MusicAlbum.alternateName` on songbook pages.
- **OG description**: songbook page appends "Also known as: …" (≤ 3 alts).

## Search

- New `_searchByAlternativeTitle()` helper joins `tblSongAlternativeTitles` to `tblSongs` with a LIKE match on alt title.
- `searchSongs()` merges alt-hits at the **top** of the result list (before lyrics-text matches) so curator-flagged alts outrank fuzzy body-text hits.
- De-duplicates on `SongId`. Each merged row carries a `matchedVia: { alternativeTitle: "<the matching alt>" }` flag for UI hint rendering.

## Backwards compatibility

- Schema-additive; pre-migration deployments load every page cleanly.
- Probes everywhere a query references the new tables.
- API response shape is purely additive (`alternativeTitles: []` / `alternativeNames: []` on every row); older PWA clients ignore them.

## Test plan

- [ ] `Apply all pending migrations` runs cleanly; re-run is no-op.
- [ ] Edit Mission Praise → add "MP" + "Mission Praise Hymnal" as alt names → save → reopen → both present.
- [ ] Drag-handle reorder + per-row note persist across save/reopen.
- [ ] `/songbook/MP` → "Also known as: MP, Mission Praise Hymnal" line.
- [ ] `/songbook/MP` page source includes JSON-LD with `alternateName: ["MP", "Mission Praise Hymnal"]`.
- [ ] Public OG description includes the alts (visible in Twitter Card validator).
- [ ] Add a `tblSongAlternativeTitles` row via SQL for Amazing Grace ("Faith's Review and Expectation"); search "Faith's Review" → Amazing Grace appears at top with `matchedVia` flag in the row.
- [ ] `/song/CP-0001` → "Also known as: …" line + JSON-LD `alternateName`.
- [ ] Pre-migration deployment: every page still loads with the new sections silently absent.

## Out of scope (separate follow-ups)

- Song-editor UI for adding/removing alt titles in `/manage/editor/`.
- Client-side Fuse.js index includes alt titles for offline search.
- Per-language UI rendering (showing only the `es` alt to Spanish-locale users).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
