### PR TITLE
fix(manage): emergency setup-database shutdown emits admin footer + flips badge (closes #868)

### DIFF
--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -953,30 +953,62 @@ $pageRenderedCleanly = false;
 register_shutdown_function(function () use (&$pageRenderedCleanly): void {
     if ($pageRenderedCleanly) return;
     /* Drain whatever's still buffered so it precedes the chrome tags
-       we're about to emit. The chrome itself is intentionally a
-       compact emergency-closure — full sidebar / footer can't be
-       reconstructed from a shutdown handler reliably (no access to
-       the open-state $GLOBALS['_adminLayoutOpen']) but closing the
-       outer wrappers + body/html prevents the browser from leaving
-       the response visually open. */
+       we're about to emit. */
     while (ob_get_level() > 0) {
         @ob_end_flush();
     }
-    echo "\n<!-- emergency chrome closure (#817) — a child script "
-       . "exited or died mid-render before the page completed. -->\n";
+    echo "\n<!-- emergency chrome closure (#817 / #868) — response "
+       . "truncated before the page completed. -->\n";
+
+    /* #868 — flip the status badge from "Running…" to "Interrupted"
+       so the curator sees a clear failed-state rather than a frozen
+       running indicator. Wrapped in `if (badge)` because the non-
+       action dashboard page doesn't render the badge at all and
+       this script runs in both contexts. */
+    echo '<script>'
+       . '(function(){'
+       . 'var b=document.getElementById("action-status-badge");'
+       . 'if(!b)return;'
+       . 'b.textContent="Interrupted";'
+       . 'b.className="badge bg-warning text-dark";'
+       . 'b.title="Response was truncated before the run completed — '
+       . 'likely a server-level timeout (FPM request_terminate_timeout '
+       . 'or proxy timeout). Retry, or run individual migrations one '
+       . 'at a time.";'
+       . '})();'
+       . '</script>' . "\n";
+
     /* Close the layers the action path opens (in order):
          <div class="output-log">    ← migration log container
          <div class="container-admin"> ← page container
-         </main>                       ← admin-nav.php opened this
-         </div><!-- /.admin-layout --> ← admin-nav.php opened this too
-         </body></html>
+       Then emit the admin footer + nav-layout closers so the page
+       has its standard chrome, not a bare <body>.
        Five closes is one too many on the non-action page (which
        doesn't open the output-log); browsers tolerate stray closing
        tags so emit them all and accept the harmless extra. */
     echo "</div><!-- /.output-log (if open) -->\n";
     echo "</div><!-- /.container-admin -->\n";
-    echo "</main>\n";
-    echo "</div><!-- /.admin-layout -->\n";
+
+    /* #868 — best-effort include of the admin footer so the page
+       has its normal chrome at the bottom (version stamp, build
+       metadata, copyright line, the close of <main> + admin-layout
+       when admin-nav.php opened them — gated on $GLOBALS
+       ['_adminLayoutOpen'] which we DON'T touch here, so the
+       footer's guarded-close logic still applies correctly).
+       Wrapped in @require + try/catch so a load failure during
+       shutdown doesn't compound into a fatal — better to ship a
+       footer-less page than a 500. admin-footer.php does NOT
+       emit </body></html> itself; we close the doc here. */
+    try {
+        $_footerName = __DIR__ . DIRECTORY_SEPARATOR
+                     . 'includes' . DIRECTORY_SEPARATOR
+                     . 'admin-footer.php';
+        if (is_file($_footerName)) {
+            @require $_footerName;
+        }
+    } catch (\Throwable $_e) {
+        /* Footer load failed — fall through to bare-body close. */
+    }
     echo "</body>\n</html>\n";
 });
 


### PR DESCRIPTION
Closes [#868](https://github.com/MWBMPartners/iHymns/issues/868).

## What you reported

> Apple All Pending Migrations is still showing as "Running...."
> Also, the Manage area footer isnt displayed on this page...it should be

Both symptoms have the same root cause. \`set_time_limit(0)\` from #863 lifts PHP's per-request cap, but **server-level timeouts** (PHP-FPM \`request_terminate_timeout\`, nginx \`proxy_read_timeout\`, hosting CDN limits) can still truncate a long bulk run. When that happens the existing emergency-chrome shutdown handler (\`setup-database.php:953\`) closes \`</body></html>\` but skips the admin footer AND doesn't flip the badge — leaving a frozen "Running…" indicator on a footer-less page.

## What this PR does

Extends the shutdown handler at [setup-database.php:953](appWeb/public_html/manage/setup-database.php#L953) so a truncated response always closes cleanly:

- Emits a \`<script>\` that flips \`#action-status-badge\` to **"Interrupted"** (warning bg, dark text) with a tooltip explaining the truncation and suggesting individual migration runs as a workaround.
- \`@require\`s \`manage/includes/admin-footer.php\` so the page gets its normal footer chrome (version stamp, copyright line, the close of \`<main>\` + admin-layout via the existing \`$GLOBALS['_adminLayoutOpen']\` guard).
- Wraps the require in try/catch so a load failure during shutdown can't compound into a fatal — falls through to a bare \`</body></html>\` so the response is at least well-formed HTML.
- Drops the unconditional \`</main></div><!-- /.admin-layout -->\` emit (admin-footer's guarded close handles that conditionally now).

## Scope clarification

This is a **UX fix**, not the architectural fix. With this commit, when the bulk run hits a server-level timeout you see a clear failed state ("Interrupted" badge + footer + nav) instead of a frozen "Running…" on a footer-less page. But Apply-All still won't *complete* on hosts whose timeouts are shorter than the bulk run — that's the proper root-cause fix tracked in [#869](https://github.com/MWBMPartners/iHymns/issues/869) (per-migration AJAX so no single request runs long enough to hit any timeout).

## Test plan

- [ ] Force a long-running migration (e.g. \`sleep(120)\` injected into one migration) and run Apply All on a host with a 60s timeout.
- [ ] Confirm: page closes with admin footer visible at the bottom (version, copyright, Terms / Privacy links), nav left-side bottom-section visible.
- [ ] Confirm: badge flips to "Interrupted" with a tooltip pointing at #869 as the structural fix.
- [ ] Confirm: any partial output that streamed before the truncation is still readable in the log panel.
- [ ] No regression on a normal bulk-run completion: badge still flips to "Complete", footer still renders.
- [ ] No regression on a single-migration card click — that path runs through the same shutdown handler in success cases (handler short-circuits via \$pageRenderedCleanly = true).

🤖 Generated with [Claude Code](https://claude.com/claude-code)