### PR TITLE
chore(release): bump app version to v0.90.0

### DIFF
--- a/appWeb/public_html/includes/infoAppVer.php
+++ b/appWeb/public_html/includes/infoAppVer.php
@@ -79,7 +79,7 @@ $app["Application"]["Description"]["Keywords"] = "hymns, worship, lyrics, songbo
 /* Semantic version number (MAJOR.MINOR.PATCH) */
 /* Auto-bumped by the version-bump GitHub Action on push to beta */
 /* v1.x.x = Phase 1 (local JSON data), v2.x.x = Phase 2 (iLyrics dB) */
-$app["Application"]["Version"]["Number"] = "0.80.0";
+$app["Application"]["Version"]["Number"] = "0.90.0";
 
 /* Version name: human-readable release name (e.g., "Hymnal", NULL if unused) */
 $app["Application"]["Version"]["Name"] = NULL;


### PR DESCRIPTION
## Summary

Bump app version 0.80.0 → 0.90.0 to reflect the 2026-05-08/09 bulk-import improvement batch landed on alpha across 8 PRs.

## What this batch contained

- **Song arrangement persistence** — `tblSongs.ArrangementJson` (#892 / #893)
- **Per-songbook breakdown of bulk-import results** — `tblBulkImportJobs.PerSongbookJson` (#906 / #909)
- **Activity-log per-failure rows + summary headers** (#908 / #910)
- **Instant + live progress UX** — XHR upload progress + phase labels + auto-dismiss + repositioned widget (#907 / #911)
- **SDA scraper void-tag depth bug fix** unblocked the durable HA #331 wall (#894)
- **SDA scraper native-script folder names** per sdahymnal.org's "Choose another Hymnal" picker (#901 / #902)
- **Reading-progress bar z-index fix** (#899 / #903)
- **CI workflow trigger fixes** for Apple / Android / Changelog (#904 / #905)
- **Session-transcript sync + sync-script portability fixes** (#900)
- **ProjectBrief / project-rules / README / wiki refresh** (#912)

## Why 0.90.0 (not 0.81.0 or 1.0.0)?

Pattern matches recent project history — 0.50 → 0.75 → 0.76 → 0.77 → 0.80 in 0.05–0.10 increments per major batch. Today's batch is comparable in scope to the 0.77 → 0.80 jump (which alone covered just #892 arrangement persistence) — six features + four fixes + one CI hardening + comprehensive docs refresh warrants a 0.10 step rather than a patch increment.

The 0.10 jump leaves room for any follow-up patch versions (0.90.1, 0.90.2) before the next major batch (#898 email delivery and friends) lands.

## Test plan

- [x] `php -l` clean.
- [ ] Spot-check on alpha after deploy: admin footer reads `v0.90.0 Alpha · <build timestamp>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)