### PR TITLE
feat: Song media uploads (audio + sheet music + MIDI/MusicXML) via Song Editor (closes #853)

### DIFF
--- a/appWeb/public_html/.htaccess
+++ b/appWeb/public_html/.htaccess
@@ -69,6 +69,14 @@ RewriteRule ^api$ api.php [QSA,L]
 # /og-image → og-image.php (hides PHP extension from OG meta tags)
 RewriteRule ^og-image$ og-image.php [QSA,L]
 
+# /song-media/<id> → song-media.php?id=<id>  (#853)
+# Gated streaming endpoint for tblSongMedia rows. The handler does
+# checkContentAccess('song', <SongId>) so this URL is safe to expose
+# regardless of the song's restriction state. Only numeric ids are
+# routed; any other shape falls through to the SPA catch-all and
+# 404s naturally.
+RewriteRule ^song-media/([0-9]+)$ song-media.php?id=$1 [L]
+
 # ==========================================================================
 # SERVICE WORKER ROUTING (#81)
 #

--- a/appWeb/public_html/includes/SongData.php
+++ b/appWeb/public_html/includes/SongData.php
@@ -794,6 +794,83 @@ class SongData
     }
 
     /**
+     * Pull `[songId => [{id, kind, fileName, mimeType, sizeBytes,
+     *                    annotation, sortOrder, streamUrl}, …]]` from
+     * tblSongMedia (#853). Schema-probed; pre-migration deployments
+     * get an empty map so the public song page just doesn't render
+     * the media block.
+     *
+     * Bytes are NEVER returned by this method — only metadata. The
+     * public surface uses streamUrl (= /song-media/<id>) which is
+     * served by the gated route (phase E) so checkContentAccess()
+     * applies regardless of whether the underlying storage is the
+     * filesystem or the database.
+     *
+     * @param string[]|null $songIds Limit to these SongIds; null = all
+     * @return array<string, array<int, array{id:int,kind:string,fileName:string,mimeType:string,sizeBytes:int,annotation:string,sortOrder:int,streamUrl:string}>>
+     */
+    private function _songMediaMap(?array $songIds = null): array
+    {
+        $hasSchema = false;
+        try {
+            $probe = $this->db->prepare(
+                "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+                  WHERE TABLE_SCHEMA = DATABASE()
+                    AND TABLE_NAME   = 'tblSongMedia'
+                  LIMIT 1"
+            );
+            $probe->execute();
+            $hasSchema = $probe->get_result()->fetch_row() !== null;
+            $probe->close();
+        } catch (\Throwable $_e) { /* fall through */ }
+        if (!$hasSchema) return [];
+
+        try {
+            $select = 'SELECT Id, SongId, Kind, FileName, MimeType, SizeBytes,
+                              Annotation, SortOrder
+                         FROM tblSongMedia';
+            if ($songIds === null) {
+                $sql  = $select . ' ORDER BY SongId, Kind ASC, SortOrder ASC, Id ASC';
+                $stmt = $this->db->prepare($sql);
+            } else {
+                $songIds = array_values(array_filter(array_unique(array_map(
+                    static fn($s) => trim((string)$s),
+                    $songIds
+                ))));
+                if (!$songIds) return [];
+                $ph   = implode(',', array_fill(0, count($songIds), '?'));
+                $sql  = $select . " WHERE SongId IN ($ph)"
+                      . ' ORDER BY SongId, Kind ASC, SortOrder ASC, Id ASC';
+                $stmt = $this->db->prepare($sql);
+                $types = str_repeat('s', count($songIds));
+                $stmt->bind_param($types, ...$songIds);
+            }
+            $stmt->execute();
+            $res = $stmt->get_result();
+            $out = [];
+            while ($row = $res->fetch_assoc()) {
+                $sid = (string)$row['SongId'];
+                if (!isset($out[$sid])) $out[$sid] = [];
+                $out[$sid][] = [
+                    'id'         => (int)$row['Id'],
+                    'kind'       => (string)$row['Kind'],
+                    'fileName'   => (string)$row['FileName'],
+                    'mimeType'   => (string)$row['MimeType'],
+                    'sizeBytes'  => (int)$row['SizeBytes'],
+                    'annotation' => (string)($row['Annotation'] ?? ''),
+                    'sortOrder'  => (int)$row['SortOrder'],
+                    'streamUrl'  => '/song-media/' . (int)$row['Id'],
+                ];
+            }
+            $stmt->close();
+            return $out;
+        } catch (\Throwable $e) {
+            error_log('[SongData::_songMediaMap] ' . $e->getMessage());
+            return [];
+        }
+    }
+
+    /**
      * Pull `[entityKey => [{slug, name, category, url, note, verified, iconClass}, ...]]`
      * from one of the three tblXxxExternalLinks join tables (#833).
      * Generic over the three entity types — `$entityType` selects the
@@ -2219,6 +2296,24 @@ class SongData
            pre-migration deployment via the schema probe. */
         $worksMap = $this->_worksMap([$songId]);
         $row['works'] = $worksMap[$songId] ?? [];
+
+        /* #853 — accompanying media (audio + sheet PDF + MIDI +
+           MusicXML). Empty array on pre-migration. The legacy
+           HasAudio / HasSheetMusic flags from MissionPraise scrape
+           data continue to populate the indicator badges, but if
+           tblSongMedia carries any rows of that kind for this song,
+           we override the flag to true so the public surface
+           reflects curator uploads — keeps the indicator badges
+           on the songbook list page in sync without a separate
+           denormalised counter. */
+        $mediaMap = $this->_songMediaMap([$songId]);
+        $row['media'] = $mediaMap[$songId] ?? [];
+        if (!empty($row['media'])) {
+            foreach ($row['media'] as $m) {
+                if (($m['kind'] ?? '') === 'audio')        $row['hasAudio']       = true;
+                if (($m['kind'] ?? '') === 'sheet-music')  $row['hasSheetMusic']  = true;
+            }
+        }
 
         return $row;
     }

--- a/appWeb/public_html/includes/infoAppVer.php
+++ b/appWeb/public_html/includes/infoAppVer.php
@@ -79,7 +79,7 @@ $app["Application"]["Description"]["Keywords"] = "hymns, worship, lyrics, songbo
 /* Semantic version number (MAJOR.MINOR.PATCH) */
 /* Auto-bumped by the version-bump GitHub Action on push to beta */
 /* v1.x.x = Phase 1 (local JSON data), v2.x.x = Phase 2 (iLyrics dB) */
-$app["Application"]["Version"]["Number"] = "0.50.0";
+$app["Application"]["Version"]["Number"] = "0.75.0";
 
 /* Version name: human-readable release name (e.g., "Hymnal", NULL if unused) */
 $app["Application"]["Version"]["Name"] = NULL;

--- a/appWeb/public_html/includes/pages/song.php
+++ b/appWeb/public_html/includes/pages/song.php
@@ -834,6 +834,89 @@ try {
     </section>
 
     <?php
+        /* #853 — accompanying media (audio + sheet PDF + MIDI + MusicXML).
+           Reads $song['media'] attached by SongData::_songMediaMap.
+           Audio gets an inline <audio> player (HTML5 native, supports
+           HTTP Range so the streaming endpoint's 206 response lets the
+           seek-bar work). Sheet music / MIDI / MusicXML get download
+           buttons. Annotations render as a per-row caption. Hidden
+           when no media is attached. */
+        $songMedia = $song['media'] ?? [];
+        if (!empty($songMedia)):
+            $mediaByKind = [
+                'audio' => [], 'sheet-music' => [], 'midi' => [], 'musicxml' => [],
+            ];
+            foreach ($songMedia as $m) {
+                $k = (string)($m['kind'] ?? '');
+                if (isset($mediaByKind[$k])) $mediaByKind[$k][] = $m;
+            }
+    ?>
+    <section id="song-media" class="song-media mt-4 pt-3 border-top" aria-label="Recordings &amp; resources">
+        <h2 class="h6 mb-3 d-flex align-items-center gap-2">
+            <i class="fa-solid fa-music me-1 text-muted" aria-hidden="true"></i>
+            Recordings &amp; resources
+        </h2>
+
+        <?php if (!empty($mediaByKind['audio'])): ?>
+            <div class="song-media-audio mb-3">
+                <?php foreach ($mediaByKind['audio'] as $m): ?>
+                    <div class="mb-2">
+                        <div class="small text-muted mb-1">
+                            <?= htmlspecialchars($m['fileName']) ?>
+                            <?php if (!empty($m['annotation'])): ?>
+                                — <em><?= htmlspecialchars($m['annotation']) ?></em>
+                            <?php endif; ?>
+                        </div>
+                        <audio controls preload="none" class="w-100"
+                               src="<?= htmlspecialchars($m['streamUrl']) ?>"
+                               type="<?= htmlspecialchars($m['mimeType']) ?>">
+                            Your browser doesn't support the audio element.
+                            <a href="<?= htmlspecialchars($m['streamUrl']) ?>">Download <?= htmlspecialchars($m['fileName']) ?></a>.
+                        </audio>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+        <?php endif; ?>
+
+        <?php
+            /* Non-audio kinds render as a chip-row of download buttons
+               so the section stays compact when a song has 1 PDF + 1
+               MIDI + 1 MusicXML. */
+            $downloadKinds = [
+                'sheet-music' => ['label' => 'Sheet music',  'icon' => 'fa-file-pdf'],
+                'midi'        => ['label' => 'MIDI',         'icon' => 'fa-music'],
+                'musicxml'    => ['label' => 'MusicXML',     'icon' => 'fa-file-code'],
+            ];
+            $hasDownloads = false;
+            foreach ($downloadKinds as $k => $_) {
+                if (!empty($mediaByKind[$k])) { $hasDownloads = true; break; }
+            }
+        ?>
+        <?php if ($hasDownloads): ?>
+            <?php foreach ($downloadKinds as $kind => $kMeta): ?>
+                <?php if (empty($mediaByKind[$kind])) continue; ?>
+                <div class="mb-2">
+                    <div class="text-uppercase small text-muted mb-1"><?= htmlspecialchars($kMeta['label']) ?></div>
+                    <div class="d-flex flex-wrap gap-2">
+                        <?php foreach ($mediaByKind[$kind] as $m): ?>
+                            <a href="<?= htmlspecialchars($m['streamUrl']) ?>"
+                               class="btn btn-sm btn-outline-secondary d-inline-flex align-items-center gap-2"
+                               download="<?= htmlspecialchars($m['fileName']) ?>">
+                                <i class="fa-solid <?= htmlspecialchars($kMeta['icon']) ?>" aria-hidden="true"></i>
+                                <span><?= htmlspecialchars($m['fileName']) ?></span>
+                                <?php if (!empty($m['annotation'])): ?>
+                                    <span class="text-muted small">— <?= htmlspecialchars($m['annotation']) ?></span>
+                                <?php endif; ?>
+                            </a>
+                        <?php endforeach; ?>
+                    </div>
+                </div>
+            <?php endforeach; ?>
+        <?php endif; ?>
+    </section>
+    <?php endif; ?>
+
+    <?php
         /* #840 — "Part of work" panel. Reads $song['works'] attached by
            SongData::_worksMap (#840). Lists each Work this song belongs
            to with its sibling members ("other versions of this work")

--- a/appWeb/public_html/js/modules/song-media-editor.js
+++ b/appWeb/public_html/js/modules/song-media-editor.js
@@ -1,0 +1,501 @@
+/*
+ * iHymns — Song Media Editor (#853)
+ *
+ * ESM module that drives the Song Editor's "Media" tab.
+ *
+ * Responsibilities:
+ *   - List existing media for the active song (one block per kind).
+ *   - Per-row: annotation edit (debounced save), drag-handle reorder
+ *     (within a kind only — kinds don't intermix), delete with confirm.
+ *   - Per-kind: file picker + upload button. Mime + size pre-checks
+ *     happen in the browser to fail fast; the server still validates
+ *     authoritatively (this module never trusts its own checks).
+ *
+ * Lifecycle:
+ *   bootSongMediaEditor(rootElement) is called once on page load. The
+ *   module subscribes to document's 'iHymns:song-loaded' event so it
+ *   refreshes whenever the curator picks a different song. It also
+ *   refreshes when the Media tab is shown — covers the case where the
+ *   tab was hidden during the load event.
+ *
+ * Talks to:
+ *   - GET  /manage/editor/api?action=song_media_list&song_id=<id>
+ *   - POST /manage/editor/api?action=song_media_upload   (multipart)
+ *   - POST /manage/editor/api?action=song_media_update
+ *   - POST /manage/editor/api?action=song_media_reorder
+ *   - POST /manage/editor/api?action=song_media_delete
+ */
+
+const API_BASE = '/manage/editor/api';
+
+const KIND_META = {
+    'audio': {
+        label: 'Audio',
+        icon: 'bi-music-note-beamed',
+        helpText: 'Recordings — MP3, M4A, AAC, OGG, WAV, FLAC, ALAC.',
+        accept: 'audio/mpeg,audio/mp4,audio/aac,audio/wav,audio/x-wav,audio/wave,audio/flac,audio/x-flac,audio/ogg,audio/aiff,audio/x-aiff,.mp3,.m4a,.aac,.wav,.flac,.ogg,.aiff,.alac',
+        sizeCap: 50 * 1024 * 1024,
+    },
+    'sheet-music': {
+        label: 'Sheet music (PDF)',
+        icon: 'bi-file-earmark-pdf',
+        helpText: 'Notation as PDF — full score, lead sheet, lyrics-only sheet, etc.',
+        accept: 'application/pdf,.pdf',
+        sizeCap: 10 * 1024 * 1024,
+    },
+    'midi': {
+        label: 'MIDI',
+        icon: 'bi-music-player',
+        helpText: 'MIDI sequence — for accompaniment apps, projection software.',
+        accept: 'audio/midi,audio/x-midi,audio/mid,.mid,.midi',
+        sizeCap: 1 * 1024 * 1024,
+    },
+    'musicxml': {
+        label: 'MusicXML',
+        icon: 'bi-file-earmark-code',
+        helpText: 'MusicXML notation — interchangeable score format.',
+        accept: 'application/vnd.recordare.musicxml+xml,application/xml,text/xml,.musicxml,.xml',
+        sizeCap: 1 * 1024 * 1024,
+    },
+};
+
+const KIND_ORDER = ['audio', 'sheet-music', 'midi', 'musicxml'];
+
+function escapeHtml(s) {
+    return String(s)
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
+
+function formatBytes(n) {
+    if (!Number.isFinite(n) || n <= 0) return '0 B';
+    const units = ['B', 'KB', 'MB', 'GB'];
+    let i = 0;
+    while (n >= 1024 && i < units.length - 1) { n /= 1024; i++; }
+    return `${n.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+function formatDate(s) {
+    if (!s) return '';
+    /* "2026-05-04 14:23:11" → "2026-05-04 14:23" — the seconds rarely
+       help and clutter the row. */
+    return String(s).replace(/:\d{2}$/, '');
+}
+
+/**
+ * Bootstrap the Song Media Editor on the given root element.
+ * @param {HTMLElement} root  The panel container (#panel-media).
+ */
+export function bootSongMediaEditor(root) {
+    if (!root) return null;
+
+    let currentSongId = null;
+    let inflight = null;       /* AbortController for the most recent list fetch */
+    let mediaByKind = {};      /* {kind: [row, ...]} keyed for render */
+
+    /* Top-level layout: per-kind block, each with its own upload form
+       and row list. Rendered once on boot; rows render dynamically. */
+    root.innerHTML = `
+        <div class="song-media-empty text-muted small py-3" data-state="empty" hidden>
+            Pick a song to manage its media.
+        </div>
+        <div class="song-media-loading text-muted small py-3" data-state="loading" hidden>
+            <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
+            Loading media…
+        </div>
+        <div class="song-media-error alert alert-danger small py-2 px-3 mb-3" data-state="error" hidden></div>
+        <div class="song-media-blocks" data-state="ready" hidden></div>
+    `;
+
+    const elEmpty   = root.querySelector('[data-state="empty"]');
+    const elLoading = root.querySelector('[data-state="loading"]');
+    const elError   = root.querySelector('[data-state="error"]');
+    const elBlocks  = root.querySelector('[data-state="ready"]');
+
+    function showState(name, message) {
+        elEmpty.hidden = name !== 'empty';
+        elLoading.hidden = name !== 'loading';
+        elError.hidden = name !== 'error';
+        elBlocks.hidden = name !== 'ready';
+        if (name === 'error') {
+            elError.textContent = message || 'Could not load media.';
+        }
+    }
+
+    /* ----- Server calls -------------------------------------------- */
+
+    async function apiList(songId) {
+        if (inflight) inflight.abort();
+        inflight = new AbortController();
+        const url = `${API_BASE}?action=song_media_list&song_id=${encodeURIComponent(songId)}`;
+        const res = await fetch(url, {
+            credentials: 'same-origin',
+            signal: inflight.signal,
+        });
+        if (!res.ok) throw new Error(`List failed: HTTP ${res.status}`);
+        const data = await res.json();
+        if (data.error) throw new Error(data.error);
+        return Array.isArray(data.media) ? data.media : [];
+    }
+
+    async function apiUpload(songId, kind, file, annotation) {
+        const fd = new FormData();
+        fd.append('song_id', songId);
+        fd.append('kind', kind);
+        fd.append('annotation', annotation || '');
+        fd.append('file', file);
+        const res = await fetch(`${API_BASE}?action=song_media_upload`, {
+            method: 'POST',
+            credentials: 'same-origin',
+            body: fd,
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok || data.error) {
+            throw new Error(data.error || `Upload failed: HTTP ${res.status}`);
+        }
+        return data.media;
+    }
+
+    async function apiUpdate(mediaId, annotation) {
+        const fd = new FormData();
+        fd.append('media_id', String(mediaId));
+        fd.append('annotation', annotation || '');
+        const res = await fetch(`${API_BASE}?action=song_media_update`, {
+            method: 'POST',
+            credentials: 'same-origin',
+            body: fd,
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok || data.error) {
+            throw new Error(data.error || `Update failed: HTTP ${res.status}`);
+        }
+        return data;
+    }
+
+    async function apiDelete(mediaId) {
+        const fd = new FormData();
+        fd.append('media_id', String(mediaId));
+        const res = await fetch(`${API_BASE}?action=song_media_delete`, {
+            method: 'POST',
+            credentials: 'same-origin',
+            body: fd,
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok || data.error) {
+            throw new Error(data.error || `Delete failed: HTTP ${res.status}`);
+        }
+        return data;
+    }
+
+    async function apiReorder(songId, kind, ids) {
+        const fd = new FormData();
+        fd.append('song_id', songId);
+        fd.append('kind', kind);
+        ids.forEach(id => fd.append('ids[]', String(id)));
+        const res = await fetch(`${API_BASE}?action=song_media_reorder`, {
+            method: 'POST',
+            credentials: 'same-origin',
+            body: fd,
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok || data.error) {
+            throw new Error(data.error || `Reorder failed: HTTP ${res.status}`);
+        }
+        return data;
+    }
+
+    /* ----- Render --------------------------------------------------- */
+
+    function groupByKind(rows) {
+        const out = {};
+        KIND_ORDER.forEach(k => { out[k] = []; });
+        rows.forEach(r => {
+            if (!out[r.kind]) out[r.kind] = [];
+            out[r.kind].push(r);
+        });
+        return out;
+    }
+
+    function rowMarkup(row) {
+        const meta = KIND_META[row.kind] || { icon: 'bi-file-earmark', label: row.kind };
+        return `
+            <div class="card bg-dark border-secondary mb-2 song-media-row"
+                 data-media-id="${row.id}"
+                 draggable="true">
+                <div class="card-body py-2">
+                    <div class="d-flex align-items-start gap-2">
+                        <i class="bi bi-grip-vertical text-muted mt-1"
+                           aria-hidden="true"
+                           title="Drag to reorder"></i>
+                        <i class="bi ${escapeHtml(meta.icon)} text-info mt-1" aria-hidden="true"></i>
+                        <div class="flex-grow-1">
+                            <div class="d-flex justify-content-between align-items-center gap-2">
+                                <a href="${escapeHtml(row.stream_url)}"
+                                   target="_blank" rel="noopener"
+                                   class="text-info text-decoration-none small fw-semibold text-truncate"
+                                   title="Open in new tab">
+                                    ${escapeHtml(row.file_name)}
+                                </a>
+                                <span class="text-muted small">
+                                    ${escapeHtml(row.mime_type)} · ${formatBytes(row.size_bytes)}
+                                </span>
+                            </div>
+                            <input type="text"
+                                   class="form-control form-control-sm mt-1 song-media-annotation"
+                                   placeholder="Optional annotation (e.g. '1989 BBC recording')"
+                                   maxlength="255"
+                                   value="${escapeHtml(row.annotation || '')}">
+                            <div class="text-muted" style="font-size: 0.7rem; margin-top: 0.15rem;">
+                                Uploaded ${escapeHtml(formatDate(row.uploaded_at))}
+                                · Backend: ${escapeHtml(row.storage_backend)}
+                            </div>
+                        </div>
+                        <button type="button"
+                                class="btn btn-sm btn-outline-danger song-media-delete"
+                                title="Remove this file">
+                            <i class="bi bi-trash"></i>
+                        </button>
+                    </div>
+                </div>
+            </div>
+        `;
+    }
+
+    function blockMarkup(kind) {
+        const meta = KIND_META[kind];
+        const rows = mediaByKind[kind] || [];
+        const rowsHtml = rows.length
+            ? rows.map(rowMarkup).join('')
+            : `<div class="text-muted small fst-italic py-2">No ${meta.label.toLowerCase()} uploaded yet.</div>`;
+        const capMb = (meta.sizeCap / (1024 * 1024)).toFixed(meta.sizeCap < 1024 * 1024 * 5 ? 1 : 0);
+        return `
+            <div class="form-section song-media-block" data-kind="${kind}">
+                <h6 class="section-title d-flex justify-content-between align-items-center">
+                    <span><i class="bi ${escapeHtml(meta.icon)} me-1"></i>${escapeHtml(meta.label)}</span>
+                    <span class="text-muted small fw-normal">${rows.length} file${rows.length === 1 ? '' : 's'}</span>
+                </h6>
+                <div class="text-muted small mb-2">${escapeHtml(meta.helpText)} Max ${capMb} MB.</div>
+                <div class="song-media-rows" data-rows="${kind}">${rowsHtml}</div>
+                <div class="row g-2 align-items-end mt-1">
+                    <div class="col-md-6">
+                        <input type="file"
+                               class="form-control form-control-sm song-media-file"
+                               data-upload-kind="${kind}"
+                               accept="${escapeHtml(meta.accept)}">
+                    </div>
+                    <div class="col-md-4">
+                        <input type="text"
+                               class="form-control form-control-sm song-media-pending-annotation"
+                               data-upload-kind="${kind}"
+                               placeholder="Optional annotation"
+                               maxlength="255">
+                    </div>
+                    <div class="col-md-2">
+                        <button type="button"
+                                class="btn btn-sm btn-amber w-100 song-media-upload-btn"
+                                data-upload-kind="${kind}"
+                                disabled>
+                            <i class="bi bi-cloud-upload me-1"></i>Upload
+                        </button>
+                    </div>
+                </div>
+                <div class="song-media-upload-status small text-muted mt-1" data-status-kind="${kind}"></div>
+            </div>
+        `;
+    }
+
+    function render() {
+        if (!currentSongId) {
+            showState('empty');
+            return;
+        }
+        elBlocks.innerHTML = KIND_ORDER.map(blockMarkup).join('');
+        showState('ready');
+        bindBlockHandlers();
+    }
+
+    /* ----- Event wiring -------------------------------------------- */
+
+    function bindBlockHandlers() {
+        elBlocks.querySelectorAll('.song-media-file').forEach(input => {
+            input.addEventListener('change', () => {
+                const kind = input.dataset.uploadKind;
+                const btn = elBlocks.querySelector(`.song-media-upload-btn[data-upload-kind="${kind}"]`);
+                btn.disabled = !(input.files && input.files[0]);
+            });
+        });
+
+        elBlocks.querySelectorAll('.song-media-upload-btn').forEach(btn => {
+            btn.addEventListener('click', async () => {
+                const kind = btn.dataset.uploadKind;
+                const fileInput = elBlocks.querySelector(`.song-media-file[data-upload-kind="${kind}"]`);
+                const noteInput = elBlocks.querySelector(`.song-media-pending-annotation[data-upload-kind="${kind}"]`);
+                const status    = elBlocks.querySelector(`[data-status-kind="${kind}"]`);
+                if (!fileInput || !fileInput.files || !fileInput.files[0]) return;
+                const file = fileInput.files[0];
+                const meta = KIND_META[kind];
+                if (file.size > meta.sizeCap) {
+                    status.className = 'song-media-upload-status small text-danger mt-1';
+                    status.textContent = `File too large (${formatBytes(file.size)} > ${formatBytes(meta.sizeCap)}).`;
+                    return;
+                }
+                btn.disabled = true;
+                status.className = 'song-media-upload-status small text-muted mt-1';
+                status.textContent = `Uploading ${escapeHtml(file.name)}…`;
+                try {
+                    const newRow = await apiUpload(currentSongId, kind, file, noteInput.value);
+                    if (!mediaByKind[kind]) mediaByKind[kind] = [];
+                    mediaByKind[kind].push(newRow);
+                    fileInput.value = '';
+                    noteInput.value = '';
+                    status.className = 'song-media-upload-status small text-success mt-1';
+                    status.textContent = `Uploaded ${escapeHtml(file.name)}.`;
+                    render();
+                } catch (err) {
+                    status.className = 'song-media-upload-status small text-danger mt-1';
+                    status.textContent = err.message || 'Upload failed.';
+                    btn.disabled = false;
+                }
+            });
+        });
+
+        elBlocks.querySelectorAll('.song-media-row').forEach(rowEl => {
+            const id = Number(rowEl.dataset.mediaId);
+
+            const noteInput = rowEl.querySelector('.song-media-annotation');
+            if (noteInput) {
+                let timer;
+                noteInput.addEventListener('input', () => {
+                    clearTimeout(timer);
+                    timer = setTimeout(() => {
+                        apiUpdate(id, noteInput.value).catch(() => {
+                            noteInput.classList.add('is-invalid');
+                            setTimeout(() => noteInput.classList.remove('is-invalid'), 1500);
+                        });
+                    }, 400);
+                });
+            }
+
+            const delBtn = rowEl.querySelector('.song-media-delete');
+            if (delBtn) {
+                delBtn.addEventListener('click', async () => {
+                    if (!confirm('Remove this file? Cannot be undone.')) return;
+                    try {
+                        await apiDelete(id);
+                        const block = rowEl.closest('.song-media-block');
+                        const kind  = block?.dataset.kind;
+                        if (kind && mediaByKind[kind]) {
+                            mediaByKind[kind] = mediaByKind[kind].filter(r => r.id !== id);
+                        }
+                        render();
+                    } catch (err) {
+                        alert(err.message || 'Delete failed.');
+                    }
+                });
+            }
+        });
+
+        /* Drag-reorder within a kind. Cross-kind drops are blocked
+           by checking the target's data-kind matches the source. */
+        elBlocks.querySelectorAll('.song-media-rows').forEach(container => {
+            const kind = container.dataset.rows;
+            let dragSrc = null;
+
+            container.addEventListener('dragstart', (e) => {
+                const card = e.target.closest('.song-media-row');
+                if (!card) return;
+                dragSrc = card;
+                card.style.opacity = '0.5';
+                e.dataTransfer.effectAllowed = 'move';
+                /* Required for Firefox to actually fire dragstart. */
+                e.dataTransfer.setData('text/plain', card.dataset.mediaId);
+            });
+
+            container.addEventListener('dragend', () => {
+                if (dragSrc) dragSrc.style.opacity = '';
+                dragSrc = null;
+            });
+
+            container.addEventListener('dragover', (e) => {
+                if (!dragSrc) return;
+                e.preventDefault();
+                const target = e.target.closest('.song-media-row');
+                if (!target || target === dragSrc) return;
+                const rect = target.getBoundingClientRect();
+                const before = (e.clientY - rect.top) < (rect.height / 2);
+                container.insertBefore(dragSrc, before ? target : target.nextSibling);
+            });
+
+            container.addEventListener('drop', async (e) => {
+                e.preventDefault();
+                if (!dragSrc) return;
+                const ids = Array.from(container.querySelectorAll('.song-media-row'))
+                    .map(el => Number(el.dataset.mediaId));
+                /* Optimistic UI: keep the new order, only revert on
+                   server failure. */
+                try {
+                    await apiReorder(currentSongId, kind, ids);
+                    if (mediaByKind[kind]) {
+                        const idMap = new Map(mediaByKind[kind].map(r => [r.id, r]));
+                        mediaByKind[kind] = ids.map(id => idMap.get(id)).filter(Boolean);
+                    }
+                } catch (err) {
+                    /* Re-fetch authoritative state on failure so UI
+                       matches server reality. */
+                    refresh();
+                }
+            });
+        });
+    }
+
+    /* ----- Refresh ------------------------------------------------- */
+
+    async function refresh() {
+        if (!currentSongId) {
+            showState('empty');
+            return;
+        }
+        showState('loading');
+        try {
+            const rows = await apiList(currentSongId);
+            mediaByKind = groupByKind(rows);
+            render();
+        } catch (err) {
+            if (err.name === 'AbortError') return;
+            showState('error', err.message || 'Could not load media.');
+        }
+    }
+
+    /* ----- Public hooks -------------------------------------------- */
+
+    /* Pre-existing song selection: read window.currentSongId on boot
+       so a curator who already had a song open before the module
+       loaded sees their media on first tab-show. */
+    if (typeof window.currentSongId === 'string' || typeof window.currentSongId === 'number') {
+        currentSongId = String(window.currentSongId || '');
+        if (currentSongId) refresh();
+    }
+
+    document.addEventListener('iHymns:song-loaded', (e) => {
+        const sid = String(e?.detail?.songId || '');
+        if (!sid || sid === currentSongId) {
+            /* Same song re-selected — no-op (avoids a redundant refetch). */
+            if (!sid) currentSongId = null;
+            if (!sid) showState('empty');
+            return;
+        }
+        currentSongId = sid;
+        refresh();
+    });
+
+    /* Tab-shown: refresh in case the tab was hidden during a song load
+       or the user switched away while a fetch was inflight. */
+    const tabBtn = document.getElementById('tab-media');
+    if (tabBtn) {
+        tabBtn.addEventListener('shown.bs.tab', () => {
+            if (currentSongId) refresh();
+        });
+    }
+
+    return { refresh };
+}

--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -79,6 +79,26 @@ function _songArtistsTableExists(\mysqli $db): bool
 }
 
 /**
+ * Cached probe for tblSongMedia (#853). The table arrives via
+ * migrate-song-media.php; until that migration has been applied, the
+ * song_media_* endpoints return early with a friendly 503 / empty
+ * list rather than 500ing on a partly-migrated install.
+ */
+function _songMedia_tableExists(\mysqli $db): bool
+{
+    static $cached = null;
+    if ($cached !== null) return $cached;
+    $stmt = $db->prepare(
+        "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tblSongMedia' LIMIT 1"
+    );
+    $stmt->execute();
+    $cached = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $cached;
+}
+
+/**
  * Validate + normalise an IETF BCP 47 language tag (#681).
  *
  * v1 grammar (matches the songbook editor's $validateBcp47): lowercase
@@ -2384,11 +2404,439 @@ switch ($action) {
         break;
 
     /* -----------------------------------------------------------------
+     * SONG_MEDIA_LIST — return the media rows attached to a song so the
+     * Song Editor's chip-list editor (#853 phase C) can render existing
+     * uploads on modal-open. Schema-probed: a pre-migration deploy
+     * returns an empty list rather than 500ing. Bytes are NEVER
+     * included in this payload — the editor surfaces filename,
+     * kind, mime, size, annotation; the bytes only travel via the
+     * /song-media/<id> streaming endpoint (phase E).
+     * ----------------------------------------------------------------- */
+    case 'song_media_list':
+        $songId = trim((string)($_GET['song_id'] ?? ''));
+        if ($songId === '') {
+            http_response_code(400);
+            echo json_encode(['error' => 'song_id required.']);
+            break;
+        }
+        try {
+            $db = getDbMysqli();
+            if (!_songMedia_tableExists($db)) {
+                /* Pre-migration deploy → empty list. */
+                echo json_encode(['ok' => true, 'media' => []]);
+                break;
+            }
+            $stmt = $db->prepare(
+                'SELECT Id, Kind, StorageBackend, FileName, MimeType, SizeBytes,
+                        Annotation, SortOrder, UploadedBy, UploadedAt
+                   FROM tblSongMedia
+                  WHERE SongId = ?
+                  ORDER BY Kind ASC, SortOrder ASC, Id ASC'
+            );
+            $stmt->bind_param('s', $songId);
+            $stmt->execute();
+            $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+            $stmt->close();
+            $media = array_map(
+                static fn(array $r): array => [
+                    'id'             => (int)$r['Id'],
+                    'kind'           => (string)$r['Kind'],
+                    'storage_backend'=> (string)$r['StorageBackend'],
+                    'file_name'      => (string)$r['FileName'],
+                    'mime_type'      => (string)$r['MimeType'],
+                    'size_bytes'     => (int)$r['SizeBytes'],
+                    'annotation'     => (string)($r['Annotation'] ?? ''),
+                    'sort_order'     => (int)$r['SortOrder'],
+                    'uploaded_by'    => isset($r['UploadedBy']) ? (int)$r['UploadedBy'] : null,
+                    'uploaded_at'    => (string)$r['UploadedAt'],
+                    'stream_url'     => '/song-media/' . (int)$r['Id'],
+                ],
+                $rows
+            );
+            echo json_encode(['ok' => true, 'media' => $media], JSON_UNESCAPED_UNICODE);
+        } catch (\Throwable $e) {
+            http_response_code(500);
+            error_log('[song_media_list] ' . $e->getMessage());
+            echo json_encode(['error' => 'Could not fetch media.']);
+        }
+        break;
+
+    /* -----------------------------------------------------------------
+     * SONG_MEDIA_UPLOAD — accept a single uploaded file for a song.
+     *
+     * Multipart fields:
+     *   song_id     — target SongId (must exist in tblSongs)
+     *   kind        — one of audio | sheet-music | midi | musicxml
+     *   annotation  — optional curator note (≤255 chars)
+     *   file        — the upload itself
+     *
+     * Pipeline:
+     *   1. requireEditor (already enforced globally at the top of the
+     *      file); upload-rights = editor / admin / global_admin.
+     *   2. Validate kind, song existence, $_FILES error code.
+     *   3. SongMediaStorage::validateUpload() — sniffs the MIME on
+     *      bytes (not the upload's declared content-type) + caps size
+     *      against per-kind SIZE_CAPS.
+     *   4. SongMediaStorage::stage() — writes to disk for FS kinds,
+     *      returns bytes for DB kinds. Handles dir mkdir + chmod.
+     *   5. INSERT tblSongMedia row, with SortOrder = (max+1) for the
+     *      same (song, kind) so new uploads land at the bottom.
+     *   6. On INSERT failure for an FS kind: unlink the staged file
+     *      so it doesn't orphan.
+     *   7. logActivity('song-media.upload', 'song', $songId, ...).
+     * ----------------------------------------------------------------- */
+    case 'song_media_upload':
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            http_response_code(405);
+            echo json_encode(['error' => 'POST method required.']);
+            break;
+        }
+        require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR
+            . 'includes' . DIRECTORY_SEPARATOR . 'SongMediaStorage.php';
+
+        $songId     = trim((string)($_POST['song_id'] ?? ''));
+        $kind       = trim((string)($_POST['kind'] ?? ''));
+        $annotation = trim((string)($_POST['annotation'] ?? ''));
+
+        if ($songId === '' || !in_array($kind, SongMediaStorage::allKinds(), true)) {
+            http_response_code(400);
+            echo json_encode(['error' => 'Missing or invalid song_id / kind.']);
+            break;
+        }
+        if ($annotation !== '' && function_exists('mb_substr')) {
+            $annotation = mb_substr($annotation, 0, 255);
+        }
+
+        if (!isset($_FILES['file']) || ($_FILES['file']['error'] ?? UPLOAD_ERR_NO_FILE) !== UPLOAD_ERR_OK) {
+            $err = $_FILES['file']['error'] ?? UPLOAD_ERR_NO_FILE;
+            $msg = match ($err) {
+                UPLOAD_ERR_INI_SIZE, UPLOAD_ERR_FORM_SIZE => 'File exceeds the server upload size limit.',
+                UPLOAD_ERR_NO_FILE                        => 'No file received — expected multipart with a "file" field.',
+                UPLOAD_ERR_PARTIAL                        => 'Upload was interrupted.',
+                default                                   => 'Upload failed.',
+            };
+            http_response_code(400);
+            echo json_encode(['error' => $msg, 'phpError' => $err]);
+            break;
+        }
+
+        $tmpPath  = (string)$_FILES['file']['tmp_name'];
+        $origName = (string)($_FILES['file']['name'] ?? 'upload');
+        $size     = (int)($_FILES['file']['size'] ?? 0);
+
+        try {
+            $db = getDbMysqli();
+            if (!_songMedia_tableExists($db)) {
+                http_response_code(503);
+                echo json_encode(['error' => 'Song Media migration has not been run.']);
+                break;
+            }
+
+            /* Song must exist — gives a clean 404 instead of an FK violation. */
+            $stmt = $db->prepare('SELECT 1 FROM tblSongs WHERE SongId = ? LIMIT 1');
+            $stmt->bind_param('s', $songId);
+            $stmt->execute();
+            $exists = $stmt->get_result()->fetch_row() !== null;
+            $stmt->close();
+            if (!$exists) {
+                http_response_code(404);
+                echo json_encode(['error' => 'Song not found.']);
+                break;
+            }
+
+            /* MIME sniff + size cap. Returns canonical extension/mime. */
+            $meta = SongMediaStorage::validateUpload($tmpPath, $kind, $size);
+
+            /* Read bytes once + stage. FS kinds get a path back; DB
+               kinds get the bytes for binding inline. */
+            $bytes = file_get_contents($tmpPath);
+            if ($bytes === false) {
+                throw new \RuntimeException('Could not read upload tempfile.');
+            }
+            $staged = SongMediaStorage::stage($bytes, $kind, $meta['extension']);
+
+            /* Sanitise the filename we record — keep just the basename
+               + clamp length so a curator-pasted weirdness doesn't end
+               up in our Content-Disposition header later. */
+            $cleanName = basename($origName);
+            $cleanName = preg_replace('/[\x00-\x1f\x7f]/', '', $cleanName) ?? 'upload';
+            $cleanName = function_exists('mb_substr')
+                ? mb_substr($cleanName, 0, 255)
+                : substr($cleanName, 0, 255);
+
+            /* SortOrder = (current max + 1) for this (song, kind) so
+               new uploads append; the curator can drag-reorder later. */
+            $stmt = $db->prepare(
+                'SELECT COALESCE(MAX(SortOrder), -1) AS m FROM tblSongMedia WHERE SongId = ? AND Kind = ?'
+            );
+            $stmt->bind_param('ss', $songId, $kind);
+            $stmt->execute();
+            $row = $stmt->get_result()->fetch_assoc();
+            $stmt->close();
+            $nextOrder = (int)($row['m'] ?? -1) + 1;
+
+            $uploadedBy = isset($currentUser['id']) ? (int)$currentUser['id'] : null;
+            $annotationOrNull = ($annotation !== '') ? $annotation : null;
+
+            /* Insert. Note: bind_param 's' for the BLOB content works
+               for our sub-16MB cap — mysqli is binary-safe; send_long_data
+               isn't required here. */
+            try {
+                $stmt = $db->prepare(
+                    'INSERT INTO tblSongMedia
+                         (SongId, Kind, StorageBackend, FileName, MimeType, SizeBytes,
+                          Sha256, Content, StoragePath, Annotation, SortOrder, UploadedBy)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+                );
+                $stmt->bind_param(
+                    'sssssissssii',
+                    $songId,
+                    $kind,
+                    $staged['backend'],
+                    $cleanName,
+                    $meta['mime'],
+                    $size,
+                    $staged['sha256'],
+                    $staged['content'],
+                    $staged['path'],
+                    $annotationOrNull,
+                    $nextOrder,
+                    $uploadedBy
+                );
+                $stmt->execute();
+                $newId = (int)$db->insert_id;
+                $stmt->close();
+            } catch (\Throwable $insertErr) {
+                /* Roll back the staged file so it doesn't orphan. */
+                if ($staged['backend'] === 'filesystem' && $staged['path'] !== null) {
+                    SongMediaStorage::deleteStorage([
+                        'StorageBackend' => 'filesystem',
+                        'StoragePath'    => $staged['path'],
+                    ]);
+                }
+                throw $insertErr;
+            }
+
+            if (function_exists('logActivity')) {
+                logActivity(
+                    'song-media.upload',
+                    'song',
+                    $songId,
+                    [
+                        'media_id'   => $newId,
+                        'kind'       => $kind,
+                        'backend'    => $staged['backend'],
+                        'file_name'  => $cleanName,
+                        'mime'       => $meta['mime'],
+                        'size_bytes' => $size,
+                        'sha256'     => $staged['sha256'],
+                    ]
+                );
+            }
+
+            echo json_encode([
+                'ok'    => true,
+                'media' => [
+                    'id'              => $newId,
+                    'kind'            => $kind,
+                    'storage_backend' => $staged['backend'],
+                    'file_name'       => $cleanName,
+                    'mime_type'       => $meta['mime'],
+                    'size_bytes'      => $size,
+                    'annotation'      => $annotation,
+                    'sort_order'      => $nextOrder,
+                    'uploaded_by'     => $uploadedBy,
+                    'uploaded_at'     => date('Y-m-d H:i:s'),
+                    'stream_url'      => '/song-media/' . $newId,
+                ],
+            ], JSON_UNESCAPED_UNICODE);
+        } catch (\Throwable $e) {
+            $msg = $e->getMessage();
+            /* SongMediaStorage throws \RuntimeException for user-fixable
+               problems (wrong mime, oversize, empty); 400 those.
+               Anything else is server-side → 500. */
+            $userFacing = $e instanceof \RuntimeException || $e instanceof \InvalidArgumentException;
+            http_response_code($userFacing ? 400 : 500);
+            error_log('[song_media_upload] ' . $msg);
+            echo json_encode(['error' => $userFacing ? $msg : 'Upload failed.']);
+        }
+        break;
+
+    /* -----------------------------------------------------------------
+     * SONG_MEDIA_DELETE — remove a single media row (and its underlying
+     * storage). FS-backed: unlinks the file too. DB-backed: blob goes
+     * with the row.
+     *
+     * POST: media_id
+     * ----------------------------------------------------------------- */
+    case 'song_media_delete':
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            http_response_code(405);
+            echo json_encode(['error' => 'POST method required.']);
+            break;
+        }
+        require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR
+            . 'includes' . DIRECTORY_SEPARATOR . 'SongMediaStorage.php';
+
+        $mediaId = (int)($_POST['media_id'] ?? 0);
+        if ($mediaId <= 0) {
+            http_response_code(400);
+            echo json_encode(['error' => 'media_id required.']);
+            break;
+        }
+
+        try {
+            $db = getDbMysqli();
+            if (!_songMedia_tableExists($db)) {
+                http_response_code(404);
+                echo json_encode(['error' => 'Media not found.']);
+                break;
+            }
+            $stmt = $db->prepare(
+                'SELECT Id, SongId, Kind, StorageBackend, StoragePath, FileName
+                   FROM tblSongMedia WHERE Id = ? LIMIT 1'
+            );
+            $stmt->bind_param('i', $mediaId);
+            $stmt->execute();
+            $row = $stmt->get_result()->fetch_assoc();
+            $stmt->close();
+            if (!$row) {
+                http_response_code(404);
+                echo json_encode(['error' => 'Media not found.']);
+                break;
+            }
+
+            /* Unlink first, then delete the row. If the unlink fails
+               we still proceed — orphan files on disk are recoverable;
+               leaving the row alive after a "delete me" is worse. */
+            SongMediaStorage::deleteStorage([
+                'StorageBackend' => (string)$row['StorageBackend'],
+                'StoragePath'    => (string)($row['StoragePath'] ?? ''),
+            ]);
+
+            $stmt = $db->prepare('DELETE FROM tblSongMedia WHERE Id = ?');
+            $stmt->bind_param('i', $mediaId);
+            $stmt->execute();
+            $stmt->close();
+
+            if (function_exists('logActivity')) {
+                logActivity(
+                    'song-media.delete',
+                    'song',
+                    (string)$row['SongId'],
+                    [
+                        'media_id'  => $mediaId,
+                        'kind'      => (string)$row['Kind'],
+                        'backend'   => (string)$row['StorageBackend'],
+                        'file_name' => (string)$row['FileName'],
+                    ]
+                );
+            }
+
+            echo json_encode(['ok' => true, 'deleted' => $mediaId]);
+        } catch (\Throwable $e) {
+            http_response_code(500);
+            error_log('[song_media_delete] ' . $e->getMessage());
+            echo json_encode(['error' => 'Delete failed.']);
+        }
+        break;
+
+    /* -----------------------------------------------------------------
+     * SONG_MEDIA_REORDER — rewrite SortOrder for one (song, kind)
+     * group. The UI posts the new ordered list; we treat array index
+     * as the new SortOrder and write each row in a single transaction.
+     *
+     * POST:
+     *   song_id
+     *   kind
+     *   ids[] — list of media row Ids in the new order
+     * ----------------------------------------------------------------- */
+    case 'song_media_reorder':
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            http_response_code(405);
+            echo json_encode(['error' => 'POST method required.']);
+            break;
+        }
+        require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR
+            . 'includes' . DIRECTORY_SEPARATOR . 'SongMediaStorage.php';
+
+        $songId = trim((string)($_POST['song_id'] ?? ''));
+        $kind   = trim((string)($_POST['kind'] ?? ''));
+        $rawIds = $_POST['ids'] ?? [];
+        if (!is_array($rawIds)) $rawIds = [];
+
+        if ($songId === '' || !in_array($kind, SongMediaStorage::allKinds(), true)) {
+            http_response_code(400);
+            echo json_encode(['error' => 'Missing or invalid song_id / kind.']);
+            break;
+        }
+
+        $orderedIds = [];
+        foreach ($rawIds as $raw) {
+            $id = (int)$raw;
+            if ($id > 0 && !in_array($id, $orderedIds, true)) $orderedIds[] = $id;
+        }
+        if (empty($orderedIds)) {
+            echo json_encode(['ok' => true, 'reordered' => 0]);
+            break;
+        }
+
+        try {
+            $db = getDbMysqli();
+            if (!_songMedia_tableExists($db)) {
+                http_response_code(503);
+                echo json_encode(['error' => 'Song Media migration has not been run.']);
+                break;
+            }
+            $db->begin_transaction();
+            try {
+                /* UPDATE one row at a time, scoped to (song, kind, id)
+                   so a curator can't accidentally reorder rows from
+                   another song or another kind by passing the wrong
+                   ids — the WHERE clause is the safety net. */
+                $stmt = $db->prepare(
+                    'UPDATE tblSongMedia SET SortOrder = ?
+                      WHERE Id = ? AND SongId = ? AND Kind = ?'
+                );
+                $written = 0;
+                foreach ($orderedIds as $i => $id) {
+                    $stmt->bind_param('iiss', $i, $id, $songId, $kind);
+                    $stmt->execute();
+                    $written += $stmt->affected_rows;
+                }
+                $stmt->close();
+                $db->commit();
+            } catch (\Throwable $txErr) {
+                try { $db->rollback(); } catch (\Throwable $_) {}
+                throw $txErr;
+            }
+
+            if (function_exists('logActivity')) {
+                logActivity(
+                    'song-media.reorder',
+                    'song',
+                    $songId,
+                    [
+                        'kind'         => $kind,
+                        'ordered_ids'  => $orderedIds,
+                    ]
+                );
+            }
+
+            echo json_encode(['ok' => true, 'reordered' => $written]);
+        } catch (\Throwable $e) {
+            http_response_code(500);
+            error_log('[song_media_reorder] ' . $e->getMessage());
+            echo json_encode(['error' => 'Reorder failed.']);
+        }
+        break;
+
+    /* -----------------------------------------------------------------
      * Unknown action
      * ----------------------------------------------------------------- */
     default:
         http_response_code(400);
-        echo json_encode(['error' => 'Unknown action. Use: load, save, save_song, save_song_tags, tag_search, credit_search, bulk_tag, list_revisions, restore_revision, get_translations, add_translation, remove_translation, get_song_links, add_song_link, remove_song_link, suggest_song_links, dismiss_song_link_suggestion, bulk_import_zip, bulk_import_status']);
+        echo json_encode(['error' => 'Unknown action. Use: load, save, save_song, save_song_tags, tag_search, credit_search, bulk_tag, list_revisions, restore_revision, get_translations, add_translation, remove_translation, get_song_links, add_song_link, remove_song_link, suggest_song_links, dismiss_song_link_suggestion, bulk_import_zip, bulk_import_status, song_media_list, song_media_upload, song_media_delete, song_media_reorder']);
         break;
 }
 

--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -2663,6 +2663,65 @@ switch ($action) {
         break;
 
     /* -----------------------------------------------------------------
+     * SONG_MEDIA_UPDATE — patch the annotation on an existing row.
+     * Only Annotation is mutable post-upload — kind / file / mime /
+     * size are immutable (delete + re-upload to change them).
+     *
+     * POST: media_id, annotation
+     * ----------------------------------------------------------------- */
+    case 'song_media_update':
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            http_response_code(405);
+            echo json_encode(['error' => 'POST method required.']);
+            break;
+        }
+        $mediaId    = (int)($_POST['media_id'] ?? 0);
+        $annotation = trim((string)($_POST['annotation'] ?? ''));
+        if ($mediaId <= 0) {
+            http_response_code(400);
+            echo json_encode(['error' => 'media_id required.']);
+            break;
+        }
+        if ($annotation !== '' && function_exists('mb_substr')) {
+            $annotation = mb_substr($annotation, 0, 255);
+        }
+        $annotationOrNull = ($annotation !== '') ? $annotation : null;
+        try {
+            $db = getDbMysqli();
+            if (!_songMedia_tableExists($db)) {
+                http_response_code(404);
+                echo json_encode(['error' => 'Media not found.']);
+                break;
+            }
+            $stmt = $db->prepare(
+                'UPDATE tblSongMedia SET Annotation = ? WHERE Id = ?'
+            );
+            $stmt->bind_param('si', $annotationOrNull, $mediaId);
+            $stmt->execute();
+            $touched = $stmt->affected_rows;
+            $stmt->close();
+            if ($touched === 0) {
+                http_response_code(404);
+                echo json_encode(['error' => 'Media not found.']);
+                break;
+            }
+            if (function_exists('logActivity')) {
+                logActivity(
+                    'song-media.update',
+                    'song-media',
+                    (string)$mediaId,
+                    ['annotation' => $annotation]
+                );
+            }
+            echo json_encode(['ok' => true, 'media_id' => $mediaId]);
+        } catch (\Throwable $e) {
+            http_response_code(500);
+            error_log('[song_media_update] ' . $e->getMessage());
+            echo json_encode(['error' => 'Update failed.']);
+        }
+        break;
+
+    /* -----------------------------------------------------------------
      * SONG_MEDIA_DELETE — remove a single media row (and its underlying
      * storage). FS-backed: unlinks the file too. DB-backed: blob goes
      * with the row.

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -544,6 +544,17 @@ function selectSong(songId) {
     currentSongId = songId;
     updateHistoryButtonState();
 
+    /* #853 — broadcast a song-loaded event so independent modules
+       (e.g. the Media tab editor) can refresh their state without
+       having to monkey-patch this function. The detail.songId is
+       canonical; window.currentSongId stays the source of truth
+       for late-joiners that miss the event. */
+    try {
+        document.dispatchEvent(new CustomEvent('iHymns:song-loaded', {
+            detail: { songId: songId }
+        }));
+    } catch (_e) { /* IE11 polyfill territory; harmless to skip */ }
+
     /* Show the editor form, hide the empty state (#246). */
     var editorEmpty = document.getElementById('editorEmpty');
     var editorForm = document.getElementById('editorForm');

--- a/appWeb/public_html/manage/editor/index.php
+++ b/appWeb/public_html/manage/editor/index.php
@@ -483,6 +483,22 @@ $currentUser = getCurrentUser();
                         </button>
                     </li>
 
+                    <!-- Media tab trigger (#853) -->
+                    <li class="nav-item" role="presentation">
+                        <button
+                            class="nav-link"
+                            id="tab-media"
+                            data-bs-toggle="tab"
+                            data-bs-target="#panel-media"
+                            type="button"
+                            role="tab"
+                            aria-controls="panel-media"
+                            aria-selected="false"
+                        >
+                            <i class="bi bi-music-note-list me-1"></i>Media
+                        </button>
+                    </li>
+
                     <!-- Preview tab trigger -->
                     <li class="nav-item" role="presentation">
                         <button
@@ -1130,6 +1146,42 @@ $currentUser = getCurrentUser();
 
 
                     <!-- -------------------------------------------------
+                         MEDIA TAB PANEL (#853)
+
+                         Per-song accompanying-files manager. The contents
+                         are rendered by the song-media-editor.js ESM
+                         module which is booted at the bottom of this file
+                         (after editor.js so the song-loaded event is
+                         observable from boot onwards).
+                         ------------------------------------------------- -->
+                    <div
+                        class="tab-pane fade"
+                        id="panel-media"
+                        role="tabpanel"
+                        aria-labelledby="tab-media"
+                    >
+                        <div class="form-section">
+                            <h6 class="section-title">
+                                <i class="bi bi-music-note-list me-1"></i>Accompanying Media
+                            </h6>
+                            <div class="text-muted small mb-3">
+                                Upload audio recordings, sheet music, MIDI sequences and
+                                MusicXML notation alongside this song. Files inherit the
+                                song's content-access rules — gated songs gate their media
+                                automatically. Sheet music / MIDI / MusicXML are stored
+                                inside the database; audio is stored on disk under
+                                <code>appWeb/uploads/songs/</code> and served via the
+                                gated <code>/song-media/&lt;id&gt;</code> route.
+                            </div>
+                            <div id="song-media-editor-root">
+                                <!-- Populated by song-media-editor.js — see <script type="module"> at the bottom of this file. -->
+                            </div>
+                        </div>
+                    </div>
+                    <!-- END Media Tab Panel -->
+
+
+                    <!-- -------------------------------------------------
                          PREVIEW TAB PANEL
                          Read-only rendered preview of the song, styled
                          similarly to how it appears in the main iHymns app.
@@ -1405,6 +1457,23 @@ $currentUser = getCurrentUser();
         const root = document.querySelector('.ietf-picker[data-ietf-picker-id="edit-song"]');
         if (root) {
             window.editSongIetfPicker = bootIetfLanguagePicker(root);
+        }
+    </script>
+
+    <!-- Song Media editor boot (#853). Subscribes to the
+         iHymns:song-loaded CustomEvent dispatched by editor.js.
+         Cache-bust on filemtime() so a deploy invalidates the
+         browser cache without a manual version bump. -->
+    <?php
+        $_mediaModulePath    = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'js' . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR . 'song-media-editor.js';
+        $_mediaModuleVersion = is_file($_mediaModulePath) ? (string)filemtime($_mediaModulePath) : '1';
+    ?>
+    <script type="module">
+        import { bootSongMediaEditor }
+            from '/js/modules/song-media-editor.js?v=<?= htmlspecialchars($_mediaModuleVersion, ENT_QUOTES) ?>';
+        const mediaRoot = document.getElementById('song-media-editor-root');
+        if (mediaRoot) {
+            window.songMediaEditor = bootSongMediaEditor(mediaRoot);
         }
     </script>
 

--- a/appWeb/public_html/song-media.php
+++ b/appWeb/public_html/song-media.php
@@ -1,0 +1,263 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Song Media Streaming Endpoint (#853)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * Routed via .htaccess:  /song-media/<id>  →  song-media.php?id=<id>
+ *
+ * PURPOSE:
+ * Single PHP route that serves the bytes for a tblSongMedia row,
+ * regardless of which backend stores them (filesystem for audio,
+ * MEDIUMBLOB for sheet-music / midi / musicxml).
+ *
+ * GATING:
+ * Every request runs through checkContentAccess('song', <SongId>) so
+ * a song-level restriction transitively gates its media. When a
+ * Bearer token is present we resolve the user; otherwise the gate
+ * runs anonymously. Note: HTML5 <audio> elements do NOT send custom
+ * Authorization headers cross-request, so authenticated-only gating
+ * for browser-played audio needs a query-param signed-URL mechanism
+ * (deliberately out of scope for this PR — anonymous-public is the
+ * supported default; everything else falls back to public-or-blocked).
+ *
+ * RANGE REQUESTS:
+ * Audio players issue HTTP Range to drive the seek bar. We honour
+ * `Range: bytes=…` with a 206 Partial Content response. For FS-backed
+ * rows the SongMediaStorage::streamRange helper uses fopen/fseek so a
+ * 50MB MP3 doesn't briefly live in PHP's memory in full.
+ *
+ * CACHING:
+ * Cache-Control: private — gated content must not be shared by
+ * intermediaries even when the response is 200 + cacheable. Browser
+ * cache lifetime is one day (re-validation cost is negligible vs the
+ * benefit of the audio element NOT re-fetching the whole file when
+ * the user clicks elsewhere on the song page).
+ */
+
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'content_access.php';
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'SongMediaStorage.php';
+
+/**
+ * Best-effort Bearer-token → user lookup. Returns null for anonymous.
+ *
+ * Slimmer than api.php's getAuthenticatedUser() — no avatar columns,
+ * no sliding expiry write, no $user payload. We only need the Id for
+ * the gating call.
+ */
+function _songMedia_resolveUserId(): ?int
+{
+    $hdr = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
+    if (!preg_match('/^Bearer\s+(.+)$/i', $hdr, $m)) return null;
+    $token = trim($m[1]);
+    if ($token === '') return null;
+
+    try {
+        $db = getDbMysqli();
+        $hashed = hash('sha256', $token);
+        $stmt = $db->prepare(
+            'SELECT t.UserId FROM tblApiTokens t
+               JOIN tblUsers u ON u.Id = t.UserId
+              WHERE t.Token = ? AND t.ExpiresAt > UTC_TIMESTAMP()
+                AND u.IsActive = 1
+              LIMIT 1'
+        );
+        $stmt->bind_param('s', $hashed);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        return $row ? (int)$row['UserId'] : null;
+    } catch (\Throwable $_e) {
+        return null;
+    }
+}
+
+/* -------------------------------------------------------------------- */
+
+$id = (int)($_GET['id'] ?? 0);
+if ($id <= 0) {
+    http_response_code(400);
+    header('Content-Type: text/plain; charset=UTF-8');
+    echo 'Bad request.';
+    exit;
+}
+
+try {
+    $db = getDbMysqli();
+} catch (\Throwable $_e) {
+    http_response_code(500);
+    header('Content-Type: text/plain; charset=UTF-8');
+    echo 'Database unavailable.';
+    exit;
+}
+
+/* Schema-probe so a pre-migration deploy returns 404 cleanly rather
+   than an SQL-not-found error. Cached per request via static. */
+$hasSchema = (function () use ($db): bool {
+    static $cached = null;
+    if ($cached !== null) return $cached;
+    try {
+        $r = $db->query(
+            "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+              WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tblSongMedia' LIMIT 1"
+        );
+        $cached = ($r && $r->fetch_row() !== null);
+        if ($r) $r->close();
+    } catch (\Throwable $_e) {
+        $cached = false;
+    }
+    return $cached;
+})();
+if (!$hasSchema) {
+    http_response_code(404);
+    header('Content-Type: text/plain; charset=UTF-8');
+    echo 'Not found.';
+    exit;
+}
+
+try {
+    $stmt = $db->prepare(
+        'SELECT Id, SongId, Kind, StorageBackend, FileName, MimeType,
+                SizeBytes, Content, StoragePath
+           FROM tblSongMedia WHERE Id = ? LIMIT 1'
+    );
+    $stmt->bind_param('i', $id);
+    $stmt->execute();
+    $row = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+} catch (\Throwable $e) {
+    error_log('[song-media] fetch failed: ' . $e->getMessage());
+    http_response_code(500);
+    header('Content-Type: text/plain; charset=UTF-8');
+    echo 'Internal error.';
+    exit;
+}
+
+if (!$row) {
+    http_response_code(404);
+    header('Content-Type: text/plain; charset=UTF-8');
+    echo 'Not found.';
+    exit;
+}
+
+/* Gate via the parent song's access rules. checkContentAccess returns
+   ['allowed' => bool, 'reason' => string]; deny → 403 with a brief
+   plaintext reason so a curator inspecting Network can see why. */
+$userId = _songMedia_resolveUserId();
+$gate   = checkContentAccess('song', (string)$row['SongId'], $userId, 'PWA');
+if (!$gate['allowed']) {
+    http_response_code(403);
+    header('Content-Type: text/plain; charset=UTF-8');
+    echo 'Access restricted: ' . ($gate['reason'] ?: 'gated content.');
+    exit;
+}
+
+$totalSize = (int)$row['SizeBytes'];
+$mime      = (string)$row['MimeType'];
+$kind      = (string)$row['Kind'];
+$fileName  = (string)$row['FileName'];
+
+/* Audio plays inline (the <audio> tag wants the bytes); everything
+   else is offered as a download with the original filename. The
+   filename is RFC 5987 encoded so non-ASCII characters survive
+   round-trips through Content-Disposition. */
+$disposition = ($kind === 'audio') ? 'inline' : 'attachment';
+$cdAscii     = preg_replace('/[^\x20-\x7e]/', '_', $fileName) ?: 'file';
+$cdUtf8      = rawurlencode($fileName);
+
+/* ---------- Range parsing ----------------------------------------- */
+
+$rangeHeader = $_SERVER['HTTP_RANGE'] ?? '';
+$rangeStart  = 0;
+$rangeEnd    = $totalSize - 1;
+$isPartial   = false;
+
+if ($rangeHeader !== '' && preg_match('/^bytes=(\d*)-(\d*)$/i', $rangeHeader, $rm)) {
+    $rs = ($rm[1] === '') ? null : (int)$rm[1];
+    $re = ($rm[2] === '') ? null : (int)$rm[2];
+
+    if ($rs === null && $re !== null) {
+        /* Suffix-form `bytes=-N` — return the LAST N bytes. */
+        $rangeStart = max(0, $totalSize - $re);
+        $rangeEnd   = $totalSize - 1;
+    } elseif ($rs !== null && $re === null) {
+        /* Open-ended `bytes=N-` — start at N, run to EOF. */
+        $rangeStart = $rs;
+        $rangeEnd   = $totalSize - 1;
+    } elseif ($rs !== null && $re !== null) {
+        $rangeStart = $rs;
+        $rangeEnd   = min($re, $totalSize - 1);
+    }
+
+    if ($rangeStart > $rangeEnd || $rangeStart >= $totalSize) {
+        http_response_code(416);
+        header('Content-Range: bytes */' . $totalSize);
+        header('Content-Type: text/plain; charset=UTF-8');
+        echo 'Requested range not satisfiable.';
+        exit;
+    }
+    $isPartial = true;
+}
+
+$length = $rangeEnd - $rangeStart + 1;
+
+/* ---------- Headers ---------------------------------------------- */
+
+header('Content-Type: ' . $mime);
+header('Accept-Ranges: bytes');
+header('Cache-Control: private, max-age=86400');
+header('Content-Length: ' . $length);
+header(
+    'Content-Disposition: ' . $disposition
+    . '; filename="' . str_replace('"', '\"', $cdAscii) . '"'
+    . "; filename*=UTF-8''" . $cdUtf8
+);
+header('X-Content-Type-Options: nosniff');
+
+if ($isPartial) {
+    http_response_code(206);
+    header('Content-Range: bytes ' . $rangeStart . '-' . $rangeEnd . '/' . $totalSize);
+}
+
+/* HEAD requests get headers only (Apache discards the body but PHP
+   needn't actually read any bytes for them — saves an unnecessary
+   FS open / BLOB substr on every <audio> probe). */
+if (($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'HEAD') {
+    exit;
+}
+
+/* ---------- Stream the body --------------------------------------- */
+
+/* Flush any buffered output (PHP usually buffers up to 4KB) so the
+   first chunk reaches the browser without delay. ob_clean only acts
+   on the topmost buffer; calling it in a loop is paranoid but cheap. */
+while (ob_get_level() > 0) {
+    @ob_end_clean();
+}
+
+$ok = SongMediaStorage::streamRange(
+    [
+        'StorageBackend' => (string)$row['StorageBackend'],
+        'StoragePath'    => (string)($row['StoragePath'] ?? ''),
+        'Content'        => $row['Content'] ?? null,
+    ],
+    $rangeStart,
+    $rangeEnd,
+    static function (string $chunk): void {
+        echo $chunk;
+        @flush();
+    }
+);
+
+if (!$ok) {
+    /* Storage missing under the row — log + return a sad-trombone
+       210 Gone so the player surfaces a "couldn't load" rather than
+       silently looping. We've already sent the headers above, so the
+       best we can do is exit cleanly. */
+    error_log('[song-media] storage missing for media id=' . $id);
+}
+exit;


### PR DESCRIPTION
Closes #853. Bumps app version to **v0.75.0**.

Adds the unified per-song accompanying-files system: curators can now upload audio (MP3 / M4A / AAC / OGG / WAV / FLAC / ALAC), sheet music (PDF), notation (MusicXML), and MIDI for any song via the Song Editor. Files are gated by the parent song's `checkContentAccess()` rules and surfaced on the public song page as an inline `<audio>` player + per-kind download chips.

## Storage strategy

Hybrid behind the new `SongMediaStorage` class:

| Kind          | Backend       | Why |
|---------------|---------------|-----|
| `audio`       | Filesystem    | Streaming + native HTTP range requests (audio scrubbing); avoids `mysqldump` bloat. |
| `sheet-music` | DB (`MEDIUMBLOB`) | Small, atomic backups, transactional gating. |
| `midi`        | DB (`MEDIUMBLOB`) | Tiny — sub-100KB typical. |
| `musicxml`    | DB (`MEDIUMBLOB`) | Small XML, fits comfortably. |

Files served via `/song-media/<id>` (gated PHP route off the public docroot at `appWeb/uploads/songs/<hash-prefix>/<sha256>.<ext>` for FS, BLOB column for DB). A future R2/S3 backend slots in as a third branch keyed on `StorageBackend = 'object-store'` with no schema change.

## Changes (5 commits)

| Commit | Phase | Files |
|--------|-------|-------|
| `2af1b2c5` | A — Schema + storage layer | `migrate-song-media.php`, `SongMediaStorage.php`, `setup-database.php` registration |
| `397fa725` | B — Upload/list/delete/reorder endpoints | `editor/api.php` |
| `b148445b` | C — Song Editor "Media" tab + ESM module | `editor/index.php`, `editor.js`, `js/modules/song-media-editor.js` |
| `001fd79e` | D — SongData attach + public song-page surface | `SongData.php`, `pages/song.php` |
| `199aa239` | E — `/song-media/<id>` streaming endpoint + v0.75.0 | `song-media.php`, `.htaccess`, `infoAppVer.php` |

## Per-kind size caps + MIME allowlist

Server-side enforcement via `SongMediaStorage::validateUpload()` — `finfo` MIME sniff on the *actual bytes* (never trust `\$_FILES['type']`):

- **audio** — 50 MB cap; MP3 / M4A / AAC / WAV / FLAC / OGG / AIFF
- **sheet-music** — 10 MB cap; PDF only
- **midi** — 1 MB cap; `.mid` / `.midi`
- **musicxml** — 1 MB cap; `.musicxml` / `.xml`

## Back-compat

`tblSongs.HasAudio` / `HasSheetMusic` boolean flags from MissionPraise scrape data continue to drive the indicator badges on the songbook list page when no `tblSongMedia` rows exist. Once a curator uploads a row of that kind, the flag flips to true automatically (computed in `_fetchSongRow`). No data migration; mixed-state deploys render coherently.

## Gating

Every `/song-media/<id>` request runs `checkContentAccess('song', SongId, userId, 'PWA')`. A song-level restriction transitively gates its media — no new entity type, no new restriction shape. Caveat: HTML5 `<audio>` elements don't send custom Authorization headers cross-request, so authenticated-only gating for browser playback needs a future signed-URL mechanism — anonymous-public is the supported default in v1.

## Test plan

- [ ] Run "Song Media Uploads (#853)" migration via `/manage/setup-database` — confirm `tblSongMedia` is created with 4 indexes + FK to `tblSongs`.
- [ ] Open Song Editor, pick a song, switch to **Media** tab — confirm 4 sections (Audio · Sheet music · MIDI · MusicXML) render with file pickers.
- [ ] Upload an MP3 — confirm it lands at `appWeb/uploads/songs/<2-char>/<sha256>.mp3` with mode 0640, row appears with `StorageBackend='filesystem'`, `Content` is NULL, audit log shows `song-media.upload`.
- [ ] Upload a PDF — confirm row has `StorageBackend='database'`, `Content` is non-NULL, `StoragePath` is NULL, no file written to disk.
- [ ] Upload an oversize MP3 (>50MB) — confirm 400 with friendly error, no row, no file.
- [ ] Upload a MIME-mismatched file (e.g. `.mp3` extension on a `.txt` payload) — confirm finfo rejects.
- [ ] Drag-reorder rows within a kind — confirm `SortOrder` updates, refresh shows new order.
- [ ] Edit annotation — confirm debounced save fires once after typing stops.
- [ ] Delete a row — confirm FS file unlinks (FS-backed) or BLOB row goes (DB-backed); audit logs.
- [ ] Visit the public song page — confirm "Recordings & resources" section renders between Translations and Works; audio plays inline; non-audio kinds appear as download chips with original filenames.
- [ ] Audio scrubbing in `<audio>` — confirm 206 Partial Content + `Content-Range` header in DevTools Network when seeking.
- [ ] Add a `tblContentRestrictions` row blocking the song — confirm `/song-media/<id>` returns 403 with reason; the songbook list page's `hasAudio` indicator still appears (intended — restriction is per-song, indicator is a hint).
- [ ] Pre-migration deploy (`tblSongMedia` absent) — confirm `_songMedia_tableExists()` short-circuits; songbook list + song page render with no media block; Song Editor's Media tab shows empty state without errors.
- [ ] HEAD `/song-media/<id>` — confirm headers only, no body.
- [ ] App version on `/manage` — confirm shows v0.75.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)