### PR TITLE
feat(editor): structured FirstNames/Surname/Suffix per credit chip (closes #960)

### DIFF
--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -1417,31 +1417,101 @@ switch ($action) {
                    without a special case. */
                 $creditInserts['artists'] = 'INSERT INTO tblSongArtists (SongId, Name) VALUES (?, ?)';
             }
-            $regNames = [];
+            /* #960 — Each credit can arrive as either a legacy
+               string ("John Newton") OR a structured-parts object
+               ({name, first, surname, suffix}). The new chip-list
+               editor sends the latter so the registry write below
+               can populate FirstNames / Surname / Suffix on
+               auto-promote (PR #935 columns). Normalise into a
+               uniform array shape up front. */
+            require_once dirname(dirname(__DIR__)) . '/includes/credit_people_helpers.php';
+            $regParts = []; /* keyed by composed Name → ['first'=>…,'surname'=>…,'suffix'=>…] */
+            $normaliseCreditEntry = static function ($v) {
+                if (is_string($v)) {
+                    $name = trim($v);
+                    if ($name === '') return null;
+                    [$first, $surname, $suffix] = decomposePersonName($name);
+                    return ['name' => $name, 'first' => $first, 'surname' => $surname, 'suffix' => $suffix];
+                }
+                if (!is_array($v)) return null;
+                $first   = trim((string)($v['first']   ?? ''));
+                $surname = trim((string)($v['surname'] ?? ''));
+                $suffix  = trim((string)($v['suffix']  ?? ''));
+                /* Prefer a client-composed `name` for byte-equal
+                   round-tripping; otherwise compose from parts. If
+                   parts are empty and the only thing the client
+                   sent is a `name` string, decompose it. */
+                $name = trim((string)($v['name'] ?? ''));
+                if ($name === '') {
+                    $name = composePersonName($first, $surname, $suffix);
+                } elseif ($first === '' && $surname === '' && $suffix === '') {
+                    [$first, $surname, $suffix] = decomposePersonName($name);
+                }
+                if ($name === '') return null;
+                return ['name' => $name, 'first' => $first, 'surname' => $surname, 'suffix' => $suffix];
+            };
+
             foreach ($creditInserts as $key => $sql) {
                 $stmt = $db->prepare($sql);
-                foreach ($song[$key] ?? [] as $name) {
-                    if (!is_string($name) || $name === '') continue;
-                    $stmt->bind_param('ss', $songId, $name);
+                foreach ($song[$key] ?? [] as $raw) {
+                    $entry = $normaliseCreditEntry($raw);
+                    if ($entry === null) continue;
+                    $stmt->bind_param('ss', $songId, $entry['name']);
                     $stmt->execute();
-                    $regNames[$name] = true;
+                    /* Keep the richest parts seen for this name across
+                       all five role lists — if "J. Newton" was typed
+                       in Writers and "John Newton" in Composers, the
+                       structured-parts version wins for the registry
+                       upsert. (Both arrived as separate junction rows
+                       above; this dedup only affects the registry.) */
+                    if (!isset($regParts[$entry['name']])
+                        || ($regParts[$entry['name']]['first'] === '' && $regParts[$entry['name']]['surname'] === '' && $regParts[$entry['name']]['suffix'] === '')
+                    ) {
+                        $regParts[$entry['name']] = [
+                            'first'   => $entry['first'],
+                            'surname' => $entry['surname'],
+                            'suffix'  => $entry['suffix'],
+                        ];
+                    }
                 }
                 $stmt->close();
             }
-            /* Silently keep the credit-people registry in sync (#545).
-               INSERT IGNORE on the unique Name index — names already in
-               the registry are no-ops. The registry row carries no
-               metadata at this point; the People page
-               (/manage/credit-people) is where that gets enriched.
-               Deduped above so a name credited in multiple roles on the
-               same song fires once, not five times. */
-            if (!empty($regNames)) {
-                $stmtRegistry = $db->prepare('INSERT IGNORE INTO tblCreditPeople (Name) VALUES (?)');
-                foreach (array_keys($regNames) as $regName) {
-                    $stmtRegistry->bind_param('s', $regName);
-                    $stmtRegistry->execute();
+            /* Silently keep the credit-people registry in sync
+               (#545 / #960). When the FirstNames / Surname / Suffix
+               columns exist (PR #935 migration applied), upsert the
+               structured parts too — but only fill them in when the
+               existing row's parts are NULL/empty, so a curated
+               edit on the /manage/credit-people page never gets
+               overwritten by an auto-promote from the editor.
+               Pre-migration installs fall back to the legacy
+               Name-only INSERT IGNORE path. */
+            if (!empty($regParts)) {
+                $partsCols = creditPeopleNamePartsColumnsExist($db);
+                if ($partsCols) {
+                    $stmtRegistry = $db->prepare(
+                        'INSERT INTO tblCreditPeople (Name, FirstNames, Surname, Suffix)
+                              VALUES (?, ?, ?, ?)
+                         ON DUPLICATE KEY UPDATE
+                              FirstNames = COALESCE(NULLIF(FirstNames, ""), VALUES(FirstNames)),
+                              Surname    = COALESCE(NULLIF(Surname,    ""), VALUES(Surname)),
+                              Suffix     = COALESCE(NULLIF(Suffix,     ""), VALUES(Suffix))'
+                    );
+                    foreach ($regParts as $regName => $p) {
+                        $first   = $p['first']   !== '' ? $p['first']   : null;
+                        $surname = $p['surname'] !== '' ? $p['surname'] : null;
+                        $suffix  = $p['suffix']  !== '' ? $p['suffix']  : null;
+                        $stmtRegistry->bind_param('ssss', $regName, $first, $surname, $suffix);
+                        $stmtRegistry->execute();
+                    }
+                    $stmtRegistry->close();
+                } else {
+                    $stmtRegistry = $db->prepare('INSERT IGNORE INTO tblCreditPeople (Name) VALUES (?)');
+                    foreach (array_keys($regParts) as $regName) {
+                        $stmtRegistry->bind_param('s', $regName);
+                        $stmtRegistry->execute();
+                    }
+                    $stmtRegistry->close();
                 }
-                $stmtRegistry->close();
             }
 
             /* #858 — schema-probe for the optional Language column.
@@ -2162,11 +2232,35 @@ switch ($action) {
             }
             /* `usage` is a MySQL reserved word, so backtick it explicitly
                to avoid any edge-case parser drift between server versions
-               or strict-mode configurations. (#593) */
-            $sql = "SELECT Name, GROUP_CONCAT(DISTINCT kindLabel) AS kinds, SUM(cnt) AS `usage`
+               or strict-mode configurations. (#593)
+
+               #960 — when the FirstNames/Surname/Suffix columns from
+               PR #935 exist, LEFT JOIN tblCreditPeople so a
+               registry-matched name surfaces its structured parts in
+               the response. The chip-list editor uses these to
+               populate all three inputs on suggestion click,
+               preferring curated parts over a client-side decompose
+               of the composed Name. Pre-migration installs return
+               NULLs and the client falls back to decomposing. */
+            require_once dirname(dirname(__DIR__)) . '/includes/credit_people_helpers.php';
+            $partsCols = creditPeopleNamePartsColumnsExist($db);
+            $partsSelect  = $partsCols
+                ? ', cp.FirstNames AS first_names, cp.Surname AS surname, cp.Suffix AS suffix'
+                : '';
+            $partsJoin    = $partsCols
+                ? 'LEFT JOIN tblCreditPeople cp ON cp.Name = u.Name'
+                : '';
+            /* ONLY_FULL_GROUP_BY requires every non-aggregated select
+               column to appear in GROUP BY. Group on the raw column
+               refs (not the aliased forms). */
+            $partsGroupBy = $partsCols
+                ? ', cp.FirstNames, cp.Surname, cp.Suffix'
+                : '';
+            $sql = "SELECT u.Name, GROUP_CONCAT(DISTINCT u.kindLabel) AS kinds, SUM(u.cnt) AS `usage`{$partsSelect}
                     FROM (" . implode(' UNION ALL ', $unionParts) . ") u
-                    GROUP BY Name
-                    ORDER BY `usage` DESC, Name ASC
+                    {$partsJoin}
+                    GROUP BY u.Name{$partsGroupBy}
+                    ORDER BY `usage` DESC, u.Name ASC
                     LIMIT ?";
             $types   .= 'i';
             $params[] = $limit;
@@ -2177,11 +2271,23 @@ switch ($action) {
             $res = $stmt->get_result();
             $suggestions = [];
             while ($row = $res->fetch_assoc()) {
-                $suggestions[] = [
+                $entry = [
                     'name'  => $row['Name'],
                     'usage' => (int)$row['usage'],
                     'kinds' => $row['kinds'] !== null ? explode(',', $row['kinds']) : [],
                 ];
+                if ($partsCols) {
+                    /* Only emit parts keys when the registry row actually
+                       had any — keeps the payload light and lets the
+                       client choose between server parts and a
+                       client-side decompose. */
+                    if (($row['first_names'] ?? '') !== '' || ($row['surname'] ?? '') !== '' || ($row['suffix'] ?? '') !== '') {
+                        $entry['first']   = (string)($row['first_names'] ?? '');
+                        $entry['surname'] = (string)($row['surname']     ?? '');
+                        $entry['suffix']  = (string)($row['suffix']      ?? '');
+                    }
+                }
+                $suggestions[] = $entry;
             }
             $stmt->close();
             echo json_encode(['suggestions' => $suggestions]);

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -1851,6 +1851,13 @@ var CREDIT_KIND_FOR_KEY = {
     artists:     'artist',     /* #587 */
 };
 
+/* #960 — Each credit is now stored in-memory as a structured-parts
+   object `{first, surname, suffix}`. Legacy entries that come in as
+   bare strings (from /api?action=load) are normalised on first
+   render and the song[key] slot is rewritten in place. The wire
+   format on save (autoSaveSongsPerSong → save_song) is upgraded to
+   send `{name, first, surname, suffix}` — the server accepts both
+   shapes for back-compat. */
 function renderCreditChipList(song, key, containerId, addLabel) {
     var container = document.getElementById(containerId);
     if (!container) return;
@@ -1859,12 +1866,24 @@ function renderCreditChipList(song, key, containerId, addLabel) {
 
     var kind = CREDIT_KIND_FOR_KEY[key] || null;
 
-    song[key].forEach(function (name, i) {
-        var row = createDynamicInputRow(
-            name,
-            function (newVal) { song[key][i] = newVal; markModified(song.id); },
-            function ()       { song[key].splice(i, 1); markModified(song.id);
-                                renderCreditChipList(song, key, containerId, addLabel); },
+    song[key].forEach(function (entry, i) {
+        /* Normalise once on render — converts a legacy
+           string-credit into {first, surname, suffix} in place so
+           every subsequent read sees the structured shape. */
+        var parts = normaliseCreditParts(entry);
+        song[key][i] = parts;
+
+        var row = createCreditNameRow(
+            parts,
+            function (newParts) {
+                song[key][i] = newParts;
+                markModified(song.id);
+            },
+            function () {
+                song[key].splice(i, 1);
+                markModified(song.id);
+                renderCreditChipList(song, key, containerId, addLabel);
+            },
             kind
         );
         container.appendChild(row);
@@ -1875,7 +1894,7 @@ function renderCreditChipList(song, key, containerId, addLabel) {
     addBtn.className = 'btn btn-sm btn-outline-primary mt-2';
     addBtn.textContent = '+ ' + addLabel;
     addBtn.addEventListener('click', function () {
-        song[key].push('');
+        song[key].push({ first: '', surname: '', suffix: '' });
         markModified(song.id);
         renderCreditChipList(song, key, containerId, addLabel);
     });
@@ -2683,6 +2702,274 @@ function initSongLinksControls() {
     }
 }
 
+/* ------------------------------------------------------------------
+ * #960 — Structured-name helpers (JS mirror of composePersonName /
+ * decomposePersonName in includes/credit_people_helpers.php).
+ *
+ * The Credits-tab chip lists render three inputs per credit
+ * (FirstNames / Surname / Suffix) but the on-disk wire format and
+ * tblSongWriters/Composers/... rows continue to store a single
+ * composed `Name`. These two helpers are the single source of
+ * truth for going between those shapes on the client.
+ *
+ * Behaviour MUST stay byte-equal to the PHP implementation so a
+ * name typed in the editor round-trips identically through save →
+ * load → re-edit.
+ * ------------------------------------------------------------------ */
+
+/* Suffix tokens recognised by decomposePersonNameJs. Mirror of the
+   regex literal in PHP decomposePersonName(). Extend in lockstep. */
+var CREDIT_NAME_SUFFIX_PATTERN = /^(?:Jr|Sr|II|III|IV|V|VI|VII|VIII|PhD|Ph\.D\.|MD|M\.D\.|Esq|Esq\.|D\.D\.|D\.Min\.|MA|M\.A\.|BA|B\.A\.)$/i;
+
+function composePersonNameJs(first, surname, suffix) {
+    var parts = [];
+    [first, surname, suffix].forEach(function (p) {
+        var t = (p == null ? '' : String(p)).trim();
+        if (t !== '') parts.push(t);
+    });
+    return parts.join(' ').replace(/\s+/g, ' ');
+}
+
+function decomposePersonNameJs(name) {
+    var s = (name == null ? '' : String(name)).replace(/\s+/g, ' ').trim();
+    if (s === '') return { first: '', surname: '', suffix: '' };
+    if (s.indexOf(',') !== -1) {
+        var idx   = s.indexOf(',');
+        var lhs   = s.slice(0, idx).trim();
+        var rhs   = s.slice(idx + 1).trim();
+        if (lhs !== '' && rhs !== '') s = rhs + ' ' + lhs;
+    }
+    var tokens = s.split(/\s+/).filter(function (t) { return t !== ''; });
+    if (tokens.length === 0) return { first: '', surname: '', suffix: '' };
+    var suffixParts = [];
+    while (tokens.length > 1) {
+        var tail     = tokens[tokens.length - 1];
+        var tailNorm = tail.replace(/[.,]+$/, '');
+        if (CREDIT_NAME_SUFFIX_PATTERN.test(tail) || CREDIT_NAME_SUFFIX_PATTERN.test(tailNorm)) {
+            suffixParts.unshift(tokens.pop());
+            continue;
+        }
+        break;
+    }
+    var suffix = suffixParts.join(' ');
+    if (tokens.length === 1) return { first: '', surname: tokens[0], suffix: suffix };
+    var surname = tokens.pop();
+    var first   = tokens.join(' ');
+    return { first: first, surname: surname, suffix: suffix };
+}
+
+/* Normalise any per-credit value into a structured-parts object.
+   Accepts: legacy string ("John Newton"), already-structured object
+   ({first, surname, suffix}), or null/undefined. Used everywhere the
+   chip list reads the in-memory song.<credits>[i] entry. */
+function normaliseCreditParts(entry) {
+    if (entry && typeof entry === 'object' && !Array.isArray(entry)) {
+        return {
+            first:   (entry.first   != null ? String(entry.first)   : '').trim(),
+            surname: (entry.surname != null ? String(entry.surname) : '').trim(),
+            suffix:  (entry.suffix  != null ? String(entry.suffix)  : '').trim(),
+        };
+    }
+    if (typeof entry === 'string') return decomposePersonNameJs(entry);
+    return { first: '', surname: '', suffix: '' };
+}
+
+/* Shorthand for "render this credit entry as a single string" —
+   handles both legacy string entries (pre-#960 in-flight data, CSV
+   export when reading the live array directly) and the new
+   structured-parts shape. The non-credit dynamic lists elsewhere
+   in the editor never call this. */
+function creditEntryAsString(entry) {
+    if (typeof entry === 'string') return entry;
+    var p = normaliseCreditParts(entry);
+    return composePersonNameJs(p.first, p.surname, p.suffix);
+}
+
+/* ------------------------------------------------------------------
+ * createCreditNameRow(parts, onChange, onRemove, creditKind)  — #960
+ *
+ * Per-credit row used by the Credits tab. Renders three inputs:
+ * FirstNames / Surname / Suffix. Fires onChange({first, surname,
+ * suffix}) on every keystroke. Surname is the discriminative field
+ * for the live-search popover (mirroring how curators search the
+ * People page); selecting a suggestion overwrites all three inputs
+ * from the matched registry row.
+ *
+ * The legacy `createDynamicInputRow` single-input factory remains
+ * for any non-credit dynamic-list use; this helper is the shape
+ * Writers / Composers / Arrangers / Adaptors / Translators /
+ * Artists all use post-#960.
+ * ------------------------------------------------------------------ */
+function createCreditNameRow(parts, onChange, onRemove, creditKind) {
+    var row = document.createElement('div');
+    row.className = 'input-group input-group-sm mb-1 position-relative credit-chip-row';
+
+    function mkInput(field, placeholder) {
+        var el = document.createElement('input');
+        el.type = 'text';
+        el.className = 'form-control credit-name-' + field + '-input';
+        el.placeholder = placeholder;
+        el.autocomplete = 'off';
+        el.value = parts[field] || '';
+        el.setAttribute('aria-label', placeholder);
+        el.addEventListener('input', function () {
+            parts[field] = el.value;
+            onChange({
+                first:   parts.first   || '',
+                surname: parts.surname || '',
+                suffix:  parts.suffix  || '',
+            });
+        });
+        return el;
+    }
+
+    var firstEl   = mkInput('first',   'First names');
+    var surnameEl = mkInput('surname', 'Surname');
+    var suffixEl  = mkInput('suffix',  'Suffix');
+
+    var removeBtn = document.createElement('button');
+    removeBtn.type = 'button';
+    removeBtn.className = 'btn btn-outline-danger';
+    removeBtn.innerHTML = '&times;';
+    removeBtn.title = 'Remove';
+    removeBtn.addEventListener('click', function () { onRemove(); });
+
+    row.appendChild(firstEl);
+    row.appendChild(surnameEl);
+    row.appendChild(suffixEl);
+    row.appendChild(removeBtn);
+
+    /* Typeahead — the popover is owned by the row, fed by whichever
+       of First/Surname input currently has focus. Suffix doesn't
+       trigger search (rarely discriminative on its own). A pick
+       overwrites all three inputs from the matched registry row
+       so a curated "John Newton" with structured columns lands
+       cleanly into the chip. */
+    if (creditKind) {
+        attachStructuredCreditAutocomplete(row, parts, firstEl, surnameEl, creditKind, onChange);
+    }
+
+    return row;
+}
+
+/* Live-search popover for the structured Credit row. Mirrors
+   attachCreditAutocomplete (the legacy single-input one) but:
+     - Listens on TWO inputs (first + surname).
+     - Sends q=<focused input value> to /api?action=credit_search.
+     - Updates all three parts inputs from the chosen suggestion.
+     - When credit_search returns `first`/`surname`/`suffix` for a
+       registry-matched row, prefers those over a client-side
+       decompose of the composed Name. Pre-enhancement servers
+       (no parts in response) fall back to decomposePersonNameJs(). */
+function attachStructuredCreditAutocomplete(row, parts, firstEl, surnameEl, kind, onChange) {
+    var popover = document.createElement('div');
+    popover.className = 'list-group position-absolute w-100 shadow d-none credit-suggestions-popover';
+    popover.style.zIndex = '1050';
+    popover.style.top = '100%';
+    popover.style.left = '0';
+    popover.style.maxHeight = '220px';
+    popover.style.overflowY = 'auto';
+    row.appendChild(popover);
+
+    var debounceTimer = null;
+
+    function close() {
+        popover.classList.add('d-none');
+        popover.innerHTML = '';
+    }
+
+    function applyPick(s) {
+        /* Prefer structured parts from the server when present;
+           otherwise decompose the composed name client-side. The
+           outer onChange call updates the song object once, after
+           all three field values are in place. */
+        var picked;
+        if (s.first != null || s.surname != null || s.suffix != null) {
+            picked = {
+                first:   s.first   != null ? String(s.first)   : '',
+                surname: s.surname != null ? String(s.surname) : '',
+                suffix:  s.suffix  != null ? String(s.suffix)  : '',
+            };
+        } else {
+            picked = decomposePersonNameJs(s.name || '');
+        }
+        parts.first   = picked.first;
+        parts.surname = picked.surname;
+        parts.suffix  = picked.suffix;
+        firstEl.value   = picked.first;
+        surnameEl.value = picked.surname;
+        /* The suffix input is the third <input> inside row. */
+        var suffixEl = row.querySelector('.credit-name-suffix-input');
+        if (suffixEl) suffixEl.value = picked.suffix;
+        onChange({ first: parts.first, surname: parts.surname, suffix: parts.suffix });
+    }
+
+    function render(suggestions) {
+        popover.innerHTML = '';
+        if (!suggestions.length) { close(); return; }
+        suggestions.forEach(function (s) {
+            var item = document.createElement('button');
+            item.type = 'button';
+            item.className = 'list-group-item list-group-item-action d-flex justify-content-between align-items-center py-1';
+            var kindsBadge = (s.kinds && s.kinds.length)
+                ? '<small class="text-muted">' + escapeHtmlSafe(s.kinds.join(' · ')) + '</small>'
+                : '';
+            var creditUsageNum = parseInt(s.usage, 10);
+            if (!Number.isFinite(creditUsageNum) || creditUsageNum < 0) creditUsageNum = 0;
+            item.innerHTML =
+                '<span><strong>' + escapeHtmlSafe(s.name || '') + '</strong> ' + kindsBadge + '</span>' +
+                '<span class="badge bg-secondary">' + creditUsageNum + '</span>';
+            item.addEventListener('click', function (e) {
+                e.preventDefault();
+                applyPick(s);
+                close();
+            });
+            popover.appendChild(item);
+        });
+        popover.classList.remove('d-none');
+    }
+
+    function fetchSuggestions(q) {
+        var url = EDITOR_API_URL + '?action=credit_search' +
+                  '&q='    + encodeURIComponent(q) +
+                  '&kind=any&limit=12';
+        fetch(url, { credentials: 'same-origin' })
+            .then(function (r) {
+                if (!r.ok) {
+                    return r.text().then(function (body) {
+                        throw new Error('credit_search ' + r.status + ': ' + body.slice(0, 200));
+                    });
+                }
+                return r.json();
+            })
+            .then(function (data) {
+                render(Array.isArray(data.suggestions) ? data.suggestions : []);
+            })
+            .catch(function (err) {
+                console.warn('[editor] credit_search failed:', err && err.message);
+                close();
+            });
+    }
+
+    function wire(inputEl) {
+        inputEl.addEventListener('input', function () {
+            clearTimeout(debounceTimer);
+            var q = inputEl.value.trim();
+            if (q.length < 1) { close(); return; }
+            debounceTimer = setTimeout(function () { fetchSuggestions(q); }, 180);
+        });
+        inputEl.addEventListener('keydown', function (e) {
+            if (e.key === 'Escape') close();
+        });
+    }
+    wire(firstEl);
+    wire(surnameEl);
+
+    document.addEventListener('click', function (e) {
+        if (!row.contains(e.target)) close();
+    });
+}
+
 /**
  * createDynamicInputRow(value, onChange, onRemove)
  * ------------------------------------------------
@@ -3060,8 +3347,8 @@ function exportCSV() {
             csvEscape(String(song.number || '')),
             csvEscape(song.title || ''),
             csvEscape(song.songbook || ''),
-            csvEscape((song.writers || []).join('; ')),
-            csvEscape((song.composers || []).join('; ')),
+            csvEscape((song.writers   || []).map(creditEntryAsString).join('; ')),
+            csvEscape((song.composers || []).map(creditEntryAsString).join('; ')),
             csvEscape(song.ccli || ''),
             String((song.components || []).length)
         ];
@@ -3498,8 +3785,9 @@ function renderPreview(song) {
     if (song.writers && song.writers.length > 0) {
         var writersEl = document.createElement('p');
         writersEl.className = 'text-muted small mt-3';
-        /* "; " separator (#495). */
-        writersEl.textContent = 'Writers: ' + song.writers.join('; ');
+        /* "; " separator (#495); creditEntryAsString handles the
+           post-#960 structured-parts shape. */
+        writersEl.textContent = 'Writers: ' + song.writers.map(creditEntryAsString).join('; ');
         container.appendChild(writersEl);
     }
     if (song.copyright) {
@@ -3655,6 +3943,46 @@ function scheduleAutoSave() {
     }, _autoSaveDelayMs);
 }
 
+/* #960 — Pre-save serialiser. The Credits-tab chip lists store
+   each credit as a structured-parts object {first, surname,
+   suffix}; the save_song endpoint accepts either a bare string
+   (legacy) or {name, first, surname, suffix} (post-#960). We
+   send the richer shape so the server can populate
+   tblCreditPeople.FirstNames/Surname/Suffix on auto-promote.
+   Non-credit fields pass through untouched. */
+function serialiseSongForSave(song) {
+    var creditKeys = ['writers', 'composers', 'arrangers', 'adaptors', 'translators', 'artists'];
+    var out = {};
+    Object.keys(song || {}).forEach(function (k) { out[k] = song[k]; });
+    creditKeys.forEach(function (k) {
+        if (!Array.isArray(out[k])) return;
+        out[k] = out[k].map(function (entry) {
+            if (typeof entry === 'string') {
+                var parts = decomposePersonNameJs(entry);
+                return {
+                    name:    entry.trim(),
+                    first:   parts.first,
+                    surname: parts.surname,
+                    suffix:  parts.suffix,
+                };
+            }
+            var p = normaliseCreditParts(entry);
+            return {
+                name:    composePersonNameJs(p.first, p.surname, p.suffix),
+                first:   p.first,
+                surname: p.surname,
+                suffix:  p.suffix,
+            };
+        }).filter(function (entry) {
+            /* Drop completely-empty credit rows (no name parts
+               typed) — keeps the existing "skip blank chip"
+               behaviour from the legacy string path. */
+            return entry.name !== '';
+        });
+    });
+    return out;
+}
+
 /**
  * autoSaveSongsPerSong(ids)
  * -------------------------
@@ -3676,7 +4004,7 @@ function autoSaveSongsPerSong(ids) {
             return fetch(EDITOR_API_URL + '?action=save_song', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(song),
+                body: JSON.stringify(serialiseSongForSave(song)),
             }).then(function (res) {
                 return res.json().then(function (data) {
                     if (res.ok && data.ok) {


### PR DESCRIPTION
## Summary
- Replaces the single free-text input on every Credits-tab chip (Writers / Composers / Arrangers / Adaptors / Translators / Artists) with three: **First names**, **Surname**, **Suffix**. Surface + typeahead unchanged otherwise.
- `save_song` now accepts a structured `{name, first, surname, suffix}` payload per credit and upserts the registry with the structured columns added in PR #935 — auto-promoted credits land sortable by Surname without a manual edit on /manage/credit-people.
- `credit_search` returns curated parts from `tblCreditPeople` when matched, so picking a registry suggestion populates all three inputs from the canonical row.

## Why
Before PR #935 `tblCreditPeople` was Name-only — sorting by Surname was impossible. #935 added FirstNames/Surname/Suffix + a backfill, but the Song Editor remained the last surface still writing into the registry by composed Name alone. Any new credit typed in the editor landed with NULL parts and needed a manual fix on the People page to sort. This PR closes that gap.

## How it works
- Adds JS mirrors `composePersonNameJs` / `decomposePersonNameJs` that are byte-equal to the PHP helpers in `includes/credit_people_helpers.php` (verified across 8 PHP + 13 JS cases).
- `song.<credits>[i]` is now a `{first, surname, suffix}` object in memory; legacy string entries from `/api?action=load` are normalised in place on first render so the upgrade is invisible to loaded songs.
- New `createCreditNameRow` + `attachStructuredCreditAutocomplete` sit alongside the legacy `createDynamicInputRow` (untouched for non-credit dynamic lists).
- `serialiseSongForSave` wraps the per-song save body so the wire shape is `{name, first, surname, suffix}`. CSV export + the editor preview footer both go through `creditEntryAsString` so the structured shape never leaks as `[object Object]`.
- `save_song` accepts BOTH the legacy string and the new object shape per credit (defence in depth). Junction tables still store composed Name; the registry write is gated on `creditPeopleNamePartsColumnsExist()` and uses
  ```sql
  INSERT … ON DUPLICATE KEY UPDATE
      FirstNames = COALESCE(NULLIF(FirstNames, ''), VALUES(FirstNames)),
      Surname    = COALESCE(NULLIF(Surname,    ''), VALUES(Surname)),
      Suffix     = COALESCE(NULLIF(Suffix,     ''), VALUES(Suffix))
  ```
  so curated edits on /manage/credit-people are never overwritten — only NULL/empty fields get backfilled.
- `credit_search` LEFT JOINs `tblCreditPeople` and emits `first/surname/suffix` on suggestions when the parts columns exist. Pre-#935 installs return without parts and the client falls back to a local decompose.

## Back-compat & rollback
- The legacy `action=save` (full-corpus) path is untouched.
- A pre-#935 deploy (parts columns missing) keeps the original `INSERT IGNORE(Name)` registry write — the new code probes the schema via `creditPeopleNamePartsColumnsExist()`.
- No schema changes here — PR #935 carried the additive migration.
- Reverting this commit cleanly restores the single-input chip list.

## Test plan
- [ ] Open Song Editor → Credits tab → add a writer "Charles Wesley" using the new three-input chip. Save. Confirm `tblSongWriters.Name` = "Charles Wesley" AND `tblCreditPeople` row has FirstNames="Charles", Surname="Wesley".
- [ ] Re-open the same song → credits decompose correctly back into the three inputs (no drift).
- [ ] Type "Wesley" in Surname → typeahead surfaces existing entries → click one → confirm all three inputs populate from the registry's curated parts.
- [ ] Curate an existing People row to have a deliberately different FirstNames (e.g. "Charles E."), then save a song citing that same composed Name → confirm the registry row is NOT overwritten back to "Charles" (NULLIF / COALESCE guard works).
- [ ] CSV export of a song with structured-shape writers contains the composed names in the writers column.
- [ ] Preview tab footer ("Writers: …") shows composed names.
- [ ] `php -l` clean on `appWeb/public_html/manage/editor/api.php`.
- [ ] `node --check` clean on `appWeb/public_html/manage/editor/editor.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)