### PR TITLE
Quick-wins batch: 7 commits closing #936 #937 #938 #939 #940 #941 #942

### DIFF
--- a/appWeb/.sql/backfill-works-from-iswc.php
+++ b/appWeb/.sql/backfill-works-from-iswc.php
@@ -1,0 +1,320 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Works backfill from existing ISWCs (#942)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Songs already carry ISWC values in tblSongs.Iswc, but the Works
+ * admin page reports zero rows because nothing has populated tblWorks
+ * yet. ISWC is the authoritative composition identifier — songs that
+ * share an ISWC are by definition the same composition. So we can
+ * derive Works directly from the existing data without any external
+ * API calls or manual curation.
+ *
+ * For each distinct ISWC in tblSongs:
+ *   1. Find or create a tblWorks row keyed on Iswc.
+ *   2. INSERT IGNORE every member song into tblWorkSongs.
+ *   3. For Works newly created in this run, set Title to the most-
+ *      common Title across member songs (alphabetic tiebreak), and
+ *      derive Slug from that Title.
+ *   4. Mark the song with the lowest-numbered Number (or first
+ *      alphabetic SongId if numbers tie) as IsCanonical=1.
+ *
+ * Idempotent — re-runs don't overwrite existing tblWorks rows; only
+ * the missing memberships are added. Curator manual edits are safe.
+ *
+ * USAGE:
+ *   Web:  /manage/setup-database → "Backfill Works from existing ISWCs"
+ *   CLI:  php appWeb/.sql/backfill-works-from-iswc.php
+ *
+ * NOT a schema migration — this is a one-shot data task. The schema
+ * lives in migrate-works.php (#840).
+ */
+
+if (PHP_SAPI === 'cli') {
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = true;
+} else {
+    if (!defined('IHYMNS_SETUP_DASHBOARD')) {
+        if (!function_exists('isAuthenticated')) {
+            require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+        }
+        if (!isAuthenticated()) {
+            http_response_code(401);
+            exit('Authentication required.');
+        }
+        $u = getCurrentUser();
+        if (!$u || $u['role'] !== 'global_admin') {
+            http_response_code(403);
+            exit('Global admin required.');
+        }
+    }
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = false;
+}
+
+function _migIswcWorks_out(string $line): void
+{
+    global $isCli;
+    echo $line . ($isCli ? "\n" : "<br>\n");
+    if ($isCli) {
+        flush();
+    }
+}
+
+function _migIswcWorks_tableExists(mysqli $db, string $table): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE()
+            AND TABLE_NAME = ? LIMIT 1'
+    );
+    $stmt->bind_param('s', $table);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+/**
+ * Slugify mirroring the Works admin's existing convention: lowercase,
+ * non-alnum collapses to '-', trim leading/trailing hyphens. Length
+ * capped at 80 to fit the UNIQUE Slug column.
+ */
+function _migIswcWorks_slug(string $name): string
+{
+    $name  = mb_strtolower(trim($name));
+    if (class_exists('Normalizer')) {
+        $name = Normalizer::normalize($name, Normalizer::FORM_KD);
+        $name = preg_replace('/\p{M}+/u', '', $name);
+    }
+    $slug = preg_replace('/[^\p{L}\p{N}]+/u', '-', $name);
+    $slug = trim((string)$slug, '-');
+    if (mb_strlen($slug) > 80) {
+        $slug = mb_substr($slug, 0, 80);
+    }
+    return $slug;
+}
+
+_migIswcWorks_out('Works ISWC backfill starting…');
+
+$db = getDbMysqli();
+if (!$db) {
+    _migIswcWorks_out('ERROR: could not connect to database.');
+    exit(1);
+}
+
+if (!_migIswcWorks_tableExists($db, 'tblWorks')
+    || !_migIswcWorks_tableExists($db, 'tblWorkSongs')
+) {
+    _migIswcWorks_out('ERROR: tblWorks / tblWorkSongs missing — run migrate-works.php first.');
+    exit(1);
+}
+
+/* ----------------------------------------------------------------------
+ * Step 1: find every ISWC in tblSongs and the songs grouped under it.
+ * ---------------------------------------------------------------------- */
+$res = $db->query(
+    "SELECT Iswc, SongId, Title, Number
+       FROM tblSongs
+      WHERE Iswc IS NOT NULL AND TRIM(Iswc) <> ''
+      ORDER BY Iswc, Number ASC, SongId ASC"
+);
+if (!$res) {
+    _migIswcWorks_out('ERROR: SELECT from tblSongs failed: ' . $db->error);
+    exit(1);
+}
+
+$byIswc = [];
+while ($row = $res->fetch_assoc()) {
+    $iswc = strtoupper(trim((string)$row['Iswc']));
+    if ($iswc === '') continue;
+    $byIswc[$iswc][] = [
+        'song_id' => (string)$row['SongId'],
+        'title'   => (string)$row['Title'],
+        'number'  => $row['Number'] !== null ? (int)$row['Number'] : null,
+    ];
+}
+$res->close();
+
+if (empty($byIswc)) {
+    _migIswcWorks_out('[seed] no ISWCs found on tblSongs — nothing to backfill.');
+    _migIswcWorks_out('Works ISWC backfill finished.');
+    return;
+}
+
+_migIswcWorks_out(sprintf(
+    '[seed] found %d distinct ISWC%s spanning %d song%s.',
+    count($byIswc), count($byIswc) === 1 ? '' : 's',
+    array_sum(array_map('count', $byIswc)),
+    array_sum(array_map('count', $byIswc)) === 1 ? '' : 's'
+));
+
+/* ----------------------------------------------------------------------
+ * Step 2: pre-load existing slugs so the new-Work creation path can
+ * collision-suffix without a per-row probe.
+ * ---------------------------------------------------------------------- */
+$takenSlugs = [];
+$res = $db->query("SELECT Slug FROM tblWorks WHERE Slug <> ''");
+if ($res) {
+    while ($r = $res->fetch_assoc()) $takenSlugs[(string)$r['Slug']] = true;
+    $res->close();
+}
+
+/* ----------------------------------------------------------------------
+ * Step 3: for each ISWC, find-or-create the Work, then add memberships.
+ * ---------------------------------------------------------------------- */
+$worksFound      = 0;
+$worksCreated    = 0;
+$membersAdded    = 0;
+$membersExisting = 0;
+
+foreach ($byIswc as $iswc => $songs) {
+    /* find existing Work row keyed on ISWC */
+    $stmt = $db->prepare('SELECT Id FROM tblWorks WHERE Iswc = ? LIMIT 1');
+    $stmt->bind_param('s', $iswc);
+    $stmt->execute();
+    $r = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+
+    if ($r) {
+        $workId = (int)$r['Id'];
+        $worksFound++;
+    } else {
+        /* Create a new Work. Title = most common across member songs,
+           with alphabetic tiebreak. Slug derived from that Title with
+           collision suffix. */
+        $titleCounts = [];
+        foreach ($songs as $s) {
+            $t = trim((string)$s['title']);
+            if ($t === '') continue;
+            $titleCounts[$t] = ($titleCounts[$t] ?? 0) + 1;
+        }
+        if (empty($titleCounts)) {
+            /* Defensive — every member missing a title shouldn't happen
+               in practice. Fall back to the ISWC itself. */
+            $title = $iswc;
+        } else {
+            arsort($titleCounts, SORT_NUMERIC);
+            $maxCount = reset($titleCounts);
+            /* Among titles tied at the max count, pick alphabetically. */
+            $tied = array_keys(array_filter(
+                $titleCounts,
+                static fn($c) => $c === $maxCount
+            ));
+            sort($tied, SORT_STRING);
+            $title = $tied[0];
+        }
+        $slugBase = _migIswcWorks_slug($title);
+        if ($slugBase === '') $slugBase = 'work';
+        $slug = $slugBase;
+        $suffix = 1;
+        while (isset($takenSlugs[$slug])) {
+            $suffix++;
+            $slug = $slugBase . '-' . $suffix;
+            if (mb_strlen($slug) > 80) {
+                /* Slug overflow — truncate base + retry. */
+                $slugBase = mb_substr($slugBase, 0, 78 - mb_strlen((string)$suffix));
+                $slug = $slugBase . '-' . $suffix;
+            }
+        }
+        $takenSlugs[$slug] = true;
+
+        $stmt = $db->prepare(
+            'INSERT INTO tblWorks (Iswc, Title, Slug, Notes)
+             VALUES (?, ?, ?, ?)'
+        );
+        $notes = sprintf('Auto-created from ISWC %s on %s by backfill task #942.',
+            $iswc, gmdate('Y-m-d'));
+        $stmt->bind_param('ssss', $iswc, $title, $slug, $notes);
+        $stmt->execute();
+        $workId = (int)$db->insert_id;
+        $stmt->close();
+
+        $worksCreated++;
+        _migIswcWorks_out(sprintf(
+            '[add ] Work #%d "%s" (slug=%s, ISWC=%s, %d member%s).',
+            $workId, $title, $slug, $iswc,
+            count($songs), count($songs) === 1 ? '' : 's'
+        ));
+    }
+
+    /* Pick the canonical member: lowest non-null Number, tiebreak by
+       alphabetic SongId. Only set if there isn't already a canonical
+       member on this Work (re-runs preserve the curator's choice). */
+    $existingCanon = null;
+    $stmt = $db->prepare(
+        'SELECT SongId FROM tblWorkSongs WHERE WorkId = ? AND IsCanonical = 1 LIMIT 1'
+    );
+    $stmt->bind_param('i', $workId);
+    $stmt->execute();
+    $cr = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+    $existingCanon = $cr['SongId'] ?? null;
+
+    $canonSongId = null;
+    if ($existingCanon === null) {
+        usort($songs, static function ($a, $b) {
+            $an = $a['number'] ?? PHP_INT_MAX;
+            $bn = $b['number'] ?? PHP_INT_MAX;
+            if ($an !== $bn) return $an <=> $bn;
+            return strcmp($a['song_id'], $b['song_id']);
+        });
+        $canonSongId = $songs[0]['song_id'] ?? null;
+    }
+
+    /* Insert memberships. INSERT IGNORE so re-runs no-op on existing
+       composite-key rows. */
+    $insMember = $db->prepare(
+        'INSERT IGNORE INTO tblWorkSongs (WorkId, SongId, IsCanonical)
+         VALUES (?, ?, ?)'
+    );
+    foreach ($songs as $s) {
+        $sid = $s['song_id'];
+        $isCanon = ($canonSongId !== null && $sid === $canonSongId) ? 1 : 0;
+        $insMember->bind_param('isi', $workId, $sid, $isCanon);
+        $insMember->execute();
+        if ($insMember->affected_rows > 0) {
+            $membersAdded++;
+        } else {
+            $membersExisting++;
+        }
+    }
+    $insMember->close();
+}
+
+_migIswcWorks_out(sprintf(
+    'Backfill complete: %d existing Work%s found, %d new Work%s created, %d member%s added, %d already linked.',
+    $worksFound,    $worksFound === 1    ? '' : 's',
+    $worksCreated,  $worksCreated === 1  ? '' : 's',
+    $membersAdded,  $membersAdded === 1  ? '' : 's',
+    $membersExisting
+));
+
+if (function_exists('logActivity')) {
+    try {
+        logActivity(
+            'admin.works.iswc_backfill',
+            'works',
+            '',
+            [
+                'works_found'      => $worksFound,
+                'works_created'    => $worksCreated,
+                'members_added'    => $membersAdded,
+                'members_existing' => $membersExisting,
+            ],
+            'success'
+        );
+    } catch (\Throwable $_e) { /* best-effort */ }
+}
+
+_migIswcWorks_out('Works ISWC backfill finished.');
+/* Don't close $db — see migrate-credit-people-slug.php for rationale. */

--- a/appWeb/.sql/migrate-catalogues.php
+++ b/appWeb/.sql/migrate-catalogues.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Catalogues migration (#941)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Adds the Catalogue concept — a free-form many-to-many grouping of
+ * songs that doesn't fit the Songbook / Songbook Series hierarchy.
+ *
+ * Use cases:
+ *   - Thematic collections ("Christmas / Advent", "Easter morning")
+ *   - Worship-leader curations ("Modern", "Traditional")
+ *   - Trans-denominational groupings ("SDA-affiliated",
+ *     "Methodist heritage")
+ *   - Public-Domain-only views
+ *   - Future: per-user personal catalogues (admin-only at v1)
+ *
+ * Schema:
+ *   tblCatalogues       — one row per catalogue (slug + title + meta)
+ *   tblCatalogueSongs   — many-to-many join (catalogue ↔ song)
+ *
+ * @migration-adds tblCatalogues
+ * @migration-adds tblCatalogueSongs
+ *
+ * Idempotent — re-running is safe; tables that exist are skipped.
+ *
+ * USAGE:
+ *   Web:  /manage/setup-database → Apply all pending migrations
+ *   CLI:  php appWeb/.sql/migrate-catalogues.php
+ */
+
+if (PHP_SAPI === 'cli') {
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = true;
+} else {
+    if (!defined('IHYMNS_SETUP_DASHBOARD')) {
+        if (!function_exists('isAuthenticated')) {
+            require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+        }
+        if (!isAuthenticated()) {
+            http_response_code(401);
+            exit('Authentication required.');
+        }
+        $u = getCurrentUser();
+        if (!$u || $u['role'] !== 'global_admin') {
+            http_response_code(403);
+            exit('Global admin required.');
+        }
+    }
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = false;
+}
+
+function _migCat_out(string $line): void
+{
+    global $isCli;
+    echo $line . ($isCli ? "\n" : "<br>\n");
+    if ($isCli) {
+        flush();
+    }
+}
+
+function _migCat_tableExists(mysqli $db, string $table): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE()
+            AND TABLE_NAME = ?
+          LIMIT 1'
+    );
+    $stmt->bind_param('s', $table);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+_migCat_out('Catalogues migration starting…');
+
+$mysqli = getDbMysqli();
+if (!$mysqli) {
+    _migCat_out('ERROR: could not connect to database.');
+    exit(1);
+}
+
+/* tblSongs must exist — Catalogue rows reference SongIds. */
+if (!_migCat_tableExists($mysqli, 'tblSongs')) {
+    _migCat_out('ERROR: tblSongs is missing — run install.php before this migration.');
+    exit(1);
+}
+
+/* ----------------------------------------------------------------------
+ * Step 1: tblCatalogues — the catalogue registry
+ * ---------------------------------------------------------------------- */
+if (_migCat_tableExists($mysqli, 'tblCatalogues')) {
+    _migCat_out('[skip] tblCatalogues already present.');
+} else {
+    $sql = "CREATE TABLE tblCatalogues (
+        Id           INT UNSIGNED      AUTO_INCREMENT PRIMARY KEY,
+        Slug         VARCHAR(255)      NOT NULL,
+        Title        VARCHAR(255)      NOT NULL,
+        Description  TEXT              NULL,
+        SortOrder    SMALLINT          NOT NULL DEFAULT 0,
+        Visibility   ENUM('public','curated','admin_only')
+                                        NOT NULL DEFAULT 'public',
+        CreatedAt    DATETIME          NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        UpdatedAt    DATETIME          NOT NULL DEFAULT CURRENT_TIMESTAMP
+                                        ON UPDATE CURRENT_TIMESTAMP,
+        UNIQUE KEY uk_Slug (Slug),
+        INDEX idx_Visibility (Visibility),
+        INDEX idx_SortOrder  (SortOrder)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
+
+    if (!$mysqli->query($sql)) {
+        _migCat_out('ERROR: creating tblCatalogues failed: ' . $mysqli->error);
+        exit(1);
+    }
+    _migCat_out('[add ] tblCatalogues.');
+}
+
+/* ----------------------------------------------------------------------
+ * Step 2: tblCatalogueSongs — the many-to-many join
+ *
+ * Composite PK on (CatalogueId, SongId) prevents duplicate links.
+ * SortOrder lets curators arrange the listing order within a catalogue.
+ * AddedBy + AddedAt give a basic audit trail without a full revisions
+ * table — adequate for a v1 admin surface.
+ * ---------------------------------------------------------------------- */
+if (_migCat_tableExists($mysqli, 'tblCatalogueSongs')) {
+    _migCat_out('[skip] tblCatalogueSongs already present.');
+} else {
+    $sql = "CREATE TABLE tblCatalogueSongs (
+        CatalogueId  INT UNSIGNED      NOT NULL,
+        SongId       VARCHAR(20)       NOT NULL,
+        SortOrder    INT               NOT NULL DEFAULT 0,
+        AddedBy      INT UNSIGNED      NULL,
+        AddedAt      DATETIME          NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (CatalogueId, SongId),
+        INDEX idx_SongId (SongId),
+        INDEX idx_SortOrder (CatalogueId, SortOrder),
+        CONSTRAINT fk_CatalogueSongs_Catalogue
+            FOREIGN KEY (CatalogueId) REFERENCES tblCatalogues(Id)
+            ON DELETE CASCADE ON UPDATE CASCADE,
+        CONSTRAINT fk_CatalogueSongs_Song
+            FOREIGN KEY (SongId) REFERENCES tblSongs(SongId)
+            ON DELETE CASCADE ON UPDATE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
+
+    if (!$mysqli->query($sql)) {
+        _migCat_out('ERROR: creating tblCatalogueSongs failed: ' . $mysqli->error);
+        exit(1);
+    }
+    _migCat_out('[add ] tblCatalogueSongs.');
+}
+
+_migCat_out('Catalogues migration finished.');
+/* Don't close $mysqli — see migrate-credit-people-slug.php for the
+   shared-singleton rationale. */

--- a/appWeb/.sql/schema.sql
+++ b/appWeb/.sql/schema.sql
@@ -1519,7 +1519,7 @@ CREATE TABLE IF NOT EXISTS tblSongLinks (
 
 -- ----------------------------------------------------------------------------
 -- tblSongLinkSuggestions (#808) — pre-computed pairwise similarity scores.
--- Populated by tools/build-song-link-suggestions.php; consumed by the
+-- Populated by appWeb/public_html/includes/tools/build-song-link-suggestions.php; consumed by the
 -- /manage/song-link-suggestions admin page. Pairs are stored canonically
 -- with SongIdA < SongIdB so each unordered pair has at most one row.
 -- ----------------------------------------------------------------------------

--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -363,6 +363,23 @@ if ($page !== null) {
             require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'pages' . DIRECTORY_SEPARATOR . 'work.php';
             break;
 
+        case 'tune':
+            /* #940 — /tune/<slug> public page listing every song that
+               uses the named tune. Empty slug → friendly empty-state
+               page rather than a hard error. */
+            $tuneSlug = isset($_GET['slug']) ? trim($_GET['slug']) : '';
+            require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'pages' . DIRECTORY_SEPARATOR . 'tune.php';
+            break;
+
+        case 'iswc':
+            /* #940 — /iswc/<code> public page listing every song that
+               shares the ISWC code (T-NNN.NNN.NNN-N format). The page
+               normalises the code defensively (strips non-T/digit
+               characters, uppercases the leading T). */
+            $iswcCode = isset($_GET['code']) ? trim($_GET['code']) : '';
+            require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'pages' . DIRECTORY_SEPARATOR . 'iswc.php';
+            break;
+
         case 'help':
             require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'pages' . DIRECTORY_SEPARATOR . 'help.php';
             break;
@@ -2611,6 +2628,137 @@ if ($action !== null) {
                 }
             }
             $stmt->close();
+
+            /* #940 — Works-graph translations. Two songs that sit anywhere
+               in the same Work's tree (ancestor, descendant, sibling at any
+               depth) and carry a different language are translations of
+               each other. The Works graph is rooted by ISWC where available
+               (#840), so this catches translations that haven't been
+               explicitly linked via tblSongTranslations. Schema-probed —
+               pre-#840 deployments silently skip. */
+            try {
+                $wprobe = $db->query(
+                    "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+                      WHERE TABLE_SCHEMA = DATABASE()
+                        AND TABLE_NAME = 'tblWorkSongs' LIMIT 1"
+                );
+                $hasWorks = $wprobe && $wprobe->fetch_row() !== null;
+                if ($wprobe) $wprobe->close();
+            } catch (\Throwable $_e) { $hasWorks = false; }
+
+            if ($hasWorks) {
+                /* Find this song's Work memberships, then walk to the
+                   tree root (ParentWorkId IS NULL), then walk down to
+                   collect every member song. We do this in one CTE-free
+                   query with three steps to keep MySQL 5.7 compatibility. */
+                $stmt = $db->prepare('SELECT WorkId FROM tblWorkSongs WHERE SongId = ?');
+                $stmt->bind_param('s', $translationSongId);
+                $stmt->execute();
+                $directWorkIds = array_column(
+                    $stmt->get_result()->fetch_all(MYSQLI_ASSOC), 'WorkId'
+                );
+                $stmt->close();
+
+                /* Walk to root for each direct Work, collecting the
+                   ancestor chain. Bounded depth (10) so a malformed
+                   self-cycle can't infinite-loop. */
+                $rootWorkIds = [];
+                foreach ($directWorkIds as $wid) {
+                    $cursor = (int)$wid;
+                    $depth = 0;
+                    while ($cursor > 0 && $depth < 10) {
+                        $stmt = $db->prepare('SELECT ParentWorkId FROM tblWorks WHERE Id = ?');
+                        $stmt->bind_param('i', $cursor);
+                        $stmt->execute();
+                        $row = $stmt->get_result()->fetch_assoc();
+                        $stmt->close();
+                        if (!$row) break;
+                        if ($row['ParentWorkId'] === null) {
+                            $rootWorkIds[$cursor] = true;
+                            break;
+                        }
+                        $cursor = (int)$row['ParentWorkId'];
+                        $depth++;
+                    }
+                }
+
+                /* Walk down from each root to collect every descendant.
+                   Iterative BFS so a deep tree doesn't blow the stack. */
+                $descendantWorkIds = [];
+                $frontier = array_keys($rootWorkIds);
+                while (!empty($frontier)) {
+                    foreach ($frontier as $f) {
+                        $descendantWorkIds[(int)$f] = true;
+                    }
+                    $placeholders = implode(',', array_fill(0, count($frontier), '?'));
+                    $types = str_repeat('i', count($frontier));
+                    $stmt = $db->prepare(
+                        "SELECT Id FROM tblWorks WHERE ParentWorkId IN ($placeholders)"
+                    );
+                    $stmt->bind_param($types, ...$frontier);
+                    $stmt->execute();
+                    $next = array_column(
+                        $stmt->get_result()->fetch_all(MYSQLI_ASSOC), 'Id'
+                    );
+                    $stmt->close();
+                    /* Filter out already-visited so a cycle (which
+                       shouldn't happen but isn't schema-prevented)
+                       doesn't loop. */
+                    $frontier = array_values(array_filter(
+                        $next,
+                        fn($n) => !isset($descendantWorkIds[(int)$n])
+                    ));
+                }
+
+                /* Pull every member song of the tree, joining for
+                   display fields + language tag. */
+                if (!empty($descendantWorkIds)) {
+                    $allWorkIds = array_keys($descendantWorkIds);
+                    $placeholders = implode(',', array_fill(0, count($allWorkIds), '?'));
+                    $types = str_repeat('i', count($allWorkIds));
+                    $stmt = $db->prepare(
+                        "SELECT s.SongId      AS songId,
+                                s.Language    AS language,
+                                s.Title       AS title,
+                                s.Number      AS number,
+                                l.Name        AS languageName,
+                                l.NativeName  AS languageNativeName
+                           FROM tblWorkSongs ws
+                           JOIN tblSongs s ON s.SongId = ws.SongId
+                           LEFT JOIN tblLanguages l ON l.Code = s.Language
+                          WHERE ws.WorkId IN ($placeholders)"
+                    );
+                    $stmt->bind_param($types, ...$allWorkIds);
+                    $stmt->execute();
+                    $currentLang = '';
+                    /* Find the current song's own language to filter
+                       out same-language Works members (they're not
+                       translations — they're the same hymn in the
+                       same language, possibly different songbooks). */
+                    foreach ($stmt->get_result()->fetch_all(MYSQLI_ASSOC) as $row) {
+                        if ((string)$row['songId'] === $translationSongId) {
+                            $currentLang = (string)$row['language'];
+                            break;
+                        }
+                    }
+                    /* Re-fetch to walk all rows (the MYSQLI result is
+                       single-pass and was consumed by the lang lookup). */
+                    $stmt->execute();
+                    foreach ($stmt->get_result()->fetch_all(MYSQLI_ASSOC) as $row) {
+                        $sid = (string)$row['songId'];
+                        if (!empty($seen[$sid])) continue;
+                        if ($sid === $translationSongId) continue;
+                        if ((string)$row['language'] === $currentLang) continue;
+                        $row['translator'] = '';
+                        $row['verified']   = false;
+                        $row['number']     = (int)$row['number'];
+                        $row['source']     = 'works_graph';
+                        $seen[$sid] = true;
+                        $translations[] = $row;
+                    }
+                    $stmt->close();
+                }
+            }
 
             sendJson(['translations' => $translations, 'sourceId' => $translationSongId]);
             break;

--- a/appWeb/public_html/includes/content_access.php
+++ b/appWeb/public_html/includes/content_access.php
@@ -121,6 +121,50 @@ function checkContentAccess(string $entityType, string $entityId, ?int $userId, 
                     }
                 }
                 continue 2;
+
+            /* ----------------------------------------------------------------
+             * PUBLIC-DOMAIN GATING — design intent (#939)
+             *
+             * Future RestrictionType values for PD-only tiers MUST treat the
+             * lyrics flag and the music flag as INDEPENDENT. The two columns
+             * on tblSongs (LyricsPublicDomain, MusicPublicDomain) describe
+             * separate concerns:
+             *
+             *   - LyricsPublicDomain — words are PD (e.g. an old hymn-text
+             *     whose author died > 70 years ago).
+             *   - MusicPublicDomain  — tune is PD (e.g. a mediaeval melody,
+             *     or one whose composer died > 70 years ago).
+             *
+             * A song can have one without the other (modern lyrics set to a
+             * traditional tune, or vice versa). When a tier exposes only PD
+             * lyrics, the gate uses LyricsPublicDomain = 1 ALONE. When a tier
+             * exposes only PD sheet music / MIDI / MusicXML, the gate uses
+             * MusicPublicDomain = 1 ALONE.
+             *
+             * Do NOT AND the two flags together — that would gate out
+             * legitimate PD-lyrics songs whose tune is still in copyright,
+             * and vice versa.
+             *
+             * Suggested future shape:
+             *
+             *     case 'require_lyrics_pd':
+             *         // Allow only when the target song has LyricsPublicDomain = 1.
+             *         // Caller is expected to already know the song's PD flags
+             *         // (e.g. via SongData::_fetchSongRow); pass them in via
+             *         // a fourth checkContentAccess() argument or do a probe
+             *         // here with a single-row SELECT keyed on EntityId.
+             *         $matches = ($entityType === 'song'
+             *                     && (bool)getSongPdFlag($entityId, 'lyrics'));
+             *         break;
+             *
+             *     case 'require_music_pd':
+             *         $matches = ($entityType === 'song'
+             *                     && (bool)getSongPdFlag($entityId, 'music'));
+             *         break;
+             *
+             * Until those cases are wired, no PD-gating tier is active and
+             * songs render unrestricted regardless of their PD flags.
+             * ---------------------------------------------------------------- */
         }
 
         if ($matches) {

--- a/appWeb/public_html/includes/pages/iswc.php
+++ b/appWeb/public_html/includes/pages/iswc.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — ISWC public page (#940)
+ *
+ * PURPOSE:
+ * Lists every song in the catalogue that shares an ISWC code (the
+ * International Standard Musical Work Code, format T-NNN.NNN.NNN-N).
+ * Reached via /iswc/<encoded-code> from the song page.
+ *
+ * Two songs that share an ISWC are by definition the same composition
+ * — different songbook entries, possibly different translations, but
+ * the same Work in CISAC's registry. This is the fastest cross-link
+ * available because the ISWC is canonical (vs. titles which drift
+ * across hymnals).
+ *
+ * Loaded via api.php?page=iswc&code=T-926.352.268-5.
+ */
+
+if (!isset($songData) || !is_object($songData)) {
+    require_once __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'SongData.php';
+    $songData = new SongData();
+}
+
+$iswcCode    = isset($iswcCode) ? (string)$iswcCode : '';
+/* Defensive normalisation: keep T, digits, dots, hyphens — anything
+   else is an injection attempt or a URL-encoding artefact. */
+$iswcCode    = preg_replace('/[^T0-9.\-]/i', '', $iswcCode) ?? '';
+$iswcCode    = strtoupper($iswcCode);
+
+$iswcRows         = [];
+$iswcTotalSongs   = 0;
+$iswcRowsByBook   = [];
+$iswcWorkSlug     = '';
+$iswcWorkTitle    = '';
+
+if ($iswcCode !== '') {
+    try {
+        $idb = getDbMysqli();
+        $stmt = $idb->prepare(
+            "SELECT s.SongId, s.Number, s.Title, s.SongbookAbbr, s.SongbookName, s.Language
+               FROM tblSongs s
+              WHERE s.Iswc = ?
+              ORDER BY s.SongbookAbbr ASC, s.Number ASC, s.Title ASC"
+        );
+        $stmt->bind_param('s', $iswcCode);
+        $stmt->execute();
+        $iswcRows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+        $stmt->close();
+
+        $iswcTotalSongs = count($iswcRows);
+        foreach ($iswcRows as $r) {
+            $abbr = (string)$r['SongbookAbbr'];
+            if (!isset($iswcRowsByBook[$abbr])) {
+                $iswcRowsByBook[$abbr] = [
+                    'name' => (string)$r['SongbookName'],
+                    'rows' => [],
+                ];
+            }
+            $iswcRowsByBook[$abbr]['rows'][] = $r;
+        }
+
+        /* If a tblWorks row exists keyed on this ISWC, link to it as
+           the canonical Work page — that surface carries richer
+           metadata (composers / arrangers / external links / member
+           grouping) that this list-view doesn't try to replicate. */
+        try {
+            $r = $idb->query(
+                "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+                  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tblWorks' LIMIT 1"
+            );
+            $hasWorks = $r && $r->fetch_row() !== null;
+            if ($r) $r->close();
+            if ($hasWorks) {
+                $stmt = $idb->prepare('SELECT Slug, Title FROM tblWorks WHERE Iswc = ? LIMIT 1');
+                $stmt->bind_param('s', $iswcCode);
+                $stmt->execute();
+                $w = $stmt->get_result()->fetch_assoc();
+                $stmt->close();
+                if ($w) {
+                    $iswcWorkSlug  = (string)$w['Slug'];
+                    $iswcWorkTitle = (string)$w['Title'];
+                }
+            }
+        } catch (\Throwable $_e) { /* tblWorks missing — silent skip */ }
+    } catch (\Throwable $e) {
+        error_log('[pages/iswc.php] lookup failed: ' . $e->getMessage());
+    }
+}
+?>
+
+<nav aria-label="breadcrumb" class="mb-3">
+    <ol class="breadcrumb small">
+        <li class="breadcrumb-item"><a href="/" data-navigate="home">Home</a></li>
+        <li class="breadcrumb-item active" aria-current="page">
+            <i class="fa-solid fa-barcode me-1" aria-hidden="true"></i>
+            ISWC: <?= htmlspecialchars($iswcCode !== '' ? $iswcCode : '?') ?>
+        </li>
+    </ol>
+</nav>
+
+<?php if ($iswcCode === ''): ?>
+    <div class="alert alert-warning" role="alert">
+        <i class="fa-solid fa-circle-exclamation me-2" aria-hidden="true"></i>
+        No ISWC specified.
+    </div>
+    <a href="/" class="btn btn-primary" data-navigate="home">
+        <i class="fa-solid fa-arrow-left me-2" aria-hidden="true"></i>Back to Home
+    </a>
+<?php elseif ($iswcTotalSongs === 0): ?>
+    <div class="alert alert-warning" role="alert">
+        <i class="fa-solid fa-circle-exclamation me-2" aria-hidden="true"></i>
+        No songs in the catalogue carry the ISWC <strong><?= htmlspecialchars($iswcCode) ?></strong>.
+    </div>
+    <p class="text-muted small">
+        ISWC values are populated by curators and bulk imports. Even if a song uses this composition,
+        it may not yet have its ISWC tagged.
+    </p>
+    <a href="/" class="btn btn-primary" data-navigate="home">
+        <i class="fa-solid fa-arrow-left me-2" aria-hidden="true"></i>Back to Home
+    </a>
+<?php else: ?>
+    <header class="mb-4">
+        <h1 class="h3 d-flex align-items-baseline gap-2">
+            <i class="fa-solid fa-barcode text-muted" aria-hidden="true"></i>
+            <span><?= htmlspecialchars($iswcCode) ?></span>
+            <small class="text-muted ms-1">(<?= $iswcTotalSongs ?> song<?= $iswcTotalSongs === 1 ? '' : 's' ?>)</small>
+        </h1>
+        <p class="small text-muted mb-2">
+            International Standard Musical Work Code — songs sharing this code are by definition the same composition,
+            even when the title or songbook differs.
+        </p>
+        <?php if ($iswcWorkSlug !== ''): ?>
+            <p class="small mb-0">
+                <i class="fa-solid fa-diagram-project me-1 text-muted" aria-hidden="true"></i>
+                Linked Work:
+                <a href="/work/<?= htmlspecialchars($iswcWorkSlug) ?>" data-navigate="work">
+                    <?= htmlspecialchars($iswcWorkTitle) ?>
+                </a>
+            </p>
+        <?php endif; ?>
+    </header>
+
+    <?php foreach ($iswcRowsByBook as $abbr => $book): ?>
+        <section class="mb-4">
+            <h2 class="h6 text-muted">
+                <span class="badge bg-body-secondary text-body-emphasis me-2"><?= htmlspecialchars($abbr) ?></span>
+                <?= htmlspecialchars($book['name']) ?>
+            </h2>
+            <div class="list-group list-group-flush">
+                <?php foreach ($book['rows'] as $r): ?>
+                    <a class="list-group-item list-group-item-action song-list-item"
+                       href="/song/<?= htmlspecialchars($r['SongId']) ?>"
+                       data-navigate="song"
+                       data-song-id="<?= htmlspecialchars($r['SongId']) ?>">
+                        <span class="song-number-badge"><?= (int)$r['Number'] ?: '?' ?></span>
+                        <div class="song-info flex-grow-1">
+                            <span class="song-title"><?= htmlspecialchars($r['Title']) ?></span>
+                            <?php if (!empty($r['Language'])): ?>
+                                <small class="text-muted ms-2">
+                                    <i class="fa-solid fa-language me-1" aria-hidden="true"></i><?= htmlspecialchars($r['Language']) ?>
+                                </small>
+                            <?php endif; ?>
+                        </div>
+                        <i class="fa-solid fa-chevron-right text-muted" aria-hidden="true"></i>
+                    </a>
+                <?php endforeach; ?>
+            </div>
+        </section>
+    <?php endforeach; ?>
+<?php endif; ?>

--- a/appWeb/public_html/includes/pages/song.php
+++ b/appWeb/public_html/includes/pages/song.php
@@ -445,15 +445,24 @@ try {
                  (#599) — same wrapper class, same icon styling, same
                  bold-label-then-value pattern — so the song header
                  reads as a single consistent credit block instead of
-                 the credits + a smaller dimmer Tune line. The link
-                 target `/tune/<slug>` is reserved for a future
-                 cross-reference listing (#494); until that ships we
-                 still render the value as plain text. -->
-            <?php if ($tuneName !== ''): ?>
+                 the credits + a smaller dimmer Tune line.
+                 #940 — tune is now a link to `/tune/<slug>` listing
+                 every song that uses that tune; lets a worship leader
+                 mix-n-match lyrics across hymns with the same melody. -->
+            <?php if ($tuneName !== ''):
+                $_tuneSlug = strtolower(trim(preg_replace('/[^A-Za-z0-9]+/', '-', $tuneName), '-'));
+                ?>
                 <div class="song-meta mb-3">
                     <p class="mb-0 song-credit-row" data-credit-kind="tune">
                         <i class="fa-solid fa-music me-2 text-muted" aria-hidden="true"></i>
-                        <strong>Tune:</strong> <?= htmlspecialchars($tuneName) ?>
+                        <strong>Tune:</strong>
+                        <?php if ($_tuneSlug !== ''): ?>
+                            <a href="/tune/<?= htmlspecialchars($_tuneSlug) ?>"
+                               data-navigate="tune"
+                               title="See all songs that use this tune"><?= htmlspecialchars($tuneName) ?></a>
+                        <?php else: ?>
+                            <?= htmlspecialchars($tuneName) ?>
+                        <?php endif; ?>
                     </p>
                 </div>
             <?php endif; ?>
@@ -564,16 +573,34 @@ try {
                     <?php endif; ?>
                     <?php if (!empty($ccli) || $iswc !== ''): ?>
                         <div class="song-id-row d-flex flex-wrap column-gap-4 row-gap-1">
-                            <?php if (!empty($ccli)): ?>
+                            <?php if (!empty($ccli)):
+                                /* #940 — link the CCLI number itself to SongSelect.
+                                   Per the spec the link opens in a new tab. */
+                                $_ccliEnc = rawurlencode((string)$ccli);
+                                ?>
                                 <span class="small text-muted">
                                     <i class="fa-solid fa-hashtag me-2" aria-hidden="true"></i>
-                                    <strong>CCLI Song #</strong>&nbsp;<?= htmlspecialchars($ccli) ?>
+                                    <strong>CCLI Song #</strong>&nbsp;<a
+                                        href="https://songselect.ccli.com/songs/<?= htmlspecialchars($_ccliEnc) ?>"
+                                        target="_blank"
+                                        rel="noopener noreferrer external"
+                                        title="View on CCLI SongSelect (opens in new tab)"><?= htmlspecialchars($ccli) ?></a>
                                 </span>
                             <?php endif; ?>
-                            <?php if ($iswc !== ''): ?>
+                            <?php if ($iswc !== ''):
+                                /* #940 — link the ISWC to an internal page listing
+                                   every song that shares this code. Internal rather
+                                   than external to ISWCnet because catalogue
+                                   navigation is more useful than a search-result
+                                   redirect. The route is /iswc/<encoded-iswc>. */
+                                $_iswcEnc = rawurlencode((string)$iswc);
+                                ?>
                                 <span class="small text-muted" title="International Standard Musical Work Code">
                                     <i class="fa-solid fa-barcode me-2" aria-hidden="true"></i>
-                                    <strong>ISWC:</strong>&nbsp;<?= htmlspecialchars($iswc) ?>
+                                    <strong>ISWC:</strong>&nbsp;<a
+                                        href="/iswc/<?= htmlspecialchars($_iswcEnc) ?>"
+                                        data-navigate="iswc"
+                                        title="See all songs sharing this ISWC"><?= htmlspecialchars($iswc) ?></a>
                                 </span>
                             <?php endif; ?>
                         </div>
@@ -828,6 +855,8 @@ try {
     <?php if (
         !empty($_creditRows) && $_hasAnyCredit
         || $tuneName !== ''
+        || !empty($ccli)
+        || $iswc !== ''
         || (!$fullyPublicDomain && !empty($copyright))
         || $fullyPublicDomain
     ): ?>
@@ -842,9 +871,44 @@ try {
                     </div>
                 <?php endforeach; ?>
             <?php endif; ?>
-            <?php if ($tuneName !== ''): ?>
+            <?php if ($tuneName !== ''):
+                /* #940 — same link as the header, mirrored in the
+                   after-lyrics credits block for parity. */
+                $_tuneSlugFooter = strtolower(trim(preg_replace('/[^A-Za-z0-9]+/', '-', $tuneName), '-'));
+                ?>
                 <div data-credit-kind="tune">
-                    <strong>Tune:</strong> <?= htmlspecialchars($tuneName) ?>
+                    <strong>Tune:</strong>
+                    <?php if ($_tuneSlugFooter !== ''): ?>
+                        <a href="/tune/<?= htmlspecialchars($_tuneSlugFooter) ?>"
+                           data-navigate="tune"
+                           title="See all songs that use this tune"><?= htmlspecialchars($tuneName) ?></a>
+                    <?php else: ?>
+                        <?= htmlspecialchars($tuneName) ?>
+                    <?php endif; ?>
+                </div>
+            <?php endif; ?>
+            <?php if (!empty($ccli)):
+                /* #940 — CCLI / ISWC are surfaced in the credits block
+                   too so a viewer who's scrolled past the masthead can
+                   still see (and click) the catalogue identifiers. */
+                $_ccliEncFooter = rawurlencode((string)$ccli);
+                ?>
+                <div data-credit-kind="ccli">
+                    <strong>CCLI Song #</strong>
+                    <a href="https://songselect.ccli.com/songs/<?= htmlspecialchars($_ccliEncFooter) ?>"
+                       target="_blank"
+                       rel="noopener noreferrer external"
+                       title="View on CCLI SongSelect (opens in new tab)"><?= htmlspecialchars($ccli) ?></a>
+                </div>
+            <?php endif; ?>
+            <?php if ($iswc !== ''):
+                $_iswcEncFooter = rawurlencode((string)$iswc);
+                ?>
+                <div data-credit-kind="iswc" title="International Standard Musical Work Code">
+                    <strong>ISWC:</strong>
+                    <a href="/iswc/<?= htmlspecialchars($_iswcEncFooter) ?>"
+                       data-navigate="iswc"
+                       title="See all songs sharing this ISWC"><?= htmlspecialchars($iswc) ?></a>
                 </div>
             <?php endif; ?>
             <?php if ($fullyPublicDomain): ?>

--- a/appWeb/public_html/includes/pages/tune.php
+++ b/appWeb/public_html/includes/pages/tune.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Tune public page (#940)
+ *
+ * PURPOSE:
+ * Lists every song that uses a given hymn tune (TuneName). Reached via
+ * /tune/<slug> from the song page (`Tune: HYFRYDOL` → click).
+ *
+ * The slug is the lowercase + hyphen-separated form of the tune name;
+ * we recover the canonical TuneName by walking tblSongs and matching
+ * any row whose normalised TuneName slug equals the URL slug. This
+ * tolerates capitalisation / punctuation drift across imported corpora
+ * without a separate tblTunes registry.
+ *
+ * Pre-tune-registry (today): heuristic match on tblSongs.TuneName.
+ * If a future tblTunes registry ships, this page becomes a single
+ * SELECT keyed on slug.
+ *
+ * Loaded via api.php?page=tune&slug=hyfrydol.
+ */
+
+if (!isset($songData) || !is_object($songData)) {
+    require_once __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'SongData.php';
+    $songData = new SongData();
+}
+
+$tuneSlug = isset($tuneSlug) ? (string)$tuneSlug : '';
+$tuneSlug = strtolower(trim(preg_replace('/[^A-Za-z0-9\-]+/', '-', $tuneSlug), '-'));
+
+$tuneRows         = [];
+$canonicalTune    = '';
+$tuneRowsByBook   = [];
+$tuneTotalSongs   = 0;
+
+if ($tuneSlug !== '') {
+    try {
+        $tdb = getDbMysqli();
+        /* SUBSTRING_INDEX-style normalisation in SQL would let MySQL
+           pre-filter, but the slug rule (lowercase + non-alnum → '-' +
+           collapse + trim) doesn't have a clean MySQL equivalent that
+           handles every Unicode edge case. Pull the distinct TuneName
+           list (it's small — a few thousand rows max) and match in PHP. */
+        $stmt = $tdb->prepare(
+            "SELECT DISTINCT TuneName
+               FROM tblSongs
+              WHERE TuneName IS NOT NULL AND TuneName <> ''"
+        );
+        $stmt->execute();
+        $allTunes = array_column($stmt->get_result()->fetch_all(MYSQLI_ASSOC), 'TuneName');
+        $stmt->close();
+
+        foreach ($allTunes as $name) {
+            $candidate = strtolower(trim(preg_replace('/[^A-Za-z0-9]+/', '-', (string)$name), '-'));
+            if ($candidate === $tuneSlug) {
+                $canonicalTune = (string)$name;
+                break;
+            }
+        }
+
+        if ($canonicalTune !== '') {
+            $stmt = $tdb->prepare(
+                "SELECT s.SongId, s.Number, s.Title, s.SongbookAbbr, s.SongbookName, s.Language
+                   FROM tblSongs s
+                  WHERE s.TuneName = ?
+                  ORDER BY s.SongbookAbbr ASC, s.Number ASC, s.Title ASC"
+            );
+            $stmt->bind_param('s', $canonicalTune);
+            $stmt->execute();
+            $tuneRows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+            $stmt->close();
+
+            $tuneTotalSongs = count($tuneRows);
+            foreach ($tuneRows as $r) {
+                $abbr = (string)$r['SongbookAbbr'];
+                if (!isset($tuneRowsByBook[$abbr])) {
+                    $tuneRowsByBook[$abbr] = [
+                        'name'  => (string)$r['SongbookName'],
+                        'rows'  => [],
+                    ];
+                }
+                $tuneRowsByBook[$abbr]['rows'][] = $r;
+            }
+        }
+    } catch (\Throwable $e) {
+        error_log('[pages/tune.php] lookup failed: ' . $e->getMessage());
+    }
+}
+?>
+
+<nav aria-label="breadcrumb" class="mb-3">
+    <ol class="breadcrumb small">
+        <li class="breadcrumb-item"><a href="/" data-navigate="home">Home</a></li>
+        <li class="breadcrumb-item active" aria-current="page">
+            <i class="fa-solid fa-music me-1" aria-hidden="true"></i>
+            Tune: <?= htmlspecialchars($canonicalTune !== '' ? $canonicalTune : $tuneSlug) ?>
+        </li>
+    </ol>
+</nav>
+
+<?php if ($tuneSlug === ''): ?>
+    <div class="alert alert-warning" role="alert">
+        <i class="fa-solid fa-circle-exclamation me-2" aria-hidden="true"></i>
+        No tune specified.
+    </div>
+    <a href="/" class="btn btn-primary" data-navigate="home">
+        <i class="fa-solid fa-arrow-left me-2" aria-hidden="true"></i>Back to Home
+    </a>
+<?php elseif ($canonicalTune === ''): ?>
+    <div class="alert alert-warning" role="alert">
+        <i class="fa-solid fa-circle-exclamation me-2" aria-hidden="true"></i>
+        No tune named <strong><?= htmlspecialchars($tuneSlug) ?></strong> in the catalogue.
+    </div>
+    <p class="text-muted small">
+        Tune names are imported from songbook metadata; if you expected this tune to be present, it may not have been catalogued under that exact spelling.
+    </p>
+    <a href="/" class="btn btn-primary" data-navigate="home">
+        <i class="fa-solid fa-arrow-left me-2" aria-hidden="true"></i>Back to Home
+    </a>
+<?php else: ?>
+    <header class="mb-4">
+        <h1 class="h3 d-flex align-items-baseline gap-2">
+            <i class="fa-solid fa-music text-muted" aria-hidden="true"></i>
+            <span><?= htmlspecialchars($canonicalTune) ?></span>
+            <small class="text-muted ms-1">(<?= $tuneTotalSongs ?> song<?= $tuneTotalSongs === 1 ? '' : 's' ?>)</small>
+        </h1>
+        <p class="small text-muted mb-0">
+            Hymns and worship songs sung to the tune <strong><?= htmlspecialchars($canonicalTune) ?></strong> across the iHymns catalogue.
+            Worship leaders can mix-and-match lyrics across hymns that share a melody.
+        </p>
+    </header>
+
+    <?php foreach ($tuneRowsByBook as $abbr => $book): ?>
+        <section class="mb-4">
+            <h2 class="h6 text-muted">
+                <span class="badge bg-body-secondary text-body-emphasis me-2"><?= htmlspecialchars($abbr) ?></span>
+                <?= htmlspecialchars($book['name']) ?>
+            </h2>
+            <div class="list-group list-group-flush">
+                <?php foreach ($book['rows'] as $r): ?>
+                    <a class="list-group-item list-group-item-action song-list-item"
+                       href="/song/<?= htmlspecialchars($r['SongId']) ?>"
+                       data-navigate="song"
+                       data-song-id="<?= htmlspecialchars($r['SongId']) ?>">
+                        <span class="song-number-badge"><?= (int)$r['Number'] ?: '?' ?></span>
+                        <div class="song-info flex-grow-1">
+                            <span class="song-title"><?= htmlspecialchars($r['Title']) ?></span>
+                            <?php if (!empty($r['Language'])): ?>
+                                <small class="text-muted ms-2">
+                                    <i class="fa-solid fa-language me-1" aria-hidden="true"></i><?= htmlspecialchars($r['Language']) ?>
+                                </small>
+                            <?php endif; ?>
+                        </div>
+                        <i class="fa-solid fa-chevron-right text-muted" aria-hidden="true"></i>
+                    </a>
+                <?php endforeach; ?>
+            </div>
+        </section>
+    <?php endforeach; ?>
+<?php endif; ?>

--- a/appWeb/public_html/includes/tools/build-song-link-suggestions.php
+++ b/appWeb/public_html/includes/tools/build-song-link-suggestions.php
@@ -27,18 +27,25 @@ declare(strict_types=1);
  * Idempotent — every run TRUNCATEs and rebuilds tblSongLinkSuggestions.
  *
  * USAGE:
- *   php tools/build-song-link-suggestions.php           # default 0.80 threshold
- *   php tools/build-song-link-suggestions.php 0.75      # custom threshold
+ *   php appWeb/public_html/includes/tools/build-song-link-suggestions.php           # default 0.80 threshold
+ *   php appWeb/public_html/includes/tools/build-song-link-suggestions.php 0.75      # custom threshold
  *
  *   Web entry: /manage/song-link-suggestions?action=rebuild
+ *
+ * NOTE: Lives under appWeb/public_html/includes/ rather than the project-root
+ * tools/ directory because the deploy pipeline only mirrors public_html to the
+ * remote — a project-root tools/ would be missing on the server (#937). The
+ * includes/ tree is web-blocked by the parent .htaccess (Deny from all on
+ * `includes/`), so this script is reachable only via PHP require, never as
+ * a direct HTTP GET.
  */
 
 if (PHP_SAPI === 'cli') {
-    require_once __DIR__ . '/../appWeb/public_html/includes/db_mysql.php';
+    require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'db_mysql.php';
     $isCli = true;
 } else {
     /* Web callers must have already set up auth before requiring this file. */
-    require_once __DIR__ . '/../appWeb/public_html/includes/db_mysql.php';
+    require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'db_mysql.php';
     $isCli = false;
 }
 

--- a/appWeb/public_html/js/modules/router.js
+++ b/appWeb/public_html/js/modules/router.js
@@ -281,6 +281,18 @@ export class Router {
                    /works/<slug> accepted as a forgiving alias matching
                    the people / person convention. */
                 return { page: 'work', params: { slug: segments[1] || '' } };
+            case 'tune':
+                /* #940 — /tune/<slug> lists every song that uses the
+                   named tune. Slugified upstream (lowercase + hyphen-
+                   separated). Empty / unknown slug renders the page's
+                   own friendly empty state. */
+                return { page: 'tune', params: { slug: segments[1] || '' } };
+            case 'iswc':
+                /* #940 — /iswc/<code> lists every song that shares the
+                   ISWC. The code is the standard T-NNN.NNN.NNN-N format
+                   url-encoded; the page handler decodes and strips
+                   non-T/digit characters defensively. */
+                return { page: 'iswc', params: { code: segments[1] || '' } };
             case 'help':
                 return { page: 'help', params: {} };
             case 'terms':
@@ -354,6 +366,12 @@ export class Router {
         /* Person page (#588) carries `slug`, not `id`. */
         if (params.slug) {
             url.searchParams.set('slug', params.slug);
+        }
+        /* #940 — ISWC pages key on the `code` parameter (the actual
+           ISWC value, not a slug — the format T-NNN.NNN.NNN-N is
+           already canonical). */
+        if (params.code) {
+            url.searchParams.set('code', params.code);
         }
         /* Request-a-song deep-link prefill (#666) — forwarded straight
            through to the partial so it can echo them into the input

--- a/appWeb/public_html/js/modules/song-media-editor.js
+++ b/appWeb/public_html/js/modules/song-media-editor.js
@@ -309,7 +309,16 @@ export function bootSongMediaEditor(root) {
             showState('empty');
             return;
         }
-        elBlocks.innerHTML = KIND_ORDER.map(blockMarkup).join('');
+        /* #938 — visually separate the four media kinds. The blockMarkup
+           output had no inter-block spacing, so Audio / Sheet music /
+           MIDI / MusicXML ran together and the curator had to read
+           carefully to find the boundary. Wrap each non-first block in
+           a top-margin + top-border separator. */
+        elBlocks.innerHTML = KIND_ORDER.map((kind, i) => {
+            const html = blockMarkup(kind);
+            if (i === 0) return html;
+            return `<div class="mt-4 pt-4 border-top border-secondary border-opacity-25">${html}</div>`;
+        }).join('');
         showState('ready');
         bindBlockHandlers();
     }

--- a/appWeb/public_html/manage/catalogues.php
+++ b/appWeb/public_html/manage/catalogues.php
@@ -1,0 +1,539 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Admin: Catalogues (#941)
+ *
+ * CRUD surface for tblCatalogues + tblCatalogueSongs.
+ *
+ * A Catalogue is a free-form many-to-many grouping of songs that
+ * doesn't fit the Songbook / Songbook Series hierarchy — themed
+ * collections, worship-leader curations, denominational groupings,
+ * Public-Domain-only views, etc. One song can belong to many
+ * catalogues; catalogues compose with songbooks rather than replace
+ * them.
+ *
+ * Gated by manage_songbooks (same coarse entitlement as Songbook
+ * Series — catalogues are a flavour of catalogue-level metadata, not
+ * a separate domain). Future: a dedicated manage_catalogues
+ * entitlement when curatorial scopes need finer slicing.
+ *
+ * Pre-migration safe: schema-probes tblCatalogues on every page
+ * load and surfaces a friendly "run the migration" page if missing.
+ */
+
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'activity_log.php';
+
+if (!isAuthenticated()) {
+    header('Location: /manage/login');
+    exit;
+}
+$currentUser = getCurrentUser();
+if (!$currentUser || !userHasEntitlement('manage_songbooks', $currentUser['role'] ?? null)) {
+    http_response_code(403);
+    echo '<!DOCTYPE html><html><body><h1>403 — manage_songbooks required</h1></body></html>';
+    exit;
+}
+$activePage = 'catalogues';
+
+$error   = '';
+$success = '';
+$db      = getDbMysqli();
+$csrf    = csrfToken();
+
+$slugFor = static function (string $name): string {
+    $ascii = (string)preg_replace('/[^A-Za-z0-9]+/u', '-', $name);
+    return trim(strtolower($ascii), '-');
+};
+
+/* Schema probe. */
+$hasSchema = false;
+try {
+    $probe = $db->prepare(
+        "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tblCatalogues' LIMIT 1"
+    );
+    $probe->execute();
+    $hasSchema = $probe->get_result()->fetch_row() !== null;
+    $probe->close();
+} catch (\Throwable $e) {
+    error_log('[catalogues] schema probe failed: ' . $e->getMessage());
+}
+
+/* ---- GET ?action=song_search ----
+ * JSON typeahead used by the manage-members panel. Returns matching
+ * songs from tblSongs ranked by title. Optional `exclude_ids` keeps
+ * already-added members out of the suggestion list. */
+if ($hasSchema
+    && ($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'GET'
+    && ($_GET['action'] ?? '') === 'song_search'
+) {
+    header('Content-Type: application/json; charset=UTF-8');
+    header('Cache-Control: no-store');
+    $q     = trim((string)($_GET['q'] ?? ''));
+    $limit = max(1, min(50, (int)($_GET['limit'] ?? 20)));
+    $excl  = array_values(array_filter(array_map('strval',
+        explode(',', (string)($_GET['exclude_ids'] ?? '')))));
+    try {
+        $like = '%' . $q . '%';
+        if ($q === '') {
+            echo json_encode(['rows' => []]);
+            exit;
+        }
+        /* Excluded-IDs filter happens in PHP rather than dynamic SQL.
+           The exclusion list is tiny (current catalogue's existing
+           members), so the simple shape avoids ref-bind awkwardness
+           with mysqli's variadic bind_param. */
+        $sql = "SELECT s.SongId AS id, s.Title AS title, s.Number AS number,
+                       s.SongbookAbbr AS songbook, s.SongbookName AS songbookName
+                  FROM tblSongs s
+                 WHERE (s.Title LIKE ? OR s.SongId LIKE ?)
+                 ORDER BY s.Title ASC
+                 LIMIT ?";
+        $stmt = $db->prepare($sql);
+        $stmt->bind_param('ssi', $like, $like, $limit);
+        $stmt->execute();
+        $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+        $stmt->close();
+        if (!empty($excl)) {
+            $exclSet = array_flip($excl);
+            $rows = array_values(array_filter($rows,
+                static fn($r) => !isset($exclSet[$r['id']])));
+        }
+        echo json_encode(['rows' => $rows]);
+    } catch (\Throwable $e) {
+        error_log('[catalogues] song_search failed: ' . $e->getMessage());
+        echo json_encode(['rows' => [], 'error' => 'search failed']);
+    }
+    exit;
+}
+
+/* ---- POST handlers ---- */
+if ($hasSchema && $_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!validateCsrf((string)($_POST['csrf_token'] ?? ''))) {
+        http_response_code(403);
+        echo 'Invalid CSRF token';
+        exit;
+    }
+    $action = (string)($_POST['action'] ?? '');
+
+    try {
+        switch ($action) {
+            case 'add': {
+                $title       = trim((string)($_POST['title']       ?? ''));
+                $slugRaw     = trim((string)($_POST['slug']        ?? ''));
+                $description = trim((string)($_POST['description'] ?? '')) ?: null;
+                $visibility  = trim((string)($_POST['visibility']  ?? 'public'));
+                $sortOrder   = (int)($_POST['sort_order'] ?? 0);
+
+                if ($title === '')                                       { $error = 'Title is required.'; break; }
+                if (mb_strlen($title) > 255)                             { $error = 'Title must be 255 characters or fewer.'; break; }
+                if (!in_array($visibility, ['public','curated','admin_only'], true)) {
+                    $error = 'Invalid visibility.'; break;
+                }
+                $slug = $slugRaw !== '' ? $slugFor($slugRaw) : $slugFor($title);
+                if ($slug === '')                                        { $error = 'Slug could not be derived — provide one explicitly.'; break; }
+                if (mb_strlen($slug) > 255)                              { $error = 'Slug must be 255 characters or fewer.'; break; }
+
+                $stmt = $db->prepare('SELECT Id FROM tblCatalogues WHERE Slug = ?');
+                $stmt->bind_param('s', $slug);
+                $stmt->execute();
+                $exists = $stmt->get_result()->fetch_row() !== null;
+                $stmt->close();
+                if ($exists) { $error = "A catalogue with slug '{$slug}' already exists."; break; }
+
+                $stmt = $db->prepare(
+                    'INSERT INTO tblCatalogues (Slug, Title, Description, SortOrder, Visibility)
+                     VALUES (?, ?, ?, ?, ?)'
+                );
+                $stmt->bind_param('sssis',
+                    $slug, $title, $description, $sortOrder, $visibility);
+                $stmt->execute();
+                $newId = (int)$db->insert_id;
+                $stmt->close();
+
+                logActivity('admin.catalogues.add', 'catalogue', (string)$newId, [
+                    'slug' => $slug, 'title' => $title, 'visibility' => $visibility,
+                ]);
+                $success = "Catalogue '{$title}' created.";
+                break;
+            }
+
+            case 'update': {
+                $id          = (int)($_POST['id']          ?? 0);
+                $title       = trim((string)($_POST['title']       ?? ''));
+                $description = trim((string)($_POST['description'] ?? '')) ?: null;
+                $visibility  = trim((string)($_POST['visibility']  ?? 'public'));
+                $sortOrder   = (int)($_POST['sort_order'] ?? 0);
+                if ($id <= 0)                                            { $error = 'Catalogue id missing.'; break; }
+                if ($title === '')                                       { $error = 'Title is required.'; break; }
+                if (!in_array($visibility, ['public','curated','admin_only'], true)) {
+                    $error = 'Invalid visibility.'; break;
+                }
+
+                $stmt = $db->prepare(
+                    'UPDATE tblCatalogues
+                        SET Title = ?, Description = ?, SortOrder = ?, Visibility = ?
+                      WHERE Id = ?'
+                );
+                $stmt->bind_param('ssisi', $title, $description, $sortOrder, $visibility, $id);
+                $stmt->execute();
+                $stmt->close();
+
+                logActivity('admin.catalogues.update', 'catalogue', (string)$id, [
+                    'title' => $title, 'visibility' => $visibility,
+                ]);
+                $success = "Catalogue updated.";
+                break;
+            }
+
+            case 'delete': {
+                $id = (int)($_POST['id'] ?? 0);
+                if ($id <= 0) { $error = 'Catalogue id missing.'; break; }
+                $stmt = $db->prepare('SELECT Title FROM tblCatalogues WHERE Id = ?');
+                $stmt->bind_param('i', $id);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_assoc();
+                $stmt->close();
+                if (!$row) { $error = 'Catalogue not found.'; break; }
+                $stmt = $db->prepare('DELETE FROM tblCatalogues WHERE Id = ?');
+                $stmt->bind_param('i', $id);
+                $stmt->execute();
+                $stmt->close();
+                /* tblCatalogueSongs cascades via FK ON DELETE CASCADE. */
+                logActivity('admin.catalogues.delete', 'catalogue', (string)$id, [
+                    'title' => $row['Title'],
+                ]);
+                $success = "Catalogue '{$row['Title']}' deleted.";
+                break;
+            }
+
+            case 'add_member': {
+                $catalogueId = (int)($_POST['catalogue_id'] ?? 0);
+                $songId      = trim((string)($_POST['song_id'] ?? ''));
+                if ($catalogueId <= 0 || $songId === '') {
+                    $error = 'catalogue_id and song_id required.'; break;
+                }
+                $userId = (int)($currentUser['id'] ?? 0) ?: null;
+                $stmt = $db->prepare(
+                    'INSERT IGNORE INTO tblCatalogueSongs
+                        (CatalogueId, SongId, AddedBy, AddedAt)
+                     VALUES (?, ?, ?, NOW())'
+                );
+                $stmt->bind_param('isi', $catalogueId, $songId, $userId);
+                $stmt->execute();
+                $added = $stmt->affected_rows > 0;
+                $stmt->close();
+                logActivity('admin.catalogues.add_member', 'catalogue', (string)$catalogueId, [
+                    'song_id' => $songId, 'added' => $added,
+                ]);
+                $success = $added
+                    ? "Added {$songId} to catalogue."
+                    : "{$songId} was already in the catalogue.";
+                break;
+            }
+
+            case 'remove_member': {
+                $catalogueId = (int)($_POST['catalogue_id'] ?? 0);
+                $songId      = trim((string)($_POST['song_id'] ?? ''));
+                if ($catalogueId <= 0 || $songId === '') {
+                    $error = 'catalogue_id and song_id required.'; break;
+                }
+                $stmt = $db->prepare(
+                    'DELETE FROM tblCatalogueSongs WHERE CatalogueId = ? AND SongId = ?'
+                );
+                $stmt->bind_param('is', $catalogueId, $songId);
+                $stmt->execute();
+                $removed = $stmt->affected_rows > 0;
+                $stmt->close();
+                logActivity('admin.catalogues.remove_member', 'catalogue', (string)$catalogueId, [
+                    'song_id' => $songId, 'removed' => $removed,
+                ]);
+                $success = $removed
+                    ? "Removed {$songId} from catalogue."
+                    : "{$songId} wasn't in the catalogue.";
+                break;
+            }
+
+            default:
+                $error = 'Unknown action: ' . $action;
+        }
+    } catch (\Throwable $e) {
+        error_log('[catalogues] action=' . $action . ' failed: ' . $e->getMessage());
+        $error = 'Database error: ' . $e->getMessage();
+    }
+}
+
+/* ---- Load catalogue list + member counts ---- */
+$catalogues = [];
+if ($hasSchema) {
+    try {
+        $stmt = $db->prepare(
+            'SELECT c.Id, c.Slug, c.Title, c.Description, c.SortOrder, c.Visibility,
+                    c.CreatedAt, c.UpdatedAt,
+                    (SELECT COUNT(*) FROM tblCatalogueSongs cs WHERE cs.CatalogueId = c.Id) AS SongCount
+               FROM tblCatalogues c
+              ORDER BY c.SortOrder ASC, c.Title ASC'
+        );
+        $stmt->execute();
+        $catalogues = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+        $stmt->close();
+    } catch (\Throwable $e) {
+        error_log('[catalogues] list failed: ' . $e->getMessage());
+        $error = 'Could not load catalogues: ' . $e->getMessage();
+    }
+}
+
+/* ---- Per-catalogue members (for the expand panels) ---- */
+$membersByCatalogueId = [];
+if ($hasSchema && !empty($catalogues)) {
+    try {
+        $stmt = $db->prepare(
+            'SELECT cs.CatalogueId, cs.SongId, cs.SortOrder,
+                    s.Title AS SongTitle, s.Number AS SongNumber,
+                    s.SongbookAbbr, s.SongbookName
+               FROM tblCatalogueSongs cs
+               JOIN tblSongs s ON s.SongId = cs.SongId
+              ORDER BY cs.CatalogueId ASC, cs.SortOrder ASC, s.Title ASC'
+        );
+        $stmt->execute();
+        foreach ($stmt->get_result()->fetch_all(MYSQLI_ASSOC) as $r) {
+            $membersByCatalogueId[(int)$r['CatalogueId']][] = $r;
+        }
+        $stmt->close();
+    } catch (\Throwable $e) {
+        error_log('[catalogues] members load failed: ' . $e->getMessage());
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Catalogues — iHymns Admin</title>
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-libs.php'; ?>
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-favicon.php'; ?>
+</head>
+<body>
+<?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-nav.php'; ?>
+
+<main class="container py-3">
+
+    <h1 class="h4 mb-3">
+        <i class="bi bi-collection me-1" aria-hidden="true"></i>Catalogues
+    </h1>
+    <p class="small text-muted mb-3">
+        A <strong>Catalogue</strong> is a free-form many-to-many grouping of songs that sits alongside
+        the Songbook hierarchy. Use it for thematic collections (Christmas, Easter), worship-leader
+        curations (Modern, Traditional), denominational groupings, Public-Domain-only views — anything
+        where one song should appear in many groupings without duplicating data.
+    </p>
+
+    <?php if (!empty($error)): ?>
+        <div class="alert alert-danger small"><?= htmlspecialchars($error) ?></div>
+    <?php endif; ?>
+    <?php if (!empty($success)): ?>
+        <div class="alert alert-success small"><?= htmlspecialchars($success) ?></div>
+    <?php endif; ?>
+
+    <?php if (!$hasSchema): ?>
+        <div class="alert alert-warning small">
+            <i class="bi bi-database-gear me-1" aria-hidden="true"></i>
+            The <code>tblCatalogues</code> table hasn't been created yet. Run the
+            <a href="/manage/setup-database">Catalogues migration</a> to enable this page.
+        </div>
+    <?php else: ?>
+
+        <!-- Add catalogue form -->
+        <div class="card-admin p-3 mb-3">
+            <h2 class="h6 mb-2"><i class="bi bi-plus-circle me-1" aria-hidden="true"></i>Add a catalogue</h2>
+            <form method="POST" class="row g-2 align-items-end small">
+                <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                <input type="hidden" name="action" value="add">
+                <div class="col-md-3">
+                    <label class="form-label small mb-0">Title <span class="text-danger">*</span></label>
+                    <input type="text" name="title" class="form-control form-control-sm" required maxlength="255"
+                           placeholder="e.g. Christmas / Advent">
+                </div>
+                <div class="col-md-3">
+                    <label class="form-label small mb-0">Slug <small class="text-muted">(auto if blank)</small></label>
+                    <input type="text" name="slug" class="form-control form-control-sm" maxlength="255"
+                           placeholder="christmas-advent">
+                </div>
+                <div class="col-md-3">
+                    <label class="form-label small mb-0">Description</label>
+                    <input type="text" name="description" class="form-control form-control-sm" maxlength="500">
+                </div>
+                <div class="col-md-1">
+                    <label class="form-label small mb-0">Sort</label>
+                    <input type="number" name="sort_order" class="form-control form-control-sm" value="0">
+                </div>
+                <div class="col-md-2">
+                    <label class="form-label small mb-0">Visibility</label>
+                    <select name="visibility" class="form-select form-select-sm">
+                        <option value="public">Public</option>
+                        <option value="curated">Curated only</option>
+                        <option value="admin_only">Admin only</option>
+                    </select>
+                </div>
+                <div class="col-12">
+                    <button type="submit" class="btn btn-sm btn-info">
+                        <i class="bi bi-plus me-1"></i>Create catalogue
+                    </button>
+                </div>
+            </form>
+        </div>
+
+        <!-- Existing catalogues -->
+        <?php if (empty($catalogues)): ?>
+            <div class="text-muted small">No catalogues yet — use the form above to create the first one.</div>
+        <?php else: ?>
+            <div class="card-admin p-0 mb-3">
+                <div class="table-responsive">
+                    <table class="table table-sm table-dark mb-0 small align-middle">
+                        <thead><tr>
+                            <th>Title</th><th>Slug</th><th>Visibility</th>
+                            <th class="text-end">Songs</th><th>Description</th>
+                            <th class="text-end">Actions</th>
+                        </tr></thead>
+                        <tbody>
+                        <?php foreach ($catalogues as $c): ?>
+                            <tr>
+                                <td><strong><?= htmlspecialchars($c['Title']) ?></strong></td>
+                                <td><code class="small"><?= htmlspecialchars($c['Slug']) ?></code></td>
+                                <td>
+                                    <span class="badge bg-body-secondary text-body-emphasis">
+                                        <?= htmlspecialchars($c['Visibility']) ?>
+                                    </span>
+                                </td>
+                                <td class="text-end"><?= (int)$c['SongCount'] ?></td>
+                                <td class="text-muted small"><?= htmlspecialchars((string)($c['Description'] ?? '')) ?></td>
+                                <td class="text-end">
+                                    <button type="button" class="btn btn-sm btn-outline-info"
+                                            data-bs-toggle="collapse"
+                                            data-bs-target="#cat-edit-<?= (int)$c['Id'] ?>"
+                                            title="Edit">
+                                        <i class="bi bi-pencil"></i>
+                                    </button>
+                                    <button type="button" class="btn btn-sm btn-outline-secondary"
+                                            data-bs-toggle="collapse"
+                                            data-bs-target="#cat-members-<?= (int)$c['Id'] ?>"
+                                            title="Members">
+                                        <i class="bi bi-music-note-list"></i>
+                                    </button>
+                                    <form method="POST" class="d-inline"
+                                          onsubmit="return confirm('Delete catalogue \'<?= htmlspecialchars($c['Title'], ENT_QUOTES) ?>\'? This unlinks every member song; the songs themselves are NOT deleted.');">
+                                        <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                                        <input type="hidden" name="action" value="delete">
+                                        <input type="hidden" name="id"     value="<?= (int)$c['Id'] ?>">
+                                        <button type="submit" class="btn btn-sm btn-outline-danger" title="Delete">
+                                            <i class="bi bi-trash"></i>
+                                        </button>
+                                    </form>
+                                </td>
+                            </tr>
+                            <!-- Edit row -->
+                            <tr class="collapse" id="cat-edit-<?= (int)$c['Id'] ?>">
+                                <td colspan="6" class="bg-body-secondary">
+                                    <form method="POST" class="row g-2 align-items-end small">
+                                        <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                                        <input type="hidden" name="action" value="update">
+                                        <input type="hidden" name="id"     value="<?= (int)$c['Id'] ?>">
+                                        <div class="col-md-3">
+                                            <label class="form-label small mb-0">Title</label>
+                                            <input type="text" name="title" class="form-control form-control-sm"
+                                                   value="<?= htmlspecialchars($c['Title']) ?>" required maxlength="255">
+                                        </div>
+                                        <div class="col-md-3">
+                                            <label class="form-label small mb-0">Description</label>
+                                            <input type="text" name="description" class="form-control form-control-sm"
+                                                   value="<?= htmlspecialchars((string)($c['Description'] ?? '')) ?>" maxlength="500">
+                                        </div>
+                                        <div class="col-md-1">
+                                            <label class="form-label small mb-0">Sort</label>
+                                            <input type="number" name="sort_order" class="form-control form-control-sm"
+                                                   value="<?= (int)$c['SortOrder'] ?>">
+                                        </div>
+                                        <div class="col-md-2">
+                                            <label class="form-label small mb-0">Visibility</label>
+                                            <select name="visibility" class="form-select form-select-sm">
+                                                <?php foreach (['public','curated','admin_only'] as $v): ?>
+                                                    <option value="<?= $v ?>" <?= $c['Visibility'] === $v ? 'selected' : '' ?>><?= $v ?></option>
+                                                <?php endforeach; ?>
+                                            </select>
+                                        </div>
+                                        <div class="col-md-3 text-end">
+                                            <button type="submit" class="btn btn-sm btn-info">
+                                                <i class="bi bi-check2 me-1"></i>Save changes
+                                            </button>
+                                        </div>
+                                    </form>
+                                </td>
+                            </tr>
+                            <!-- Members row -->
+                            <?php $members = $membersByCatalogueId[(int)$c['Id']] ?? []; ?>
+                            <tr class="collapse" id="cat-members-<?= (int)$c['Id'] ?>">
+                                <td colspan="6" class="bg-body-secondary">
+                                    <h3 class="h6 mb-2"><i class="bi bi-music-note-list me-1"></i>Members of "<?= htmlspecialchars($c['Title']) ?>"</h3>
+                                    <?php if (empty($members)): ?>
+                                        <p class="text-muted small mb-2">No songs in this catalogue yet — use the form below to add some.</p>
+                                    <?php else: ?>
+                                        <ul class="list-group list-group-flush small mb-2">
+                                            <?php foreach ($members as $m): ?>
+                                                <li class="list-group-item bg-transparent d-flex align-items-center gap-2">
+                                                    <span class="badge bg-body-secondary text-body-emphasis"><?= htmlspecialchars($m['SongbookAbbr']) ?></span>
+                                                    <span class="fw-semibold flex-grow-1">
+                                                        <a href="/song/<?= htmlspecialchars($m['SongId']) ?>" target="_blank" rel="noopener">
+                                                            <?= htmlspecialchars($m['SongTitle']) ?>
+                                                        </a>
+                                                        <small class="text-muted ms-2">#<?= (int)$m['SongNumber'] ?></small>
+                                                    </span>
+                                                    <form method="POST" class="d-inline"
+                                                          onsubmit="return confirm('Remove this song from the catalogue?');">
+                                                        <input type="hidden" name="csrf_token"   value="<?= htmlspecialchars($csrf) ?>">
+                                                        <input type="hidden" name="action"       value="remove_member">
+                                                        <input type="hidden" name="catalogue_id" value="<?= (int)$c['Id'] ?>">
+                                                        <input type="hidden" name="song_id"      value="<?= htmlspecialchars($m['SongId']) ?>">
+                                                        <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-2" title="Remove">
+                                                            <i class="bi bi-x"></i>
+                                                        </button>
+                                                    </form>
+                                                </li>
+                                            <?php endforeach; ?>
+                                        </ul>
+                                    <?php endif; ?>
+                                    <form method="POST" class="row g-2 align-items-end small">
+                                        <input type="hidden" name="csrf_token"   value="<?= htmlspecialchars($csrf) ?>">
+                                        <input type="hidden" name="action"       value="add_member">
+                                        <input type="hidden" name="catalogue_id" value="<?= (int)$c['Id'] ?>">
+                                        <div class="col-md-4">
+                                            <label class="form-label small mb-0">Add a song (paste a song id, e.g. <code>CP-0001</code>)</label>
+                                            <input type="text" name="song_id" class="form-control form-control-sm"
+                                                   placeholder="CP-0001" pattern="[A-Za-z]+-\d+" required>
+                                        </div>
+                                        <div class="col-md-2">
+                                            <button type="submit" class="btn btn-sm btn-info">
+                                                <i class="bi bi-plus me-1"></i>Add
+                                            </button>
+                                        </div>
+                                    </form>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        <?php endif; ?>
+
+    <?php endif; /* hasSchema */ ?>
+
+</main>
+
+<?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>
+</body>
+</html>

--- a/appWeb/public_html/manage/credit-people-bulk-promote.php
+++ b/appWeb/public_html/manage/credit-people-bulk-promote.php
@@ -57,7 +57,7 @@ const _CP_BULK_CREDIT_TABLES = [
 
 /**
  * Cheap normalised-name similarity in [0, 1]. Mirrors the scoring
- * shape from tools/build-song-link-suggestions.php (#808): lowercase,
+ * shape from includes/tools/build-song-link-suggestions.php (#808 / #937): lowercase,
  * strip punctuation, collapse whitespace, then 1 - (edit-distance /
  * max-length). Token-set bonus boosts "John Newton" vs "Newton, John".
  *

--- a/appWeb/public_html/manage/includes/admin-links.php
+++ b/appWeb/public_html/manage/includes/admin-links.php
@@ -49,6 +49,7 @@ $_adminLinks = [
     /* Catalogue — collection / metadata surfaces (#819) */
     ['songbooks',            '/manage/songbooks',              'bi-book',            'Songbooks',             'manage_songbooks',            'Catalogue'  ],
     ['songbook-series',      '/manage/songbook-series',        'bi-collection',      'Songbook Series',       'manage_songbooks',            'Catalogue'  ],
+    ['catalogues',           '/manage/catalogues',             'bi-collection-fill', 'Catalogues',            'manage_songbooks',            'Catalogue'  ],
     ['works',                '/manage/works',                  'bi-diagram-3',       'Works',                 'manage_works',                'Catalogue'  ],
     ['external-link-types',  '/manage/external-link-types',    'bi-link-45deg',      'External-Link Types',   'manage_external_link_types',  'Catalogue'  ],
     ['credit-people',        '/manage/credit-people',          'bi-person-badge',    'Credit People',         'manage_credit_people',        'Catalogue'  ],

--- a/appWeb/public_html/manage/my-organisations.php
+++ b/appWeb/public_html/manage/my-organisations.php
@@ -553,28 +553,43 @@ $csrf = csrfToken();
                                 <tr>
                                     <td><code><?= htmlspecialchars((string)$l['LicenceType']) ?></code></td>
                                     <td>
-                                        <form method="POST" class="d-inline-flex align-items-center gap-1">
+                                        <form method="POST" class="d-inline-flex align-items-center gap-1 flex-wrap">
                                             <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
                                             <input type="hidden" name="action" value="licence_change">
                                             <input type="hidden" name="org_id"     value="<?= $orgId ?>">
                                             <input type="hidden" name="licence_id" value="<?= (int)($l['Id'] ?? 0) ?>">
+                                            <!-- #936: inline labels so each input is self-describing
+                                                 without depending on the table-header alignment, which
+                                                 doesn't work here because the form is contained inside
+                                                 a single cell with colspan="3" trailing it. -->
+                                            <span class="text-muted small" aria-hidden="true">№</span>
                                             <input type="text" name="licence_number"
                                                    class="form-control form-control-sm py-0"
                                                    value="<?= htmlspecialchars((string)$l['LicenceNumber']) ?>"
+                                                   title="Licence number"
+                                                   aria-label="Licence number"
+                                                   placeholder="Licence number"
                                                    style="width: 10rem;">
+                                            <span class="text-muted small" aria-hidden="true">Expires</span>
                                             <input type="date" name="expires_at"
                                                    class="form-control form-control-sm py-0"
                                                    value="<?= htmlspecialchars(substr((string)($l['ExpiresAt'] ?? ''), 0, 10)) ?>"
+                                                   title="Licence expiration date"
+                                                   aria-label="Licence expiration date"
                                                    style="width: 9rem;">
                                             <div class="form-check form-check-inline mb-0">
                                                 <input class="form-check-input" type="checkbox" name="is_active" value="1"
-                                                       <?= !empty($l['IsActive']) ? 'checked' : '' ?>>
+                                                       <?= !empty($l['IsActive']) ? 'checked' : '' ?>
+                                                       title="Licence is currently active"
+                                                       aria-label="Licence is currently active">
                                                 <label class="form-check-label small">active</label>
                                             </div>
                                             <input type="text" name="notes"
                                                    class="form-control form-control-sm py-0"
                                                    value="<?= htmlspecialchars((string)($l['Notes'] ?? '')) ?>"
-                                                   placeholder="notes" style="width: 11rem;">
+                                                   title="Notes"
+                                                   aria-label="Licence notes"
+                                                   placeholder="Notes" style="width: 11rem;">
                                             <button type="submit" class="btn btn-sm btn-outline-info py-0 px-2" title="Save">
                                                 <i class="bi bi-check2"></i>
                                             </button>

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -211,6 +211,7 @@ $friendlyTitles = [
     'credit-people-slug'               => 'Credit People Slug + public page (#588)',
     'credit-people-name-parts'         => 'Credit People Structured Name (FirstNames / Surname / Suffix) (#934)',
     'catalogues'                       => 'Catalogues — many-to-many song grouping (#941)',
+    'backfill-works-from-iswc'         => 'Backfill Works from existing ISWCs (#942)',
     'user-avatar-service'              => 'Per-user Avatar Service (#616)',
     'organisation-licences'            => 'Multiple Licence Types per Organisation (#640)',
     'songbook-affiliations'            => 'Songbook Affiliations Registry (#670)',
@@ -286,6 +287,7 @@ $scriptMap = [
     'credit-people-slug' => 'migrate-credit-people-slug.php',
     'credit-people-name-parts' => 'migrate-credit-people-name-parts.php',
     'catalogues' => 'migrate-catalogues.php',
+    'backfill-works-from-iswc' => 'backfill-works-from-iswc.php',
     'user-avatar-service' => 'migrate-user-avatar-service.php',
     'organisation-licences' => 'migrate-organisation-licences.php',
     'songbook-affiliations' => 'migrate-songbook-affiliations.php',
@@ -345,6 +347,7 @@ $migrationOrder = [
     'credit-people-slug',
     'credit-people-name-parts',
     'catalogues',
+    'backfill-works-from-iswc',
     'user-avatar-service',
     'organisation-licences',
     'songbook-affiliations',
@@ -476,6 +479,17 @@ $migrationCards = [
                   . ' bio, lifespan, external links, and a discography grouped by role'
                   . ' across the six song-credit tables. Idempotent — safe to re-run.',
         'button' => 'Run Credit People Slug Migration',
+    ],
+    'backfill-works-from-iswc' => [
+        'title'  => 'Backfill Works from existing ISWCs (#942)',
+        'body'   => 'Walks <code>tblSongs.Iswc</code> and creates one <code>tblWorks</code> row per'
+                  . ' distinct ISWC, then links every song carrying that ISWC into <code>tblWorkSongs</code>.'
+                  . ' Title for new Works is derived from the most-common Title across member songs;'
+                  . ' the lowest-numbered member is flagged <code>IsCanonical=1</code>. Idempotent —'
+                  . ' re-runs add only the genuinely missing memberships and never overwrite a'
+                  . ' curator\'s existing Work row. External-API enrichment (ISWCnet / MusicBrainz / MRO IDs)'
+                  . ' is a separate follow-up (#943).',
+        'button' => 'Backfill Works from ISWCs',
     ],
     'catalogues' => [
         'title'  => 'Catalogues — many-to-many song grouping (#941)',
@@ -1015,6 +1029,23 @@ $migrationProbes = [
     'credit-people-slug'                 => static fn(\mysqli $db) => !_migProbe_columnExists($db, 'tblCreditPeople', 'Slug'),
     'credit-people-name-parts'           => static fn(\mysqli $db) => !_migProbe_columnExists($db, 'tblCreditPeople', 'Surname'),
     'catalogues'                         => static fn(\mysqli $db) => !_migProbe_tableExists($db, 'tblCatalogues'),
+    /* #942 — pending whenever any ISWC-tagged song doesn't have a
+       matching tblWorks row. Re-runnable: as new ISWCs land in
+       tblSongs, the probe surfaces them as outstanding work. */
+    'backfill-works-from-iswc'           => static function (\mysqli $db): bool {
+        if (!_migProbe_tableExists($db, 'tblWorks')) return false;
+        try {
+            $r = $db->query(
+                "SELECT 1 FROM tblSongs s
+                  WHERE s.Iswc IS NOT NULL AND TRIM(s.Iswc) <> ''
+                    AND NOT EXISTS (SELECT 1 FROM tblWorks w WHERE w.Iswc = s.Iswc)
+                  LIMIT 1"
+            );
+            $pending = $r && $r->fetch_row() !== null;
+            if ($r) $r->close();
+            return $pending;
+        } catch (\Throwable $_e) { return false; }
+    },
     'user-avatar-service'                => static fn(\mysqli $db) => !_migProbe_columnExists($db, 'tblUsers', 'AvatarService'),
     'organisation-licences'              => static fn(\mysqli $db) => !_migProbe_tableExists($db, 'tblOrganisationLicences'),
     'songbook-affiliations'              => static fn(\mysqli $db) => !_migProbe_tableExists($db, 'tblSongbookAffiliations'),

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -210,6 +210,7 @@ $friendlyTitles = [
     'song-artists'                     => 'Songs Artist credit (#587)',
     'credit-people-slug'               => 'Credit People Slug + public page (#588)',
     'credit-people-name-parts'         => 'Credit People Structured Name (FirstNames / Surname / Suffix) (#934)',
+    'catalogues'                       => 'Catalogues — many-to-many song grouping (#941)',
     'user-avatar-service'              => 'Per-user Avatar Service (#616)',
     'organisation-licences'            => 'Multiple Licence Types per Organisation (#640)',
     'songbook-affiliations'            => 'Songbook Affiliations Registry (#670)',
@@ -284,6 +285,7 @@ $scriptMap = [
     'song-artists'  => 'migrate-song-artists.php',
     'credit-people-slug' => 'migrate-credit-people-slug.php',
     'credit-people-name-parts' => 'migrate-credit-people-name-parts.php',
+    'catalogues' => 'migrate-catalogues.php',
     'user-avatar-service' => 'migrate-user-avatar-service.php',
     'organisation-licences' => 'migrate-organisation-licences.php',
     'songbook-affiliations' => 'migrate-songbook-affiliations.php',
@@ -342,6 +344,7 @@ $migrationOrder = [
     'song-artists',
     'credit-people-slug',
     'credit-people-name-parts',
+    'catalogues',
     'user-avatar-service',
     'organisation-licences',
     'songbook-affiliations',
@@ -473,6 +476,16 @@ $migrationCards = [
                   . ' bio, lifespan, external links, and a discography grouped by role'
                   . ' across the six song-credit tables. Idempotent — safe to re-run.',
         'button' => 'Run Credit People Slug Migration',
+    ],
+    'catalogues' => [
+        'title'  => 'Catalogues — many-to-many song grouping (#941)',
+        'body'   => 'Adds <code>tblCatalogues</code> + <code>tblCatalogueSongs</code> so songs can'
+                  . ' be tagged into free-form thematic / curatorial groupings (Christmas, Modern'
+                  . ' worship, Public-Domain only, denominational affiliations, …) — orthogonal to'
+                  . ' the existing songbook hierarchy. One song can sit in many catalogues; admin'
+                  . ' CRUD lives at <a href="/manage/catalogues">/manage/catalogues</a>.'
+                  . ' Idempotent — safe to re-run.',
+        'button' => 'Run Catalogues Migration',
     ],
     'credit-people-name-parts' => [
         'title'  => 'Credit People Structured Name (#934)',
@@ -1001,6 +1014,7 @@ $migrationProbes = [
     'song-artists'                       => static fn(\mysqli $db) => !_migProbe_tableExists($db, 'tblSongArtists'),
     'credit-people-slug'                 => static fn(\mysqli $db) => !_migProbe_columnExists($db, 'tblCreditPeople', 'Slug'),
     'credit-people-name-parts'           => static fn(\mysqli $db) => !_migProbe_columnExists($db, 'tblCreditPeople', 'Surname'),
+    'catalogues'                         => static fn(\mysqli $db) => !_migProbe_tableExists($db, 'tblCatalogues'),
     'user-avatar-service'                => static fn(\mysqli $db) => !_migProbe_columnExists($db, 'tblUsers', 'AvatarService'),
     'organisation-licences'              => static fn(\mysqli $db) => !_migProbe_tableExists($db, 'tblOrganisationLicences'),
     'songbook-affiliations'              => static fn(\mysqli $db) => !_migProbe_tableExists($db, 'tblSongbookAffiliations'),

--- a/appWeb/public_html/manage/song-link-suggestions.php
+++ b/appWeb/public_html/manage/song-link-suggestions.php
@@ -9,8 +9,10 @@ declare(strict_types=1);
  * can one-click link them as the same hymn (writing into
  * tblSongLinks) or dismiss them (writing into
  * tblSongLinkSuggestionsDismissed). The producer side of the
- * pipeline is tools/build-song-link-suggestions.php — this page
- * only consumes that table.
+ * pipeline is appWeb/public_html/includes/tools/build-song-link-suggestions.php
+ * (relocated from project-root tools/ in #937 so it actually deploys —
+ * lftp only mirrors public_html/ to the remote). This page only
+ * consumes the populated table.
  *
  * Entitlement: edit_songs (curators who can fix song metadata
  * are the same set who should triage candidate links).
@@ -69,7 +71,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
            flash so the curator sees what was rebuilt. */
         ob_start();
         try {
-            require dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'tools' . DIRECTORY_SEPARATOR . 'build-song-link-suggestions.php';
+            require dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes'
+                . DIRECTORY_SEPARATOR . 'tools'
+                . DIRECTORY_SEPARATOR . 'build-song-link-suggestions.php';
             $output = ob_get_clean();
             $flash = 'Rebuilt suggestion list. ' . strip_tags(str_replace('<br>', ' · ', $output));
         } catch (\Throwable $e) {


### PR DESCRIPTION
## Summary

Seven commits closing seven issues from the 2026-05-10 multi-item batch. Five additional issues (#943, #944, #945, #946, #947) were created with full design but deliberately deferred — each is a multi-week piece of work that needs its own focused PR rather than being rushed inside a quick-wins bundle.

## Commits in this PR

| Issue | Commit | One-liner |
|---|---|---|
| [#937](https://github.com/MWBMPartners/iHymns/issues/937) | `7c4d247a` | **fix(song-link-suggestions):** relocate builder script into deployed path |
| [#936](https://github.com/MWBMPartners/iHymns/issues/936) | `dd78d744` | **fix(my-organisations):** inline labels on licence-row inputs |
| [#938](https://github.com/MWBMPartners/iHymns/issues/938) | `f77f8719` | **fix(editor-media):** visual separation between Audio / Sheet music / MIDI / MusicXML blocks |
| [#939](https://github.com/MWBMPartners/iHymns/issues/939) | `96141c66` | **docs(content-access):** document PD-gating independent-flag rule |
| [#940](https://github.com/MWBMPartners/iHymns/issues/940) | `5e3d626b` | **feat(song-page):** clickable Tune / CCLI / ISWC + credits parity + Works-graph translations |
| [#941](https://github.com/MWBMPartners/iHymns/issues/941) | `b6691f56` | **feat(catalogues):** many-to-many song grouping concept |
| [#942](https://github.com/MWBMPartners/iHymns/issues/942) | `9fa00f63` | **feat(works):** one-shot backfill task to derive Works from existing ISWCs |

## Highlights

### Bug fixes

- **#937 — Song Link Suggestions rebuild was 500'ing** because `tools/build-song-link-suggestions.php` lived at project root, but the deploy pipeline only mirrors `appWeb/public_html/` to the remote SFTP target — the file was never on the server. Moved into `appWeb/public_html/includes/tools/` (deploys, but `.htaccess Deny from all` keeps it unreachable as a direct GET).
- **#936 — Licence-row date input had no visible label** because the form jammed Number / Expires / Active / Notes into one `<td>` while the actual `<th>Expires</th>` sat over an empty cell. Added inline labels + `title` + `aria-label` per input.
- **#938 — Media tab subsections ran together** with no visual separation. Each non-first block now wraps in `mt-4 pt-4 border-top border-secondary border-opacity-25`.

### Documentation

- **#939 — PD-gating design intent** captured as an inline comment in `content_access.php` plus a memory entry. Future implementers of `require_lyrics_pd` / `require_music_pd` won't accidentally AND the two flags.

### Features

- **#940 — Public song page metadata becomes navigation:**
  - Tune name → `/tune/<slug>` (new page lists every song using that tune).
  - CCLI Song # → `https://songselect.ccli.com/songs/<num>` (new tab).
  - ISWC → `/iswc/<code>` (new page lists every song sharing that ISWC, links to matching Work when one exists).
  - Same three links mirrored in the after-lyrics credits block.
  - The existing Translations section between "Report a missing song" and "Related Songs" is now also fed by Works-graph siblings (via the extended `?action=song_translations` API), not just `tblSongTranslations` direct links.

- **#941 — Catalogue concept:** a many-to-many song grouping orthogonal to the songbook hierarchy. Schema (`tblCatalogues` + `tblCatalogueSongs`) + admin CRUD at `/manage/catalogues`. Use cases: thematic collections, worship-leader curations, Public-Domain views, denominational affiliations.

- **#942 — Works ISWC backfill:** one-shot data task at `appWeb/.sql/backfill-works-from-iswc.php` that derives `tblWorks` rows from existing `tblSongs.Iswc` values without any external API calls. Idempotent — re-runs add only the missing rows. Probe surfaces the task as pending whenever new ISWCs land in `tblSongs` without matching Works.

## Deferred to follow-up issues (no code in this PR)

- [#943](https://github.com/MWBMPartners/iHymns/issues/943) — Works ISWC API integration (ISWCnet + MusicBrainz + Music Rights Organisation IDs).
- [#944](https://github.com/MWBMPartners/iHymns/issues/944) — UI i18n + Translator role + Roles admin area.
- [#945](https://github.com/MWBMPartners/iHymns/issues/945) — Naming cleanup: User Groups / Access Tiers / Roles / Entitlements / Licence Types.
- [#946](https://github.com/MWBMPartners/iHymns/issues/946) — Analytics expansion + external analytics platform integration.
- [#947](https://github.com/MWBMPartners/iHymns/issues/947) — Login forms: integrate Cloudflare Turnstile / reCAPTCHA / hCaptcha.

Each issue carries a full design + acceptance criteria so the work is properly scoped when picked up.

## Test plan

- [ ] **#937** — `/manage/song-link-suggestions` → Rebuild button completes without 500; activity-log row captured.
- [ ] **#936** — `/manage/my-organisations` → licence-edit row shows inline `№` / `Expires` labels; date input has hover tooltip and aria-label.
- [ ] **#938** — Song Editor → Media tab → confirm visible gap + divider line between Audio / Sheet music / MIDI / MusicXML.
- [ ] **#939** — no runtime test (doc-only); verify the `content_access.php` comment is intact.
- [ ] **#940**:
  - Visit a song with Tune / CCLI / ISWC → all three are clickable.
  - CCLI link opens SongSelect in new tab.
  - `/tune/<slug>` page renders songs grouped by songbook.
  - `/iswc/<code>` page renders songs grouped by songbook + Work link if present.
  - After-lyrics credits block carries CCLI + ISWC parity.
  - Translations section populates with Works-graph siblings on a song that has cross-language Work members.
- [ ] **#941** — Run the migration via `/manage/setup-database` → `/manage/catalogues` accessible; create / edit / delete a catalogue; add a song member; remove a member.
- [ ] **#942** — Run the backfill via `/manage/setup-database` → confirm `tblWorks` populated for songs that have ISWCs; re-run reports zero new rows.
- [ ] `php -l` clean on every touched PHP file (verified locally).
- [ ] `node --check` clean on every touched JS file (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)