### PR TITLE
feat(manage): per-migration AJAX runner for Apply-All (closes #869)

### DIFF
--- a/appWeb/public_html/js/modules/setup-bulk-runner.js
+++ b/appWeb/public_html/js/modules/setup-bulk-runner.js
@@ -1,0 +1,288 @@
+/*
+ * iHymns — Setup Bulk Migration Runner (#869)
+ *
+ * Replaces the legacy "Apply All Pending Migrations" full-page
+ * redirect with a per-migration AJAX runner that stays on the
+ * dashboard. Each migration is its own short HTTP request so
+ * the bulk run never sits in a single long PHP request that
+ * could hit a server-level timeout (PHP-FPM
+ * `request_terminate_timeout`, nginx `proxy_read_timeout`,
+ * hosting CDN limits — all of which `set_time_limit(0)` cannot
+ * override). #862 / #863 / #868 papered over the timeout
+ * symptom; this module removes the timeout exposure entirely.
+ *
+ * UX:
+ *   - User clicks "Apply All Pending Migrations".
+ *   - JS intercepts the click; opens an inline progress panel
+ *     above the migration cards.
+ *   - For each pending migration:
+ *       1. Mark its row as "running" (spinner).
+ *       2. fetch(`?action=<name>&format=text`).
+ *       3. Server returns a plain-text envelope:
+ *            STATUS: ok
+ *            ACTION: <name>
+ *            SCRIPT: migrate-<name>.php
+ *            ELAPSED_MS: <ms>
+ *            ---
+ *            <captured migration output>
+ *       4. Append the output to the live log + flip the row
+ *          icon to ✓ (or ✗ on error).
+ *   - On any error, stop the run; surface a banner pointing the
+ *     curator at the failed migration's output.
+ *   - On success, reload the dashboard so pending-probe state
+ *     refreshes (some migrations no-op when re-run, some flip
+ *     "pending" → "applied" in the cards-grid partition).
+ *
+ * Fallback: if the user has JS disabled, the Apply All <a>'s
+ * native href ("?action=apply-all-migrations") still works as
+ * before, with the chrome / footer / badge fixes from
+ * #862 / #863 / #868 / #870.
+ */
+
+const ENDPOINT = '/manage/setup-database.php';
+
+/**
+ * Boot the bulk runner. Idempotent — re-calling on the same DOM is
+ * safe (the wrapper carries a data flag).
+ *
+ * @param {ParentNode} [root=document]
+ */
+export function bootSetupBulkRunner(root) {
+    const scope  = root || document;
+    const button = scope.querySelector('[data-bulk-runner-trigger]');
+    if (!button || button.dataset.bulkRunnerBooted === '1') return;
+    button.dataset.bulkRunnerBooted = '1';
+
+    button.addEventListener('click', (e) => {
+        /* Non-JS path falls through to the <a href="?action=apply-all-migrations">
+           navigation. With JS we own the click. */
+        e.preventDefault();
+        const csv = button.dataset.pendingMigrations || '';
+        const pending = csv.split(',').map(s => s.trim()).filter(Boolean);
+        if (pending.length === 0) {
+            window.alert('No pending migrations — every migration\'s probe reports its work as already applied.');
+            return;
+        }
+        if (!window.confirm(
+            `Run ${pending.length} pending migration${pending.length === 1 ? '' : 's'} `
+            + 'in dependency order?\n\n'
+            + 'Each runs as its own short request so server-level timeouts can\'t '
+            + 'truncate the bulk run. Safe to re-run — applied migrations no-op.'
+        )) return;
+        runSequence(scope, button, pending).catch(err => {
+            console.error('[setup-bulk-runner] run failed:', err);
+        });
+    });
+}
+
+/**
+ * Drive the sequence: render the progress panel, then loop.
+ */
+async function runSequence(scope, triggerBtn, pending) {
+    triggerBtn.classList.add('disabled');
+    triggerBtn.setAttribute('aria-disabled', 'true');
+
+    const panel = ensurePanel(scope);
+    panel.dataset.state = 'running';
+    panel.querySelector('[data-bulk-status]').textContent = `Running 0 / ${pending.length}…`;
+    const list = panel.querySelector('[data-bulk-list]');
+    list.innerHTML = '';
+
+    /* Pre-render rows so the curator sees the full plan upfront. */
+    const rows = new Map();
+    pending.forEach(action => {
+        const row = document.createElement('div');
+        row.className = 'd-flex align-items-start gap-2 py-1 border-bottom border-secondary';
+        row.dataset.bulkRow = action;
+        row.innerHTML = `
+            <span class="bulk-row-icon flex-shrink-0" aria-hidden="true"
+                  style="display:inline-block;width:1.25rem;text-align:center;">○</span>
+            <code class="flex-shrink-0 text-info">${escapeHtml(action)}</code>
+            <span class="bulk-row-meta text-muted small ms-auto"></span>
+        `;
+        list.appendChild(row);
+        rows.set(action, row);
+    });
+
+    let completed = 0;
+    let failed = false;
+    for (const action of pending) {
+        const row = rows.get(action);
+        const icon = row.querySelector('.bulk-row-icon');
+        const meta = row.querySelector('.bulk-row-meta');
+        icon.textContent = '⟳';
+        icon.classList.add('text-warning');
+        meta.textContent = 'Running…';
+        panel.querySelector('[data-bulk-status]').textContent =
+            `Running ${completed + 1} / ${pending.length}: ${action}…`;
+
+        try {
+            const result = await runOne(action);
+            const ms = result.elapsedMs > 0 ? `${result.elapsedMs} ms` : '';
+            if (result.ok) {
+                icon.textContent = '✓';
+                icon.classList.remove('text-warning');
+                icon.classList.add('text-success');
+                meta.textContent = ms;
+                appendLog(panel, action, result.output, true);
+                completed++;
+            } else {
+                icon.textContent = '✗';
+                icon.classList.remove('text-warning');
+                icon.classList.add('text-danger');
+                meta.textContent = result.error || 'Failed';
+                appendLog(panel, action, result.output, false, result.error);
+                failed = true;
+                break;
+            }
+        } catch (err) {
+            icon.textContent = '✗';
+            icon.classList.remove('text-warning');
+            icon.classList.add('text-danger');
+            meta.textContent = err.message || 'Network error';
+            appendLog(panel, action, '', false, err.message || String(err));
+            failed = true;
+            break;
+        }
+    }
+
+    /* Final state. */
+    if (failed) {
+        panel.dataset.state = 'error';
+        panel.querySelector('[data-bulk-status]').textContent =
+            `Stopped after ${completed} successful migration${completed === 1 ? '' : 's'} — see the failed step's output below.`;
+        panel.querySelector('[data-bulk-status-badge]').className = 'badge bg-danger';
+        panel.querySelector('[data-bulk-status-badge]').textContent = 'Error';
+    } else {
+        panel.dataset.state = 'complete';
+        panel.querySelector('[data-bulk-status]').textContent =
+            `Complete — ${completed} migration${completed === 1 ? '' : 's'} ran successfully.`;
+        panel.querySelector('[data-bulk-status-badge]').className = 'badge bg-success';
+        panel.querySelector('[data-bulk-status-badge]').textContent = 'Complete';
+
+        /* Re-render the dashboard so pending-vs-applied probes refresh
+           after a clean run. Small delay so the curator sees the
+           "Complete" state for a moment first. */
+        setTimeout(() => {
+            window.location.href = ENDPOINT;
+        }, 1200);
+    }
+
+    triggerBtn.classList.remove('disabled');
+    triggerBtn.removeAttribute('aria-disabled');
+}
+
+/**
+ * Run one migration via the text-format endpoint.
+ * @returns {Promise<{ok:boolean, output:string, elapsedMs:number, error?:string}>}
+ */
+async function runOne(action) {
+    const url = `${ENDPOINT}?action=${encodeURIComponent(action)}&format=text`;
+    const res = await fetch(url, {
+        credentials: 'same-origin',
+        headers: { 'X-Requested-With': 'XMLHttpRequest', 'Accept': 'text/plain' },
+    });
+    const text = await res.text();
+    return parseEnvelope(text, res.ok);
+}
+
+/**
+ * Parse the server's `STATUS / ACTION / ... --- output` envelope.
+ */
+function parseEnvelope(text, httpOk) {
+    const sepIdx = text.indexOf('\n---\n');
+    let header = '';
+    let output = '';
+    if (sepIdx === -1) {
+        header = text;
+        output = '';
+    } else {
+        header = text.slice(0, sepIdx);
+        output = text.slice(sepIdx + 5);
+    }
+    const fields = {};
+    header.split('\n').forEach(line => {
+        const m = line.match(/^([A-Z_]+):\s*(.*)$/);
+        if (m) fields[m[1]] = m[2];
+    });
+    const status = (fields.STATUS || '').toLowerCase();
+    return {
+        ok: httpOk && status === 'ok',
+        output: output,
+        elapsedMs: parseInt(fields.ELAPSED_MS || '0', 10) || 0,
+        error: fields.ERROR || (httpOk ? '' : 'HTTP error'),
+    };
+}
+
+/**
+ * Lazily create the inline progress panel + return it.
+ */
+function ensurePanel(scope) {
+    let panel = scope.querySelector('[data-bulk-runner-panel]');
+    if (panel) return panel;
+
+    panel = document.createElement('section');
+    panel.dataset.bulkRunnerPanel = '';
+    panel.dataset.state = 'idle';
+    panel.className = 'card bg-dark border-secondary mb-4';
+    panel.setAttribute('role', 'region');
+    panel.setAttribute('aria-label', 'Bulk migration progress');
+    panel.innerHTML = `
+        <div class="card-body">
+            <h4 class="card-title d-flex align-items-center gap-2 mb-2">
+                <span>Apply All Pending Migrations</span>
+                <span class="badge bg-warning text-dark" data-bulk-status-badge>Running</span>
+            </h4>
+            <p class="text-muted small mb-3" data-bulk-status>Preparing…</p>
+            <div data-bulk-list class="mb-3"></div>
+            <details>
+                <summary class="text-muted small" style="cursor:pointer;">
+                    Show migration output log
+                </summary>
+                <pre class="bg-black text-light small p-3 mt-2 mb-0"
+                     data-bulk-log
+                     style="max-height:400px;overflow:auto;"></pre>
+            </details>
+        </div>
+    `;
+
+    /* Insert just below the page heading + intro paragraph, above
+       the action cards. The setup-database template renders a
+       `<div class="row g-3 mb-4">` for the cards; place the panel
+       right before it for natural reading order. */
+    const cards = scope.querySelector('.container-admin .row.g-3');
+    if (cards && cards.parentNode) {
+        cards.parentNode.insertBefore(panel, cards);
+    } else {
+        const main = scope.querySelector('.container-admin') || document.body;
+        main.appendChild(panel);
+    }
+    return panel;
+}
+
+/**
+ * Append a migration's captured output to the live log inside the
+ * panel's <details> drawer.
+ */
+function appendLog(panel, action, output, ok, errorMsg) {
+    const log = panel.querySelector('[data-bulk-log]');
+    if (!log) return;
+    const banner = ok
+        ? `═══ ${action} — completed ═══\n`
+        : `═══ ${action} — FAILED ═══\n${errorMsg ? '  ' + errorMsg + '\n' : ''}`;
+    log.textContent += banner;
+    if (output) {
+        log.textContent += output;
+        if (!output.endsWith('\n')) log.textContent += '\n';
+    }
+    log.textContent += '\n';
+    /* Auto-scroll to the bottom on each append so the curator sees
+       the latest chunk. */
+    log.scrollTop = log.scrollHeight;
+}
+
+function escapeHtml(s) {
+    return String(s)
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -1033,6 +1033,98 @@ if ($action !== '') {
     @ini_set('max_execution_time', '0');
     @ignore_user_abort(true);
 
+    /* #869 — text-format fast-path. The dashboard's per-migration
+       AJAX runner (js/modules/setup-bulk-runner.js) calls into this
+       same action endpoint one migration at a time. It doesn't want
+       the full HTML chrome — just the migration's captured stdout
+       framed by a small text header so the runner can distinguish
+       success / error and surface per-migration progress live on
+       the dashboard. Each request is short (one migration only),
+       so the bulk run never sits in a single long PHP request that
+       could hit a server-level timeout (FPM request_terminate_timeout,
+       proxy timeout, CDN limit) — which is the real root cause of
+       the symptom that #862 / #863 / #868 only papered over. */
+    $requestedFormat = (string)($_GET['format'] ?? '');
+    if ($requestedFormat === 'text' && $action !== 'apply-all-migrations') {
+        header('Content-Type: text/plain; charset=UTF-8');
+        header('Cache-Control: no-store, no-cache, must-revalidate');
+        header('X-Content-Type-Options: nosniff');
+
+        $scriptName = $scriptMap[$action] ?? null;
+        if ($scriptName === null) {
+            http_response_code(400);
+            echo "STATUS: error\n";
+            echo "ACTION: {$action}\n";
+            echo "ERROR: Unknown action.\n";
+            $pageRenderedCleanly = true;
+            exit;
+        }
+        if (!$hasCredentials && $action !== 'install') {
+            http_response_code(412);
+            echo "STATUS: error\n";
+            echo "ACTION: {$action}\n";
+            echo "ERROR: Database credentials not configured.\n";
+            $pageRenderedCleanly = true;
+            exit;
+        }
+        $scriptDir = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR
+                   . '.sql' . DIRECTORY_SEPARATOR;
+        $scriptPath = $scriptDir . $scriptName;
+        if (!file_exists($scriptPath)) {
+            http_response_code(404);
+            echo "STATUS: error\n";
+            echo "ACTION: {$action}\n";
+            echo "ERROR: Script not found: {$scriptName}\n";
+            $pageRenderedCleanly = true;
+            exit;
+        }
+
+        /* Capture the migration's output (echo / _migXxx_out / etc.)
+           so we can frame it with a status header. The migration may
+           emit <br> tags expecting an HTML context — strip them so
+           the AJAX runner gets readable plaintext. */
+        ob_start();
+        $migOk = true;
+        $migErr = '';
+        $migErrFile = '';
+        $migErrLine = 0;
+        $migStart = microtime(true);
+        try {
+            require $scriptPath;
+        } catch (\Throwable $e) {
+            $migOk = false;
+            $migErr = $e->getMessage();
+            $migErrFile = (string)$e->getFile();
+            $migErrLine = (int)$e->getLine();
+        }
+        $migOutput = (string)ob_get_clean();
+        /* Migration scripts use `_migXxx_out()` helpers that emit
+           `<br>\n` for the dashboard context; the AJAX runner shows
+           output as preformatted text so we replace those with a
+           plain newline. */
+        $migOutput = str_replace(['<br>', '<br/>', '<br />'], '', $migOutput);
+        $elapsed = (int)round((microtime(true) - $migStart) * 1000);
+
+        if (!$migOk) {
+            http_response_code(500);
+        }
+        echo "STATUS: " . ($migOk ? 'ok' : 'error') . "\n";
+        echo "ACTION: {$action}\n";
+        echo "SCRIPT: {$scriptName}\n";
+        echo "ELAPSED_MS: {$elapsed}\n";
+        if (!$migOk) {
+            echo "ERROR: {$migErr}\n";
+            if ($migErrFile !== '') {
+                echo "ERROR_AT: " . basename($migErrFile) . ":{$migErrLine}\n";
+            }
+        }
+        echo "---\n";
+        echo $migOutput;
+
+        $pageRenderedCleanly = true;
+        exit;
+    }
+
     /* #817 round 2 — render the page chrome BEFORE the bulk run, so:
        (a) Content-Type: text/html is committed to the response before
            any child script's `header('Content-Type: text/plain')` could
@@ -1582,9 +1674,24 @@ if ($hasCredentials && defined('DB_HOST')) {
                     <?php endif; ?>
                 </p>
             </div>
+            <?php
+                /* #869 — pending-migration list serialised onto the
+                   button so the per-migration AJAX runner can pick
+                   it up without a second round-trip. Comma-separated
+                   to avoid HTML-escaping JSON-with-quotes inside an
+                   attribute. The legacy href stays in place as a
+                   no-JS fallback (with the chrome / footer / badge
+                   fixes from #862 / #863 / #868 / #870 / #871 to
+                   handle the timeout edge case). */
+                $bulkRunnerPending = array_values(array_filter(
+                    $pendingActions,
+                    static fn(string $slug): bool => isset($migrationCards[$slug])
+                ));
+            ?>
             <a href="?action=apply-all-migrations"
                class="btn btn-primary btn-lg flex-shrink-0 <?= $hasCredentials ? '' : 'disabled' ?>"
-               onclick="return confirm('Run every pending migration in dependency order?\n\nSafe to re-run — applied migrations are skipped automatically.');">
+               data-bulk-runner-trigger
+               data-pending-migrations="<?= htmlspecialchars(implode(',', $bulkRunnerPending), ENT_QUOTES, 'UTF-8') ?>">
                 <i class="bi bi-play-fill me-1" aria-hidden="true"></i>
                 Apply all
             </a>
@@ -2043,6 +2150,20 @@ if ($hasCredentials && defined('DB_HOST')) {
         }
     });
 })();
+</script>
+
+<!-- #869 — Per-migration AJAX bulk runner. Replaces the legacy
+     full-page "Apply All" redirect with a sequential fetch loop on
+     the dashboard, so no single request hits a server-level
+     timeout. Falls through to the legacy <a href> on no-JS. -->
+<?php
+    $_bulkRunnerPath    = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'js' . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR . 'setup-bulk-runner.js';
+    $_bulkRunnerVersion = is_file($_bulkRunnerPath) ? (string)filemtime($_bulkRunnerPath) : '1';
+?>
+<script type="module">
+    import { bootSetupBulkRunner }
+        from '/js/modules/setup-bulk-runner.js?v=<?= htmlspecialchars($_bulkRunnerVersion, ENT_QUOTES) ?>';
+    bootSetupBulkRunner();
 </script>
 
 <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>


### PR DESCRIPTION
Closes [#869](https://github.com/MWBMPartners/iHymns/issues/869). The proper architectural fix for the user-reported "Apply All stuck on Running…" symptom. Replaces the legacy full-page redirect with a per-migration AJAX runner so no single request hits a server-level timeout in the first place.

## Why

\`set_time_limit(0)\` (#863) lifts PHP's per-request cap, but **server-level** timeouts can't be overridden from PHP:
- PHP-FPM \`request_terminate_timeout\` (typically 60s on shared hosting)
- nginx \`proxy_read_timeout\` / Apache \`Timeout\` / FastCGI proxy timeouts
- Hosting CDN timeouts (Cloudflare free tier: 100s)

PRs #862 / #863 / #868 / #870 / #871 papered over the timeout symptom with a graceful "Interrupted" badge + clean footer chrome. This PR removes the timeout exposure entirely by making each migration its own short HTTP request.

## What changes

### Server (\`setup-database.php\`)

A text-format fast-path for individual migrations. Any \`?action=<name>&format=text\` request:
- Sets \`Content-Type: text/plain\`, no-cache, nosniff.
- Skips the full HTML chrome.
- Runs the single migration with the existing \`require\` + try/catch.
- Strips the migration helpers' \`<br>\` separators so the response is readable plaintext.
- Returns a tiny envelope:

\`\`\`text
STATUS: ok
ACTION: external-links
SCRIPT: migrate-external-links.php
ELAPSED_MS: 247
---
External Links migration starting (#833)…
[skip] tblExternalLinkTypes already present.
…
\`\`\`

On error: HTTP 500, \`STATUS: error\`, plus \`ERROR\` / \`ERROR_AT\` fields above the \`---\` divider.

### Client (\`js/modules/setup-bulk-runner.js\`, new)

\`bootSetupBulkRunner()\` intercepts the Apply-All button click and runs the pending list sequentially:
1. Reads the pending-migration list from a \`data-pending-migrations="action1,action2,…"\` attribute on the button.
2. Opens an inline progress panel above the migration cards.
3. Pre-renders rows for every pending migration (○ icon).
4. For each: marks ⟳, \`fetch(?action=…&format=text)\`, parses the envelope, flips icon to ✓ / ✗, appends per-migration output to a live \`<pre>\` log (auto-scrolling, in an expandable details drawer).
5. Stops on first error with a clear banner; surfaces the failed step's output.
6. On clean completion: 1.2s pause to show "Complete" then reloads the dashboard so the pending-vs-applied probe partition refreshes.

### Dashboard

- Apply-All button gets \`data-bulk-runner-trigger\` + \`data-pending-migrations\` attributes.
- Legacy \`<a href="?action=apply-all-migrations">\` href stays in place as a no-JS fallback (with the chrome / footer / badge fixes from #862 / #863 / #868 / #870 / #871 to handle the timeout edge case if a curator with no JS hits it on a slow host).
- Boot script at the bottom imports the module and calls \`bootSetupBulkRunner()\`.

## Curator UX improvement

Before:
- Click Apply All → full-page redirect → streaming text wall → eventually freeze on "Running…" + missing footer.

After:
- Click Apply All → confirm dialog → inline progress panel appears.
- Per-migration row with status icon (○ / ⟳ / ✓ / ✗), action slug, elapsed ms.
- Live log in an expandable drawer.
- Stays on the dashboard the whole time. On completion, dashboard refreshes; pending count updates.

## Test plan

- [ ] Fresh DB with all migrations pending. Click Apply All → confirm panel appears → all rows flip to ✓ → dashboard reloads → pending grid empties.
- [ ] Force a single migration to fail (drop a prereq table) → confirm the loop stops at that row, banner explains, "Show migration output log" reveals the captured failure trace.
- [ ] Slow host with FPM \`request_terminate_timeout\` = 30s → confirm the bulk run completes successfully (each request is short, none hits the cap).
- [ ] Disable JS in the browser → confirm Apply-All still works via the legacy path (with the #871 chrome fixes).
- [ ] No regression on individual migration cards (\`?action=<name>\` without \`format=\`) — they still render the legacy HTML chrome with badge flip + footer.
- [ ] \`prefers-reduced-motion: reduce\` → confirm the spinner / animations don't flash distractingly (the ⟳ glyph is static; the dashboard refresh respects motion preferences via the page-transition system).

🤖 Generated with [Claude Code](https://claude.com/claude-code)