### PR TITLE
feat(import): instant + live progress UX for bulk imports (closes #907)

### DIFF
--- a/appWeb/.sql/migrate-bulk-import-phase-label.php
+++ b/appWeb/.sql/migrate-bulk-import-phase-label.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Bulk-Import Phase Label Migration (#907)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Adds a `PhaseLabel` column to `tblBulkImportJobs` so the bulk-
+ * import worker can record its current phase ("walking-zip",
+ * "parsing-songs", "flushing-songbooks", etc.) and the polling
+ * frontend can surface a human-readable status above the progress
+ * bar even at 0% progress.
+ *
+ * Pre-#907 the curator saw a blank "0%" indicator for the first
+ * several seconds while the worker was reading the upload, walking
+ * the archive index, and probing the schema — none of which advance
+ * the ProcessedEntries counter. The new column lets the frontend
+ * render "Walking ZIP archive…" or "Parsing songs…" so the user
+ * understands progress is happening even when the percentage isn't
+ * moving.
+ *
+ * Schema-additive: pre-migration code returns null for this column
+ * and the response shape stays back-compat.
+ *
+ * Idempotent: probes INFORMATION_SCHEMA.COLUMNS first; skips if
+ * the column already exists.
+ *
+ * USAGE:
+ *   CLI: php appWeb/.sql/migrate-bulk-import-phase-label.php
+ *   Web: /manage/setup-database → "Bulk-Import Phase Label (#907)"
+ *
+ * @migration-modifies tblBulkImportJobs (adds PhaseLabel)
+ */
+
+if (PHP_SAPI === 'cli') {
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = true;
+} else {
+    if (!defined('IHYMNS_SETUP_DASHBOARD')) {
+        if (!function_exists('isAuthenticated')) {
+            require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+        }
+        if (!isAuthenticated()) {
+            http_response_code(401);
+            exit('Authentication required.');
+        }
+        $u = getCurrentUser();
+        if (!$u || $u['role'] !== 'global_admin') {
+            http_response_code(403);
+            exit('Global admin required.');
+        }
+    }
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = false;
+}
+
+function _migBulkPhase_out(string $line): void
+{
+    global $isCli;
+    echo $line . ($isCli ? "\n" : "<br>\n");
+    if ($isCli) flush();
+}
+
+function _migBulkPhase_columnExists(\mysqli $db, string $table, string $column): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ? LIMIT 1'
+    );
+    $stmt->bind_param('ss', $table, $column);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+function _migBulkPhase_tableExists(\mysqli $db, string $table): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? LIMIT 1'
+    );
+    $stmt->bind_param('s', $table);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+_migBulkPhase_out('Bulk-Import Phase Label migration starting (#907)…');
+
+$mysqli = getDbMysqli();
+if (!$mysqli) {
+    throw new \RuntimeException('Could not connect to database.');
+}
+
+if (!_migBulkPhase_tableExists($mysqli, 'tblBulkImportJobs')) {
+    _migBulkPhase_out('ERROR: tblBulkImportJobs not found. Run "Bulk Import Jobs Tracking (#676)" first.');
+    return;
+}
+
+if (_migBulkPhase_columnExists($mysqli, 'tblBulkImportJobs', 'PhaseLabel')) {
+    _migBulkPhase_out('[skip] tblBulkImportJobs.PhaseLabel already present.');
+} else {
+    /* AFTER ProcessedEntries keeps the phase column adjacent to the
+       progress columns it complements. */
+    $sql = "ALTER TABLE tblBulkImportJobs
+              ADD COLUMN PhaseLabel VARCHAR(64) NULL DEFAULT NULL
+              AFTER ProcessedEntries";
+    if (!$mysqli->query($sql)) {
+        throw new \RuntimeException('ALTER TABLE tblBulkImportJobs add PhaseLabel failed: ' . $mysqli->error);
+    }
+    _migBulkPhase_out('[add ] tblBulkImportJobs.PhaseLabel (VARCHAR(64) NULL).');
+}
+
+_migBulkPhase_out('Bulk-Import Phase Label migration finished (#907).');

--- a/appWeb/public_html/js/modules/bulk-import-progress.js
+++ b/appWeb/public_html/js/modules/bulk-import-progress.js
@@ -39,12 +39,27 @@ const STORAGE_KEY     = 'ihymns:bulk-import-active-job';
 const POLL_INTERVAL_MS = 1500;
 const POLL_BACKOFF_MS  = 5000; // after an error, slow down rather than spam
 
+/* #907 — auto-dismiss windows for completion / failure states. The
+   curator gets enough time to read the result; hover-to-pause
+   suspends the timer for as long as the cursor is over the widget,
+   so a curator copying numbers from the summary doesn't have it
+   yanked away mid-read. */
+const AUTO_DISMISS_SUCCESS_MS = 15000; // 15s on a clean import
+const AUTO_DISMISS_FAILURE_MS = 45000; // 45s when something failed (more to read)
+
 /* In-module state. We never expose these directly — bootstrap
    path mounts the widget and stashes the polling timer here. */
-let widgetEl       = null;
-let pollTimer      = null;
-let activeJob      = null; // { jobId, filename, pollUrl }
-let isPollingNow   = false;
+let widgetEl         = null;
+let pollTimer        = null;
+let activeJob        = null; // { jobId, filename, pollUrl }
+let isPollingNow     = false;
+let autoDismissTimer = null;
+let autoDismissPaused = false;
+/* #907 — upload-phase tracking. The widget mounts BEFORE the upload
+   starts so the curator sees byte-level feedback during the upload.
+   `uploadState` is null once the job_id arrives and polling takes
+   over. */
+let uploadState      = null; // { filename, sizeBytes, loaded, total }
 
 /* ------------------------------------------------------------------
  * localStorage helpers — best-effort; private-browsing failures
@@ -92,10 +107,14 @@ function ensureWidget() {
     /* Inline styles so the widget works on every iHymns surface
        without a per-page CSS dependency. Conservative palette
        (theme-aware via CSS variables when present, opaque dark
-       fallback otherwise). */
+       fallback otherwise).
+       #907 — TOP-right (was bottom-right). The bulk-import widget
+       was getting overlapped by Bootstrap's app-toast queue, which
+       is also bottom-right by default. Moving to top-right gives
+       each surface its own corner with no z-index gymnastics. */
     widgetEl.style.cssText = `
         position: fixed;
-        bottom: 1rem;
+        top: 1rem;
         right: 1rem;
         z-index: 9999;
         min-width: 18rem;
@@ -112,7 +131,11 @@ function ensureWidget() {
 
     /* Initial markup — gets replaced wholesale by render() each
        poll. The skeleton just gives the user something to see while
-       the first poll is in flight. */
+       the first poll is in flight.
+       #907 — dismiss button is ALWAYS visible (was only shown after
+       completion). Mid-run dismiss closes the visible widget but
+       leaves the import running on the server; the curator can
+       check job state later via /manage/activity-log. */
     widgetEl.innerHTML = `
         <div class="d-flex align-items-center gap-2 mb-1">
             <i class="fa-solid fa-cloud-arrow-up"></i>
@@ -124,7 +147,7 @@ function ensureWidget() {
                     style="color: var(--text-secondary,#9ca3af);">
                 <i class="fa-solid fa-window-minimize"></i>
             </button>
-            <button type="button" class="btn btn-sm btn-link text-decoration-none p-0 d-none"
+            <button type="button" class="btn btn-sm btn-link text-decoration-none p-0"
                     data-bulk-action="dismiss"
                     aria-label="Dismiss"
                     title="Dismiss"
@@ -132,12 +155,31 @@ function ensureWidget() {
                 <i class="fa-solid fa-xmark"></i>
             </button>
         </div>
+        <div class="ihymns-bulk-import-phase text-muted small" data-phase
+             style="font-size:0.7rem; margin-bottom:0.15rem; display:none;"></div>
         <div class="ihymns-bulk-import-summary text-muted" style="font-size:0.75rem;">Connecting…</div>
         <div class="progress mt-2" style="height: 0.5rem;">
             <div class="progress-bar" role="progressbar"
                  style="width: 0%;" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"></div>
         </div>
     `;
+
+    /* #907 — hover pauses the auto-dismiss timer; mouse-leave resumes
+       it from where it was. The user can read the result without
+       it disappearing mid-glance. */
+    widgetEl.addEventListener('mouseenter', () => {
+        autoDismissPaused = true;
+        if (autoDismissTimer) { clearTimeout(autoDismissTimer); autoDismissTimer = null; }
+    });
+    widgetEl.addEventListener('mouseleave', () => {
+        autoDismissPaused = false;
+        /* If we were already in a final state, restart the dismiss
+           timer at its full duration on mouse-leave. Tiny extra
+           dismiss budget on hover-pause is acceptable for the UX win. */
+        const status = activeJob?._lastStatus;
+        if (status === 'completed') scheduleAutoDismiss(AUTO_DISMISS_SUCCESS_MS);
+        if (status === 'failed')    scheduleAutoDismiss(AUTO_DISMISS_FAILURE_MS);
+    });
 
     /* Click handlers via delegation so we don't have to re-bind
        after each render. */
@@ -151,6 +193,13 @@ function ensureWidget() {
             widgetEl.style.maxWidth = isMini ? 'unset' : '22rem';
             widgetEl.style.padding  = isMini ? '0.4rem 0.6rem' : '0.75rem 0.9rem';
         } else if (action === 'dismiss') {
+            /* #907 — dismiss is now always available. Mid-run
+               dismiss only closes the widget; the import keeps
+               running on the server. localStorage is cleared so the
+               next page-load doesn't auto-resume tracking — the
+               curator can verify completion via /manage/activity-log
+               or via the next page-load's own widget if they navigate
+               away and come back. */
             stopAndRemove();
             clearActiveJob();
         }
@@ -160,11 +209,32 @@ function ensureWidget() {
     return widgetEl;
 }
 
+/* #907 — helper: schedule an auto-dismiss timer. Idempotent — clears
+   any existing timer before starting a new one. Suspended while
+   `autoDismissPaused` is true (cursor over widget). */
+function scheduleAutoDismiss(ms) {
+    if (autoDismissTimer) { clearTimeout(autoDismissTimer); autoDismissTimer = null; }
+    if (autoDismissPaused) return; // hover suspends; mouseleave will reschedule
+    autoDismissTimer = setTimeout(() => {
+        autoDismissTimer = null;
+        stopAndRemove();
+        clearActiveJob();
+    }, ms);
+}
+
+/* #907 — translate worker phase labels into human-readable status text. */
+const PHASE_LABEL_TEXT = {
+    'walking-zip':         'Walking ZIP archive…',
+    'parsing-songs':       'Parsing songs…',
+    'flushing-songbooks':  'Finalising…',
+    'completed':           '',                        // hide on completion
+};
+
 function render(job) {
     if (!widgetEl) return;
     const summary  = widgetEl.querySelector('.ihymns-bulk-import-summary');
+    const phaseEl  = widgetEl.querySelector('[data-phase]');
     const bar      = widgetEl.querySelector('.progress-bar');
-    const dismiss  = widgetEl.querySelector('[data-bulk-action="dismiss"]');
     const titleEl  = widgetEl.querySelector('strong');
 
     if (!job) {
@@ -176,12 +246,17 @@ function render(job) {
     if (titleEl) titleEl.textContent = filename;
 
     const status   = job.status || 'queued';
+    const phase    = job.phase_label || null; // #907
     const total    = Number(job.total_entries || 0);
     const done     = Number(job.processed_entries || 0);
     const percent  = Number(job.percent || 0);
     const created  = Number(job.songs_created || 0);
     const skipped  = Number(job.songs_skipped_existing || 0);
     const failed   = Number(job.songs_failed || 0);
+
+    /* Stash status on activeJob so the hover handlers can decide
+       whether to reschedule auto-dismiss on mouse-leave. */
+    if (activeJob) activeJob._lastStatus = status;
 
     if (bar) {
         bar.style.width = Math.min(100, Math.max(0, percent)) + '%';
@@ -191,6 +266,15 @@ function render(job) {
         } else if (status === 'failed') {
             bar.style.background = '#dc2626';
         }
+    }
+
+    /* #907 — phase label above the summary. Hidden on pre-migration
+       deploys (phase_label = null) and on completion (no useful
+       phase to surface). */
+    if (phaseEl) {
+        const text = phase && phase !== 'completed' ? PHASE_LABEL_TEXT[phase] || phase : '';
+        phaseEl.textContent = text;
+        phaseEl.style.display = text ? 'block' : 'none';
     }
 
     if (summary) {
@@ -217,15 +301,52 @@ function render(job) {
         }
     }
 
-    /* Show the dismiss button only when the job is in a final
-       state — otherwise the user might dismiss a still-running
-       import and lose the tracking handle. */
-    if (dismiss) {
-        if (status === 'completed' || status === 'failed') {
-            dismiss.classList.remove('d-none');
-        } else {
-            dismiss.classList.add('d-none');
-        }
+    /* #907 — auto-dismiss on completion / failure. Pre-#907 the
+       widget stuck around indefinitely until the user found the ×
+       button (which was only visible after completion anyway).
+       Auto-dismiss runs after a generous delay and pauses on hover. */
+    if (status === 'completed' && !autoDismissTimer && !autoDismissPaused) {
+        scheduleAutoDismiss(failed > 0 ? AUTO_DISMISS_FAILURE_MS : AUTO_DISMISS_SUCCESS_MS);
+    } else if (status === 'failed' && !autoDismissTimer && !autoDismissPaused) {
+        scheduleAutoDismiss(AUTO_DISMISS_FAILURE_MS);
+    }
+}
+
+/* #907 — render the upload-phase state. Uses the same widget
+   skeleton as the polling render() but reads from `uploadState`
+   (loaded / total bytes) rather than the server's job row. */
+function renderUploadPhase() {
+    if (!widgetEl || !uploadState) return;
+    const titleEl  = widgetEl.querySelector('strong');
+    const phaseEl  = widgetEl.querySelector('[data-phase]');
+    const summary  = widgetEl.querySelector('.ihymns-bulk-import-summary');
+    const bar      = widgetEl.querySelector('.progress-bar');
+
+    const filename = uploadState.filename || 'import.zip';
+    const total    = Number(uploadState.total || uploadState.sizeBytes || 0);
+    const loaded   = Number(uploadState.loaded || 0);
+    const percent  = total > 0 ? Math.round((loaded / total) * 100) : 0;
+
+    if (titleEl) titleEl.textContent = filename;
+    if (phaseEl) {
+        phaseEl.textContent = 'Uploading…';
+        phaseEl.style.display = 'block';
+    }
+    if (bar) {
+        bar.style.width = Math.min(100, Math.max(0, percent)) + '%';
+        bar.setAttribute('aria-valuenow', String(percent));
+        bar.style.background = ''; // default theme accent
+    }
+    if (summary) {
+        const fmt = (b) => {
+            if (!b) return '0 B';
+            if (b < 1024) return b + ' B';
+            if (b < 1024 * 1024) return (b / 1024).toFixed(1) + ' KB';
+            return (b / 1024 / 1024).toFixed(1) + ' MB';
+        };
+        summary.textContent = total > 0
+            ? `${fmt(loaded)} / ${fmt(total)} (${percent}%)`
+            : `${fmt(loaded)} uploaded…`;
     }
 }
 
@@ -287,10 +408,13 @@ function pollOnce() {
 }
 
 function stopAndRemove() {
-    if (pollTimer) { clearTimeout(pollTimer); pollTimer = null; }
+    if (pollTimer)        { clearTimeout(pollTimer);        pollTimer = null; }
+    if (autoDismissTimer) { clearTimeout(autoDismissTimer); autoDismissTimer = null; }
     if (widgetEl && widgetEl.parentNode) widgetEl.parentNode.removeChild(widgetEl);
-    widgetEl  = null;
-    activeJob = null;
+    widgetEl     = null;
+    activeJob    = null;
+    uploadState  = null;
+    autoDismissPaused = false;
 }
 
 /* ------------------------------------------------------------------
@@ -320,18 +444,68 @@ export function bootBulkImportProgressWidget() {
 
 /**
  * Called by editor.js right after the upload returns its job_id.
- * Persists the handle to localStorage and starts the widget.
+ * Persists the handle to localStorage and starts polling — fires
+ * the first poll immediately rather than waiting POLL_INTERVAL_MS so
+ * the curator sees real worker state within ~100ms of upload return
+ * (#907).
  */
 export function startTracking({ jobId, filename, pollUrl }) {
-    activeJob = { jobId, filename, pollUrl };
+    /* Don't tear down the widget — if it's already mounted from
+       startUploadTracking() (#907), keep the same DOM node so the
+       transition from upload → polling is visually seamless. */
+    activeJob   = { jobId, filename, pollUrl };
+    uploadState = null;        // upload phase done; polling takes over
     writeActiveJob(activeJob);
-    /* Re-mount even if a stale widget existed (e.g. from a
-       previous import that's already complete). */
-    stopAndRemove();
-    activeJob = { jobId, filename, pollUrl };
     ensureWidget();
     render({ status: 'queued', filename });
+    /* Immediate first poll so the worker's current PhaseLabel /
+       progress lands within ~100ms of the upload return. */
     pollOnce();
+}
+
+/**
+ * #907 — called by editor.js BEFORE the upload starts. Mounts the
+ * widget in upload-tracking mode so the curator sees byte-level
+ * progress during the upload phase (which can be 60+s on a 38 MB
+ * ZIP under a constrained connection). Pre-#907 the widget mounted
+ * only after the server returned the job_id, leaving the upload
+ * phase entirely silent.
+ */
+export function startUploadTracking({ filename, sizeBytes }) {
+    uploadState = {
+        filename:  filename || 'import.zip',
+        sizeBytes: Number(sizeBytes || 0),
+        loaded:    0,
+        total:     Number(sizeBytes || 0),
+    };
+    /* Don't restore activeJob from localStorage — this is a fresh
+       upload, not a resumption. */
+    activeJob = null;
+    ensureWidget();
+    renderUploadPhase();
+}
+
+/**
+ * #907 — called by editor.js's `xhr.upload.onprogress` handler
+ * during the upload phase. Updates the loaded/total counters and
+ * re-renders. No-op if the widget isn't in upload mode (e.g. the
+ * upload completed and we transitioned to polling).
+ */
+export function updateUploadProgress({ loaded, total }) {
+    if (!uploadState) return;
+    uploadState.loaded = Number(loaded || 0);
+    if (total) uploadState.total = Number(total);
+    renderUploadPhase();
+}
+
+/**
+ * #907 — programmatic dismiss for editor.js's error path (server
+ * rejected the upload, no job to track). Tears down the widget +
+ * any auto-dismiss timer cleanly.
+ */
+export function dismiss() {
+    stopAndRemove();
+    clearActiveJob();
 }
 
 /* Convenience: surface a global so the legacy classic-script
@@ -342,5 +516,8 @@ if (typeof window !== 'undefined') {
     window.bulkImportProgress = {
         boot: bootBulkImportProgressWidget,
         startTracking,
+        startUploadTracking,
+        updateUploadProgress,
+        dismiss,
     };
 }

--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -2427,6 +2427,7 @@ switch ($action) {
                 'SongsFailed'           => (int)($summary['songs_failed'] ?? 0),
                 'ErrorsJson'            => json_encode($summary['errors'] ?? [], JSON_UNESCAPED_UNICODE),
                 'PerSongbookJson'       => json_encode($summary['per_songbook'] ?? [], JSON_UNESCAPED_UNICODE),
+                'PhaseLabel'            => 'completed',
                 'TempPath'              => '',
             ];
             _bulkImport_jobMark($db, $jobId, 'completed', $completedExtras);
@@ -2633,11 +2634,12 @@ switch ($action) {
             }
 
             $userId = isset($currentUser['id']) ? (int)$currentUser['id'] : 0;
-            /* #906 — schema-probe for PerSongbookJson so a pre-migration
-               deploy returns a clean response without 1054. The probe
-               result is request-cached via a static so a polling client
-               doesn't fire a new probe per request. */
+            /* #906 / #907 — schema-probe for newer columns so a pre-
+               migration deploy returns a clean response without 1054.
+               Both probes are request-cached via static so a polling
+               client doesn't fire fresh probes per request. */
             static $hasPerSongbookCol = null;
+            static $hasPhaseLabelCol  = null;
             if ($hasPerSongbookCol === null) {
                 try {
                     $probeCol = $db->query(
@@ -2650,13 +2652,26 @@ switch ($action) {
                     if ($probeCol) $probeCol->close();
                 } catch (\Throwable $_e) { $hasPerSongbookCol = false; }
             }
+            if ($hasPhaseLabelCol === null) {
+                try {
+                    $probeCol = $db->query(
+                        "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+                          WHERE TABLE_SCHEMA = DATABASE()
+                            AND TABLE_NAME   = 'tblBulkImportJobs'
+                            AND COLUMN_NAME  = 'PhaseLabel' LIMIT 1"
+                    );
+                    $hasPhaseLabelCol = $probeCol && $probeCol->fetch_row() !== null;
+                    if ($probeCol) $probeCol->close();
+                } catch (\Throwable $_e) { $hasPhaseLabelCol = false; }
+            }
             $perSongbookSelect = $hasPerSongbookCol ? ', PerSongbookJson' : ', NULL AS PerSongbookJson';
+            $phaseLabelSelect  = $hasPhaseLabelCol  ? ', PhaseLabel'      : ', NULL AS PhaseLabel';
             $stmt = $db->prepare(
                 'SELECT Id, UserId, Filename, SizeBytes, Status,
                         TotalEntries, ProcessedEntries,
                         SongbooksCreatedJson, SongbooksExistingJson,
                         SongsCreated, SongsSkippedExisting, SongsFailed,
-                        ErrorsJson' . $perSongbookSelect . ',
+                        ErrorsJson' . $perSongbookSelect . $phaseLabelSelect . ',
                         StartedAt, CompletedAt, CreatedAt, UpdatedAt
                    FROM tblBulkImportJobs
                   WHERE Id = ? AND UserId = ?
@@ -2704,6 +2719,10 @@ switch ($action) {
                        Pre-migration deploys return null (column read as
                        NULL via `, NULL AS PerSongbookJson` above). */
                     'per_songbook'            => $decode($row['PerSongbookJson'])       ?? null,
+                    /* #907 — current worker phase: walking-zip / parsing-songs /
+                       flushing-songbooks / completed. Pre-migration deploys
+                       return null and the frontend hides the phase label. */
+                    'phase_label'             => $row['PhaseLabel']                     ?? null,
                     'started_at'              => $row['StartedAt'],
                     'completed_at'            => $row['CompletedAt'],
                     'created_at'              => $row['CreatedAt'],
@@ -3882,14 +3901,29 @@ function _bulkImport_processZip(string $zipPath, ?\mysqli $jobDb = null, ?int $j
     /* Initial progress write — set TotalEntries to the post-filter
        count so the polling endpoint's percentage uses the right
        denominator. We don't know it precisely until we've walked
-       once, so send the raw entry count as a ceiling. (#676) */
+       once, so send the raw entry count as a ceiling. (#676)
+       PhaseLabel (#907) gives the frontend a human-readable status
+       above the progress bar even at 0% — the curator never sees a
+       silent "0%" while the worker is doing real preflight work. */
     if ($jobDb !== null && $jobId !== null) {
         _bulkImport_jobMark($jobDb, $jobId, 'running', [
             'TotalEntries'     => (int)$entryCount,
             'ProcessedEntries' => 0,
+            'PhaseLabel'       => 'walking-zip',
         ]);
     }
     $progressFlushCounter = 0;
+
+    /* #907 — phase transition: walking-zip → parsing-songs. The
+       walk-and-classify above (entry count, format detection) was
+       phase 'walking-zip'; we're about to start the per-entry parse +
+       save loop, which is the bulk of the work and updates
+       ProcessedEntries every $PROGRESS_BATCH iterations. */
+    if ($jobDb !== null && $jobId !== null) {
+        _bulkImport_jobMark($jobDb, $jobId, 'running', [
+            'PhaseLabel' => 'parsing-songs',
+        ]);
+    }
 
     /* Single pass over the archive: for each .txt entry, parse the
        enclosing folder name to learn (songbook name, abbrev), upsert
@@ -4131,6 +4165,17 @@ function _bulkImport_processZip(string $zipPath, ?\mysqli $jobDb = null, ?int $j
     }
 
     $zip->close();
+
+    /* #907 — phase transition: parsing-songs → flushing-songbooks.
+       The per-entry loop is done; we're now refreshing SongCount on
+       any newly-created songbooks. Brief phase but worth a label so
+       the bar at 100% briefly shows "Finalising…" rather than
+       lingering at "Parsing songs" with no progress. */
+    if ($jobDb !== null && $jobId !== null) {
+        _bulkImport_jobMark($jobDb, $jobId, 'running', [
+            'PhaseLabel' => 'flushing-songbooks',
+        ]);
+    }
 
     /* Refresh SongCount only for songbooks we created in this run.
        Existing songbooks are off-limits per the no-overwrite contract,

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -3217,63 +3217,95 @@ function importVideoPsalmSongbook(file) {
  * stays untouched.
  */
 function importBulkZip(file) {
-    /* Cheap UX hint while the multipart upload is climbing the
-       wire. The server response now lands almost immediately
-       once the upload completes (the server returns the job_id
-       and processes asynchronously per #676), so this toast is
-       only on screen for a few seconds before the persistent
-       progress widget takes over. */
-    showToast('Uploading ' + file.name + '…', 'info');
-
+    /* #907 — mount the progress widget IMMEDIATELY (before the upload
+       starts) so the curator sees byte-level feedback during the
+       upload phase. Pre-#907 the curator saw nothing for the entire
+       duration of the upload (could be 60+s on a 38 MB ZIP) — the
+       persistent widget only mounted AFTER the server returned the
+       job_id, which itself happens AFTER the full upload completes.
+       The widget is loaded as a dynamic ES-module import; if it fails
+       (broken deploy / offline / etc.) we fall through to a toast. */
     var fd = new FormData();
     fd.append('zip', file, file.name);
 
-    fetch(EDITOR_API_URL + '?action=bulk_import_zip', {
-        method:      'POST',
-        body:        fd,
-        credentials: 'same-origin',
-    }).then(function (res) {
-        return res.json().catch(function () {
-            return { error: 'Server returned an unparseable response (status ' + res.status + ').' };
-        }).then(function (data) {
-            return { ok: res.ok, data: data };
+    /* Hand the widget a synthetic "uploading" job up-front so it can
+       mount, start showing progress, and switch to real polling once
+       the server returns its job_id. */
+    var widgetReady = import('/js/modules/bulk-import-progress.js?v=' + Date.now())
+        .then(function (m) {
+            try {
+                m.startUploadTracking({ filename: file.name, sizeBytes: file.size });
+            } catch (_e) { /* startUploadTracking is opt-in; older bundles fall through */ }
+            return m;
+        })
+        .catch(function (err) {
+            try { console.warn('[bulk_import_zip] progress widget load failed:', err); } catch (_e) {}
+            showToast('Uploading ' + file.name + '…', 'info');
+            return null;
         });
-    }).then(function (out) {
+
+    /* XMLHttpRequest replaces fetch here SOLELY because fetch has no
+       upload-progress event in any production browser as of 2026.
+       xhr.upload.onprogress fires every ~50ms with byte counts. */
+    var uploadXhr = new XMLHttpRequest();
+    uploadXhr.open('POST', EDITOR_API_URL + '?action=bulk_import_zip', true);
+    uploadXhr.withCredentials = true;
+    uploadXhr.upload.onprogress = function (ev) {
+        if (!ev.lengthComputable) return;
+        widgetReady.then(function (m) {
+            if (m && typeof m.updateUploadProgress === 'function') {
+                m.updateUploadProgress({ loaded: ev.loaded, total: ev.total });
+            }
+        });
+    };
+    /* Promise wrapper so the rest of the existing flow stays
+       fetch-shaped. Resolves with `{ok, data}` like the prior code. */
+    var uploadPromise = new Promise(function (resolve) {
+        uploadXhr.onload = function () {
+            var data;
+            try { data = JSON.parse(uploadXhr.responseText); }
+            catch (_e) { data = { error: 'Server returned an unparseable response (status ' + uploadXhr.status + ').' }; }
+            resolve({ ok: uploadXhr.status >= 200 && uploadXhr.status < 300, data: data });
+        };
+        uploadXhr.onerror = function () {
+            resolve({ ok: false, data: { error: 'Network error while uploading.' } });
+        };
+        uploadXhr.send(fd);
+    });
+
+    uploadPromise.then(function (out) {
         if (!out.ok || !out.data || out.data.ok !== true) {
             var msg = (out.data && out.data.error) || 'Import failed.';
             showToast('Import failed: ' + msg, 'danger');
+            /* Tear down the upload-phase widget — server rejected the
+               upload, no job to track. */
+            widgetReady.then(function (m) {
+                if (m && typeof m.dismiss === 'function') m.dismiss();
+            });
             return;
         }
         var d = out.data;
 
-        /* Async path (#676) — the server returned a job_id; hand it
-           off to the persistent progress widget which polls the
-           status endpoint, survives navigation, and refreshes the
-           editor catalogue on completion. The widget is loaded as
-           an ES module from this classic-script context. */
+        /* Async path (#676) — the server returned a job_id; transition
+           the already-mounted widget from upload-tracking to job-
+           tracking. The first poll fires immediately inside
+           startTracking() so the curator sees server-side state
+           within ~100ms of upload completion (#907). */
         if (d.async && d.job_id) {
-            showToast('Import started — see progress widget.', 'success');
-            import('/js/modules/bulk-import-progress.js?v=' + Date.now())
-                .then(function (m) {
-                    m.startTracking({
-                        jobId:    d.job_id,
-                        filename: file.name,
-                        pollUrl:  d.poll_url
-                                || ('/manage/editor/api?action=bulk_import_status&job_id=' + d.job_id),
-                    });
-                })
-                .catch(function (err) {
-                    /* If the dynamic import fails (broken deploy /
-                       offline / etc.) the import itself still ran on
-                       the server — we just lose the live UI. Fall
-                       through to a manual-reload notice so the
-                       curator knows their data is on the way. */
-                    showToast(
-                        'Import is running in the background. Refresh the page in a minute to see results.',
-                        'info'
-                    );
-                    try { console.warn('[bulk_import_zip] progress widget load failed:', err); } catch (_e) {}
+            widgetReady.then(function (m) {
+                if (!m) {
+                    /* Widget failed to load — surface a fallback toast
+                       and let the user refresh later to see results. */
+                    showToast('Import is running in the background. Refresh the page in a minute to see results.', 'info');
+                    return;
+                }
+                m.startTracking({
+                    jobId:    d.job_id,
+                    filename: file.name,
+                    pollUrl:  d.poll_url
+                            || ('/manage/editor/api?action=bulk_import_status&job_id=' + d.job_id),
                 });
+            });
             return;
         }
 

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -237,6 +237,7 @@ $friendlyTitles = [
     'song-component-language'          => 'Song Component Language Override (#858)',
     'song-arrangement'                 => 'Song Arrangement Persistence (#892)',
     'bulk-import-per-songbook'         => 'Bulk-Import Per-Songbook Breakdown (#906)',
+    'bulk-import-phase-label'          => 'Bulk-Import Phase Label (#907)',
     /* `recompute-songbook-songcount` no longer exposed via the dashboard
        (#818) — the SongCount Triggers migration above includes its own
        initial recompute. The CLI script stays on disk for emergency
@@ -299,6 +300,7 @@ $scriptMap = [
     'song-component-language'       => 'migrate-song-component-language.php',
     'song-arrangement'              => 'migrate-song-arrangement.php',
     'bulk-import-per-songbook'      => 'migrate-bulk-import-per-songbook.php',
+    'bulk-import-phase-label'       => 'migrate-bulk-import-phase-label.php',
     'cleanup'     => 'cleanup.php',
     'backup'      => 'backup.php',
     'restore'     => 'restore.php',
@@ -351,6 +353,7 @@ $migrationOrder = [
     'song-component-language',
     'song-arrangement',
     'bulk-import-per-songbook',
+    'bulk-import-phase-label',
 ];
 
 /* Per-migration card content (#816). Single source of truth for the
@@ -794,6 +797,23 @@ $migrationCards = [
                   . ' summary. Idempotent.',
         'button' => 'Run Bulk-Import Per-Songbook Migration',
     ],
+    'bulk-import-phase-label' => [
+        'title'  => 'Bulk-Import Phase Label (#907)',
+        'body'   => 'Adds <code>PhaseLabel VARCHAR(64) NULL</code> to'
+                  . ' <code>tblBulkImportJobs</code> so the bulk-import worker'
+                  . ' can record its current phase ("walking-zip", "parsing-songs",'
+                  . ' "flushing-songbooks", etc.) and the polling frontend can'
+                  . ' surface a human-readable status above the progress bar even'
+                  . ' at 0% progress. Pre-#907 the curator saw a blank "0%"'
+                  . ' indicator for the first several seconds while the worker'
+                  . ' was reading the upload, walking the archive index, and'
+                  . ' probing the schema — none of which advance the'
+                  . ' <code>ProcessedEntries</code> counter. The new column lets'
+                  . ' the frontend render "Walking ZIP archive…" so the user'
+                  . ' understands progress is happening even when the percentage'
+                  . ' isn\'t moving. Idempotent.',
+        'button' => 'Run Bulk-Import Phase Label Migration',
+    ],
     /* recompute-songbook-songcount card removed (#818) — its work is
        now covered by the SongCount Triggers migration above, which
        runs an initial recompute as part of its installation. The
@@ -955,6 +975,9 @@ $migrationProbes = [
     /* Bulk-import per-songbook breakdown: pending when the column is absent. */
     'bulk-import-per-songbook'           => static fn(\mysqli $db) =>
         !_migProbe_columnExists($db, 'tblBulkImportJobs', 'PerSongbookJson'),
+    /* Bulk-import phase label: pending when the column is absent. */
+    'bulk-import-phase-label'            => static fn(\mysqli $db) =>
+        !_migProbe_columnExists($db, 'tblBulkImportJobs', 'PhaseLabel'),
     /* Backfills run once after schema lands. They're idempotent so
        always-show is safe — but we can be smarter: pending when the
        new table has fewer rows than the legacy source had non-empty


### PR DESCRIPTION
## Summary

The bulk-import progress indicator was unusable in **five distinct ways** observed during the 2026-05-08 import of `_SDAHymnal Export 2.zip`:

1. **60+ seconds of complete silence during upload phase** — widget mounted only AFTER upload return.
2. **First poll fired POLL_INTERVAL_MS late** — even once mounted, sat at "Connecting…" for 1.5s before first real status.
3. **0% with no signal** — worker did real preflight (zip walk + schema probes) but the bar showed nothing was happening.
4. **No way to dismiss running imports + completion toast didn't auto-dismiss** — × button only appeared after completion.
5. **Widget overlapped general toast queue** — both lived bottom-right at z-index 9999, hiding "Could n…" toasts behind the import indicator.

This PR fixes all five.

## Changes by file

### `appWeb/.sql/migrate-bulk-import-phase-label.php` (new)

Idempotent migration adds `tblBulkImportJobs.PhaseLabel VARCHAR(64) NULL`. Registered across all 5 sites in setup-database.php.

### `appWeb/public_html/manage/editor/api.php`

- `_bulkImport_processZip()` writes phase labels at each major transition: `walking-zip` → `parsing-songs` → `flushing-songbooks` → `completed`.
- `bulk_import_status` endpoint schema-probes for `PhaseLabel` and surfaces `phase_label` in the response. Pre-migration deploys return null gracefully.

### `appWeb/public_html/manage/editor/editor.js`

`importBulkZip()` reworked:
- Mounts the progress widget BEFORE upload starts via new `startUploadTracking()`.
- Replaces `fetch()` with `XMLHttpRequest` solely because fetch has no upload-progress event in any production browser as of 2026.
- `xhr.upload.onprogress` wired to `updateUploadProgress()` for byte-level feedback during upload.
- On upload return, transitions to job-tracking; first poll fires immediately (no timer wait).

### `appWeb/public_html/js/modules/bulk-import-progress.js`

Substantial rework:
- New `startUploadTracking({filename, sizeBytes})` + `updateUploadProgress({loaded, total})` + `dismiss()` API.
- Phase-label row above the summary; hidden when null/completed.
- Widget moved from `bottom: 1rem; right: 1rem` to `top: 1rem; right: 1rem` so it doesn't overlap Bootstrap's bottom-right toast queue.
- Dismiss button always visible (was: only after completion).
- Auto-dismiss timer: 15s on success, 45s on failure. Hover-to-pause via `mouseenter`/`mouseleave` listeners.
- `startTracking()` fires immediate first poll.

## Test plan

- [x] PHP `php -l` clean on every touched file.
- [x] JS `node --check` clean.
- [ ] Run migration on alpha; confirm `tblBulkImportJobs.PhaseLabel` column exists.
- [ ] Upload `_SDAHymnal Export 2.zip` (~38 MB) → expect within 200ms: widget mounts top-right showing "Uploading… 0 MB / 38 MB (0%)" with a moving bar.
- [ ] During upload → byte counter ticks every ~50ms; bar fills.
- [ ] On upload completion → widget transitions to "Walking ZIP archive…" within ~100ms (immediate poll).
- [ ] During parsing → "Parsing songs…" + N / 5167 entries + per-status counters.
- [ ] At ~99% → "Finalising…" briefly.
- [ ] On completion → green tick + summary; auto-dismiss after 15s.
- [ ] Hover during 15s window → timer pauses; mouse-leave → timer resets to 15s.
- [ ] Bootstrap toast (bottom-right) remains fully visible alongside import widget (top-right) — no overlap.
- [ ] × button visible throughout; clicking mid-run closes widget but import keeps running on server (verifiable via `/manage/activity-log`).
- [ ] Pre-migration sanity check: revert PhaseLabel migration, run an import → expect graceful behaviour with no phase label rendered, no 1054 errors.

## Related

- #906 (PR #909) — per-songbook breakdown (data shape this PR's frontend reads).
- #908 (PR #910) — activity-log per-failure rows (separate concern; both ship in parallel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)