### PR TITLE
feat(editor): persist editor-load failures to tblActivityLog

### DIFF
--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -55,6 +55,13 @@ if (!$currentUser || !hasRole($currentUser['role'], 'editor')) {
 require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'config.php';
 require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
 require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'SongData.php';
+/* logActivity / logActivityError — needed by every action that
+   wants to write a tblActivityLog row (save_song, bulk_import_*,
+   load failure path). Was previously imported transitively in
+   some call sites and absent in others; pulling it here means
+   `function_exists('logActivity')` is always true inside this
+   endpoint and the helper is available unconditionally. */
+require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'activity_log.php';
 
 /**
  * Cached check for the tblSongArtists table (#587). The table arrives
@@ -286,6 +293,29 @@ switch ($action) {
                 $e->getLine()
             );
             error_log($logLine);
+
+            /* Persist the failure to tblActivityLog so the curator who
+               hit the 500 (and the curator triaging from the activity
+               log later) sees the same exception class + message +
+               file:line that the toast surfaces. Best-effort —
+               logActivityError swallows its own failures so a logging
+               outage can't compound the original 500. */
+            $stack = $e->getTraceAsString();
+            logActivityError(
+                'editor.load_failed',
+                'song_corpus',
+                '',
+                $e,
+                [
+                    /* Truncate the trace defensively — tblActivityLog.Details
+                       is JSON, so MySQL imposes its own size limit and a
+                       full PHP backtrace can blow past 64 KB on a deep
+                       call stack. 4 KB is plenty to identify the failing
+                       frame without flooding the table. */
+                    'trace' => mb_substr($stack, 0, 4096),
+                ]
+            );
+
             /* Endpoint is editor+ gated (auth check at the top of this
                file), so returning the real exception class + message
                is safe and gives the toast something actionable. */


### PR DESCRIPTION
## Summary

Follow-up to #916. That PR widened the catch + plumbed the real exception detail through to the toast / PHP `error_log`, but the failure never landed in `tblActivityLog` — which is the audit trail curators (and `/manage/activity-log`) actually read. A 500 on `/manage/editor/?song=X` should leave a `Result='error'` row behind so the incident is grep-able from the admin UI alongside every other server-side failure.

## Changes

Two small edits to `appWeb/public_html/manage/editor/api.php`:

1. **Unconditional `require_once includes/activity_log.php`** at the bootstrap, alongside `config` / `db_mysql` / `SongData`. Existing call sites (`save_song`, `bulk_import_*`) all guard with `function_exists('logActivity')` because the helper was previously loaded transitively in some paths and absent in others — pulling it in here lets the load handler call `logActivityError` directly and removes the footgun for future call sites too.

2. **Add `logActivityError` to the `case 'load':` catch-block** (after the `error_log` line). The helper captures `class` + `message` + `file` + `line` automatically; we add a `trace` field truncated to 4 KB via `mb_substr` so a deep PHP stack doesn't blow past the JSON column size limit on `tblActivityLog.Details`. `logActivityError` is best-effort — swallows its own failures — so a logging outage cannot compound the original 500.

## Activity-log row produced

```
Action      = editor.load_failed
EntityType  = song_corpus
EntityId    = ""
Result      = error
Details     = { error, class, file, line, trace[≤4096] }
```

Curators can filter `/manage/activity-log` by `Action=editor.load_failed` to find every editor 500 with full server-side context.

## Test plan

- [ ] Deploy to alpha → trigger a known failure (e.g. drop a column SongData reads) → confirm a `Result='error'` row lands in `tblActivityLog` with the expected `Details` shape
- [ ] Confirm `/manage/activity-log` filters cleanly on the new `editor.load_failed` action
- [ ] Confirm a deliberate `logActivityError` failure (e.g. DB unreachable mid-handler) does NOT propagate — the 500 JSON response should still be returned cleanly
- [ ] `php -l` clean on `api.php`

## Related

- #916 (the diagnostic-visibility commit this builds on)

https://claude.ai/code/session_01HiuUAf9BLgZ1cuf6WsPGL4

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiuUAf9BLgZ1cuf6WsPGL4)_