### PR TITLE
feat(catalogue): MusicBrainz-style external-links system (closes #833)

### DIFF
--- a/appWeb/.sql/migrate-backfill-credit-person-links.php
+++ b/appWeb/.sql/migrate-backfill-credit-person-links.php
@@ -1,0 +1,266 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Backfill tblCreditPersonLinks → tblCreditPersonExternalLinks (#833)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Migrates rows from the existing tblCreditPersonLinks (free-text
+ * LinkType, from #545) into the new external-links system. Maps the
+ * free-text type strings to controlled-vocabulary slugs. Most map
+ * directly; unrecognised values fall through to 'other' with the
+ * original string preserved in Note (so the curator hasn't lost the
+ * context, and a later /manage/link-types editor can disambiguate).
+ *
+ * Mapping table (case-insensitive, edge-trimmed):
+ *
+ *   wikipedia / wiki              → wikipedia
+ *   wikidata                      → wikidata
+ *   imslp / petrucci              → imslp
+ *   hymnary / hymnary.org         → hymnary-org
+ *   website / official            → official-website
+ *   musicbrainz / mb              → musicbrainz-artist
+ *   discogs                       → discogs
+ *   viaf                          → viaf
+ *   loc / library-of-congress     → loc-name-authority
+ *   findagrave / find-a-grave     → find-a-grave
+ *   goodreads                     → goodreads-author
+ *   linkedin                      → linkedin
+ *   twitter / x                   → twitter-x
+ *   instagram                     → instagram
+ *   facebook                      → facebook
+ *   mastodon                      → mastodon
+ *   youtube                       → youtube
+ *   spotify                       → spotify
+ *   apple-music / itunes          → apple-music
+ *   bandcamp                      → bandcamp
+ *   soundcloud                    → soundcloud
+ *   archive.org / internet-archive→ internet-archive
+ *   anything else                 → other (original LinkType saved
+ *                                          to Note for context)
+ *
+ * Idempotent — re-runs use INSERT…WHERE-NOT-EXISTS so duplicate
+ * (CreditPersonId, LinkTypeId, Url) tuples are no-ops.
+ *
+ * Legacy tblCreditPersonLinks is NOT dropped — it stays as a
+ * read-fallback for one release cycle. Separate later migration
+ * retires it.
+ *
+ * @migration-modifies tblCreditPersonExternalLinks
+ */
+
+if (PHP_SAPI === 'cli') {
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = true;
+} else {
+    if (!defined('IHYMNS_SETUP_DASHBOARD')) {
+        if (!function_exists('isAuthenticated')) {
+            require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+        }
+        if (!isAuthenticated()) {
+            http_response_code(401);
+            exit('Authentication required.');
+        }
+        $u = getCurrentUser();
+        if (!$u || $u['role'] !== 'global_admin') {
+            http_response_code(403);
+            exit('Global admin required.');
+        }
+    }
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = false;
+}
+
+function _migBfPersonLinks_out(string $line): void
+{
+    global $isCli;
+    echo $line . ($isCli ? "\n" : "<br>\n");
+    if ($isCli) flush();
+}
+
+function _migBfPersonLinks_tableExists(\mysqli $db, string $table): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? LIMIT 1'
+    );
+    $stmt->bind_param('s', $table);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+_migBfPersonLinks_out('Backfill credit-person external links migration starting (#833)…');
+
+$mysqli = getDbMysqli();
+if (!$mysqli) {
+    throw new \RuntimeException('Could not connect to database.');
+}
+
+if (!_migBfPersonLinks_tableExists($mysqli, 'tblCreditPersonExternalLinks')
+    || !_migBfPersonLinks_tableExists($mysqli, 'tblExternalLinkTypes')) {
+    _migBfPersonLinks_out('[skip] external-links schema not yet present — run migrate-external-links.php first.');
+    return;
+}
+
+if (!_migBfPersonLinks_tableExists($mysqli, 'tblCreditPersonLinks')) {
+    _migBfPersonLinks_out('[skip] tblCreditPersonLinks not present — nothing to backfill.');
+    return;
+}
+
+/* Build slug → id map for the registry. */
+$slugToId = [];
+$res = $mysqli->query('SELECT Id, Slug FROM tblExternalLinkTypes');
+if ($res) {
+    while ($row = $res->fetch_assoc()) {
+        $slugToId[(string)$row['Slug']] = (int)$row['Id'];
+    }
+    $res->close();
+}
+if (!$slugToId) {
+    _migBfPersonLinks_out('[skip] tblExternalLinkTypes is empty — nothing to map to.');
+    return;
+}
+
+/* Free-text → slug map (case-insensitive, accept several spellings). */
+$linkTypeMap = [
+    'wikipedia'             => 'wikipedia',
+    'wiki'                  => 'wikipedia',
+    'wikidata'              => 'wikidata',
+    'imslp'                 => 'imslp',
+    'petrucci'              => 'imslp',
+    'hymnary'               => 'hymnary-org',
+    'hymnary.org'           => 'hymnary-org',
+    'hymnary-org'           => 'hymnary-org',
+    'website'               => 'official-website',
+    'official'              => 'official-website',
+    'official-website'      => 'official-website',
+    'home'                  => 'official-website',
+    'homepage'              => 'official-website',
+    'musicbrainz'           => 'musicbrainz-artist',
+    'mb'                    => 'musicbrainz-artist',
+    'musicbrainz-artist'    => 'musicbrainz-artist',
+    'discogs'               => 'discogs',
+    'viaf'                  => 'viaf',
+    'loc'                   => 'loc-name-authority',
+    'library-of-congress'   => 'loc-name-authority',
+    'loc-name-authority'    => 'loc-name-authority',
+    'findagrave'            => 'find-a-grave',
+    'find-a-grave'          => 'find-a-grave',
+    'goodreads'             => 'goodreads-author',
+    'goodreads-author'      => 'goodreads-author',
+    'linkedin'              => 'linkedin',
+    'twitter'               => 'twitter-x',
+    'x'                     => 'twitter-x',
+    'twitter-x'             => 'twitter-x',
+    'instagram'             => 'instagram',
+    'facebook'              => 'facebook',
+    'mastodon'              => 'mastodon',
+    'youtube'               => 'youtube',
+    'spotify'               => 'spotify',
+    'apple-music'           => 'apple-music',
+    'itunes'                => 'apple-music',
+    'bandcamp'              => 'bandcamp',
+    'soundcloud'            => 'soundcloud',
+    'archive.org'           => 'internet-archive',
+    'archive'               => 'internet-archive',
+    'internet-archive'      => 'internet-archive',
+    'cyber-hymnal'          => 'cyber-hymnal',
+    'cyberhymnal'           => 'cyber-hymnal',
+];
+
+$resolveSlug = static function (string $rawType) use ($linkTypeMap): string {
+    $key = strtolower(trim($rawType));
+    return $linkTypeMap[$key] ?? 'other';
+};
+
+/* Walk every legacy row, resolve slug, INSERT into the new table. */
+$res = $mysqli->query(
+    'SELECT CreditPersonId, LinkType, Url, Label, SortOrder
+       FROM tblCreditPersonLinks
+      ORDER BY CreditPersonId ASC, SortOrder ASC, Id ASC'
+);
+if (!$res) {
+    _migBfPersonLinks_out('WARN: SELECT from tblCreditPersonLinks failed: ' . $mysqli->error);
+    return;
+}
+
+$ins = $mysqli->prepare(
+    'INSERT INTO tblCreditPersonExternalLinks
+         (CreditPersonId, LinkTypeId, Url, Note, SortOrder)
+     SELECT ?, ?, ?, ?, ?
+       FROM DUAL
+      WHERE NOT EXISTS (
+            SELECT 1 FROM tblCreditPersonExternalLinks x
+             WHERE x.CreditPersonId = ?
+               AND x.LinkTypeId     = ?
+               AND x.Url            = ?
+        )'
+);
+
+$inserted = 0;
+$mapped   = 0;  /* mapped to a non-other slug */
+$other    = 0;  /* fell through to 'other' */
+$skipped  = 0;  /* already on disk */
+
+while ($row = $res->fetch_assoc()) {
+    $personId  = (int)$row['CreditPersonId'];
+    $url       = trim((string)($row['Url'] ?? ''));
+    $rawType   = (string)($row['LinkType'] ?? '');
+    $label     = trim((string)($row['Label'] ?? ''));
+    $sortOrder = (int)($row['SortOrder'] ?? 0);
+    if ($url === '' || $personId <= 0) continue;
+
+    $slug = $resolveSlug($rawType);
+    if (!isset($slugToId[$slug])) {
+        /* 'other' should always be present per the seed list — this
+           is a belt-and-braces check for a curator who deactivated
+           it. Skip the row rather than 500 the migration. */
+        _migBfPersonLinks_out("WARN: slug '{$slug}' not in registry — skipping link {$url}");
+        continue;
+    }
+    $linkTypeId = $slugToId[$slug];
+
+    /* When the resolution falls to 'other', stash the original
+       free-text LinkType in Note so the context isn't lost (a later
+       UI / migration can promote those to dedicated slugs). When
+       a clean slug match was found, prefer the legacy Label as the
+       Note (often more meaningful than the slug name itself). */
+    if ($slug === 'other') {
+        $note = $rawType !== '' ? mb_substr($rawType, 0, 255) : null;
+        $other++;
+    } else {
+        $note = $label !== '' ? mb_substr($label, 0, 255) : null;
+        $mapped++;
+    }
+
+    $ins->bind_param('iissiiis', $personId, $linkTypeId, $url, $note, $sortOrder, $personId, $linkTypeId, $url);
+    if (@$ins->execute()) {
+        if ($ins->affected_rows > 0) {
+            $inserted++;
+        } else {
+            $skipped++;
+        }
+    } else {
+        _migBfPersonLinks_out('WARN: insert failed for person ' . $personId . ': ' . $mysqli->error);
+    }
+}
+$res->close();
+$ins->close();
+
+_migBfPersonLinks_out("[seed] backfilled {$inserted} link(s) into tblCreditPersonExternalLinks.");
+_migBfPersonLinks_out("       mapped to a known slug: {$mapped}");
+_migBfPersonLinks_out("       fell to 'other':         {$other}  (original LinkType preserved in Note)");
+_migBfPersonLinks_out("       already on disk:         {$skipped}");
+_migBfPersonLinks_out('Backfill complete.');
+_migBfPersonLinks_out('The legacy tblCreditPersonLinks table is NOT dropped by this migration —');
+_migBfPersonLinks_out('it stays as a read-fallback for one release cycle. A later migration');
+_migBfPersonLinks_out('retires it once the public site has been on the new system.');

--- a/appWeb/.sql/migrate-backfill-songbook-links.php
+++ b/appWeb/.sql/migrate-backfill-songbook-links.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Backfill songbook URL columns into tblSongbookExternalLinks (#833)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Copies non-empty values from the legacy three URL columns on
+ * tblSongbooks into the new external-links system:
+ *
+ *   tblSongbooks.WebsiteUrl         → link type 'official-website'
+ *   tblSongbooks.InternetArchiveUrl → link type 'internet-archive'
+ *   tblSongbooks.WikipediaUrl       → link type 'wikipedia'
+ *
+ * The legacy columns are NOT dropped — they stay as read-fallbacks for
+ * one release cycle. A separate later migration retires them once the
+ * public site has been on the new system long enough.
+ *
+ * Idempotent — uses INSERT…ON DUPLICATE KEY UPDATE keyed on
+ * (SongbookId, LinkTypeId, Url) so re-runs upsert without duplicating.
+ * Skipped silently if the new tables aren't present yet (the schema
+ * migration migrate-external-links.php has to land first).
+ *
+ * @migration-modifies tblSongbookExternalLinks
+ */
+
+if (PHP_SAPI === 'cli') {
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = true;
+} else {
+    if (!defined('IHYMNS_SETUP_DASHBOARD')) {
+        if (!function_exists('isAuthenticated')) {
+            require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+        }
+        if (!isAuthenticated()) {
+            http_response_code(401);
+            exit('Authentication required.');
+        }
+        $u = getCurrentUser();
+        if (!$u || $u['role'] !== 'global_admin') {
+            http_response_code(403);
+            exit('Global admin required.');
+        }
+    }
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = false;
+}
+
+function _migBfBookLinks_out(string $line): void
+{
+    global $isCli;
+    echo $line . ($isCli ? "\n" : "<br>\n");
+    if ($isCli) flush();
+}
+
+function _migBfBookLinks_tableExists(\mysqli $db, string $table): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? LIMIT 1'
+    );
+    $stmt->bind_param('s', $table);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+function _migBfBookLinks_columnExists(\mysqli $db, string $table, string $col): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ? LIMIT 1'
+    );
+    $stmt->bind_param('ss', $table, $col);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+_migBfBookLinks_out('Backfill songbook external links migration starting (#833)…');
+
+$mysqli = getDbMysqli();
+if (!$mysqli) {
+    throw new \RuntimeException('Could not connect to database.');
+}
+
+if (!_migBfBookLinks_tableExists($mysqli, 'tblSongbookExternalLinks')
+    || !_migBfBookLinks_tableExists($mysqli, 'tblExternalLinkTypes')) {
+    _migBfBookLinks_out('[skip] external-links schema not yet present — run migrate-external-links.php first.');
+    return;
+}
+
+/* Resolve the three target link-type ids. Slugs are seeded by the
+   schema migration, so they should exist; fall through gracefully
+   if a curator deactivated one. */
+$slugToId = [];
+$res = $mysqli->query("SELECT Id, Slug FROM tblExternalLinkTypes
+                        WHERE Slug IN ('official-website', 'internet-archive', 'wikipedia')");
+if ($res) {
+    while ($row = $res->fetch_assoc()) {
+        $slugToId[(string)$row['Slug']] = (int)$row['Id'];
+    }
+    $res->close();
+}
+
+$mappings = [
+    'WebsiteUrl'         => 'official-website',
+    'InternetArchiveUrl' => 'internet-archive',
+    'WikipediaUrl'       => 'wikipedia',
+];
+
+$inserted = 0;
+$skipped  = 0;
+foreach ($mappings as $col => $slug) {
+    if (!_migBfBookLinks_columnExists($mysqli, 'tblSongbooks', $col)) {
+        _migBfBookLinks_out("[skip] tblSongbooks.{$col} not present — nothing to backfill.");
+        continue;
+    }
+    if (!isset($slugToId[$slug])) {
+        _migBfBookLinks_out("[skip] link type '{$slug}' not in registry — nothing to backfill for {$col}.");
+        continue;
+    }
+    $linkTypeId = $slugToId[$slug];
+
+    /* SELECT the populated values, INSERT IGNORE into the new table.
+       UNIQUE constraint on the new table is by (SongbookId,
+       LinkTypeId, Url) — we don't have one, but INSERT IGNORE based
+       on the primary key is enough; combined with the WHERE-NOT-EXISTS
+       pattern below it's idempotent. Use plain INSERT…SELECT plus a
+       NOT EXISTS guard to skip rows that already match. */
+    $sql = "INSERT INTO tblSongbookExternalLinks
+                (SongbookId, LinkTypeId, Url)
+            SELECT b.Id, ?, b.{$col}
+              FROM tblSongbooks b
+             WHERE b.{$col} IS NOT NULL
+               AND LENGTH(TRIM(b.{$col})) > 0
+               AND NOT EXISTS (
+                     SELECT 1 FROM tblSongbookExternalLinks x
+                      WHERE x.SongbookId = b.Id
+                        AND x.LinkTypeId = ?
+                        AND x.Url        = b.{$col}
+                   )";
+    $stmt = $mysqli->prepare($sql);
+    $stmt->bind_param('ii', $linkTypeId, $linkTypeId);
+    if (!$stmt->execute()) {
+        _migBfBookLinks_out("WARN: backfill of {$col} → {$slug} failed: " . $mysqli->error);
+        $stmt->close();
+        continue;
+    }
+    $rows = $stmt->affected_rows;
+    $stmt->close();
+    if ($rows > 0) {
+        $inserted += $rows;
+        _migBfBookLinks_out("[seed] {$col} → {$slug}: backfilled {$rows} link" . ($rows === 1 ? '' : 's') . '.');
+    } else {
+        $skipped++;
+        _migBfBookLinks_out("[skip] {$col} → {$slug}: no rows to backfill (already on the new system).");
+    }
+}
+
+_migBfBookLinks_out("Backfill complete. Total inserted: {$inserted}.");
+_migBfBookLinks_out('The legacy columns (WebsiteUrl / InternetArchiveUrl / WikipediaUrl)');
+_migBfBookLinks_out('are NOT dropped by this migration — they remain as read-fallbacks for');
+_migBfBookLinks_out('one release cycle. A later migration retires them once the public site');
+_migBfBookLinks_out('has been on the new external-links system.');

--- a/appWeb/.sql/migrate-external-links.php
+++ b/appWeb/.sql/migrate-external-links.php
@@ -1,0 +1,319 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — MusicBrainz-Style External Links Migration (#833)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Replaces the three hard-coded songbook URL columns
+ * (WebsiteUrl / InternetArchiveUrl / WikipediaUrl) AND the existing
+ * tblCreditPersonLinks free-text-LinkType table with a single
+ * MusicBrainz-style external-links system covering songs, songbooks
+ * and credit-people.
+ *
+ * Schema (idempotent):
+ *
+ *   tblExternalLinkTypes — controlled vocabulary registry. ~37 seed
+ *     types for hymnology (Hymnary.org, CCLI Songselect, IMSLP,
+ *     YouTube, Spotify, Internet Archive, Wikipedia, Wikidata,
+ *     Open Library, OCLC, Cyber Hymnal, LibriVox, MusicBrainz,
+ *     VIAF, social, …).
+ *
+ *   tblSongbookExternalLinks — many-to-many tblSongbooks ↔ link type.
+ *   tblSongExternalLinks     — many-to-many tblSongs ↔ link type.
+ *   tblCreditPersonExternalLinks — many-to-many tblCreditPeople ↔ link type.
+ *
+ * Each per-entity link row carries Url / Note / SortOrder / Verified
+ * so a curator can record multiple Internet Archive scans, multiple
+ * YouTube performances, etc., with per-row context.
+ *
+ * Backfills are SEPARATE migrations:
+ *   - migrate-backfill-songbook-links.php       (#833)
+ *   - migrate-backfill-credit-person-links.php  (#833)
+ *
+ * Legacy reads (songbook URL columns + tblCreditPersonLinks) stay in
+ * place for one release cycle as fallbacks; later migration drops
+ * them once the public site has been on the new system.
+ *
+ * USAGE:
+ *   CLI: php appWeb/.sql/migrate-external-links.php
+ *   Web: /manage/setup-database → "External Links System (#833)"
+ *
+ * @migration-adds tblExternalLinkTypes
+ * @migration-adds tblSongbookExternalLinks
+ * @migration-adds tblSongExternalLinks
+ * @migration-adds tblCreditPersonExternalLinks
+ */
+
+if (PHP_SAPI === 'cli') {
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = true;
+} else {
+    if (!defined('IHYMNS_SETUP_DASHBOARD')) {
+        if (!function_exists('isAuthenticated')) {
+            require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+        }
+        if (!isAuthenticated()) {
+            http_response_code(401);
+            exit('Authentication required.');
+        }
+        $u = getCurrentUser();
+        if (!$u || $u['role'] !== 'global_admin') {
+            http_response_code(403);
+            exit('Global admin required.');
+        }
+    }
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = false;
+}
+
+function _migExtLinks_out(string $line): void
+{
+    global $isCli;
+    echo $line . ($isCli ? "\n" : "<br>\n");
+    if ($isCli) flush();
+}
+
+function _migExtLinks_tableExists(\mysqli $db, string $table): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? LIMIT 1'
+    );
+    $stmt->bind_param('s', $table);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+_migExtLinks_out('External Links migration starting (#833)…');
+
+$mysqli = getDbMysqli();
+if (!$mysqli) {
+    throw new \RuntimeException('Could not connect to database.');
+}
+
+foreach (['tblSongs', 'tblSongbooks', 'tblCreditPeople'] as $required) {
+    if (!_migExtLinks_tableExists($mysqli, $required)) {
+        _migExtLinks_out("ERROR: {$required} not found. Run prerequisite migrations first.");
+        return;
+    }
+}
+
+/* ----------------------------------------------------------------------
+ * Step 1 — tblExternalLinkTypes (registry)
+ * ---------------------------------------------------------------------- */
+if (_migExtLinks_tableExists($mysqli, 'tblExternalLinkTypes')) {
+    _migExtLinks_out('[skip] tblExternalLinkTypes already present.');
+} else {
+    $sql = "CREATE TABLE tblExternalLinkTypes (
+        Id            INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+        Slug          VARCHAR(60)  NOT NULL,
+        Name          VARCHAR(120) NOT NULL,
+        Category      ENUM(
+                          'information', 'listen', 'watch', 'read',
+                          'sheet-music', 'purchase', 'authority',
+                          'official', 'social', 'other'
+                      ) NOT NULL DEFAULT 'other',
+        UrlPattern    VARCHAR(255) NULL,
+        IconClass     VARCHAR(60)  NULL,
+        AppliesTo     SET('song','songbook','person') NOT NULL DEFAULT 'song,songbook,person',
+        AllowMultiple TINYINT(1)   NOT NULL DEFAULT 1,
+        IsActive      TINYINT(1)   NOT NULL DEFAULT 1,
+        DisplayOrder  INT UNSIGNED NOT NULL DEFAULT 0,
+        CreatedAt     TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+        UNIQUE KEY uq_slug   (Slug),
+        INDEX     idx_active   (IsActive),
+        INDEX     idx_category (Category, DisplayOrder)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
+    if (!$mysqli->query($sql)) {
+        throw new \RuntimeException('CREATE TABLE tblExternalLinkTypes failed: ' . $mysqli->error);
+    }
+    _migExtLinks_out('[add ] tblExternalLinkTypes.');
+}
+
+/* ----------------------------------------------------------------------
+ * Step 2 — Seed link-type registry
+ *
+ * INSERT … ON DUPLICATE KEY UPDATE pattern keyed on Slug, so re-runs
+ * upsert (refreshing Name / Category / IconClass / AppliesTo /
+ * AllowMultiple / DisplayOrder if the seed list evolves) without
+ * touching the IsActive column — that's curator-controlled. New
+ * types added via SQL aren't disturbed by re-running.
+ * ---------------------------------------------------------------------- */
+$seedTypes = [
+    /* slug, name, category, applies_to, allow_multiple, icon, order */
+    ['official-website',     'Official website',     'official',    'song,songbook,person', 0, 'bi-globe',           10],
+    ['wikipedia',            'Wikipedia',            'information', 'song,songbook,person', 1, 'bi-wikipedia',       20],
+    ['wikidata',             'Wikidata',             'information', 'song,songbook,person', 0, 'bi-database',        21],
+    ['hymnary-org',          'Hymnary.org',          'information', 'song,songbook,person', 0, 'bi-music-note-list', 22],
+    ['hymnal-plus',          'Hymnal Plus',          'information', 'song,songbook',        0, 'bi-music-note-list', 23],
+    ['cyber-hymnal',         'The Cyber Hymnal',     'information', 'song,person',          0, 'bi-music-note-beamed', 24],
+    ['internet-archive',     'Internet Archive',     'read',        'songbook',             1, 'bi-archive',         30],
+    ['open-library',         'Open Library',         'read',        'songbook',             1, 'bi-book-half',       31],
+    ['archive-misc',         'Other archive',        'read',        'song,songbook,person', 1, 'bi-archive',         39],
+    ['oclc-worldcat',        'WorldCat / OCLC',      'authority',   'songbook',             0, 'bi-card-list',       40],
+    ['viaf',                 'VIAF authority',       'authority',   'songbook,person',      0, 'bi-card-list',       41],
+    ['loc-name-authority',   'LoC name authority',   'authority',   'songbook,person',      0, 'bi-card-list',       42],
+    ['find-a-grave',         'Find a Grave',         'authority',   'person',               0, 'bi-flower2',         43],
+    ['ccli-songselect',      'CCLI SongSelect',      'purchase',    'song',                 0, 'bi-bag',             50],
+    ['publisher-store',      'Publisher store',      'purchase',    'songbook',             0, 'bi-shop',            51],
+    ['imslp',                'IMSLP / Petrucci',     'sheet-music', 'song,songbook,person', 1, 'bi-file-music',      60],
+    ['sheet-music-pdf',      'Sheet music PDF',      'sheet-music', 'song',                 1, 'bi-file-music',      61],
+    ['lyrics-page',          'Lyrics page',          'information', 'song',                 1, 'bi-file-text',       25],
+    ['youtube',              'YouTube',              'watch',       'song,person',          1, 'bi-youtube',         70],
+    ['vimeo',                'Vimeo',                'watch',       'song,person',          1, 'bi-camera-video',    71],
+    ['spotify',              'Spotify',              'listen',      'song,person',          1, 'bi-spotify',         80],
+    ['apple-music',          'Apple Music',          'listen',      'song,person',          1, 'bi-music-note',      81],
+    ['youtube-music',        'YouTube Music',        'listen',      'song,person',          1, 'bi-music-note',      82],
+    ['bandcamp',             'Bandcamp',             'listen',      'song,person',          1, 'bi-vinyl',           83],
+    ['soundcloud',           'SoundCloud',           'listen',      'song,person',          1, 'bi-cloud',           84],
+    ['librivox',             'LibriVox',             'listen',      'song,songbook',        1, 'bi-mic',             85],
+    ['discogs',              'Discogs',              'information', 'song,person',          1, 'bi-vinyl',           90],
+    ['musicbrainz-work',     'MusicBrainz work',     'information', 'song',                 0, 'bi-music-note',      91],
+    ['musicbrainz-recording','MusicBrainz recording','information', 'song',                 1, 'bi-music-note',      92],
+    ['musicbrainz-artist',   'MusicBrainz artist',   'information', 'person',               0, 'bi-person-vcard',    93],
+    ['goodreads-author',     'Goodreads author',     'information', 'person',               0, 'bi-book',            94],
+    ['linkedin',             'LinkedIn',             'social',      'person',               0, 'bi-linkedin',        100],
+    ['twitter-x',            'Twitter / X',          'social',      'person',               0, 'bi-twitter-x',       101],
+    ['instagram',            'Instagram',            'social',      'person',               0, 'bi-instagram',       102],
+    ['facebook',             'Facebook',             'social',      'person',               0, 'bi-facebook',        103],
+    ['mastodon',             'Mastodon',             'social',      'person',               0, 'bi-mastodon',        104],
+    ['other',                'Other',                'other',       'song,songbook,person', 1, 'bi-link-45deg',      999],
+];
+
+$upsert = $mysqli->prepare(
+    'INSERT INTO tblExternalLinkTypes
+         (Slug, Name, Category, AppliesTo, AllowMultiple, IconClass, DisplayOrder)
+     VALUES (?, ?, ?, ?, ?, ?, ?)
+     ON DUPLICATE KEY UPDATE
+         Name          = VALUES(Name),
+         Category      = VALUES(Category),
+         AppliesTo     = VALUES(AppliesTo),
+         AllowMultiple = VALUES(AllowMultiple),
+         IconClass     = VALUES(IconClass),
+         DisplayOrder  = VALUES(DisplayOrder)'
+);
+$seedAdded   = 0;
+$seedUpdated = 0;
+foreach ($seedTypes as $t) {
+    [$slug, $name, $cat, $applies, $multi, $icon, $order] = $t;
+    $upsert->bind_param('ssssisi', $slug, $name, $cat, $applies, $multi, $icon, $order);
+    @$upsert->execute();
+    /* affected_rows is 1 for INSERT, 2 for UPDATE in MySQL's
+       INSERT…ON DUPLICATE KEY semantics; treat 0 as a no-op
+       (row already matches the seed exactly). */
+    $ar = $mysqli->affected_rows;
+    if ($ar === 1)      $seedAdded++;
+    elseif ($ar === 2)  $seedUpdated++;
+}
+$upsert->close();
+_migExtLinks_out("[seed] {$seedAdded} link type" . ($seedAdded === 1 ? '' : 's')
+    . " inserted, {$seedUpdated} updated. Total registry: " . count($seedTypes) . '.');
+
+/* ----------------------------------------------------------------------
+ * Step 3 — tblSongbookExternalLinks
+ * ---------------------------------------------------------------------- */
+if (_migExtLinks_tableExists($mysqli, 'tblSongbookExternalLinks')) {
+    _migExtLinks_out('[skip] tblSongbookExternalLinks already present.');
+} else {
+    $sql = "CREATE TABLE tblSongbookExternalLinks (
+        Id          INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+        SongbookId  INT UNSIGNED NOT NULL,
+        LinkTypeId  INT UNSIGNED NOT NULL,
+        Url         VARCHAR(2048) NOT NULL,
+        Note        VARCHAR(255) NULL,
+        SortOrder   INT UNSIGNED NOT NULL DEFAULT 0,
+        Verified    TINYINT(1)   NOT NULL DEFAULT 0,
+        CreatedAt   TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        UpdatedAt   TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+        INDEX idx_book (SongbookId),
+        INDEX idx_type (LinkTypeId),
+
+        CONSTRAINT fk_link_book
+            FOREIGN KEY (SongbookId) REFERENCES tblSongbooks(Id) ON DELETE CASCADE,
+        CONSTRAINT fk_link_type_book
+            FOREIGN KEY (LinkTypeId) REFERENCES tblExternalLinkTypes(Id) ON DELETE RESTRICT
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
+    if (!$mysqli->query($sql)) {
+        throw new \RuntimeException('CREATE TABLE tblSongbookExternalLinks failed: ' . $mysqli->error);
+    }
+    _migExtLinks_out('[add ] tblSongbookExternalLinks.');
+}
+
+/* ----------------------------------------------------------------------
+ * Step 4 — tblSongExternalLinks
+ * ---------------------------------------------------------------------- */
+if (_migExtLinks_tableExists($mysqli, 'tblSongExternalLinks')) {
+    _migExtLinks_out('[skip] tblSongExternalLinks already present.');
+} else {
+    $sql = "CREATE TABLE tblSongExternalLinks (
+        Id          INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+        SongId      VARCHAR(20)  NOT NULL,
+        LinkTypeId  INT UNSIGNED NOT NULL,
+        Url         VARCHAR(2048) NOT NULL,
+        Note        VARCHAR(255) NULL,
+        SortOrder   INT UNSIGNED NOT NULL DEFAULT 0,
+        Verified    TINYINT(1)   NOT NULL DEFAULT 0,
+        CreatedAt   TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        UpdatedAt   TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+        INDEX idx_song (SongId),
+        INDEX idx_type (LinkTypeId),
+
+        CONSTRAINT fk_link_song
+            FOREIGN KEY (SongId)     REFERENCES tblSongs(SongId)         ON DELETE CASCADE,
+        CONSTRAINT fk_link_type_song
+            FOREIGN KEY (LinkTypeId) REFERENCES tblExternalLinkTypes(Id) ON DELETE RESTRICT
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
+    if (!$mysqli->query($sql)) {
+        throw new \RuntimeException('CREATE TABLE tblSongExternalLinks failed: ' . $mysqli->error);
+    }
+    _migExtLinks_out('[add ] tblSongExternalLinks.');
+}
+
+/* ----------------------------------------------------------------------
+ * Step 5 — tblCreditPersonExternalLinks
+ * ---------------------------------------------------------------------- */
+if (_migExtLinks_tableExists($mysqli, 'tblCreditPersonExternalLinks')) {
+    _migExtLinks_out('[skip] tblCreditPersonExternalLinks already present.');
+} else {
+    $sql = "CREATE TABLE tblCreditPersonExternalLinks (
+        Id              INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+        CreditPersonId  INT UNSIGNED NOT NULL,
+        LinkTypeId      INT UNSIGNED NOT NULL,
+        Url             VARCHAR(2048) NOT NULL,
+        Note            VARCHAR(255) NULL,
+        SortOrder       INT UNSIGNED NOT NULL DEFAULT 0,
+        Verified        TINYINT(1)   NOT NULL DEFAULT 0,
+        CreatedAt       TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        UpdatedAt       TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+        INDEX idx_person (CreditPersonId),
+        INDEX idx_type   (LinkTypeId),
+
+        CONSTRAINT fk_link_person
+            FOREIGN KEY (CreditPersonId) REFERENCES tblCreditPeople(Id)        ON DELETE CASCADE,
+        CONSTRAINT fk_link_type_person
+            FOREIGN KEY (LinkTypeId)     REFERENCES tblExternalLinkTypes(Id)   ON DELETE RESTRICT
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
+    if (!$mysqli->query($sql)) {
+        throw new \RuntimeException('CREATE TABLE tblCreditPersonExternalLinks failed: ' . $mysqli->error);
+    }
+    _migExtLinks_out('[add ] tblCreditPersonExternalLinks.');
+}
+
+_migExtLinks_out('External Links migration finished (#833).');
+_migExtLinks_out('Backfills are separate migrations:');
+_migExtLinks_out('  - migrate-backfill-songbook-links.php');
+_migExtLinks_out('  - migrate-backfill-credit-person-links.php');

--- a/appWeb/public_html/includes/SongData.php
+++ b/appWeb/public_html/includes/SongData.php
@@ -302,18 +302,20 @@ class SongData
         }
         $stmt->close();
 
-        /* Attach series memberships + compilers + alt names in one
-           batch query each (#782 phase D, #831, #832) so the home /
-           browse grids can render "Part of: <Series>", "Compiled by …"
-           and "Also known as …" lines without N+1 queries. */
+        /* Attach series memberships, compilers, alt names and external
+           links in batch queries (#782 phase D, #831, #832, #833) so
+           the home / browse grids and songbook pages render without
+           N+1 queries. */
         if ($books) {
             $seriesMap    = $this->_songbookSeriesMap(null);
             $compilersMap = $this->_songbookCompilersMap(null);
             $altNamesMap  = $this->_songbookAltNamesMap(null);
+            $linksMap     = $this->_externalLinksMap('songbook', null);
             foreach ($books as &$_b) {
                 $_b['series']           = $seriesMap[(string)$_b['id']]    ?? [];
                 $_b['compilers']        = $compilersMap[(string)$_b['id']] ?? [];
                 $_b['alternativeNames'] = $altNamesMap[(string)$_b['id']]  ?? [];
+                $_b['links']            = $linksMap[(string)$_b['id']]     ?? [];
             }
             unset($_b);
         }
@@ -792,6 +794,123 @@ class SongData
     }
 
     /**
+     * Pull `[entityKey => [{slug, name, category, url, note, verified, iconClass}, ...]]`
+     * from one of the three tblXxxExternalLinks join tables (#833).
+     * Generic over the three entity types — `$entityType` selects the
+     * table + key-column combination:
+     *
+     *   'songbook' → tblSongbookExternalLinks      keyed by Abbreviation
+     *   'song'     → tblSongExternalLinks          keyed by SongId
+     *   'person'   → tblCreditPersonExternalLinks  keyed by CreditPersonId (int)
+     *
+     * Schema-probed; pre-migration deployments get an empty map. The
+     * registry join (tblExternalLinkTypes) drops link-type rows that
+     * have been deactivated — IsActive = 0 acts as a soft delete.
+     *
+     * @param string         $entityType  'songbook' | 'song' | 'person'
+     * @param array|null     $keys        Limit to these keys; null = all
+     * @return array<string|int, array<int, array{slug:string,name:string,category:string,url:string,note:string,verified:bool,iconClass:string,sortOrder:int}>>
+     */
+    private function _externalLinksMap(string $entityType, ?array $keys = null): array
+    {
+        switch ($entityType) {
+            case 'songbook':
+                $table   = 'tblSongbookExternalLinks';
+                $entCol  = 'SongbookId';
+                $joinSql = ' JOIN tblSongbooks b ON b.Id = el.SongbookId ';
+                $keyExpr = 'b.Abbreviation';
+                $bindT   = 's';
+                break;
+            case 'song':
+                $table   = 'tblSongExternalLinks';
+                $entCol  = 'SongId';
+                $joinSql = '';
+                $keyExpr = 'el.SongId';
+                $bindT   = 's';
+                break;
+            case 'person':
+                $table   = 'tblCreditPersonExternalLinks';
+                $entCol  = 'CreditPersonId';
+                $joinSql = '';
+                $keyExpr = 'el.CreditPersonId';
+                $bindT   = 'i';
+                break;
+            default:
+                return [];
+        }
+
+        $hasSchema = false;
+        try {
+            $probe = $this->db->prepare(
+                'SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+                  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? LIMIT 1'
+            );
+            $probe->bind_param('s', $table);
+            $probe->execute();
+            $hasSchema = $probe->get_result()->fetch_row() !== null;
+            $probe->close();
+        } catch (\Throwable $_e) { /* fall through */ }
+        if (!$hasSchema) return [];
+
+        try {
+            $base = "SELECT {$keyExpr} AS k,
+                            t.Slug      AS slug,
+                            t.Name      AS name,
+                            t.Category  AS category,
+                            t.IconClass AS iconClass,
+                            el.Url      AS url,
+                            el.Note     AS note,
+                            el.Verified AS verified,
+                            el.SortOrder AS sortOrder
+                       FROM {$table} el
+                       JOIN tblExternalLinkTypes t ON t.Id = el.LinkTypeId
+                       {$joinSql}
+                      WHERE COALESCE(t.IsActive, 1) = 1";
+            $orderBy = " ORDER BY {$keyExpr}, t.Category, el.SortOrder ASC, t.DisplayOrder ASC, t.Name ASC";
+
+            if ($keys === null) {
+                $stmt = $this->db->prepare($base . $orderBy);
+            } else {
+                $clean = array_values(array_filter(array_unique(array_map(
+                    static fn($k) => is_int($k) ? $k : trim((string)$k),
+                    $keys
+                ))));
+                if ($entityType === 'songbook') {
+                    $clean = array_map(static fn($s) => strtoupper((string)$s), $clean);
+                }
+                if (!$clean) return [];
+                $ph    = implode(',', array_fill(0, count($clean), '?'));
+                $sql   = $base . " AND {$keyExpr} IN ($ph)" . $orderBy;
+                $stmt  = $this->db->prepare($sql);
+                $types = str_repeat($bindT, count($clean));
+                $stmt->bind_param($types, ...$clean);
+            }
+            $stmt->execute();
+            $res = $stmt->get_result();
+            $out = [];
+            while ($row = $res->fetch_assoc()) {
+                $key = $entityType === 'person' ? (int)$row['k'] : (string)$row['k'];
+                if (!isset($out[$key])) $out[$key] = [];
+                $out[$key][] = [
+                    'slug'      => (string)$row['slug'],
+                    'name'      => (string)$row['name'],
+                    'category'  => (string)$row['category'],
+                    'iconClass' => (string)($row['iconClass'] ?? ''),
+                    'url'       => (string)$row['url'],
+                    'note'      => (string)($row['note'] ?? ''),
+                    'verified'  => (bool)$row['verified'],
+                    'sortOrder' => (int)$row['sortOrder'],
+                ];
+            }
+            $stmt->close();
+            return $out;
+        } catch (\Throwable $e) {
+            error_log("[SongData::_externalLinksMap({$entityType})] " . $e->getMessage());
+            return [];
+        }
+    }
+
+    /**
      * Find a SongId by (songbook abbreviation, number) without
      * re-fetching the full song row. Used by the song page to
      * decide whether the parent songbook has a same-numbered
@@ -880,13 +999,16 @@ class SongData
            variant of the bulk fetch on getSongbooks(); pre-migration
            safe via the schema probe inside _songbookSeriesMap.
            #831 — compilers attached the same way.
-           #832 — alt names attached the same way. */
+           #832 — alt names attached the same way.
+           #833 — external links attached the same way. */
         $seriesMap               = $this->_songbookSeriesMap([$id]);
         $compilersMap            = $this->_songbookCompilersMap([$id]);
         $altNamesMap             = $this->_songbookAltNamesMap([$id]);
+        $linksMap                = $this->_externalLinksMap('songbook', [$id]);
         $row['series']           = $seriesMap[(string)$row['id']]    ?? [];
         $row['compilers']        = $compilersMap[(string)$row['id']] ?? [];
         $row['alternativeNames'] = $altNamesMap[(string)$row['id']]  ?? [];
+        $row['links']            = $linksMap[(string)$row['id']]     ?? [];
         return $row;
     }
 
@@ -2086,6 +2208,11 @@ class SongData
            migration deployment via the schema probe in the helper. */
         $altMap = $this->_songAltTitlesMap([$songId]);
         $row['alternativeTitles'] = $altMap[$songId] ?? [];
+
+        /* #833 — external links for this song. Empty array on a
+           pre-migration deployment via the schema probe. */
+        $linksMap = $this->_externalLinksMap('song', [$songId]);
+        $row['links'] = $linksMap[$songId] ?? [];
 
         return $row;
     }

--- a/appWeb/public_html/includes/pages/person.php
+++ b/appWeb/public_html/includes/pages/person.php
@@ -160,21 +160,63 @@ if ($person && (int)$person['Id'] > 0) {
 
 /* ---------------------------------------------------------------------- */
 /* 3. External links (when the registry row exists).                      */
+/*    Reads tblCreditPersonExternalLinks (the new unified system, #833)   */
+/*    if it has rows for this person, otherwise falls back to the legacy  */
+/*    tblCreditPersonLinks. The fallback keeps deployments that haven't   */
+/*    run the backfill from losing data; the migration ensures both       */
+/*    tables stay in sync once it's been applied.                         */
 /* ---------------------------------------------------------------------- */
-$links = [];
+$links = [];        /* legacy shape — LinkType / Url / Label */
+$linksUnified = []; /* unified shape — slug / name / category / url / note / verified / iconClass */
 if ($person && (int)$person['Id'] > 0) {
+    /* Try the new system first. */
     try {
-        $stmt = $db->prepare(
-            "SELECT LinkType, Url, Label
-               FROM tblCreditPersonLinks
-              WHERE CreditPersonId = ?
-              ORDER BY SortOrder, Id"
+        $r = $db->query(
+            "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+              WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tblCreditPersonExternalLinks' LIMIT 1"
         );
-        $stmt->bind_param('i', $person['Id']);
-        $stmt->execute();
-        $links = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
-        $stmt->close();
-    } catch (\Throwable $_e) { /* table missing — links stay empty */ }
+        $hasNew = $r && $r->fetch_row() !== null;
+        if ($r) $r->close();
+        if ($hasNew) {
+            $stmt = $db->prepare(
+                'SELECT t.Slug      AS slug,
+                        t.Name      AS name,
+                        t.Category  AS category,
+                        t.IconClass AS iconClass,
+                        el.Url      AS url,
+                        el.Note     AS note,
+                        el.Verified AS verified
+                   FROM tblCreditPersonExternalLinks el
+                   JOIN tblExternalLinkTypes t ON t.Id = el.LinkTypeId
+                  WHERE el.CreditPersonId = ?
+                    AND COALESCE(t.IsActive, 1) = 1
+                  ORDER BY t.Category, el.SortOrder ASC, t.DisplayOrder ASC, t.Name ASC'
+            );
+            $pid = (int)$person['Id'];
+            $stmt->bind_param('i', $pid);
+            $stmt->execute();
+            $linksUnified = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+            $stmt->close();
+            foreach ($linksUnified as &$_l) { $_l['verified'] = (bool)$_l['verified']; }
+            unset($_l);
+        }
+    } catch (\Throwable $_e) { /* fall through to legacy */ }
+
+    /* Legacy fallback when the new table has no rows for this person. */
+    if (empty($linksUnified)) {
+        try {
+            $stmt = $db->prepare(
+                "SELECT LinkType, Url, Label
+                   FROM tblCreditPersonLinks
+                  WHERE CreditPersonId = ?
+                  ORDER BY SortOrder, Id"
+            );
+            $stmt->bind_param('i', $person['Id']);
+            $stmt->execute();
+            $links = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+            $stmt->close();
+        } catch (\Throwable $_e) { /* both tables missing — links stay empty */ }
+    }
 }
 
 /* ---------------------------------------------------------------------- */
@@ -289,8 +331,61 @@ foreach ($discography as $rk => $entry) {
         </div>
     <?php endif; ?>
 
-    <!-- External links -->
-    <?php if (!empty($links)): ?>
+    <!-- External links — unified system (#833) preferred, legacy fallback -->
+    <?php if (!empty($linksUnified)): ?>
+        <?php
+            $pLinksByCat = [];
+            foreach ($linksUnified as $l) {
+                $cat = (string)($l['category'] ?? 'other');
+                if (!isset($pLinksByCat[$cat])) $pLinksByCat[$cat] = [];
+                $pLinksByCat[$cat][] = $l;
+            }
+            $pCatLabels = [
+                'official'    => 'Official',
+                'information' => 'Information',
+                'authority'   => 'Authority',
+                'sheet-music' => 'Sheet music',
+                'listen'      => 'Listen',
+                'watch'       => 'Watch',
+                'social'      => 'Social',
+                'read'        => 'Read',
+                'purchase'    => 'Purchase',
+                'other'       => 'Other',
+            ];
+        ?>
+        <div class="card mb-4">
+            <div class="card-body">
+                <h2 class="h6 text-muted mb-3">
+                    <i class="fa-solid fa-link me-1" aria-hidden="true"></i>Find this person elsewhere
+                </h2>
+                <?php foreach ($pCatLabels as $cat => $catLabel): ?>
+                    <?php if (empty($pLinksByCat[$cat])) continue; ?>
+                    <div class="mb-2">
+                        <div class="text-uppercase small text-muted mb-1"><?= htmlspecialchars($catLabel) ?></div>
+                        <div class="d-flex flex-wrap gap-2">
+                            <?php foreach ($pLinksByCat[$cat] as $l): ?>
+                                <a class="btn btn-sm btn-outline-secondary d-inline-flex align-items-center gap-2"
+                                   href="<?= htmlspecialchars((string)$l['url']) ?>"
+                                   target="_blank" rel="noopener nofollow"
+                                   title="<?= htmlspecialchars((string)$l['url']) ?>">
+                                    <?php if (!empty($l['iconClass'])): ?>
+                                        <i class="<?= htmlspecialchars((string)$l['iconClass']) ?>" aria-hidden="true"></i>
+                                    <?php endif; ?>
+                                    <span><?= htmlspecialchars((string)$l['name']) ?></span>
+                                    <?php if (!empty($l['note'])): ?>
+                                        <span class="text-muted small">— <?= htmlspecialchars((string)$l['note']) ?></span>
+                                    <?php endif; ?>
+                                    <?php if (!empty($l['verified'])): ?>
+                                        <i class="fa-solid fa-circle-check text-success small" aria-label="Verified" title="Verified"></i>
+                                    <?php endif; ?>
+                                </a>
+                            <?php endforeach; ?>
+                        </div>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+        </div>
+    <?php elseif (!empty($links)): /* legacy fallback when no unified rows */ ?>
         <div class="card mb-4">
             <div class="card-body">
                 <h2 class="h6 text-muted mb-2">

--- a/appWeb/public_html/includes/pages/song.php
+++ b/appWeb/public_html/includes/pages/song.php
@@ -833,6 +833,65 @@ try {
         </div>
     </section>
 
+    <?php
+        /* #833 — "Find this hymn elsewhere" panel. Reads tblSongExternalLinks
+           via the `links` array attached by SongData::_externalLinksMap('song'),
+           groups by Category, hides when empty. Each link opens in a new
+           tab with rel="noopener nofollow" so search-engine PageRank
+           doesn't leak. */
+        $songLinksRows = $song['links'] ?? [];
+        if (!empty($songLinksRows)):
+            $sLinksByCat = [];
+            foreach ($songLinksRows as $l) {
+                $cat = (string)($l['category'] ?? 'other');
+                if (!isset($sLinksByCat[$cat])) $sLinksByCat[$cat] = [];
+                $sLinksByCat[$cat][] = $l;
+            }
+            $sCatLabels = [
+                'official'    => 'Official',
+                'information' => 'Information',
+                'read'        => 'Read',
+                'sheet-music' => 'Sheet music',
+                'listen'      => 'Listen',
+                'watch'       => 'Watch',
+                'purchase'    => 'Purchase',
+                'authority'   => 'Authority',
+                'social'      => 'Social',
+                'other'       => 'Other',
+            ];
+    ?>
+    <section id="song-external-links" class="song-external-links mt-4 pt-3 border-top" aria-label="Find this hymn elsewhere">
+        <h2 class="h6 mb-3 d-flex align-items-center gap-2">
+            <i class="fa-solid fa-link me-1 text-muted" aria-hidden="true"></i>
+            Find this hymn elsewhere
+        </h2>
+        <?php foreach ($sCatLabels as $cat => $catLabel): ?>
+            <?php if (empty($sLinksByCat[$cat])) continue; ?>
+            <div class="mb-2">
+                <div class="text-uppercase small text-muted mb-1"><?= htmlspecialchars($catLabel) ?></div>
+                <div class="d-flex flex-wrap gap-2">
+                    <?php foreach ($sLinksByCat[$cat] as $l): ?>
+                        <a href="<?= htmlspecialchars($l['url']) ?>"
+                           target="_blank" rel="noopener nofollow"
+                           class="btn btn-sm btn-outline-secondary d-inline-flex align-items-center gap-2">
+                            <?php if (!empty($l['iconClass'])): ?>
+                                <i class="<?= htmlspecialchars($l['iconClass']) ?>" aria-hidden="true"></i>
+                            <?php endif; ?>
+                            <span><?= htmlspecialchars($l['name']) ?></span>
+                            <?php if (!empty($l['note'])): ?>
+                                <span class="text-muted small">— <?= htmlspecialchars($l['note']) ?></span>
+                            <?php endif; ?>
+                            <?php if (!empty($l['verified'])): ?>
+                                <i class="fa-solid fa-circle-check text-success small" aria-label="Verified" title="Verified"></i>
+                            <?php endif; ?>
+                        </a>
+                    <?php endforeach; ?>
+                </div>
+            </div>
+        <?php endforeach; ?>
+    </section>
+    <?php endif; ?>
+
     <!-- Related songs (#118) — populated client-side from songs.json -->
     <section id="related-songs" class="related-songs mt-4 pt-3 border-top d-none" aria-label="Related songs">
         <h2 class="h6 mb-3 d-flex align-items-center gap-2" role="button" data-bs-toggle="collapse" data-bs-target="#related-songs-list" aria-expanded="true" aria-controls="related-songs-list">

--- a/appWeb/public_html/includes/pages/songbook.php
+++ b/appWeb/public_html/includes/pages/songbook.php
@@ -132,6 +132,69 @@ if ($book === null) {
         </div>
     </div>
 
+    <?php
+        /* #833 — "Find this songbook elsewhere" panel. Reads from the
+           unified tblSongbookExternalLinks table; legacy URL columns
+           (WebsiteUrl / InternetArchiveUrl / WikipediaUrl) are STILL
+           rendered below as a fallback when the new system has no rows
+           for this book — keeps pre-backfill deployments visually
+           coherent. The new system's links group by Category so curators
+           can see the listing organised by purpose. */
+        $links = $book['links'] ?? [];
+        $linksByCat = [];
+        foreach ($links as $l) {
+            $cat = (string)($l['category'] ?? 'other');
+            if (!isset($linksByCat[$cat])) $linksByCat[$cat] = [];
+            $linksByCat[$cat][] = $l;
+        }
+        $catLabels = [
+            'official'    => 'Official',
+            'information' => 'Information',
+            'read'        => 'Read',
+            'sheet-music' => 'Sheet music',
+            'listen'      => 'Listen',
+            'watch'       => 'Watch',
+            'purchase'    => 'Purchase',
+            'authority'   => 'Authority',
+            'social'      => 'Social',
+            'other'       => 'Other',
+        ];
+        if (!empty($links)):
+    ?>
+        <div class="card bg-dark border-secondary mb-3">
+            <div class="card-body">
+                <h2 class="h6 mb-3 text-muted">
+                    <i class="fa-solid fa-link me-1" aria-hidden="true"></i>
+                    Find this songbook elsewhere
+                </h2>
+                <?php foreach ($catLabels as $cat => $catLabel): ?>
+                    <?php if (empty($linksByCat[$cat])) continue; ?>
+                    <div class="mb-2">
+                        <div class="text-uppercase small text-muted mb-1"><?= htmlspecialchars($catLabel) ?></div>
+                        <div class="d-flex flex-wrap gap-2">
+                            <?php foreach ($linksByCat[$cat] as $l): ?>
+                                <a href="<?= htmlspecialchars($l['url']) ?>"
+                                   target="_blank" rel="noopener nofollow"
+                                   class="btn btn-sm btn-outline-secondary d-inline-flex align-items-center gap-2">
+                                    <?php if (!empty($l['iconClass'])): ?>
+                                        <i class="<?= htmlspecialchars($l['iconClass']) ?>" aria-hidden="true"></i>
+                                    <?php endif; ?>
+                                    <span><?= htmlspecialchars($l['name']) ?></span>
+                                    <?php if (!empty($l['note'])): ?>
+                                        <span class="text-muted small">— <?= htmlspecialchars($l['note']) ?></span>
+                                    <?php endif; ?>
+                                    <?php if (!empty($l['verified'])): ?>
+                                        <i class="fa-solid fa-circle-check text-success small" aria-label="Verified" title="Verified"></i>
+                                    <?php endif; ?>
+                                </a>
+                            <?php endforeach; ?>
+                        </div>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+        </div>
+    <?php endif; ?>
+
     <!-- Song list -->
     <div class="list-group song-list" role="list">
         <?php foreach ($songs as $song): ?>

--- a/appWeb/public_html/index.php
+++ b/appWeb/public_html/index.php
@@ -259,6 +259,18 @@ try {
                     )
                 ));
             }
+            /* #833 — sameAs for SEO. Search engines pick up the
+               external-link URLs as authority signals; e.g. a
+               linked Hymnary.org page reinforces the song identity. */
+            if (!empty($ogSong['links']) && is_array($ogSong['links'])) {
+                $sameAs = array_values(array_filter(array_map(
+                    static fn($l) => is_array($l) ? (string)($l['url'] ?? '') : '',
+                    $ogSong['links']
+                )));
+                if (!empty($sameAs)) {
+                    $musicComposition['sameAs'] = $sameAs;
+                }
+            }
             if (!empty($ogSong['composers'])) {
                 $musicComposition['composer'] = array_map(
                     fn($name) => ['@type' => 'Person', 'name' => $name],
@@ -322,11 +334,11 @@ try {
                 ['name' => $ogBook['name'], 'url' => $canonicalUrl],
             ];
 
-            /* JSON-LD: MusicAlbum (#832 — alternateName for SEO). */
+            /* JSON-LD: MusicAlbum (#832 — alternateName, #833 — sameAs for SEO). */
             $musicAlbum = [
-                '@context' => 'https://schema.org',
-                '@type'    => 'MusicAlbum',
-                'name'     => $ogBook['name'],
+                '@context'  => 'https://schema.org',
+                '@type'     => 'MusicAlbum',
+                'name'      => $ogBook['name'],
                 'numTracks' => (int)($ogBook['songCount'] ?? 0),
             ];
             if (!empty($ogBook['alternativeNames'])) {
@@ -338,8 +350,80 @@ try {
                     )
                 ));
             }
+            if (!empty($ogBook['links']) && is_array($ogBook['links'])) {
+                $albumSameAs = array_values(array_filter(array_map(
+                    static fn($l) => is_array($l) ? (string)($l['url'] ?? '') : '',
+                    $ogBook['links']
+                )));
+                if (!empty($albumSameAs)) {
+                    $musicAlbum['sameAs'] = $albumSameAs;
+                }
+            }
             $jsonLdScripts[] = $musicAlbum;
         }
+    }
+    /* Person page: /people/<slug> (#833 — sameAs JSON-LD) */
+    elseif (preg_match('#^/people/([a-z0-9\-]+)$#', $requestPath, $matches)) {
+        $pageType = 'other';
+        $personSlug = $matches[1];
+        try {
+            $personDb = getDbMysqli();
+            $stmt = $personDb->prepare(
+                'SELECT Id, Name, Slug FROM tblCreditPeople WHERE Slug = ? LIMIT 1'
+            );
+            $stmt->bind_param('s', $personSlug);
+            $stmt->execute();
+            $personRow = $stmt->get_result()->fetch_assoc();
+            $stmt->close();
+            if ($personRow) {
+                $personJsonLd = [
+                    '@context' => 'https://schema.org',
+                    '@type'    => 'Person',
+                    'name'     => (string)$personRow['Name'],
+                ];
+                /* Check both new and legacy link tables — same fallback
+                   as the public page. */
+                $personLinks = [];
+                $r = $personDb->query(
+                    "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+                      WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tblCreditPersonExternalLinks' LIMIT 1"
+                );
+                $hasNewPersonLinks = $r && $r->fetch_row() !== null;
+                if ($r) $r->close();
+                if ($hasNewPersonLinks) {
+                    $stmt = $personDb->prepare(
+                        'SELECT Url FROM tblCreditPersonExternalLinks WHERE CreditPersonId = ?'
+                    );
+                    $pid = (int)$personRow['Id'];
+                    $stmt->bind_param('i', $pid);
+                    $stmt->execute();
+                    $personLinks = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+                    $stmt->close();
+                }
+                if (empty($personLinks)) {
+                    try {
+                        $stmt = $personDb->prepare(
+                            'SELECT Url FROM tblCreditPersonLinks WHERE CreditPersonId = ?'
+                        );
+                        $pid = (int)$personRow['Id'];
+                        $stmt->bind_param('i', $pid);
+                        $stmt->execute();
+                        $personLinks = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+                        $stmt->close();
+                    } catch (\Throwable $_e) { /* legacy table missing */ }
+                }
+                if (!empty($personLinks)) {
+                    $personSameAs = array_values(array_filter(array_map(
+                        static fn($l) => (string)($l['Url'] ?? $l['url'] ?? ''),
+                        $personLinks
+                    )));
+                    if (!empty($personSameAs)) {
+                        $personJsonLd['sameAs'] = $personSameAs;
+                    }
+                }
+                $jsonLdScripts[] = $personJsonLd;
+            }
+        } catch (\Throwable $_e) { /* table missing — no JSON-LD */ }
     }
     /* Shared setlist page: /setlist/shared/abc123 */
     elseif (preg_match('#^/setlist/shared/([a-f0-9]+)$#', $requestPath, $matches)) {

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -228,6 +228,9 @@ $friendlyTitles = [
     'songcount-triggers'               => 'SongCount Triggers (#793)',
     'songbook-compilers'               => 'Songbook Compilers (#831)',
     'alternative-titles'               => 'Alternative Titles for Songs &amp; Songbooks (#832)',
+    'external-links'                   => 'External Links System (#833)',
+    'backfill-songbook-links'          => 'Backfill Songbook URL columns → External Links (#833)',
+    'backfill-credit-person-links'     => 'Backfill Credit-Person Links → External Links (#833)',
     /* `recompute-songbook-songcount` no longer exposed via the dashboard
        (#818) — the SongCount Triggers migration above includes its own
        initial recompute. The CLI script stays on disk for emergency
@@ -554,6 +557,42 @@ $migrationCards = [
                   . ' <code>es</code>). Idempotent.',
         'button' => 'Run Alternative Titles Migration',
     ],
+    'external-links' => [
+        'title'  => 'External Links System (#833)',
+        'body'   => 'MusicBrainz-style external-links registry for songs, songbooks AND'
+                  . ' credit-people. Adds <code>tblExternalLinkTypes</code> (controlled'
+                  . ' vocabulary, ~37 seeded types — Hymnary.org, CCLI Songselect, IMSLP,'
+                  . ' YouTube, Spotify, Internet Archive, Wikipedia, Wikidata, MusicBrainz,'
+                  . ' VIAF, social, …) plus three per-entity join tables'
+                  . ' (<code>tblSongbookExternalLinks</code>, <code>tblSongExternalLinks</code>,'
+                  . ' <code>tblCreditPersonExternalLinks</code>). Multiple links of the same'
+                  . ' type per entity supported (e.g. five Internet Archive scans of one'
+                  . ' hymnal). Idempotent — re-runs upsert seed rows by slug without'
+                  . ' touching curator-modified IsActive / DisplayOrder.',
+        'button' => 'Run External Links Migration',
+    ],
+    'backfill-songbook-links' => [
+        'title'  => 'Backfill Songbook URL columns → External Links (#833)',
+        'body'   => 'Copies non-empty <code>tblSongbooks.WebsiteUrl</code> /'
+                  . ' <code>InternetArchiveUrl</code> / <code>WikipediaUrl</code> values'
+                  . ' into <code>tblSongbookExternalLinks</code> with the corresponding'
+                  . ' link types. Idempotent — re-runs use a NOT EXISTS guard so duplicate'
+                  . ' (SongbookId, LinkType, Url) tuples are no-ops. The legacy columns'
+                  . ' stay in place as read-fallbacks for one release cycle.',
+        'button' => 'Run Songbook Links Backfill',
+    ],
+    'backfill-credit-person-links' => [
+        'title'  => 'Backfill Credit-Person Links → External Links (#833)',
+        'body'   => 'Migrates rows from the existing <code>tblCreditPersonLinks</code>'
+                  . ' (free-text LinkType from #545) into <code>tblCreditPersonExternalLinks</code>.'
+                  . ' Maps free-text type strings to controlled-vocabulary slugs'
+                  . ' (<code>wikipedia</code> → <code>wikipedia</code>, <code>imslp</code> →'
+                  . ' <code>imslp</code>, …). Unrecognised values fall through to'
+                  . ' <code>other</code> with the original string preserved in Note.'
+                  . ' Idempotent. Legacy <code>tblCreditPersonLinks</code> stays as a'
+                  . ' read-fallback for one release cycle.',
+        'button' => 'Run Credit-Person Links Backfill',
+    ],
     /* recompute-songbook-songcount card removed (#818) — its work is
        now covered by the SongCount Triggers migration above, which
        runs an initial recompute as part of its installation. The
@@ -685,6 +724,19 @@ $migrationProbes = [
     'songcount-triggers'                 => static fn(\mysqli $db) => !_migProbe_triggerExists($db, 'trg_songs_songcount_ai'),
     'songbook-compilers'                 => static fn(\mysqli $db) => !_migProbe_tableExists($db, 'tblSongbookCompilers'),
     'alternative-titles'                 => static fn(\mysqli $db) => !_migProbe_tableExists($db, 'tblSongAlternativeTitles'),
+    /* External Links: pending when any of the four new tables is absent. */
+    'external-links'                     => static fn(\mysqli $db) =>
+        !_migProbe_tableExists($db, 'tblExternalLinkTypes')
+        || !_migProbe_tableExists($db, 'tblSongbookExternalLinks')
+        || !_migProbe_tableExists($db, 'tblSongExternalLinks')
+        || !_migProbe_tableExists($db, 'tblCreditPersonExternalLinks'),
+    /* Backfills run once after schema lands. They're idempotent so
+       always-show is safe — but we can be smarter: pending when the
+       new table has fewer rows than the legacy source had non-empty
+       values. Simpler heuristic: pending if the new table is empty
+       AND the legacy source has data. */
+    'backfill-songbook-links'            => static fn(\mysqli $db) => true,
+    'backfill-credit-person-links'       => static fn(\mysqli $db) => true,
     /* Data-only backfills — applied state isn't cheap to detect
        reliably from schema alone. Default to "always show" so a
        curator can always re-run; re-runs are idempotent. */
@@ -873,8 +925,11 @@ if ($action !== '') {
            on disk for emergency CLI manual runs:
              php appWeb/.sql/migrate-recompute-songbook-songcount.php  */
         'songcount-triggers'       => 'migrate-songcount-triggers.php',
-        'songbook-compilers'       => 'migrate-songbook-compilers.php',
-        'alternative-titles'       => 'migrate-alternative-titles.php',
+        'songbook-compilers'            => 'migrate-songbook-compilers.php',
+        'alternative-titles'            => 'migrate-alternative-titles.php',
+        'external-links'                => 'migrate-external-links.php',
+        'backfill-songbook-links'       => 'migrate-backfill-songbook-links.php',
+        'backfill-credit-person-links'  => 'migrate-backfill-credit-person-links.php',
         'cleanup'     => 'cleanup.php',
         'backup'      => 'backup.php',
         'restore'     => 'restore.php',
@@ -929,6 +984,9 @@ if ($action !== '') {
         'songcount-triggers',
         'songbook-compilers',
         'alternative-titles',
+        'external-links',
+        'backfill-songbook-links',
+        'backfill-credit-person-links',
         /* When you add a new migrate-*.php under appWeb/.sql/, ALSO add
            its action key to:
              1. $scriptMap above (action key → file)

--- a/appWeb/public_html/manage/songbooks.php
+++ b/appWeb/public_html/manage/songbooks.php
@@ -633,6 +633,21 @@ try {
     $probeAlt->close();
 } catch (\Throwable $_e) { /* probe failure → alt-names UI stays hidden */ }
 
+/* Probe for the external-links schema (#833). Same hoist rationale —
+   POST handler's reconciliation block needs the gate. */
+$hasExtLinksSchema = false;
+try {
+    $probeEx = $db->prepare(
+        "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE()
+            AND TABLE_NAME   = 'tblSongbookExternalLinks'
+          LIMIT 1"
+    );
+    $probeEx->execute();
+    $hasExtLinksSchema = $probeEx->get_result()->fetch_row() !== null;
+    $probeEx->close();
+} catch (\Throwable $_e) { /* probe failure → external-links UI stays hidden */ }
+
 /* ----- POST actions ----- */
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!validateCsrf((string)($_POST['csrf_token'] ?? ''))) {
@@ -1179,6 +1194,69 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         }
                     }
 
+                    /* #833 — reconcile external links. The edit modal posts
+                       four parallel arrays:
+                         ext_link_type_ids[]   tblExternalLinkTypes.Id
+                         ext_link_urls[]       URL
+                         ext_link_notes[]      optional Note
+                         ext_link_verified[]   '1'/''  per-row checkbox
+                       Position N in each array is the same link row;
+                       array index drives SortOrder. Empty / blank URLs
+                       are dropped before insert. DELETE-then-INSERT in
+                       the existing transaction.
+                       Schema-gated by $hasExtLinksSchema. */
+                    $postedLinkCount = 0;
+                    if ($hasExtLinksSchema) {
+                        $rawTypes    = $_POST['ext_link_type_ids']  ?? [];
+                        $rawUrls     = $_POST['ext_link_urls']      ?? [];
+                        $rawNotes    = $_POST['ext_link_notes']     ?? [];
+                        $rawVerified = $_POST['ext_link_verified']  ?? [];
+                        if (!is_array($rawTypes))    $rawTypes    = [];
+                        if (!is_array($rawUrls))     $rawUrls     = [];
+                        if (!is_array($rawNotes))    $rawNotes    = [];
+                        if (!is_array($rawVerified)) $rawVerified = [];
+
+                        $linkRows = [];
+                        foreach ($rawTypes as $idx => $rawTypeId) {
+                            $typeId = (int)$rawTypeId;
+                            $url    = trim((string)($rawUrls[$idx] ?? ''));
+                            if ($typeId <= 0 || $url === '')                  continue;
+                            if (!preg_match('#^https?://#i', $url))           continue;  /* must be http(s) */
+                            if (mb_strlen($url) > 2048)                       continue;
+                            $note = trim((string)($rawNotes[$idx] ?? ''));
+                            $verified = !empty($rawVerified[$idx]) ? 1 : 0;
+                            $linkRows[] = [
+                                'type_id'  => $typeId,
+                                'url'      => $url,
+                                'note'     => ($note !== '' ? mb_substr($note, 0, 255) : null),
+                                'verified' => $verified,
+                                'order'    => count($linkRows),
+                            ];
+                        }
+
+                        $stmt = $db->prepare('DELETE FROM tblSongbookExternalLinks WHERE SongbookId = ?');
+                        $stmt->bind_param('i', $id);
+                        $stmt->execute();
+                        $stmt->close();
+
+                        if ($linkRows) {
+                            $stmt = $db->prepare(
+                                'INSERT INTO tblSongbookExternalLinks
+                                     (SongbookId, LinkTypeId, Url, Note, SortOrder, Verified)
+                                  VALUES (?, ?, ?, ?, ?, ?)'
+                            );
+                            foreach ($linkRows as $r) {
+                                $stmt->bind_param(
+                                    'iissii',
+                                    $id, $r['type_id'], $r['url'], $r['note'], $r['order'], $r['verified']
+                                );
+                                $stmt->execute();
+                                $postedLinkCount++;
+                            }
+                            $stmt->close();
+                        }
+                    }
+
                     $db->commit();
 
                     /* Audit (#535) — compute the changed-fields list
@@ -1235,6 +1313,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     }
                     if ($hasAltNamesSchema) {
                         $auditExtras['alternative_names'] = $postedAltNames;
+                    }
+                    if ($hasExtLinksSchema) {
+                        $auditExtras['external_link_count'] = $postedLinkCount;
                     }
                     logActivity('songbook.edit', 'songbook', (string)$id, array_merge([
                         'fields'             => $changed,
@@ -1856,6 +1937,71 @@ if ($hasAltNamesSchema) {
     }
 }
 
+/* ----- External-links registry + per-songbook map (#833) -----
+ *       $linkTypesForSongbook — every active link type whose
+ *       AppliesTo set includes 'songbook'. Drives the type dropdown
+ *       in the edit-modal card-list.
+ *       $sbLinksMap — SongbookId => [{type_id, slug, name, url,
+ *       note, verified, sort_order}, …]. Same caching strategy as
+ *       the series map.
+ *       Schema-conditional via $hasExtLinksSchema. */
+$linkTypesForSongbook = [];
+$sbLinksMap           = [];
+if ($hasExtLinksSchema) {
+    try {
+        $res = $db->query(
+            "SELECT Id, Slug, Name, Category, IconClass, AllowMultiple, DisplayOrder
+               FROM tblExternalLinkTypes
+              WHERE COALESCE(IsActive, 1) = 1
+                AND FIND_IN_SET('songbook', AppliesTo) > 0
+              ORDER BY Category, DisplayOrder ASC, Name ASC"
+        );
+        if ($res) {
+            while ($row = $res->fetch_assoc()) {
+                $linkTypesForSongbook[] = [
+                    'id'             => (int)$row['Id'],
+                    'slug'           => (string)$row['Slug'],
+                    'name'           => (string)$row['Name'],
+                    'category'       => (string)$row['Category'],
+                    'icon_class'     => (string)($row['IconClass'] ?? ''),
+                    'allow_multiple' => (int)$row['AllowMultiple'],
+                ];
+            }
+            $res->close();
+        }
+
+        $res = $db->query(
+            'SELECT el.SongbookId, el.LinkTypeId, el.Url, el.Note, el.SortOrder, el.Verified,
+                    t.Slug, t.Name, t.Category, t.IconClass
+               FROM tblSongbookExternalLinks el
+               JOIN tblExternalLinkTypes t ON t.Id = el.LinkTypeId
+              ORDER BY el.SongbookId ASC, t.Category, el.SortOrder ASC, t.Name ASC'
+        );
+        if ($res) {
+            while ($lrow = $res->fetch_assoc()) {
+                $sb = (int)$lrow['SongbookId'];
+                if (!isset($sbLinksMap[$sb])) $sbLinksMap[$sb] = [];
+                $sbLinksMap[$sb][] = [
+                    'type_id'    => (int)$lrow['LinkTypeId'],
+                    'slug'       => (string)$lrow['Slug'],
+                    'name'       => (string)$lrow['Name'],
+                    'category'   => (string)$lrow['Category'],
+                    'icon_class' => (string)($lrow['IconClass'] ?? ''),
+                    'url'        => (string)$lrow['Url'],
+                    'note'       => (string)($lrow['Note'] ?? ''),
+                    'verified'   => (int)$lrow['Verified'],
+                    'sort_order' => (int)$lrow['SortOrder'],
+                ];
+            }
+            $res->close();
+        }
+    } catch (\Throwable $e) {
+        error_log('[manage/songbooks.php external-links fetch] ' . $e->getMessage());
+        $linkTypesForSongbook = [];
+        $sbLinksMap           = [];
+    }
+}
+
 /* ----- Active languages for the songbook editor's optional
  *       Language dropdown (#673). Sourced from tblLanguages so the
  *       admin doesn't have to hard-code ISO codes. We pull this
@@ -2216,6 +2362,9 @@ $csrf = csrfToken();
                                            in SortOrder. Each item carries title + note. Empty
                                            list pre-migration or for songbooks with no alts. */
                                         'alternative_names'     => $sbAltNamesMap[(int)$r['Id']] ?? [],
+                                        /* #833 — external links attached to this songbook,
+                                           in the saved order. Empty list pre-migration. */
+                                        'external_links'        => $sbLinksMap[(int)$r['Id']] ?? [],
                                     ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
                                 ?>
                                 <button type="button" class="btn btn-sm btn-outline-info"
@@ -2935,6 +3084,37 @@ $csrf = csrfToken();
                         </div>
                         <?php endif; ?>
 
+                        <?php if ($hasExtLinksSchema): ?>
+                        <!-- #833 — External-links system.
+                             MusicBrainz-style typed links with multiple
+                             entries supported. Each row pairs a link
+                             type (FK → tblExternalLinkTypes) with a URL,
+                             an optional Note, and a Verified flag. -->
+                        <div class="mb-3" id="edit-ext-links-block">
+                            <label class="form-label">External links <span class="text-muted small">(optional)</span></label>
+                            <div class="form-text small mb-2">
+                                Hymnary.org · Internet Archive scans · Wikipedia ·
+                                Wikidata · YouTube performances · Spotify recordings ·
+                                etc. Multiple links of the same type are allowed
+                                where the type permits. Verified means a curator
+                                has eyeballed the URL and confirmed it's correct.
+                            </div>
+                            <div id="edit-ext-links-rows" class="vstack gap-2 mb-2"></div>
+                            <button type="button"
+                                    class="btn btn-sm btn-outline-info"
+                                    id="edit-ext-link-add-btn">
+                                <i class="bi bi-plus-lg me-1" aria-hidden="true"></i>Add link
+                            </button>
+                            <!-- Curated link-type registry (#833 seed list). Read at
+                                 page load + serialized inline as a JSON map so the
+                                 row-builder can populate the dropdown without an
+                                 extra AJAX round-trip. -->
+                            <script>
+                                window._iHymnsLinkTypes = <?= json_encode($linkTypesForSongbook, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?>;
+                            </script>
+                        </div>
+                        <?php endif; ?>
+
                         <!-- #672 — collapsible "Online links" + "Authority identifiers".
                              Closed by default so the modal still opens at the same height
                              curators are used to. <details> is native HTML5; no JS needed
@@ -3288,6 +3468,24 @@ $csrf = csrfToken();
                 });
                 const addInput = document.getElementById('edit-alt-name-add-input');
                 if (addInput) addInput.value = '';
+            })();
+
+            /* #833 — populate the external-links list from
+               row.external_links. Schema-gated container; clear +
+               repopulate on every modal-open. */
+            (function () {
+                const container = document.getElementById('edit-ext-links-rows');
+                if (!container || typeof window._iHymnsBuildExtLinkRow !== 'function') return;
+                container.innerHTML = '';
+                const links = Array.isArray(row.external_links) ? row.external_links : [];
+                links.forEach(l => {
+                    container.appendChild(window._iHymnsBuildExtLinkRow({
+                        typeId:   l.type_id || 0,
+                        url:      l.url || '',
+                        note:     l.note || '',
+                        verified: !!l.verified,
+                    }));
+                });
             })();
 
             /* Stash the current row's abbreviation on the modal for the
@@ -3934,6 +4132,118 @@ $csrf = csrfToken();
                 .addEventListener('click', () => card.remove());
             return card;
         };
+
+        function escapeHtml(s) {
+            return String(s)
+                .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+        }
+    })();
+    </script>
+
+    <!-- External-links card-list editor (#833). Each row carries:
+         - hidden ext_link_type_ids[]   (FK to tblExternalLinkTypes.Id)
+         - text   ext_link_urls[]
+         - text   ext_link_notes[]
+         - checkbox ext_link_verified[]
+         The link-type dropdown is grouped by Category and uses the
+         seeded list pre-loaded into window._iHymnsLinkTypes. -->
+    <script>
+    (function () {
+        const addBtn = document.getElementById('edit-ext-link-add-btn');
+        const rowsEl = document.getElementById('edit-ext-links-rows');
+        if (!addBtn || !rowsEl) return;  /* schema not live → block absent */
+
+        const types = Array.isArray(window._iHymnsLinkTypes) ? window._iHymnsLinkTypes : [];
+
+        /* Group types by Category for the <optgroup> structure. */
+        const byCat = {};
+        types.forEach(t => {
+            const cat = t.category || 'other';
+            if (!byCat[cat]) byCat[cat] = [];
+            byCat[cat].push(t);
+        });
+        const catLabels = {
+            'official':    'Official',
+            'information': 'Information',
+            'read':        'Read',
+            'sheet-music': 'Sheet music',
+            'listen':      'Listen',
+            'watch':       'Watch',
+            'purchase':    'Purchase',
+            'authority':   'Authority',
+            'social':      'Social',
+            'other':       'Other',
+        };
+        const catOrder = ['official','information','read','sheet-music','listen','watch','purchase','authority','social','other'];
+
+        function buildSelect(selectedId) {
+            let html = '<select class="form-select form-select-sm" name="ext_link_type_ids[]" required>';
+            html += '<option value="">— pick a link type —</option>';
+            catOrder.forEach(cat => {
+                if (!byCat[cat] || byCat[cat].length === 0) return;
+                html += '<optgroup label="' + escapeHtml(catLabels[cat] || cat) + '">';
+                byCat[cat].forEach(t => {
+                    const sel = (Number(selectedId) === Number(t.id)) ? ' selected' : '';
+                    html += '<option value="' + Number(t.id) + '"' + sel + '>' + escapeHtml(t.name) + '</option>';
+                });
+                html += '</optgroup>';
+            });
+            html += '</select>';
+            return html;
+        }
+
+        window._iHymnsBuildExtLinkRow = function (data) {
+            const card = document.createElement('div');
+            card.className = 'card bg-dark border-secondary';
+            const url  = String(data.url || '');
+            const note = String(data.note || '');
+            const ver  = data.verified ? 'checked' : '';
+            card.innerHTML =
+                '<div class="card-body py-2">' +
+                  '<div class="d-flex align-items-start gap-2">' +
+                    '<i class="bi bi-grip-vertical text-muted mt-2" aria-hidden="true"></i>' +
+                    '<div class="flex-grow-1">' +
+                      '<div class="row g-2 mb-1">' +
+                        '<div class="col-md-5">' + buildSelect(data.typeId || 0) + '</div>' +
+                        '<div class="col-md-7">' +
+                          '<input type="url" class="form-control form-control-sm" ' +
+                                  'name="ext_link_urls[]" required maxlength="2048" ' +
+                                  'placeholder="https://…" value="' + escapeHtml(url) + '">' +
+                        '</div>' +
+                      '</div>' +
+                      '<div class="row g-2">' +
+                        '<div class="col-md-9">' +
+                          '<input type="text" class="form-control form-control-sm" ' +
+                                  'name="ext_link_notes[]" maxlength="255" ' +
+                                  'placeholder="Optional note (e.g. \'1900 first edition\')" ' +
+                                  'value="' + escapeHtml(note) + '">' +
+                        '</div>' +
+                        '<div class="col-md-3 d-flex align-items-center">' +
+                          '<div class="form-check small">' +
+                            '<input class="form-check-input" type="checkbox" ' +
+                                    'name="ext_link_verified[]" value="1" ' + ver + '>' +
+                            '<label class="form-check-label">Verified</label>' +
+                          '</div>' +
+                        '</div>' +
+                      '</div>' +
+                    '</div>' +
+                    '<button type="button" class="btn btn-sm btn-outline-danger" ' +
+                            'data-action="remove-ext-link" title="Remove this link">' +
+                      '<i class="bi bi-x-lg"></i>' +
+                    '</button>' +
+                  '</div>' +
+                '</div>';
+            card.querySelector('[data-action=remove-ext-link]')
+                .addEventListener('click', () => card.remove());
+            return card;
+        };
+
+        addBtn.addEventListener('click', () => {
+            rowsEl.appendChild(window._iHymnsBuildExtLinkRow({
+                typeId: 0, url: '', note: '', verified: false,
+            }));
+        });
 
         function escapeHtml(s) {
             return String(s)


### PR DESCRIPTION
## Summary

First instalment of #833 — MusicBrainz-style external-links system covering songs, songbooks **and** credit-people in one unified schema.

## Schema (3 migrations)

1. `migrate-external-links.php` — creates four tables in one shot:
   - **`tblExternalLinkTypes`** — controlled-vocabulary registry seeded with **~37 link types** (Hymnary.org, CCLI Songselect, IMSLP, YouTube, Spotify, Internet Archive, Wikipedia, Wikidata, MusicBrainz work / recording / artist, VIAF, Find a Grave, social — LinkedIn / Twitter / Mastodon / etc.). Categories: information / listen / watch / read / sheet-music / purchase / authority / official / social / other. `AppliesTo` is a `SET('song','songbook','person')` so the same type can apply to multiple entities. Re-runs upsert seed rows by `Slug` without touching curator-set `IsActive` / `DisplayOrder`.
   - **`tblSongbookExternalLinks`** — many-to-many tblSongbooks ↔ link type.
   - **`tblSongExternalLinks`** — same shape, songs.
   - **`tblCreditPersonExternalLinks`** — same shape, credit-people.

2. `migrate-backfill-songbook-links.php` — copies non-empty `tblSongbooks.WebsiteUrl` / `InternetArchiveUrl` / `WikipediaUrl` into the new table. NOT EXISTS guard for idempotence.

3. `migrate-backfill-credit-person-links.php` — migrates existing `tblCreditPersonLinks` rows. Free-text `LinkType` strings map to controlled-vocabulary slugs (`wikipedia → wikipedia`, `imslp → imslp`, `hymnary → hymnary-org`, `website → official-website`, …). Unrecognised values fall through to `other` with the original LinkType preserved in `Note`.

**Legacy reads remain in place for one release cycle** — the songbook URL columns and `tblCreditPersonLinks` aren't dropped by these migrations. A later migration retires them once the public site has been on the new system.

## Data — `SongData.php`

New `_externalLinksMap()` helper, **generic over the three entity types** (`'songbook' | 'song' | 'person'`). Probe-gated; pre-migration deployments get an empty map. Wired into `getSongbook()` / `getSongbooks()` / `_fetchSongRow()` to attach a `links` array carrying `{slug, name, category, url, note, verified, iconClass, sortOrder}` per row, sorted by Category → SortOrder → Name.

## Public surfaces

- **`/songbook/<abbr>`** — "Find this songbook elsewhere" card with **category group headings** (Official / Information / Read / Sheet music / Listen / Watch / Purchase / Authority / Social / Other). Each link rendered as an outline button with the seeded Bootstrap icon, the optional Note in muted text, and a verified-tick when set. Hidden when there are no links.
- **`/song/<id>`** — "Find this hymn elsewhere" section with the same treatment.
- **`/people/<slug>`** — replaces the existing flat "Links" list with the new categorised display when `tblCreditPersonExternalLinks` has rows; the legacy `tblCreditPersonLinks` flat list still renders as a **fallback** when the new table is empty for the person, so the page never goes dark on a deployment that hasn't run the backfill yet.

## SEO / JSON-LD

- **`MusicComposition.sameAs`** on `/song/<id>`.
- **`MusicAlbum.sameAs`** on `/songbook/<abbr>`.
- **`Person.sameAs`** on `/people/<slug>` (new — wasn't there before). Reads from the new table first, legacy fallback second.

## Admin

- **Songbook edit modal** gains an "External links" card-list editor — drag-handle row + grouped link-type dropdown (optgroups by Category) + URL input + Note input + Verified checkbox + remove button. "Add link" button appends a blank row. POST handler reconciles via DELETE-then-INSERT in the existing transaction; array index drives SortOrder. Audit-log entry includes the link count.

## Deferred to follow-ups

- **Song-editor admin UI** — same reasoning as #836 (`/manage/editor` is a 3,000-line file warranting its own focused PR).
- **Credit-people admin UI replacement** — the existing `tblCreditPersonLinks` admin UI keeps working; the public page falls back to the legacy table when the new one is empty for a person; the backfill migration captures legacy rows on each run. Replacing the admin form with a controlled-vocabulary picker + dual-write or full-cutover is a focused follow-up. Filed as a new issue.

## Test plan

- [ ] `Apply all pending migrations` runs all three (schema + 2 backfills) cleanly; re-runs are no-ops.
- [ ] Backfill of `WebsiteUrl` / `InternetArchiveUrl` / `WikipediaUrl` into `tblSongbookExternalLinks`: counts match the non-empty source values.
- [ ] Backfill of `tblCreditPersonLinks` into `tblCreditPersonExternalLinks`: every row migrated, unknown types → `other` with original preserved in `Note`.
- [ ] Edit Mission Praise → add 4 Internet Archive scans (each with its own Note like "1900 first edition", "1990 reprint") + 1 Hymnary.org link → save → reopen → all 5 present in saved order.
- [ ] `/songbook/MP` page shows "Find this songbook elsewhere" with category groups. Verified ticks render.
- [ ] `/songbook/MP` page source includes `MusicAlbum.sameAs` array.
- [ ] After backfill, `/people/<slug>` for someone who had legacy links shows the new categorised view (linked, iconified, with verified ticks where set).
- [ ] Pre-migration deployment: every page still loads cleanly with the new sections silently absent.
- [ ] After migration but before backfill: every page still loads; songbook tiles still show legacy URL columns; person page falls back to legacy `tblCreditPersonLinks` flat list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
