### PR TITLE
fix(catalogues): honour the admin dark-mode convention (closes #953)

### DIFF
--- a/appWeb/public_html/manage/catalogues.php
+++ b/appWeb/public_html/manage/catalogues.php
@@ -310,7 +310,7 @@ if ($hasSchema && !empty($catalogues)) {
 }
 ?>
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-bs-theme="dark">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
## Summary

One-line bug fix. \`/manage/catalogues\` (shipped in PR #948 as part of the #941 quick-win) rendered in light mode while every other admin page renders in dark — because the new page's \`<html>\` tag was missing the \`data-bs-theme=\"dark\"\` attribute that 20+ other admin pages hardcode.

## Diff

\`\`\`diff
- <html lang=\"en\">
+ <html lang=\"en\" data-bs-theme=\"dark\">
\`\`\`

## Out of scope

The admin convention itself is a wart — every \`/manage/*.php\` page hardcodes \`data-bs-theme=\"dark\"\`, so the theme picker in admin-nav only affects runtime state until reload. That's worth fixing separately so admin pages honour the user's profile preference (Light / Dark / System) like the public site does. Separate issue / PR.

## Test plan

- [ ] On alpha after merge: visit \`/manage/catalogues\` → renders in dark mode.
- [ ] Visual style now matches \`/manage/songbook-series\`, \`/manage/works\`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)