### PR TITLE
fix(ci): Auto-Merge Alpha workflow no longer skips deploy when PR is fast-mergeable

### DIFF
--- a/.github/workflows/auto-merge-alpha.yml
+++ b/.github/workflows/auto-merge-alpha.yml
@@ -61,12 +61,44 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
         # --delete-branch is explicit: gh's --auto path doesn't propagate
         # the repo-level delete_branch_on_merge setting through to the
         # GraphQL enablePullRequestAutoMerge mutation. Without this flag
         # every auto-merged PR's head branch sticks around after merge,
         # which is exactly the regression behind #750.
-        run: gh pr merge --auto --squash --delete-branch "$PR_URL"
+        #
+        # Why this step is failure-tolerant: when a PR has no pending
+        # required checks, `gh pr merge --auto` can exit non-zero
+        # (there's no "pending" state to attach auto-merge to). The PR
+        # still merges via GitHub's native flow once the checks queue
+        # clears, but this step exiting non-zero used to skip the
+        # wait-and-dispatch step below — which is what dispatches
+        # deploy.yml. Result: #849 merged but its deploy never fired.
+        # We log the gh output, classify the exit, and pass through.
+        run: |
+          set +e
+          OUTPUT=$(gh pr merge --auto --squash --delete-branch "$PR_URL" 2>&1)
+          STATUS=$?
+          set -e
+          echo "$OUTPUT"
+          if [ "$STATUS" -eq 0 ]; then
+            echo "auto-merge enabled."
+            exit 0
+          fi
+          # Classify common benign failures so the wait-and-dispatch
+          # step still runs.
+          if echo "$OUTPUT" | grep -qiE 'already|clean status|queued'; then
+            echo "::notice::gh pr merge --auto returned $STATUS but the PR appears mergeable / already-enabled — proceeding to wait-and-dispatch."
+            exit 0
+          fi
+          # Real failure (auth / scope / repo setting): surface it but
+          # still let the wait-and-dispatch step run, because the merge
+          # might land via a parallel route (manual button, branch-rule
+          # auto-merge) and we'd still want the deploy to fire.
+          echo "::warning::gh pr merge --auto exited $STATUS — see output above. Continuing so the wait-and-dispatch step still runs."
+          exit 0
 
       # ---------------------------------------------------------------------
       # Bridge GitHub's GITHUB_TOKEN anti-recursion rule (#551).


### PR DESCRIPTION
## Symptom

PR #849 merged successfully (squashed to alpha as `8c42581`), but its deploy never fired — the alpha server may still be running #848's code, missing the CI-guard comment fix.

## Root cause

`Auto-Merge Alpha PRs` workflow run #140 failed at step 1:

```yaml
run: gh pr merge --auto --squash --delete-branch "$PR_URL"
```

When a PR has no pending required checks, `gh pr merge --auto` exits non-zero — no "pending" state to attach auto-merge to. GitHub still merges the PR via its native flow once the checks queue clears, but with `set -e` and no `continue-on-error`, the **second** step in the same job (the polling watcher that calls `gh workflow run deploy.yml --ref alpha`) never ran. So #849 merged but no deploy fired.

#847 and #848 both got their deploys dispatched normally (they had pending Lint & Validate checks). #849 — a tiny CI-only fix — fell through this gap.

## Fix

Wrap the first step in proper status handling:
- Capture stdout/stderr + exit code instead of letting `set -e` kill the job.
- Exit 0 cleanly for the common benign outputs (`already`, `clean status`, `queued`) — these mean "GitHub will handle the merge".
- For genuine failures, log a `::warning::` but still exit 0 so the wait-and-dispatch step runs. If the merge lands via any parallel route, the deploy still fires; if the PR never merges, the watcher's `CLOSED` branch handles it cleanly.

`deploy.yml` itself is unchanged.

## Action item for the missing #849 deploy

Please **manually re-run `Deploy via SFTP` on `alpha`** from the Actions tab once this PR merges, to push #849's code to the alpha server. Going forward this hole is patched.

https://claude.ai/code/session_019L8SKwRdyuzt7VLAo83JU2

---
_Generated by [Claude Code](https://claude.ai/code/session_019L8SKwRdyuzt7VLAo83JU2)_