### PR TITLE
fix(css): centralise link styling — kill browser-blue default site-wide; credits-block author parity (closes #951)

### DIFF
--- a/appWeb/public_html/css/app.css
+++ b/appWeb/public_html/css/app.css
@@ -398,6 +398,61 @@ body {
 }
 
 /* ==========================================================================
+   2.5  GLOBAL LINK DEFAULTS (#951)
+
+   Kills Bootstrap / browser-default `<a>` styling (bright blue + solid
+   underline) that visually shouts against iHymns' otherwise-muted
+   palette. Replaces it with the same look the writer-credit links have
+   used since #145 — inherits the surrounding text colour, no solid
+   underline, subtle dotted bottom-border that becomes solid + accent
+   on hover.
+
+   Bootstrap component classes (`.btn`, `.nav-link`, `.dropdown-item`,
+   `.breadcrumb-item a`, `.alert-link`, `.page-link`, `.list-group-item-
+   action`, `.navbar-brand`, etc.) carry their own explicit `color` /
+   `text-decoration` declarations and win on specificity (one-class
+   selector beats one-element selector), so chrome links keep their
+   existing styling. Only naked `<a>` tags inherit this default.
+
+   Loaded on every page (public + admin) — `app.css` is included from
+   both the public head and `manage/includes/head-libs.php`, so this
+   rule is genuinely global.
+
+   For semantic clarity, prose links inside the song page still tag
+   themselves with `.song-meta-link` — the visual outcome is identical
+   to this default, but the class makes the intent explicit and lets
+   future tweaks target it without disturbing the global default.
+   ========================================================================== */
+
+a {
+    color: inherit;
+    text-decoration: none;
+    border-bottom: 1px dotted var(--bs-secondary-color, #6c757d);
+    transition: color var(--transition-fast, 150ms ease),
+                border-color var(--transition-fast, 150ms ease);
+}
+
+a:hover {
+    color: var(--accent-solid, var(--bs-primary));
+    border-bottom-style: solid;
+    border-bottom-color: var(--accent-solid, var(--bs-primary));
+    text-decoration: none;
+}
+
+/* Visited inherits — no purple "you've been here" tint. */
+a:visited {
+    color: inherit;
+}
+
+/* Anchors that wrap an image / icon-only / no-text-content shouldn't
+   carry a dotted underline. Add `.link-bare` to opt-out, e.g.
+   `<a class="link-bare" href="..."><i class="bi-x"></i></a>`. */
+a.link-bare,
+a.link-bare:hover {
+    border-bottom: none;
+}
+
+/* ==========================================================================
    3. LAYOUT — Header, Footer, Main Content
    ========================================================================== */
 
@@ -2794,24 +2849,35 @@ body.reduce-motion .related-songs-chevron {
 }
 
 /* =========================================================================
- * WRITER/COMPOSER LINKS (#145)
+ * SONG META LINKS — was .writer-link (#145 / #951)
+ *
+ * Inline credit-row links — author / composer / adapter / translator /
+ * tune / CCLI / ISWC and any other inline metadata that should be a
+ * navigable link without screaming "I'M A LINK" in browser-default
+ * blue. Inherits the surrounding text colour, no underline, subtle
+ * dotted bottom-border that becomes solid + accent on hover.
+ *
+ * Renamed from .writer-link in #951 because the same style now applies
+ * to non-writer credits (tune, CCLI, ISWC). The bare global `a` rule
+ * above handles the "kill browser blue" concern; this class adds the
+ * explicit visual link-affordance for prose-flow links.
  * ========================================================================= */
 
-.writer-link {
+.song-meta-link {
     color: inherit;
     text-decoration: none;
     border-bottom: 1px dotted var(--bs-secondary-color, #6c757d);
     transition: color var(--transition-fast), border-color var(--transition-fast);
 }
 
-.writer-link:hover {
+.song-meta-link:hover {
     color: var(--accent-solid, var(--bs-primary));
     border-bottom-style: solid;
     border-bottom-color: var(--accent-solid, var(--bs-primary));
     text-decoration: none;
 }
 
-.writer-link:focus-visible {
+.song-meta-link:focus-visible {
     outline: 2px solid var(--accent-solid, var(--bs-primary));
     outline-offset: 2px;
     border-radius: 2px;

--- a/appWeb/public_html/includes/pages/song.php
+++ b/appWeb/public_html/includes/pages/song.php
@@ -432,7 +432,7 @@ try {
                             <i class="<?= htmlspecialchars($rowIcon) ?> me-2 text-muted" aria-hidden="true"></i>
                             <strong><?= htmlspecialchars($rowLabel) ?>:</strong>
                             <?php foreach ($rowNames as $i => $name): ?><a href="/people/<?= htmlspecialchars(urlencode(strtolower(str_replace(' ', '-', $name)))) ?>"
-                                   class="writer-link"
+                                   class="song-meta-link"
                                    data-navigate="person"><?= htmlspecialchars($name) ?></a><?php if ($i < count($rowNames) - 1): ?>;&nbsp;<?php endif; ?><?php endforeach; ?>
                         </p>
                     <?php endforeach; ?>
@@ -458,6 +458,7 @@ try {
                         <strong>Tune:</strong>
                         <?php if ($_tuneSlug !== ''): ?>
                             <a href="/tune/<?= htmlspecialchars($_tuneSlug) ?>"
+                               class="song-meta-link"
                                data-navigate="tune"
                                title="See all songs that use this tune"><?= htmlspecialchars($tuneName) ?></a>
                         <?php else: ?>
@@ -582,6 +583,7 @@ try {
                                     <i class="fa-solid fa-hashtag me-2" aria-hidden="true"></i>
                                     <strong>CCLI Song #</strong>&nbsp;<a
                                         href="https://songselect.ccli.com/songs/<?= htmlspecialchars($_ccliEnc) ?>"
+                                        class="song-meta-link"
                                         target="_blank"
                                         rel="noopener noreferrer external"
                                         title="View on CCLI SongSelect (opens in new tab)"><?= htmlspecialchars($ccli) ?></a>
@@ -599,6 +601,7 @@ try {
                                     <i class="fa-solid fa-barcode me-2" aria-hidden="true"></i>
                                     <strong>ISWC:</strong>&nbsp;<a
                                         href="/iswc/<?= htmlspecialchars($_iswcEnc) ?>"
+                                        class="song-meta-link"
                                         data-navigate="iswc"
                                         title="See all songs sharing this ISWC"><?= htmlspecialchars($iswc) ?></a>
                                 </span>
@@ -867,7 +870,15 @@ try {
                     <?php if (empty($rowNames)) continue; ?>
                     <div data-credit-kind="<?= htmlspecialchars($rowId) ?>">
                         <strong><?= htmlspecialchars($rowLabel) ?>:</strong>
-                        <?= htmlspecialchars(implode('; ', $rowNames)) ?>
+                        <?php /* #951 — credits-block author / composer / etc. now
+                                 click through to the same /people/<slug> page the
+                                 header credits do. Same .song-meta-link styling so
+                                 the footer reads as a muted parity copy of the
+                                 header, not a separate visual treatment. */
+                              foreach ($rowNames as $i => $name): ?><a
+                            href="/people/<?= htmlspecialchars(urlencode(strtolower(str_replace(' ', '-', $name)))) ?>"
+                            class="song-meta-link"
+                            data-navigate="person"><?= htmlspecialchars($name) ?></a><?php if ($i < count($rowNames) - 1): ?>;&nbsp;<?php endif; ?><?php endforeach; ?>
                     </div>
                 <?php endforeach; ?>
             <?php endif; ?>
@@ -880,6 +891,7 @@ try {
                     <strong>Tune:</strong>
                     <?php if ($_tuneSlugFooter !== ''): ?>
                         <a href="/tune/<?= htmlspecialchars($_tuneSlugFooter) ?>"
+                           class="song-meta-link"
                            data-navigate="tune"
                            title="See all songs that use this tune"><?= htmlspecialchars($tuneName) ?></a>
                     <?php else: ?>
@@ -896,6 +908,7 @@ try {
                 <div data-credit-kind="ccli">
                     <strong>CCLI Song #</strong>
                     <a href="https://songselect.ccli.com/songs/<?= htmlspecialchars($_ccliEncFooter) ?>"
+                       class="song-meta-link"
                        target="_blank"
                        rel="noopener noreferrer external"
                        title="View on CCLI SongSelect (opens in new tab)"><?= htmlspecialchars($ccli) ?></a>
@@ -907,6 +920,7 @@ try {
                 <div data-credit-kind="iswc" title="International Standard Musical Work Code">
                     <strong>ISWC:</strong>
                     <a href="/iswc/<?= htmlspecialchars($_iswcEncFooter) ?>"
+                       class="song-meta-link"
                        data-navigate="iswc"
                        title="See all songs sharing this ISWC"><?= htmlspecialchars($iswc) ?></a>
                 </div>


### PR DESCRIPTION
## Summary

The new Tune / CCLI / ISWC links shipped in PR #948 rendered in browser-default bright-blue + solid-underline while the existing author-credit links used the muted `.writer-link` style. They visually shouted against the otherwise-muted credit block.

This PR fixes the styling **centrally** — every naked `<a>` site-wide now inherits the muted look (dotted bottom-border, accent-coloured on hover) so future code doesn't have to remember to opt in. Plus credits-block author/composer parity that was missing in #948.

## What changed

### 1. Global `<a>` default — `appWeb/public_html/css/app.css`

New top-level rule (Section 2.5) that overrides the browser / Bootstrap default site-wide:

```css
a {
    color: inherit;
    text-decoration: none;
    border-bottom: 1px dotted var(--bs-secondary-color);
    transition: ...;
}
a:hover {
    color: var(--accent-solid);
    border-bottom-style: solid;
    border-bottom-color: var(--accent-solid);
}
a:visited { color: inherit; }
```

**Bootstrap component classes win on specificity** — `.btn`, `.nav-link`, `.dropdown-item`, `.breadcrumb-item a`, `.alert-link`, `.page-link`, `.list-group-item-action`, `.navbar-brand` etc. carry their own explicit `color` / `text-decoration` declarations. Only naked `<a>` tags pick up the new default.

Loaded on every page (public + admin) — `app.css` is included from both the public head and `manage/includes/head-libs.php`, so this is genuinely site-wide.

A `.link-bare` opt-out class is provided for icon-only / image-wrapping anchors.

### 2. `.writer-link` renamed `.song-meta-link`

Always slightly mis-named — composers used it too, and now Tune / CCLI / ISWC do as well. Renamed in CSS and at the one consumer site in `song.php`.

### 3. New tune / CCLI / ISWC links opt into `.song-meta-link`

Both header (PR #940) and credits-block footer get the class explicitly. Visual outcome matches the new global default; the explicit class makes intent legible.

### 4. Credits-block author / composer / etc. now clickable

The after-lyrics credits footer used to render plain text:

```php
<?= htmlspecialchars(implode('; ', $rowNames)) ?>
```

Now wraps each name in the same `/people/<slug>` link the header uses, with `class=\"song-meta-link\" data-navigate=\"person\"`. Parity restored.

## Visual comparison

| Where | Before | After |
|---|---|---|
| Header author / composer | muted dotted underline | (unchanged) |
| Header tune / CCLI / ISWC | **browser-blue + solid underline** | muted dotted underline |
| Footer author / composer | **plain text, not clickable** | muted dotted underline + clickable |
| Footer tune / CCLI / ISWC | **browser-blue + solid underline** | muted dotted underline |
| Admin description links (e.g. data-health.php) | browser-blue + solid underline | muted dotted underline |

## Test plan

- [ ] On the song page, every metadata field (header + footer) renders with the same muted dotted-underline style.
- [ ] Hover on any link surfaces the accent colour + solid-underline transition.
- [ ] Bootstrap chrome (navbar, breadcrumbs, dropdown items, button-styled links) is visually unchanged.
- [ ] CCLI link still opens in a new tab (`target=\"_blank\"` preserved).
- [ ] Footer author / composer / adapter / translator names are clickable and route to `/people/<slug>`.
- [ ] Admin pages (e.g. `/manage/data-health`) — inline-prose links no longer pop out in blue but still visibly underlined.
- [ ] No `:focus-visible` regression — the existing `:focus-visible` outline rule still works on every anchor.

## Out of scope / follow-ups

- Audit each naked `<a>` in admin descriptions to decide whether the dotted underline reads correctly in context. Most should be fine; surgical fixes possible per-site if not.
- Consider extending the `.link-bare` opt-out to any future icon-only anchors discovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)