### PR TITLE
feat(editor): Import OpenSong XML songs in bulk-import ZIPs (#882)

### DIFF
--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -3464,7 +3464,9 @@ function _bulkImport_processZip(string $zipPath, ?\mysqli $jobDb = null, ?int $j
     /* Single pass over the archive: for each .txt entry, parse the
        enclosing folder name to learn (songbook name, abbrev), upsert
        the songbook on first encounter, then parse + save the song. */
-    $songbookSeen = [];   // abbrev → (created|existing) — caches the songbook upsert per archive
+    $songbookSeen      = [];   // abbrev → (created|existing) — caches the songbook upsert per archive
+    $songbookCounters  = [];   // abbrev → next auto-assigned number (OpenSong fallback, #882)
+    $songsParsedByKind = ['txt' => 0, 'opensong' => 0];
 
     for ($i = 0; $i < $entryCount; $i++) {
         /* Periodic progress flush every $PROGRESS_BATCH iterations so
@@ -3492,14 +3494,26 @@ function _bulkImport_processZip(string $zipPath, ?\mysqli $jobDb = null, ?int $j
             continue;
         }
 
-        /* Skip directory entries and non-.txt files (a future revision
-           might also accept .json metadata; for now .txt is the
-           contract). Zip mac metadata stores ('__MACOSX/', '.DS_Store')
-           are silently ignored. */
+        /* Skip directory entries, mac metadata, and dot-files. */
         if (str_ends_with($name, '/'))                continue;
-        if (!preg_match('/\.txt$/i', $name))          continue;
         if (str_contains($name, '__MACOSX/'))         continue;
         if (str_contains($name, '/.'))                continue;
+
+        /* Detect file format by extension. .txt → existing plain-text
+           per-song parser; .xml / .opensong → OpenSong XML parser
+           (#882). Anything else is silently skipped so a curator can
+           drop a hymnal folder containing mixed assets (PDFs, cover
+           art) without each non-song entry surfacing as a parse
+           error. */
+        $ext = strtolower(pathinfo($name, PATHINFO_EXTENSION));
+        $kind = null;
+        if ($ext === 'txt') {
+            $kind = 'txt';
+        } elseif ($ext === 'xml' || $ext === 'opensong') {
+            $kind = 'opensong';
+        } else {
+            continue;
+        }
 
         /* Pull out the folder + file segments. We expect exactly one
            level of nesting: "<Hymnal Name> [<ABBR>]/<filename>.txt". */
@@ -3515,28 +3529,41 @@ function _bulkImport_processZip(string $zipPath, ?\mysqli $jobDb = null, ?int $j
             $errors[] = ['entry' => $name, 'error' => 'folder name does not match "<Title> [<ABBR>]"'];
             continue;
         }
-        if (!preg_match(_BULK_IMPORT_FILE_RE, $file, $fileMatch)) {
-            $errors[] = ['entry' => $name, 'error' => 'filename does not match "<#> (<ABBR>) - <Title>.txt"'];
-            continue;
-        }
 
         $abbr     = strtoupper($folderMatch['abbr']);
         $bookName = trim($folderMatch['name']);
         /* Optional `_<LangName>-<ISO>` suffix on the folder (#780). The
            ISO code becomes the songbook's Language at upsert time. */
         $folderLang = isset($folderMatch['lang']) ? trim((string)$folderMatch['lang']) : '';
-        $fileAbbr = strtoupper($fileMatch['abbr']);
-        $songNum  = (int)$fileMatch['num'];
 
-        /* Cross-check: the abbreviation in the filename must match
-           the folder's abbreviation. Otherwise we'd silently put a
-           song from book A into book B. */
-        if ($fileAbbr !== $abbr) {
-            $errors[] = [
-                'entry' => $name,
-                'error' => "filename abbrev '$fileAbbr' does not match folder abbrev '$abbr'",
-            ];
-            continue;
+        /* Filename → song-number extraction. The two formats use
+           different conventions: */
+        $songNum = 0;
+        if ($kind === 'txt') {
+            /* Strict: "<#> (<ABBR>) - <Title>.txt". The number is
+               authoritative, the embedded abbreviation is cross-
+               checked against the folder. */
+            if (!preg_match(_BULK_IMPORT_FILE_RE, $file, $fileMatch)) {
+                $errors[] = ['entry' => $name, 'error' => 'filename does not match "<#> (<ABBR>) - <Title>.txt"'];
+                continue;
+            }
+            $fileAbbr = strtoupper($fileMatch['abbr']);
+            $songNum  = (int)$fileMatch['num'];
+            if ($fileAbbr !== $abbr) {
+                $errors[] = [
+                    'entry' => $name,
+                    'error' => "filename abbrev '$fileAbbr' does not match folder abbrev '$abbr'",
+                ];
+                continue;
+            }
+        } else {
+            /* OpenSong (#882): leading digits in the filename, if
+               present, are a hint only. The XML's <hymn_number>
+               element wins; the parser falls back to this hint, then
+               to a per-songbook auto-increment. */
+            if (preg_match('/^(\d{1,5})/', $file, $m)) {
+                $songNum = (int)$m[1];
+            }
         }
 
         /* Songbook upsert — once per abbreviation per import. */
@@ -3559,7 +3586,27 @@ function _bulkImport_processZip(string $zipPath, ?\mysqli $jobDb = null, ?int $j
             continue;
         }
 
-        [$song, $reason] = _bulkImport_parseTxt($body, $abbr, $bookName, $songNum);
+        if ($kind === 'opensong') {
+            /* OpenSong: derive the next per-songbook auto-increment
+               so a parser fallback (no <hymn_number>, no leading
+               digits in filename) still produces a unique SongId. */
+            if (!isset($songbookCounters[$abbr])) {
+                $songbookCounters[$abbr] = _bulkImport_nextSongNumberFor($db, $abbr);
+            }
+            [$song, $reason] = _bulkImport_parseOpenSong($body, $abbr, $bookName, $songNum, $songbookCounters[$abbr]);
+            if ($song !== null) {
+                /* Bump the auto-counter to whatever number landed so a
+                   second OpenSong file in the same songbook doesn't
+                   collide on SongId. */
+                $songbookCounters[$abbr] = max($songbookCounters[$abbr], (int)$song['number']) + 1;
+                $songsParsedByKind['opensong']++;
+            }
+        } else {
+            [$song, $reason] = _bulkImport_parseTxt($body, $abbr, $bookName, $songNum);
+            if ($song !== null) {
+                $songsParsedByKind['txt']++;
+            }
+        }
         if ($song === null) {
             $errors[] = ['entry' => $name, 'error' => 'parse failed: ' . $reason];
             $songsFailed++;
@@ -3606,6 +3653,243 @@ function _bulkImport_processZip(string $zipPath, ?\mysqli $jobDb = null, ?int $j
         'songs_created'          => $songsCreated,
         'songs_skipped_existing' => $songsSkippedExisting,
         'songs_failed'           => $songsFailed,
+        'parsed_by_format'       => $songsParsedByKind,
         'errors'                 => $errors,
     ];
+}
+
+/* ===========================================================================
+ * OPENSONG PARSER (#882)
+ *
+ * OpenSong stores each song as a single XML document. Reference:
+ *   https://opensong.org/documentation/importing/#songs
+ *
+ * Lyrics live in <lyrics> as plain text with bracketed section markers
+ * ([V1], [C], [B], …), chord rows (lines starting with ".") and
+ * comment rows (lines starting with ";"). The chord rows are dropped —
+ * iHymns is a lyrics catalogue. Lyric lines conventionally begin with
+ * a single space; that space is stripped to recover the real text.
+ *
+ * The output shape mirrors _bulkImport_parseTxt() so the same
+ * _bulkImport_saveSong() write path consumes it without any branching.
+ * =========================================================================== */
+
+/**
+ * Map OpenSong section letters to iHymns component types.
+ *
+ * Falls back to 'refrain' for anything we don't recognise (e.g. a
+ * non-English label slipped into the section marker), matching the
+ * fallback _bulkImport_componentTypeFor() uses for the TXT parser.
+ */
+function _bulkImport_openSongComponentTypeFor(string $letter): string
+{
+    return [
+        'V' => 'verse',
+        'C' => 'chorus',
+        'B' => 'bridge',
+        'P' => 'pre-chorus',
+        'T' => 'outro',
+        'E' => 'outro',
+        'I' => 'intro',
+    ][strtoupper($letter)] ?? 'refrain';
+}
+
+/**
+ * Parse one OpenSong XML body into the song-object shape that
+ * _bulkImport_saveSong() consumes.
+ *
+ * @param string $body         Raw XML (UTF-8; BOM tolerated).
+ * @param string $abbrev       Songbook abbreviation from the folder.
+ * @param string $songbook     Songbook display name from the folder.
+ * @param int    $numberHint   Number derived from the filename's
+ *                             leading digits (0 if none).
+ * @param int    $autoNumber   Per-songbook auto-increment fallback when
+ *                             neither the XML nor the filename supply
+ *                             a number.
+ * @return array{0: ?array, 1: ?string}  [songObject, errorReason]
+ */
+function _bulkImport_parseOpenSong(string $body, string $abbrev, string $songbook, int $numberHint, int $autoNumber): array
+{
+    /* Strip a UTF-8 BOM so SimpleXML doesn't choke. */
+    $body = preg_replace('/^\xEF\xBB\xBF/', '', $body);
+
+    /* Capture libxml errors locally so a malformed file produces a
+       readable per-entry error rather than a global warning splatter. */
+    $prevInternal = libxml_use_internal_errors(true);
+    libxml_clear_errors();
+    /* LIBXML_NONET prevents the parser from following any external
+       entity URI — DTD-based SSRF / billion-laughs hardening. */
+    $xml = simplexml_load_string($body, \SimpleXMLElement::class, LIBXML_NONET);
+    if ($xml === false) {
+        $err = libxml_get_last_error();
+        libxml_clear_errors();
+        libxml_use_internal_errors($prevInternal);
+        return [null, 'invalid XML' . ($err ? ': ' . trim($err->message) : '')];
+    }
+    libxml_clear_errors();
+    libxml_use_internal_errors($prevInternal);
+
+    if (strtolower($xml->getName()) !== 'song') {
+        return [null, 'XML root is <' . $xml->getName() . '>, expected <song>'];
+    }
+
+    $title = trim((string)($xml->title ?? ''));
+    if ($title === '') {
+        return [null, 'no <title> element'];
+    }
+
+    /* Number resolution priority: <hymn_number> in XML → filename
+       leading digits → per-songbook auto-increment. The auto-increment
+       guarantees a unique SongId even for OpenSong corpora that don't
+       carry numbers at all (which is most non-hymnal song libraries). */
+    $hymnNumberRaw = trim((string)($xml->hymn_number ?? ''));
+    $hymnNumber    = ($hymnNumberRaw !== '' && ctype_digit($hymnNumberRaw))
+        ? (int)$hymnNumberRaw
+        : 0;
+    $number = $hymnNumber > 0
+        ? $hymnNumber
+        : ($numberHint > 0 ? $numberHint : $autoNumber);
+    if ($number <= 0) {
+        return [null, 'could not determine song number'];
+    }
+
+    $components = _bulkImport_parseOpenSongLyrics((string)($xml->lyrics ?? ''));
+    if (empty($components)) {
+        return [null, 'no lyric components found in <lyrics>'];
+    }
+
+    /* Author fields in OpenSong commonly stack multiple credits with
+       slashes, ampersands or commas — split into individual writers
+       to match the way the editor stores credit names. */
+    $authors  = trim((string)($xml->author ?? ''));
+    $writers  = [];
+    if ($authors !== '') {
+        foreach (preg_split('/\s*[\/&,;]\s*/u', $authors) as $w) {
+            $w = trim((string)$w);
+            if ($w !== '') $writers[] = $w;
+        }
+    }
+
+    $songId = sprintf('%s-%04d', strtoupper($abbrev), $number);
+
+    return [[
+        'id'                 => $songId,
+        'title'              => $title,
+        'number'             => $number,
+        'songbook'           => strtoupper($abbrev),
+        'songbookName'       => $songbook,
+        'language'           => 'en',
+        'ccli'               => trim((string)($xml->ccli ?? '')),
+        'iswc'               => '',
+        'tuneName'           => '',
+        'copyright'          => trim((string)($xml->copyright ?? '')),
+        'verified'           => 0,
+        'lyricsPublicDomain' => 0,
+        'musicPublicDomain'  => 0,
+        'hasAudio'           => 0,
+        'hasSheetMusic'      => 0,
+        'writers'            => $writers,
+        'composers'          => [],
+        'arrangers'          => [],
+        'adaptors'           => [],
+        'translators'        => [],
+        'components'         => $components,
+    ], null];
+}
+
+/**
+ * Parse the body of an OpenSong <lyrics> block into the same
+ * components[] shape produced by _bulkImport_parseTxt().
+ */
+function _bulkImport_parseOpenSongLyrics(string $lyrics): array
+{
+    $lyrics = str_replace(["\r\n", "\r"], "\n", $lyrics);
+    $lines  = explode("\n", $lyrics);
+    $components = [];
+    $current    = null;
+
+    foreach ($lines as $rawLine) {
+        $trim = trim($rawLine);
+
+        /* Comment row → drop. OpenSong reserves leading ";" for
+           in-corpus notes the projector should never display. */
+        if ($trim !== '' && $trim[0] === ';') {
+            continue;
+        }
+        /* Chord row → drop. OpenSong puts chord names on a row that
+           starts with "." so the projector can suppress them; iHymns
+           is lyrics-only, so we strip them entirely rather than try
+           to interleave them with the lyric line. */
+        if ($rawLine !== '' && $rawLine[0] === '.') {
+            continue;
+        }
+
+        /* Section marker, e.g. "[V1]", "[C]", "[B]". The optional
+           trailing digits become the verse number; bare "[V]" implies
+           the next sequential verse. */
+        if (preg_match('/^\[([A-Za-z]+)(\d*)\]$/', $trim, $m)) {
+            if ($current !== null && !empty($current['lines'])) {
+                $components[] = $current;
+            }
+            $current = [
+                'type'   => _bulkImport_openSongComponentTypeFor($m[1]),
+                'number' => $m[2] !== '' ? (int)$m[2] : 0,
+                'lines'  => [],
+            ];
+            continue;
+        }
+
+        /* Blank line ends the current section so consecutive section
+           markers don't accidentally merge. */
+        if ($trim === '') {
+            if ($current !== null && !empty($current['lines'])) {
+                $components[] = $current;
+                $current = null;
+            }
+            continue;
+        }
+
+        if ($current === null) {
+            /* Lyrics before any section marker — assume verse 1 so
+               files without explicit markers (rare but legal) still
+               produce a usable song object. */
+            $current = ['type' => 'verse', 'number' => 1, 'lines' => []];
+        }
+
+        /* Strip a single leading space — OpenSong convention for lyric
+           rows; preserving it would ladder the text in the editor. */
+        $line = $rawLine;
+        if (isset($line[0]) && $line[0] === ' ') {
+            $line = substr($line, 1);
+        }
+        $current['lines'][] = rtrim($line);
+    }
+
+    if ($current !== null && !empty($current['lines'])) {
+        $components[] = $current;
+    }
+
+    return $components;
+}
+
+/**
+ * Return one greater than the maximum existing song number for a
+ * songbook, used as the OpenSong auto-increment seed when neither
+ * <hymn_number> nor the filename supply a number (#882).
+ */
+function _bulkImport_nextSongNumberFor(\mysqli $db, string $abbr): int
+{
+    try {
+        $stmt = $db->prepare(
+            'SELECT COALESCE(MAX(Number), 0) + 1 FROM tblSongs WHERE SongbookAbbr = ?'
+        );
+        $stmt->bind_param('s', $abbr);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_row();
+        $stmt->close();
+        return (int)($row[0] ?? 1);
+    } catch (\Throwable $e) {
+        error_log('[_bulkImport_nextSongNumberFor] ' . $e->getMessage());
+        return 1;
+    }
 }

--- a/appWeb/public_html/manage/editor/index.php
+++ b/appWeb/public_html/manage/editor/index.php
@@ -86,9 +86,12 @@ $currentUser = getCurrentUser();
     >
 
     <!-- Hidden file input for importing songs from an external file.
-         Accepts .json (curator-edited corpus) and .zip bulk archives
-         that mirror the .SourceSongData/ folder layout (#664). The
-         zip path inserts directly into MySQL via the
+         Accepts .json (curator-edited corpus) and .zip bulk archives.
+         A bulk-import ZIP mirrors the .SourceSongData/ folder layout
+         (#664) and may contain either plain-text .txt files (one per
+         song) OR OpenSong .xml files (#882). Both kinds may be mixed
+         in the same archive — the server dispatches per-entry by
+         extension. The zip path inserts directly into MySQL via the
          /manage/editor/api.php?action=bulk_import_zip endpoint and
          never overwrites existing songbook or song rows. -->
     <input
@@ -220,7 +223,7 @@ $currentUser = getCurrentUser();
                 type="button"
                 class="btn btn-sm btn-amber"
                 id="btn-import"
-                title="Import songs from a JSON file (in-memory merge) or a .zip bulk archive (.SourceSongData layout — inserts directly into MySQL, never overwrites existing rows)"
+                title="Import songs from a JSON corpus (in-memory merge) or a .zip bulk archive. ZIPs accept the .SourceSongData layout (one .txt per song) or OpenSong .xml files in the same &lt;Hymnal&gt; [&lt;ABBR&gt;]/ folder shape. Bulk imports insert directly into MySQL and never overwrite existing rows."
             >
                 <i class="bi bi-box-arrow-in-down me-1"></i>Import
             </button>

--- a/appWeb/public_html/manage/help.php
+++ b/appWeb/public_html/manage/help.php
@@ -486,9 +486,16 @@ foreach ($sections as $s) {
                         <li><strong>Export</strong> the current view as JSON or CSV.</li>
                         <li><strong>Revisions</strong> for the selected song shows a diff of every previous edit and a Restore button.</li>
                     </ul>
-                    <h3 class="h6">Bulk Import ZIP (#664 / #676)</h3>
+                    <h3 class="h6">Bulk Import ZIP (#664 / #676 / #882)</h3>
                     <p>
-                        For onboarding an entire songbook at once. Upload a ZIP whose top-level folders match <code>&lt;Hymnal Name&gt; [&lt;ABBR&gt;]/</code> and whose files match <code>&lt;number&gt; (&lt;ABBR&gt;) - &lt;Title&gt;.txt</code>. The importer creates the songbook on first encounter, then parses + inserts every song.
+                        For onboarding an entire songbook at once. Upload a ZIP whose top-level folders match <code>&lt;Hymnal Name&gt; [&lt;ABBR&gt;]/</code> and whose files are one of:
+                    </p>
+                    <ul>
+                        <li><strong>Plain text</strong> — <code>&lt;number&gt; (&lt;ABBR&gt;) - &lt;Title&gt;.txt</code> with the canonical title / blank / section-marker / lyric-block layout the scrapers emit. The number in the filename and folder ABBR cross-check; mismatches are reported per-entry.</li>
+                        <li><strong>OpenSong XML</strong> (#882) — <code>.xml</code> or <code>.opensong</code> files anywhere inside the hymnal folder. The song number comes from the <code>&lt;hymn_number&gt;</code> element first, then any leading digits in the filename, then a per-songbook auto-increment. <code>&lt;author&gt;</code> splits on <code>/</code>, <code>&amp;</code>, <code>,</code>, <code>;</code> into the writers list. Chord rows (lines beginning with <code>.</code>) and comment rows (lines beginning with <code>;</code>) are stripped from the lyrics.</li>
+                    </ul>
+                    <p>
+                        Both file kinds may be mixed in the same archive — the importer dispatches per entry by extension. The summary's <code>parsed_by_format</code> counter shows how many of each landed.
                     </p>
                     <ul>
                         <li><strong>INSERT-only contract:</strong> if a songbook or song already exists, it's left untouched — never overwritten. The summary reports created vs. existing counts so you can see what landed.</li>

--- a/tests/php/fixtures/opensong/be-thou-my-vision.xml
+++ b/tests/php/fixtures/opensong/be-thou-my-vision.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<song>
+  <title>Be Thou My Vision</title>
+  <author>Mary E. Byrne / Eleanor H. Hull</author>
+  <copyright>Public Domain</copyright>
+  <ccli>30639</ccli>
+  <hymn_number>123</hymn_number>
+  <key>D</key>
+  <tempo>72</tempo>
+  <theme>Worship; Devotion</theme>
+  <user1></user1>
+  <lyrics>;An OpenSong corpus comment that should be ignored
+[V1]
+.D       G       A     D
+ Be Thou my vision, O Lord of my heart
+ Naught be all else to me, save that Thou art
+
+[V2]
+ Thou my best thought, by day or by night
+ Waking or sleeping, Thy presence my light
+
+[C]
+ Heart of my own heart, whatever befall
+ Still be my vision, O Ruler of all
+</lyrics>
+</song>

--- a/tests/php/fixtures/opensong/malformed.xml
+++ b/tests/php/fixtures/opensong/malformed.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<song>
+  <title>Broken
+  <lyrics>[V1]
+ nope</lyrics>

--- a/tests/php/fixtures/opensong/no-number.xml
+++ b/tests/php/fixtures/opensong/no-number.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<song>
+  <title>Numberless Song</title>
+  <author>Anon</author>
+  <lyrics>[V1]
+ First line
+ Second line
+
+[C]
+ Refrain line one
+ Refrain line two
+</lyrics>
+</song>

--- a/tests/php/test-opensong-parser.php
+++ b/tests/php/test-opensong-parser.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * iHymns — OpenSong Importer Smoke Test (#882)
+ *
+ * Exercises _bulkImport_parseOpenSong() / _bulkImport_parseOpenSongLyrics()
+ * against representative fixtures. Doesn't touch the database — only the
+ * pure-parser surface.
+ *
+ *   php tests/php/test-opensong-parser.php
+ *
+ * Exit status 0 = all tests pass, 1 = at least one assertion failed.
+ */
+
+declare(strict_types=1);
+
+/* The parser helpers live at the bottom of the editor's API file but
+   require none of its DB / HTTP machinery to function. We isolate the
+   helper definitions by extracting them into a temp file the test
+   includes — the alternative (require api.php) would emit headers and
+   short-circuit the response handler at the top of the file. */
+$apiPath = dirname(__DIR__, 2) . '/appWeb/public_html/manage/editor/api.php';
+$src     = file_get_contents($apiPath);
+if ($src === false) {
+    fwrite(STDERR, "could not read api.php\n");
+    exit(1);
+}
+
+/* Pull out only the OpenSong helpers + their dependencies. The block
+   we care about is delimited by the OPENSONG PARSER comment header
+   and runs to EOF. */
+$marker = '/* ===========================================================================' . "\n"
+        . ' * OPENSONG PARSER (#882)';
+$pos = strpos($src, $marker);
+if ($pos === false) {
+    fwrite(STDERR, "OPENSONG PARSER block not found in api.php\n");
+    exit(1);
+}
+$tmp = tempnam(sys_get_temp_dir(), 'ihymns-opensong-');
+file_put_contents($tmp, "<?php\n" . substr($src, $pos));
+require $tmp;
+@unlink($tmp);
+
+/* -------------------------------------------------------------------- */
+/* Test runner — one-line PASS/FAIL per assertion.                       */
+/* -------------------------------------------------------------------- */
+$passed = 0;
+$failed = 0;
+function assertEq($actual, $expected, string $label): void
+{
+    global $passed, $failed;
+    if ($actual === $expected) {
+        echo "  PASS  $label\n";
+        $passed++;
+    } else {
+        echo "  FAIL  $label\n";
+        echo "        expected: " . var_export($expected, true) . "\n";
+        echo "        actual:   " . var_export($actual, true) . "\n";
+        $failed++;
+    }
+}
+function assertTrue($actual, string $label): void
+{
+    assertEq((bool)$actual, true, $label);
+}
+
+$fixtureDir = __DIR__ . '/fixtures/opensong';
+
+/* -------------------------------------------------------------------- */
+/* Fixture 1: typical hymn — verses, chorus, chord rows, comments.       */
+/* -------------------------------------------------------------------- */
+echo "fixture: be-thou-my-vision.xml\n";
+$body  = file_get_contents("$fixtureDir/be-thou-my-vision.xml");
+[$song, $err] = _bulkImport_parseOpenSong($body, 'TST', 'Test Hymnal', 0, 1);
+assertEq($err,                    null,                  'no parse error');
+assertTrue(is_array($song),                              'song dict returned');
+assertEq($song['title'],          'Be Thou My Vision',   'title');
+assertEq($song['number'],         123,                   'number from <hymn_number>');
+assertEq($song['id'],             'TST-0123',            'songId format');
+assertEq($song['songbook'],       'TST',                 'songbook abbr');
+assertEq($song['copyright'],      'Public Domain',       'copyright');
+assertEq($song['ccli'],           '30639',               'ccli');
+assertEq($song['writers'],        ['Mary E. Byrne', 'Eleanor H. Hull'], 'writers split on /');
+assertEq(count($song['components']), 3,                  'three components (V1, V2, C)');
+assertEq($song['components'][0]['type'],   'verse',      'first component type');
+assertEq($song['components'][0]['number'], 1,            'first component number');
+assertEq($song['components'][2]['type'],   'chorus',     'third component type');
+/* Lyric content — chord rows dropped, comment row dropped, leading
+   space stripped from lyric rows. */
+assertEq($song['components'][0]['lines'][0], 'Be Thou my vision, O Lord of my heart', 'V1 line 1');
+assertEq($song['components'][0]['lines'][1], 'Naught be all else to me, save that Thou art', 'V1 line 2');
+assertEq(count($song['components'][0]['lines']), 2,      'V1 has exactly 2 lyric lines (chord row stripped)');
+
+/* -------------------------------------------------------------------- */
+/* Fixture 2: no <hymn_number>, no filename hint → auto-increment seed.  */
+/* -------------------------------------------------------------------- */
+echo "fixture: no-number.xml\n";
+$body  = file_get_contents("$fixtureDir/no-number.xml");
+[$song, $err] = _bulkImport_parseOpenSong($body, 'TST', 'Test Hymnal', 0, 42);
+assertEq($err,             null,                'no parse error');
+assertEq($song['number'],  42,                  'number falls back to auto-increment');
+assertEq($song['id'],      'TST-0042',          'songId uses auto-increment');
+assertEq($song['writers'], ['Anon'],            'single writer, no split');
+
+/* -------------------------------------------------------------------- */
+/* Fixture 3: malformed XML — graceful parse error.                      */
+/* -------------------------------------------------------------------- */
+echo "fixture: malformed.xml\n";
+$body  = file_get_contents("$fixtureDir/malformed.xml");
+[$song, $err] = _bulkImport_parseOpenSong($body, 'TST', 'Test Hymnal', 0, 1);
+assertEq($song,            null,                'malformed XML returns null song');
+assertTrue(is_string($err) && str_starts_with($err, 'invalid XML'), 'error message starts with "invalid XML"');
+
+/* -------------------------------------------------------------------- */
+/* Fixture 4: filename hint when no <hymn_number>.                       */
+/* -------------------------------------------------------------------- */
+echo "filename-hint precedence:\n";
+$body  = file_get_contents("$fixtureDir/no-number.xml");
+[$song, $err] = _bulkImport_parseOpenSong($body, 'TST', 'Test Hymnal', 17, 99);
+assertEq($song['number'],  17,                  'filename hint beats auto-increment when XML has no number');
+
+/* -------------------------------------------------------------------- */
+/* Fixture 5: <hymn_number> always wins over hint + auto-increment.      */
+/* -------------------------------------------------------------------- */
+echo "<hymn_number> precedence:\n";
+$body  = file_get_contents("$fixtureDir/be-thou-my-vision.xml");
+[$song, $err] = _bulkImport_parseOpenSong($body, 'TST', 'Test Hymnal', 17, 99);
+assertEq($song['number'],  123,                 '<hymn_number> wins over hint and auto-increment');
+
+/* -------------------------------------------------------------------- */
+/* Component-type map.                                                   */
+/* -------------------------------------------------------------------- */
+echo "component-type mapping:\n";
+assertEq(_bulkImport_openSongComponentTypeFor('V'), 'verse',      'V → verse');
+assertEq(_bulkImport_openSongComponentTypeFor('C'), 'chorus',     'C → chorus');
+assertEq(_bulkImport_openSongComponentTypeFor('B'), 'bridge',     'B → bridge');
+assertEq(_bulkImport_openSongComponentTypeFor('P'), 'pre-chorus', 'P → pre-chorus');
+assertEq(_bulkImport_openSongComponentTypeFor('T'), 'outro',      'T → outro (Tag)');
+assertEq(_bulkImport_openSongComponentTypeFor('I'), 'intro',      'I → intro');
+assertEq(_bulkImport_openSongComponentTypeFor('Z'), 'refrain',    'unknown letter → refrain fallback');
+
+echo "\n";
+echo "$passed passed, $failed failed\n";
+exit($failed === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

- Files five GitHub issues scoping import support for the four most common third-party worship-software formats (OpenSong, VideoPsalm, FreeShow, ProPresenter 7+) plus an umbrella tracking issue (#881).
- Implements the easiest of the four — **OpenSong XML import** — under the existing bulk-import ZIP route (#882).
- Both file kinds (existing `.txt`, new `.xml`/`.opensong`) may be mixed in one archive; the importer dispatches per-entry by extension and feeds a single `_bulkImport_saveSong()` write path so audit, dedupe, async progress, and INSERT-only contract all flow unchanged.

## Issues filed

- #881 — umbrella `feat(editor): Import lyrics from third-party worship-software formats`
- #882 — OpenSong XML *(implemented in this PR)*
- #883 — VideoPsalm JSON
- #884 — FreeShow `.show`
- #885 — ProPresenter 7+ `.pro`

## What's in this PR

- New `_bulkImport_parseOpenSong()` + lyric tokenizer + section-letter map + per-songbook auto-increment helper in `appWeb/public_html/manage/editor/api.php`.
- `_bulkImport_processZip()` per-entry dispatcher: `.txt` → existing parser; `.xml` / `.opensong` → OpenSong parser; everything else silently skipped (so a hymnal folder with cover-art PDFs no longer surfaces per-file parse errors).
- Number-resolution priority: `<hymn_number>` → filename leading digits → per-songbook `MAX(Number)+1` auto-increment, so an OpenSong corpus with no numbers at all still imports without SongId collisions.
- Drops chord rows (`.`-prefixed) and comment rows (`;`-prefixed) per OpenSong's projector convention; strips the conventional single leading space; maps `[V]/[C]/[B]/[P]/[T]/[E]/[I]` to iHymns component types; unknown letters fall through to `refrain` rather than rejecting the song.
- XML parsing uses `simplexml_load_string()` with `LIBXML_NONET` (SSRF / billion-laughs hardening) and locally-scoped libxml internal-error mode (no global warning splatter).
- Bulk-import summary gains `parsed_by_format: {txt: n, opensong: n}`.
- Editor toolbar tooltip + `manage/help.php` updated with the new format.
- Standalone smoke test under `tests/php/` with three fixtures (typical hymn, no `<hymn_number>`, malformed XML) — 31 assertions, all passing locally.

## Out of scope (covered in #883/#884/#885)

- VideoPsalm, FreeShow, ProPresenter 7+ parsers.
- Single-file (non-ZIP) drag-drop for OpenSong — curators wrap their OpenSong folder in a ZIP today, same as the existing `.SourceSongData` flow.
- Chord-chart preservation. iHymns is a lyrics catalogue; chord rows are stripped, and the issue notes this explicitly.

## Test plan

- [ ] `php -l` clean on `api.php`, `index.php`, `help.php`.
- [ ] `php tests/php/test-opensong-parser.php` → `31 passed, 0 failed`.
- [ ] Drop a ZIP containing one folder `Test [TST]/` with both an `.xml` OpenSong song and an existing-format `.txt` song — both land, summary shows `parsed_by_format: {txt: 1, opensong: 1}`.
- [ ] Drop an existing `.SourceSongData`-shaped ZIP (TXT-only) — regression check, count matches pre-PR behaviour.
- [ ] Drop a ZIP whose folder does not match `<Title> [<ABBR>]` — entry rejected with the existing folder-shape error.
- [ ] Drop an OpenSong XML with malformed XML — single per-entry error reported, rest of archive continues.
- [ ] Help page renders the updated Bulk Import ZIP section.

https://claude.ai/code/session_01V4sVR1Mwwn5KXta2k6dto5

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4sVR1Mwwn5KXta2k6dto5)_