### PR TITLE
fix(manage): lift max_execution_time on setup-database actions (closes #862)

### DIFF
--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -988,6 +988,19 @@ if ($action !== '') {
      * still fine — only the header propagates via buffered output). */
     define('IHYMNS_SETUP_DASHBOARD', true);
 
+    /* #862 — lift the execution-time cap for any setup-database action.
+       Shared hosts default to max_execution_time = 30s, which the bulk
+       Apply-All run blows through with ~30 migrations + real backfills.
+       Without this, PHP terminates mid-loop, the closing chrome never
+       reaches the browser, and the JS that flips #action-status-badge
+       from "Running…" to "Complete" / "Error" never runs — the badge
+       stays stuck on the initial state.
+       ignore_user_abort makes the run survive a curator closing the
+       tab mid-stream — better to land all migrations than half. */
+    @set_time_limit(0);
+    @ini_set('max_execution_time', '0');
+    @ignore_user_abort(true);
+
     /* #817 round 2 — render the page chrome BEFORE the bulk run, so:
        (a) Content-Type: text/html is committed to the response before
            any child script's `header('Content-Type: text/plain')` could
@@ -1125,6 +1138,13 @@ if ($action !== '') {
             });
 
             foreach ($migrationOrder as $migAction) {
+                /* #862 — reset the execution-time alarm before EACH
+                   migration in case the host enforces a per-script
+                   limit that survives the require() boundary. Cheap
+                   to call repeatedly; harmless when set_time_limit
+                   is disabled by safe_mode / disable_functions. */
+                @set_time_limit(0);
+
                 $migScript = $scriptMap[$migAction] ?? null;
                 if ($migScript === null) {
                     echo "  ✗ Unknown migration key: {$migAction} — skipped.\n\n";


### PR DESCRIPTION
Closes [#862](https://github.com/MWBMPartners/iHymns/issues/862).

The bulk **Apply All Pending Migrations** runner streams output as it goes, but the badge that flips from "Running…" to "Complete" / "Error" lives in a `<script>` tag emitted **after** the loop finishes. With ~30 migrations and real backfill work in several of them (#735 / #738 / #778 / #833), the run regularly blew through `max_execution_time` on shared hosts (typically 30s). PHP terminated the script mid-loop, the closing chrome — including the badge-flip script — never reached the browser, and the curator was left with output frozen mid-run and the badge stuck on "Running…" forever.

## Fix

In `appWeb/public_html/manage/setup-database.php`:

- `@set_time_limit(0)` + `@ini_set('max_execution_time', '0')` at the top of the action handler (every action, not just apply-all — single migrations like `iana-language-subtag-registry` can also exceed 30s on first run).
- `@ignore_user_abort(true)` so a curator who closes the tab mid-stream doesn't abort PHP — better to land all migrations than half.
- Defensive `@set_time_limit(0)` reset inside the per-migration loop, in case a host enforces a per-script clock that doesn't carry across the `require()` boundary.

All four are no-ops where `set_time_limit` / `ini_set` are disabled by `disable_functions`, so no regression on locked-down hosts.

## Test plan

- [ ] On the alpha host, click **Apply All Pending Migrations** with everything pending — confirm the badge flips to **Complete** when the last migration finishes.
- [ ] Force a failure (drop a prerequisite table) and re-run — confirm the badge flips to **Error**, the failure banner appears below the panel.
- [ ] Re-run when everything is already applied — confirm the badge still flips to **Complete**.
- [ ] Run a long single migration (`iana-language-subtag-registry`) standalone — confirm it completes without timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)