### PR TITLE
fix(ci): stop Apple/Android/Changelog workflows failing on beta→main promotion (closes #904)

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -22,14 +22,33 @@
 
 name: Android Build & Distribution
 
+# TRIGGERS: workflow_dispatch + version tags only.
+#
+# The push trigger was removed in #904 to stop the workflow from
+# auto-firing on every change in `appAndroid/**`. The path filter
+# was tripping on the auto-generated `appAndroid/CHANGELOG.md`
+# updates that the Changelog workflow writes to beta on every
+# commit — those then rode along into main on the next beta→main
+# promotion and triggered this build, which fails because the
+# Android app code isn't yet ready (Gradle wrapper not wired up,
+# no signing keystore in secrets — workflow exited 127 on its
+# first build step on the 2026-05-07 promotion).
+#
+# When the Android app is ready to build:
+#   1. Confirm `./gradlew assembleDebug` runs locally without errors.
+#   2. Add the release keystore + Play Store credentials to repo
+#      secrets (RELEASE_KEYSTORE_B64 + RELEASE_KEY_ALIAS + RELEASE_KEY_PASSWORD
+#      + PLAY_SERVICE_ACCOUNT_JSON_B64).
+#   3. Re-add the push trigger below, restricting `paths:` to actual
+#      source / project files (NOT including `appAndroid/CHANGELOG.md`):
+#
+#        push:
+#          branches: [beta, main]
+#          paths-ignore:
+#            - 'appAndroid/CHANGELOG.md'
+#            - 'appAndroid/**/*.md'
+#          # Or use dorny/paths-filter at the job level for finer control.
 on:
-  push:
-    branches: [beta, main]
-    paths:
-      - 'appAndroid/**'
-      - '.github/workflows/build-android.yml'
-    tags:
-      - 'v*'
   workflow_dispatch:
     inputs:
       build_type:
@@ -41,6 +60,9 @@ on:
           - debug
           - release
           - all
+  push:
+    tags:
+      - 'v*'
 
 permissions:
   contents: read

--- a/.github/workflows/build-apple.yml
+++ b/.github/workflows/build-apple.yml
@@ -16,12 +16,35 @@
 
 name: Apple Build & Distribution
 
+# TRIGGERS: workflow_dispatch only.
+#
+# The push trigger was removed in #904 to stop the workflow from
+# auto-firing on every change in `appApple/**`. The path filter was
+# tripping on the auto-generated `appApple/CHANGELOG.md` updates that
+# the Changelog workflow writes to beta on every commit — those then
+# rode along into main on the next beta→main promotion and triggered
+# this build, which fails because the Apple app code isn't yet ready
+# (no certificates / provisioning profiles / Xcode project wired up).
+#
+# When the Apple app is ready to build:
+#   1. Confirm Xcode project + fastlane setup compiles locally.
+#   2. Add the App Store Connect API key + provisioning profiles to
+#      repo secrets / Apple App Manager.
+#   3. Re-add the push trigger below, restricting `paths:` to actual
+#      source / project files (NOT including `appApple/CHANGELOG.md`):
+#
+#        push:
+#          branches: [beta, main]
+#          paths:
+#            - 'appApple/**'
+#            - '!appApple/CHANGELOG.md'
+#            - '.github/workflows/build-apple.yml'
+#
+#      Note: GH Actions doesn't support negation in `paths:` — instead
+#      use `paths-ignore: ['appApple/CHANGELOG.md', 'appApple/**/*.md']`
+#      with a complementary `paths:` whitelist OR a job-level
+#      `dorny/paths-filter` action.
 on:
-  push:
-    branches: [beta, main]
-    paths:
-      - 'appApple/**'
-      - '.github/workflows/build-apple.yml'
   workflow_dispatch:
     inputs:
       lane:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -22,10 +22,24 @@
 
 name: Changelog
 
+# TRIGGERS: push to beta only.
+#
+# `main` was removed from the trigger in #904. The workflow used to
+# also run on push-to-main and try to git-push the regenerated
+# CHANGELOG.md files back to main, but the branch-protection rule
+# on main rejects direct pushes (Run #27 from the 2026-05-07 beta→
+# main promotion failed with `GH013: Repository rule violations
+# found for refs/heads/main` after 5 retry attempts).
+#
+# Running on main is also structurally redundant: the Changelog
+# workflow runs on every push to beta and writes the four
+# CHANGELOG.md files there. When beta is promoted to main via PR,
+# those CHANGELOG updates ride along automatically — main's
+# changelogs stay current without ever needing the workflow to
+# fire on main itself.
 on:
   push:
     branches:
-      - main
       - beta
     paths:
       - 'appWeb/**'


### PR DESCRIPTION
## Summary

Three GH Actions workflows failed simultaneously on the 2026-05-07 beta→main promotion (PR #896, merge commit `76154dc`). Three independent root causes — all fixed in this PR.

## Failures fixed

### 1. Apple Build & Distribution #5 + Android Build & Distribution #10 — wrong trigger

Both workflows had `paths: ['appApple/**' | 'appAndroid/**', ...]`. The **Changelog workflow itself writes `appApple/CHANGELOG.md` and `appAndroid/CHANGELOG.md` on every push to beta** — those updates accumulate on beta and ride along into main on each promotion PR. The build workflows then fire "as designed" and fail because the apps aren't yet ready to compile:

- **Apple**: `fastlane runs in non-interactive mode: Could not retrieve response` — no certificates / App Store Connect API key configured.
- **Android**: `Process completed with exit code 127` (command not found) — no Gradle wrapper / signing keystore wired up.

**Fix:**
- `build-apple.yml` — drop `push:` trigger entirely; `workflow_dispatch` only until app is buildable.
- `build-android.yml` — drop `push: branches:`; keep `push: tags: ['v*']` so version-tag releases still fire.

Workflow files retain their full job definitions as canonical templates for when builds come online; they just don't auto-fire on branch pushes. Comments in each file document precisely how to re-enable safely (use `paths-ignore: ['*/CHANGELOG.md', '*/**/*.md']` so docs changes don't trip a build).

### 2. Changelog #27 — push to branch-protected main

Workflow tried to git-push regenerated CHANGELOG files back to main:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
Push rejected on attempt 5 — rebasing on origin/main and retrying
##[error]Failed to push changelog after 5 attempts
```

Critical observation: the Changelog workflow runs on beta too and writes the same files there successfully. By the time we promote beta→main via PR, those CHANGELOGs are already accurate and ride along with the promotion PR's diff. **Running the workflow on main is structurally redundant.**

**Fix:** `changelog.yml` — remove `main` from the branch list, leaving `[beta]` only. main inherits CHANGELOG.md updates via the beta→main promotion mechanism we already use.

## Diff summary

```diff
# build-apple.yml
-on:
-  push:
-    branches: [beta, main]
-    paths:
-      - 'appApple/**'
-      - '.github/workflows/build-apple.yml'
+on:
   workflow_dispatch:
     ...

# build-android.yml
-on:
-  push:
-    branches: [beta, main]
-    paths:
-      - 'appAndroid/**'
-      - '.github/workflows/build-android.yml'
-    tags:
-      - 'v*'
+on:
   workflow_dispatch:
     ...
+  push:
+    tags:
+      - 'v*'

# changelog.yml
 on:
   push:
     branches:
-      - main
       - beta
```

Plus a multi-line block comment in each workflow file explaining why the trigger was changed and how to re-enable safely.

## Test plan

- [x] All three YAML files validate via `python3 -c "import yaml; yaml.safe_load(open(...))"`.
- [x] Trigger sections inspect cleanly — Apple is `workflow_dispatch:` only, Android is `workflow_dispatch:` + `push: tags: ['v*']`, Changelog is `push: branches: ['beta'] paths: [...]`.
- [ ] **Validation post-merge**: next beta→main promotion (or any push to main) should NOT trigger any of the three workflows. Currently three red ❌ on every promotion; expected zero post-fix.
- [ ] **Beta-side regression check**: a no-op commit to beta should still trigger the Changelog workflow and successfully push generated CHANGELOG.md files. Mechanism unchanged.
- [ ] **Tag release check**: pushing a `v*` tag should trigger Android build (still wired). Apple has no tag trigger today and we didn't add one — re-evaluate when Apple builds come online.

## Out of scope (separate concerns)

- **Re-enabling Apple/Android push triggers** — gated on the apps actually being buildable, which involves Composer / Gradle wrapper setup, signing-cert provisioning, and CI secret configuration. Tracked as part of the Apple/Android phase-1 work.
- **Workflow Node.js 20 → 24 deprecation warning** — visible at the bottom of every failed run log (`actions/checkout@v4`, `actions/setup-java@v4`). Not blocking; address before June 2026 deadline as a separate housekeeping PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)