### PR TITLE
chore(deploy): force-redeploy setup-database.php for #919 card

### DIFF
--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -239,6 +239,12 @@ $friendlyTitles = [
     'bulk-import-per-songbook'         => 'Bulk-Import Per-Songbook Breakdown (#906)',
     'bulk-import-phase-label'          => 'Bulk-Import Phase Label (#907)',
     'activity-log-proxy-vpn'           => 'Activity Log Proxy/VPN + Per-Request',
+    /* No-op file-touch (force-deploy 2026-05-09) — the previous SFTP
+       deploy of #919 skipped this file under lftp `--only-newer`
+       because the local file mtime didn't surpass the remote's
+       prior-deploy mtime. This whitespace nudge gives the next
+       deploy a fresh-mtime file to upload, getting the new
+       activity-log-proxy-vpn card onto the dashboard. */
     /* `recompute-songbook-songcount` no longer exposed via the dashboard
        (#818) — the SongCount Triggers migration above includes its own
        initial recompute. The CLI script stays on disk for emergency


### PR DESCRIPTION
## Summary

Force-redeploy `setup-database.php` so the new "Activity Log Proxy/VPN + Per-Request" card from #919 actually lands on `dev.ihymns.app`.

The card definition + probe + migration script all merged in #919 and the deploy job ran successfully ~2 minutes after merge. Yet the card isn't visible on the dashboard, and `tblIpReputation` isn't in the table list — ruling out "already applied".

Cause: `deploy.yml` uses `lftp mirror --only-newer`, which compares mtimes. GitHub Actions' `git checkout` doesn't always bump the local mtime above the remote's prior-deploy mtime, so a file with a real git diff can be silently skipped on upload. Other files in the same PR (the new `migrate-*.php`, `activity_log.php`, `schema.sql`) were brand-new or had longer diffs and presumably uploaded.

## Changes

Whitespace + comment nudge in `setup-database.php` to give the next deploy a fresh-mtime file. Commit message includes `[deploy all]` which `deploy.yml` honours as a belt-and-braces full-deploy override (deploy.yml L130-133).

No functional change.

## Test plan

- [ ] Deploy completes successfully on alpha
- [ ] Refresh `/manage/setup-database` on dev → "Activity Log Proxy/VPN + Per-Request" card appears in the pending list
- [ ] Run the migration → card moves into the applied expander, `tblIpReputation` appears in the table list, `tblActivityLog.ProxyVpnIndicator` column exists

## Related

- #919 (the merged PR whose card got skipped)

https://claude.ai/code/session_01HiuUAf9BLgZ1cuf6WsPGL4

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiuUAf9BLgZ1cuf6WsPGL4)_