### PR TITLE
fix(manage): emergency footer renders version + copyright on shutdown

### DIFF
--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -952,6 +952,16 @@ $bulkTotalFailed      = 0;
 $pageRenderedCleanly = false;
 register_shutdown_function(function () use (&$pageRenderedCleanly): void {
     if ($pageRenderedCleanly) return;
+
+    /* #868 — pull the global $app into closure scope so admin-footer.php's
+       version / copyright lines render with their real values. Without
+       this, admin-footer's `$app['Application']['Version']['Number'] ?? ''`
+       returns '' because require_once on infoAppVer.php is a no-op
+       (already loaded at top-level) and the closure doesn't inherit
+       global state by default. Symptom: footer reads "| v | Terms |
+       Privacy" with no version + no copyright string. */
+    global $app;
+
     /* Drain whatever's still buffered so it precedes the chrome tags
        we're about to emit. */
     while (ob_get_level() > 0) {
@@ -995,11 +1005,31 @@ register_shutdown_function(function () use (&$pageRenderedCleanly): void {
        when admin-nav.php opened them — gated on $GLOBALS
        ['_adminLayoutOpen'] which we DON'T touch here, so the
        footer's guarded-close logic still applies correctly).
+
+       admin-footer.php reads `$app['Application']['Version']…` —
+       require_once on infoAppVer.php is a no-op when it was already
+       loaded at top-level, and admin-footer would then see $app
+       undefined in this closure's local scope. So if the global
+       $app is empty (early-fatal path where the action handler
+       never reached the line that loads infoAppVer), pull it in
+       directly here so the footer renders with real values rather
+       than "| v |  Terms |  Privacy". Required: the include's
+       `$app = [];` populates the closure's local scope, which
+       admin-footer.php inherits when require'd below.
+
        Wrapped in @require + try/catch so a load failure during
        shutdown doesn't compound into a fatal — better to ship a
        footer-less page than a 500. admin-footer.php does NOT
        emit </body></html> itself; we close the doc here. */
     try {
+        if (!isset($app) || empty($app)) {
+            $_appVerPath = dirname(__DIR__) . DIRECTORY_SEPARATOR
+                         . 'includes' . DIRECTORY_SEPARATOR
+                         . 'infoAppVer.php';
+            if (is_file($_appVerPath)) {
+                @require $_appVerPath;
+            }
+        }
         $_footerName = __DIR__ . DIRECTORY_SEPARATOR
                      . 'includes' . DIRECTORY_SEPARATOR
                      . 'admin-footer.php';


### PR DESCRIPTION
Follow-up on PR #870. With #870 merged, the shutdown handler correctly emits the admin footer when the bulk runner gets truncated by a server-level timeout. But the footer rendered as **\`| v |  Terms |  Privacy\`** — empty version, empty copyright string. As shown in the latest screenshot.

## Cause

\`admin-footer.php\` reads \`\$app['Application']['Version']['Number']\` and \`\$app['Application']['Copyright']['Full']\` to populate the footer. Those values are populated by \`infoAppVer.php\`, which is loaded via \`require_once\` at top-level scope of the request, putting \`\$app\` in the global scope.

The shutdown handler runs as a closure. When that closure \`require\`s \`admin-footer.php\`, the included file inherits the *closure's local scope* — not the global scope where \`\$app\` actually lives. Inside admin-footer's own \`require_once 'infoAppVer.php'\`, the include is a no-op (already loaded), so \`\$app\` never gets populated locally either, and the null-coalescing fallbacks render empty strings.

## Fix

Two lines in \`appWeb/public_html/manage/setup-database.php\`'s emergency-chrome shutdown handler:

1. \`global \$app;\` — pulls the populated array from global scope into the closure's local scope. \`require\`d files (admin-footer.php) inherit it.
2. Defensive direct \`require\` of \`infoAppVer.php\` when \`\$app\` is still empty — covers the early-fatal path where the action handler died before the footer would have loaded \`infoAppVer\` for the first time. The include's \`\$app = [...]\` populates the closure's local scope, which admin-footer inherits via require's lexical scoping.

Curators on a host that hits server-level timeouts now see:
- Badge: **Interrupted** (yellow), tooltip explains the cause
- Footer: full version stamp + copyright line + Terms / Privacy

## Scope

Still a UX fix, not the architectural fix. The proper root-cause is to refactor Apply-All into per-migration AJAX so no single request hits a server timeout in the first place — tracked in [#869](https://github.com/MWBMPartners/iHymns/issues/869) and starting next.

## Test plan

- [ ] Force a long-running migration (\`sleep(120)\` injection) on a host with a 60s timeout.
- [ ] Confirm: badge reads "Interrupted" AND the footer shows the proper version + copyright + Terms / Privacy line.
- [ ] No regression on a clean bulk-run completion: badge still flips to "Complete", footer still renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)