### PR TITLE
fix(editor): surface 5xx error detail from /api?action=load (closes #925)

### DIFF
--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -140,15 +140,28 @@ function loadSongsFromURL(url) {
     /* Otherwise, try each candidate path in order until one succeeds. */
     var candidates = SONGS_URL_CANDIDATES.slice();
 
-    function tryNext() {
+    /* #925 — capture the most-recent candidate's error and surface it
+       in the final fallback toast. Pre-#925 the catch silently
+       discarded the error and tried the next candidate; if every
+       candidate failed (e.g. /api?action=load returns 500 with a real
+       exception), the curator only saw the bare "could not load from
+       any path" message and lost the diagnostic detail that the API
+       already returns in its `detail` field. */
+    function tryNext(lastErr) {
         if (candidates.length === 0) {
-            showToast('Could not load songs.json from any path. Use "Load JSON" to load manually.', 'warning');
+            var msg = 'Could not load songs.json from any path. Use "Load JSON" to load manually.';
+            if (lastErr && lastErr.message) {
+                msg += ' Last error: ' + lastErr.message;
+            }
+            showToast(msg, 'warning');
             return Promise.resolve();
         }
         var candidate = candidates.shift();
-        return _fetchAndParseSongs(candidate).catch(function () {
-            /* This path failed — try the next one */
-            return tryNext();
+        return _fetchAndParseSongs(candidate).catch(function (err) {
+            /* This path failed — try the next one, carrying the
+               error forward so we can surface it if every
+               candidate also fails. */
+            return tryNext(err);
         });
     }
 


### PR DESCRIPTION
## Summary

The Song Editor's load path was correctly **fetching** the server-side error detail but then **discarding** it in the candidate-URL fallback chain. Two-line fix: pass the error forward through `tryNext()` so the final fallback toast can append it.

## Reproducer

In #923's MP-0450 case (or any case where `SongData::exportAsJson()` throws), the server returns:

```json
{
  "error":   "Failed to load song data from database.",
  "detail":  "TypeError: Cannot read property 'x' of undefined",
  "file":    "SongData.php:1543"
}
```

`_fetchAndParseSongs()` correctly parses the `detail` field and rejects with `new Error('HTTP 500 Internal Server Error — TypeError: Cannot read …')`. But:

```js
function tryNext() {
    if (candidates.length === 0) {
        showToast('Could not load songs.json from any path. …', 'warning');  // ← no error context
        return Promise.resolve();
    }
    return _fetchAndParseSongs(candidate).catch(function () {
        return tryNext();  // ← swallows `err`
    });
}
```

After every candidate fails, the curator sees only `"Could not load songs.json from any path. Use 'Load JSON' to load manually."` — no clue what actually broke.

## Diff

```diff
-    function tryNext() {
+    function tryNext(lastErr) {
         if (candidates.length === 0) {
-            showToast('Could not load songs.json from any path. Use "Load JSON" to load manually.', 'warning');
+            var msg = 'Could not load songs.json from any path. Use "Load JSON" to load manually.';
+            if (lastErr && lastErr.message) {
+                msg += ' Last error: ' + lastErr.message;
+            }
+            showToast(msg, 'warning');
             return Promise.resolve();
         }
         var candidate = candidates.shift();
-        return _fetchAndParseSongs(candidate).catch(function () {
-            return tryNext();
+        return _fetchAndParseSongs(candidate).catch(function (err) {
+            return tryNext(err);
         });
     }
```

Pattern matches PR #759's `save_song` admin/global_admin error_detail surfacing. The editor is admin-gated so showing the exception detail is safe and gives the toast something actionable.

## Test plan

- [x] `node --check appWeb/public_html/manage/editor/editor.js` clean.
- [ ] Post-deploy: hit the editor when the API is intentionally broken (e.g. drop a `tblSongbooks` FK temporarily on dev DB) → toast shows the captured server error with file:line.
- [ ] Fresh-dev fallback regression check: in a setup where the API isn't reachable, the toast still surfaces the warning + a benign network-error message. `"Last error: Failed to fetch"` is more useful than no context.

## Related

- #923 / #924 — the activity-log silent regression that surfaced this UX gap. Once #924 lands the MP-0450 500 will produce a `request.error` row in `/manage/activity-log` with full server-side detail; this PR is the matching frontend surfacing for curators who don't have the activity log open when they hit the error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)