### PR TITLE
fix(home): songbook count excludes empty songbooks (closes #963)

### DIFF
--- a/appWeb/public_html/includes/SongData.php
+++ b/appWeb/public_html/includes/SongData.php
@@ -249,7 +249,18 @@ class SongData
         $totalSongs = (int)$result->fetch_assoc()['total'];
         $stmt->close();
 
-        $stmt = $this->db->prepare("SELECT COUNT(*) AS total FROM tblSongbooks");
+        /* #963 — only count songbooks that have at least one song.
+           Empty placeholder rows in tblSongbooks would otherwise
+           inflate the home-page "N Songbooks" badge and the PWA
+           cache's meta.totalSongbooks. */
+        $stmt = $this->db->prepare(
+            "SELECT COUNT(*) AS total
+               FROM tblSongbooks b
+              WHERE EXISTS (
+                  SELECT 1 FROM tblSongs s
+                   WHERE s.SongbookAbbr = b.Abbreviation
+              )"
+        );
         $stmt->execute();
         $result = $stmt->get_result();
         $totalSongbooks = (int)$result->fetch_assoc()['total'];
@@ -2242,9 +2253,21 @@ class SongData
             ];
         }
 
+        /* #963 — only count songbooks that have at least one song.
+           Mirrors getMeta()'s SQL-side filter so every surface reads
+           the same number whether it comes from the live DB
+           (this method) or the precomputed static cache (getMeta()
+           feeds exportAsJson()). */
+        $populatedSongbooks = 0;
+        foreach ($songbooks as $book) {
+            if ((int)($book['songCount'] ?? 0) > 0) {
+                $populatedSongbooks++;
+            }
+        }
+
         return [
             'totalSongs'     => $totalSongs,
-            'totalSongbooks' => count($songbooks),
+            'totalSongbooks' => $populatedSongbooks,
             'songbooks'      => $bookStats,
         ];
     }


### PR DESCRIPTION
## Summary

The home-page hero badge \`N Songbooks\` counted every row in \`tblSongbooks\` including placeholder rows with zero songs. Fixed at both compute sites so the number is consistent across all surfaces (home page, PWA cache, native clients).

## Changes

`appWeb/public_html/includes/SongData.php`

### \`getMeta()\` — consumed by \`exportAsJson()\` → static cache → PWA + native clients

Adds \`WHERE EXISTS (SELECT 1 FROM tblSongs s WHERE s.SongbookAbbr = b.Abbreviation)\` to the count query.

### \`getStats()\` — consumed by \`/\` home page render

Replaces \`count(\$songbooks)\` with a loop that counts only books with \`songCount > 0\`. Mirrors the SQL filter.

## Test plan

- [ ] Home-page badge reads the count of songbooks with ≥1 song (lower than the raw \`SELECT COUNT(*) FROM tblSongbooks\`).
- [ ] \`/api?action=songs_json\` returns the same filtered value in \`meta.totalSongbooks\`.
- [ ] Songbooks card grid below the badge still shows every songbook including empties — only the count is affected.

## Out of scope

- Per-language filter recomputation of the badge (currently server-rendered; toggling language pills filters cards client-side but doesn't update the count).
- Hiding empty songbooks from the card grid — separate UX decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)