### PR TITLE
docs(.claude): port durable engineering conventions from stale branch + version bump 0.110.0 (closes #949)

### DIFF
--- a/.claude/ProjectBrief.md
+++ b/.claude/ProjectBrief.md
@@ -95,6 +95,23 @@ A multiplatform Christian lyrics application providing searchable hymn and worsh
 - Auto-bumped via conventional commits on push to `beta` (single source of truth)
 - Alpha builds display commit date timestamp (yyyymmddhhmmss) in footer
 
+### Cross-environment data sharing
+
+The three subdomains (`dev.ihymns.app` = alpha, `beta.ihymns.app` = beta, `www.ihymns.app` = main) connect to **one shared MySQL** at `mysql.MWBMpartners.ltd:3306` / DB name `ihymns`. There is no separate alpha-DB / beta-DB / prod-DB.
+
+State sharing across subdomains is **asymmetric** — easy to misdiagnose if you forget which axis is per-origin and which is `.ihymns.app`-scoped:
+
+| Layer | Scope | Notes |
+| --- | --- | --- |
+| MySQL row data | shared | One DB. A row written on alpha is immediately visible to beta + main. |
+| `ihymns_auth` cookie | `.ihymns.app` | Set by `setAuthTokenCookie()` / `_authCookieOpts()`. Cross-subdomain auth IS designed to work. |
+| `ihymns_sync` cookie | `.ihymns.app` | Lightweight settings sync (theme, font size, default songbook) via `js/modules/subdomain-sync.js`. Only path for cross-subdomain settings. |
+| Bearer token in localStorage | per-origin | W3C spec — each subdomain has its own. The cookie fallback in `getAuthBearerToken()` covers the gap. |
+| Service-worker cache | per-origin | Most common cause of "alpha data not appearing on main" symptoms when the underlying DB row is verified-present. |
+| Setlist / favourite localStorage | per-origin | Sharing across subdomains requires explicit DB sync via the auth flow, not magic. |
+
+When debugging "subdomain X has the data but Y doesn't", follow the diagnostic sequence in `.claude/project-rules.md` Section 14.3.
+
 ---
 
 ## 🎨 Design

--- a/.claude/project-rules.md
+++ b/.claude/project-rules.md
@@ -225,3 +225,46 @@ is free-form, which makes it tempting to dump request bodies wholesale.
 When in doubt, log the field NAME but not the field VALUE. A row that
 says `{ "fields": ["PasswordHash"] }` is fine; one that includes the
 hash itself is a bug.
+
+## 14. Conventions established post-#852 (HTTP / parser / browser-state)
+
+Durable patterns extracted from the diagnostic / scraper / auth-audit work after the catalogue-refresh batch. Read these before similar work — each rule has been paid for in real debugging time.
+
+### 14.1 Triage durable HTTP blocks via browser → curl → script (NOT VPN/UA swaps)
+
+When a scraper, fetcher, or any HTTP-driven script reports a block / rate-limit / wall that **survives across multiple sessions, networks, VPN endpoints, and User-Agents**, do NOT keep iterating on the network/UA dimension. Run a three-tier triage:
+
+1. Does the URL load in a normal browser on the same network? If no, it's truly a server-side block; VPN/UA swap may help.
+2. Does `curl` with realistic headers fetch the same content? If no, the block is at the HTTP-client level (TLS fingerprint, header order, ALPN); upgrade the client.
+3. Does the script's parser produce the right shape from that same byte stream? If no, **the bug is in our code**, not theirs.
+
+Only after steps 1–3 rule everything out, suspect a server-side bug.
+
+**Apply this whenever a "rate limit" survives more than ~3 attempted variations on the network/UA axis.** Real precedent: HA hymn 331 wall, 2026-05-07. Multiple sessions worth of VPN swaps + residential UA pools were spent on what turned out to be a parser bug (Section 14.2). `curl` with a Safari UA on the same machine returned full hymn HTML in 1.6s every time.
+
+### 14.2 Custom HTML parsers must keep void elements depth-neutral
+
+When writing or maintaining a depth-tracking HTML parser (subclass of `html.parser.HTMLParser` in Python or equivalent in any language), HTML void elements (`<br>`, `<hr>`, `<img>`, `<input>`, `<meta>`, `<link>`, `<area>`, `<base>`, `<col>`, `<embed>`, `<param>`, `<source>`, `<track>`, `<wbr>`) must NOT contribute to the depth counter on either `handle_starttag` or `handle_endtag`.
+
+Reason: `<br>` (no closing tag) fires only `handle_starttag`, while `<br />` (XHTML self-closing) fires both via `handle_startendtag`'s default. Treating either consistently — both increment + decrement, OR both skipped — keeps depth balanced.
+
+The bug shape is: title parses but no sections / children, page looks empty, structural rate-limit fallback misfires. That's the signature.
+
+Reference implementation: `.importers/scrapers/SDAHymnals_SDAHymnal.org.py` after PR #894. Don't repeat the depth-mistake pattern in any new parser.
+
+### 14.3 Per-origin browser state vs cross-origin cookies — known confusion
+
+iHymns runs at `dev.ihymns.app` (alpha), `beta.ihymns.app` (beta), and `www.ihymns.app` (main) sharing one MySQL DB. The shape of cross-subdomain state-sharing is asymmetric and easy to misdiagnose:
+
+- **Server-side auth via the `ihymns_auth` cookie** is `Domain=.ihymns.app`-scoped (set by `setAuthTokenCookie()` / `_authCookieOpts()` in `api.php`), so a server-side render or API call on any subdomain reads it. Cross-subdomain auth IS designed to work.
+- **Client-side bearer token in localStorage** is per-origin by W3C spec — each subdomain has its own. The frontend reads `localStorage.getItem('ihymns_auth_token')` and attaches it as `Authorization: Bearer …`. If main's localStorage is empty, the JS sets no Authorization header, but the browser still sends the `ihymns_auth` cookie automatically (default `credentials: 'same-origin'`), so the server still authenticates via the cookie fallback in `getAuthBearerToken()`.
+- **Cross-subdomain settings sync** (theme, font size, default songbook, etc.) goes via the `ihymns_sync` cookie at `.ihymns.app` scope — see `js/modules/subdomain-sync.js`. This is the ONLY lightweight-settings sharing mechanism; large data (setlists, favourites) is excluded by design.
+- **Service-worker caches** are per-origin too. A stale `?action=user_setlists` GET response on main can persist after the alpha-side sync wrote the new row to the shared DB. **Per-origin SW cache is the most common cause of "alpha data not appearing on main" symptoms** when the underlying DB row is verified-present.
+- **localStorage data** (setlists, favourites, history) is per-origin; sharing across subdomains requires explicit DB sync via the auth flow, not magic.
+
+**Diagnostic sequence when "subdomain X has the data but Y doesn't":**
+
+1. Confirm the data actually exists in the shared DB via `/manage/setup-database`'s tables panel or a direct SQL query.
+2. On Y, DevTools → Application → check `ihymns_auth` cookie (Domain should be `.ihymns.app`, not the subdomain).
+3. On Y, run `fetch('/api?action=user_setlists').then(r=>r.json())` in the console — if it returns the data fresh, the SW cache is the culprit; unregister via DevTools → Application → Service Workers → Unregister, reload.
+4. Only after steps 1–3 rule everything out, suspect a server-side bug.

--- a/appWeb/public_html/includes/infoAppVer.php
+++ b/appWeb/public_html/includes/infoAppVer.php
@@ -79,7 +79,7 @@ $app["Application"]["Description"]["Keywords"] = "hymns, worship, lyrics, songbo
 /* Semantic version number (MAJOR.MINOR.PATCH) */
 /* Auto-bumped by the version-bump GitHub Action on push to beta */
 /* v1.x.x = Phase 1 (local JSON data), v2.x.x = Phase 2 (iLyrics dB) */
-$app["Application"]["Version"]["Number"] = "0.100.0";
+$app["Application"]["Version"]["Number"] = "0.110.0";
 
 /* Version name: human-readable release name (e.g., "Hymnal", NULL if unused) */
 $app["Application"]["Version"]["Name"] = NULL;


### PR DESCRIPTION
## Summary

Recovers durable engineering content from the stale `claude/chore-claude-context-sync` branch (created yesterday but couldn't be merged as-is — `Section 13` numbering collision + week-old situational content mixed in with the durable bits). Plus version bump 0.100.0 → 0.110.0.

## Stale-branch investigation

Four `claude/*` branches survived auto-delete. After thorough analysis (`git cherry`, `merge-tree --write-tree`, file-level + line-level branch-vs-alpha diffs):

| Branch | Status | Action |
|---|---|---|
| `claude/fix-footer-songbook-bugs-ZcPNg` | Fully merged via PR #891 (squash collapsed hashes; auto-delete couldn't match). | Delete after this lands |
| `claude/import-videopsalm-files-jpXnE` | Substantively merged via PR #891. The 9 line-level deltas in `editor.js` are absorbed under different surrounding code on alpha (`_postFile` helper at line 3202). | Delete after this lands |
| `claude/update-claude-context-batch-840-852` | Superseded; the 2 unique lines describe v0.50.0 / pre-#852 state which alpha's docs have rewritten through v0.100.0. | Delete after this lands |
| `claude/chore-claude-context-sync` | **Has genuinely missing durable content**: 3 conventions (after dedup against alpha's existing rules) + a Cross-environment data sharing block. | **Port via this PR**; delete after merge |

## What this PR does

### `.claude/project-rules.md` — new Section 14

Three durable rules ported from the stranded branch, cross-checked against alpha's existing rules to avoid duplication:

- **14.1 Triage durable HTTP blocks via browser → curl → script (NOT VPN/UA swaps).** Three-tier triage. Real precedent: HA hymn 331 wall, where multiple sessions of VPN swaps + UA pools were burned on what turned out to be a parser bug.
- **14.2 Custom HTML parsers must keep void elements depth-neutral.** Lists every void element; explains why `<br>` + `<br />` need consistent treatment. Reference: `.importers/scrapers/SDAHymnals_SDAHymnal.org.py` after PR #894.
- **14.3 Per-origin browser state vs cross-origin cookies.** Tabulates which storage layer is shared vs per-origin; diagnostic sequence for "subdomain X has data but Y doesn't" debugging.

**Skipped:** a fourth original convention ("we sent it" honesty) was already covered by alpha's Section 13.2 with the same precedent (`api.php:1631 / 1751 / 7464` and #898). Re-porting would have been duplication.

### `.claude/ProjectBrief.md` — new Cross-environment data sharing subsection

Under Deployment & Versioning. Tabulates the asymmetric state-sharing layers across the three subdomains (shared MySQL row data, `.ihymns.app`-scoped auth + sync cookies, per-origin localStorage + SW cache). References Section 14.3 for the diagnostic flow.

### `appWeb/public_html/includes/infoAppVer.php` — version bump 0.100.0 → 0.110.0

Single source of truth (verified — no other file in the repo carries a literal version string). New minor reflects this docs-port plus the recent quick-wins batch (#948), credit-people split (#935), and songs static cache (#933) that all landed since 0.100.0.

## Explicitly NOT ported

Stale situational content — in-flight PR lists from a week ago, references to #893 awaiting merge, "Current Version: alpha at 0.80.0" descriptions. All superseded multiple times since the branch was created.

## Test plan

- [ ] Verify `.claude/project-rules.md` Section 14 renders cleanly in GitHub markdown.
- [ ] Verify `.claude/ProjectBrief.md` Cross-environment data sharing table renders cleanly.
- [ ] Confirm 0.110.0 shows in the admin / public footer post-deploy.

## After merge

Delete the four stale remote branches (pending user confirmation in the next session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)