### PR TITLE
fix(admin): Configuration + Notifications obey theme preference (closes #965)

### DIFF
--- a/appWeb/public_html/manage/configuration.php
+++ b/appWeb/public_html/manage/configuration.php
@@ -241,10 +241,11 @@ require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Configuration — iHymns Admin</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.2/font/bootstrap-icons.css">
-    <link rel="stylesheet" href="/css/app.css">
-    <link rel="stylesheet" href="/css/admin.css">
+    <?php /* #965 — use the shared head bundler. Loads admin-theme-init.php
+             so the page obeys the user's theme preference (was light-only),
+             and syncs Bootstrap + Bootstrap-Icons versions with the rest
+             of the admin area via APP_CONFIG['libraries']['bootstrap']. */ ?>
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-libs.php'; ?>
 </head>
 <body>
 <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-nav.php'; ?>

--- a/appWeb/public_html/manage/notifications.php
+++ b/appWeb/public_html/manage/notifications.php
@@ -318,10 +318,11 @@ require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Notifications — iHymns Admin</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.2/font/bootstrap-icons.css">
-    <link rel="stylesheet" href="/css/app.css">
-    <link rel="stylesheet" href="/css/admin.css">
+    <?php /* #965 — use the shared head bundler. Loads admin-theme-init.php
+             so the page obeys the user's theme preference (was light-only),
+             and syncs Bootstrap + Bootstrap-Icons versions with the rest
+             of the admin area via APP_CONFIG['libraries']['bootstrap']. */ ?>
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-libs.php'; ?>
 </head>
 <body>
 <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-nav.php'; ?>


### PR DESCRIPTION
## Summary

PR #956 made admin pages obey the user's theme preference via the synchronous \`admin-theme-init.php\` resolver. Two pages were missed because they hand-rolled their \`<head>\` block instead of including \`head-libs.php\`:

- \`/manage/configuration\`
- \`/manage/notifications\`

Both fell back to Bootstrap's light-mode default regardless of the user's chosen theme.

## Fix

Replaced the bespoke \`<head>\` block in both files with the standard \`head-libs.php\` include — same pattern as the 30+ admin pages that already use it.

Side benefits from joining the shared include:

| Improvement | Was | Now |
|---|---|---|
| Theme obedience | Light-only | Light / Dark / High-contrast / CVD / System |
| Bootstrap version | Hardcoded 5.3.2 | \`APP_CONFIG\` (5.3.6) |
| Bootstrap-Icons | Hardcoded 1.11.2 | 1.11.3 |
| CSS cache-busting | None | \`?v=<filemtime>\` |
| external-link-detect.js | Missing | Loaded |

## Test plan

- [ ] On alpha after merge: visit \`/manage/configuration\` → renders in user's chosen theme.
- [ ] Same for \`/manage/notifications\`.
- [ ] Both pages still function normally (form submits, dropdowns, recipient pickers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)