### PR TITLE
feat: page transitions — sync timing, new modern types, admin coverage + v0.77.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **A multiplatform Christian lyrics application for worship enhancement**
 
-[![Version: 0.76.0 Alpha](https://img.shields.io/badge/Version-0.76.0%20Alpha-orange.svg)](#environments)
+[![Version: 0.77.0 Alpha](https://img.shields.io/badge/Version-0.77.0%20Alpha-orange.svg)](#environments)
 [![License: Proprietary](https://img.shields.io/badge/License-Proprietary-red.svg)](#license)
 [![Platform: Web](https://img.shields.io/badge/Platform-Web%20PWA-blue.svg)](#platforms)
 [![Platform: iOS](https://img.shields.io/badge/Platform-iOS%20%7C%20iPadOS%20%7C%20tvOS-black.svg)](#platforms)
@@ -55,7 +55,7 @@ Songs are tagged at song-level with their actual IETF BCP 47 language (#681), so
 
 | Platform | Technology | Status |
 | --- | --- | --- |
-| Web PWA | HTML5, CSS3, Bootstrap 5.3, vanilla JS, PHP 8.1+, MySQL 5.7+ / MariaDB 10.3+ | **Alpha** (v0.76.0) |
+| Web PWA | HTML5, CSS3, Bootstrap 5.3, vanilla JS, PHP 8.1+, MySQL 5.7+ / MariaDB 10.3+ | **Alpha** (v0.77.0) |
 | iOS / iPadOS / tvOS | Swift 6.3, SwiftUI | In progress |
 | Android / Fire OS | Kotlin, Jetpack Compose | Planned |
 

--- a/appWeb/public_html/css/admin.css
+++ b/appWeb/public_html/css/admin.css
@@ -18,6 +18,58 @@
  */
 
 /* ==========================================================================
+   ADMIN PAGE TRANSITIONS (#866)
+   ----------------------------------------------------------------------------
+   Cross-document View Transitions on every full-page nav inside /manage/*.
+   On Chromium 126+ / Safari 18.2+ / Firefox 134+ the browser captures a
+   snapshot of the outgoing admin page, issues the GET, snapshots the new
+   page, then animates a smooth cross-fade between the two — no white-flash,
+   no JS plumbing required.
+
+   On older browsers `@view-transition` is ignored silently and the body
+   keyframe below provides a quick CSS-only fade-in on every page load
+   (200ms, opacity 0 → 1) so curators on Safari 17 / Edge 110 still see a
+   smoother experience than the legacy white-flash.
+
+   The bulk migration runner (#862) is unaffected: that page flushes its
+   chrome before the streaming bulk run starts, so the cross-doc snapshot
+   captures the chrome fully — output streams INTO the new page after the
+   transition has already completed.
+   ========================================================================== */
+
+@view-transition {
+    navigation: auto;
+}
+
+/* Per-pseudo styling — keep it gentle. Admin work is task-focused, so a
+   smooth opacity cross-fade reads as professional rather than flashy. */
+::view-transition-old(root),
+::view-transition-new(root) {
+    animation-duration: 220ms;
+    animation-timing-function: cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+/* CSS-only fallback for browsers without View Transitions API support.
+   Plays once per full-page load. The animation is short enough that
+   Chromium-with-VT-API doesn't notice it visually (the @view-transition
+   block runs first and replaces this), but on Safari 17 / Edge 110 it's
+   the only animation and gives a 200ms fade-in instead of a white flash. */
+@keyframes ihymns-admin-fadein {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+/* prefers-reduced-motion / manual reduce-motion class collapses both
+   the View Transitions and the body fade-in to instant. */
+@media (prefers-reduced-motion: reduce) {
+    ::view-transition-old(root),
+    ::view-transition-new(root) {
+        animation-duration: 1ms !important;
+        animation-timing-function: linear !important;
+    }
+}
+
+/* ==========================================================================
    ADMIN BASE — body & typography
    ========================================================================== */
 
@@ -26,6 +78,20 @@ body {
     color: var(--text-primary);
     font-family: 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont,
                  'Helvetica Neue', Arial, sans-serif;
+    /* #866 — fallback fade-in on browsers without the View Transitions
+       API. On supported browsers the @view-transition block above takes
+       precedence and this animation is invisible. reduce-motion overrides
+       below collapse it to nothing. */
+    animation: ihymns-admin-fadein 200ms ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    body {
+        animation: none;
+    }
+}
+body.reduce-motion {
+    animation: none !important;
 }
 
 a:not(.btn):not(.nav-link):not(.dropdown-item) {

--- a/appWeb/public_html/css/app.css
+++ b/appWeb/public_html/css/app.css
@@ -663,6 +663,184 @@ body[data-page-transition="crossfade"] #page-content.page-visible {
     transform: none;
 }
 
+/* ------------------------------------------------------------------
+ * View Transitions API page transitions (#864 / #865)
+ *
+ * The browser handles snapshot + crossfade plumbing — these CSS
+ * rules just describe per-type keyframes. The DOM update happens
+ * synchronously inside transitions.runViewTransition(); the browser
+ * captures an "old" snapshot before the call and a "new" snapshot
+ * after, then animates BOTH at the same time using whichever rules
+ * match the active body[data-page-transition] selector.
+ *
+ * Because old + new are visible simultaneously during the
+ * transition, the animations all start at the same instant — no
+ * "blank gap" between the legacy pageOut and pageIn phases.
+ *
+ * Default browser cross-fade is overridden so "none" really means
+ * none (instant); per-type rules below restore animations.
+ * ------------------------------------------------------------------ */
+
+/* Disable the browser's default cross-fade so per-type rules can
+   take over without compounding two animations. */
+::view-transition-old(root),
+::view-transition-new(root) {
+    animation: none;
+    mix-blend-mode: normal;
+}
+
+/* Position the snapshots so they overlap during the animation
+   rather than stacking — the default `::view-transition-image-pair`
+   is set to overlap, this just makes our intent explicit. */
+::view-transition-image-pair(root) {
+    isolation: auto;
+}
+
+/* fade — opacity-only crossfade with the same gentle vertical
+   offset as the legacy default (matches user expectations on
+   upgrade). Both snapshots animate simultaneously. */
+body[data-page-transition="fade"] ::view-transition-old(root) {
+    animation: ihymns-vt-fade-out 250ms ease forwards;
+}
+body[data-page-transition="fade"] ::view-transition-new(root) {
+    animation: ihymns-vt-fade-in 250ms ease forwards;
+}
+
+/* slide — horizontal directional slide. Forward = old slides left,
+   new comes from right; back is mirrored. The browser snapshots
+   the old page-content as it was, so the translate looks like a
+   single piece of paper sliding past the viewport. */
+body[data-page-transition="slide"][data-nav-direction="forward"] ::view-transition-old(root) {
+    animation: ihymns-vt-slide-out-left 280ms cubic-bezier(0.32, 0.72, 0, 1) forwards;
+}
+body[data-page-transition="slide"][data-nav-direction="forward"] ::view-transition-new(root) {
+    animation: ihymns-vt-slide-in-right 280ms cubic-bezier(0.32, 0.72, 0, 1) forwards;
+}
+body[data-page-transition="slide"][data-nav-direction="back"] ::view-transition-old(root) {
+    animation: ihymns-vt-slide-out-right 280ms cubic-bezier(0.32, 0.72, 0, 1) forwards;
+}
+body[data-page-transition="slide"][data-nav-direction="back"] ::view-transition-new(root) {
+    animation: ihymns-vt-slide-in-left 280ms cubic-bezier(0.32, 0.72, 0, 1) forwards;
+}
+
+/* crossfade — pure opacity, no translate. Cleanest option for
+   information-dense pages. */
+body[data-page-transition="crossfade"] ::view-transition-old(root) {
+    animation: ihymns-vt-cross-out 250ms ease forwards;
+}
+body[data-page-transition="crossfade"] ::view-transition-new(root) {
+    animation: ihymns-vt-cross-in 250ms ease forwards;
+}
+
+/* scale (#865) — gentle zoom; old fades out at 0.96×, new fades
+   in from 1.04×. Subtle "depth" without being flashy. */
+body[data-page-transition="scale"] ::view-transition-old(root) {
+    animation: ihymns-vt-scale-out 280ms cubic-bezier(0.32, 0.72, 0, 1) forwards;
+}
+body[data-page-transition="scale"] ::view-transition-new(root) {
+    animation: ihymns-vt-scale-in 280ms cubic-bezier(0.32, 0.72, 0, 1) forwards;
+}
+
+/* lift (#865) — old slides DOWN + fades, new lifts up from below
+   + fades. Tactile, kinetic — like an Instagram story dismissal. */
+body[data-page-transition="lift"] ::view-transition-old(root) {
+    animation: ihymns-vt-lift-out 320ms cubic-bezier(0.32, 0.72, 0, 1) forwards;
+}
+body[data-page-transition="lift"] ::view-transition-new(root) {
+    animation: ihymns-vt-lift-in 320ms cubic-bezier(0.32, 0.72, 0, 1) forwards;
+}
+
+/* depth (#865) — cinematic. Old recedes (scales to 0.92, dims),
+   new emerges (scales 1.05 → 1.00, brightens). Like an iOS app
+   launch. */
+body[data-page-transition="depth"] ::view-transition-old(root) {
+    animation: ihymns-vt-depth-out 320ms cubic-bezier(0.32, 0.72, 0, 1) forwards;
+}
+body[data-page-transition="depth"] ::view-transition-new(root) {
+    animation: ihymns-vt-depth-in 320ms cubic-bezier(0.32, 0.72, 0, 1) forwards;
+}
+
+/* blur (#865) — cinematic dissolve. Old blurs to 8px while
+   fading; new starts blurred and sharpens in. Great for
+   slow-network cases where the user otherwise notices the swap. */
+body[data-page-transition="blur"] ::view-transition-old(root) {
+    animation: ihymns-vt-blur-out 320ms ease forwards;
+}
+body[data-page-transition="blur"] ::view-transition-new(root) {
+    animation: ihymns-vt-blur-in 320ms ease forwards;
+}
+
+@keyframes ihymns-vt-fade-out {
+    from { opacity: 1; transform: translateY(0); }
+    to   { opacity: 0; transform: translateY(-8px); }
+}
+@keyframes ihymns-vt-fade-in {
+    from { opacity: 0; transform: translateY(8px); }
+    to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes ihymns-vt-slide-out-left {
+    from { opacity: 1; transform: translateX(0); }
+    to   { opacity: 0; transform: translateX(-32px); }
+}
+@keyframes ihymns-vt-slide-in-right {
+    from { opacity: 0; transform: translateX(32px); }
+    to   { opacity: 1; transform: translateX(0); }
+}
+@keyframes ihymns-vt-slide-out-right {
+    from { opacity: 1; transform: translateX(0); }
+    to   { opacity: 0; transform: translateX(32px); }
+}
+@keyframes ihymns-vt-slide-in-left {
+    from { opacity: 0; transform: translateX(-32px); }
+    to   { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes ihymns-vt-cross-out {
+    from { opacity: 1; }
+    to   { opacity: 0; }
+}
+@keyframes ihymns-vt-cross-in {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+@keyframes ihymns-vt-scale-out {
+    from { opacity: 1; transform: scale(1.00); }
+    to   { opacity: 0; transform: scale(0.96); }
+}
+@keyframes ihymns-vt-scale-in {
+    from { opacity: 0; transform: scale(1.04); }
+    to   { opacity: 1; transform: scale(1.00); }
+}
+
+@keyframes ihymns-vt-lift-out {
+    from { opacity: 1; transform: translateY(0); }
+    to   { opacity: 0; transform: translateY(24px); }
+}
+@keyframes ihymns-vt-lift-in {
+    from { opacity: 0; transform: translateY(40px); }
+    to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes ihymns-vt-depth-out {
+    from { opacity: 1; transform: scale(1.00); filter: brightness(1.00); }
+    to   { opacity: 0; transform: scale(0.92); filter: brightness(0.85); }
+}
+@keyframes ihymns-vt-depth-in {
+    from { opacity: 0; transform: scale(1.05); filter: brightness(1.10); }
+    to   { opacity: 1; transform: scale(1.00); filter: brightness(1.00); }
+}
+
+@keyframes ihymns-vt-blur-out {
+    from { opacity: 1; filter: blur(0); }
+    to   { opacity: 0; filter: blur(8px); }
+}
+@keyframes ihymns-vt-blur-in {
+    from { opacity: 0; filter: blur(8px); }
+    to   { opacity: 1; filter: blur(0); }
+}
+
 /* Staggered list items (#149) */
 .page-song .song-list-item,
 .page-songbook .song-list-item,
@@ -1632,6 +1810,24 @@ body.reduce-motion .song-list-item {
     animation: none !important;
     opacity: 1 !important;
     transform: none !important;
+}
+
+/* #864 / #865 — collapse all View Transitions API animations to a
+   1ms cross-fade when reduce-motion is in effect. The browser still
+   runs a transition (so the DOM swap is atomic) but it's
+   imperceptible. Same treatment under the @media query above and
+   under the manual `body.reduce-motion` toggle. */
+@media (prefers-reduced-motion: reduce) {
+    ::view-transition-old(root),
+    ::view-transition-new(root) {
+        animation-duration: 1ms !important;
+        animation-timing-function: linear !important;
+    }
+}
+body.reduce-motion ::view-transition-old(root),
+body.reduce-motion ::view-transition-new(root) {
+    animation-duration: 1ms !important;
+    animation-timing-function: linear !important;
 }
 
 /* ==========================================================================

--- a/appWeb/public_html/includes/infoAppVer.php
+++ b/appWeb/public_html/includes/infoAppVer.php
@@ -79,7 +79,7 @@ $app["Application"]["Description"]["Keywords"] = "hymns, worship, lyrics, songbo
 /* Semantic version number (MAJOR.MINOR.PATCH) */
 /* Auto-bumped by the version-bump GitHub Action on push to beta */
 /* v1.x.x = Phase 1 (local JSON data), v2.x.x = Phase 2 (iLyrics dB) */
-$app["Application"]["Version"]["Number"] = "0.76.0";
+$app["Application"]["Version"]["Number"] = "0.77.0";
 
 /* Version name: human-readable release name (e.g., "Hymnal", NULL if unused) */
 $app["Application"]["Version"]["Name"] = NULL;

--- a/appWeb/public_html/includes/pages/settings.php
+++ b/appWeb/public_html/includes/pages/settings.php
@@ -509,13 +509,23 @@ declare(strict_types=1);
                     Page Transition
                 </label>
                 <select class="form-select" id="setting-transition" aria-label="Page transition style">
-                    <option value="none">None (instant)</option>
-                    <option value="fade">Fade</option>
-                    <option value="slide">Slide</option>
-                    <option value="crossfade">Crossfade</option>
+                    <option value="none">None — instant</option>
+                    <optgroup label="Classic">
+                        <option value="fade">Fade — opacity with subtle vertical drift</option>
+                        <option value="crossfade">Crossfade — pure opacity, no motion</option>
+                        <option value="slide">Slide — directional horizontal slide</option>
+                    </optgroup>
+                    <optgroup label="Modern (#865)">
+                        <option value="scale">Scale — gentle zoom with fade</option>
+                        <option value="lift">Lift — page rises from below</option>
+                        <option value="depth">Depth — cinematic recede &amp; emerge</option>
+                        <option value="blur">Blur — cinematic dissolve</option>
+                    </optgroup>
                 </select>
                 <small class="text-muted mt-1 d-block">
-                    Overridden by Reduce Motion when enabled.
+                    Overridden by Reduce Motion when enabled. Modern types use the
+                    View Transitions API for fluid, simultaneous old / new motion;
+                    they fall back to the Classic timing on older browsers.
                 </small>
             </div>
 

--- a/appWeb/public_html/js/modules/router.js
+++ b/appWeb/public_html/js/modules/router.js
@@ -384,9 +384,15 @@ export class Router {
         this.abortController = new AbortController();
 
         try {
-            /* Start loading bar and exit transition in parallel */
+            /* #864 — fetch FIRST, animate the swap second, so old and
+               new content animate simultaneously via the View
+               Transitions API. The previous implementation was
+               sequential (out → fetch → in) which produced a "blank
+               gap" between the old and new pages that looked staged
+               rather than fluid. Loading bar still kicks off here so
+               the user has a visible affordance during the fetch
+               itself (especially on slow networks). */
             this.app.transitions.startLoading();
-            await this.app.transitions.pageOut(content);
 
             /* Fetch the page content from the API */
             const response = await fetch(url, {
@@ -403,21 +409,28 @@ export class Router {
 
             const html = await response.text();
 
-            /* Inject the new content */
-            content.innerHTML = html;
+            /* Hand the DOM swap to the transition runner. On modern
+               browsers (View Transitions API), the browser snapshots
+               the current page, runs the swap synchronously, and
+               animates the cross-fade in CSS — all in one frame, no
+               class-toggle dance. On older browsers it falls back
+               to the legacy pageOut → swap → pageIn flow. */
+            await this.app.transitions.runViewTransition(() => {
+                content.innerHTML = html;
+                /* Browsers intentionally do NOT run <script> tags
+                   inserted via innerHTML, so any inline JS in the
+                   injected page template (e.g. home.php's Popular
+                   Songs / Browse by Theme / Recently Viewed fetches)
+                   silently no-ops. Replace each script node with a
+                   freshly-created one so the browser parses and runs
+                   it as if it had been in the original document.
+                   Preserves type, src, async/defer and other
+                   attributes. */
+                this._executeInlineScripts(content);
+            }, content);
 
-            /* Browsers intentionally do NOT run <script> tags inserted via
-               innerHTML, so any inline JS in the injected page template
-               (e.g. home.php's Popular Songs / Browse by Theme / Recently
-               Viewed fetches) silently no-ops. Replace each script node
-               with a freshly-created one so the browser parses and runs
-               it as if it had been in the original document. Preserves
-               type, src, async/defer and other attributes. */
-            this._executeInlineScripts(content);
-
-            /* Complete loading bar and start enter transition */
+            /* Complete loading bar after the transition is done. */
             this.app.transitions.completeLoading();
-            await this.app.transitions.pageIn(content);
 
         } catch (error) {
             if (error.name === 'AbortError') {

--- a/appWeb/public_html/js/modules/transitions.js
+++ b/appWeb/public_html/js/modules/transitions.js
@@ -57,6 +57,82 @@ export class Transitions {
     }
 
     /**
+     * #864 — Run a DOM-update callback inside a synchronized
+     * old-out / new-in page transition.
+     *
+     * Modern path: uses the View Transitions API
+     * (`document.startViewTransition`, Chromium 111+, Safari 18+,
+     * Firefox 134+). The browser snapshots the current page,
+     * synchronously calls `updateDOM`, snapshots the new page, then
+     * animates BOTH at the same time per the CSS rules on
+     * `::view-transition-old(root)` / `::view-transition-new(root)`.
+     * No "blank gap" between old and new — the slide / fade / etc.
+     * happens as a single fluid motion instead of three staged
+     * phases (out → fetch → in).
+     *
+     * Legacy path (older browsers, or animations disabled): falls
+     * back to the old class-toggle dance via pageOut / pageIn so
+     * deployments on Safari 17 / Edge 110 keep working without
+     * console errors. The legacy path is intentionally lightly
+     * polished — it's a safety net, not the supported experience.
+     *
+     * @param {() => (void|Promise<void>)} updateDOM Callback that
+     *        mutates the DOM (typically `el.innerHTML = html` plus
+     *        any post-insert hooks).
+     * @param {HTMLElement} el Element being animated (used by the
+     *        fallback path to drive class toggles).
+     * @returns {Promise<void>} Resolves once the transition has
+     *        finished (or the DOM update has run, when animations
+     *        are off).
+     */
+    async runViewTransition(updateDOM, el) {
+        this.loadType();
+
+        /* Animations disabled — just run the DOM update synchronously
+           and bail. Caller doesn't need to special-case the no-anim
+           path; this method always works. */
+        if (!this.isAnimationEnabled()) {
+            await updateDOM();
+            if (el) {
+                el.classList.remove('page-leaving', 'page-entering');
+                el.classList.add('page-visible');
+            }
+            return;
+        }
+
+        /* Modern path: View Transitions API. The browser handles all
+           the snapshot + crossfade plumbing; we just hand it the
+           DOM update and let the CSS rules in app.css drive the
+           per-type animation. */
+        if (typeof document.startViewTransition === 'function') {
+            const transition = document.startViewTransition(async () => {
+                await updateDOM();
+            });
+            try {
+                await transition.finished;
+            } catch (_e) {
+                /* startViewTransition rejects on aborted transitions
+                   (e.g. another navigation overrides this one). The
+                   DOM update still applied; safe to swallow. */
+            }
+            /* Reset legacy classes so any stylesheet still keying off
+               them doesn't render in a stale state on the new page. */
+            if (el) {
+                el.classList.remove('page-leaving', 'page-entering');
+                el.classList.add('page-visible');
+            }
+            return;
+        }
+
+        /* Legacy fallback. Two-phase out → swap → in. Less polished
+           than the modern path (the "blank gap" #864 fixed for
+           supported browsers re-emerges here) but functional. */
+        if (el) await this.pageOut(el);
+        await updateDOM();
+        if (el) await this.pageIn(el);
+    }
+
+    /**
      * Animate page content out (exit transition).
      *
      * @param {HTMLElement} el The page content container


### PR DESCRIPTION
Bundle of three page-transition improvements + a v0.77.0 bump. One branch, four commits, three issues closed.

| Commit | Issue | Closes |
|--------|-------|--------|
| [\`8017d7b7\`](https://github.com/MWBMPartners/iHymns/commit/8017d7b7) | A — Synchronize transition timing via View Transitions API | [#864](https://github.com/MWBMPartners/iHymns/issues/864) |
| [\`1b64a1e9\`](https://github.com/MWBMPartners/iHymns/commit/1b64a1e9) | B — Four new modern transition types | [#865](https://github.com/MWBMPartners/iHymns/issues/865) |
| [\`b9a479ff\`](https://github.com/MWBMPartners/iHymns/commit/b9a479ff) | C — Page transitions on admin / manage pages | [#866](https://github.com/MWBMPartners/iHymns/issues/866) |
| [\`e7b5803b\`](https://github.com/MWBMPartners/iHymns/commit/e7b5803b) | — | Version bump to v0.77.0 |

## Why

The user reported that the **slide** transition fired BEFORE the new content arrived: old page slid out → blank gap during fetch → new page slid in. Looked staged and disconnected. Fade variants suffered the same flaw less visibly.

The fix is the modern **View Transitions API** — `document.startViewTransition()` snapshots the old page, runs the DOM update synchronously, snapshots the new page, then animates BOTH simultaneously per CSS rules. One frame, no class-toggle dance, no blank gap. While we were there, layered on four new transition types (scale / lift / depth / blur) and lifted the same approach to the admin area via cross-document View Transitions (`@view-transition { navigation: auto }`).

## Surface coverage

- **Public PWA** (#864 + #865) — same-document SPA transitions via `transitions.runViewTransition()`
- **Admin / manage** (#866) — cross-document transitions on every full-page nav, no JS plumbing
- **Both** — `prefers-reduced-motion: reduce` and the manual `body.reduce-motion` toggle collapse every transition to a 1ms imperceptible cross-fade

## Settings → Page Transition (now 8 options)

\`\`\`
None — instant
Classic ─ Fade · Crossfade · Slide
Modern  ─ Scale · Lift · Depth · Blur
\`\`\`

| Type | Vibe |
|------|------|
| **scale** | Gentle zoom (0.96 ↔ 1.04). iOS-like, subtle "depth" |
| **lift** | Old drops + fades, new lifts from below. Tactile, kinetic |
| **depth** | Old recedes (0.92, dims), new emerges (1.05 → 1.00). Cinematic |
| **blur** | 8px blur dissolve. Cinematic, smooths slow-network swaps |

## Compatibility matrix

| Browser | Public SPA | Admin (cross-doc) | Behaviour |
|---------|------------|-------------------|-----------|
| Chrome 126+ | ✓ Modern | ✓ Modern | Full View Transitions API |
| Safari 18.2+ | ✓ Modern | ✓ Modern | Full View Transitions API |
| Firefox 134+ | ✓ Modern | ✓ Modern | Full View Transitions API |
| Safari 17 / Edge 110 / older Chrome | ✓ Legacy fallback | ✓ CSS body fade-in | Less polished but functional |
| `prefers-reduced-motion: reduce` | ✓ 1ms instant | ✓ 1ms instant | Imperceptible |

## Files changed

- \`appWeb/public_html/js/modules/transitions.js\` — `runViewTransition(updateDOM, el)` entry point
- \`appWeb/public_html/js/modules/router.js\` — `loadPage()` reordered: fetch → swap+animate
- \`appWeb/public_html/css/app.css\` — `::view-transition-*` rules + 8 keyframe sets, reduce-motion overrides
- \`appWeb/public_html/css/admin.css\` — `@view-transition { navigation: auto }`, body fade-in fallback, reduce-motion overrides
- \`appWeb/public_html/includes/pages/settings.php\` — `<optgroup>`'d picker with all 8 options
- \`appWeb/public_html/includes/infoAppVer.php\` + \`README.md\` — v0.77.0 bump

## Test plan

### Issue A (#864)
- [ ] On Chrome 130+, navigate home → songbook → song → confirm transitions feel like one fluid motion. Old + new visible during the swap.
- [ ] Set transition to **slide** — old slides left WHILE new slides in from right (not sequentially).
- [ ] Slow 3G — no "blank gap"; transition only fires when new content is ready.
- [ ] Safari 18+ / Firefox 134+ — same behaviour.
- [ ] Older browser (Safari 17) — falls back to legacy pageOut/pageIn cleanly, no JS errors.
- [ ] `prefers-reduced-motion: reduce` — near-instant cross-fade.

### Issue B (#865)
- [ ] Each new type (scale, lift, depth, blur) saved to localStorage round-trips through a page reload.
- [ ] Switching types in Settings swaps the active animation on the next nav.
- [ ] Each new type completes within 320ms — no perceptible drag.
- [ ] `prefers-reduced-motion` collapses every type to instant.

### Issue C (#866)
- [ ] Click between admin nav items (Dashboard → Songs → Catalogue → Operations) on Chrome 130+ — confirm a smooth cross-fade between pages, no white-flash.
- [ ] Same on Safari 18.2+ and Firefox 134+.
- [ ] Older browser (Safari 17 / Edge 110) — confirm graceful fallback (200ms body fade-in), no errors.
- [ ] `prefers-reduced-motion: reduce` — transitions collapse to instant.
- [ ] Setup-database streaming bulk runner (#862) — confirm no regression: chrome flushes before bulk run starts, transition completes BEFORE output starts streaming.
- [ ] Form submit POST → 302 → GET round-trips still feel responsive (transition only fires on the GET response).

### Cross-issue
- [ ] All commits leave `node --check` clean for JS, `php -l` clean for PHP.
- [ ] Public-site footer + admin footer both show v0.77.0.
- [ ] Service-worker cache name reflects 0.77.0 after first reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)