### PR TITLE
fix(editor): persist song arrangement on save (closes #892)

### DIFF
--- a/appWeb/.sql/migrate-song-arrangement.php
+++ b/appWeb/.sql/migrate-song-arrangement.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Song Arrangement Persistence Migration (#892)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Adds an `ArrangementJson` JSON column to `tblSongs` so the Song
+ * Editor's Structure-tab arrangement (an array of indices into the
+ * components[] list, allowing repetition — e.g. a refrain played
+ * between every verse) can finally round-trip through the editor's
+ * save → reload path.
+ *
+ * Pre-#892 the editor rendered the arrangement chips and POSTed
+ * `song.arrangement` to `?action=save_song`, but the server-side
+ * handler had no column to write into and silently dropped the
+ * field. Curators saw the "Saved" toast, then reloaded to find
+ * their custom order replaced by the bare SortOrder sequence.
+ *
+ * Schema: one nullable JSON column. NULL means "render components
+ * in their stored SortOrder" (current behaviour); a JSON array of
+ * non-negative integer indices overrides the order and may include
+ * repetitions (the entire reason this column exists).
+ *
+ * Idempotent: probes INFORMATION_SCHEMA.COLUMNS first; skips if
+ * the column already exists.
+ *
+ * USAGE:
+ *   CLI: php appWeb/.sql/migrate-song-arrangement.php
+ *   Web: /manage/setup-database → "Song Arrangement Persistence (#892)"
+ *
+ * @migration-modifies tblSongs (adds ArrangementJson)
+ */
+
+if (PHP_SAPI === 'cli') {
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = true;
+} else {
+    if (!defined('IHYMNS_SETUP_DASHBOARD')) {
+        if (!function_exists('isAuthenticated')) {
+            require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+        }
+        if (!isAuthenticated()) {
+            http_response_code(401);
+            exit('Authentication required.');
+        }
+        $u = getCurrentUser();
+        if (!$u || $u['role'] !== 'global_admin') {
+            http_response_code(403);
+            exit('Global admin required.');
+        }
+    }
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = false;
+}
+
+function _migSongArr_out(string $line): void
+{
+    global $isCli;
+    echo $line . ($isCli ? "\n" : "<br>\n");
+    if ($isCli) flush();
+}
+
+function _migSongArr_columnExists(\mysqli $db, string $table, string $column): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ? LIMIT 1'
+    );
+    $stmt->bind_param('ss', $table, $column);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+function _migSongArr_tableExists(\mysqli $db, string $table): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? LIMIT 1'
+    );
+    $stmt->bind_param('s', $table);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+_migSongArr_out('Song Arrangement Persistence migration starting (#892)…');
+
+$mysqli = getDbMysqli();
+if (!$mysqli) {
+    throw new \RuntimeException('Could not connect to database.');
+}
+
+if (!_migSongArr_tableExists($mysqli, 'tblSongs')) {
+    _migSongArr_out('ERROR: tblSongs not found. Run prerequisite migrations first.');
+    return;
+}
+
+if (_migSongArr_columnExists($mysqli, 'tblSongs', 'ArrangementJson')) {
+    _migSongArr_out('[skip] tblSongs.ArrangementJson already present.');
+} else {
+    /* AFTER LyricsText keeps the column adjacent to the lyric-shape
+       data it qualifies. The JSON type validates well-formedness on
+       INSERT — a malformed payload from a buggy client fails fast at
+       the DB rather than silently storing garbage. */
+    $sql = "ALTER TABLE tblSongs
+              ADD COLUMN ArrangementJson JSON NULL DEFAULT NULL
+              AFTER LyricsText";
+    if (!$mysqli->query($sql)) {
+        throw new \RuntimeException('ALTER TABLE tblSongs add ArrangementJson failed: ' . $mysqli->error);
+    }
+    _migSongArr_out('[add ] tblSongs.ArrangementJson (JSON NULL).');
+}
+
+_migSongArr_out('Song Arrangement Persistence migration finished (#892).');

--- a/appWeb/public_html/includes/SongData.php
+++ b/appWeb/public_html/includes/SongData.php
@@ -121,6 +121,10 @@ class SongData
     private bool $_componentLangColumn = false;
     private bool $_componentLangColumnChecked = false;
 
+    /** #892 — schema-probe result for tblSongs.ArrangementJson. */
+    private bool $_arrangementColumn = false;
+    private bool $_arrangementColumnChecked = false;
+
     /** Check if running in JSON fallback mode (no MySQL) */
     public function isJsonFallback(): bool { return $this->jsonMode; }
 
@@ -1588,12 +1592,18 @@ class SongData
            sorts under T in the un-numbered tail. Future enhancement:
            add a generated column TitleSortKey on tblSongs that
            strips the article at write-time. */
+        /* #892 — append ArrangementJson to the bulk-load SELECT only
+           when the column exists, so the Song Editor's `?action=load`
+           round-trip surfaces the persisted custom order. Pre-
+           migration deploys keep the legacy column list. */
+        $arrSelect = $this->_hasArrangementColumn() ? ', s.ArrangementJson AS arrangementJson' : '';
         $sql = "SELECT s.SongId AS id, s.Number AS number, s.Title AS title, s.SongbookAbbr AS songbook,
                        s.SongbookName AS songbookName, s.Language AS language, s.Copyright AS copyright,
                        s.TuneName AS tuneName, s.Ccli AS ccli, s.Iswc AS iswc,
                        s.Verified AS verified, s.LyricsPublicDomain AS lyricsPublicDomain,
                        s.MusicPublicDomain AS musicPublicDomain,
                        s.HasAudio AS hasAudio, s.HasSheetMusic AS hasSheetMusic
+                       {$arrSelect}
                 FROM tblSongs s
                 LEFT JOIN tblSongbooks b ON b.Abbreviation = s.SongbookAbbr
                 {$whereClause}
@@ -1625,6 +1635,13 @@ class SongData
                text inputs without null-checking every reader. */
             $row['tuneName'] = $row['tuneName'] ?? '';
             $row['iswc']     = $row['iswc']     ?? '';
+            /* #892 — decode the JSON int-array column when present.
+               Surfaces as `arrangement` to match the shape that the
+               Song Editor (`editor.js`) and pages/song.php both read. */
+            if (array_key_exists('arrangementJson', $row)) {
+                $row['arrangement'] = $this->_decodeArrangement($row['arrangementJson']);
+                unset($row['arrangementJson']);
+            }
             $songs[] = $row;
         }
         $stmt->close();
@@ -2324,6 +2341,11 @@ class SongData
      */
     private function _fetchSongRow(string $songId): ?array
     {
+        /* #892 — append ArrangementJson to the SELECT only when the
+           column exists. Pre-migration deploys keep the legacy
+           15-column shape so single-song reads don't 1054 on a
+           half-migrated install. */
+        $arrSelect = $this->_hasArrangementColumn() ? ', ArrangementJson AS arrangementJson' : '';
         $stmt = $this->db->prepare(
             "SELECT SongId AS id, Number AS number, Title AS title, SongbookAbbr AS songbook,
                     SongbookName AS songbookName, Language AS language, Copyright AS copyright,
@@ -2331,6 +2353,7 @@ class SongData
                     Verified AS verified, LyricsPublicDomain AS lyricsPublicDomain,
                     MusicPublicDomain AS musicPublicDomain,
                     HasAudio AS hasAudio, HasSheetMusic AS hasSheetMusic
+                    {$arrSelect}
              FROM tblSongs
              WHERE SongId = ?
              LIMIT 1"
@@ -2353,6 +2376,15 @@ class SongData
         $row['hasSheetMusic'] = (bool)$row['hasSheetMusic'];
         $row['tuneName'] = $row['tuneName'] ?? '';
         $row['iswc']     = $row['iswc']     ?? '';
+        /* #892 — decode the stored JSON int-array; the public render in
+           pages/song.php reads `$song['arrangement']` directly. The
+           helper drops malformed payloads (defensive) and returns NULL
+           when the column was unset, keeping the existing
+           "fallback to plain SortOrder" path live. */
+        if (array_key_exists('arrangementJson', $row)) {
+            $row['arrangement'] = $this->_decodeArrangement($row['arrangementJson']);
+            unset($row['arrangementJson']);
+        }
         $row['writers']      = $this->_getWriters($songId);
         $row['composers']    = $this->_getComposers($songId);
         $row['arrangers']    = $this->_getArrangers($songId);
@@ -2513,6 +2545,59 @@ class SongData
             $this->_componentLangColumn = false;
         }
         return $this->_componentLangColumn;
+    }
+
+    /**
+     * #892 — schema-probe for tblSongs.ArrangementJson. Same caching
+     * pattern as the component-language probe so editor-load (which
+     * reads ~3,600 rows) doesn't fire INFORMATION_SCHEMA per row.
+     * Pre-migration deploys return false and the SELECT skips the
+     * column, keeping the legacy 15-column shape intact.
+     */
+    private function _hasArrangementColumn(): bool
+    {
+        if ($this->_arrangementColumnChecked) {
+            return $this->_arrangementColumn;
+        }
+        $this->_arrangementColumnChecked = true;
+        try {
+            $stmt = $this->db->prepare(
+                "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+                  WHERE TABLE_SCHEMA = DATABASE()
+                    AND TABLE_NAME   = 'tblSongs'
+                    AND COLUMN_NAME  = 'ArrangementJson' LIMIT 1"
+            );
+            $stmt->execute();
+            $this->_arrangementColumn = $stmt->get_result()->fetch_row() !== null;
+            $stmt->close();
+        } catch (\Throwable $_e) {
+            $this->_arrangementColumn = false;
+        }
+        return $this->_arrangementColumn;
+    }
+
+    /**
+     * #892 — Decode the JSON string read from tblSongs.ArrangementJson
+     * back into a plain int[]. Returns null when the column was NULL
+     * or when the stored payload is malformed (defensive — the JSON
+     * type validates well-formedness on write so this should be
+     * unreachable, but a hand-edited row shouldn't 500 the read).
+     */
+    private function _decodeArrangement($raw): ?array
+    {
+        if ($raw === null || $raw === '') return null;
+        if (is_array($raw)) {
+            $decoded = $raw;
+        } else {
+            $decoded = json_decode((string)$raw, true);
+            if (!is_array($decoded)) return null;
+        }
+        $out = [];
+        foreach ($decoded as $i) {
+            if (!is_int($i) && !(is_string($i) && ctype_digit($i))) return null;
+            $out[] = (int)$i;
+        }
+        return empty($out) ? null : $out;
     }
 
     /**

--- a/appWeb/public_html/includes/infoAppVer.php
+++ b/appWeb/public_html/includes/infoAppVer.php
@@ -79,7 +79,7 @@ $app["Application"]["Description"]["Keywords"] = "hymns, worship, lyrics, songbo
 /* Semantic version number (MAJOR.MINOR.PATCH) */
 /* Auto-bumped by the version-bump GitHub Action on push to beta */
 /* v1.x.x = Phase 1 (local JSON data), v2.x.x = Phase 2 (iLyrics dB) */
-$app["Application"]["Version"]["Number"] = "0.77.0";
+$app["Application"]["Version"]["Number"] = "0.80.0";
 
 /* Version name: human-readable release name (e.g., "Hymnal", NULL if unused) */
 $app["Application"]["Version"]["Name"] = NULL;

--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -141,6 +141,38 @@ function _ietfBcp47Validate(string $raw)
     return $tag;
 }
 
+/**
+ * Sanitise an incoming `arrangement` payload from the Song Editor (#892).
+ *
+ * The editor sends an int[] of indices into `components[]` (with
+ * repetition allowed — that is the entire reason this column exists,
+ * so a refrain can play between every verse). Anything outside that
+ * shape — null, empty array, non-integer entries, indices outside
+ * the components range — collapses to NULL so the public render
+ * falls back to plain stored SortOrder (the pre-#892 behaviour).
+ *
+ * Returning a JSON string (or null) so the caller can bind it
+ * straight into mysqli without a second encode step.
+ *
+ * @param mixed $raw            The decoded `arrangement` field from the request body.
+ * @param int   $componentCount Bound — every index must be 0 ≤ i < $componentCount.
+ * @return string|null          JSON-encoded int array, or null when the input is
+ *                              missing / empty / malformed / out-of-range.
+ */
+function _sanitiseArrangement($raw, int $componentCount): ?string
+{
+    if (!is_array($raw) || $componentCount <= 0) return null;
+    $clean = [];
+    foreach ($raw as $idx) {
+        if (!is_int($idx) && !(is_string($idx) && ctype_digit($idx))) return null;
+        $i = (int)$idx;
+        if ($i < 0 || $i >= $componentCount) return null;
+        $clean[] = $i;
+    }
+    if (empty($clean)) return null;
+    return json_encode(array_values($clean), JSON_UNESCAPED_UNICODE);
+}
+
 /* =========================================================================
  * BULK_IMPORT_ZIP constants (#664)
  *
@@ -321,16 +353,42 @@ switch ($action) {
             }
             $stmtSongbook->close();
 
+            /* #892 — schema-probe for tblSongs.ArrangementJson once
+               per bulk save so the per-song INSERT loop binds the
+               right column shape. Pre-migration deploys keep the
+               legacy 16-column INSERT. */
+            $hasArrangementCol = false;
+            try {
+                $arrProbe = $db->prepare(
+                    "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+                      WHERE TABLE_SCHEMA = DATABASE()
+                        AND TABLE_NAME   = 'tblSongs'
+                        AND COLUMN_NAME  = 'ArrangementJson' LIMIT 1"
+                );
+                $arrProbe->execute();
+                $hasArrangementCol = $arrProbe->get_result()->fetch_row() !== null;
+                $arrProbe->close();
+            } catch (\Throwable $_e) { /* default false */ }
+
             /* Prepare song statements. tblSongs INSERT now carries the
                #497 TuneName + Iswc columns; both are nullable and bind
                as the string types below (mysqli emits NULL when the
                bound PHP value is null). */
-            $stmtSong = $db->prepare(
-                "INSERT INTO tblSongs (SongId, Number, Title, SongbookAbbr, SongbookName,
-                 Language, Copyright, TuneName, Ccli, Iswc, Verified, LyricsPublicDomain,
-                 MusicPublicDomain, HasAudio, HasSheetMusic, LyricsText)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
-            );
+            if ($hasArrangementCol) {
+                $stmtSong = $db->prepare(
+                    "INSERT INTO tblSongs (SongId, Number, Title, SongbookAbbr, SongbookName,
+                     Language, Copyright, TuneName, Ccli, Iswc, Verified, LyricsPublicDomain,
+                     MusicPublicDomain, HasAudio, HasSheetMusic, LyricsText, ArrangementJson)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+                );
+            } else {
+                $stmtSong = $db->prepare(
+                    "INSERT INTO tblSongs (SongId, Number, Title, SongbookAbbr, SongbookName,
+                     Language, Copyright, TuneName, Ccli, Iswc, Verified, LyricsPublicDomain,
+                     MusicPublicDomain, HasAudio, HasSheetMusic, LyricsText)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+                );
+            }
             $stmtWriter     = $db->prepare("INSERT INTO tblSongWriters     (SongId, Name) VALUES (?, ?)");
             $stmtComposer   = $db->prepare("INSERT INTO tblSongComposers   (SongId, Name) VALUES (?, ?)");
             $stmtArranger   = $db->prepare("INSERT INTO tblSongArrangers   (SongId, Name) VALUES (?, ?)");
@@ -399,12 +457,31 @@ switch ($action) {
                 }
                 $lyricsText = implode("\n", $lyricsLines);
 
-                $stmtSong->bind_param(
-                    'sissssssssiiiiis',
-                    $songId, $number, $title, $songbookAbbr, $songbookName,
-                    $language, $copyright, $tuneName, $ccli, $iswc,
-                    $verified, $lyricsPD, $musicPD, $hasAudio, $hasSheet, $lyricsText
-                );
+                if ($hasArrangementCol) {
+                    /* #892 — round-trip the per-song arrangement when
+                       the column is present. The bulk-save path is
+                       used by the legacy "save the entire songs.json"
+                       flow, which already carries `arrangement` per
+                       song in the JSON shape. */
+                    $arrangementJson = _sanitiseArrangement(
+                        $song['arrangement'] ?? null,
+                        is_array($song['components'] ?? null) ? count($song['components']) : 0
+                    );
+                    $stmtSong->bind_param(
+                        'sissssssssiiiiiss',
+                        $songId, $number, $title, $songbookAbbr, $songbookName,
+                        $language, $copyright, $tuneName, $ccli, $iswc,
+                        $verified, $lyricsPD, $musicPD, $hasAudio, $hasSheet, $lyricsText,
+                        $arrangementJson
+                    );
+                } else {
+                    $stmtSong->bind_param(
+                        'sissssssssiiiiis',
+                        $songId, $number, $title, $songbookAbbr, $songbookName,
+                        $language, $copyright, $tuneName, $ccli, $iswc,
+                        $verified, $lyricsPD, $musicPD, $hasAudio, $hasSheet, $lyricsText
+                    );
+                }
                 $stmtSong->execute();
 
                 /* Credit collections — one table each. The registry sync
@@ -1138,6 +1215,15 @@ switch ($action) {
         }
         $lyricsText = implode("\n", $lyricsLines);
 
+        /* #892 — sanitise the arrangement payload before the txn so any
+           validation rejection 400s the caller cleanly. The editor sends
+           an int[] of indices into components[] (repetition allowed —
+           the entire reason this column exists). NULL / empty / invalid
+           → store NULL so the public render falls back to plain
+           SortOrder (current pre-#892 behaviour). */
+        $componentCount = is_array($song['components'] ?? null) ? count($song['components']) : 0;
+        $arrangementJson = _sanitiseArrangement($song['arrangement'] ?? null, $componentCount);
+
         try {
             $db = getDbMysqli();
             $db->begin_transaction();
@@ -1154,31 +1240,80 @@ switch ($action) {
             }
             $action = $prevRow === null ? 'create' : 'edit';
 
-            /* UPSERT tblSongs — now carries TuneName + Iswc (#497). */
-            $upsert = $db->prepare(
-                'INSERT INTO tblSongs
-                    (SongId, Number, Title, SongbookAbbr, SongbookName, Language,
-                     Copyright, TuneName, Ccli, Iswc, Verified, LyricsPublicDomain,
-                     MusicPublicDomain, HasAudio, HasSheetMusic, LyricsText)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                 ON DUPLICATE KEY UPDATE
-                    Number = VALUES(Number), Title = VALUES(Title),
-                    SongbookAbbr = VALUES(SongbookAbbr), SongbookName = VALUES(SongbookName),
-                    Language = VALUES(Language), Copyright = VALUES(Copyright),
-                    TuneName = VALUES(TuneName),
-                    Ccli = VALUES(Ccli), Iswc = VALUES(Iswc),
-                    Verified = VALUES(Verified),
-                    LyricsPublicDomain = VALUES(LyricsPublicDomain),
-                    MusicPublicDomain = VALUES(MusicPublicDomain),
-                    HasAudio = VALUES(HasAudio), HasSheetMusic = VALUES(HasSheetMusic),
-                    LyricsText = VALUES(LyricsText)'
-            );
-            $upsert->bind_param(
-                'sissssssssiiiiis',
-                $songId, $number, $title, $songbookAbbr, $songbookName,
-                $language, $copyright, $tuneName, $ccli, $iswc,
-                $verified, $lyricsPD, $musicPD, $hasAudio, $hasSheet, $lyricsText
-            );
+            /* #892 — schema-probe for the optional ArrangementJson column.
+               Pre-migration deploys keep the legacy 16-column UPSERT; once
+               the column exists we add a 17th bound parameter so the
+               curator's chosen verse/refrain/verse… order finally
+               round-trips through save → reload. */
+            $hasArrangementCol = false;
+            try {
+                $arrProbe = $db->prepare(
+                    "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+                      WHERE TABLE_SCHEMA = DATABASE()
+                        AND TABLE_NAME   = 'tblSongs'
+                        AND COLUMN_NAME  = 'ArrangementJson' LIMIT 1"
+                );
+                $arrProbe->execute();
+                $hasArrangementCol = $arrProbe->get_result()->fetch_row() !== null;
+                $arrProbe->close();
+            } catch (\Throwable $_e) { /* default false */ }
+
+            /* UPSERT tblSongs — now carries TuneName + Iswc (#497) and
+               ArrangementJson (#892) when the column exists. */
+            if ($hasArrangementCol) {
+                $upsert = $db->prepare(
+                    'INSERT INTO tblSongs
+                        (SongId, Number, Title, SongbookAbbr, SongbookName, Language,
+                         Copyright, TuneName, Ccli, Iswc, Verified, LyricsPublicDomain,
+                         MusicPublicDomain, HasAudio, HasSheetMusic, LyricsText,
+                         ArrangementJson)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                     ON DUPLICATE KEY UPDATE
+                        Number = VALUES(Number), Title = VALUES(Title),
+                        SongbookAbbr = VALUES(SongbookAbbr), SongbookName = VALUES(SongbookName),
+                        Language = VALUES(Language), Copyright = VALUES(Copyright),
+                        TuneName = VALUES(TuneName),
+                        Ccli = VALUES(Ccli), Iswc = VALUES(Iswc),
+                        Verified = VALUES(Verified),
+                        LyricsPublicDomain = VALUES(LyricsPublicDomain),
+                        MusicPublicDomain = VALUES(MusicPublicDomain),
+                        HasAudio = VALUES(HasAudio), HasSheetMusic = VALUES(HasSheetMusic),
+                        LyricsText = VALUES(LyricsText),
+                        ArrangementJson = VALUES(ArrangementJson)'
+                );
+                $upsert->bind_param(
+                    'sissssssssiiiiiss',
+                    $songId, $number, $title, $songbookAbbr, $songbookName,
+                    $language, $copyright, $tuneName, $ccli, $iswc,
+                    $verified, $lyricsPD, $musicPD, $hasAudio, $hasSheet, $lyricsText,
+                    $arrangementJson
+                );
+            } else {
+                $upsert = $db->prepare(
+                    'INSERT INTO tblSongs
+                        (SongId, Number, Title, SongbookAbbr, SongbookName, Language,
+                         Copyright, TuneName, Ccli, Iswc, Verified, LyricsPublicDomain,
+                         MusicPublicDomain, HasAudio, HasSheetMusic, LyricsText)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                     ON DUPLICATE KEY UPDATE
+                        Number = VALUES(Number), Title = VALUES(Title),
+                        SongbookAbbr = VALUES(SongbookAbbr), SongbookName = VALUES(SongbookName),
+                        Language = VALUES(Language), Copyright = VALUES(Copyright),
+                        TuneName = VALUES(TuneName),
+                        Ccli = VALUES(Ccli), Iswc = VALUES(Iswc),
+                        Verified = VALUES(Verified),
+                        LyricsPublicDomain = VALUES(LyricsPublicDomain),
+                        MusicPublicDomain = VALUES(MusicPublicDomain),
+                        HasAudio = VALUES(HasAudio), HasSheetMusic = VALUES(HasSheetMusic),
+                        LyricsText = VALUES(LyricsText)'
+                );
+                $upsert->bind_param(
+                    'sissssssssiiiiis',
+                    $songId, $number, $title, $songbookAbbr, $songbookName,
+                    $language, $copyright, $tuneName, $ccli, $iswc,
+                    $verified, $lyricsPD, $musicPD, $hasAudio, $hasSheet, $lyricsText
+                );
+            }
             $upsert->execute();
             $upsert->close();
 
@@ -3245,19 +3380,60 @@ function _bulkImport_saveSong(\mysqli $db, array $song): array
            than half-succeeding. */
         $action = 'create';
         $previousData = null;
-        $insert = $db->prepare(
-            'INSERT INTO tblSongs
-                (SongId, Number, Title, SongbookAbbr, SongbookName, Language,
-                 Copyright, TuneName, Ccli, Iswc, Verified, LyricsPublicDomain,
-                 MusicPublicDomain, HasAudio, HasSheetMusic, LyricsText)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
-        );
-        $insert->bind_param(
-            'sissssssssiiiiis',
-            $songId, $number, $title, $songbookAbbr, $songbookName,
-            $language, $copyright, $tuneName, $ccli, $iswc,
-            $verified, $lyricsPD, $musicPD, $hasAudio, $hasSheet, $lyricsText
-        );
+
+        /* #892 — schema-probe for tblSongs.ArrangementJson. The TXT /
+           OpenSong parsers in this file don't produce arrangements
+           today, so this is a no-op for current bulk imports — but
+           future parsers (e.g. a richer XML format) may carry one,
+           and the path needs to round-trip it through. */
+        $hasArrangementCol = false;
+        try {
+            $arrProbe = $db->prepare(
+                "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+                  WHERE TABLE_SCHEMA = DATABASE()
+                    AND TABLE_NAME   = 'tblSongs'
+                    AND COLUMN_NAME  = 'ArrangementJson' LIMIT 1"
+            );
+            $arrProbe->execute();
+            $hasArrangementCol = $arrProbe->get_result()->fetch_row() !== null;
+            $arrProbe->close();
+        } catch (\Throwable $_e) { /* default false */ }
+
+        if ($hasArrangementCol) {
+            $arrangementJson = _sanitiseArrangement(
+                $song['arrangement'] ?? null,
+                count($song['components'] ?? [])
+            );
+            $insert = $db->prepare(
+                'INSERT INTO tblSongs
+                    (SongId, Number, Title, SongbookAbbr, SongbookName, Language,
+                     Copyright, TuneName, Ccli, Iswc, Verified, LyricsPublicDomain,
+                     MusicPublicDomain, HasAudio, HasSheetMusic, LyricsText,
+                     ArrangementJson)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+            );
+            $insert->bind_param(
+                'sissssssssiiiiiss',
+                $songId, $number, $title, $songbookAbbr, $songbookName,
+                $language, $copyright, $tuneName, $ccli, $iswc,
+                $verified, $lyricsPD, $musicPD, $hasAudio, $hasSheet, $lyricsText,
+                $arrangementJson
+            );
+        } else {
+            $insert = $db->prepare(
+                'INSERT INTO tblSongs
+                    (SongId, Number, Title, SongbookAbbr, SongbookName, Language,
+                     Copyright, TuneName, Ccli, Iswc, Verified, LyricsPublicDomain,
+                     MusicPublicDomain, HasAudio, HasSheetMusic, LyricsText)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+            );
+            $insert->bind_param(
+                'sissssssssiiiiis',
+                $songId, $number, $title, $songbookAbbr, $songbookName,
+                $language, $copyright, $tuneName, $ccli, $iswc,
+                $verified, $lyricsPD, $musicPD, $hasAudio, $hasSheet, $lyricsText
+            );
+        }
         $insert->execute();
         $insert->close();
 

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -235,6 +235,7 @@ $friendlyTitles = [
     'external-link-patterns'           => 'External-Link URL Patterns (#845)',
     'song-media'                       => 'Song Media Uploads (#853)',
     'song-component-language'          => 'Song Component Language Override (#858)',
+    'song-arrangement'                 => 'Song Arrangement Persistence (#892)',
     /* `recompute-songbook-songcount` no longer exposed via the dashboard
        (#818) — the SongCount Triggers migration above includes its own
        initial recompute. The CLI script stays on disk for emergency
@@ -295,6 +296,7 @@ $scriptMap = [
     'external-link-patterns'        => 'migrate-external-link-patterns.php',
     'song-media'                    => 'migrate-song-media.php',
     'song-component-language'       => 'migrate-song-component-language.php',
+    'song-arrangement'              => 'migrate-song-arrangement.php',
     'cleanup'     => 'cleanup.php',
     'backup'      => 'backup.php',
     'restore'     => 'restore.php',
@@ -345,6 +347,7 @@ $migrationOrder = [
     'external-link-patterns',
     'song-media',
     'song-component-language',
+    'song-arrangement',
 ];
 
 /* Per-migration card content (#816). Single source of truth for the
@@ -760,6 +763,20 @@ $migrationCards = [
                   . ' union. Idempotent.',
         'button' => 'Run Song Component Language Migration',
     ],
+    'song-arrangement' => [
+        'title'  => 'Song Arrangement Persistence (#892)',
+        'body'   => 'Adds <code>ArrangementJson JSON NULL</code> to'
+                  . ' <code>tblSongs</code> so the Song Editor\'s Structure-tab'
+                  . ' arrangement (an array of indices into <code>components[]</code>'
+                  . ' that allows repetition — e.g. a refrain played between every'
+                  . ' verse) can finally round-trip through save → reload. Pre-#892'
+                  . ' the editor rendered the chips and POSTed the field, but the'
+                  . ' server had no column to write into and silently dropped it.'
+                  . ' <code>NULL</code> = render in stored <code>SortOrder</code>'
+                  . ' (current behaviour); a JSON int-array overrides the order.'
+                  . ' Idempotent.',
+        'button' => 'Run Song Arrangement Migration',
+    ],
     /* recompute-songbook-songcount card removed (#818) — its work is
        now covered by the SongCount Triggers migration above, which
        runs an initial recompute as part of its installation. The
@@ -915,6 +932,9 @@ $migrationProbes = [
     /* Song component language: pending when the column is absent. */
     'song-component-language'            => static fn(\mysqli $db) =>
         !_migProbe_columnExists($db, 'tblSongComponents', 'Language'),
+    /* Song arrangement: pending when the column is absent. */
+    'song-arrangement'                   => static fn(\mysqli $db) =>
+        !_migProbe_columnExists($db, 'tblSongs', 'ArrangementJson'),
     /* Backfills run once after schema lands. They're idempotent so
        always-show is safe — but we can be smarter: pending when the
        new table has fewer rows than the legacy source had non-empty


### PR DESCRIPTION
## Summary

- Adds `tblSongs.ArrangementJson JSON NULL` so the Song Editor's Structure-tab arrangement (an int-array of indices into `components[]`, repetition allowed — the whole reason this column exists) finally round-trips through save → reload.
- Pre-#892 the editor rendered the chips, POSTed `song.arrangement`, and the server silently dropped it: no column on `tblSongs`, no read or write path in `save_song` / `_fetchSongRow`. Curators saw "Saved", reloaded, and watched their custom verse-with-refrain-between order vanish (e.g. SDAH-93's `V1, V2, V1, V3, V1, V4, V1, V5, V1`).
- Fix is schema-additive + schema-probed throughout — half-migrated installs keep saving / loading without `1054 Unknown column`.
- App version bump 0.77.0 → 0.80.0.

## Why this stayed silent for weeks

The arrangement UI shipped in #161 but never landed a DB column. Typical `V1, C, V2, C, V3, C` hymns survived because the source TXT scrapers (MissionPraise / SDAH) emit the chorus inline as separate components for each verse — SortOrder iteration alone produced the right render. SDAH-93's pattern (Verse 1 acting as the refrain between every other verse) is the case where the curator naturally reaches for the arrangement UI, and that's where the silent loss surfaces.

## Files

- New: `appWeb/.sql/migrate-song-arrangement.php` — adds `ArrangementJson JSON NULL`. Idempotent INFORMATION_SCHEMA probe.
- `appWeb/public_html/manage/setup-database.php` — registered in 5 sites (`$friendlyTitles`, `$scriptMap`, `$migrationOrder`, `$migrationCards`, `$migrationProbes`).
- `appWeb/public_html/manage/editor/api.php` — `_sanitiseArrangement($raw, $componentCount)` helper. Schema-probed bind paths in `save_song`, the full-tree `save`, and `_bulkImport_saveSong`.
- `appWeb/public_html/includes/SongData.php` — request-cached `_hasArrangementColumn()` probe + `_decodeArrangement()` JSON→int[] decoder. `_fetchSongRow()` and `getSongs()` surface `$row['arrangement']` when the column exists.
- `appWeb/public_html/includes/infoAppVer.php` — version 0.77.0 → 0.80.0.

## Test plan

- [ ] `/manage/setup-database` → "Apply All Pending Migrations" runs cleanly (the new "Song Arrangement Persistence (#892)" card appears in the pending grid; runs idempotently on re-apply).
- [ ] Open SDAH-93 → Structure tab → set arrangement to `Verse 1, Verse 2, Verse 1, Verse 3, Verse 1, Verse 4, Verse 1, Verse 5, Verse 1` → save → reload → arrangement persists.
- [ ] Public `/song/SDAH-93` page renders the verses interleaved with Verse 1 between each.
- [ ] Pre-migration deploy (drop the column manually) → editor save / load still works (legacy 16-column INSERT path).
- [ ] PHP `php -l` clean on every touched file.
- [ ] JS `node --check` clean on `editor.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)