### PR TITLE
fix(ci): Lint &amp; Validate runs on every PR — fixes auto-merge deadlock (#851)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,16 +32,14 @@ on:
       - '.eslintrc*'
       - 'eslint.config.*'
 
-  pull_request:
-    paths:
-      - 'appWeb/**/*.js'
-      - 'appWeb/**/*.css'
-      - 'appWeb/**/*.php'
-      - 'appWeb/**/*.html'
-      - 'package.json'
-      - 'package-lock.json'
-      - '.eslintrc*'
-      - 'eslint.config.*'
+  # PRs intentionally have NO paths filter — see #851. Branch protection
+  # on `alpha` requires this workflow as a status check; skipping the
+  # workflow on workflow-only / docs-only PRs leaves the required check
+  # in a permanent "not satisfied" state and deadlocks auto-merge. Each
+  # lint step internally early-exits with "skipping" when its target file
+  # set is empty, so running unconditionally here is cheap and keeps the
+  # required check satisfiable on every PR shape.
+  pull_request: {}
 
 # Cancel any in-progress CI run on the same branch / PR
 concurrency:


### PR DESCRIPTION
Closes #851.

## Summary

Drops the `paths:` filter from the `pull_request` trigger of `Lint & Validate`. The workflow now runs on every PR, internal steps each early-exit with "skipping" when their target file set is empty, and branch protection's required check is always satisfiable.

Push trigger keeps its `paths:` filter — push to main/beta still skips when not relevant.

## Why

Branch protection on `alpha` requires `Lint & Validate` as a status check. Path filters at the trigger level meant that workflow-only / docs-only / tests-only PRs didn't trigger the workflow at all → required check status missing → auto-merge waited forever. PR #850 hit this exact deadlock and had to be unblocked manually.

## Self-test

Once merged, this PR's *own* commit on `alpha` will validate the fix on the next workflow-only PR. Previous trip wires (#849, #850) would no longer reproduce.

## Test plan

- [ ] CI Lint & Validate runs on this PR (test.yml is itself in `.github/workflows/`, which previously didn't trigger; it should now run and pass green).
- [ ] On the next workflow-only / docs-only PR after this lands, auto-merge fires without manual intervention.

https://claude.ai/code/session_019L8SKwRdyuzt7VLAo83JU2

---
_Generated by [Claude Code](https://claude.ai/code/session_019L8SKwRdyuzt7VLAo83JU2)_