### PR TITLE
fix(ci): clear PHP-tag-guard false positive on setup-database.php (root cause of CI #303 + #304 failures)

### DIFF
--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -1432,9 +1432,15 @@ if ($hasCredentials && defined('DB_HOST')) {
            is fully self-rendered higher up — DOCTYPE through
            admin-footer.php — and `exit`s before reaching this block.
            So everything below this point only ever runs on the
-           dashboard view. The legacy `<?php if ($action !== ''):` /
-           `<?php else: ?>` wrapper around the dashboard cards has been
-           removed accordingly. */
+           dashboard view. The legacy "if action then run, else show
+           dashboard" wrapper around the dashboard cards has been
+           removed accordingly.
+
+           [CI note: this comment used to spell out the legacy
+           wrapper using literal PHP open tags inside backticks, which
+           tripped Step 5a of CI Lint & Validate — the guard added
+           after PR #536 to catch the embedded-tag-execution bug.
+           Re-worded prose-only to keep the guard a hard error.] */
     ?>
         <!-- ============================================================
              ONE-STEP MIGRATIONS RUNNER (#577)


### PR DESCRIPTION
## Summary

CI Lint & Validate has been failing on every PR that touches `appWeb/public_html/manage/setup-database.php` — the most recent victims were #847 (run #303) and #848 (run #304). Auto-merge fired on both anyway because it doesn't gate on CI, but the red ✗ in Actions is real.

## Root cause

`test.yml` Step 5a runs:

```bash
grep -rnP '`[^`]*<\?|<!--[^>]*<\?' appWeb --include='*.php'
```

…to catch the embedded-PHP-open-tag bug from **PR #536** (commit `96cd14a`) where a doc-snippet like `` `<?= json_encode(...) ?>` `` was parsed as live PHP at runtime and fataled when PHP 8.1+ first-class-callable syntax made `json_encode(...)` return a `Closure` that `<?=` couldn't echo. **The guard is correct and should stay.**

The hit in `setup-database.php` was a `/* … */` PHP block-comment citing the legacy wrapper using literal `` `<?php if ($action !== ''):` `` / `` `<?php else: ?>` `` inside backticks. Inside a PHP comment that's safe at runtime — but the regex doesn't know that and treats the file as poisoned.

## Fix

Re-worded the comment prose-only. No `<?` inside backticks anywhere in `appWeb/`. Guard remains a hard error (the right default).

```bash
$ grep -rnP '`[^`]*<\?|<!--[^>]*<\?' appWeb --include='*.php'
$ # (no output — clean)
```

## Test plan

- [ ] CI Lint & Validate runs green on this PR.
- [ ] Step 5a still rejects a deliberate test case (manual local check, not in this PR).

https://claude.ai/code/session_019L8SKwRdyuzt7VLAo83JU2

---
_Generated by [Claude Code](https://claude.ai/code/session_019L8SKwRdyuzt7VLAo83JU2)_