### PR TITLE
fix(ui): reading-progress bar disappears behind app-header on scroll (closes #899)

### DIFF
--- a/appWeb/public_html/css/app.css
+++ b/appWeb/public_html/css/app.css
@@ -2423,7 +2423,10 @@ body.reduce-motion .shortcuts-overlay {
     width: 0;
     height: 3px;
     background: var(--bs-primary, #6366f1);
-    z-index: 1030;
+    /* z-index above .app-header (1030) so the bar paints on top of the
+       header's blurred composite layer regardless of DOM order. Stays
+       below the modal / overlay band (1100). #899 */
+    z-index: 1031;
     transition: width 80ms linear;
     border-radius: 0 2px 2px 0;
     pointer-events: none;


### PR DESCRIPTION
## Summary

Single-line CSS fix. The per-song reading-progress bar was visible at the top of scroll but disappeared behind the sticky `.app-header` once the user scrolled further down — both elements shared `z-index: 1030` and the header's `backdrop-filter: blur(16px)` composite layer ended up painting above the bar. Bumping the bar to `1031` puts it above the header without crowding the modal / overlay band at 1100.

## Diff

```diff
 .reading-progress-bar {
     position: fixed;
     top: env(safe-area-inset-top, 0px);
     left: 0;
     width: 0;
     height: 3px;
     background: var(--bs-primary, #6366f1);
-    z-index: 1030;
+    /* z-index above .app-header (1030) so the bar paints on top of the
+       header's blurred composite layer regardless of DOM order. Stays
+       below the modal / overlay band (1100). #899 */
+    z-index: 1031;
     transition: width 80ms linear;
     border-radius: 0 2px 2px 0;
     pointer-events: none;
 }
```

## Z-index audit

`grep z-index: 1030` shows 4 occurrences in `app.css`:

| Line | Selector | Concern |
|---|---|---|
| 412 | `.app-header` | The header; was tied with the bar — now correctly below the bar. |
| 903 | (unrelated rule) | Unaffected — different surface. |
| 2426 | `.reading-progress-bar` | **This fix** — bumped to `1031`. |
| 2583 | (unrelated rule) | Unaffected — different surface. |

Modal overlays at `z-index: 1100` still cover the bar correctly (modal opens → bar hidden behind modal as expected). The bar is 3px tall and `pointer-events: none`, so it sits visually on top of the header's blurred background without intercepting any clicks.

## Test plan

- [ ] Visit any song page on alpha after deploy (e.g. `/song/SDAH-373`).
- [ ] Scroll down past where the bar previously disappeared — the bar should remain visible at the top of the viewport throughout.
- [ ] Open the PWA install banner; bar still visible above (banner pushes header down via the existing `~ .app-header` rule, bar stays at `top: env(safe-area-inset-top, 0px)`).
- [ ] Open any modal (e.g. share dialog) — confirm the bar is hidden behind the modal as before; modal overlay at `1100` correctly covers `1031`.
- [ ] Standalone PWA mode (Add to Home Screen on iOS): notch / Dynamic Island spacing preserved by the existing `env(safe-area-inset-top)` math.

🤖 Generated with [Claude Code](https://claude.com/claude-code)