### PR TITLE
feat: multilingual UX batch — SoTD, tooltips, songbook visibility, verse-level language, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,31 +2,52 @@
 
 > **A multiplatform Christian lyrics application for worship enhancement**
 
-[![License: Proprietary](https://img.shields.io/badge/License-Proprietary-red.svg)](#-license)
-[![Platform: Web](https://img.shields.io/badge/Platform-Web%20PWA-blue.svg)](#-platforms)
-[![Platform: iOS](https://img.shields.io/badge/Platform-iOS%20%7C%20iPadOS%20%7C%20tvOS-black.svg)](#-platforms)
-[![Platform: Android](https://img.shields.io/badge/Platform-Android-green.svg)](#-platforms)
+[![Version: 0.75.0 Alpha](https://img.shields.io/badge/Version-0.75.0%20Alpha-orange.svg)](#environments)
+[![License: Proprietary](https://img.shields.io/badge/License-Proprietary-red.svg)](#license)
+[![Platform: Web](https://img.shields.io/badge/Platform-Web%20PWA-blue.svg)](#platforms)
+[![Platform: iOS](https://img.shields.io/badge/Platform-iOS%20%7C%20iPadOS%20%7C%20tvOS-black.svg)](#platforms)
+[![Platform: Android](https://img.shields.io/badge/Platform-Android-green.svg)](#platforms)
 
 ---
 
 ## About
 
-**iHymns** provides searchable hymn and worship song lyrics from multiple songbooks, designed to enhance Christian worship across all devices. Browse, search, and save your favourite hymns — online or offline.
+**iHymns** provides searchable hymn and worship-song lyrics from a curated library of hymnals, designed to enhance Christian worship across all devices. Browse, search, and save your favourite hymns — online or offline — in any of the ~20 languages currently catalogued.
 
-**Website**: [iHymns.app](https://ihymns.app) | **Alpha**: [dev.iHymns.app](https://dev.ihymns.app) | **Beta**: [beta.iHymns.app](https://beta.ihymns.app)
+**Website**: [iHymns.app](https://ihymns.app) · **Alpha**: [dev.iHymns.app](https://dev.ihymns.app) · **Beta**: [beta.iHymns.app](https://beta.ihymns.app)
 
 ---
 
 ## Song Library
 
-| Songbook | Abbr | Songs | Audio | Sheet Music |
-| --- | --- | ---: | :---: | :---: |
-| Carol Praise | CP | 243 | MIDI | PDF |
-| Junior Praise | JP | 617 | MIDI | PDF |
-| Mission Praise | MP | 1,355 | MIDI | PDF |
-| Seventh-day Adventist Hymnal | SDAH | 695 | — | — |
-| The Church Hymnal | CH | 702 | — | — |
-| **Total** | | **3,612** | | |
+The catalogue currently spans **30+ songbooks, ~12,370 songs across ~20 languages**. Counts grow as scrapers and curator-imports add new hymnals; the seed is dynamic — query `tblSongbooks` for the live count on any deployment.
+
+**Original English hymnals** — Carol Praise (CP), Junior Praise (JP), Mission Praise (MP), Seventh-day Adventist Hymnal (SDAH), The Church Hymnal (CH).
+
+**Christ in Song family** (#663) — 20+ multilingual SDA hymnals including:
+
+| Language | Code | Songbook | Songs |
+| --- | --- | --- | --- |
+| English | en | Christ in Song (CIS) | ~700 |
+| Spanish | es | Himnario Adventista (HA) | ~600 |
+| Portuguese | pt | HASD | ~600 |
+| French | fr | Hymnes & Louanges (DLG) | ~600 |
+| Russian | ru | GASD | ~600 |
+| Twi | tw | DRG | ~500 |
+| Tonga | to | – | ~500 |
+| Tswana | tn | – | ~500 |
+| Sotho / Sesotho | st | – | ~500 |
+| Chichewa / Shona / Venda | ny / sn / ve | – | ~500 each |
+| Swahili | sw | – | ~500 |
+| Ndebele | nr | – | ~500 |
+| Xhosa | xh | – | ~500 |
+| Xitsonga / Gikuyu / Abagusii | ts / ki / luo | – | ~400 each |
+| Dholuo / Kinyarwanda | luo / rw | – | ~400 each |
+| Tumbuka / Sepedi / Bemba / Afrikaans | tum / nso / bem / af | – | ~400 each |
+
+Plus: Advent Hymns (AH), Adventist Youth Sing (AYS), New Adventist Hymnal (NAH) and a Misc collection for community contributions.
+
+Songs are tagged at song-level with their actual IETF BCP 47 language (#681), so a Spanish translation living in an English-primary songbook surfaces correctly under language filters.
 
 ---
 
@@ -34,95 +55,119 @@
 
 | Platform | Technology | Status |
 | --- | --- | --- |
-| Web PWA | HTML5, CSS3, Bootstrap 5.3, Vanilla JS, PHP 8.1+ | **Alpha** |
-| iOS / iPadOS / tvOS | Swift 6.3, SwiftUI | In Progress |
+| Web PWA | HTML5, CSS3, Bootstrap 5.3, vanilla JS, PHP 8.1+, MySQL 5.7+ / MariaDB 10.3+ | **Alpha** (v0.75.0) |
+| iOS / iPadOS / tvOS | Swift 6.3, SwiftUI | In progress |
 | Android / Fire OS | Kotlin, Jetpack Compose | Planned |
 
 ---
 
 ## Features
 
-### Song Browsing & Search
-- **Full-text search** — by title, lyrics, songbook, song number, writer, composer (Fuse.js client-side + MySQL FULLTEXT)
-- **Scripture search** — `Ps 23`, `1 Cor 13`, `Rev 21` etc. match through abbreviation expansion + curated tags (#397)
-- **Songbook browser** — organised by songbook with alphabetical index
-- **Number search** — numeric keypad with physical keyboard support; configurable live search (off by default)
-- **Default songbook** — pre-selects in number search, keyboard quick-jump, and shuffle
-- **Formatted lyrics** — verse, chorus, refrain, bridge with optional numbering and chorus highlighting
+### Song browsing & search
 
-### Worship Tools
-- **Favourites** — save songs with custom tags for quick access
-- **Setlists** — create, arrange, and share worship setlists with custom component arrangements
-- **Setlist scheduling & collaboration** — schedule setlists for a date/time with an "Up next" overview and invite collaborators with view/edit permissions (#398)
-- **Presentation mode** — fullscreen lyrics display with configurable auto-scroll
-- **Practice / memorisation mode** — Full / Dimmed / Hidden cycle with tap-to-reveal (#402)
-- **Shuffle** — random song from any songbook, highlights your default songbook
-- **Translation linking** — songs linked to equivalent translations in other languages
-- **Audio playback** — MIDI files where available
-- **Sheet music** — PDF viewer where available
-- **Transpose** — shift song key up/down (persisted per song)
+- **Full-text search** — title, lyrics, songbook, song number, writer, composer (Fuse.js client-side + MySQL FULLTEXT). Multi-language with primary-subtag filtering.
+- **Scripture search** — `Ps 23`, `1 Cor 13`, `Rev 21` etc. via abbreviation expansion + curated tags (#397).
+- **Alternative titles** (#832) — songs and songbooks carry "also known as …" entries that surface in search and the public page (search for *Faith's Review and Expectation* finds *Amazing Grace*).
+- **Songbook browser** — alphabetical index, language filter, downloadable per book.
+- **Number search** — numeric keypad with physical keyboard support; configurable live search.
+- **Default songbook** — pre-selects in number search, keyboard quick-jump, and shuffle.
+- **Formatted lyrics** — verse, chorus, refrain, bridge with optional numbering and chorus highlighting.
+- **Multi-language medleys** (#858) — per-component language overrides apply correct screen-reader pronunciation, browser hyphenation, and JSON-LD `inLanguage` indexing.
+
+### Worship tools
+
+- **Favourites** — save songs with custom tags for quick access.
+- **Setlists** — create, arrange, and share worship setlists with custom component arrangements.
+- **Setlist scheduling & collaboration** — schedule setlists for a date / time with an "Up next" overview; invite collaborators with view / edit permissions (#398).
+- **Presentation mode** — fullscreen lyrics display with configurable auto-scroll.
+- **Practice / memorisation mode** — Full / Dimmed / Hidden cycle with tap-to-reveal (#402).
+- **Shuffle** — random song from any songbook; highlights your default.
+- **Translation linking** — songs linked to equivalent translations in other languages.
+- **Song media** (#853) — curators upload audio (MP3 / M4A / OGG / WAV / FLAC / ALAC), sheet music (PDF), MIDI, and MusicXML via the Song Editor; served behind a gated `/song-media/<id>` route with HTTP Range support for audio scrubbing.
+- **Transpose** — shift song key up / down (persisted per song).
+
+### Catalogue
+
+- **Compilers / editors** (#831) — songbooks credit the people who compiled / edited them, linking to the Credit-People registry.
+- **External links** (#833) — MusicBrainz-style typed links registry across songs / songbooks / credit-people: Hymnary.org, IMSLP, Wikipedia, Wikidata, Internet Archive, MusicBrainz, VIAF, YouTube, Spotify, etc. Curator-driven categorisation; surfaces as JSON-LD `sameAs` for SEO.
+- **External-link patterns** (#845) — curator-editable URL → link-type registry replaces hard-coded JS rules; new providers are a row insert.
+- **Works** (#840) — composition grouping links the same hymn across translations, arrangements, and songbooks (mirrors MusicBrainz Work ↔ Recording).
+- **IETF BCP 47** (#681 → #738) — all language tags through the IANA registry + CLDR native-name overlay; an in-app picker composes language / script / region / variant.
+- **Parent songbooks** (#782) — express series and family relationships between songbooks ("Mission Praise" → "MP Combined" → "MP Combined Music Edition").
 
 ### Discovery
-- **Popular songs** — homepage shows trending songs (server-side view counts with client-side fallback)
-- **Browse by theme** — filter songs by thematic tags
-- **Related songs** — content-based similarity matching using TF-IDF cosine similarity
-- **Song of the Day** — daily featured song on homepage
-- **Recently viewed** — quick access to your recent songs
+
+- **Popular songs** — homepage shows trending songs (server-side view counts with client-side fallback).
+- **Browse by theme** — filter songs by thematic tags.
+- **Related songs** — content-based similarity matching using TF-IDF cosine similarity.
+- **Song of the Day** (#108, language-aware in #855) — daily featured song respecting the user's active "Show languages" filter, with English fallback when the filter excludes English and we have no themed match.
+- **Recently viewed** — quick access to your recent songs.
+
+### Multilingual UX
+
+- **"Show languages" filter** — pill-toggle group on the home page; per-user preference syncs across devices via `tblUsers.PreferredLanguagesJson` (#736).
+- **Songbook visibility** (#857) — a songbook surfaces under any language filter that matches **any of its contained songs**, not just its own primary language.
+- **Language-name tooltips** (#856) — every language pill / badge in the UI shows the full English language name on hover, resolved against `tblLanguages`.
+- **Accept-Language honoured server-side** via the `X-Preferred-Languages` header injected into every fetch.
 
 ### Offline & PWA
-- **Offline downloads** — individual songbooks or all at once (~14 MB)
-- **Bulk download API** — optimised endpoint fetches entire songbooks in ~6 requests (not 3,612 individual requests)
-- **Offline audio** — opt-in pre-cache of MIDI/OGG so playback works without a connection (#401)
-- **Per-songbook size readout + eviction** — Settings shows actual cached bytes per songbook with a remove-from-offline button (#401)
-- **Background downloads** — continue when navigating away from Settings
-- **Auto-update** — optional automatic update of saved offline songs; service-worker update toast restored (#396)
-- **Service worker** — precaches all app assets for instant offline access
-- **Offline indicator** — shows connection status in UI
-- **JSON fallback** — full functionality when MySQL is unavailable
 
-### Appearance & Accessibility
-- **Themes** — light, dark, high contrast, and system-adaptive modes
-- **Colour vision deficiency** — accessible palette with pattern-based songbook indicators
-- **WCAG 2.1 AA** — screen reader support, ARIA landmarks, keyboard shortcuts (toggleable via Accessibility settings, #406)
-- **Responsive songbook names** — full name by default, abbreviation on narrow screens
-- **Adjustable font size** — lyrics scale from 14px to 28px
-- **Reduced motion** — respects `prefers-reduced-motion` and manual toggle
-- **Safe areas** — respects device notch, camera cutout, and home indicator on all screens
+- **Offline downloads** — individual songbooks or all at once.
+- **Bulk download API** — optimised endpoint fetches entire songbooks in a handful of requests.
+- **Offline audio** — opt-in pre-cache so playback works without a connection (#401).
+- **Per-songbook size readout + eviction** — Settings shows actual cached bytes per songbook with a remove-from-offline button (#401).
+- **Background downloads** — continue when navigating away from Settings.
+- **Auto-update** — optional automatic update of saved offline songs; service-worker update toast (#396).
+- **Service worker** — precaches all app assets; cache version auto-derived from `infoAppVer.php` so every alpha build invalidates cleanly.
+- **Offline indicator** — shows connection status in UI.
+- **JSON fallback** — full functionality when MySQL is unavailable.
 
-### Authentication & Access
-- **Magic-link sign-in** — primary auth path (email + 6-digit code); password sign-in available as a fallback (#395)
-- **Cross-subdomain cookie** — `HttpOnly`, `SameSite=Lax`, `Secure` auth cookie on `.ihymns.app` with 30-day sliding expiry survives iOS ITP (#390)
-- **User accounts** — role-based access (Global Admin, Admin, Editor, User)
-- **Entitlements** — capability-based permissions, editable at runtime by a global admin
-- **Channel gating** — alpha / beta subdomains require the relevant access entitlement
+### Appearance & accessibility
+
+- **Themes** — light, dark, high contrast, and system-adaptive modes.
+- **Colour vision deficiency** — accessible palette with pattern-based songbook indicators.
+- **WCAG 2.1 AA** — screen-reader support, ARIA landmarks, keyboard shortcuts (toggleable via Accessibility settings, #406).
+- **Responsive songbook names** — full name by default, abbreviation on narrow screens.
+- **Adjustable font size** — lyrics scale from 14px to 28px.
+- **Reduced motion** — respects `prefers-reduced-motion` and manual toggle.
+- **Safe areas** — respects device notch, camera cutout, and home indicator on all screens.
+
+### Authentication & access
+
+- **Magic-link sign-in** — primary auth path (email + 6-digit code); password sign-in available as a fallback (#395).
+- **Cross-subdomain cookie** — `HttpOnly`, `SameSite=Lax`, `Secure` auth cookie on `.ihymns.app` with 30-day sliding expiry survives iOS ITP (#390).
+- **Roles** — Global Admin, Admin, Editor, User; capability-based entitlements editable at runtime by a global admin.
+- **Channel gating** — alpha / beta subdomains require the relevant access entitlement.
+- **Content access tiers** — public, free, CCLI, premium, pro with organisation licensing (#640).
+- **Songs and song-media respect `checkContentAccess()`** — the gated `/song-media/<id>` endpoint enforces the same restriction rules as the public song page.
 
 ### Community
-- **Song request form** — public, rate-limited, honeypot-protected (#403); admin triage queue at `/manage/requests`
+
+- **Song request form** — public, rate-limited, honeypot-protected (#403); admin triage queue at `/manage/requests`.
 
 ### Administration
-- **Song editor** — per-song auto-save, multi-select bulk **delete / verify / tag / move / export** (#399)
-- **Revision history** — every save writes `tblSongRevisions`; editor History modal with JSON diff + per-revision Restore + global audit log at `/manage/revisions` (#400)
-- **Database setup** — web-accessible installer with backup restore upload, **pre-flight summary**, pre-restore auto-snapshot, and transactional data-load (#405)
-- **Content access tiers** — public, free, CCLI, premium, pro with organisation licensing
-- **Activity logging** — audit trail for significant actions (logins, admin writes, backup restores)
-- **Analytics** — GA4, Plausible, Clarity, Matomo, Fathom with GDPR consent; admin dashboard with top songs/books/queries + zero-result queries + CSV export (#404)
+
+- **Song Editor** — per-song auto-save, multi-select bulk **delete / verify / tag / move / export** (#399). Five tabs: Metadata, Structure (with per-component language overrides #858), Credits, Tags, **Media** (#853), Preview.
+- **Revision history** — every save writes `tblSongRevisions`; editor History modal with JSON diff + per-revision Restore + global audit log at `/manage/revisions` (#400).
+- **Database setup** — web-accessible installer with backup restore upload, **pre-flight summary**, pre-restore auto-snapshot, transactional data-load, and live migration cards that auto-hide when fully applied (#820, #824, #405).
+- **Activity logging** — audit trail for significant actions (logins, admin writes, backup restores, song-media uploads).
+- **Analytics** — GA4, Plausible, Clarity, Matomo, Fathom with GDPR consent; admin dashboard with top songs / books / queries + zero-result queries + CSV export (#404).
 
 ---
 
 ## Admin Portal
 
-Accessible at **`/manage/`** (alias: `/admin/`) for users with the appropriate role. Main surfaces:
+Accessible at **`/manage/`** (alias: `/admin/`) for users with the appropriate role. The admin nav is grouped into seven sections; ~39 distinct surfaces in total.
 
-| Surface | Purpose | Default role |
-| --- | --- | --- |
-| Dashboard | Library + activity snapshot, quick-links | editor+ |
-| Song Editor | Per-song UPSERT + auto-save, multi-select bulk delete/verify/tag/move/export, History modal | editor+ |
-| User Management | Roles, passwords, activation | admin+ |
-| Song Requests | Triage user-submitted requests | editor+ |
-| Analytics | Top songs/books/queries, zero-result queries, CSV export | admin+ |
-| Revisions | Global revision audit across every song edit | admin+ |
-| Entitlements | Reassign capabilities to roles | global_admin |
-| Database Setup | Install schema, migrate, backup, restore (with pre-flight), drop legacy | admin+ |
+| Group | Surfaces |
+| --- | --- |
+| **Dashboard** | Library + activity snapshot, quick-links |
+| **Songs** | Song Editor · Song Requests · Revisions Audit · Missing Numbers · Song Link Suggestions |
+| **Catalogue** | Songbooks · Songbook Series · Works · External-Link Types · Credit People · Languages · Tags & Themes |
+| **Access** | Content Restrictions · Access Tiers · Entitlements |
+| **People** | Users · User Groups · Organisations · My Organisations |
+| **Operations** | Analytics · CCLI Usage Report · Data Health · Activity Log · Schema Audit · Database Setup · Configuration · Notifications |
+| **Help** | Help / Guides |
 
 Every write on these pages is CSRF-protected. DB error messages are never leaked to clients (see server error log).
 
@@ -133,11 +178,10 @@ Every write on these pages is CSRF-protected. DB error messages are never leaked
 ### Prerequisites
 
 - **PHP 8.1+** with `mysqli` extension
-- **MySQL 5.7+** or **MariaDB 10.3+**
-- **Node.js** v22+ (for build tools)
-- **npm** v10+
+- **MySQL 5.7+** or **MariaDB 10.3+** (InnoDB)
+- **Node.js v22+** and **npm v10+** (for build tools)
 
-### 1. Clone & Install
+### 1. Clone & install
 
 ```bash
 git clone https://github.com/MWBMPartners/iHymns.git
@@ -145,13 +189,13 @@ cd iHymns
 npm install
 ```
 
-### 2. Generate Song Data
+### 2. Generate song data
 
 ```bash
-npm run parse-songs    # Generates data/songs.json from .SourceSongData/
+npm run parse-songs    # data/songs.json from .SourceSongData/
 ```
 
-### 3. Set Up Database
+### 3. Set up the database
 
 ```bash
 # Interactive installer — prompts for MySQL credentials, creates tables
@@ -161,7 +205,7 @@ php appWeb/.sql/install.php
 php appWeb/.sql/migrate-json.php
 ```
 
-Or use the **web-based installer** at `/manage/setup-database.php` (accessible during initial setup or as a global admin).
+Or use the **web-based installer** at `/manage/setup-database.php` (accessible during initial setup or as a global admin) and click each migration card in turn.
 
 **One-shot alternative** (schema + all data in one command):
 
@@ -169,110 +213,68 @@ Or use the **web-based installer** at `/manage/setup-database.php` (accessible d
 mysql -u user -p ihymns < appWeb/.sql/.fulldata/ihymns-full.sql
 ```
 
-See [Database Setup](#-database-setup) below for detailed instructions.
+### 4. Create admin user
 
-### 4. Create Admin User
+Visit `/manage/setup` in the browser to create the initial admin account. The first account becomes the **Global Admin**.
 
-Visit `/manage/setup` in the browser to create the initial admin account.
-
-### 5. Start Development Server
+### 5. Start dev server
 
 ```bash
-npm run dev    # Starts PHP dev server at http://localhost:8000
+npm run dev    # PHP dev server at http://localhost:8000
 ```
 
 ---
 
 ## Database Setup
 
-### Prerequisites
+iHymns uses MySQL with a `tblCamelCase` schema spanning ~50 tables. The full migration manifest lives in `appWeb/public_html/manage/setup-database.php` (`$friendlyTitles`); see the [Database & Migrations](iHymns.wiki/Database-&-Migrations.md) wiki page for an authoritative per-table reference.
 
-- **MySQL 5.7+** or **MariaDB 10.3+** with InnoDB support
-- **PHP 8.1+** with `mysqli` extension
-- A MySQL database created for iHymns:
-  ```sql
-  CREATE DATABASE ihymns CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-  ```
+### Database prerequisites
 
-### Step 1: Run the Interactive Installer
+- MySQL 5.7+ or MariaDB 10.3+ with InnoDB support
+- PHP 8.1+ with `mysqli` extension
+- A database created for iHymns:
+
+```sql
+CREATE DATABASE ihymns CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+```
+
+### Step 1 — interactive installer
 
 ```bash
 php appWeb/.sql/install.php
 ```
 
-The wizard prompts for:
+The wizard tests the connection, writes credentials to `appWeb/.auth/db_credentials.php` (mode `0600`), creates all base tables from `schema.sql`, and seeds default reference data (user groups, languages, access tiers, app settings).
 
-| Prompt | Default | Description |
-| --- | --- | --- |
-| MySQL Host | `127.0.0.1` | Server hostname or IP |
-| MySQL Port | `3306` | Server port |
-| Database Name | `ihymns` | Must already exist |
-| Username | `ihymns_user` | MySQL user with full privileges on the database |
-| Password | _(none)_ | Hidden input on supported terminals |
-| Table Prefix | _(none)_ | Optional prefix for shared databases |
+### Step 2 — migrations
 
-The installer will:
-1. Test the connection before writing anything
-2. Write credentials to `appWeb/.auth/db_credentials.php` (permissions `0600`)
-3. Create all 30+ tables from `schema.sql` (idempotent — safe to re-run)
-4. Seed default data: user groups, languages (14), access tiers, app settings
+Migrations under `appWeb/.sql/migrate-*.php` add features incrementally (every one is idempotent — re-running a fully-applied migration is a no-op):
 
-> **Manual credentials**: If you can't use the interactive installer, copy `appWeb/.auth/db_credentials.example.php` to `db_credentials.php` and edit it, then re-run the installer.
+- IETF BCP 47 language tagging + IANA registry import + CLDR overlay (#681 / #738)
+- Multi-language tables for songs and songbooks (#778)
+- Parent songbooks (#782) · Songbook compilers (#831) · Alternative titles (#832)
+- External-links registry + backfills (#833) · External-link URL patterns (#845)
+- Works composition grouping (#840)
+- Song media uploads (#853) · Song component language overrides (#858)
+- Plus: bulk-import jobs, song revisions, credit-people registry, organisation licences, activity log, song-link suggestions, and many more.
 
-### Step 2: Import Song Data
+Run them via `/manage/setup-database` (web-based, with pending-state probes that auto-hide already-applied migrations) or via `php appWeb/.sql/migrate-<name>.php` from CLI.
 
-```bash
-php appWeb/.sql/migrate-json.php
-```
+### Step 3 — initial admin
 
-This imports all songs from `data/songs.json` into MySQL. The migration:
-- Clears existing song data and re-imports (transaction-wrapped, rolls back on error)
-- Populates: songbooks, songs, writers, composers, components, translation links
-- Builds `LyricsText` column for MySQL FULLTEXT search
+Navigate to `/manage/setup` in the browser. The first account created becomes the Global Admin.
 
-### Step 3: Create Initial Admin User
+### Web-based setup (no CLI)
 
-Navigate to `/manage/setup` in the browser. The first account created becomes the **Global Admin**.
+For shared hosting:
 
-### Step 4: Verify via Web Dashboard
-
-Navigate to `/manage/setup-database.php` to see database connection status, table row counts, and run maintenance tasks.
-
-### Web-Based Setup (No CLI Required)
-
-For shared hosting without SSH access:
-
-1. Copy `appWeb/.auth/db_credentials.example.php` to `db_credentials.php` and edit with your MySQL details
-2. Navigate to `/manage/setup-database.php`
-3. Click **Run Install** to create tables
-4. Click **Run Song Migration** to import song data
-5. Visit `/manage/setup` to create the admin account
-
-### File Structure
-
-```text
-appWeb/
-├── .auth/
-│   ├── .htaccess                      # Blocks web access (defense-in-depth)
-│   ├── db_credentials.example.php     # Template (tracked in git)
-│   └── db_credentials.php             # Your credentials (NOT in git)
-├── .sql/
-│   ├── schema.sql                     # Full MySQL schema (30+ tables)
-│   ├── install.php                    # Interactive DB installer
-│   ├── migrate-json.php              # JSON-to-MySQL data migration
-│   ├── migrate-users.php             # User/setlist migration
-│   ├── cleanup.php                    # Token/session cleanup
-│   ├── backup.php                     # Database backup
-│   └── .fulldata/
-│       ├── generate-full-sql.php      # Generates one-shot SQL dump
-│       └── ihymns-full.sql            # Pre-built full SQL (~6.8 MB)
-└── public_html/
-    ├── includes/
-    │   ├── db_mysql.php               # MySQLi connection factory
-    │   └── SongData.php               # Song data (MySQL with JSON fallback)
-    └── manage/
-        └── setup-database.php         # Web-based DB admin dashboard
-```
+1. Copy `appWeb/.auth/db_credentials.example.php` to `db_credentials.php` and edit with your MySQL details.
+2. Navigate to `/manage/setup-database.php`.
+3. Run **Install** to create base tables.
+4. Run each **migration** card in order (the dashboard shows pending migrations above the fold).
+5. Run **Song Migration** to import song data from `songs.json`.
+6. Visit `/manage/setup` to create the admin account.
 
 ---
 
@@ -280,11 +282,11 @@ appWeb/
 
 | Branch | Subdomain | Purpose |
 | --- | --- | --- |
-| `alpha` | dev.ihymns.app | Development / Alpha testing |
-| `beta` | beta.ihymns.app | Beta testing |
-| `main` | ihymns.app | Production |
+| `alpha` | `dev.ihymns.app` | Development / Alpha testing |
+| `beta` | `beta.ihymns.app` | Beta testing |
+| `main` | `ihymns.app` | Production |
 
-Deployment is automated via GitHub Actions (SFTP). See [DEV_NOTES.md](DEV_NOTES.md) for full deployment architecture.
+Deployment is automated via GitHub Actions (SFTP). See `DEV_NOTES.md` for full deployment architecture.
 
 ---
 
@@ -292,25 +294,35 @@ Deployment is automated via GitHub Actions (SFTP). See [DEV_NOTES.md](DEV_NOTES.
 
 ```text
 iHymns/
-├── .claude/              # Claude AI context & project brief
-├── .github/workflows/    # CI/CD: deploy, version bump, changelog
-├── .SourceSongData/      # Raw song text files (source of truth)
-├── tools/                # Build tools & song data parser
-├── data/                 # Generated song data (songs.json, schema)
-├── appWeb/               # Web PWA application
-│   ├── .auth/            #   Database credentials (not in git)
-│   ├── .sql/             #   Schema, installers, migrations
-│   ├── public_html/      #   Web app source (deployed)
-│   ├── data_share/       #   Shared data (songs.json, setlists)
-│   └── private_html/     #   Admin tools, song editor
-├── appApple/             # Native Apple app (Swift/SwiftUI)
-├── appAndroid/           # Android app (Kotlin/Compose)
-├── wiki/                 # GitHub wiki pages
-├── help/                 # User documentation
-├── Project_Plan.md       # Detailed project plan
-├── PROJECT_STATUS.md     # Current status tracker
-├── CHANGELOG.md          # Change log
-└── DEV_NOTES.md          # Developer notes & deployment setup
+├── .claude/              Claude AI context, ProjectBrief.md, project-rules.md
+├── .github/workflows/    CI/CD: deploy, version bump, changelog
+├── .SourceSongData/      Raw song text files (source of truth)
+├── tools/                Build tools & song-data parser
+├── data/                 Generated song data (songs.json, schema)
+├── appWeb/               Web PWA application
+│   ├── .auth/                Database credentials (NOT in git)
+│   ├── .sql/                 Schema, installers, migrations
+│   ├── uploads/songs/        Song media uploads (audio files; off the public docroot)
+│   ├── public_html/          Web app source (deployed)
+│   │   ├── includes/             Shared PHP (SongData, MediaStorage, language_names, …)
+│   │   ├── js/modules/           ES modules (song-of-the-day, song-media-editor, …)
+│   │   ├── manage/               Admin area + Song Editor
+│   │   └── song-media.php        Gated streaming endpoint (#853)
+│   └── .bulk_import_uploads/  Staging for bulk-import ZIPs
+├── appApple/             Native Apple app (Swift / SwiftUI)
+├── appAndroid/           Android app (Kotlin / Compose)
+├── iHymns.wiki/          GitHub wiki (cloned alongside as a sibling — see below)
+├── help/                 User documentation
+├── Project_Plan.md       Detailed project plan
+├── PROJECT_STATUS.md     Current status tracker
+├── CHANGELOG.md          Change log
+└── DEV_NOTES.md          Developer notes & deployment setup
+```
+
+The wiki sibling-clone pattern: clone the wiki repo alongside the main checkout so it stays in sync without polluting the app tree:
+
+```bash
+git clone https://github.com/MWBMPartners/iHymns.wiki.git
 ```
 
 ---
@@ -319,11 +331,14 @@ iHymns/
 
 | Document | Description |
 | --- | --- |
-| [Project Plan](Project_Plan.md) | Architecture, milestones, tech stack |
-| [Project Status](PROJECT_STATUS.md) | Current progress |
-| [Changelog](CHANGELOG.md) | All changes |
-| [Developer Notes](DEV_NOTES.md) | Deployment, secrets, architecture decisions |
-| [Wiki](wiki/) | Comprehensive developer & user documentation |
+| [`.claude/ProjectBrief.md`](.claude/ProjectBrief.md) | **Current-state snapshot** — version, phase, schema summary, in-flight initiatives. Auto-loaded by Claude Code; the canonical "where are we" reference. |
+| [`.claude/ProjectOverview.md`](.claude/ProjectOverview.md) | Original multi-platform scoping document. |
+| [`.claude/project-rules.md`](.claude/project-rules.md) | Naming, data-access layers, error handling, i18n, test discipline. |
+| [`Project_Plan.md`](Project_Plan.md) | Architecture, milestones, tech stack. |
+| [`PROJECT_STATUS.md`](PROJECT_STATUS.md) | Current progress tracker. |
+| [`CHANGELOG.md`](CHANGELOG.md) | All changes by version. |
+| [`DEV_NOTES.md`](DEV_NOTES.md) | Deployment, secrets, architecture decisions. |
+| `iHymns.wiki/` | **Comprehensive developer & user documentation** — API reference, database & migrations, deployment, security, PWA features, setlists & arrangements. Sibling-cloned (see Project Structure above). |
 
 ---
 
@@ -333,14 +348,14 @@ Copyright (c) 2026 MWBM Partners Ltd. All rights reserved.
 
 This software is proprietary. Unauthorized copying, modification, or distribution is strictly prohibited.
 
-Third-party components retain their respective licenses (MIT, Apache 2.0, etc.).
+Third-party components retain their respective licences (MIT, Apache 2.0, etc.).
 
 ---
 
 ## Credits
 
 - **MWBM Partners Ltd** — Development & maintenance
-- Song data sourced from published hymnals and songbooks
+- Song data sourced from published hymnals and songbooks; respective publishers and rights-holders credited per song
 
 ---
 

--- a/appWeb/.sql/migrate-song-component-language.php
+++ b/appWeb/.sql/migrate-song-component-language.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Song Component Language Override Migration (#858)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Adds a per-component language override column to tblSongComponents
+ * so a multi-language medley (e.g. an English carol with a Spanish
+ * chorus) can record the actual language of each verse / chorus /
+ * bridge instead of forcing the whole song under a single
+ * tblSongs.Language tag. Public render uses the column to set
+ * lang="…" on each component <div> (correct screen-reader
+ * pronunciation, browser hyphenation) and to populate the JSON-LD
+ * MusicComposition.inLanguage union.
+ *
+ * Schema: one nullable VARCHAR(35) column matching the IETF BCP 47
+ * width established for tblSongs.Language and tblSongbooks.Language
+ * (#681). NULL = inherit from the parent song's language; a
+ * curator-set value overrides per-component.
+ *
+ * Idempotent: probes INFORMATION_SCHEMA.COLUMNS first; skips if
+ * the column already exists.
+ *
+ * USAGE:
+ *   CLI: php appWeb/.sql/migrate-song-component-language.php
+ *   Web: /manage/setup-database → "Song Component Language Override (#858)"
+ *
+ * @migration-modifies tblSongComponents (adds Language)
+ */
+
+if (PHP_SAPI === 'cli') {
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = true;
+} else {
+    if (!defined('IHYMNS_SETUP_DASHBOARD')) {
+        if (!function_exists('isAuthenticated')) {
+            require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+        }
+        if (!isAuthenticated()) {
+            http_response_code(401);
+            exit('Authentication required.');
+        }
+        $u = getCurrentUser();
+        if (!$u || $u['role'] !== 'global_admin') {
+            http_response_code(403);
+            exit('Global admin required.');
+        }
+    }
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = false;
+}
+
+function _migComponentLang_out(string $line): void
+{
+    global $isCli;
+    echo $line . ($isCli ? "\n" : "<br>\n");
+    if ($isCli) flush();
+}
+
+function _migComponentLang_columnExists(\mysqli $db, string $table, string $column): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ? LIMIT 1'
+    );
+    $stmt->bind_param('ss', $table, $column);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+function _migComponentLang_tableExists(\mysqli $db, string $table): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? LIMIT 1'
+    );
+    $stmt->bind_param('s', $table);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+_migComponentLang_out('Song Component Language migration starting (#858)…');
+
+$mysqli = getDbMysqli();
+if (!$mysqli) {
+    throw new \RuntimeException('Could not connect to database.');
+}
+
+if (!_migComponentLang_tableExists($mysqli, 'tblSongComponents')) {
+    _migComponentLang_out('ERROR: tblSongComponents not found. Run prerequisite migrations first.');
+    return;
+}
+
+if (_migComponentLang_columnExists($mysqli, 'tblSongComponents', 'Language')) {
+    _migComponentLang_out('[skip] tblSongComponents.Language already present.');
+} else {
+    /* AFTER LinesJson keeps the column adjacent to the lyric content
+       it qualifies, so a SHOW CREATE TABLE / DESCRIBE reads in the
+       order a curator would expect. */
+    $sql = "ALTER TABLE tblSongComponents
+              ADD COLUMN Language VARCHAR(35) NULL DEFAULT NULL
+              AFTER LinesJson";
+    if (!$mysqli->query($sql)) {
+        throw new \RuntimeException('ALTER TABLE tblSongComponents add Language failed: ' . $mysqli->error);
+    }
+    _migComponentLang_out('[add ] tblSongComponents.Language (VARCHAR(35) NULL).');
+}
+
+_migComponentLang_out('Song Component Language migration finished (#858).');

--- a/appWeb/public_html/includes/SongData.php
+++ b/appWeb/public_html/includes/SongData.php
@@ -117,6 +117,10 @@ class SongData
     /** Whether we're using JSON fallback mode */
     private bool $jsonMode = false;
 
+    /** #858 — schema-probe result for tblSongComponents.Language. */
+    private bool $_componentLangColumn = false;
+    private bool $_componentLangColumnChecked = false;
+
     /** Check if running in JSON fallback mode (no MySQL) */
     public function isJsonFallback(): bool { return $this->jsonMode; }
 
@@ -2483,15 +2487,47 @@ class SongData
     }
 
     /**
+     * Schema-probe for tblSongComponents.Language (#858). Cached for
+     * the lifetime of the SongData instance — every call to
+     * _getComponents / _getComponentsMap shares the same answer.
+     * Pre-migration deploys return false and the SELECT skips the
+     * column to stay 1.x-compatible.
+     */
+    private function _hasComponentLanguageColumn(): bool
+    {
+        if ($this->_componentLangColumnChecked) {
+            return $this->_componentLangColumn;
+        }
+        $this->_componentLangColumnChecked = true;
+        try {
+            $stmt = $this->db->prepare(
+                "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+                  WHERE TABLE_SCHEMA = DATABASE()
+                    AND TABLE_NAME   = 'tblSongComponents'
+                    AND COLUMN_NAME  = 'Language' LIMIT 1"
+            );
+            $stmt->execute();
+            $this->_componentLangColumn = $stmt->get_result()->fetch_row() !== null;
+            $stmt->close();
+        } catch (\Throwable $_e) {
+            $this->_componentLangColumn = false;
+        }
+        return $this->_componentLangColumn;
+    }
+
+    /**
      * Get components (verses, choruses) for a song.
      *
      * @param string $songId Song ID
-     * @return array Array of component objects with type, number, and lines
+     * @return array Array of component objects with type, number, lines, language
      */
     private function _getComponents(string $songId): array
     {
+        $langSelect = $this->_hasComponentLanguageColumn()
+            ? ', Language AS language'
+            : ', NULL AS language';
         $stmt = $this->db->prepare(
-            "SELECT Type AS type, Number AS number, LinesJson AS lines_json
+            "SELECT Type AS type, Number AS number, LinesJson AS lines_json{$langSelect}
              FROM tblSongComponents
              WHERE SongId = ?
              ORDER BY SortOrder"
@@ -2502,9 +2538,10 @@ class SongData
         $components = [];
         while ($row = $result->fetch_assoc()) {
             $components[] = [
-                'type'   => $row['type'],
-                'number' => (int)$row['number'],
-                'lines'  => json_decode($row['lines_json'], true) ?? [],
+                'type'     => $row['type'],
+                'number'   => (int)$row['number'],
+                'lines'    => json_decode($row['lines_json'], true) ?? [],
+                'language' => $row['language'] !== null ? (string)$row['language'] : null,
             ];
         }
         $stmt->close();
@@ -2581,8 +2618,11 @@ class SongData
         if (empty($songIds)) return [];
         $placeholders = implode(',', array_fill(0, count($songIds), '?'));
         $types = str_repeat('s', count($songIds));
+        $langSelect = $this->_hasComponentLanguageColumn()
+            ? ', Language AS language'
+            : ', NULL AS language';
         $stmt = $this->db->prepare(
-            "SELECT SongId, Type AS type, Number AS number, LinesJson AS lines_json
+            "SELECT SongId, Type AS type, Number AS number, LinesJson AS lines_json{$langSelect}
              FROM tblSongComponents
              WHERE SongId IN ($placeholders)
              ORDER BY SongId, SortOrder"
@@ -2593,9 +2633,10 @@ class SongData
         $map = [];
         while ($row = $result->fetch_assoc()) {
             $map[$row['SongId']][] = [
-                'type'   => $row['type'],
-                'number' => (int)$row['number'],
-                'lines'  => json_decode($row['lines_json'], true) ?? [],
+                'type'     => $row['type'],
+                'number'   => (int)$row['number'],
+                'lines'    => json_decode($row['lines_json'], true) ?? [],
+                'language' => $row['language'] !== null ? (string)$row['language'] : null,
             ];
         }
         $stmt->close();

--- a/appWeb/public_html/includes/SongData.php
+++ b/appWeb/public_html/includes/SongData.php
@@ -302,20 +302,38 @@ class SongData
         }
         $stmt->close();
 
-        /* Attach series memberships, compilers, alt names and external
-           links in batch queries (#782 phase D, #831, #832, #833) so
-           the home / browse grids and songbook pages render without
-           N+1 queries. */
+        /* Attach series memberships, compilers, alt names, external
+           links and contained-language sets in batch queries (#782
+           phase D, #831, #832, #833, #857) so the home / browse
+           grids and songbook pages render without N+1 queries. */
         if ($books) {
-            $seriesMap    = $this->_songbookSeriesMap(null);
-            $compilersMap = $this->_songbookCompilersMap(null);
-            $altNamesMap  = $this->_songbookAltNamesMap(null);
-            $linksMap     = $this->_externalLinksMap('songbook', null);
+            $seriesMap        = $this->_songbookSeriesMap(null);
+            $compilersMap     = $this->_songbookCompilersMap(null);
+            $altNamesMap      = $this->_songbookAltNamesMap(null);
+            $linksMap         = $this->_externalLinksMap('songbook', null);
+            $songLanguagesMap = $this->_songbookSongLanguagesMap();
             foreach ($books as &$_b) {
                 $_b['series']           = $seriesMap[(string)$_b['id']]    ?? [];
                 $_b['compilers']        = $compilersMap[(string)$_b['id']] ?? [];
                 $_b['alternativeNames'] = $altNamesMap[(string)$_b['id']]  ?? [];
                 $_b['links']            = $linksMap[(string)$_b['id']]     ?? [];
+
+                /* #857 — union of: (a) the songbook's own primary
+                   subtag, and (b) every distinct primary subtag
+                   carried by songs within it. Drives the "Show
+                   languages" filter visibility and the badge
+                   tooltip. Returns an empty array on pre-#673
+                   deploys; the existing single-language behaviour
+                   then takes over via the legacy `language` field. */
+                $contained = $songLanguagesMap[(string)$_b['id']] ?? [];
+                $own       = '';
+                if (!empty($_b['language']) && preg_match('/^([a-z]{2,3})/i', (string)$_b['language'], $m)) {
+                    $own = strtolower($m[1]);
+                }
+                $merged = $own !== '' ? array_merge([$own], $contained) : $contained;
+                $merged = array_values(array_unique($merged));
+                sort($merged);
+                $_b['languages'] = $merged;
             }
             unset($_b);
         }
@@ -566,6 +584,73 @@ class SongData
             return $out;
         } catch (\Throwable $e) {
             error_log('[SongData::_songbookSeriesMap] ' . $e->getMessage());
+            return [];
+        }
+    }
+
+    /**
+     * Pull `[abbr => ['en','af',…]]` — for each songbook, the set of
+     * distinct primary language subtags that appear on its songs (#857).
+     *
+     * Used to fix songbook-tile visibility under the "Show languages"
+     * filter: a songbook tagged English (e.g. Advent Hymns) which
+     * happens to contain Afrikaans-tagged songs should still surface
+     * when the user filters for Afrikaans. The home page combines
+     * this with `tblSongbooks.Language` to produce the union list,
+     * stored on the tile as `data-songbook-languages`.
+     *
+     * Schema-probed: pre-#673 (no Language column on tblSongs)
+     * returns an empty map and the legacy single-language filter
+     * behaviour stays in effect.
+     *
+     * @return array<string, string[]>
+     */
+    private function _songbookSongLanguagesMap(): array
+    {
+        $hasSchema = false;
+        try {
+            $probe = $this->db->prepare(
+                "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+                  WHERE TABLE_SCHEMA = DATABASE()
+                    AND TABLE_NAME   = 'tblSongs'
+                    AND COLUMN_NAME  = 'Language' LIMIT 1"
+            );
+            $probe->execute();
+            $hasSchema = $probe->get_result()->fetch_row() !== null;
+            $probe->close();
+        } catch (\Throwable $_e) { /* fall through */ }
+        if (!$hasSchema) return [];
+
+        try {
+            /* GROUP_CONCAT keeps everything in one round-trip; the
+               primary-subtag extraction lives in SQL because the
+               sub-string is cheap there and avoids a per-row
+               PHP regex on a result set that can be tens of
+               thousands of rows. */
+            $sql = "SELECT SongbookAbbr,
+                           GROUP_CONCAT(
+                               DISTINCT LOWER(SUBSTRING_INDEX(Language, '-', 1))
+                               ORDER BY Language SEPARATOR ','
+                           ) AS langs
+                      FROM tblSongs
+                     WHERE Language IS NOT NULL AND Language <> ''
+                     GROUP BY SongbookAbbr";
+            $res = $this->db->query($sql);
+            $out = [];
+            if ($res) {
+                while ($row = $res->fetch_assoc()) {
+                    $abbr  = (string)$row['SongbookAbbr'];
+                    $langs = array_values(array_filter(
+                        explode(',', (string)($row['langs'] ?? '')),
+                        static fn($s) => $s !== '' && preg_match('/^[a-z]{2,3}$/', $s)
+                    ));
+                    $out[$abbr] = $langs;
+                }
+                $res->close();
+            }
+            return $out;
+        } catch (\Throwable $e) {
+            error_log('[SongData::_songbookSongLanguagesMap] ' . $e->getMessage());
             return [];
         }
     }

--- a/appWeb/public_html/includes/language_names.php
+++ b/appWeb/public_html/includes/language_names.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Language-Name Resolver (#856)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Maps an IETF BCP 47 language tag (or its primary subtag) to a
+ * human-readable display name from `tblLanguages`, so every PHP
+ * template that renders a language pill / badge can attach a
+ * tooltip showing the full name without each one re-querying the
+ * database.
+ *
+ * Backed by tblLanguages (#738 — IANA registry import + #ietf
+ * CLDR overlay). Pre-migration deployments fall back to the
+ * uppercase code unchanged so old installs render with no errors.
+ *
+ * DESIGN NOTES:
+ * - Static-cached per request: one SELECT, ~250 rows, indexed by
+ *   lowercase Code in PHP memory. A page rendering 50 badges is
+ *   one DB query.
+ * - Look-ups try the full tag first (e.g. 'pt-BR' → "Portuguese
+ *   (Brazil)"); if the full tag isn't seeded, fall back to the
+ *   primary subtag ('pt' → "Portuguese"). Same fallback used by
+ *   the IETF picker module for compose / decompose.
+ * - Schema-probed: a deploy without `tblLanguages` returns the
+ *   uppercase code identity (so a tooltip just says "EN" / "AF"
+ *   rather than 500-ing the page).
+ */
+
+if (basename($_SERVER['SCRIPT_FILENAME'] ?? '') === basename(__FILE__)) {
+    http_response_code(403);
+    exit('Access denied.');
+}
+
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'db_mysql.php';
+
+/**
+ * Resolve a language code or BCP 47 tag to a display name.
+ * Returns the original code uppercased on lookup miss / pre-migration.
+ *
+ * @param string $code Language code or tag (e.g. 'en', 'pt-BR', 'AF').
+ * @return string Display name (e.g. 'English', 'Afrikaans') or the
+ *                normalized code on miss.
+ */
+function resolveLanguageName(string $code): string
+{
+    $code = trim($code);
+    if ($code === '') return '';
+    $key = strtolower($code);
+    $map = getLanguageNamesMap();
+
+    if (isset($map[$key])) return $map[$key];
+
+    /* Try the primary subtag — pt-BR not seeded? Try pt. */
+    if (str_contains($key, '-')) {
+        $primary = explode('-', $key, 2)[0];
+        if (isset($map[$primary])) return $map[$primary];
+    }
+
+    /* No match — return the code uppercased so the tooltip degrades
+       gracefully ("EN" reads better than empty). */
+    return strtoupper($code);
+}
+
+/**
+ * Return the full code → name map, statically cached for the
+ * request. Best-effort: probe tblLanguages first; if absent
+ * (pre-#738 deploy), return an empty map and let resolveLanguageName
+ * fall back to identity.
+ *
+ * @return array<string, string> Lowercase code → English Name.
+ */
+function getLanguageNamesMap(): array
+{
+    static $cached = null;
+    if ($cached !== null) return $cached;
+
+    try {
+        $db = getDbMysqli();
+        if (!$db) {
+            $cached = [];
+            return $cached;
+        }
+
+        /* Schema-probe so a pre-migration deploy doesn't spam the
+           error log with "table not found" for every page render. */
+        $probe = $db->prepare(
+            "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+              WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tblLanguages' LIMIT 1"
+        );
+        $probe->execute();
+        $hasSchema = $probe->get_result()->fetch_row() !== null;
+        $probe->close();
+        if (!$hasSchema) {
+            $cached = [];
+            return $cached;
+        }
+
+        $res = $db->query(
+            'SELECT Code, Name FROM tblLanguages
+              WHERE COALESCE(IsActive, 1) = 1'
+        );
+        $out = [];
+        if ($res) {
+            while ($row = $res->fetch_assoc()) {
+                $code = strtolower((string)$row['Code']);
+                $name = (string)$row['Name'];
+                if ($code !== '' && $name !== '') {
+                    $out[$code] = $name;
+                }
+            }
+            $res->close();
+        }
+        $cached = $out;
+        return $cached;
+    } catch (\Throwable $e) {
+        error_log('[language_names] ' . $e->getMessage());
+        $cached = [];
+        return $cached;
+    }
+}

--- a/appWeb/public_html/includes/pages/home.php
+++ b/appWeb/public_html/includes/pages/home.php
@@ -14,6 +14,11 @@
 
 declare(strict_types=1);
 
+/* Language-name resolver (#856) — used for the songbook tile badge
+   tooltip. Static-cached per request so this require + map build
+   only fires once per page load. */
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'language_names.php';
+
 /* Load song data for statistics */
 $stats = $songData->getStats();
 $songbooks = $songData->getSongbooks();
@@ -161,9 +166,13 @@ $songbooks = $songData->getSongbooks();
                                      ISO 639 code in the tile's top-right corner,
                                      positioned to clear the offline-download cloud
                                      button below. aria-hidden because the language
-                                     is already announced by the stretched link. -->
+                                     is already announced by the stretched link.
+                                     #856: tooltip shows the full English language
+                                     name (e.g. "English", "Afrikaans") via
+                                     resolveLanguageName(). Pre-tblLanguages deploys
+                                     fall back to the code unchanged. -->
                                 <span class="songbook-tile-language-badge"
-                                      title="Language: <?= htmlspecialchars($bookLang) ?>"
+                                      title="<?= htmlspecialchars(resolveLanguageName($bookLang)) ?>"
                                       aria-hidden="true"><?= htmlspecialchars($langCode) ?></span>
                             <?php endif; ?>
                             <div class="card-body text-center">

--- a/appWeb/public_html/includes/pages/home.php
+++ b/appWeb/public_html/includes/pages/home.php
@@ -141,18 +141,37 @@ $songbooks = $songData->getSongbooks();
                            the 2-3 letter language subtag for the badge
                            (#680). Empty = no badge — communicates
                            "multi-lingual / not specified" the same way
-                           the filter in #679 does. */
+                           the filter in #679 does.
+                           #857: the songbook's contained-languages
+                           union (book.Language ∪ DISTINCT songs.Language
+                           within this book) is attached as
+                           data-songbook-languages so a book tagged
+                           English but holding Afrikaans songs surfaces
+                           when the user filters for Afrikaans. */
                         $bookLang = (string)($book['language'] ?? '');
                         $langCode = '';
                         if ($bookLang !== '' && preg_match('/^([a-z]{2,3})/i', $bookLang, $m)) {
                             $langCode = mb_strtoupper($m[1]);
                         }
+                        $bookLangs    = $book['languages'] ?? [];
+                        $bookLangsCsv = !empty($bookLangs) ? implode(',', $bookLangs) : '';
+                        /* Tooltip lists every contained language by its
+                           full English name. Falls back to just the
+                           primary tag when there's only one. */
+                        $bookLangNames = [];
+                        foreach ($bookLangs as $sub) {
+                            $bookLangNames[] = resolveLanguageName($sub);
+                        }
+                        $bookLangsTitle = !empty($bookLangNames)
+                            ? implode(', ', $bookLangNames)
+                            : resolveLanguageName($bookLang);
                     ?>
                     <div class="col" id="songbook-<?= htmlspecialchars($book['id']) ?>">
                         <div class="card card-songbook h-100 position-relative"
                              data-songbook-id="<?= htmlspecialchars($book['id']) ?>"
                              data-songbook-songs="<?= (int)$book['songCount'] ?>"
-                             <?php if ($langCode !== ''): ?>data-songbook-language="<?= htmlspecialchars($bookLang) ?>"<?php endif; ?>>
+                             <?php if ($langCode !== ''): ?>data-songbook-language="<?= htmlspecialchars($bookLang) ?>"<?php endif; ?>
+                             <?php if ($bookLangsCsv !== ''): ?>data-songbook-languages="<?= htmlspecialchars($bookLangsCsv) ?>"<?php endif; ?>>
                             <!-- Stretched link covers the whole card body,
                                  keeping the download button clickable because
                                  the button's stacking context is raised by
@@ -163,16 +182,15 @@ $songbooks = $songData->getSongbooks();
                                aria-label="<?= htmlspecialchars($book['name']) ?> — <?= $book['songCount'] ?> songs<?= $langCode !== '' ? ' (' . htmlspecialchars($langCode) . ')' : '' ?>"></a>
                             <?php if ($langCode !== ''): ?>
                                 <!-- Language indicator badge (#680) — small uppercase
-                                     ISO 639 code in the tile's top-right corner,
-                                     positioned to clear the offline-download cloud
-                                     button below. aria-hidden because the language
-                                     is already announced by the stretched link.
-                                     #856: tooltip shows the full English language
-                                     name (e.g. "English", "Afrikaans") via
-                                     resolveLanguageName(). Pre-tblLanguages deploys
-                                     fall back to the code unchanged. -->
+                                     ISO 639 code in the tile's top-right corner.
+                                     #856: tooltip resolves to the full language
+                                     name. #857: when the songbook contains songs
+                                     in multiple languages, the tooltip lists ALL
+                                     of them (e.g. "English, Afrikaans") so the
+                                     user knows why an EN-tagged book is appearing
+                                     under an Afrikaans filter. -->
                                 <span class="songbook-tile-language-badge"
-                                      title="<?= htmlspecialchars(resolveLanguageName($bookLang)) ?>"
+                                      title="<?= htmlspecialchars($bookLangsTitle) ?>"
                                       aria-hidden="true"><?= htmlspecialchars($langCode) ?></span>
                             <?php endif; ?>
                             <div class="card-body text-center">

--- a/appWeb/public_html/includes/pages/song.php
+++ b/appWeb/public_html/includes/pages/song.php
@@ -735,11 +735,38 @@ try {
                 : $components;
             $renderOrder = array_filter($renderOrder);
         ?>
+        <?php
+            /* #858 — collect the union of song-level + per-component
+               languages so we can extend the JSON-LD MusicComposition
+               with a multi-valued inLanguage further down. Tracked in
+               $songLanguageUnion (lowercase BCP 47 tags). */
+            $songLanguageUnion = [];
+            $songPrimaryLang = (string)($song['language'] ?? '');
+            if ($songPrimaryLang !== '') {
+                $songLanguageUnion[] = strtolower($songPrimaryLang);
+            }
+        ?>
         <?php foreach ($renderOrder as $component): ?>
             <?php
                 $type   = $component['type'] ?? 'verse';
                 $number = $component['number'] ?? null;
                 $lines  = $component['lines'] ?? [];
+                /* #858 — per-component language override. NULL / empty
+                   means "inherit from the song"; an explicit value
+                   sets lang="…" on this <div> so screen readers /
+                   browser hyphenation switch locales correctly, and
+                   surfaces a small badge so a reader can see that
+                   "this verse is in Spanish" at a glance. */
+                $compLangRaw = $component['language'] ?? null;
+                $compLang    = ($compLangRaw && trim((string)$compLangRaw) !== '')
+                             ? trim((string)$compLangRaw)
+                             : '';
+                $effectiveLang = $compLang !== ''
+                                ? $compLang
+                                : ($songPrimaryLang !== '' ? $songPrimaryLang : 'en');
+                if ($compLang !== '' && !in_array(strtolower($compLang), $songLanguageUnion, true)) {
+                    $songLanguageUnion[] = strtolower($compLang);
+                }
 
                 /* Build a human-readable label for the component.
                    "refrain" is an alias for "chorus" — display as Chorus.
@@ -755,11 +782,29 @@ try {
 
                 /* CSS class for styling different component types */
                 $typeClass = 'lyric-' . htmlspecialchars($type);
+
+                /* Badge shows the resolved name only when the component
+                   override DIFFERS from the song's primary language —
+                   no point flagging "this English verse is English". */
+                $showLangBadge = $compLang !== ''
+                              && strtolower($compLang) !== strtolower($songPrimaryLang);
+                if ($showLangBadge) {
+                    require_once __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'language_names.php';
+                }
             ?>
-            <div class="lyric-component <?= $typeClass ?>" role="group" aria-label="<?= htmlspecialchars($label) ?>">
+            <div class="lyric-component <?= $typeClass ?>"
+                 lang="<?= htmlspecialchars($effectiveLang) ?>"
+                 role="group" aria-label="<?= htmlspecialchars($label) ?>">
                 <!-- Component type label -->
                 <div class="lyric-label" aria-hidden="true">
                     <?= htmlspecialchars($label) ?>
+                    <?php if ($showLangBadge): ?>
+                        <span class="badge bg-info text-dark ms-2"
+                              style="font-size: 0.65rem; vertical-align: middle;"
+                              title="<?= htmlspecialchars(resolveLanguageName($compLang)) ?>">
+                            <?= htmlspecialchars(strtoupper(preg_replace('/-.*$/', '', $compLang) ?: $compLang)) ?>
+                        </span>
+                    <?php endif; ?>
                 </div>
                 <!-- Lyrics lines -->
                 <div class="lyric-lines">

--- a/appWeb/public_html/includes/pages/song.php
+++ b/appWeb/public_html/includes/pages/song.php
@@ -312,7 +312,15 @@ try {
                                 <?php if ($i > 0): ?>, <?php endif; ?>
                                 <em><?= htmlspecialchars($a['title']) ?></em>
                                 <?php if (!empty($a['language'])): ?>
-                                    <span class="badge bg-secondary text-light small"><?= htmlspecialchars($a['language']) ?></span>
+                                    <?php
+                                        /* #856 — tooltip resolves the IETF tag to
+                                           the full language name. Lazy-require here
+                                           because most songs have no alt titles and
+                                           we don't want a SELECT for every page. */
+                                        require_once __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'language_names.php';
+                                    ?>
+                                    <span class="badge bg-secondary text-light small"
+                                          title="<?= htmlspecialchars(resolveLanguageName($a['language'])) ?>"><?= htmlspecialchars($a['language']) ?></span>
                                 <?php endif; ?>
                                 <?php if (!empty($a['note'])): ?>
                                     <span class="text-muted">(<?= htmlspecialchars($a['note']) ?>)</span>

--- a/appWeb/public_html/includes/pages/songbooks.php
+++ b/appWeb/public_html/includes/pages/songbooks.php
@@ -50,12 +50,24 @@ $stats = $songData->getStats();
                     /* Language indicator badge data (#680) — same pattern
                        as home.php: pull the IETF tag, extract the 2-3
                        letter language subtag, uppercase. Empty = no
-                       badge (multi-lingual / not specified). */
+                       badge (multi-lingual / not specified).
+                       #857 — also expose the contained-languages union
+                       so a book tagged English but holding Afrikaans
+                       songs surfaces under an Afrikaans filter. */
                     $bookLang = (string)($book['language'] ?? '');
                     $langCode = '';
                     if ($bookLang !== '' && preg_match('/^([a-z]{2,3})/i', $bookLang, $m)) {
                         $langCode = mb_strtoupper($m[1]);
                     }
+                    $bookLangs    = $book['languages'] ?? [];
+                    $bookLangsCsv = !empty($bookLangs) ? implode(',', $bookLangs) : '';
+                    $bookLangNames = [];
+                    foreach ($bookLangs as $sub) {
+                        $bookLangNames[] = resolveLanguageName($sub);
+                    }
+                    $bookLangsTitle = !empty($bookLangNames)
+                        ? implode(', ', $bookLangNames)
+                        : resolveLanguageName($bookLang);
                 ?>
                 <div class="col-12 col-sm-6 col-md-4 col-lg-3">
                     <a href="/songbook/<?= htmlspecialchars($book['id']) ?>"
@@ -63,12 +75,14 @@ $stats = $songData->getStats();
                        data-navigate="songbook"
                        data-songbook-id="<?= htmlspecialchars($book['id']) ?>"
                        <?php if ($langCode !== ''): ?>data-songbook-language="<?= htmlspecialchars($bookLang) ?>"<?php endif; ?>
+                       <?php if ($bookLangsCsv !== ''): ?>data-songbook-languages="<?= htmlspecialchars($bookLangsCsv) ?>"<?php endif; ?>
                        aria-label="Open <?= htmlspecialchars($book['name']) ?><?= $langCode !== '' ? ' (' . htmlspecialchars($langCode) . ')' : '' ?>">
                         <?php if ($langCode !== ''): ?>
-                            <!-- #856: tooltip resolves the IETF tag to the
-                                 full language name (e.g. "English"). -->
+                            <!-- #856 / #857: tooltip resolves the IETF tag to
+                                 the full language name; when the book contains
+                                 songs in multiple languages, all are listed. -->
                             <span class="songbook-tile-language-badge"
-                                  title="<?= htmlspecialchars(resolveLanguageName($bookLang)) ?>"
+                                  title="<?= htmlspecialchars($bookLangsTitle) ?>"
                                   aria-hidden="true"><?= htmlspecialchars($langCode) ?></span>
                         <?php endif; ?>
                         <div class="card-body">

--- a/appWeb/public_html/includes/pages/songbooks.php
+++ b/appWeb/public_html/includes/pages/songbooks.php
@@ -13,6 +13,9 @@
 
 declare(strict_types=1);
 
+/* #856 — language-name resolver for the tile badge tooltip. */
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'language_names.php';
+
 $songbooks = $songData->getSongbooks();
 $stats = $songData->getStats();
 
@@ -62,8 +65,10 @@ $stats = $songData->getStats();
                        <?php if ($langCode !== ''): ?>data-songbook-language="<?= htmlspecialchars($bookLang) ?>"<?php endif; ?>
                        aria-label="Open <?= htmlspecialchars($book['name']) ?><?= $langCode !== '' ? ' (' . htmlspecialchars($langCode) . ')' : '' ?>">
                         <?php if ($langCode !== ''): ?>
+                            <!-- #856: tooltip resolves the IETF tag to the
+                                 full language name (e.g. "English"). -->
                             <span class="songbook-tile-language-badge"
-                                  title="Language: <?= htmlspecialchars($bookLang) ?>"
+                                  title="<?= htmlspecialchars(resolveLanguageName($bookLang)) ?>"
                                   aria-hidden="true"><?= htmlspecialchars($langCode) ?></span>
                         <?php endif; ?>
                         <div class="card-body">

--- a/appWeb/public_html/includes/partials/songbook-language-filter.php
+++ b/appWeb/public_html/includes/partials/songbook-language-filter.php
@@ -111,6 +111,11 @@ ksort($languageOptions);
 if (count($languageOptions) <= 1) {
     return;
 }
+
+/* #856 — resolve each subtag to a human-readable language name for
+   the pill tooltip. The helper is request-scoped + static-cached
+   so this is one extra DB query for the whole partial. */
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'language_names.php';
 ?>
 <div class="songbook-language-filter mb-3"
      data-songbook-language-filter
@@ -125,12 +130,18 @@ if (count($languageOptions) <= 1) {
                    id="songbook-language-filter-all" autocomplete="off" checked>
             <label class="btn btn-outline-info" for="songbook-language-filter-all">All</label>
             <?php foreach ($languageOptions as $sub => $label): ?>
-                <?php $id = 'songbook-language-filter-' . htmlspecialchars($sub, ENT_QUOTES, 'UTF-8'); ?>
+                <?php
+                    $id       = 'songbook-language-filter-' . htmlspecialchars($sub, ENT_QUOTES, 'UTF-8');
+                    /* #856 — resolved name for the tooltip; falls back to
+                       the uppercase code when tblLanguages isn't seeded. */
+                    $langName = resolveLanguageName($sub);
+                ?>
                 <input type="checkbox" class="btn-check js-songbook-language-filter-option"
                        id="<?= $id ?>"
                        value="<?= htmlspecialchars($sub, ENT_QUOTES, 'UTF-8') ?>"
                        autocomplete="off">
-                <label class="btn btn-outline-info" for="<?= $id ?>">
+                <label class="btn btn-outline-info" for="<?= $id ?>"
+                       title="<?= htmlspecialchars($langName, ENT_QUOTES, 'UTF-8') ?>">
                     <?= htmlspecialchars($label, ENT_QUOTES, 'UTF-8') ?>
                 </label>
             <?php endforeach; ?>

--- a/appWeb/public_html/index.php
+++ b/appWeb/public_html/index.php
@@ -238,12 +238,35 @@ try {
             $ogImage = getCanonicalUrl('/og-image?song=' . urlencode($matches[1]));
             $ogImageAlt = 'Preview of "' . $ogSong['title'] . '" from ' . $ogSong['songbookName'];
 
-            /* JSON-LD: MusicComposition */
+            /* JSON-LD: MusicComposition. #858 — inLanguage is the
+               union of the song's primary language and every per-
+               component override, so a Spanish-chorus / English-verse
+               medley is correctly indexed as multilingual. Falls back
+               to a single-string $locale when no per-component data
+               is attached (pre-migration / no overrides). */
+            $jsonLdLanguages = [];
+            if (!empty($ogSong['language'])) {
+                $jsonLdLanguages[] = (string)$ogSong['language'];
+            } elseif ($locale !== '') {
+                $jsonLdLanguages[] = $locale;
+            }
+            foreach (($ogSong['components'] ?? []) as $cmp) {
+                $cl = trim((string)($cmp['language'] ?? ''));
+                if ($cl !== '' && !in_array($cl, $jsonLdLanguages, true)) {
+                    $jsonLdLanguages[] = $cl;
+                }
+            }
             $musicComposition = [
                 '@context' => 'https://schema.org',
                 '@type'    => 'MusicComposition',
                 'name'     => $ogSong['title'],
-                'inLanguage' => $locale,
+                /* Single-value when only one language; array when the
+                   song carries per-component overrides. Both shapes
+                   are valid schema.org per the Web Schemas
+                   recommendation. */
+                'inLanguage' => count($jsonLdLanguages) > 1
+                    ? $jsonLdLanguages
+                    : ($jsonLdLanguages[0] ?? $locale),
             ];
             /* #832 — alternateName for SEO. Search engines pick this up
                so a query for the original title / common misspelling /

--- a/appWeb/public_html/js/modules/song-of-the-day.js
+++ b/appWeb/public_html/js/modules/song-of-the-day.js
@@ -113,8 +113,43 @@ export class SongOfTheDay {
         ];
     }
 
-    /** Initialise — nothing needed on startup */
-    init() {}
+    /**
+     * Initialise — wire a single iHymns:language-filter-changed listener
+     * (#855) so the SoTD card re-picks when the user toggles the
+     * "Show languages" filter. We deliberately bind on document (not
+     * the container) so the listener survives the SPA's home-section
+     * re-renders without rebinding on each pass.
+     */
+    init() {
+        if (this._langFilterBound) return;
+        this._langFilterBound = true;
+        document.addEventListener('iHymns:language-filter-changed', () => {
+            this.renderHomeSection();
+        });
+    }
+
+    /**
+     * Read the active language-filter subtag set the same way the
+     * songbook-language-filter module does — single source of truth
+     * is localStorage['songbook-language-filter'] (a JSON array of
+     * lowercase primary subtags). Returns [] when the user has
+     * "All" selected (no filter), and likewise on parse errors.
+     *
+     * Kept as a tiny inline helper rather than imported from the
+     * filter module so SoTD stays decoupled — the filter module
+     * does the writes; we only read.
+     */
+    getActiveSubtags() {
+        try {
+            const raw = localStorage.getItem('songbook-language-filter');
+            if (!raw) return [];
+            const parsed = JSON.parse(raw);
+            if (!Array.isArray(parsed)) return [];
+            return parsed.filter(s => typeof s === 'string' && /^[a-z]{2,3}$/.test(s));
+        } catch (_e) {
+            return [];
+        }
+    }
 
     /**
      * Render the Song of the Day card on the home page.
@@ -172,16 +207,64 @@ export class SongOfTheDay {
      * @returns {object|null}
      */
     pickSong(songs, date) {
-        /* Check calendar themes */
-        for (const theme of this.calendarThemes) {
-            if (theme.check(date)) {
-                const match = this.findThemedSong(songs, theme.keywords, date);
-                if (match) return match;
-            }
-        }
+        /* #855 — apply the user's active "Show languages" filter so
+           a non-English user doesn't get an English daily song they
+           can't read. Fallback ladder:
+             1. Filtered pool (filter ∪ untagged) → themed pick
+             2. Filtered pool (filter ∪ untagged) → deterministic pick
+             3. English subset (en* ∪ untagged) → themed pick
+             4. English subset → deterministic pick
+             5. Unfiltered pool → deterministic pick (zero language
+                data on the catalogue; pre-#681 deploys fall here)
+           The themed-keyword bank stays English; Spanish/etc. carols
+           still match because hymnologists carry English-borrowed
+           proper nouns ("Adviento", "Pascua") and shared roots. */
+        const active = this.getActiveSubtags();
+        const filteredPool = this.filterSongsByLanguage(songs, active);
 
-        /* Deterministic pseudo-random pick */
-        return this.deterministicPick(songs, date);
+        const tryPool = (pool) => {
+            if (!pool || pool.length === 0) return null;
+            for (const theme of this.calendarThemes) {
+                if (theme.check(date)) {
+                    const match = this.findThemedSong(pool, theme.keywords, date);
+                    if (match) return match;
+                }
+            }
+            return this.deterministicPick(pool, date);
+        };
+
+        /* Skip the English fallback when the user's active filter
+           IS English (or "All" — already covers English) since it'd
+           just rerun the same selection over the same pool. */
+        const isEnglishOrAll = active.length === 0
+            || (active.length === 1 && active[0] === 'en');
+
+        return tryPool(filteredPool)
+            || (isEnglishOrAll ? null : tryPool(this.filterSongsByLanguage(songs, ['en'])))
+            || this.deterministicPick(songs, date);
+    }
+
+    /**
+     * Filter a songs[] array against a set of primary subtags. An
+     * empty subtags array returns the full songs array (no filter).
+     * Untagged songs (no `language` field) ALWAYS pass — we treat
+     * them as "multi-lingual / not specified" rather than "exclude
+     * because we don't know", matching the songbook-language-filter
+     * module's behaviour for tiles.
+     *
+     * @param {Array} songs
+     * @param {string[]} subtags Lowercase primary subtags; empty = no filter
+     * @returns {Array} New filtered array (may share elements with input)
+     */
+    filterSongsByLanguage(songs, subtags) {
+        if (!subtags || subtags.length === 0) return songs;
+        const set = new Set(subtags.map(s => s.toLowerCase()));
+        return songs.filter(s => {
+            const lang = (s.language || '').toLowerCase();
+            if (!lang) return true; /* untagged → always pass */
+            const primary = lang.split('-', 1)[0];
+            return set.has(primary);
+        });
     }
 
     /**

--- a/appWeb/public_html/js/modules/songbook-language-filter.js
+++ b/appWeb/public_html/js/modules/songbook-language-filter.js
@@ -197,6 +197,16 @@ function applyFilter(rootEl, subtags) {
             row.setAttribute('aria-hidden', 'true');
         }
     });
+
+    /* #855 — broadcast the change so independent modules (Song of
+       the Day in particular) can re-render without a page reload.
+       Detail.subtags carries the canonical lowercase array; an empty
+       array means "All" / no filter. */
+    try {
+        document.dispatchEvent(new CustomEvent('iHymns:language-filter-changed', {
+            detail: { subtags: Array.from(set) },
+        }));
+    } catch (_e) { /* polyfill territory; harmless to skip */ }
 }
 
 /**

--- a/appWeb/public_html/js/modules/songbook-language-filter.js
+++ b/appWeb/public_html/js/modules/songbook-language-filter.js
@@ -158,17 +158,28 @@ function findTileColumn(tile) {
 function applyFilter(rootEl, subtags) {
     const set = new Set(subtags.map(s => s.toLowerCase()));
 
-    /* Songbook tiles. */
+    /* Songbook tiles.
+       #857: visibility is decided on the union of (the songbook's
+       own primary subtag) ∪ (every distinct primary subtag carried
+       by songs within that book). Server emits this union as
+       data-songbook-languages (comma-separated). The legacy
+       data-songbook-language attribute stays populated for one
+       release-cycle of back-compat with cached JS bundles, and as
+       a fallback when the union attribute is absent. */
     rootEl.querySelectorAll('[data-songbook-id]').forEach(tile => {
-        const tileLang = (tile.dataset.songbookLanguage || '').toLowerCase();
+        const langsCsv  = (tile.dataset.songbookLanguages || '').toLowerCase();
+        const fallback  = (tile.dataset.songbookLanguage  || '').toLowerCase();
         const col = findTileColumn(tile);
         if (!col) return;
 
+        const tilePrimaries = (langsCsv
+            ? langsCsv.split(',').map(s => s.trim()).filter(Boolean)
+            : (fallback ? [fallback.split('-', 1)[0]] : []));
+
         const shouldShow = (() => {
-            if (set.size === 0) return true;
-            if (!tileLang) return true;
-            const primary = tileLang.split('-', 1)[0];
-            return set.has(primary);
+            if (set.size === 0) return true;        /* "All" → everything */
+            if (tilePrimaries.length === 0) return true; /* untagged → always pass */
+            return tilePrimaries.some(p => set.has(p));
         })();
 
         if (shouldShow) {

--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -1251,17 +1251,55 @@ switch ($action) {
                 $stmtRegistry->close();
             }
 
-            $insComp = $db->prepare(
-                'INSERT INTO tblSongComponents
-                    (SongId, Type, Number, SortOrder, LinesJson)
-                 VALUES (?, ?, ?, ?, ?)'
-            );
+            /* #858 — schema-probe for the optional Language column.
+               When present, the INSERT carries a per-component
+               override; pre-migration deploys keep the legacy
+               5-column INSERT shape. */
+            $hasComponentLanguage = false;
+            try {
+                $colProbe = $db->prepare(
+                    "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+                      WHERE TABLE_SCHEMA = DATABASE()
+                        AND TABLE_NAME   = 'tblSongComponents'
+                        AND COLUMN_NAME  = 'Language' LIMIT 1"
+                );
+                $colProbe->execute();
+                $hasComponentLanguage = $colProbe->get_result()->fetch_row() !== null;
+                $colProbe->close();
+            } catch (\Throwable $_e) { /* default false */ }
+
+            if ($hasComponentLanguage) {
+                $insComp = $db->prepare(
+                    'INSERT INTO tblSongComponents
+                        (SongId, Type, Number, SortOrder, LinesJson, Language)
+                     VALUES (?, ?, ?, ?, ?, ?)'
+                );
+            } else {
+                $insComp = $db->prepare(
+                    'INSERT INTO tblSongComponents
+                        (SongId, Type, Number, SortOrder, LinesJson)
+                     VALUES (?, ?, ?, ?, ?)'
+                );
+            }
             $order = 0;
             foreach ($song['components'] ?? [] as $comp) {
                 $type   = (string)($comp['type'] ?? 'verse');
                 $cNum   = isset($comp['number']) ? (int)$comp['number'] : 0;
                 $lines  = json_encode($comp['lines'] ?? [], JSON_UNESCAPED_UNICODE);
-                $insComp->bind_param('ssiis', $songId, $type, $cNum, $order, $lines);
+                if ($hasComponentLanguage) {
+                    /* Trim + cap to 35 chars (the BCP 47 column width).
+                       Empty / null = inherit from the song; only persist
+                       a value that's plausibly a tag. */
+                    $lang = trim((string)($comp['language'] ?? ''));
+                    if ($lang === '' || !preg_match('/^[A-Za-z]{2,3}([-_][A-Za-z0-9]{1,8})*$/', $lang)) {
+                        $lang = null;
+                    } else {
+                        $lang = function_exists('mb_substr') ? mb_substr($lang, 0, 35) : substr($lang, 0, 35);
+                    }
+                    $insComp->bind_param('ssiiss', $songId, $type, $cNum, $order, $lines, $lang);
+                } else {
+                    $insComp->bind_param('ssiis', $songId, $type, $cNum, $order, $lines);
+                }
                 $insComp->execute();
                 $order++;
             }

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -895,10 +895,56 @@ function renderComponents(song) {
         btnGroup.appendChild(btnDown);
         btnGroup.appendChild(btnRemove);
 
+        /* #858 — per-component language override. NULL / empty value
+           means "inherit from the parent song's language"; an explicit
+           pick overrides for this component only. The dropdown is
+           populated from window.iHymnsLanguageOptions which is
+           pre-loaded at editor boot from /api?action=languages.
+           Disabled when the schema column is absent (pre-migration);
+           the boot script sets dataset.componentLangColumn = '0' in
+           that case so this just becomes a no-op. */
+        var langSelect = document.createElement('select');
+        langSelect.className = 'form-select form-select-sm component-language-select';
+        langSelect.style.maxWidth = '160px';
+        langSelect.title = 'Language override (optional) — defaults to the song language';
+        var langInherit = document.createElement('option');
+        langInherit.value = '';
+        langInherit.textContent = 'Same as song';
+        langSelect.appendChild(langInherit);
+        var languageOptions = Array.isArray(window.iHymnsLanguageOptions)
+            ? window.iHymnsLanguageOptions : [];
+        var currentLang = comp.language ? String(comp.language) : '';
+        var sawCurrent = false;
+        languageOptions.forEach(function (opt) {
+            var o = document.createElement('option');
+            o.value = opt.code;
+            o.textContent = opt.name + ' (' + opt.code + ')';
+            if (currentLang && currentLang.toLowerCase() === String(opt.code).toLowerCase()) {
+                o.selected = true;
+                sawCurrent = true;
+            }
+            langSelect.appendChild(o);
+        });
+        /* If the saved tag isn't in the registry (pt-BR when only pt
+           is seeded, or a brand-new tag), surface it as an extra
+           option so it doesn't silently revert on save. */
+        if (currentLang && !sawCurrent) {
+            var oExtra = document.createElement('option');
+            oExtra.value = currentLang;
+            oExtra.textContent = currentLang;
+            oExtra.selected = true;
+            langSelect.appendChild(oExtra);
+        }
+        langSelect.addEventListener('change', function () {
+            comp.language = langSelect.value || null;
+            markModified(song.id);
+        });
+
         /* Assemble the header. */
         header.appendChild(typeLabel);
         header.appendChild(typeSelect);
         header.appendChild(numInput);
+        header.appendChild(langSelect);
         header.appendChild(btnGroup);
 
         /* ---- Card body with lyrics textarea ---- */

--- a/appWeb/public_html/manage/editor/index.php
+++ b/appWeb/public_html/manage/editor/index.php
@@ -1439,6 +1439,32 @@ $currentUser = getCurrentUser();
          is handled in this separate file to keep concerns separated -->
     <script src="editor.js"></script>
 
+    <!-- #858 — pre-load tblLanguages once per page so the per-component
+         language override picker (rendered by editor.js renderComponents)
+         can populate without each card re-fetching. Empty array fallback
+         on a 4xx/5xx so the dropdown still shows "Same as song" only. -->
+    <script>
+    (function () {
+        window.iHymnsLanguageOptions = window.iHymnsLanguageOptions || [];
+        fetch('/api?action=languages', { credentials: 'same-origin' })
+            .then(function (r) { return r.ok ? r.json() : null; })
+            .then(function (j) {
+                if (!j || !Array.isArray(j.languages)) return;
+                window.iHymnsLanguageOptions = j.languages
+                    .filter(function (l) { return l && l.code && l.name; })
+                    .map(function (l) { return { code: l.code, name: l.name }; });
+                /* Notify any rendered components that we're ready —
+                   editor.js doesn't currently subscribe, so the
+                   first selectSong() after this resolves picks up
+                   the populated list naturally. */
+                try {
+                    document.dispatchEvent(new CustomEvent('iHymns:languages-loaded'));
+                } catch (_e) {}
+            })
+            .catch(function () { /* registry unavailable — fallback to identity */ });
+    })();
+    </script>
+
     <!-- IETF BCP 47 picker boot (#687). The shared module is the same one
          that powers /manage/songbooks. We expose the booted instance on
          window.editSongIetfPicker so editor.js (a classic script that

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -234,6 +234,7 @@ $friendlyTitles = [
     'works'                            => 'Works — composition grouping (#840)',
     'external-link-patterns'           => 'External-Link URL Patterns (#845)',
     'song-media'                       => 'Song Media Uploads (#853)',
+    'song-component-language'          => 'Song Component Language Override (#858)',
     /* `recompute-songbook-songcount` no longer exposed via the dashboard
        (#818) — the SongCount Triggers migration above includes its own
        initial recompute. The CLI script stays on disk for emergency
@@ -293,6 +294,7 @@ $scriptMap = [
     'works'                         => 'migrate-works.php',
     'external-link-patterns'        => 'migrate-external-link-patterns.php',
     'song-media'                    => 'migrate-song-media.php',
+    'song-component-language'       => 'migrate-song-component-language.php',
     'cleanup'     => 'cleanup.php',
     'backup'      => 'backup.php',
     'restore'     => 'restore.php',
@@ -342,6 +344,7 @@ $migrationOrder = [
     'works',
     'external-link-patterns',
     'song-media',
+    'song-component-language',
 ];
 
 /* Per-migration card content (#816). Single source of truth for the
@@ -741,6 +744,22 @@ $migrationCards = [
                   . ' release cycle. Idempotent.',
         'button' => 'Run Song Media Migration',
     ],
+    'song-component-language' => [
+        'title'  => 'Song Component Language Override (#858)',
+        'body'   => 'Adds <code>Language VARCHAR(35) NULL</code> to'
+                  . ' <code>tblSongComponents</code> so a multi-language medley'
+                  . ' (e.g. an English carol with a Spanish chorus) can record'
+                  . ' the actual language of each verse / chorus / bridge instead'
+                  . ' of forcing the whole song under a single'
+                  . ' <code>tblSongs.Language</code> tag. <code>NULL</code> means'
+                  . ' "inherit from the parent song"; an explicit value overrides'
+                  . ' per-component. Public render uses the column to set'
+                  . ' <code>lang="…"</code> on each component <code>&lt;div&gt;</code>'
+                  . ' (correct screen-reader pronunciation, browser hyphenation)'
+                  . ' and to populate the JSON-LD <code>MusicComposition.inLanguage</code>'
+                  . ' union. Idempotent.',
+        'button' => 'Run Song Component Language Migration',
+    ],
     /* recompute-songbook-songcount card removed (#818) — its work is
        now covered by the SongCount Triggers migration above, which
        runs an initial recompute as part of its installation. The
@@ -893,6 +912,9 @@ $migrationProbes = [
     /* Song media uploads: pending when tblSongMedia is absent. */
     'song-media'                         => static fn(\mysqli $db) =>
         !_migProbe_tableExists($db, 'tblSongMedia'),
+    /* Song component language: pending when the column is absent. */
+    'song-component-language'            => static fn(\mysqli $db) =>
+        !_migProbe_columnExists($db, 'tblSongComponents', 'Language'),
     /* Backfills run once after schema lands. They're idempotent so
        always-show is safe — but we can be smarter: pending when the
        new table has fewer rows than the legacy source had non-empty

--- a/appWeb/public_html/manage/songbooks.php
+++ b/appWeb/public_html/manage/songbooks.php
@@ -23,6 +23,7 @@ require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 
    abbrev / colour / IETF-tag grammar lands on both surfaces in one go. */
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'songbook_validation.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'external_link_helpers.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'language_names.php';
 
 if (!isAuthenticated()) {
     header('Location: /manage/login');
@@ -2247,13 +2248,21 @@ $csrf = csrfToken();
                                         /* Show the full tag (e.g. en-GB, zh-Hans-CN)
                                            but render only the primary subtag in
                                            the badge for compactness, matching the
-                                           public-site badge convention. The full
-                                           tag goes in the title for hover. */
-                                        $primary = strtoupper(preg_replace('/-.*$/', '', $bookLang) ?: $bookLang);
+                                           public-site badge convention. The title
+                                           composes the resolved English name
+                                           ("English (United Kingdom)") with the
+                                           raw tag in parens for power-users —
+                                           gives both audiences the right level
+                                           of detail (#856). */
+                                        $primary    = strtoupper(preg_replace('/-.*$/', '', $bookLang) ?: $bookLang);
+                                        $resolvedLn = resolveLanguageName($bookLang);
+                                        $titleAttr  = ($resolvedLn !== '' && strtoupper($resolvedLn) !== strtoupper($bookLang))
+                                                    ? $resolvedLn . ' (' . $bookLang . ')'
+                                                    : $bookLang;
                                     ?>
                                     <span class="badge bg-info text-dark"
                                           style="font-size: 0.7rem; font-weight: 600;"
-                                          title="<?= htmlspecialchars($bookLang, ENT_QUOTES, 'UTF-8') ?>">
+                                          title="<?= htmlspecialchars($titleAttr, ENT_QUOTES, 'UTF-8') ?>">
                                         <?= htmlspecialchars($primary, ENT_QUOTES, 'UTF-8') ?>
                                     </span>
                                 <?php else: ?>


### PR DESCRIPTION
Bundle of five user-facing multilingual improvements for the Alpha catalogue, plus a v0.75.0 README refresh. One branch, five commits, one issue per commit.

| Commit | Issue | Closes |
|--------|-------|--------|
| [`36c1e92f`](https://github.com/MWBMPartners/iHymns/commit/36c1e92f) | A — Song of the Day respects active language filter | [#855](https://github.com/MWBMPartners/iHymns/issues/855) |
| [`05c0afff`](https://github.com/MWBMPartners/iHymns/commit/05c0afff) | B — Language-name tooltips on every language tag | [#856](https://github.com/MWBMPartners/iHymns/issues/856) |
| [`71d79adb`](https://github.com/MWBMPartners/iHymns/commit/71d79adb) | C — Songbook tiles surface under any contained-language match | [#857](https://github.com/MWBMPartners/iHymns/issues/857) |
| [`6be9b1e1`](https://github.com/MWBMPartners/iHymns/commit/6be9b1e1) | D — Verse-level language override on song components | [#858](https://github.com/MWBMPartners/iHymns/issues/858) |
| [`08fb743a`](https://github.com/MWBMPartners/iHymns/commit/08fb743a) | E — Comprehensive README refresh for v0.75.0 | [#859](https://github.com/MWBMPartners/iHymns/issues/859) |

## Why

The catalogue has expanded from 5 English songbooks (~3,612 songs) to 30+ songbooks (~12,370 songs) covering ~20 languages. Several public-facing surfaces still assumed an English-only world; this batch closes the gaps.

## What changes

### A — Song of the Day (#855)

- New module-internal `getActiveSubtags()` reads the same localStorage key (`songbook-language-filter`) that the filter module writes.
- `pickSong()` runs through a fallback ladder: filtered pool → themed → deterministic → English subset → unfiltered.
- `init()` binds a single document-level `iHymns:language-filter-changed` listener so SoTD re-picks when the user toggles pills, no page reload.
- `applyFilter()` in the filter module dispatches the new event after each visual pass.

### B — Language tooltips (#856)

- New `appWeb/public_html/includes/language_names.php` helper: `resolveLanguageName(string)` + request-scoped static-cached `getLanguageNamesMap()`.
- Tooltips swept in: home tile badge, songbooks tile badge, "Show languages" filter pills, song-page alt-titles badge, admin Languages-column badge.
- Pre-`tblLanguages` deploys fall back to the uppercase code unchanged.

### C — Songbook visibility (#857)

- `SongData::_songbookSongLanguagesMap()` — single bulk SELECT, GROUP_CONCAT(DISTINCT primary subtag), schema-probed.
- `getSongbooks()` attaches `book['languages']` = union of (book's own primary subtag) ∪ (contained song subtags), sorted + de-duplicated.
- Tiles now carry `data-songbook-languages="en,af"` alongside the existing `data-songbook-language` (back-compat for one release-cycle).
- Filter JS reads the new attribute; ANY-intersection match shows the tile. Untagged tiles still always pass.
- Badge tooltip lists ALL contained languages (e.g. "English, Afrikaans") so a curator inspecting why an EN-tagged book appeared under an AF filter has the answer.

### D — Verse-level language override (#858)

- New idempotent migration `migrate-song-component-language.php` adds `Language VARCHAR(35) NULL` after `LinesJson`.
- `SongData::_hasComponentLanguageColumn()` instance-cached probe; both component fetch paths schema-probe and include `Language` (or `NULL AS language` for back-compat).
- `editor/api.php` save_song INSERT switches to a 6-column shape when the column exists; pre-migration deploys keep the legacy 5-column INSERT.
- Editor: pre-loads `/api?action=languages` once at boot; `renderComponents()` adds a per-card language `<select>` with "Same as song" default.
- Public song page: component `<div>` carries `lang="…"` (correct screen-reader pronunciation, browser hyphenation); a small badge appears next to the verse number when the override differs from the song's primary language.
- JSON-LD `MusicComposition.inLanguage` becomes the union when a song carries per-component overrides.

### E — README.md refresh (#859)

- 30+ songbooks / ~12,370 songs / ~20 languages snapshot replaces the 5-song table.
- Features section now reflects #831 / #832 / #833 / #840 / #845 / #853 / #855–#858.
- Admin Portal updated with the seven nav groups + ~39 surfaces.
- Cross-links `.claude/ProjectBrief.md` and the sibling `iHymns.wiki/` clone.
- Version badge bumped to 0.75.0 Alpha.

## Test plan

### Issue A
- [ ] On Christmas Day with filter "All" → English Christmas-themed song.
- [ ] Filter to Afrikaans only → Afrikaans (or untagged) song; theme keyword still hits via shared roots.
- [ ] Filter to Tumbuka on Christmas Day → English fallback fires; theme label remains.
- [ ] Toggle pills mid-page → SoTD card re-renders without reload.
- [ ] Sign in with `PreferredLanguagesJson = ["af"]` → SoTD respects server preference.

### Issue B
- [ ] Hover every language badge on home, songbooks, song page, admin → English name in tooltip.
- [ ] Pre-`tblLanguages` deploy: badges render with bare uppercase code, no error.

### Issue C
- [ ] Advent Hymns shows when filter is "Afrikaans" only (assuming any AF song lives in AH).
- [ ] AH tile tooltip lists "English, Afrikaans".
- [ ] A songbook with zero matching songs hides as before.
- [ ] Untagged songbooks always show regardless of filter.

### Issue D
- [ ] Run `migrate-song-component-language.php` → confirm `tblSongComponents.Language` exists, NULLABLE.
- [ ] Editor → Structure tab → per-card "Language" dropdown defaults to "Same as song".
- [ ] Override a verse to Spanish, save → DB has `Language='es'` only on that component.
- [ ] Public song page: overridden `<div>` carries `lang="es"`; `[ES]` badge appears; JSON-LD `inLanguage` includes both.
- [ ] Drop the column → editor still works (schema-probe back-compat).

### Issue E
- [ ] `npx markdownlint-cli --config /tmp/mdrc.json README.md` clean (MD013 disabled).
- [ ] Spot-check links: `.claude/ProjectBrief.md`, `iHymns.wiki/`, the wiki Database-&-Migrations page.
- [ ] `gh repo view --web` renders the README correctly.

### Cross-issue
- [ ] All commits leave `php -l` clean.
- [ ] All commits leave `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)