### PR TITLE
fix(security): two CodeQL HIGH XSS alerts + .gitignore wiki & SourceSongData (closes #958)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -228,6 +228,23 @@ appWeb/public_html/vendor/
 # ----------------------------------------------------------------------------
 # Source Scraped Song data
 # ----------------------------------------------------------------------------
+# `.SourceSongData/*` is the legacy path (some files are tracked beneath
+# it for the original 5 English songbooks). The `*` glob lets the rule
+# ignore newly-added files without breaking the existing tracked tree.
 .SourceSongData/*
+# `SourceSongData/` is the newer no-leading-dot convention used by every
+# scrape since 2026-04 (#699 multilingual; #663 CIS) — nothing under
+# it is tracked, so we ignore the whole tree.
+SourceSongData/
 *_debug_*_raw.html
 *_debug_*_skipped.html
+
+# ----------------------------------------------------------------------------
+# GitHub Wiki sibling clone (#958)
+# ----------------------------------------------------------------------------
+# GitHub stores wikis as a separate git repo (`<project>.wiki.git`); cloning
+# it alongside the main repo lets Claude / IDEs read wiki content without a
+# network round-trip. The clone is its own repository — never commit it
+# inside the main repo.
+iHymns.wiki/
+iHymns.wiki.git/

--- a/appWeb/public_html/js/modules/favorites.js
+++ b/appWeb/public_html/js/modules/favorites.js
@@ -456,7 +456,7 @@ export class Favorites {
                            data-song-id="${escapeHtml(fav.id)}"
                            aria-label="Select ${escapeHtml(toTitleCase(fav.title))}"
                            onclick="event.stopPropagation()">
-                    <span class="song-number-badge" data-songbook="${escapeHtml(fav.songbook)}">${fav.number ?? ''}</span>
+                    <span class="song-number-badge" data-songbook="${escapeHtml(fav.songbook)}">${escapeHtml(String(fav.number ?? ''))}</span>
                     <div class="song-info flex-grow-1">
                         <span class="song-title">${escapeHtml(toTitleCase(fav.title))}${verifiedBadge(fav)}</span>
                         <small class="text-muted d-block">${songbookLabel(fav.songbook)}${tagsHtml}</small>
@@ -535,15 +535,28 @@ export class Favorites {
 
         if (toolbar) toolbar.classList.toggle('d-none', !this.selectMode);
 
-        /* In select mode, clicks toggle checkboxes instead of navigating */
+        /* In select mode, clicks toggle checkboxes instead of
+           navigating. We strip `href` to disable native anchor
+           navigation. To restore, we REBUILD from `data-song-id`
+           (escapeHtml'd at row creation in loadFavoritesList) rather
+           than round-tripping the previous href through a data
+           attribute — the round-trip pattern trips CodeQL's "DOM text
+           reinterpreted as HTML" rule even when the source is
+           trusted (#958). */
         listItems.forEach(item => {
             if (this.selectMode) {
-                item.setAttribute('data-original-href', item.getAttribute('href'));
                 item.removeAttribute('href');
                 item.addEventListener('click', this._handleSelectClick);
             } else {
-                const original = item.getAttribute('data-original-href');
-                if (original) item.setAttribute('href', original);
+                const songId = item.dataset.songId;
+                if (songId) {
+                    /* dataset.songId is read back as a string, but
+                       it was set via escapeHtml() in loadFavoritesList,
+                       so any HTML-special chars are already entities.
+                       Anchor-href reads strings as URL-text, not HTML,
+                       so the `/song/<id>` shape is safe. */
+                    item.setAttribute('href', '/song/' + encodeURIComponent(songId));
+                }
                 item.removeEventListener('click', this._handleSelectClick);
             }
         });

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -2109,9 +2109,16 @@ function bindTagSearchInput() {
             var item = document.createElement('button');
             item.type = 'button';
             item.className = 'list-group-item list-group-item-action d-flex justify-content-between align-items-center';
+            /* #958 — s.usage is a count from the tag_search API but
+               it's still an untrusted string from the server's
+               perspective. Coerce to a non-negative integer before
+               interpolation; defends against a stored-XSS path where
+               a malicious tag-row could carry a string usage value. */
+            var usageNum = parseInt(s.usage, 10);
+            if (!Number.isFinite(usageNum) || usageNum < 0) usageNum = 0;
             item.innerHTML =
                 '<span>' + escapeHtmlSafe(s.name) + '</span>' +
-                '<span class="badge bg-secondary">' + s.usage + '</span>';
+                '<span class="badge bg-secondary">' + usageNum + '</span>';
             item.addEventListener('click', function () {
                 var song = findSongById(currentSongId);
                 if (song) addSongTag(song, s.name);
@@ -2761,9 +2768,15 @@ function attachCreditAutocomplete(input, row, kind, onChange) {
             var kindsBadge = (s.kinds && s.kinds.length)
                 ? '<small class="text-muted">' + escapeHtmlSafe(s.kinds.join(' · ')) + '</small>'
                 : '';
+            /* #958 — same coerce-to-integer pattern as the tag-search
+               sink above. `s.usage` from the credit_search API is a
+               count, but defence-in-depth: coerce before interpolation
+               so a stored-XSS via a string `usage` is impossible. */
+            var creditUsageNum = parseInt(s.usage, 10);
+            if (!Number.isFinite(creditUsageNum) || creditUsageNum < 0) creditUsageNum = 0;
             item.innerHTML =
                 '<span><strong>' + escapeHtmlSafe(s.name) + '</strong> ' + kindsBadge + '</span>' +
-                '<span class="badge bg-secondary">' + (s.usage || 0) + '</span>';
+                '<span class="badge bg-secondary">' + creditUsageNum + '</span>';
             item.addEventListener('click', function (e) {
                 e.preventDefault();
                 input.value = s.name;


### PR DESCRIPTION
## Summary

Resolves both open CodeQL HIGH alerts plus adjacent `.gitignore` hygiene.

## CodeQL fixes

### `editor.js` — Client-side XSS (tag + credit suggestions)

\`s.usage\` from the search-suggestion API responses was concatenated into innerHTML without escaping:

\`\`\`js
'<span class=\"badge bg-secondary\">' + s.usage + '</span>'
\`\`\`

Coerced to non-negative integer via \`parseInt\` + \`Number.isFinite\` guard before interpolation. Same fix at both sinks (tag_search + credit_search).

### `favorites.js` — DOM XSS (number + href round-trip)

- \`\${fav.number ?? ''}\` → \`\${escapeHtml(String(fav.number ?? ''))}\`.
- \`data-original-href\` round-trip on select-mode toggle replaced with rebuild from \`item.dataset.songId\` (already escaped at row creation). Eliminates the DOM-read → DOM-write pattern CodeQL's \"DOM text reinterpreted as HTML\" rule flagged — cleaner code, no round-trip.

## .gitignore additions

- **\`iHymns.wiki/\`** — GitHub Wiki sibling clone (its own repo at \`MWBMPartners/iHymns.wiki.git\`). Cloned alongside for offline access; never meant to live inside the main repo. Was showing on every \`git status\`.
- **\`SourceSongData/\`** — newer no-leading-dot scrape-output convention. Legacy \`.SourceSongData/*\` (with dot, partial tracked) stays as-is.

## Test plan

- [ ] CodeQL re-scan post-merge dismisses both alerts.
- [ ] \`/manage/editor\` tag autocomplete + credit autocomplete still render correctly.
- [ ] \`/favourites\` page still works — select-mode toggle, anchor restoration on cancel.
- [ ] \`git status\` no longer shows untracked \`iHymns.wiki/\` or \`SourceSongData/\` (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)