### PR TITLE
feat(db): defensive bindParamSafe() helper + retrofit activity_log (closes #926)

### DIFF
--- a/appWeb/public_html/includes/activity_log.php
+++ b/appWeb/public_html/includes/activity_log.php
@@ -292,8 +292,15 @@ function logActivity(
                error_log line, so every logActivity() call after the
                proxy/VPN migration ran landed silently in the file
                log instead of tblActivityLog — the audit trail went
-               dark from #919 deploy until this fix shipped. */
-            $stmt->bind_param(
+               dark from #919 deploy until #924 shipped.
+               #926 — defensive `bindParamSafe()` from db_mysql.php
+               throws a context-named RuntimeException ("bind_param
+               mismatch in logActivity (post-#919) INSERT: …") if
+               the type string and arg count ever drift again,
+               instead of mysqli's generic message that originally
+               masked the regression. */
+            bindParamSafe(
+                'logActivity (post-#919) INSERT', $stmt,
                 'issssssssssssi',
                 $resolvedUserId,
                 $actionTrim,
@@ -311,7 +318,10 @@ function logActivity(
                 $duration
             );
         } else {
-            $stmt->bind_param(
+            /* #926 — same defensive helper for the legacy 11-col
+               INSERT (pre-migration deploys). */
+            bindParamSafe(
+                'logActivity (legacy) INSERT', $stmt,
                 'isssssssssi',
                 $resolvedUserId,
                 $actionTrim,

--- a/appWeb/public_html/includes/db_mysql.php
+++ b/appWeb/public_html/includes/db_mysql.php
@@ -94,3 +94,55 @@ function getDbMysqli(): mysqli
 
     return $_mysqliConnection;
 }
+
+/**
+ * Defensive `bind_param` wrapper. Asserts that the type-string length
+ * matches the number of bound variables BEFORE calling
+ * `$stmt->bind_param`, so a typo throws a clear error naming the
+ * calling site rather than mysqli's generic "Number of elements in
+ * type definition string doesn't match number of bind variables"
+ * which is easy to misattribute to a query-level problem.
+ *
+ * Motivated by #923 — a one-character typo in
+ * `activity_log.php`'s INSERT type string (`'isssssssssssssi'`,
+ * 15 chars vs 14 placeholders) caused every logActivity() call to
+ * silently fail for hours after #919's deploy. The function-level
+ * try/catch swallowed mysqli's exception to a single error_log line
+ * and `tblActivityLog` got nothing — the audit trail went dark.
+ *
+ * Helper signature:
+ *
+ *     bindParamSafe(string $context, \mysqli_stmt $stmt,
+ *                   string $types, mixed ...$args): bool
+ *
+ *     - $context: short descriptor of the calling site, used in
+ *                 the thrown error so the maintainer can find it
+ *                 without grepping. e.g. 'logActivity INSERT'.
+ *     - $stmt:    the prepared statement to bind against.
+ *     - $types:   the mysqli type-string ('issssi' etc.).
+ *     - $args:    the variables, varargs.
+ *
+ * Throws \RuntimeException with a clear message when length(types)
+ * !== count(args). Otherwise delegates to $stmt->bind_param() and
+ * returns its bool.
+ *
+ * Adoption: incremental — use in any new bind_param site, plus
+ * targeted retrofit of files where the regression originated
+ * (activity_log.php at minimum). The full repo-wide sweep is
+ * tracked in #926's "out of scope" section as a separate concern.
+ */
+function bindParamSafe(string $context, \mysqli_stmt $stmt, string $types, mixed ...$args): bool
+{
+    $expected = strlen($types);
+    $given    = count($args);
+    if ($expected !== $given) {
+        throw new \RuntimeException(sprintf(
+            'bind_param mismatch in %s: type string has %d chars (%s) but %d args were passed',
+            $context,
+            $expected,
+            $types,
+            $given
+        ));
+    }
+    return $stmt->bind_param($types, ...$args);
+}


### PR DESCRIPTION
## Summary

Defensive wrapper around `mysqli_stmt::bind_param()` that asserts the type-string length matches the variable count BEFORE delegating, so a future typo throws a context-named error naming the calling site rather than mysqli's generic "Number of elements doesn't match" — which originally masked the #923 regression for hours.

## API

```php
bindParamSafe(string $context, \mysqli_stmt $stmt, string $types, mixed ...$args): bool
```

On mismatch, throws:

```
RuntimeException("bind_param mismatch in logActivity (post-#919) INSERT:
                  type string has 14 chars (issssssssssssi) but 13 args were passed")
```

The calling function's try/catch then writes a useful `error_log` line instead of the previous generic message.

## Retrofit

`activity_log.php`'s two `bind_param` sites now use the helper, each named so a future mismatch is grep-friendly:

- `logActivity (post-#919) INSERT` — 14 cols (post-migration)
- `logActivity (legacy) INSERT` — 11 cols (pre-migration)

These are the hot-development sites that produced the regression. The full repo-wide sweep is **deliberately out of scope** — see issue #926's "out of scope" section for the rationale.

## Diff summary

```
 appWeb/public_html/includes/db_mysql.php     | +47   (helper)
 appWeb/public_html/includes/activity_log.php | +13 -3 (retrofit)
 2 files changed, 65 insertions(+), 3 deletions(-)
```

## Test plan

- [x] `php -l` clean on both touched files.
- [x] Helper logic 5 lines, trivial to audit.
- [ ] Post-deploy: `tblActivityLog` keeps writing rows (regression check — confirms the retrofit didn't introduce a different bug). Easy verification — hit any /manage/* page and confirm a `request.success` row appears within ~2s in `/manage/activity-log`.
- [ ] Hostile test: deliberately introduce a typo in one of the retrofitted sites locally; confirm the resulting error_log line names the calling site (`'logActivity (post-#919) INSERT'`) rather than the generic mysqli message. Don't ship the typo.

## Future work (separate issues if needed)

- Repo-wide sweep of remaining `bind_param` sites — only worth it for new development; stable code stays put.
- Equivalent helper for `prepare()` SQL-string placeholder count vs vars — different shape, separate concern.
- `.claude/project-rules.md` §13 rule: "use `bindParamSafe()` for any new `bind_param` site that's not in proven legacy code" — worth adding next docs refresh.

## Related

- #923 — the regression this defends against.
- #924 — the one-character hotfix already shipped.
- #925 / #927 — sibling editor 5xx surfacing fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)