### PR TITLE
chore(release): bump app version to v0.76.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **A multiplatform Christian lyrics application for worship enhancement**
 
-[![Version: 0.75.0 Alpha](https://img.shields.io/badge/Version-0.75.0%20Alpha-orange.svg)](#environments)
+[![Version: 0.76.0 Alpha](https://img.shields.io/badge/Version-0.76.0%20Alpha-orange.svg)](#environments)
 [![License: Proprietary](https://img.shields.io/badge/License-Proprietary-red.svg)](#license)
 [![Platform: Web](https://img.shields.io/badge/Platform-Web%20PWA-blue.svg)](#platforms)
 [![Platform: iOS](https://img.shields.io/badge/Platform-iOS%20%7C%20iPadOS%20%7C%20tvOS-black.svg)](#platforms)
@@ -55,7 +55,7 @@ Songs are tagged at song-level with their actual IETF BCP 47 language (#681), so
 
 | Platform | Technology | Status |
 | --- | --- | --- |
-| Web PWA | HTML5, CSS3, Bootstrap 5.3, vanilla JS, PHP 8.1+, MySQL 5.7+ / MariaDB 10.3+ | **Alpha** (v0.75.0) |
+| Web PWA | HTML5, CSS3, Bootstrap 5.3, vanilla JS, PHP 8.1+, MySQL 5.7+ / MariaDB 10.3+ | **Alpha** (v0.76.0) |
 | iOS / iPadOS / tvOS | Swift 6.3, SwiftUI | In progress |
 | Android / Fire OS | Kotlin, Jetpack Compose | Planned |
 

--- a/appWeb/public_html/includes/infoAppVer.php
+++ b/appWeb/public_html/includes/infoAppVer.php
@@ -79,7 +79,7 @@ $app["Application"]["Description"]["Keywords"] = "hymns, worship, lyrics, songbo
 /* Semantic version number (MAJOR.MINOR.PATCH) */
 /* Auto-bumped by the version-bump GitHub Action on push to beta */
 /* v1.x.x = Phase 1 (local JSON data), v2.x.x = Phase 2 (iLyrics dB) */
-$app["Application"]["Version"]["Number"] = "0.75.0";
+$app["Application"]["Version"]["Number"] = "0.76.0";
 
 /* Version name: human-readable release name (e.g., "Hymnal", NULL if unused) */
 $app["Application"]["Version"]["Name"] = NULL;


### PR DESCRIPTION
Marks the multilingual UX batch (PR #860) as a meaningful step-up from 0.75.0.

Bumps:
- `appWeb/public_html/includes/infoAppVer.php` → `0.76.0`
- `README.md` version badge + the Web PWA row in the Platforms table

Surfaces that pick up the new value automatically:
- Service worker cache key (auto-derived from `infoAppVer.php` so every alpha build gets a unique cache version)
- Public site footer
- Admin footer
- API metadata
- Settings → About

## Why 0.76.0?

PR #860 (just merged into alpha) shipped five distinct user-facing improvements:

| Issue | Change |
|-------|--------|
| #855 | Song of the Day respects the active language filter; English fallback when filter excludes English |
| #856 | Tooltips on every language tag — tile badges, filter pills, alt-titles, admin badges |
| #857 | Songbook tiles surface under any contained-language match, not just the book's own primary language |
| #858 | Verse-level language override on `tblSongComponents` for multi-language medleys |
| #859 | Comprehensive README refresh — 30+ songbooks, ~12,370 songs, ~20 languages |

Per the established convention (last bump was 0.50.0 → 0.75.0 with the catalogue feature run #831 / #832 / #833 / #840 / #845 / #853 in PR #854), this minor-version step keeps the version number meaningfully reflective of catalogue capability rather than just commit count.

## Test plan

- [ ] Public-site footer shows `v0.76.0`.
- [ ] `/manage` admin footer shows `v0.76.0`.
- [ ] DevTools → Application → Service Workers — cache name reflects 0.76.0 after first reload.
- [ ] `gh repo view --web` — README badge reads `Version 0.76.0 Alpha`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)