### PR TITLE
fix(manage + songbooks): mobile-edge footer + Apply button + tiles cleanup + offline-download button

### DIFF
--- a/appWeb/public_html/css/admin.css
+++ b/appWeb/public_html/css/admin.css
@@ -198,11 +198,18 @@ a:not(.btn):not(.nav-link):not(.dropdown-item):hover {
     z-index: 1030;
     /* Honour the iOS home-indicator safe area so the footer doesn't
        sit under it on installed PWA. env() is universally supported;
-       desktop browsers fall back to the literal `0px`. */
+       desktop browsers fall back to the literal `0px`. Horizontal
+       padding clamps to a 12 px floor (#875) — on iPhones in
+       portrait, env(safe-area-inset-left/right) is 0, which left
+       the inline copyright + version + build-stamp text flush against
+       the curved screen corners and clipped the leading/trailing
+       characters under the curve. max() keeps the existing landscape /
+       notch behaviour (where the inset legitimately exceeds 12 px)
+       while guaranteeing breathing room everywhere else. */
     padding-top: 0.4rem;
     padding-bottom: calc(0.4rem + env(safe-area-inset-bottom, 0px));
-    padding-left: env(safe-area-inset-left, 0px);
-    padding-right: env(safe-area-inset-right, 0px);
+    padding-left:  max(env(safe-area-inset-left,  0px), 12px);
+    padding-right: max(env(safe-area-inset-right, 0px), 12px);
     background-color: var(--surface-card);
     border-top: 1px solid var(--card-border);
     box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.35);

--- a/appWeb/public_html/manage/songbooks.php
+++ b/appWeb/public_html/manage/songbooks.php
@@ -3623,9 +3623,17 @@ $csrf = csrfToken();
             /* #873 — wire the "Apply this language to all songs" block.
                Stash the row metadata on the button so the click handler
                below has the songbook id + abbr + name without needing
-               another DOM round-trip. The button's enabled/disabled
-               state mirrors the picker — empty Language = nothing to
-               push, so the action is meaningless. */
+               another DOM round-trip.
+
+               #876: the button is enabled iff the songbook contains
+               songs. We deliberately don't gate on the picker's
+               composed tag here, because editIetfPicker.setTag() above
+               is async (it awaits loadLanguages() + a region lookup)
+               and getTag() returns '' until those resolve — which
+               left the button stuck disabled even when the songbook
+               had a saved language. The click handler validates the
+               picker tag at click time and surfaces "Pick a language
+               first." cleanly. */
             (function () {
                 const btn   = document.getElementById('edit-apply-song-language-btn');
                 const lbl   = document.getElementById('edit-apply-song-language-label');
@@ -3646,12 +3654,10 @@ $csrf = csrfToken();
                 lbl.textContent = count > 0
                     ? 'Apply to ' + count + ' song' + (count === 1 ? '' : 's')
                     : 'Apply to songs';
-                /* Disable when the picker is empty — pull the current
-                   composed tag from the picker module. */
-                const currentTag = (typeof window.editIetfPicker?.getTag === 'function')
-                    ? (window.editIetfPicker.getTag() || '')
-                    : (row.language || '');
-                btn.disabled = (currentTag === '' || count === 0);
+                /* Only disable for the legitimate "nothing to update"
+                   case — empty songbook. The picker-tag check happens
+                   inside the click handler. */
+                btn.disabled = (count === 0);
             })();
 
             /* #672 — bibliographic + authority-control identifiers. The


### PR DESCRIPTION
## Summary

Three bugs + one small feature against `alpha`, one commit each so any of them can be reverted independently.

### 1. Admin footer text touches curved-screen edges on mobile — closes #875

`.admin-footer-static` set `padding-left/right: env(safe-area-inset-*, 0px)` — on iPhones in portrait the insets are `0`, so the rule overrode `.footer-info`'s `padding: 4px 12px` and left text flush against the curved corners.

```css
padding-left:  max(env(safe-area-inset-left,  0px), 12px);
padding-right: max(env(safe-area-inset-right, 0px), 12px);
```

Commit: `2ea8908`.

### 2. "Apply to N songs" bulk-language button silently no-op'd — closes #876

`openEditModal()` called `editIetfPicker.setTag(row.language)` then **synchronously** read `getTag()` to gate `btn.disabled`. `setTag()` is async, so `getTag()` returned `''` on first read; nothing re-evaluated the button when the tag eventually resolved → permanently disabled.

**Fix:** drop the picker-tag gate from the modal-open IIFE. The click handler already validates the tag at click time and shows "Pick a language first." cleanly. Button is now only disabled for `count === 0`.

Commit: `7ced510`.

### 3. /songbooks tile chevron overlapped language-tag badge — closes #878

Chevron at `~1rem` from card right collided with the absolute language badge at `right: 0.45rem` (left edge ~2.45–3.45 rem from card right depending on 2- vs 3-letter codes).

**Fix:** `:has()`-scoped right padding bump on tiles carrying a language badge — chevron pushed leftward, clears the badge.

Commit: `79afe1f`. *(Superseded by commit 4 below — the new download button changes the cluster geometry; the padding rule was rewritten to fit the new layout.)*

### 4. Add offline-download button to /songbooks tiles — closes #879

User request: mirror the home-grid tile pattern so a curator / reader can save a whole songbook for offline use without first navigating into it.

- Refactored each tile from `<a class="card">` (single anchor) to `<div class="card">` + nested `<a class="stretched-link">` + sibling `<button class="songbook-download-btn">` (button-inside-anchor would be invalid HTML).
- Added `data-songbook-songs` so the existing `js/modules/offline-ui.js` boot picks up the new buttons automatically — no JS module change.
- Chevron now `d-none d-sm-block`-scoped: hidden on `xs` (portrait phone) where the absolute [badge + download-button] cluster would crowd the title; restored from `sm` up.
- CSS: dropped the legacy badge corner-pin override on `/songbooks`; replaced the chevron-clearance `:has()` rule with an unconditional `padding-right: 5.75rem` on `.card-body` to clear the worst-case [button + 3-letter badge] cluster + the `sm+` chevron with a small breathing gap.

Commit: `4b2f51b`.

## Test plan

### Footer (#875)
- [ ] Curved-corner iPhone in portrait → footer text has 12 px clearance from each edge; no characters clipped under the corner curve.
- [ ] Same device in landscape → notch-avoidance preserved (existing safe-area behaviour wins via `max()`).
- [ ] Desktop → unchanged (12 px floor matches `.footer-info`'s base padding).

### Apply-language (#876)
- [ ] `/manage/songbooks` → Edit a songbook with a Language saved and ≥ 1 songs → button is **enabled** and reads "Apply to N songs".
- [ ] Click → confirm dialog with impact preview → OK → status reports affected count; tblSongs.Language updates.
- [ ] Both modes work: default (untagged-only) and overwrite (destructive).
- [ ] Picker-empty click → "Pick a language first." status; no silent no-op.
- [ ] Empty songbook → button remains disabled.

### Songbooks tiles (#878 + #879)
- [ ] On `/songbooks` portrait phone (`xs`): every tile shows the language badge in the top-right with the **download button** in the corner. **No chevron.** Title text wraps cleanly without underlapping the cluster.
- [ ] From `sm` up: chevron returns, sitting just left of the badge+button cluster with a small breathing gap.
- [ ] Tap the download button → the offline-ui module starts caching the songbook (downloading state on the button); on completion it transitions to the `cached` style. Card click on any other area still navigates.
- [ ] 3-letter codes (GUZ / LUO / NSO / TOI / TUM) — no overlap, title still readable.
- [ ] `body.offline-unsupported` browsers — download button hides cleanly via the existing global rule.
- [ ] No regression on the home-grid tile cluster.

### Cross-cutting
- [ ] No regression on adjacent admin pages that share the footer (`/manage/login`, `/manage/setup-database`, `/manage/editor`).
