### PR TITLE
fix(editor): unblock save when songbook lacks a number + regen cache on songbook CRUD (closes #961)

### DIFF
--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -261,11 +261,19 @@ function saveSongs() {
 
     /* Validate only the songs we're about to save. The user should
        never be blocked from saving a fix on song X because song Y (that
-       they never opened) is missing a field. */
-    var errors = validateSongsByIds(ids);
-    if (errors.length > 0) {
-        errors.forEach(function (msg) { showToast(msg, 'danger'); });
+       they never opened) is missing a field. #961 — split into hard
+       errors (block) and warnings (toast then proceed). Saved a real
+       case where a song in an Official-flagged songbook didn't have
+       a number yet — the curator wanted to capture the lyrics first
+       and number later. */
+    var validation = validateSongsByIds(ids);
+    if (validation.errors.length > 0) {
+        validation.errors.forEach(function (msg) { showToast(msg, 'danger'); });
         return;
+    }
+    if (validation.warnings.length > 0) {
+        validation.warnings.forEach(function (msg) { showToast(msg, 'warning'); });
+        /* fall through — warnings are informational, save proceeds */
     }
 
     /* Refresh the generatedAt timestamp so any subsequent export
@@ -2837,6 +2845,14 @@ function attachCreditAutocomplete(input, row, kind, onChange) {
  *
  * @returns {string[]} An array of human-readable error messages. Empty = valid.
  */
+/* #961 — both validateSongData() and validateSongsByIds() now return
+   { errors: [...], warnings: [...] }. The split lets the save handlers
+   block on genuine integrity problems (missing id / title / songbook /
+   components) while passing along soft cautions (e.g. missing number
+   on an official songbook) as informational toasts that DON'T block
+   the save. The server's save_song handler already accepts NULL number
+   when no value is provided, so the warning is purely user-facing —
+   the data path remains correct either way. */
 function validateSongData() {
     /* Accumulator for error messages. */
     var errors = [];
@@ -2853,6 +2869,7 @@ function validateSongData() {
     }, Object.create(null));
 
     /* Iterate over every song. */
+    var warnings = [];
     songData.songs.forEach(function (song, i) {
         /* Build a label for this song to make errors identifiable. */
         var label = 'Song [' + i + '] (' + (song.title || 'no title') + ')';
@@ -2872,13 +2889,18 @@ function validateSongData() {
             errors.push(label + ': missing or empty "songbook".');
         }
 
-        /* number is required only when the song's songbook is flagged
-           IsOfficial=1. Unofficial songbooks (Misc and any other
-           custom collection) keep number as nullable since their
-           songs typically aren't numbered in the source. (#392) */
+        /* #961 — number is WARNING-only when the songbook is flagged
+           IsOfficial=1 and no number is supplied. The save proceeds
+           (server accepts NULL number gracefully), and a non-blocking
+           toast surfaces the gap so the curator notices. Previously
+           this was a hard error that blocked the save entirely —
+           unhelpful when the curator legitimately doesn't have the
+           number yet, or when the songbook is flagged Official by
+           mistake. The "official requires number" expectation lives
+           in the songbook's metadata, not in this validator. (#392) */
         var isOfficial = !!officialByAbbr[(song.songbook || '').trim()];
         if (isOfficial && (song.number == null || String(song.number).trim() === '')) {
-            errors.push(label + ': missing "number" (required for official songbooks).');
+            warnings.push(label + ': no "number" supplied. The songbook is flagged Official — saved as NULL.');
         }
 
         /* components must be a non-empty array. */
@@ -2887,8 +2909,7 @@ function validateSongData() {
         }
     });
 
-    /* Return the collected errors (empty array means everything is valid). */
-    return errors;
+    return { errors: errors, warnings: warnings };
 }
 
 /**
@@ -2905,6 +2926,7 @@ function validateSongData() {
 function validateSongsByIds(ids) {
     var wanted = new Set(ids);
     var errors = [];
+    var warnings = [];
     /* Same IsOfficial map as validateSongData() — number is required
        only when the song's songbook is flagged IsOfficial=1. (#392) */
     var officialByAbbr = (songData.songbooks || []).reduce(function (map, b) {
@@ -2924,15 +2946,18 @@ function validateSongsByIds(ids) {
         if (!song.songbook || typeof song.songbook !== 'string' || song.songbook.trim() === '') {
             errors.push(label + ': missing or empty "songbook".');
         }
+        /* #961 — see validateSongData() for the rationale. Missing
+           number on an official songbook is now a non-blocking
+           warning, not a hard error. The server accepts NULL. */
         var isOfficial = !!officialByAbbr[(song.songbook || '').trim()];
         if (isOfficial && (song.number == null || String(song.number).trim() === '')) {
-            errors.push(label + ': missing "number" (required for official songbooks).');
+            warnings.push(label + ': no "number" supplied. The songbook is flagged Official — saved as NULL.');
         }
         if (!Array.isArray(song.components) || song.components.length === 0) {
             errors.push(label + ': must have at least one component.');
         }
     });
-    return errors;
+    return { errors: errors, warnings: warnings };
 }
 
 /* ========================================================================
@@ -3584,7 +3609,11 @@ function scheduleAutoSave() {
         _autoSaveTimer = null;
         if (_autoSaveRunning)      return;
         if (modifiedSongIds.size === 0) return;
-        if (validateSongData().length > 0) return;
+        /* #961 — auto-save only blocks on hard errors; warnings are
+           informational (and we don't surface them on auto-save to
+           avoid toast spam when the user pauses on an in-progress
+           edit). The user gets the warning on manual Save instead. */
+        if (validateSongData().errors.length > 0) return;
 
         _autoSaveRunning = true;
         var text = document.getElementById('status-text');
@@ -4194,12 +4223,19 @@ function bindGlobalEventListeners() {
     var validateBtn = document.getElementById('btn-validate');
     if (validateBtn) {
         validateBtn.addEventListener('click', function () {
-            var errors = validateSongData();
-            if (errors.length === 0) {
+            /* #961 — split errors (toast danger) from warnings
+               (toast warning). The standalone Validate button is the
+               one place where surfacing warnings is unambiguously
+               useful — the curator explicitly asked for a check. */
+            var validation = validateSongData();
+            if (validation.errors.length === 0 && validation.warnings.length === 0) {
                 showToast('All songs are valid.', 'success');
             } else {
-                errors.forEach(function (msg) {
+                validation.errors.forEach(function (msg) {
                     showToast(msg, 'danger');
+                });
+                validation.warnings.forEach(function (msg) {
+                    showToast(msg, 'warning');
                 });
             }
         });

--- a/appWeb/public_html/manage/songbooks.php
+++ b/appWeb/public_html/manage/songbooks.php
@@ -1009,6 +1009,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 /* Self-populate the affiliation registry so the next
                    open of the typeahead surfaces this value (#670). */
                 $registerAffiliation($affiliation);
+                /* #961 — refresh the on-disk songs cache so the Song
+                   Editor's view of songbooks (incl. IsOfficial flag)
+                   stays current. Best-effort — a regen failure must
+                   not undo the create that just committed. */
+                require_once dirname(__DIR__) . DIRECTORY_SEPARATOR
+                    . 'includes' . DIRECTORY_SEPARATOR . 'songs_cache.php';
+                songsCacheRegenerateBestEffort('songbooks.create');
                 $success = "Songbook '{$abbr}' created.";
                 break;
             }
@@ -1535,6 +1542,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         $registerAffiliation($affiliation);
                     }
 
+                    /* #961 — refresh the on-disk songs cache so the
+                       Song Editor's IsOfficial-aware validator (and
+                       every other client-side consumer) sees the
+                       fresh flag value on next load. Best-effort. */
+                    require_once dirname(__DIR__) . DIRECTORY_SEPARATOR
+                        . 'includes' . DIRECTORY_SEPARATOR . 'songs_cache.php';
+                    songsCacheRegenerateBestEffort('songbooks.update');
                     $success = $abbrChanged
                         ? "Songbook '{$oldAbbr}' → '{$newAbbr}'" . ($alsoRename ? ' (song references updated).' : ' (song references kept — resolve manually).')
                         : "Songbook '{$oldAbbr}' updated.";
@@ -1613,6 +1627,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     'abbreviation' => $abbr,
                 ]);
 
+                /* #961 — refresh the songs cache so the deleted
+                   songbook stops appearing in the Song Editor's
+                   dropdown on next load. */
+                require_once dirname(__DIR__) . DIRECTORY_SEPARATOR
+                    . 'includes' . DIRECTORY_SEPARATOR . 'songs_cache.php';
+                songsCacheRegenerateBestEffort('songbooks.delete');
+
                 $success = "Songbook '{$abbr}' deleted.";
                 break;
             }
@@ -1683,6 +1704,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         'abbreviation' => $abbr,
                         'song_count'   => $songCount,
                     ]);
+
+                    /* #961 — cascade-delete removed many songs + a
+                       songbook from the catalogue. Regenerate the
+                       cache so the public site stops serving the
+                       phantom rows. */
+                    require_once dirname(__DIR__) . DIRECTORY_SEPARATOR
+                        . 'includes' . DIRECTORY_SEPARATOR . 'songs_cache.php';
+                    songsCacheRegenerateBestEffort('songbooks.delete_cascade');
 
                     $success = "Songbook '{$abbr}' deleted along with {$songCount} song"
                              . ($songCount === 1 ? '' : 's')


### PR DESCRIPTION
## Summary

Two compounding bugs that left curators unable to save songs to certain songbooks:

1. **Validator was too strict** — \`editor.js\` hard-blocked the save when a song's songbook was flagged \`IsOfficial=1\` and the number was empty.
2. **Songbook CRUD didn't regenerate the songs cache** — flipping IsOfficial in \`/manage/songbooks\` didn't propagate to the editor's view, so the editor kept enforcing the OLD value.

## Fix 1 — validator returns \`{errors, warnings}\`

Both \`validateSongData()\` and \`validateSongsByIds()\` in \`editor.js\` now split:

- **Hard errors** (block save): missing \`id\` / \`title\` / \`songbook\` / \`components\`.
- **Warnings** (toast, don't block): missing \`number\` on an Official songbook.

The server's \`save_song\` already accepts \`number = NULL\` gracefully, so the warning is purely informational.

Three callers updated:

| Caller | Hard errors | Warnings |
|---|---|---|
| \`manualSave\` | Toast danger + block | Toast warning + proceed |
| \`autoSave\` debounce | Skip silently | Ignored (no toast spam) |
| Validate button | Toast danger | Toast warning |

## Fix 2 — songbook CRUD regenerates the cache

Wires \`songsCacheRegenerateBestEffort('songbooks.<action>')\` into all four success exits in \`manage/songbooks.php\`:

- \`songbooks.create\`
- \`songbooks.update\` (the relevant one for IsOfficial flips)
- \`songbooks.delete\`
- \`songbooks.delete_cascade\`

\`songbooks.reorder\` is skipped — DisplayOrder changes don't affect editor behaviour.

## Test plan

- [ ] Save a song to a songbook flagged \`IsOfficial=1\` without entering a number → save succeeds, toast says \"saved as NULL\".
- [ ] Save a song missing a real required field (no title) → still hard-blocks with a danger toast.
- [ ] Auto-save fires for a song missing only the number → proceeds silently (no toast spam).
- [ ] Standalone Validate button → surfaces both errors AND warnings.
- [ ] Flip a songbook's \`IsOfficial\` flag in \`/manage/songbooks\` → reload the editor → dropdown's IsOfficial-aware behaviour reflects the new value.
- [ ] Create / delete a songbook → editor's dropdown refreshes on next load.
- [ ] \`node --check\` clean (verified locally); \`php -l\` clean (verified locally).

## Out of scope

- Catalogues / Works / Credit-people CRUD also don't regenerate the cache. Same pattern applies; follow-ups can wire them when needed.
- The chip-list editor extension for structured FirstNames/Surname/Suffix on song credits — captured separately in #960.

🤖 Generated with [Claude Code](https://claude.com/claude-code)