### PR TITLE
fix(web): escape songbookLabel inputs to close CodeQL XSS-through-DOM alerts

### DIFF
--- a/appWeb/public_html/js/constants.js
+++ b/appWeb/public_html/js/constants.js
@@ -66,6 +66,17 @@ export const SONGBOOK_NAMES = {
     Misc: 'Miscellaneous',
 };
 
+/* Local HTML escaper — kept inline to keep constants.js DOM-free and
+   avoid pulling utils/html.js into the dependency graph. The output of
+   songbookLabel is interpolated into innerHTML across many modules, so
+   any caller-supplied abbr/fullName must be escaped here at the source
+   to satisfy CodeQL's "DOM text reinterpreted as HTML" rule and stay
+   safe even when callers forget to escape. */
+const _ESC_MAP = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
+function _escSongbook(s) {
+    return String(s ?? '').replace(/[&<>"']/g, c => _ESC_MAP[c]);
+}
+
 /**
  * Return responsive songbook label HTML showing full name by default
  * and abbreviation on narrow screens. Both are always present in the
@@ -77,6 +88,7 @@ export const SONGBOOK_NAMES = {
  */
 export function songbookLabel(abbr, fullName) {
     const full = fullName || SONGBOOK_NAMES[abbr] || abbr;
-    if (full === abbr) return abbr; /* no full name available */
-    return `<span class="songbook-name-full">${full}</span><span class="songbook-name-abbr">${abbr}</span>`;
+    const safeAbbr = _escSongbook(abbr);
+    if (full === abbr) return safeAbbr; /* no full name available */
+    return `<span class="songbook-name-full">${_escSongbook(full)}</span><span class="songbook-name-abbr">${safeAbbr}</span>`;
 }


### PR DESCRIPTION
## Summary

Closes both open CodeQL **"DOM text reinterpreted as HTML"** alerts (#1, #2) flagged on `appWeb/public_html/js/modules/favorites.js`.

### The flow CodeQL was tracing

1. `favorites.js:333-334` reads `.badge` / `.song-number-badge-lg` `textContent` — DOM-text **source**
2. Values flow through `toggle()` → `localStorage` → `fav.songbook`
3. `loadFavoritesList()` at line 442 interpolates `${songbookLabel(fav.songbook)}` into `listEl.innerHTML` — **sink**

### Root cause

`songbookLabel()` in `appWeb/public_html/js/constants.js` returned a template-literal string with `abbr` / `full` interpolated **raw**. Every direct caller already used `escapeHtml()` on the surrounding fields, but trusted `songbookLabel`'s output — so the helper itself was the unescaped link in the chain. It's used from five modules (`favorites.js`, `history.js`, `router.js`, `search.js`, `setlist.js`), so escaping at the source fixes them all in one edit.

### Fix

Escape both `abbr` and `full` inside `songbookLabel` before interpolation. Inlined a small escaper rather than importing `utils/html.js` so `constants.js` stays DOM-free (the existing `escapeHtml` uses a module-level `<div>` and would break Node/SSR consumers of `constants.js`).

Output is unchanged for the canonical songbook abbreviations (`CP`, `JP`, `MP`, `SDAH`, `CH`, `Misc`) — none contain characters that need escaping.

### CodeQL config error banner

The "CodeQL is reporting errors" banner shown alongside the alerts is a **separate signal** — this repo uses GitHub's *default setup* (no `.github/workflows/codeql*.yml`), which is configured from repo Settings, not code. Pushing this branch re-triggers a scan; if the banner persists after a successful re-scan it needs a re-enable from **Settings → Code security → Code scanning**.

## Test plan

- [x] `node --check` on `constants.js` and every JS module under `appWeb/public_html/js/` passes
- [ ] After merge, confirm CodeQL alerts #1 and #2 close on the next scan
- [ ] Verify favourites list still renders songbook labels correctly (canonical abbrs unchanged)
- [ ] Confirm CodeQL config-error banner clears (or, if it persists, re-enable default setup in repo Settings)

https://claude.ai/code/session_01DDmc5wsksj5gKzdacYeY6H

---
_Generated by [Claude Code](https://claude.ai/code/session_01DDmc5wsksj5gKzdacYeY6H)_