### PR TITLE
feat(admin): admin pages obey user theme preference (Light / Dark / High-contrast / CVD / System) (closes #955)

### DIFF
--- a/appWeb/public_html/manage/activity-log.php
+++ b/appWeb/public_html/manage/activity-log.php
@@ -294,7 +294,7 @@ $buildQuery = function (array $overrides = []) {
 };
 ?>
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/appWeb/public_html/manage/analytics.php
+++ b/appWeb/public_html/manage/analytics.php
@@ -174,7 +174,7 @@ try {
 
 ?>
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/appWeb/public_html/manage/catalogues.php
+++ b/appWeb/public_html/manage/catalogues.php
@@ -310,7 +310,7 @@ if ($hasSchema && !empty($catalogues)) {
 }
 ?>
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/appWeb/public_html/manage/ccli-report.php
+++ b/appWeb/public_html/manage/ccli-report.php
@@ -137,7 +137,7 @@ foreach ($rows as $r) $totalViews += (int)$r['view_count'];
 
 ?>
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/appWeb/public_html/manage/configuration.php
+++ b/appWeb/public_html/manage/configuration.php
@@ -236,7 +236,7 @@ $currentService  = $currentSettings['email_service'] ?? 'none';
 require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-favicon.php';
 ?>
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/appWeb/public_html/manage/credit-people-bulk-promote.php
+++ b/appWeb/public_html/manage/credit-people-bulk-promote.php
@@ -331,7 +331,7 @@ if (!empty($registryByName)) {
 
 ?>
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/appWeb/public_html/manage/credit-people.php
+++ b/appWeb/public_html/manage/credit-people.php
@@ -1180,7 +1180,7 @@ $totalInUseUnregistered = count(array_filter($people, static fn($p) =>
 ));
 ?>
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/appWeb/public_html/manage/data-health.php
+++ b/appWeb/public_html/manage/data-health.php
@@ -265,7 +265,7 @@ function health_badge(string $state, string $label): string {
 $csrf = csrfToken();
 ?>
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/appWeb/public_html/manage/editor/index.php
+++ b/appWeb/public_html/manage/editor/index.php
@@ -26,7 +26,7 @@ requireEditor();
 $currentUser = getCurrentUser();
 ?>
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en">
 <head>
     <!-- =================================================================
          HEAD — Meta, Bootstrap 5.3 CDN, Bootstrap Icons, Page Title
@@ -36,6 +36,14 @@ $currentUser = getCurrentUser();
 
     <!-- Page title shown in the browser tab -->
     <title>iHymns Song Editor</title>
+
+    <!-- #955 — synchronous theme resolver. Sets data-bs-theme,
+         data-ihymns-theme, data-ihymns-contrast, data-ihymns-cvd
+         from localStorage BEFORE any CSS loads so the editor paints
+         with the correct theme. The Song Editor has its own bespoke
+         <head> (doesn't go through head-libs.php), so we include the
+         partial directly. -->
+    <?php require dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-theme-init.php'; ?>
 
     <!-- Bootstrap 5.3 CSS — loaded from CDN for convenience (no local dependency) -->
     <link

--- a/appWeb/public_html/manage/entitlements.php
+++ b/appWeb/public_html/manage/entitlements.php
@@ -143,7 +143,7 @@ $isGlobalAdmin = ($currentUser['role'] ?? '') === 'global_admin';
 
 ?>
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/appWeb/public_html/manage/external-link-types.php
+++ b/appWeb/public_html/manage/external-link-types.php
@@ -230,7 +230,7 @@ $categoryLabels = [
 
 ?>
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/appWeb/public_html/manage/groups.php
+++ b/appWeb/public_html/manage/groups.php
@@ -229,7 +229,7 @@ if ($editId > 0) {
 $csrf = csrfToken();
 ?>
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/appWeb/public_html/manage/help.php
+++ b/appWeb/public_html/manage/help.php
@@ -190,7 +190,7 @@ foreach ($sections as $s) {
 
 ?>
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/appWeb/public_html/manage/includes/admin-nav.php
+++ b/appWeb/public_html/manage/includes/admin-nav.php
@@ -137,9 +137,12 @@ $_avatarUrlLarge = userAvatarUrl($_userEmail, 64, $_userAvatarSvc);
                     <i class="bi bi-search" aria-hidden="true"></i>
                 </button>
 
-                <!-- Theme toggle — same shape as main site but admin is
-                     currently always dark. Offered anyway so admins can
-                     temporarily switch for screenshots / demos. -->
+                <!-- Theme toggle — picks Light / Dark / System and persists
+                     to localStorage.ihymns_theme so the choice survives
+                     page reloads and is shared with the public site
+                     (#955). For high-contrast / CVD modes, users go to
+                     the public-site Settings page; admin pages still
+                     pick those preferences up via admin-theme-init.php. -->
                 <div class="dropdown">
                     <button type="button"
                             class="btn btn-header-icon dropdown-toggle"
@@ -162,6 +165,26 @@ $_avatarUrlLarge = userAvatarUrl($_userEmail, 64, $_userAvatarSvc);
                         </button></li>
                     </ul>
                 </div>
+                <script>
+                /* #955 — admin theme dropdown handler. Maps the BS-docs
+                   data-bs-theme-value attribute (light/dark/auto) onto
+                   the public-site storage key (ihymns_theme; with auto →
+                   system) and re-applies via the helper exposed by
+                   admin-theme-init.php. Idempotent — re-runs no-op. */
+                (function () {
+                    var KEY = 'ihymns_theme';
+                    document.querySelectorAll('[data-bs-theme-value]').forEach(function (btn) {
+                        btn.addEventListener('click', function () {
+                            var v = btn.getAttribute('data-bs-theme-value');
+                            var t = (v === 'auto') ? 'system' : v;
+                            try { localStorage.setItem(KEY, t); } catch (_e) { /* private browsing */ }
+                            if (typeof window.iHymnsAdminApplyTheme === 'function') {
+                                window.iHymnsAdminApplyTheme(t);
+                            }
+                        });
+                    });
+                })();
+                </script>
 
                 <!-- Account dropdown (#579) — single circular avatar
                      button at every viewport, matching the main-app

--- a/appWeb/public_html/manage/includes/admin-theme-init.php
+++ b/appWeb/public_html/manage/includes/admin-theme-init.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Admin theme-init resolver (#955)
+ *
+ * Synchronous inline <script> that runs early in <head> on every
+ * admin page, BEFORE any CSS loads. Reads the user's theme
+ * preference from localStorage (same key the public site uses) and
+ * sets the matching attributes on <html> so the page paints with
+ * the correct theme — no flash of wrong content.
+ *
+ * Sets the same attributes the public site's settings.js applyTheme()
+ * sets:
+ *   - data-bs-theme         ∈ {light, dark}
+ *   - data-ihymns-theme     ∈ {light, dark, high-contrast}
+ *   - data-ihymns-contrast="high" when ihymns-theme === 'high-contrast'
+ *   - data-ihymns-cvd       ∈ {protanopia, deuteranopia, tritanopia, achromatopsia} or absent
+ *
+ * Also exposes `window.iHymnsAdminApplyTheme(theme)` so the admin-nav
+ * theme dropdown can re-apply after writing to storage.
+ *
+ * USAGE
+ *   <head>
+ *     ... <title> ...
+ *     <?php require __DIR__ . '/admin-theme-init.php'; ?>
+ *     ... <link rel="stylesheet" ...> ...
+ *
+ * Loaded from `head-libs.php` (every admin page) and from
+ * `manage/editor/index.php` (which has its own bespoke <head>
+ * that doesn't go through head-libs.php).
+ *
+ * Replaces the per-page hardcoded `<html data-bs-theme="dark">`
+ * convention that ignored user preference (#953 / #955).
+ */
+
+if (basename($_SERVER['SCRIPT_FILENAME'] ?? '') === basename(__FILE__)) {
+    http_response_code(403);
+    exit('Access denied.');
+}
+?>
+<script>
+(function () {
+    /* Mirror of the storage keys used by js/modules/settings.js +
+       js/constants.js so admin pages share the SAME preference the
+       public site reads/writes. Keep in lock-step if those keys ever
+       change. */
+    var THEME_KEY = 'ihymns_theme';
+    var CVD_KEY   = 'ihymns_cvd_mode';
+
+    /**
+     * Apply a chosen theme by setting the four <html> attributes the
+     * stylesheets read. Mirrors settings.js applyTheme() semantics so
+     * admin pages and the public site stay visually consistent.
+     *
+     * @param {string} rawTheme One of 'light' | 'dark' | 'high-contrast' | 'system'
+     */
+    function applyTheme(rawTheme) {
+        rawTheme = rawTheme || 'system';
+        var ihymnsTheme = rawTheme;
+        var bsTheme     = 'light';
+
+        if (rawTheme === 'system') {
+            var prefersDark = window.matchMedia
+                && window.matchMedia('(prefers-color-scheme: dark)').matches;
+            ihymnsTheme = prefersDark ? 'dark' : 'light';
+            bsTheme = ihymnsTheme;
+        } else if (rawTheme === 'dark') {
+            bsTheme = 'dark';
+        } else if (rawTheme === 'high-contrast') {
+            /* High-contrast uses light Bootstrap base + the overrides
+               in accessibility.css. Same convention as settings.js. */
+            bsTheme = 'light';
+        }
+
+        var html = document.documentElement;
+        html.setAttribute('data-bs-theme', bsTheme);
+        html.setAttribute('data-ihymns-theme', ihymnsTheme);
+        if (ihymnsTheme === 'high-contrast') {
+            html.setAttribute('data-ihymns-contrast', 'high');
+        } else {
+            html.removeAttribute('data-ihymns-contrast');
+        }
+
+        /* CVD palette is independent of theme. */
+        try {
+            var cvd = localStorage.getItem(CVD_KEY);
+            if (cvd) {
+                html.setAttribute('data-ihymns-cvd', cvd);
+            } else {
+                html.removeAttribute('data-ihymns-cvd');
+            }
+        } catch (_e) { /* localStorage unavailable — leave CVD alone */ }
+    }
+
+    /* Synchronous first-paint resolution. */
+    try {
+        var raw = (window.localStorage && localStorage.getItem(THEME_KEY)) || 'system';
+        applyTheme(raw);
+    } catch (_e) {
+        /* localStorage blocked (private browsing, third-party context).
+           Fall back to OS pref alone — that's still better than the old
+           hardcoded `dark` for users who actually want light. */
+        try {
+            var dark = window.matchMedia
+                && window.matchMedia('(prefers-color-scheme: dark)').matches;
+            document.documentElement.setAttribute('data-bs-theme', dark ? 'dark' : 'light');
+            document.documentElement.setAttribute('data-ihymns-theme', dark ? 'dark' : 'light');
+        } catch (_e2) { /* nothing else we can do */ }
+    }
+
+    /* Live-update on OS theme change for users on 'system' preference.
+       Mirrors settings.js init()'s matchMedia listener so admin pages
+       respond to OS toggles without a manual reload. */
+    try {
+        if (window.matchMedia) {
+            var mql = window.matchMedia('(prefers-color-scheme: dark)');
+            var onChange = function () {
+                var current = (window.localStorage && localStorage.getItem(THEME_KEY)) || 'system';
+                if (current === 'system') applyTheme('system');
+            };
+            if (mql.addEventListener) {
+                mql.addEventListener('change', onChange);
+            } else if (mql.addListener) {
+                /* Safari < 14 / older WebKit */
+                mql.addListener(onChange);
+            }
+        }
+    } catch (_e) { /* swallow — listener is a nice-to-have */ }
+
+    /* Expose so the admin-nav dropdown can re-apply after persisting. */
+    window.iHymnsAdminApplyTheme = applyTheme;
+})();
+</script>

--- a/appWeb/public_html/manage/includes/head-libs.php
+++ b/appWeb/public_html/manage/includes/head-libs.php
@@ -33,6 +33,11 @@ if (basename($_SERVER['SCRIPT_FILENAME'] ?? '') === basename(__FILE__)) {
     exit('Access denied.');
 }
 
+/* #955 — synchronous theme resolver MUST run before any CSS link
+   so the browser has the correct data-bs-theme / data-ihymns-theme
+   attributes set before computing layout. No FOUC. */
+require __DIR__ . DIRECTORY_SEPARATOR . 'admin-theme-init.php';
+
 $_bs = APP_CONFIG['libraries']['bootstrap'] ?? null;
 if ($_bs && !empty($_bs['css_cdn'])):
     ?>

--- a/appWeb/public_html/manage/index.php
+++ b/appWeb/public_html/manage/index.php
@@ -106,7 +106,7 @@ try {
 $csrf = csrfToken();
 ?>
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/appWeb/public_html/manage/languages.php
+++ b/appWeb/public_html/manage/languages.php
@@ -434,7 +434,7 @@ $summary = $db->query(
 require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-favicon.php';
 ?>
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/appWeb/public_html/manage/login.php
+++ b/appWeb/public_html/manage/login.php
@@ -67,7 +67,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 $csrf = csrfToken();
 ?>
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/appWeb/public_html/manage/missing-numbers.php
+++ b/appWeb/public_html/manage/missing-numbers.php
@@ -97,7 +97,7 @@ foreach ($reports as $r) {
 
 ?>
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/appWeb/public_html/manage/my-organisations.php
+++ b/appWeb/public_html/manage/my-organisations.php
@@ -392,7 +392,7 @@ render:
 $csrf = csrfToken();
 ?>
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/appWeb/public_html/manage/notifications.php
+++ b/appWeb/public_html/manage/notifications.php
@@ -313,7 +313,7 @@ if ($typesRes) {
 require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-favicon.php';
 ?>
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/appWeb/public_html/manage/organisations.php
+++ b/appWeb/public_html/manage/organisations.php
@@ -419,7 +419,7 @@ if ($editId > 0) {
 $csrf = csrfToken();
 ?>
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/appWeb/public_html/manage/requests.php
+++ b/appWeb/public_html/manage/requests.php
@@ -126,7 +126,7 @@ try {
 
 ?>
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/appWeb/public_html/manage/restrictions.php
+++ b/appWeb/public_html/manage/restrictions.php
@@ -264,7 +264,7 @@ try {
 $csrf = csrfToken();
 ?>
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/appWeb/public_html/manage/revisions.php
+++ b/appWeb/public_html/manage/revisions.php
@@ -94,7 +94,7 @@ try {
 
 ?>
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/appWeb/public_html/manage/schema-audit.php
+++ b/appWeb/public_html/manage/schema-audit.php
@@ -147,7 +147,7 @@ if ($audit !== null) {
 }
 ?>
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -1430,7 +1430,7 @@ if ($action !== '') {
 <!DOCTYPE html>
 <!-- IHYMNS_APPLY_ALL_CHROME_v3 — if you can see this comment in View Source,
      the chrome-first render is reaching the browser. (#817 round 2) -->
-<html lang="en" data-bs-theme="dark">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -1743,7 +1743,7 @@ if ($hasCredentials && defined('DB_HOST')) {
  * ========================================================================= */
 ?>
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/appWeb/public_html/manage/setup.php
+++ b/appWeb/public_html/manage/setup.php
@@ -51,7 +51,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 $csrf = csrfToken();
 ?>
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/appWeb/public_html/manage/song-link-suggestions.php
+++ b/appWeb/public_html/manage/song-link-suggestions.php
@@ -244,7 +244,7 @@ $csrf = csrfToken();
 
 ?>
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/appWeb/public_html/manage/songbook-series.php
+++ b/appWeb/public_html/manage/songbook-series.php
@@ -393,7 +393,7 @@ if ($hasSchema) {
 }
 ?>
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/appWeb/public_html/manage/songbooks.php
+++ b/appWeb/public_html/manage/songbooks.php
@@ -2332,7 +2332,7 @@ try {
 $csrf = csrfToken();
 ?>
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/appWeb/public_html/manage/tags.php
+++ b/appWeb/public_html/manage/tags.php
@@ -351,7 +351,7 @@ if ($res) $res->close();
 require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-favicon.php';
 ?>
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/appWeb/public_html/manage/tiers.php
+++ b/appWeb/public_html/manage/tiers.php
@@ -212,7 +212,7 @@ $csrf = csrfToken();
 $tierTableCols = 3 + count(TIER_CAPS) + 2;
 ?>
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/appWeb/public_html/manage/users.php
+++ b/appWeb/public_html/manage/users.php
@@ -270,7 +270,7 @@ function canManage(array $target, array $actor): bool {
 }
 ?>
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/appWeb/public_html/manage/works.php
+++ b/appWeb/public_html/manage/works.php
@@ -537,7 +537,7 @@ if ($hasSchema) {
 /* ----- Page render ----- */
 ?>
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
## Summary

Every `/manage/*` admin page hardcoded `<html lang=\"en\" data-bs-theme=\"dark\">`. The user's theme preference (Light / Dark / High-contrast / CVD / System), set on the public-site Settings page, was completely ignored on admin surfaces — they were always dark. The admin-nav theme dropdown's Light/Dark/System buttons literally did nothing (no click handler).

This PR closes the gap with a synchronous theme resolver that runs in `<head>` on every admin page, reads the same localStorage keys the public site uses, and sets the matching `<html>` attributes before any CSS loads — no flash of wrong content.

**Supersedes PR #954** (the one-line catalogues fix). Same underlying issue, narrower scope. This PR makes the fix site-wide and removes the hardcoded attribute from `catalogues.php` along with every other admin page.

## What changed

### New file — `appWeb/public_html/manage/includes/admin-theme-init.php`

Tiny inline `<script>` partial. Reads `localStorage.ihymns_theme` (default `'system'`) + `localStorage.ihymns_cvd_mode`, resolves to:

| Attribute | Values |
|---|---|
| `data-bs-theme` | `light` \| `dark` |
| `data-ihymns-theme` | `light` \| `dark` \| `high-contrast` |
| `data-ihymns-contrast` | `high` (when ihymns-theme is high-contrast; absent otherwise) |
| `data-ihymns-cvd` | `protanopia` \| `deuteranopia` \| `tritanopia` \| `achromatopsia` (or absent) |

Mirrors the semantics of `js/modules/settings.js applyTheme()` so admin and public pages stay visually consistent.

- Defensive against `localStorage` exceptions (private browsing, third-party context).
- Live-listens for OS theme changes when the user is on `'system'` — admin pages recolour mid-session if the OS toggles, matching public-site behaviour.
- Exposes `window.iHymnsAdminApplyTheme(theme)` so the dropdown handler can re-apply after persisting.

### Wiring

- **`head-libs.php`** requires the new partial **before** the Bootstrap CSS link. Covers every admin page that uses the shared head bundler.
- **`manage/editor/index.php`** requires the new partial directly in its bespoke `<head>`. The Song Editor shares the same semantics without going through `head-libs.php`.

### Dropdown handler in `admin-nav.php`

Small inline `<script>` after the theme dropdown markup. Listens for clicks on `[data-bs-theme-value]`, maps `auto` → `system`, persists to `localStorage.ihymns_theme`, and re-applies via `iHymnsAdminApplyTheme()`. Choice survives reloads and is mirrored to the public site via the shared key.

### Sweep — 32 admin pages

Removed `data-bs-theme=\"dark\"` from every admin page's `<html>` tag. The resolver script overrides on first paint anyway, but the hardcoded attribute would cause a brief flash of dark for users who want light.

## Stat

```
36 files changed, 208 insertions(+), 37 deletions(-)
1 new file: admin-theme-init.php
35 files modified
```

## Test plan

- [ ] Set theme to `Light` on public-site Settings → reload `/manage/*` → admin pages render light, no flash.
- [ ] Set theme to `Dark` → admin renders dark.
- [ ] Set theme to `High-contrast` → admin renders high-contrast variant.
- [ ] Set CVD mode (any of protanopia/deuteranopia/tritanopia/achromatopsia) → admin pages pick up `data-ihymns-cvd` and render with the CVD palette overrides.
- [ ] Set theme to `System` → admin matches OS dark/light. Toggle OS dark mode while on an admin page → admin recolours immediately (no reload needed).
- [ ] Click `Light` / `Dark` / `System` in the admin-nav theme dropdown → choice persists across reloads AND propagates to the public site (same `localStorage.ihymns_theme` key).
- [ ] Open the Song Editor (`/manage/editor/`) → editor honours theme too.
- [ ] No regression — every admin page reads correctly.
- [ ] `php -l` clean on every touched file (verified locally — 35/35 clean).

## Out of scope

- Admin-nav doesn't expose High-contrast or CVD pickers — those stay on the public-site Settings page. Admin pages just READ the preferences.
- The Song Editor's bespoke `<head>` could be migrated to use `head-libs.php` for consistency, but that's a bigger refactor for another PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)