### PR TITLE
fix(editor): defensive registry upsert avoids empty-Slug corruption (follow-up to #960)

### DIFF
--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -1487,30 +1487,47 @@ switch ($action) {
                Name-only INSERT IGNORE path. */
             if (!empty($regParts)) {
                 $partsCols = creditPeopleNamePartsColumnsExist($db);
+                /* Defensive two-step (INSERT IGNORE → targeted UPDATE
+                   by Name) instead of ON DUPLICATE KEY UPDATE.
+                   migrate-credit-people-slug.php declares
+                   `Slug VARCHAR(255) NOT NULL DEFAULT ''` with a
+                   UNIQUE index. If an orphan empty-Slug row exists
+                   in the registry (we've seen one in the wild), an
+                   INSERT that omits Slug collides on uk_Slug and
+                   ODKU would target THAT orphan row, overwriting
+                   FirstNames/Surname/Suffix with the new person's
+                   parts — silent corruption. INSERT IGNORE turns
+                   the slug collision into a no-op, then the
+                   targeted UPDATE-by-Name only ever touches a row
+                   whose Name actually matches. The full slug-on-
+                   every-insert fix lives in a follow-up audit PR. */
+                $stmtRegistry = $db->prepare('INSERT IGNORE INTO tblCreditPeople (Name) VALUES (?)');
+                foreach (array_keys($regParts) as $regName) {
+                    $stmtRegistry->bind_param('s', $regName);
+                    $stmtRegistry->execute();
+                }
+                $stmtRegistry->close();
+
                 if ($partsCols) {
-                    $stmtRegistry = $db->prepare(
-                        'INSERT INTO tblCreditPeople (Name, FirstNames, Surname, Suffix)
-                              VALUES (?, ?, ?, ?)
-                         ON DUPLICATE KEY UPDATE
-                              FirstNames = COALESCE(NULLIF(FirstNames, ""), VALUES(FirstNames)),
-                              Surname    = COALESCE(NULLIF(Surname,    ""), VALUES(Surname)),
-                              Suffix     = COALESCE(NULLIF(Suffix,     ""), VALUES(Suffix))'
+                    /* Backfill structured parts only when the
+                       registry row currently has them empty —
+                       same "never overwrite a curated value"
+                       guarantee as the ODKU clause we replaced. */
+                    $stmtParts = $db->prepare(
+                        'UPDATE tblCreditPeople
+                            SET FirstNames = COALESCE(NULLIF(FirstNames, ""), ?),
+                                Surname    = COALESCE(NULLIF(Surname,    ""), ?),
+                                Suffix     = COALESCE(NULLIF(Suffix,     ""), ?)
+                          WHERE Name = ?'
                     );
                     foreach ($regParts as $regName => $p) {
                         $first   = $p['first']   !== '' ? $p['first']   : null;
                         $surname = $p['surname'] !== '' ? $p['surname'] : null;
                         $suffix  = $p['suffix']  !== '' ? $p['suffix']  : null;
-                        $stmtRegistry->bind_param('ssss', $regName, $first, $surname, $suffix);
-                        $stmtRegistry->execute();
+                        $stmtParts->bind_param('ssss', $first, $surname, $suffix, $regName);
+                        $stmtParts->execute();
                     }
-                    $stmtRegistry->close();
-                } else {
-                    $stmtRegistry = $db->prepare('INSERT IGNORE INTO tblCreditPeople (Name) VALUES (?)');
-                    foreach (array_keys($regParts) as $regName) {
-                        $stmtRegistry->bind_param('s', $regName);
-                        $stmtRegistry->execute();
-                    }
-                    $stmtRegistry->close();
+                    $stmtParts->close();
                 }
             }
 


### PR DESCRIPTION
## Hotfix

PR #960 (just merged) introduced an `ON DUPLICATE KEY UPDATE` registry upsert in `save_song`. The intent — backfill empty `FirstNames`/`Surname`/`Suffix` on a registry row whose `Name` matches — held for the `uk_Name` conflict path. But `tblCreditPeople` also carries a UNIQUE index `uk_Slug` on a `NOT NULL DEFAULT ''` column (`migrate-credit-people-slug.php`), and an orphan empty-Slug row currently exists on alpha (surfaces as **"Registry-only (not yet used) 1"** on the Credit People page).

For a genuinely-new credit (Name not yet in the registry), the INSERT omits `Slug`, MySQL defaults it to `''`, the row collides on `uk_Slug` with the orphan, and ODKU then targets **the orphan row** — overwriting its `FirstNames`/`Surname`/`Suffix` with the new person's parts via the `COALESCE(NULLIF(FirstNames, ''), VALUES(FirstNames))` clauses (those columns start NULL on the orphan). Silent corruption.

This PR swaps the single ODKU for a defensive two-step:

1. `INSERT IGNORE INTO tblCreditPeople (Name) VALUES (?)` — the slug collision now silently no-ops, so the orphan row is never touched.
2. `UPDATE tblCreditPeople SET FirstNames = COALESCE(NULLIF(FirstNames, ''), ?), … WHERE Name = ?` — backfills parts on the row whose `Name` actually matches (or no-ops when there's no such row, e.g. when the IGNORE above was the no-op path).

End-state semantics for the happy path are unchanged. The corruption path is eliminated.

## Why not fix the slug column on every insert?
That's the right comprehensive fix — eight INSERT call sites across `credit-people.php`, `credit-people-bulk-promote.php`, `api.php`, and `editor/api.php` all omit `Slug`. It needs:
- a shared `slugifyCreditPersonName()` helper in `includes/credit_people_helpers.php`
- collision-safe slug generation (`-2`, `-3` suffix)
- a data-fix migration that backfills the orphan empty-Slug row

That work is queued in the admin-surfaces audit branch. This PR is the **immediate stop-the-bleeding fix** so the corruption window on alpha closes within minutes rather than after the audit cycle finishes.

## Test plan
- [ ] Edit a song → add a brand-new writer name → save → confirm a row appears in `tblCreditPeople` with that Name; orphan empty-Slug row is untouched.
- [ ] Re-save the same song → registry row's FirstNames/Surname/Suffix get backfilled if they were NULL; if curated, they stay.
- [ ] `php -l appWeb/public_html/manage/editor/api.php` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)