### PR TITLE
fix(ci): make [deploy all] actually force re-upload (drop --only-newer)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -131,6 +131,19 @@ jobs:
             echo "Full deploy requested via [deploy all]"
             echo "has_changes=true" >> $GITHUB_OUTPUT
             echo "full_deploy=true" >> $GITHUB_OUTPUT
+            # Drop --only-newer so lftp mirror compares size+content
+            # rather than mtime — mtime alone is unreliable in CI
+            # because actions/checkout sets every file's mtime to the
+            # checkout time, which can be EARLIER than the remote's
+            # prior-deploy mtime if the previous deploy ran later
+            # than this one's checkout step. That's the failure mode
+            # that left #919's setup-database.php diff stranded on
+            # the runner during deploy 280 even though the diff
+            # itself was real (the file got [deploy all]'d in #920
+            # and STILL didn't upload because that flag was being
+            # ignored). With --only-newer dropped, lftp re-uploads
+            # any file whose size or content differs.
+            echo "mirror_newer_flag=" >> $GITHUB_OUTPUT
           else
             # Check last 5 commits for changes in the source directory OR
             # the sibling directories we also deploy (.sql, .auth).
@@ -140,10 +153,12 @@ jobs:
             if [[ -z "$CHANGED" ]]; then
               echo "has_changes=false" >> $GITHUB_OUTPUT
               echo "full_deploy=false" >> $GITHUB_OUTPUT
+              echo "mirror_newer_flag=--only-newer" >> $GITHUB_OUTPUT
               echo "No deployable files changed in $SOURCE_DIR"
             else
               echo "has_changes=true" >> $GITHUB_OUTPUT
               echo "full_deploy=false" >> $GITHUB_OUTPUT
+              echo "mirror_newer_flag=--only-newer" >> $GITHUB_OUTPUT
               echo "Changed files:"
               echo "$CHANGED"
             fi
@@ -318,7 +333,7 @@ jobs:
           cat > /tmp/lftp_script.txt <<LFTP_EOF
           set sftp:connect-program "ssh -o StrictHostKeyChecking=no -i $HOME/.ssh/deploy_key -p ${SFTP_PORT}"
           open sftp://${SFTP_USER}@${SFTP_HOST}:${SFTP_PORT}
-          mirror --reverse --delete --verbose --only-newer --no-empty-dirs $LFTP_EXCLUDES ${SOURCE_DIR} ${REMOTE_PATH}
+          mirror --reverse --delete --verbose ${{ steps.changes.outputs.mirror_newer_flag }} --no-empty-dirs $LFTP_EXCLUDES ${SOURCE_DIR} ${REMOTE_PATH}
           bye
           LFTP_EOF
           lftp -f /tmp/lftp_script.txt
@@ -336,7 +351,7 @@ jobs:
         run: |
           lftp -u "${SFTP_USER},${SFTP_PASS}" \
             -e "set sftp:auto-confirm yes; set ssl:verify-certificate no; \
-            mirror --reverse --delete --verbose --only-newer --no-empty-dirs \
+            mirror --reverse --delete --verbose ${{ steps.changes.outputs.mirror_newer_flag }} --no-empty-dirs \
             $LFTP_EXCLUDES \
             ${SOURCE_DIR} ${REMOTE_PATH}; bye" \
             "sftp://${SFTP_HOST}:${SFTP_PORT}"
@@ -394,7 +409,7 @@ jobs:
           cat > /tmp/lftp_private.txt <<LFTP_EOF
           set sftp:connect-program "ssh -o StrictHostKeyChecking=no -i $HOME/.ssh/deploy_key -p ${SFTP_PORT}"
           open sftp://${SFTP_USER}@${SFTP_HOST}:${SFTP_PORT}
-          mirror --reverse --delete --verbose --only-newer --no-empty-dirs $LFTP_EXCLUDES appWeb/private_html/ ${REMOTE_PATH}
+          mirror --reverse --delete --verbose ${{ steps.changes.outputs.mirror_newer_flag }} --no-empty-dirs $LFTP_EXCLUDES appWeb/private_html/ ${REMOTE_PATH}
           bye
           LFTP_EOF
           lftp -f /tmp/lftp_private.txt
@@ -419,7 +434,7 @@ jobs:
           fi
           lftp -u "${SFTP_USER},${SFTP_PASS}" \
             -e "set sftp:auto-confirm yes; set ssl:verify-certificate no; \
-            mirror --reverse --delete --verbose --only-newer --no-empty-dirs \
+            mirror --reverse --delete --verbose ${{ steps.changes.outputs.mirror_newer_flag }} --no-empty-dirs \
             $LFTP_EXCLUDES \
             appWeb/private_html/ ${REMOTE_PATH}; bye" \
             "sftp://${SFTP_HOST}:${SFTP_PORT}"
@@ -450,7 +465,7 @@ jobs:
           cat > /tmp/lftp_datashare.txt <<LFTP_EOF
           set sftp:connect-program "ssh -o StrictHostKeyChecking=no -i $HOME/.ssh/deploy_key -p ${SFTP_PORT}"
           open sftp://${SFTP_USER}@${SFTP_HOST}:${SFTP_PORT}
-          mirror --reverse --verbose --only-newer --no-empty-dirs $LFTP_EXCLUDES appWeb/data_share/ ${DATA_SHARE_PATH}
+          mirror --reverse --verbose ${{ steps.changes.outputs.mirror_newer_flag }} --no-empty-dirs $LFTP_EXCLUDES appWeb/data_share/ ${DATA_SHARE_PATH}
           bye
           LFTP_EOF
           lftp -f /tmp/lftp_datashare.txt
@@ -470,7 +485,7 @@ jobs:
           echo "Deploying data_share to: $DATA_SHARE_PATH"
           lftp -u "${SFTP_USER},${SFTP_PASS}" \
             -e "set sftp:auto-confirm yes; set ssl:verify-certificate no; \
-            mirror --reverse --verbose --only-newer --no-empty-dirs \
+            mirror --reverse --verbose ${{ steps.changes.outputs.mirror_newer_flag }} --no-empty-dirs \
             $LFTP_EXCLUDES \
             appWeb/data_share/ ${DATA_SHARE_PATH}; bye" \
             "sftp://${SFTP_HOST}:${SFTP_PORT}"
@@ -499,7 +514,7 @@ jobs:
           cat > /tmp/lftp_sql.txt <<LFTP_EOF
           set sftp:connect-program "ssh -o StrictHostKeyChecking=no -i $HOME/.ssh/deploy_key -p ${SFTP_PORT}"
           open sftp://${SFTP_USER}@${SFTP_HOST}:${SFTP_PORT}
-          mirror --reverse --delete --verbose --only-newer --no-empty-dirs $LFTP_EXCLUDES appWeb/.sql/ ${SQL_PATH}
+          mirror --reverse --delete --verbose ${{ steps.changes.outputs.mirror_newer_flag }} --no-empty-dirs $LFTP_EXCLUDES appWeb/.sql/ ${SQL_PATH}
           bye
           LFTP_EOF
           lftp -f /tmp/lftp_sql.txt
@@ -519,7 +534,7 @@ jobs:
           echo "Deploying .sql to: $SQL_PATH"
           lftp -u "${SFTP_USER},${SFTP_PASS}" \
             -e "set sftp:auto-confirm yes; set ssl:verify-certificate no; \
-            mirror --reverse --delete --verbose --only-newer --no-empty-dirs \
+            mirror --reverse --delete --verbose ${{ steps.changes.outputs.mirror_newer_flag }} --no-empty-dirs \
             $LFTP_EXCLUDES \
             appWeb/.sql/ ${SQL_PATH}; bye" \
             "sftp://${SFTP_HOST}:${SFTP_PORT}"
@@ -550,7 +565,7 @@ jobs:
           cat > /tmp/lftp_auth.txt <<LFTP_EOF
           set sftp:connect-program "ssh -o StrictHostKeyChecking=no -i $HOME/.ssh/deploy_key -p ${SFTP_PORT}"
           open sftp://${SFTP_USER}@${SFTP_HOST}:${SFTP_PORT}
-          mirror --reverse --verbose --only-newer --no-empty-dirs --exclude ^db_credentials\.php$ $LFTP_EXCLUDES appWeb/.auth/ ${AUTH_PATH}
+          mirror --reverse --verbose ${{ steps.changes.outputs.mirror_newer_flag }} --no-empty-dirs --exclude ^db_credentials\.php$ $LFTP_EXCLUDES appWeb/.auth/ ${AUTH_PATH}
           bye
           LFTP_EOF
           lftp -f /tmp/lftp_auth.txt
@@ -570,7 +585,7 @@ jobs:
           echo "Deploying .auth to: $AUTH_PATH (excluding db_credentials.php)"
           lftp -u "${SFTP_USER},${SFTP_PASS}" \
             -e "set sftp:auto-confirm yes; set ssl:verify-certificate no; \
-            mirror --reverse --verbose --only-newer --no-empty-dirs \
+            mirror --reverse --verbose ${{ steps.changes.outputs.mirror_newer_flag }} --no-empty-dirs \
             --exclude ^db_credentials\.php$ $LFTP_EXCLUDES \
             appWeb/.auth/ ${AUTH_PATH}; bye" \
             "sftp://${SFTP_HOST}:${SFTP_PORT}"


### PR DESCRIPTION
## Summary

The `deploy.yml` workflow advertised a `[deploy all]` commit-message flag for "force full deploy regardless of change detection" — but the flag only set a `full_deploy=true` step output that **nothing in the workflow consumed**. Every `lftp mirror` command (10 of them — public_html, private_html, data_share, .sql, .auth × ssh + password paths) still ran with `--only-newer`, so the "force" semantic was a lie.

This bit us in #919 → #920:

1. PR #919 added a real diff to `appWeb/public_html/manage/setup-database.php` (registering a new "Activity Log Proxy/VPN + Per-Request" migration card)
2. The deploy job ran successfully ~2min after merge, but the file never landed on `dev.ihymns.app`
3. PR #920 added `[deploy all]` in the commit message expecting it to force a re-upload — but the flag was ignored, so the second deploy was just as impotent as the first

Cause: `actions/checkout@v5` sets every file's mtime to the time of the checkout step on the runner. `lftp mirror --only-newer` compares LOCAL mtime against REMOTE mtime — if the remote file's mtime (from a previous deploy that ran AFTER this run's checkout) is newer than local, the upload is silently skipped.

## Fix

- The change-detect step now also exports a `mirror_newer_flag` output: **empty string in `[deploy all]` mode**, `--only-newer` in every other case
- All 10 `lftp mirror` commands now substitute `${{ steps.changes.outputs.mirror_newer_flag }}` where they previously hardcoded `--only-newer`
- When the flag is empty, lftp falls back to its default size-and-mtime comparison (still upload-only-when-different, not "re-upload everything every time"), which catches the case where mtime is wrong but size or content actually changed

## This PR self-tests the fix

This commit's own message includes `[deploy all]`, so the fix deploys itself AND carries the still-stranded `setup-database.php` diff from #919 up to the server in one go. After this merges:

1. `deploy.yml` worker reads `[deploy all]` from the commit message
2. Sets `mirror_newer_flag=""` (empty)
3. lftp mirror runs without `--only-newer`
4. Sees `setup-database.php` differs in content (the #919 changes never reached the server)
5. Re-uploads it

Reload `/manage/setup-database` after the deploy completes — the "Activity Log Proxy/VPN + Per-Request" card should finally appear.

## Test plan

- [ ] Deploy job completes successfully on alpha
- [ ] `/manage/setup-database` shows the new card in the pending list
- [ ] Run the migration → `tblIpReputation` appears in the table list

## Related

- #919 (the PR whose `setup-database.php` diff got skipped)
- #920 (the first attempt to force re-deploy, which proved that `[deploy all]` was a no-op)

https://claude.ai/code/session_01HiuUAf9BLgZ1cuf6WsPGL4

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiuUAf9BLgZ1cuf6WsPGL4)_