### PR TITLE
fix(editor): surface real load-error detail when api?action=load 500s

### DIFF
--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -271,10 +271,29 @@ switch ($action) {
                whitespace inflates the 3,600-song payload by ~25% on
                the wire. */
             echo json_encode($fullData, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
+            /* \Throwable (not \Exception) so PHP \Error subclasses —
+               TypeError, ValueError, mysqli_sql_exception edge cases
+               etc. — also land in the JSON 500 path instead of
+               escaping into an HTML fatal-error response that the
+               editor's toast can't read. */
             http_response_code(500);
-            error_log('[iHymns Editor] Failed to load song data: ' . $e->getMessage());
-            echo json_encode(['error' => 'Failed to load song data from database.']);
+            $logLine = sprintf(
+                '[iHymns Editor] Failed to load song data: %s: %s @ %s:%d',
+                get_class($e),
+                $e->getMessage(),
+                $e->getFile(),
+                $e->getLine()
+            );
+            error_log($logLine);
+            /* Endpoint is editor+ gated (auth check at the top of this
+               file), so returning the real exception class + message
+               is safe and gives the toast something actionable. */
+            echo json_encode([
+                'error'   => 'Failed to load song data from database.',
+                'detail'  => get_class($e) . ': ' . $e->getMessage(),
+                'file'    => basename($e->getFile()) . ':' . $e->getLine(),
+            ]);
         }
         break;
 

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -167,9 +167,25 @@ function _fetchAndParseSongs(target) {
     /* Fetch the remote JSON file. */
     return fetch(target)
         .then(function (response) {
-            /* If the HTTP status indicates failure, throw so we land in .catch(). */
+            /* If the HTTP status indicates failure, try to read the
+               server's JSON error body so the toast shows the real
+               cause instead of a bare "HTTP 500". The editor's API
+               returns `{error, detail, file}` on the load path; older
+               / non-API fallback URLs (static songs.json) won't have
+               a body, so we fall through to the status-line message. */
             if (!response.ok) {
-                throw new Error('HTTP ' + response.status + ' ' + response.statusText);
+                return response.text().then(function (body) {
+                    var detail = '';
+                    try {
+                        var parsed = body ? JSON.parse(body) : null;
+                        if (parsed && typeof parsed === 'object') {
+                            detail = parsed.detail || parsed.error || '';
+                        }
+                    } catch (_e) { /* not JSON — ignore */ }
+                    var msg = 'HTTP ' + response.status + ' ' + response.statusText;
+                    if (detail) msg += ' — ' + detail;
+                    throw new Error(msg);
+                });
             }
             /* Parse the response body as JSON. */
             return response.json();


### PR DESCRIPTION
## Summary

The Song Editor sidebar showed a bare `Could not load from URL: HTTP 500` toast when the load API failed (reproduced on `/manage/editor/?song=MP-0450`) with no information about what went wrong server-side. This PR widens the catch + plumbs the real exception detail through to the toast so the underlying cause can actually be diagnosed.

Three underlying issues fixed:

1. **`case 'load':` caught `\Exception` only** — so a PHP `\Error` subclass (`TypeError`, `ValueError`, `mysqli_sql_exception` edge cases, etc.) bypassed the JSON-500 path and emitted an HTML fatal-error response that the editor's `_fetchAndParseSongs` couldn't read. Widened to `\Throwable`.
2. **Error response was generic** — `Failed to load song data from database.` is fine for a public surface but this endpoint is editor+ gated, and the curator seeing the toast is the same person who needs to fix the issue. Response now includes `detail` (`ClassName: message`) + `file:line`. `error_log` gets the full line too for grepping server logs.
3. **`_fetchAndParseSongs` discarded the response body on non-OK** — now reads the body, parses as JSON when possible, and appends the server's `detail` (or `error`) string to the toast. Curator now sees e.g. `HTTP 500 Internal Server Error — mysqli_sql_exception: Unknown column 'X' in 'field list' @ SongData.php:1604` instead of the bare status line.

Static / non-API fallback URLs in `SONGS_URL_CANDIDATES` (plain `songs.json`) won't have a JSON body — the fall-through keeps the bare HTTP-status message for those.

## Why diagnostic-first

Without server-log access from this branch I can't see the actual stack trace. This commit makes the next reproduction self-diagnosing: once deployed to alpha, refreshing `/manage/editor/?song=MP-0450` will produce a toast carrying the exception class + message + file:line, which then drives the actual root-cause fix.

## Test plan

- [ ] Deploy to alpha → `dev.ihymns.app/manage/editor/?song=MP-0450` → confirm toast now carries `detail` instead of bare `HTTP 500`
- [ ] Capture toast text → file follow-up commit fixing the underlying cause
- [ ] Verify pre-#892 / pre-migration deployment still loads cleanly when no error path is exercised
- [ ] `php -l` clean on `api.php`
- [ ] `node --check` clean on `editor.js`

https://claude.ai/code/session_01HiuUAf9BLgZ1cuf6WsPGL4

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiuUAf9BLgZ1cuf6WsPGL4)_