### PR TITLE
feat(import): per-songbook breakdown of bulk-import results (closes #906)

### DIFF
--- a/appWeb/.sql/migrate-bulk-import-per-songbook.php
+++ b/appWeb/.sql/migrate-bulk-import-per-songbook.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Bulk-Import Per-Songbook Breakdown Migration (#906)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Adds a `PerSongbookJson` column to `tblBulkImportJobs` so the bulk-
+ * import flow can persist a per-songbook breakdown of created /
+ * skipped / failed counts alongside the existing aggregate totals.
+ *
+ * Pre-#906 the import notification only surfaced "Imported X new
+ * (Y skipped)" — the curator couldn't tell whether Y was "songs
+ * already in DB" (legitimate skip) or "songs that failed to parse"
+ * (real bug). The new column carries enough detail to render a
+ * per-songbook table:
+ *
+ *   [{"abbr":"HA","name":"El Himnario Adventista (1962)",
+ *     "created":0,"skipped":527,"failed":0,
+ *     "first_errors":[]}, ...]
+ *
+ * Schema-additive: pre-migration code returns null for this column
+ * and the response shape stays back-compat.
+ *
+ * Idempotent: probes INFORMATION_SCHEMA.COLUMNS first; skips if
+ * the column already exists.
+ *
+ * USAGE:
+ *   CLI: php appWeb/.sql/migrate-bulk-import-per-songbook.php
+ *   Web: /manage/setup-database → "Bulk-Import Per-Songbook Breakdown (#906)"
+ *
+ * @migration-modifies tblBulkImportJobs (adds PerSongbookJson)
+ */
+
+if (PHP_SAPI === 'cli') {
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = true;
+} else {
+    if (!defined('IHYMNS_SETUP_DASHBOARD')) {
+        if (!function_exists('isAuthenticated')) {
+            require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+        }
+        if (!isAuthenticated()) {
+            http_response_code(401);
+            exit('Authentication required.');
+        }
+        $u = getCurrentUser();
+        if (!$u || $u['role'] !== 'global_admin') {
+            http_response_code(403);
+            exit('Global admin required.');
+        }
+    }
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = false;
+}
+
+function _migBulkPerBook_out(string $line): void
+{
+    global $isCli;
+    echo $line . ($isCli ? "\n" : "<br>\n");
+    if ($isCli) flush();
+}
+
+function _migBulkPerBook_columnExists(\mysqli $db, string $table, string $column): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ? LIMIT 1'
+    );
+    $stmt->bind_param('ss', $table, $column);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+function _migBulkPerBook_tableExists(\mysqli $db, string $table): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? LIMIT 1'
+    );
+    $stmt->bind_param('s', $table);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+_migBulkPerBook_out('Bulk-Import Per-Songbook migration starting (#906)…');
+
+$mysqli = getDbMysqli();
+if (!$mysqli) {
+    throw new \RuntimeException('Could not connect to database.');
+}
+
+if (!_migBulkPerBook_tableExists($mysqli, 'tblBulkImportJobs')) {
+    _migBulkPerBook_out('ERROR: tblBulkImportJobs not found. Run "Bulk Import Jobs Tracking (#676)" first.');
+    return;
+}
+
+if (_migBulkPerBook_columnExists($mysqli, 'tblBulkImportJobs', 'PerSongbookJson')) {
+    _migBulkPerBook_out('[skip] tblBulkImportJobs.PerSongbookJson already present.');
+} else {
+    /* AFTER ErrorsJson keeps the JSON columns adjacent so a
+       SHOW CREATE TABLE / DESCRIBE reads in the order the bulk-import
+       handler writes them. */
+    $sql = "ALTER TABLE tblBulkImportJobs
+              ADD COLUMN PerSongbookJson JSON NULL DEFAULT NULL
+              AFTER ErrorsJson";
+    if (!$mysqli->query($sql)) {
+        throw new \RuntimeException('ALTER TABLE tblBulkImportJobs add PerSongbookJson failed: ' . $mysqli->error);
+    }
+    _migBulkPerBook_out('[add ] tblBulkImportJobs.PerSongbookJson (JSON NULL).');
+}
+
+_migBulkPerBook_out('Bulk-Import Per-Songbook migration finished (#906).');

--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -2413,7 +2413,12 @@ switch ($action) {
             $db = getDbMysqli();
             _bulkImport_jobMark($db, $jobId, 'running', ['StartedAt' => 'NOW()']);
             $summary = _bulkImport_processZip($persistPath, $db, $jobId);
-            _bulkImport_jobMark($db, $jobId, 'completed', [
+            /* #906 — persist the per-songbook breakdown alongside the
+               aggregate counts when the schema carries the column.
+               _bulkImport_jobMark()'s schema-probe + extras-merge
+               handles a pre-migration deploy gracefully (the unknown
+               column is dropped from the UPDATE). */
+            $completedExtras = [
                 'CompletedAt'           => 'NOW()',
                 'SongbooksCreatedJson'  => json_encode($summary['songbooks_created']  ?? [], JSON_UNESCAPED_UNICODE),
                 'SongbooksExistingJson' => json_encode($summary['songbooks_existing'] ?? [], JSON_UNESCAPED_UNICODE),
@@ -2421,8 +2426,10 @@ switch ($action) {
                 'SongsSkippedExisting'  => (int)($summary['songs_skipped_existing'] ?? 0),
                 'SongsFailed'           => (int)($summary['songs_failed'] ?? 0),
                 'ErrorsJson'            => json_encode($summary['errors'] ?? [], JSON_UNESCAPED_UNICODE),
+                'PerSongbookJson'       => json_encode($summary['per_songbook'] ?? [], JSON_UNESCAPED_UNICODE),
                 'TempPath'              => '',
-            ]);
+            ];
+            _bulkImport_jobMark($db, $jobId, 'completed', $completedExtras);
             @unlink($persistPath);
 
             /* Notify the curator so they find the result on their
@@ -2583,12 +2590,30 @@ switch ($action) {
             }
 
             $userId = isset($currentUser['id']) ? (int)$currentUser['id'] : 0;
+            /* #906 — schema-probe for PerSongbookJson so a pre-migration
+               deploy returns a clean response without 1054. The probe
+               result is request-cached via a static so a polling client
+               doesn't fire a new probe per request. */
+            static $hasPerSongbookCol = null;
+            if ($hasPerSongbookCol === null) {
+                try {
+                    $probeCol = $db->query(
+                        "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+                          WHERE TABLE_SCHEMA = DATABASE()
+                            AND TABLE_NAME   = 'tblBulkImportJobs'
+                            AND COLUMN_NAME  = 'PerSongbookJson' LIMIT 1"
+                    );
+                    $hasPerSongbookCol = $probeCol && $probeCol->fetch_row() !== null;
+                    if ($probeCol) $probeCol->close();
+                } catch (\Throwable $_e) { $hasPerSongbookCol = false; }
+            }
+            $perSongbookSelect = $hasPerSongbookCol ? ', PerSongbookJson' : ', NULL AS PerSongbookJson';
             $stmt = $db->prepare(
                 'SELECT Id, UserId, Filename, SizeBytes, Status,
                         TotalEntries, ProcessedEntries,
                         SongbooksCreatedJson, SongbooksExistingJson,
                         SongsCreated, SongsSkippedExisting, SongsFailed,
-                        ErrorsJson,
+                        ErrorsJson' . $perSongbookSelect . ',
                         StartedAt, CompletedAt, CreatedAt, UpdatedAt
                    FROM tblBulkImportJobs
                   WHERE Id = ? AND UserId = ?
@@ -2630,6 +2655,12 @@ switch ($action) {
                     'songbooks_created'       => $decode($row['SongbooksCreatedJson'])  ?? [],
                     'songbooks_existing'      => $decode($row['SongbooksExistingJson']) ?? [],
                     'errors'                  => $decode($row['ErrorsJson'])            ?? [],
+                    /* #906 — per-songbook breakdown of created / skipped /
+                       failed counts so the frontend can render a per-book
+                       table without re-deriving from `errors[]` heuristics.
+                       Pre-migration deploys return null (column read as
+                       NULL via `, NULL AS PerSongbookJson` above). */
+                    'per_songbook'            => $decode($row['PerSongbookJson'])       ?? null,
                     'started_at'              => $row['StartedAt'],
                     'completed_at'            => $row['CompletedAt'],
                     'created_at'              => $row['CreatedAt'],
@@ -3573,6 +3604,32 @@ function _bulkImport_upsertSongbook(\mysqli $db, string $abbr, string $name, ?st
 function _bulkImport_jobMark(\mysqli $db, ?int $jobId, string $status, array $extra = []): void
 {
     if ($jobId === null || $jobId <= 0) return;
+
+    /* Schema-probe the columns on tblBulkImportJobs once per request
+       so newer columns (e.g. #906's PerSongbookJson) get dropped
+       from the UPDATE on pre-migration deploys. Without the filter,
+       a single unknown-column extra would 1054 the entire UPDATE
+       and the rest of the legit columns wouldn't get updated either.
+       Static-cached so the SELECT runs once even when this function
+       is called dozens of times during a long import. */
+    static $knownCols = null;
+    if ($knownCols === null) {
+        $knownCols = [];
+        try {
+            $r = $db->query(
+                "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+                  WHERE TABLE_SCHEMA = DATABASE()
+                    AND TABLE_NAME   = 'tblBulkImportJobs'"
+            );
+            if ($r) {
+                while ($row = $r->fetch_assoc()) {
+                    $knownCols[$row['COLUMN_NAME']] = true;
+                }
+                $r->close();
+            }
+        } catch (\Throwable $_e) { /* best-effort; empty map = filter rejects everything */ }
+    }
+
     /* Build the SET fragment — status always, plus any extras. */
     $setParts = ['Status = ?'];
     $bindTypes  = 's';
@@ -3582,6 +3639,11 @@ function _bulkImport_jobMark(\mysqli $db, ?int $jobId, string $status, array $ex
            caller can't accidentally splice user data into the SQL.
            tblBulkImportJobs columns only. */
         if (!preg_match('/^[A-Za-z][A-Za-z0-9]*$/', $col)) continue;
+        /* Schema gate — skip columns not present on this deploy.
+           Empty $knownCols (probe failed) falls through to the
+           pre-#906 behaviour and tries every extra; the catch below
+           still suppresses the resulting error. */
+        if (!empty($knownCols) && !isset($knownCols[$col])) continue;
         if ($val === 'NOW()') {
             $setParts[] = "{$col} = NOW()";
             continue;
@@ -3691,6 +3753,40 @@ function _bulkImport_processZip(string $zipPath, ?\mysqli $jobDb = null, ?int $j
     $songsSkippedExisting     = 0;
     $songsFailed              = 0;
     $errors                   = [];
+
+    /* Per-songbook breakdown (#906). Keyed by abbreviation; carries
+       the songbook display name plus per-status counts so the import
+       summary can render a "HA: 0 created, 527 skipped, 0 failed"
+       row per book. Without this the curator sees only the aggregate
+       totals and can't tell which songbook accounts for the skips. */
+    $perSongbook              = [];   // abbr → ['name'=>str, 'created'=>int, 'skipped'=>int, 'failed'=>int, 'first_errors'=>[]]
+    $_perBookBump = static function (string $abbr, string $bookName, string $kind, ?string $errorMsg = null, ?string $entryName = null) use (&$perSongbook): void {
+        if ($abbr === '') $abbr = '_unknown';
+        if (!isset($perSongbook[$abbr])) {
+            $perSongbook[$abbr] = [
+                'abbr'         => $abbr,
+                'name'         => $bookName,
+                'created'      => 0,
+                'skipped'      => 0,
+                'failed'       => 0,
+                'first_errors' => [],
+            ];
+        }
+        if ($bookName !== '' && $perSongbook[$abbr]['name'] === '') {
+            $perSongbook[$abbr]['name'] = $bookName;
+        }
+        if (in_array($kind, ['created', 'skipped', 'failed'], true)) {
+            $perSongbook[$abbr][$kind]++;
+        }
+        if ($kind === 'failed' && $errorMsg !== null
+            && count($perSongbook[$abbr]['first_errors']) < 10
+        ) {
+            $perSongbook[$abbr]['first_errors'][] = [
+                'entry' => $entryName ?? '',
+                'error' => $errorMsg,
+            ];
+        }
+    };
 
     /* Initial progress write — set TotalEntries to the post-filter
        count so the polling endpoint's percentage uses the right
@@ -3807,14 +3903,17 @@ function _bulkImport_processZip(string $zipPath, ?\mysqli $jobDb = null, ?int $j
                 if ($action === 'create') {
                     $songsCreated++;
                     $songsParsedByKind['videopsalm']++;
+                    $_perBookBump($vpAbbr, $vpName, 'created');
                 } elseif ($action === 'skipped') {
                     $songsSkippedExisting++;
+                    $_perBookBump($vpAbbr, $vpName, 'skipped');
                 } else {
                     $errors[] = [
                         'entry' => $name . ': ' . ($song['id'] ?? '?'),
                         'error' => 'save failed: ' . $saveErr,
                     ];
                     $songsFailed++;
+                    $_perBookBump($vpAbbr, $vpName, 'failed', 'save failed: ' . $saveErr, $name . ': ' . ($song['id'] ?? '?'));
                 }
             }
             continue;
@@ -3832,6 +3931,7 @@ function _bulkImport_processZip(string $zipPath, ?\mysqli $jobDb = null, ?int $j
 
         if (!preg_match(_BULK_IMPORT_FOLDER_RE, $folder, $folderMatch)) {
             $errors[] = ['entry' => $name, 'error' => 'folder name does not match "<Title> [<ABBR>]"'];
+            $_perBookBump('_unknown', $folder, 'failed', 'folder name does not match "<Title> [<ABBR>]"', $name);
             continue;
         }
 
@@ -3850,6 +3950,7 @@ function _bulkImport_processZip(string $zipPath, ?\mysqli $jobDb = null, ?int $j
                checked against the folder. */
             if (!preg_match(_BULK_IMPORT_FILE_RE, $file, $fileMatch)) {
                 $errors[] = ['entry' => $name, 'error' => 'filename does not match "<#> (<ABBR>) - <Title>.txt"'];
+                $_perBookBump($abbr, $bookName, 'failed', 'filename does not match "<#> (<ABBR>) - <Title>.txt"', $name);
                 continue;
             }
             $fileAbbr = strtoupper($fileMatch['abbr']);
@@ -3859,6 +3960,7 @@ function _bulkImport_processZip(string $zipPath, ?\mysqli $jobDb = null, ?int $j
                     'entry' => $name,
                     'error' => "filename abbrev '$fileAbbr' does not match folder abbrev '$abbr'",
                 ];
+                $_perBookBump($abbr, $bookName, 'failed', "filename abbrev '$fileAbbr' does not match folder abbrev '$abbr'", $name);
                 continue;
             }
         } else {
@@ -3915,21 +4017,25 @@ function _bulkImport_processZip(string $zipPath, ?\mysqli $jobDb = null, ?int $j
         if ($song === null) {
             $errors[] = ['entry' => $name, 'error' => 'parse failed: ' . $reason];
             $songsFailed++;
+            $_perBookBump($abbr, $bookName, 'failed', 'parse failed: ' . $reason, $name);
             continue;
         }
 
         [$action, $err] = _bulkImport_saveSong($db, $song);
         if ($action === 'create') {
             $songsCreated++;
+            $_perBookBump($abbr, $bookName, 'created');
         } elseif ($action === 'skipped') {
             /* Existing row — left untouched per the no-overwrite
                contract. Counted separately from failures so a curator
                can see at a glance how many imports were no-ops because
                the songs were already in the database. */
             $songsSkippedExisting++;
+            $_perBookBump($abbr, $bookName, 'skipped');
         } else {
             $errors[] = ['entry' => $name, 'error' => 'save failed: ' . $err];
             $songsFailed++;
+            $_perBookBump($abbr, $bookName, 'failed', 'save failed: ' . $err, $name);
         }
     }
 
@@ -3960,6 +4066,12 @@ function _bulkImport_processZip(string $zipPath, ?\mysqli $jobDb = null, ?int $j
         'songs_failed'           => $songsFailed,
         'parsed_by_format'       => $songsParsedByKind,
         'errors'                 => $errors,
+        /* #906 — per-songbook breakdown so the import summary can
+           render "HA: 0 created, 527 skipped, 0 failed" rows instead
+           of just an aggregate. Re-keyed to a list (drop the abbr
+           keys) so the JSON shape is a stable array, not an object
+           whose keys depend on the input. */
+        'per_songbook'           => array_values($perSongbook),
     ];
 }
 

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -236,6 +236,7 @@ $friendlyTitles = [
     'song-media'                       => 'Song Media Uploads (#853)',
     'song-component-language'          => 'Song Component Language Override (#858)',
     'song-arrangement'                 => 'Song Arrangement Persistence (#892)',
+    'bulk-import-per-songbook'         => 'Bulk-Import Per-Songbook Breakdown (#906)',
     /* `recompute-songbook-songcount` no longer exposed via the dashboard
        (#818) — the SongCount Triggers migration above includes its own
        initial recompute. The CLI script stays on disk for emergency
@@ -297,6 +298,7 @@ $scriptMap = [
     'song-media'                    => 'migrate-song-media.php',
     'song-component-language'       => 'migrate-song-component-language.php',
     'song-arrangement'              => 'migrate-song-arrangement.php',
+    'bulk-import-per-songbook'      => 'migrate-bulk-import-per-songbook.php',
     'cleanup'     => 'cleanup.php',
     'backup'      => 'backup.php',
     'restore'     => 'restore.php',
@@ -348,6 +350,7 @@ $migrationOrder = [
     'song-media',
     'song-component-language',
     'song-arrangement',
+    'bulk-import-per-songbook',
 ];
 
 /* Per-migration card content (#816). Single source of truth for the
@@ -777,6 +780,20 @@ $migrationCards = [
                   . ' Idempotent.',
         'button' => 'Run Song Arrangement Migration',
     ],
+    'bulk-import-per-songbook' => [
+        'title'  => 'Bulk-Import Per-Songbook Breakdown (#906)',
+        'body'   => 'Adds <code>PerSongbookJson JSON NULL</code> to'
+                  . ' <code>tblBulkImportJobs</code> so the bulk-import flow can'
+                  . ' persist a per-songbook breakdown of created / skipped /'
+                  . ' failed counts alongside the existing aggregate totals.'
+                  . ' Pre-#906 the import notification only said'
+                  . ' "Imported X new (Y skipped)" — the curator couldn\'t tell'
+                  . ' whether the skips were "songs already in DB" (legitimate'
+                  . ' skip) or parse failures (real bug). The new column carries'
+                  . ' enough detail to render a per-songbook table in the import'
+                  . ' summary. Idempotent.',
+        'button' => 'Run Bulk-Import Per-Songbook Migration',
+    ],
     /* recompute-songbook-songcount card removed (#818) — its work is
        now covered by the SongCount Triggers migration above, which
        runs an initial recompute as part of its installation. The
@@ -935,6 +952,9 @@ $migrationProbes = [
     /* Song arrangement: pending when the column is absent. */
     'song-arrangement'                   => static fn(\mysqli $db) =>
         !_migProbe_columnExists($db, 'tblSongs', 'ArrangementJson'),
+    /* Bulk-import per-songbook breakdown: pending when the column is absent. */
+    'bulk-import-per-songbook'           => static fn(\mysqli $db) =>
+        !_migProbe_columnExists($db, 'tblBulkImportJobs', 'PerSongbookJson'),
     /* Backfills run once after schema lands. They're idempotent so
        always-show is safe — but we can be smarter: pending when the
        new table has fewer rows than the legacy source had non-empty


### PR DESCRIPTION
## Summary

Bulk-import surfaced "Imported X new (Y skipped)" without a per-book breakdown — when 1,137 songs were skipped on 2026-05-08's import of `_SDAHymnal Export 2.zip`, the curator's first read was "HA + HASD failed" because the math (527+610=1137) was exact and the toast offered no further detail. Actually those two songbooks were already in the DB from a prior import attempt, but verifying that required a manual SQL query.

This PR adds the **backend data shape** for a per-songbook breakdown. Frontend rendering of the table ships with #907's progress-UI rework.

## Per-book entry shape

```json
{
  "abbr":         "HA",
  "name":         "El Himnario Adventista (1962)",
  "created":      0,
  "skipped":      527,
  "failed":       0,
  "first_errors": []
}
```

One entry per songbook touched in the run. `first_errors` carries up to 10 entries (zip path + reason) so the frontend can show inline failures without round-tripping to `tblBulkImportJobs.ErrorsJson`.

## Changes

1. **Migration** — `migrate-bulk-import-per-songbook.php` adds `tblBulkImportJobs.PerSongbookJson JSON NULL`. Idempotent. Registered in `setup-database.php` across all five sites (`$friendlyTitles`, `$scriptMap`, `$migrationOrder`, `$migrationCards`, `$migrationProbes`).
2. **`_bulkImport_processZip()`** — new `$_perBookBump` closure keyed by abbreviation. Mirrored to all four call sites: VideoPsalm path, folder-regex rejection, filename-regex rejection, parse/save failures. No class of failure goes uncounted.
3. **`_bulkImport_jobMark()`** — schema-aware. Probes `tblBulkImportJobs.COLUMNS` once per request and filters unknown extras. Without this, passing `PerSongbookJson` on a pre-migration deploy would 1054 the UPDATE and legit columns wouldn't persist either.
4. **`bulk_import_status` endpoint** — schema-probes for the new column and returns `per_songbook` in the response. Null on pre-migration deploys; full breakdown post-migration.

## Test plan

- [x] PHP `php -l` clean on all three touched files.
- [x] Migration registered + visible in `/manage/setup-database` pending grid (added under "Bulk-Import Per-Songbook Breakdown (#906)" card).
- [ ] Run migration on alpha; confirm column appears in `tblBulkImportJobs`.
- [ ] Re-import `_SDAHymnal Export 2.zip` after migration runs; verify `bulk_import_status` returns a populated `per_songbook` array showing HA: 0/527/0, HASD: 0/610/0, NHA: 613/0/0, etc.
- [ ] Pre-migration sanity check: revert the migration, run an import, verify `bulk_import_status.per_songbook = null` and no 1054 errors in the log.
- [ ] No regression on aggregate `songs_created` / `songs_skipped_existing` / `songs_failed` totals.

## Related

- #907 — progress indicator latency fix (will render this `per_songbook` data in the toast / inline report).
- #908 — activity-log capture of per-failure detail (uses the same `_perBookBump` data; ships separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)