### PR TITLE
fix(activity-log): drop extra 's' from bind_param type string (closes #923)

### DIFF
--- a/appWeb/public_html/includes/activity_log.php
+++ b/appWeb/public_html/includes/activity_log.php
@@ -279,8 +279,22 @@ function logActivity(
         $proxyIndTrim   = $proxyInd   !== null ? substr($proxyInd,   0, 50)  : null;
 
         if ($hasProxyCols) {
+            /* 14 placeholders → 14 type chars: 1×'i' (UserId)
+               + 12×'s' (Action / EntityType / EntityId / Result /
+               Details / IpAddress / IpProxyChain / ProxyVpnIndicator /
+               ProxyVpnDetail / UserAgent / RequestId / Method)
+               + 1×'i' (DurationMs).
+               #923 — was previously `'isssssssssssssi'` (15 chars,
+               one extra 's'), which made bind_param throw
+               `Number of elements in type definition string
+               doesn't match number of bind variables`. The catch at
+               the bottom of this function swallows the throw to an
+               error_log line, so every logActivity() call after the
+               proxy/VPN migration ran landed silently in the file
+               log instead of tblActivityLog — the audit trail went
+               dark from #919 deploy until this fix shipped. */
             $stmt->bind_param(
-                'isssssssssssssi',
+                'issssssssssssi',
                 $resolvedUserId,
                 $actionTrim,
                 $entityTrim,


### PR DESCRIPTION
## P0 / regression hotfix

`tblActivityLog` writes have been silently failing for every request since #919's proxy/VPN migration ran on alpha around 10:32 UK time on 2026-05-09. The audit trail went dark — `/manage/activity-log` shows 218 entries, none newer than 10:32:35, despite continued service use.

## One-character fix

```diff
 if ($hasProxyCols) {
+    /* 14 placeholders → 14 type chars: 1×'i' (UserId) + 12×'s' …
+       #923 — was previously `'isssssssssssssi'` (15 chars, one extra 's'). */
     $stmt->bind_param(
-        'isssssssssssssi',
+        'issssssssssssi',
         $resolvedUserId, $actionTrim, $entityTrim, $entityIdTrim,
         $result, $detailsJson, $ip, $proxyChainTrim,
         $proxyIndTrim, $proxyDetailJson, $ua, $rid,
         $methodTrim, $duration
     );
 }
```

The bound variables were correct (14 values). The type string had one extra `s`. Every call to this branch threw `mysqli_sql_exception: Number of elements in type definition string doesn't match number of bind variables`, the function-level try/catch swallowed it to a single `error_log` line, and `tblActivityLog` got nothing.

The legacy fallback (`$hasProxyCols=false`, line 300) has the correct 11-char type string for its 11 placeholders — pre-migration deployments were unaffected.

## What this restores

Once deployed:

- Per-request rows from `installRequestActivityLogger()` start landing again (`request.success` / `request.failure` / `request.error`).
- Uncaught throwables / PHP fatals from `installGlobalActivityLogHandlers()` resume mirroring to `tblActivityLog`.
- Editor / admin / auth events that call `logActivity()` directly resume working.
- The MP-0450 500 reported in #923 will produce a visible `request.error` row with status=500 + path + duration + IP/proxy detail. The curator can at least *find* the failed request in `/manage/activity-log` even though the toast still won't surface error detail (separate follow-up).

## Verification

- [x] `php -l` clean.
- [x] Type string length verified: `len('issssssssssssi') = 14` matches 14 placeholders.
- [ ] Post-deploy: smoke-test by hitting any /manage/* page; confirm a `request.success` row appears within seconds in `/manage/activity-log`.
- [ ] `error_log` no longer carries a sustained stream of `[activity_log] write failed` lines (a sustained stream of those is the symptom of the regression).

## Why this is also a security finding

`/manage/activity-log` is the **audit trail surface** used to detect anomalous behaviour — failed login bursts, unusual admin activity, abuse patterns. With it silent, none of those signals were visible. Combined with #898's existing finding (auth tokens leaking to file-based error_log), this left curator audit visibility in PHP's file log only — harder to access, harder to filter, harder to monitor than the activity-log UI. Hotfix priority.

## Out of scope (separate follow-ups)

- Editor → 5xx surfacing: when `/manage/editor/?song=MP-0450` 500s, the toast says "Failed to load song" with no error class / message. Pattern to copy: PR #759's `save_song` admin/global_admin error_detail surfacing.
- Defensive: bind_param type-string length check at runtime so a future similar typo throws a clearer error than mysqli's generic "Number of elements doesn't match" — possibly via a `_logActivityBindParam()` helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)