### PR TITLE
fix(migrations): use getDbMysqli() instead of bogus MYSQL_HOST constants (#898 hotfix)

### DIFF
--- a/appWeb/.sql/migrate-email-login-token-hashing.php
+++ b/appWeb/.sql/migrate-email-login-token-hashing.php
@@ -28,48 +28,69 @@ declare(strict_types=1);
  * the helper changes deployed leaves new rows unhashed; running the
  * helper changes without this leaves old rows that lookups can't
  * match (they expire in 10 min anyway). Apply the migration as part
- * of the same deploy. (#898 follow-up)
+ * of the same deploy.
  *
  * @migration-modifies tblEmailLoginTokens (drops unused rows)
  *
  * USAGE:
  *   CLI:  php appWeb/.sql/migrate-email-login-token-hashing.php
- *   Web:  /manage/setup-database -> "Email Login Token Hashing" button
+ *   Web:  /manage/setup-database -> "Email Login Token Hashing (#898 follow-up)" button
  *
  * @requires PHP 8.1+ with mysqli extension
  */
 
-$isCli = (php_sapi_name() === 'cli');
-
-if (!$isCli && !defined('IHYMNS_SETUP_DASHBOARD')) {
-    header('Content-Type: text/plain; charset=UTF-8');
-    header('X-Content-Type-Options: nosniff');
-    header('Cache-Control: no-store');
+if (PHP_SAPI === 'cli') {
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = true;
+} else {
+    if (!defined('IHYMNS_SETUP_DASHBOARD')) {
+        if (!function_exists('isAuthenticated')) {
+            require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+        }
+        if (!isAuthenticated()) {
+            http_response_code(401);
+            exit('Authentication required.');
+        }
+        $u = getCurrentUser();
+        if (!$u || $u['role'] !== 'global_admin') {
+            http_response_code(403);
+            exit('Global admin required.');
+        }
+    }
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = false;
 }
 
-function _migEmailLoginHash_output(string $msg): void {
+function _migEmailLoginHash_out(string $line): void
+{
     global $isCli;
-    echo $msg . ($isCli ? "\n" : "<br>\n");
-    if (!$isCli) flush();
+    echo $line . ($isCli ? "\n" : "<br>\n");
+    if ($isCli) flush();
 }
 
-$credFile = dirname(__DIR__) . DIRECTORY_SEPARATOR . '.auth' . DIRECTORY_SEPARATOR . 'db_credentials.php';
-if (!file_exists($credFile)) {
-    _migEmailLoginHash_output('ERROR: MySQL credentials not found. Run install.php first.');
-    return;
+function _migEmailLoginHash_tableExists(\mysqli $db, string $table): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? LIMIT 1'
+    );
+    $stmt->bind_param('s', $table);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
 }
-require_once $credFile;
 
-_migEmailLoginHash_output('');
-_migEmailLoginHash_output('=== iHymns - Email Login Token Hashing Migration (#898 follow-up) ===');
-_migEmailLoginHash_output('');
+_migEmailLoginHash_out('Email Login Token Hashing migration starting (#898 follow-up)…');
 
-$mysqli = new mysqli(MYSQL_HOST, MYSQL_USER, MYSQL_PASS, MYSQL_DB);
-if ($mysqli->connect_errno) {
-    _migEmailLoginHash_output('ERROR: MySQL connection failed: ' . $mysqli->connect_error);
-    return;
+$mysqli = getDbMysqli();
+if (!$mysqli) {
+    throw new \RuntimeException('Could not connect to database.');
 }
-$mysqli->set_charset('utf8mb4');
 
 /* Sentinel-driven idempotency. */
 $sentinelKey = 'email_login_token_hashed';
@@ -81,25 +102,13 @@ $check->execute();
 $sentinelRow = $check->get_result()->fetch_row();
 $check->close();
 if ($sentinelRow && (string)$sentinelRow[0] === '1') {
-    _migEmailLoginHash_output('SKIP: sentinel email_login_token_hashed=1 already set.');
-    _migEmailLoginHash_output('');
-    _migEmailLoginHash_output('Migration complete (no changes needed).');
-    $mysqli->close();
+    _migEmailLoginHash_out('[skip] sentinel email_login_token_hashed=1 already set.');
+    _migEmailLoginHash_out('Email Login Token Hashing migration finished (#898 follow-up).');
     return;
 }
 
-/* Confirm the table exists; nothing to do if a fresh install already
-   has the new schema. */
-$probe = $mysqli->query(
-    "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
-      WHERE TABLE_SCHEMA = DATABASE()
-        AND TABLE_NAME   = 'tblEmailLoginTokens' LIMIT 1"
-);
-$tableExists = $probe && $probe->fetch_row();
-if ($probe) { $probe->close(); }
-
-if (!$tableExists) {
-    _migEmailLoginHash_output('SKIP: tblEmailLoginTokens not present yet — running install.php / fresh install.');
+if (!_migEmailLoginHash_tableExists($mysqli, 'tblEmailLoginTokens')) {
+    _migEmailLoginHash_out('[skip] tblEmailLoginTokens not present yet — fresh install / install.php first.');
 } else {
     /* Drop any rows holding raw tokens. The new helpers will start
        writing sha256-hashed values; mixing the two would let a
@@ -110,14 +119,12 @@ if (!$tableExists) {
     $rowCount = (int)($countRow[0] ?? 0);
     if ($rowCount > 0) {
         if (!$mysqli->query('DELETE FROM tblEmailLoginTokens')) {
-            _migEmailLoginHash_output('ERROR: DELETE failed: ' . $mysqli->error);
-            $mysqli->close();
-            return;
+            throw new \RuntimeException('DELETE FROM tblEmailLoginTokens failed: ' . $mysqli->error);
         }
-        _migEmailLoginHash_output("CLEARED: {$rowCount} legacy row(s) from tblEmailLoginTokens.");
-        _migEmailLoginHash_output('Any user mid-sign-in will need to request a fresh code.');
+        _migEmailLoginHash_out("[purge] cleared {$rowCount} legacy row(s) from tblEmailLoginTokens.");
+        _migEmailLoginHash_out('        any user mid-sign-in needs to request a fresh code.');
     } else {
-        _migEmailLoginHash_output('OK: tblEmailLoginTokens already empty — nothing to clear.');
+        _migEmailLoginHash_out('[ok  ] tblEmailLoginTokens already empty — nothing to clear.');
     }
 }
 
@@ -131,13 +138,10 @@ $set = $mysqli->prepare(
 $one = '1';
 $set->bind_param('sss', $sentinelKey, $one, $desc);
 if (!$set->execute()) {
-    _migEmailLoginHash_output('WARN: could not set sentinel (' . $mysqli->error . '); migration body still ran.');
+    _migEmailLoginHash_out('[warn] could not set sentinel (' . $mysqli->error . '); migration body still ran.');
 } else {
-    _migEmailLoginHash_output('SENTINEL: tblAppSettings.email_login_token_hashed = 1');
+    _migEmailLoginHash_out('[mark] tblAppSettings.email_login_token_hashed = 1.');
 }
 $set->close();
 
-_migEmailLoginHash_output('');
-_migEmailLoginHash_output('Migration complete.');
-
-$mysqli->close();
+_migEmailLoginHash_out('Email Login Token Hashing migration finished (#898 follow-up).');

--- a/appWeb/.sql/migrate-email-verification-tokens.php
+++ b/appWeb/.sql/migrate-email-verification-tokens.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * iHymns — Email Verification Tokens Migration (#898)
+ * iHymns - Email Verification Tokens Migration (#898)
  *
  * Copyright (c) 2026 iHymns. All rights reserved.
  *
@@ -13,64 +13,73 @@ declare(strict_types=1);
  * SHA-256 hash of the raw token (raw token only ever lives in the
  * outbound email body); 24-hour expiry; single-use.
  *
- * @migration-creates tblEmailVerificationTokens
- *
  * Idempotent — re-running is a no-op when the table already exists.
+ *
+ * @migration-creates tblEmailVerificationTokens
  *
  * USAGE:
  *   CLI:  php appWeb/.sql/migrate-email-verification-tokens.php
- *   Web:  /manage/setup-database -> "Email Verification Tokens" button
- *         (entry point requires global_admin)
+ *   Web:  /manage/setup-database -> "Email Verification Tokens (#898)" button
  *
  * @requires PHP 8.1+ with mysqli extension
  */
 
-$isCli = (php_sapi_name() === 'cli');
-
-if (!$isCli && !defined('IHYMNS_SETUP_DASHBOARD')) {
-    header('Content-Type: text/plain; charset=UTF-8');
-    header('X-Content-Type-Options: nosniff');
-    header('Cache-Control: no-store');
+if (PHP_SAPI === 'cli') {
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = true;
+} else {
+    if (!defined('IHYMNS_SETUP_DASHBOARD')) {
+        if (!function_exists('isAuthenticated')) {
+            require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+        }
+        if (!isAuthenticated()) {
+            http_response_code(401);
+            exit('Authentication required.');
+        }
+        $u = getCurrentUser();
+        if (!$u || $u['role'] !== 'global_admin') {
+            http_response_code(403);
+            exit('Global admin required.');
+        }
+    }
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = false;
 }
 
-function _migEmailVerify_output(string $msg): void {
+function _migEmailVerify_out(string $line): void
+{
     global $isCli;
-    echo $msg . ($isCli ? "\n" : "<br>\n");
-    if (!$isCli) flush();
+    echo $line . ($isCli ? "\n" : "<br>\n");
+    if ($isCli) flush();
 }
 
-$credFile = dirname(__DIR__) . DIRECTORY_SEPARATOR . '.auth' . DIRECTORY_SEPARATOR . 'db_credentials.php';
-if (!file_exists($credFile)) {
-    _migEmailVerify_output('ERROR: MySQL credentials not found. Run install.php first.');
-    return;
+function _migEmailVerify_tableExists(\mysqli $db, string $table): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? LIMIT 1'
+    );
+    $stmt->bind_param('s', $table);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
 }
-require_once $credFile;
 
-_migEmailVerify_output('');
-_migEmailVerify_output('=== iHymns - Email Verification Tokens Migration (#898) ===');
-_migEmailVerify_output('');
+_migEmailVerify_out('Email Verification Tokens migration starting (#898)…');
 
-$mysqli = new mysqli(MYSQL_HOST, MYSQL_USER, MYSQL_PASS, MYSQL_DB);
-if ($mysqli->connect_errno) {
-    _migEmailVerify_output('ERROR: MySQL connection failed: ' . $mysqli->connect_error);
-    return;
+$mysqli = getDbMysqli();
+if (!$mysqli) {
+    throw new \RuntimeException('Could not connect to database.');
 }
-$mysqli->set_charset('utf8mb4');
 
-/* Existence check — keep the migration idempotent. */
-$check = $mysqli->query(
-    "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
-      WHERE TABLE_SCHEMA = DATABASE()
-        AND TABLE_NAME   = 'tblEmailVerificationTokens' LIMIT 1"
-);
-$exists = $check && $check->fetch_row();
-if ($check) { $check->close(); }
-
-if ($exists) {
-    _migEmailVerify_output('SKIP: tblEmailVerificationTokens already exists.');
-    _migEmailVerify_output('');
-    _migEmailVerify_output('Migration complete (no changes needed).');
-    $mysqli->close();
+if (_migEmailVerify_tableExists($mysqli, 'tblEmailVerificationTokens')) {
+    _migEmailVerify_out('[skip] tblEmailVerificationTokens already exists.');
+    _migEmailVerify_out('Email Verification Tokens migration finished (#898).');
     return;
 }
 
@@ -93,12 +102,8 @@ CREATE TABLE tblEmailVerificationTokens (
 SQL;
 
 if (!$mysqli->query($sql)) {
-    _migEmailVerify_output('ERROR: CREATE TABLE failed: ' . $mysqli->error);
-    $mysqli->close();
-    return;
+    throw new \RuntimeException('CREATE TABLE tblEmailVerificationTokens failed: ' . $mysqli->error);
 }
-_migEmailVerify_output('CREATED: tblEmailVerificationTokens');
-_migEmailVerify_output('');
-_migEmailVerify_output('Migration complete.');
 
-$mysqli->close();
+_migEmailVerify_out('[add ] tblEmailVerificationTokens (CHAR(64) PK, FK to tblUsers).');
+_migEmailVerify_out('Email Verification Tokens migration finished (#898).');

--- a/appWeb/.sql/migrate-password-reset-token-hash-width.php
+++ b/appWeb/.sql/migrate-password-reset-token-hash-width.php
@@ -14,55 +14,62 @@ declare(strict_types=1);
  *
  * @migration-modifies tblPasswordResetTokens.Token
  *
- * Pre-existing rows hold a 48-char prefix; lookups for them stay
- * functional (the lookup query also produces a 64-char hash, but the
- * primary-key match against an old row would now fail). Reset tokens
- * expire in 1 hour, so any in-flight tokens at deploy time naturally
- * cycle out within the hour and the issue self-resolves.
+ * Pre-existing rows hold a 48-char prefix; the post-ALTER lookup
+ * computes a 64-char hash that won't match a 48-char-prefix row.
+ * Reset tokens expire in 1 hour, so any in-flight tokens at deploy
+ * time naturally cycle out within the hour and the issue self-resolves.
  *
  * Idempotent — re-running is a no-op when the column is already wide.
  *
  * USAGE:
  *   CLI:  php appWeb/.sql/migrate-password-reset-token-hash-width.php
- *   Web:  /manage/setup-database -> "Password Reset Token Hash Width" button
+ *   Web:  /manage/setup-database -> "Password Reset Token Hash Width (#898 follow-up)" button
  *
  * @requires PHP 8.1+ with mysqli extension
  */
 
-$isCli = (php_sapi_name() === 'cli');
-
-if (!$isCli && !defined('IHYMNS_SETUP_DASHBOARD')) {
-    header('Content-Type: text/plain; charset=UTF-8');
-    header('X-Content-Type-Options: nosniff');
-    header('Cache-Control: no-store');
+if (PHP_SAPI === 'cli') {
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = true;
+} else {
+    if (!defined('IHYMNS_SETUP_DASHBOARD')) {
+        if (!function_exists('isAuthenticated')) {
+            require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+        }
+        if (!isAuthenticated()) {
+            http_response_code(401);
+            exit('Authentication required.');
+        }
+        $u = getCurrentUser();
+        if (!$u || $u['role'] !== 'global_admin') {
+            http_response_code(403);
+            exit('Global admin required.');
+        }
+    }
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = false;
 }
 
-function _migPwResetWidth_output(string $msg): void {
+function _migPwResetWidth_out(string $line): void
+{
     global $isCli;
-    echo $msg . ($isCli ? "\n" : "<br>\n");
-    if (!$isCli) flush();
+    echo $line . ($isCli ? "\n" : "<br>\n");
+    if ($isCli) flush();
 }
 
-$credFile = dirname(__DIR__) . DIRECTORY_SEPARATOR . '.auth' . DIRECTORY_SEPARATOR . 'db_credentials.php';
-if (!file_exists($credFile)) {
-    _migPwResetWidth_output('ERROR: MySQL credentials not found. Run install.php first.');
-    return;
-}
-require_once $credFile;
+_migPwResetWidth_out('Password Reset Token Hash Width migration starting (#898 follow-up)…');
 
-_migPwResetWidth_output('');
-_migPwResetWidth_output('=== iHymns - Password Reset Token Hash Width Migration (#898 follow-up) ===');
-_migPwResetWidth_output('');
-
-$mysqli = new mysqli(MYSQL_HOST, MYSQL_USER, MYSQL_PASS, MYSQL_DB);
-if ($mysqli->connect_errno) {
-    _migPwResetWidth_output('ERROR: MySQL connection failed: ' . $mysqli->connect_error);
-    return;
+$mysqli = getDbMysqli();
+if (!$mysqli) {
+    throw new \RuntimeException('Could not connect to database.');
 }
-$mysqli->set_charset('utf8mb4');
 
 /* Probe the current column width before touching it. */
-$probe = $mysqli->query(
+$stmt = $mysqli->prepare(
     "SELECT DATA_TYPE, CHARACTER_MAXIMUM_LENGTH
        FROM INFORMATION_SCHEMA.COLUMNS
       WHERE TABLE_SCHEMA = DATABASE()
@@ -70,41 +77,35 @@ $probe = $mysqli->query(
         AND COLUMN_NAME  = 'Token'
       LIMIT 1"
 );
-$row = $probe ? $probe->fetch_assoc() : null;
-if ($probe) { $probe->close(); }
+$stmt->execute();
+$row = $stmt->get_result()->fetch_assoc();
+$stmt->close();
 
 if (!$row) {
-    _migPwResetWidth_output('SKIP: tblPasswordResetTokens.Token column not found '
-                          . '(table may not exist yet — run install.php first).');
-    $mysqli->close();
+    _migPwResetWidth_out('[skip] tblPasswordResetTokens.Token column not found '
+                       . '(table may not exist yet — run install.php first).');
+    _migPwResetWidth_out('Password Reset Token Hash Width migration finished (#898 follow-up).');
     return;
 }
 
 $len  = (int)($row['CHARACTER_MAXIMUM_LENGTH'] ?? 0);
 $type = strtolower((string)$row['DATA_TYPE']);
 if ($len >= 64 && $type === 'char') {
-    _migPwResetWidth_output('SKIP: tblPasswordResetTokens.Token is already CHAR(64) — no change needed.');
-    _migPwResetWidth_output('');
-    _migPwResetWidth_output('Migration complete (no changes needed).');
-    $mysqli->close();
+    _migPwResetWidth_out('[skip] tblPasswordResetTokens.Token is already CHAR(64).');
+    _migPwResetWidth_out('Password Reset Token Hash Width migration finished (#898 follow-up).');
     return;
 }
 
-_migPwResetWidth_output("Current column: {$type}({$len}) — widening to CHAR(64)...");
+_migPwResetWidth_out("Current column: {$type}({$len}) — widening to CHAR(64)…");
 
 if (!$mysqli->query('ALTER TABLE tblPasswordResetTokens MODIFY Token CHAR(64) NOT NULL')) {
-    _migPwResetWidth_output('ERROR: ALTER TABLE failed: ' . $mysqli->error);
-    $mysqli->close();
-    return;
+    throw new \RuntimeException(
+        'ALTER TABLE tblPasswordResetTokens MODIFY Token CHAR(64) failed: ' . $mysqli->error
+    );
 }
 
-_migPwResetWidth_output('MODIFIED: tblPasswordResetTokens.Token -> CHAR(64) NOT NULL');
-_migPwResetWidth_output('');
-_migPwResetWidth_output('Note: any password-reset tokens created before this migration ran');
-_migPwResetWidth_output('hold a 48-char prefix and will fail to validate. They expire in 1');
-_migPwResetWidth_output('hour, so any user who started a reset just before deploy needs to');
-_migPwResetWidth_output('request a fresh link.');
-_migPwResetWidth_output('');
-_migPwResetWidth_output('Migration complete.');
-
-$mysqli->close();
+_migPwResetWidth_out('[add ] tblPasswordResetTokens.Token -> CHAR(64) NOT NULL.');
+_migPwResetWidth_out('Note: any password-reset tokens created before this migration ran');
+_migPwResetWidth_out('hold a 48-char prefix and will fail to validate. They expire in 1');
+_migPwResetWidth_out('hour, so any user mid-reset needs to request a fresh link.');
+_migPwResetWidth_out('Password Reset Token Hash Width migration finished (#898 follow-up).');


### PR DESCRIPTION
Hotfix for #922 / #898 follow-up — the three new migrations failed at runtime with `Undefined constant "MYSQL_HOST"` when triggered from `/manage/setup-database`.

## Summary

- Root cause: I authored the three migrations against a hallucinated `MYSQL_HOST` / `MYSQL_USER` / `MYSQL_PASS` / `MYSQL_DB` credential contract. Those constants don't exist anywhere in the repo — `grep -r MYSQL_HOST appWeb` returns zero hits.
- Canonical pattern: `getDbMysqli()` from `appWeb/public_html/includes/db_mysql.php` reads `DB_HOST` / `DB_USER` / `DB_PASS` / `DB_NAME` (+ optional `DB_PORT` / `DB_CHARSET`) from `appWeb/.auth/db_credentials.php`. Every PHP request that touches the DB goes through this path.
- Fix: rewrote all three to mirror `migrate-bulk-import-phase-label.php` (#907) — CLI/web SAPI gate, global_admin guard for unauthenticated web invocations, `getDbMysqli()` singleton, `throw \RuntimeException` on failure so the dashboard's runner surfaces a real trace.

## Behaviour unchanged

- `migrate-email-verification-tokens.php` — still creates `tblEmailVerificationTokens` (idempotent: skip if present).
- `migrate-password-reset-token-hash-width.php` — still `ALTER`s `tblPasswordResetTokens.Token` to `CHAR(64)` (idempotent: skip if already wide).
- `migrate-email-login-token-hashing.php` — still purges raw rows and sets the `email_login_token_hashed=1` sentinel in `tblAppSettings` (idempotent: skip if sentinel set).

## Test plan

- [x] `php -l` clean on all three migrations.
- [ ] Deploy to alpha → `/manage/setup-database` → run each of the three migrations. Each shows the expected `[skip]` output on a re-run.
- [ ] Re-run a fourth time after sleeping a moment → still no-ops (sentinel / probe paths exercised).

## Out of scope

`db_credentials.php` itself doesn't need changes — it already follows the modern `DB_*` pattern that `getDbMysqli()` consumes. Nothing to clean up there.

https://claude.ai/code/session_01XRgvsMurPiSpQHA7h6Jv2q

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRgvsMurPiSpQHA7h6Jv2q)_