### PR TITLE
fix(admin-audit): 6 bug fixes from the admin-surfaces audit — Tags / Slug+Notifications / Works buttons / ISWC→Work / Recently Viewed / SoTD filter

### DIFF
--- a/appWeb/.sql/migrate-credit-people-slug-rebackfill.php
+++ b/appWeb/.sql/migrate-credit-people-slug-rebackfill.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Credit People slug RE-backfill (audit follow-up)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * The original migrate-credit-people-slug.php backfilled Slug at the
+ * time it ran, but several INSERT INTO tblCreditPeople call sites
+ * (Add Person, Edit, the editor save_song registry upsert, etc.)
+ * have continued to omit Slug. Combined with the column's
+ * `NOT NULL DEFAULT ''` declaration that means any new row was
+ * inserted with Slug=''. The UNIQUE constraint on uk_Slug allows
+ * at most ONE such row, after which every subsequent INSERT trips
+ * `Duplicate entry '' for key 'tblCreditPeople.uk_Slug'`.
+ *
+ * This migration is the data-fix for that drift: it finds every row
+ * whose Slug is '' or NULL and assigns a collision-safe slug computed
+ * from Name. The application-side fix that keeps every NEW insert
+ * carrying a slug ships alongside this migration.
+ *
+ * @migration-rebackfills tblCreditPeople.Slug
+ *
+ * Idempotent — re-running is safe; only rows whose Slug is currently
+ * empty get touched.
+ *
+ * USAGE:
+ *   Web:  /manage/setup-database → Apply all pending migrations
+ *   CLI:  php appWeb/.sql/migrate-credit-people-slug-rebackfill.php
+ */
+
+if (PHP_SAPI === 'cli') {
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = true;
+} else {
+    if (!defined('IHYMNS_SETUP_DASHBOARD')) {
+        if (!function_exists('getDbMysqli')) {
+            require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+        }
+    }
+    $isCli = false;
+}
+
+function _migCpSlugRebackfill_out(string $line): void
+{
+    if (PHP_SAPI === 'cli') {
+        echo $line . "\n";
+    } else {
+        echo htmlspecialchars($line, ENT_QUOTES) . "<br>\n";
+    }
+}
+
+function _migCpSlugRebackfill_columnExists(\mysqli $db, string $table, string $column): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+          WHERE TABLE_SCHEMA = DATABASE()
+            AND TABLE_NAME   = ?
+            AND COLUMN_NAME  = ? LIMIT 1'
+    );
+    $stmt->bind_param('ss', $table, $column);
+    $stmt->execute();
+    $ok = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $ok;
+}
+
+function _migCpSlugRebackfill_slugify(string $name): string
+{
+    $s = mb_strtolower(trim($name));
+    if (class_exists('Normalizer')) {
+        $s = \Normalizer::normalize($s, \Normalizer::FORM_KD);
+        $s = preg_replace('/\p{M}+/u', '', $s) ?? '';
+    }
+    $slug = preg_replace('/[^\p{L}\p{N}]+/u', '-', $s) ?? '';
+    return trim($slug, '-');
+}
+
+_migCpSlugRebackfill_out('Credit People slug RE-backfill starting…');
+
+$db = getDbMysqli();
+if (!$db) {
+    _migCpSlugRebackfill_out('ERROR: could not connect to database.');
+    if ($isCli) exit(1); else return;
+}
+
+/* Bail early if the Slug column was never added — earlier migration
+   not yet applied. The original migrate-credit-people-slug.php is the
+   right tool for that scenario; this one is purely a re-backfill. */
+if (!_migCpSlugRebackfill_columnExists($db, 'tblCreditPeople', 'Slug')) {
+    _migCpSlugRebackfill_out('[skip] tblCreditPeople.Slug column missing — run migrate-credit-people-slug.php first.');
+    if ($isCli) exit(0); else return;
+}
+
+/* Step 1: load every row that needs a slug. */
+$res = $db->query("SELECT Id, Name FROM tblCreditPeople WHERE Slug = '' OR Slug IS NULL");
+$toUpdate = [];
+while ($row = $res->fetch_assoc()) {
+    $toUpdate[] = ['id' => (int)$row['Id'], 'name' => (string)$row['Name']];
+}
+$res->close();
+
+if (empty($toUpdate)) {
+    _migCpSlugRebackfill_out('[ok  ] no rows needed re-backfill — every row already has a slug.');
+    return;
+}
+
+_migCpSlugRebackfill_out('[scan] ' . count($toUpdate) . ' row' . (count($toUpdate) === 1 ? '' : 's') . ' need a slug.');
+
+/* Step 2: pre-load existing non-empty slugs so we can resolve
+   collisions without round-tripping per row. */
+$taken = [];
+$res2  = $db->query("SELECT Slug FROM tblCreditPeople WHERE Slug <> '' AND Slug IS NOT NULL");
+while ($row2 = $res2->fetch_assoc()) {
+    $taken[(string)$row2['Slug']] = true;
+}
+$res2->close();
+
+/* Step 3: assign + UPDATE. */
+$update = $db->prepare('UPDATE tblCreditPeople SET Slug = ? WHERE Id = ?');
+$filled = 0;
+foreach ($toUpdate as $entry) {
+    $base = _migCpSlugRebackfill_slugify($entry['name']);
+    if ($base === '') $base = 'person';
+    $candidate = $base;
+    $suffix    = 1;
+    while (isset($taken[$candidate])) {
+        $suffix++;
+        $candidate = $base . '-' . $suffix;
+    }
+    $taken[$candidate] = true;
+    $update->bind_param('si', $candidate, $entry['id']);
+    $update->execute();
+    $filled++;
+}
+$update->close();
+_migCpSlugRebackfill_out("[fill] re-backfilled slug on {$filled} row" . ($filled === 1 ? '' : 's') . '.');
+_migCpSlugRebackfill_out('Credit People slug RE-backfill complete.');

--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -4410,7 +4410,18 @@ if ($action !== null) {
             $body = json_decode($rawBody, true);
             $viewSongId = trim($body['song_id'] ?? '');
 
-            if (!preg_match('/^[A-Za-z]+-\d+$/', $viewSongId)) {
+            /* Accept both the legacy <ABBREV>-<NUMBER> format
+               (e.g. HA-0520) AND the synthetic "song-<ts>-<rand>"
+               format used by songs created in non-official
+               songbooks where the per-songbook number is NULL
+               (#392 / PR #740). The old `^[A-Za-z]+-\d+$` regex
+               rejected the synthetic shape, which meant any view
+               of a newly-created Psalty/Misc song never landed
+               in tblSongHistory — and Recently Viewed on the home
+               page silently skipped them despite repeat visits.
+               Matches the same character class + length used
+               everywhere else SongId is validated. */
+            if (!preg_match('/^[A-Za-z0-9_-]{1,32}$/', $viewSongId)) {
                 sendJson(['error' => 'Invalid song ID.'], 400);
                 break;
             }

--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -9430,7 +9430,25 @@ if ($action !== null) {
                     /* #630 — flag columns may not exist on a partly-
                        migrated install. Skip them when absent. */
                     $hasFlagsCols = creditPeopleFlagsColumnsExist($db);
-                    if ($hasFlagsCols) {
+                    /* Slug — NOT NULL DEFAULT '' with UNIQUE uk_Slug
+                       per migrate-credit-people-slug.php. Every INSERT
+                       MUST carry a slug or it'll trip the orphan
+                       empty-Slug collision. The helper returns '' when
+                       the column doesn't exist yet so a pre-migration
+                       install can still INSERT. */
+                    $slug       = generateUniqueCreditPersonSlug($db, $name);
+                    $hasSlugCol = $slug !== '';
+                    if ($hasFlagsCols && $hasSlugCol) {
+                        $stmt = $db->prepare(
+                            'INSERT INTO tblCreditPeople
+                                (Name, Slug, Notes, BirthPlace, BirthDate, DeathPlace, DeathDate, IsSpecialCase, IsGroup)
+                             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)'
+                        );
+                        $stmt->bind_param('sssssssii',
+                            $name, $slug, $notes, $birthPlace, $birthDate, $deathPlace, $deathDate,
+                            $isSpecialCase, $isGroup
+                        );
+                    } elseif ($hasFlagsCols) {
                         $stmt = $db->prepare(
                             'INSERT INTO tblCreditPeople
                                 (Name, Notes, BirthPlace, BirthDate, DeathPlace, DeathDate, IsSpecialCase, IsGroup)
@@ -9439,6 +9457,15 @@ if ($action !== null) {
                         $stmt->bind_param('ssssssii',
                             $name, $notes, $birthPlace, $birthDate, $deathPlace, $deathDate,
                             $isSpecialCase, $isGroup
+                        );
+                    } elseif ($hasSlugCol) {
+                        $stmt = $db->prepare(
+                            'INSERT INTO tblCreditPeople
+                                (Name, Slug, Notes, BirthPlace, BirthDate, DeathPlace, DeathDate)
+                             VALUES (?, ?, ?, ?, ?, ?, ?)'
+                        );
+                        $stmt->bind_param('sssssss',
+                            $name, $slug, $notes, $birthPlace, $birthDate, $deathPlace, $deathDate
                         );
                     } else {
                         $stmt = $db->prepare(

--- a/appWeb/public_html/includes/credit_people_helpers.php
+++ b/appWeb/public_html/includes/credit_people_helpers.php
@@ -244,6 +244,165 @@ function creditPeopleNamePartsColumnsExist(\mysqli $db): bool
 }
 
 /**
+ * Slugify a person's name for the URL component. Lower-cases, strips
+ * combining marks, collapses non-letter/digit runs to single hyphens.
+ * Mirrors the migration-time slugify in migrate-credit-people-slug.php
+ * — when both implementations drift, the backfill stops being idempotent
+ * with new inserts.
+ *
+ * Returns '' for an empty / punctuation-only name; callers should fall
+ * back to a stable default (e.g. 'person') in that case.
+ */
+function slugifyCreditPersonName(string $name): string
+{
+    $s = mb_strtolower(trim($name));
+    if (class_exists('Normalizer')) {
+        $s = \Normalizer::normalize($s, \Normalizer::FORM_KD);
+        $s = preg_replace('/\p{M}+/u', '', $s) ?? '';
+    }
+    $slug = preg_replace('/[^\p{L}\p{N}]+/u', '-', $s) ?? '';
+    return trim($slug, '-');
+}
+
+/**
+ * Generate a unique slug for a tblCreditPeople row.
+ *
+ * Computes the base slug from $name, then appends -2 / -3 / … until the
+ * candidate isn't already taken. When $excludeId is provided, the row
+ * with that Id is excluded from the collision check — needed by UPDATE
+ * paths so a curator renaming a row doesn't collide with the row's own
+ * existing slug.
+ *
+ * Returns 'person' (or 'person-2', etc.) when the input slugifies to
+ * empty — keeps the UNIQUE constraint satisfied without a NOT NULL
+ * violation, and stays consistent with the migration's fallback.
+ *
+ * Schema-tolerant: if the Slug column doesn't exist yet (pre-migration
+ * install), returns '' so callers can omit the column from the INSERT.
+ */
+function generateUniqueCreditPersonSlug(\mysqli $db, string $name, ?int $excludeId = null): string
+{
+    /* If the column hasn't been added yet, no slug is needed. */
+    static $hasSlugCol = null;
+    if ($hasSlugCol === null) {
+        try {
+            $probe = $db->prepare(
+                "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+                  WHERE TABLE_SCHEMA = DATABASE()
+                    AND TABLE_NAME   = 'tblCreditPeople'
+                    AND COLUMN_NAME  = 'Slug' LIMIT 1"
+            );
+            $probe->execute();
+            $hasSlugCol = $probe->get_result()->fetch_row() !== null;
+            $probe->close();
+        } catch (\Throwable $_e) {
+            $hasSlugCol = false;
+        }
+    }
+    if (!$hasSlugCol) return '';
+
+    $base = slugifyCreditPersonName($name);
+    if ($base === '') $base = 'person';
+
+    /* Pull all taken slugs that share this base prefix in one query.
+       VARCHAR(255) with utf8mb4_unicode_ci, indexed via idx_Slug + the
+       uk_Slug unique key — the LIKE scan stays fast even on a large
+       registry. */
+    $like = $base . '%';
+    if ($excludeId !== null) {
+        $stmt = $db->prepare('SELECT Slug FROM tblCreditPeople WHERE Slug LIKE ? AND Id <> ?');
+        $stmt->bind_param('si', $like, $excludeId);
+    } else {
+        $stmt = $db->prepare('SELECT Slug FROM tblCreditPeople WHERE Slug LIKE ?');
+        $stmt->bind_param('s', $like);
+    }
+    $stmt->execute();
+    $taken = [];
+    $res   = $stmt->get_result();
+    while ($r = $res->fetch_row()) { $taken[(string)$r[0]] = true; }
+    $stmt->close();
+
+    if (!isset($taken[$base])) return $base;
+    $suffix = 2;
+    while (isset($taken[$base . '-' . $suffix])) { $suffix++; }
+    return $base . '-' . $suffix;
+}
+
+/**
+ * Idempotent "register this name in the registry" helper.
+ *
+ * Looks up tblCreditPeople by Name and returns the existing Id if a row
+ * already matches. Otherwise INSERTs a new row carrying:
+ *   - Name        (the trimmed input)
+ *   - Slug        (computed via generateUniqueCreditPersonSlug if the
+ *                  column exists)
+ *   - FirstNames  | OPTIONAL — only set when the name-parts columns
+ *   - Surname     | from PR #935 are present AND $parts is supplied;
+ *   - Suffix      | otherwise these are simply omitted from the INSERT
+ *
+ * Returns the row's Id (existing or new). Returns 0 only when $name is
+ * empty — callers should guard.
+ *
+ * This is the canonical insertion point for the registry — every other
+ * path that previously called `INSERT INTO tblCreditPeople (Name)` and
+ * silently relied on `NOT NULL DEFAULT ''` Slug semantics MUST route
+ * through here, or it will trip the `Duplicate entry '' for uk_Slug`
+ * UNIQUE collision the moment an orphan empty-Slug row exists.
+ */
+function registerCreditPersonByName(
+    \mysqli $db,
+    string  $name,
+    ?array  $parts = null
+): int {
+    $name = trim($name);
+    if ($name === '') return 0;
+
+    /* Fast path: row already exists. */
+    $stmt = $db->prepare('SELECT Id FROM tblCreditPeople WHERE Name = ? LIMIT 1');
+    $stmt->bind_param('s', $name);
+    $stmt->execute();
+    $row = $stmt->get_result()->fetch_row();
+    $stmt->close();
+    if ($row) return (int)$row[0];
+
+    /* Slug is computed even if the column is technically nullable —
+       generateUniqueCreditPersonSlug() returns '' when the column
+       isn't present yet (pre-migration), in which case we just omit
+       it from the INSERT. */
+    $slug          = generateUniqueCreditPersonSlug($db, $name);
+    $hasSlugCol    = $slug !== '';
+    $hasNamePartCols = creditPeopleNamePartsColumnsExist($db);
+    $first  = $parts['first']   ?? null;
+    $surname= $parts['surname'] ?? null;
+    $suffix = $parts['suffix']  ?? null;
+    if ($first  !== null && trim((string)$first)  === '') $first  = null;
+    if ($surname!== null && trim((string)$surname)=== '') $surname= null;
+    if ($suffix !== null && trim((string)$suffix) === '') $suffix = null;
+
+    if ($hasSlugCol && $hasNamePartCols) {
+        $sql   = 'INSERT INTO tblCreditPeople (Name, Slug, FirstNames, Surname, Suffix) VALUES (?, ?, ?, ?, ?)';
+        $stmt  = $db->prepare($sql);
+        $stmt->bind_param('sssss', $name, $slug, $first, $surname, $suffix);
+    } elseif ($hasSlugCol) {
+        $sql   = 'INSERT INTO tblCreditPeople (Name, Slug) VALUES (?, ?)';
+        $stmt  = $db->prepare($sql);
+        $stmt->bind_param('ss', $name, $slug);
+    } elseif ($hasNamePartCols) {
+        $sql   = 'INSERT INTO tblCreditPeople (Name, FirstNames, Surname, Suffix) VALUES (?, ?, ?, ?)';
+        $stmt  = $db->prepare($sql);
+        $stmt->bind_param('ssss', $name, $first, $surname, $suffix);
+    } else {
+        $sql   = 'INSERT INTO tblCreditPeople (Name) VALUES (?)';
+        $stmt  = $db->prepare($sql);
+        $stmt->bind_param('s', $name);
+    }
+    $stmt->execute();
+    $newId = (int)$db->insert_id;
+    $stmt->close();
+    return $newId;
+}
+
+/**
  * Cached check for the IsSpecialCase / IsGroup columns from
  * #584/#585 (#630). Both ship together via
  * migrate-credit-people-flags.php; detecting one is sufficient to

--- a/appWeb/public_html/js/modules/search.js
+++ b/appWeb/public_html/js/modules/search.js
@@ -178,6 +178,12 @@ export class Search {
             const data = await response.json();
 
             this.songsData = data.songs || [];
+            /* Capture the songbook index alongside songs so other
+               modules (Song of the Day, language filters, …) can
+               consult per-songbook metadata — primary `language`,
+               `languages` array, `isOfficial`, etc. — without an
+               extra round-trip. */
+            this.songbooksData = Array.isArray(data.songbooks) ? data.songbooks : [];
             this.FuseClass = Fuse;
 
             /* Prepare lyricsText field for lyrics search (#93) */

--- a/appWeb/public_html/js/modules/song-of-the-day.js
+++ b/appWeb/public_html/js/modules/song-of-the-day.js
@@ -245,12 +245,44 @@ export class SongOfTheDay {
     }
 
     /**
-     * Filter a songs[] array against a set of primary subtags. An
-     * empty subtags array returns the full songs array (no filter).
-     * Untagged songs (no `language` field) ALWAYS pass — we treat
-     * them as "multi-lingual / not specified" rather than "exclude
-     * because we don't know", matching the songbook-language-filter
-     * module's behaviour for tiles.
+     * Build a lookup from songbook abbreviation → array of primary
+     * subtags drawn from the songbook's `languages` field (#857).
+     * Cached on the instance — songbooksData is loaded once per
+     * page-load by the search module. Empty map on pre-#857 deploys.
+     */
+    getSongbookLanguagesMap() {
+        if (this._sbLangMap) return this._sbLangMap;
+        const map = Object.create(null);
+        const books = this.app.search?.songbooksData || [];
+        for (const b of books) {
+            const id = (b?.id || '').toUpperCase();
+            if (!id) continue;
+            const langs = Array.isArray(b.languages) ? b.languages : [];
+            map[id] = langs.map(l => String(l).toLowerCase().split('-', 1)[0]).filter(Boolean);
+        }
+        this._sbLangMap = map;
+        return map;
+    }
+
+    /**
+     * Filter a songs[] array against a set of primary subtags.
+     *
+     * Empty subtags array → no filter (returns input).
+     * Untagged songs (no detectable language AND songbook has no
+     * languages metadata) ALWAYS pass — we treat them as
+     * "multi-lingual / not specified", matching the songbook-language-
+     * filter module's behaviour for tiles.
+     *
+     * Language source preference (#audit-follow-up):
+     *   1. If the song's parent songbook has a NON-AMBIGUOUS languages
+     *      set (length === 1), that single subtag is authoritative —
+     *      this corrects the case where a bulk-import mis-tagged every
+     *      song in a non-English songbook (e.g. HAC) as `language:'en'`
+     *      while the songbook itself is correctly marked as Croatian.
+     *   2. Otherwise, fall back to the song's own `language` field —
+     *      legitimate for multi-language songbooks where individual
+     *      songs carry the authoritative tag.
+     *   3. Empty → untagged → pass.
      *
      * @param {Array} songs
      * @param {string[]} subtags Lowercase primary subtags; empty = no filter
@@ -259,11 +291,21 @@ export class SongOfTheDay {
     filterSongsByLanguage(songs, subtags) {
         if (!subtags || subtags.length === 0) return songs;
         const set = new Set(subtags.map(s => s.toLowerCase()));
+        const bookMap = this.getSongbookLanguagesMap();
         return songs.filter(s => {
-            const lang = (s.language || '').toLowerCase();
-            if (!lang) return true; /* untagged → always pass */
-            const primary = lang.split('-', 1)[0];
-            return set.has(primary);
+            const bookId    = (s.songbook || '').toUpperCase();
+            const bookLangs = bookMap[bookId] || [];
+            let candidates;
+            if (bookLangs.length === 1) {
+                /* Unambiguous: the songbook itself is single-language. */
+                candidates = [bookLangs[0]];
+            } else {
+                const lang = (s.language || '').toLowerCase();
+                if (lang) candidates = [lang.split('-', 1)[0]];
+                else      candidates = bookLangs;
+            }
+            if (candidates.length === 0) return true; /* untagged → always pass */
+            return candidates.some(c => set.has(c));
         });
     }
 

--- a/appWeb/public_html/manage/credit-people-bulk-promote.php
+++ b/appWeb/public_html/manage/credit-people-bulk-promote.php
@@ -159,11 +159,12 @@ if (($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'POST') {
                     $stmt->close();
                     if ($existing) { $skipped++; continue; }
 
-                    $stmt = $db->prepare('INSERT INTO tblCreditPeople (Name) VALUES (?)');
-                    $stmt->bind_param('s', $name);
-                    $stmt->execute();
-                    $newId = (int)$db->insert_id;
-                    $stmt->close();
+                    /* Route through the shared registry helper so the
+                       new row carries a Slug — direct
+                       `INSERT (Name)` would default Slug='' and
+                       collide on uk_Slug after the first such row. */
+                    require_once dirname(__DIR__) . '/includes/credit_people_helpers.php';
+                    $newId = registerCreditPersonByName($db, $name);
 
                     if (function_exists('logActivity')) {
                         logActivity('credit_person.bulk_register', 'credit_person', (string)$newId, [

--- a/appWeb/public_html/manage/credit-people.php
+++ b/appWeb/public_html/manage/credit-people.php
@@ -274,7 +274,29 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                        fall through to the legacy INSERT shape; the three
                        parts simply aren't persisted yet. */
                     $hasNameParts = creditPeopleNamePartsColumnsExist($db);
-                    if ($hasFlagsCols && $hasNameParts) {
+                    /* Slug — NOT NULL DEFAULT '' with UNIQUE uk_Slug
+                       per migrate-credit-people-slug.php. Every INSERT
+                       MUST carry a slug or it'll trip the orphan
+                       empty-Slug collision documented in
+                       migrate-credit-people-slug-rebackfill.php.
+                       Returns '' when the column doesn't exist yet so
+                       a pre-migration install can still INSERT — the
+                       helper omits the column conditionally below. */
+                    $slug         = generateUniqueCreditPersonSlug($db, $name);
+                    $hasSlugCol   = $slug !== '';
+                    if ($hasFlagsCols && $hasNameParts && $hasSlugCol) {
+                        $stmt = $db->prepare(
+                            'INSERT INTO tblCreditPeople
+                                (Name, Slug, Notes, BirthPlace, BirthDate, DeathPlace, DeathDate,
+                                 IsSpecialCase, IsGroup, FirstNames, Surname, Suffix)
+                             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+                        );
+                        $stmt->bind_param('sssssssiisss',
+                            $name, $slug, $notes, $birthPlace, $birthDate, $deathPlace, $deathDate,
+                            $isSpecialCase, $isGroup,
+                            $firstNames, $surname, $suffix
+                        );
+                    } elseif ($hasFlagsCols && $hasNameParts) {
                         $stmt = $db->prepare(
                             'INSERT INTO tblCreditPeople
                                 (Name, Notes, BirthPlace, BirthDate, DeathPlace, DeathDate,
@@ -286,6 +308,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                             $isSpecialCase, $isGroup,
                             $firstNames, $surname, $suffix
                         );
+                    } elseif ($hasFlagsCols && $hasSlugCol) {
+                        $stmt = $db->prepare(
+                            'INSERT INTO tblCreditPeople
+                                (Name, Slug, Notes, BirthPlace, BirthDate, DeathPlace, DeathDate, IsSpecialCase, IsGroup)
+                             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)'
+                        );
+                        $stmt->bind_param('sssssssii',
+                            $name, $slug, $notes, $birthPlace, $birthDate, $deathPlace, $deathDate,
+                            $isSpecialCase, $isGroup
+                        );
                     } elseif ($hasFlagsCols) {
                         $stmt = $db->prepare(
                             'INSERT INTO tblCreditPeople
@@ -295,6 +327,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         $stmt->bind_param('ssssssii',
                             $name, $notes, $birthPlace, $birthDate, $deathPlace, $deathDate,
                             $isSpecialCase, $isGroup
+                        );
+                    } elseif ($hasSlugCol) {
+                        $stmt = $db->prepare(
+                            'INSERT INTO tblCreditPeople
+                                (Name, Slug, Notes, BirthPlace, BirthDate, DeathPlace, DeathDate)
+                             VALUES (?, ?, ?, ?, ?, ?, ?)'
+                        );
+                        $stmt->bind_param('sssssss',
+                            $name, $slug, $notes, $birthPlace, $birthDate, $deathPlace, $deathDate
                         );
                     } else {
                         $stmt = $db->prepare(
@@ -577,11 +618,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     if ($regRow) {
                         $id = (int)$regRow[0];
                     } else {
-                        $ins = $db->prepare('INSERT INTO tblCreditPeople (Name) VALUES (?)');
-                        $ins->bind_param('s', $sourceName);
-                        $ins->execute();
-                        $id = (int)$db->insert_id;
-                        $ins->close();
+                        /* Route through the shared helper so the new
+                           registry row carries a Slug — direct
+                           `INSERT (Name)` would default Slug='' and
+                           collide on uk_Slug whenever the orphan
+                           empty-Slug row exists. */
+                        $id = registerCreditPersonByName($db, $sourceName);
                     }
                 }
 
@@ -686,19 +728,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                    path can assume both sides have a registry id. */
                 $resolvePersonId = static function (int $id, string $name) use ($db): int {
                     if ($id > 0)       return $id;
-                    if ($name === '')  return 0;
-                    $stmt = $db->prepare('SELECT Id FROM tblCreditPeople WHERE Name = ?');
-                    $stmt->bind_param('s', $name);
-                    $stmt->execute();
-                    $row = $stmt->get_result()->fetch_row();
-                    $stmt->close();
-                    if ($row) return (int)$row[0];
-                    $ins = $db->prepare('INSERT INTO tblCreditPeople (Name) VALUES (?)');
-                    $ins->bind_param('s', $name);
-                    $ins->execute();
-                    $newId = (int)$db->insert_id;
-                    $ins->close();
-                    return $newId;
+                    /* registerCreditPersonByName handles the
+                       lookup-or-insert with a slug — same shape this
+                       closure used to have, minus the empty-slug
+                       collision footgun. */
+                    return registerCreditPersonByName($db, $name);
                 };
                 $sourceId = $resolvePersonId($sourceId, $sourceName);
                 $targetId = $resolvePersonId($targetId, $targetName);

--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -1673,6 +1673,122 @@ switch ($action) {
                 );
             }
 
+            /* ISWC auto-link to tblWorks (admin audit follow-up).
+               When this song carries an ISWC the editor expects a
+               matching Work row to exist so the public /song page
+               can show the "Part of work X" panel and so the Works
+               admin reflects every catalogued composition. The
+               batch backfill-works-from-iswc migration handles
+               existing rows; this block keeps the invariant on
+               every NEW save. Schema-tolerant: silently skips when
+               tblWorks isn't present yet (pre-migration installs). */
+            if ($iswc !== null && $iswc !== '') {
+                try {
+                    /* Probe schema once per request. */
+                    static $hasWorksSchema = null;
+                    if ($hasWorksSchema === null) {
+                        $probe = $db->prepare(
+                            "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+                              WHERE TABLE_SCHEMA = DATABASE()
+                                AND TABLE_NAME   IN ('tblWorks', 'tblWorkSongs')"
+                        );
+                        $probe->execute();
+                        $hasWorksSchema = count($probe->get_result()->fetch_all()) === 2;
+                        $probe->close();
+                    }
+                    if ($hasWorksSchema) {
+                        /* Look for an existing Work keyed on this ISWC. */
+                        $wStmt = $db->prepare('SELECT Id FROM tblWorks WHERE Iswc = ? LIMIT 1');
+                        $wStmt->bind_param('s', $iswc);
+                        $wStmt->execute();
+                        $wRow = $wStmt->get_result()->fetch_row();
+                        $wStmt->close();
+
+                        if ($wRow) {
+                            $workId = (int)$wRow[0];
+                        } else {
+                            /* Create a new Work — Title mirrors this song's
+                               title; Slug derived from Title with
+                               collision suffix to satisfy uq_slug. */
+                            $slugBase = mb_strtolower(trim((string)$title));
+                            if (class_exists('Normalizer')) {
+                                $slugBase = \Normalizer::normalize($slugBase, \Normalizer::FORM_KD);
+                                $slugBase = preg_replace('/\p{M}+/u', '', $slugBase) ?? '';
+                            }
+                            $slugBase = preg_replace('/[^\p{L}\p{N}]+/u', '-', $slugBase) ?? '';
+                            $slugBase = trim((string)$slugBase, '-');
+                            if ($slugBase === '') $slugBase = 'work';
+                            if (mb_strlen($slugBase) > 76) $slugBase = mb_substr($slugBase, 0, 76);
+
+                            $slug      = $slugBase;
+                            $slugCheck = $db->prepare('SELECT 1 FROM tblWorks WHERE Slug = ? LIMIT 1');
+                            $suffix    = 1;
+                            while (true) {
+                                $slugCheck->bind_param('s', $slug);
+                                $slugCheck->execute();
+                                $taken = $slugCheck->get_result()->fetch_row() !== null;
+                                if (!$taken) break;
+                                $suffix++;
+                                $slug = $slugBase . '-' . $suffix;
+                            }
+                            $slugCheck->close();
+
+                            $notes = sprintf('Auto-created from ISWC %s when song %s was saved.', $iswc, $songId);
+                            $wIns  = $db->prepare(
+                                'INSERT INTO tblWorks (Iswc, Title, Slug, Notes) VALUES (?, ?, ?, ?)'
+                            );
+                            $wIns->bind_param('ssss', $iswc, $title, $slug, $notes);
+                            $wIns->execute();
+                            $workId = (int)$db->insert_id;
+                            $wIns->close();
+
+                            if (function_exists('logActivity')) {
+                                logActivity('work.auto_create', 'work', (string)$workId, [
+                                    'iswc'      => $iswc,
+                                    'title'     => $title,
+                                    'slug'      => $slug,
+                                    'source'    => 'song_editor.save_song',
+                                    'song_id'   => $songId,
+                                ]);
+                            }
+                        }
+
+                        /* Idempotent membership. IsCanonical defaults to 0
+                           — the first member of a brand-new Work is
+                           promoted to canonical inline via a follow-up
+                           UPDATE only when no canonical member exists. */
+                        $linkStmt = $db->prepare(
+                            'INSERT IGNORE INTO tblWorkSongs (WorkId, SongId, IsCanonical, SortOrder)
+                             VALUES (?, ?, 0, 0)'
+                        );
+                        $linkStmt->bind_param('is', $workId, $songId);
+                        $linkStmt->execute();
+                        $linkStmt->close();
+
+                        $canonStmt = $db->prepare(
+                            'SELECT 1 FROM tblWorkSongs WHERE WorkId = ? AND IsCanonical = 1 LIMIT 1'
+                        );
+                        $canonStmt->bind_param('i', $workId);
+                        $canonStmt->execute();
+                        $hasCanon = $canonStmt->get_result()->fetch_row() !== null;
+                        $canonStmt->close();
+                        if (!$hasCanon) {
+                            $upd = $db->prepare(
+                                'UPDATE tblWorkSongs SET IsCanonical = 1 WHERE WorkId = ? AND SongId = ?'
+                            );
+                            $upd->bind_param('is', $workId, $songId);
+                            $upd->execute();
+                            $upd->close();
+                        }
+                    }
+                } catch (\Throwable $_e) {
+                    /* Best-effort — Works linkage must never block the
+                       core song save. The user's edit is already
+                       captured in tblSongs + tblSongRevisions. */
+                    error_log('[editor save_song] Works auto-link failed: ' . $_e->getMessage());
+                }
+            }
+
             $db->commit();
 
             /* Refresh the on-disk songs cache so the editor's next

--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -454,11 +454,12 @@ switch ($action) {
             $stmtTranslator = $db->prepare("INSERT INTO tblSongTranslators (SongId, Name) VALUES (?, ?)");
             /* Silently keep the credit-people registry in sync with every
                name that lands in the five song-credit tables (#545).
-               INSERT IGNORE on the unique Name index — adding a name
-               that's already in the registry is a no-op. The registry
-               row carries no metadata at this point; the People page
-               (/manage/credit-people) is where that gets enriched. */
-            $stmtRegistry = $db->prepare("INSERT IGNORE INTO tblCreditPeople (Name) VALUES (?)");
+               Route through the shared helper so the new row carries
+               a Slug — direct `INSERT IGNORE (Name)` would default
+               Slug='' and silently no-op on every new credit once an
+               orphan empty-Slug row exists. The helper does its own
+               existence check so concurrent saves stay idempotent. */
+            require_once dirname(dirname(__DIR__)) . '/includes/credit_people_helpers.php';
             $stmtComponent  = $db->prepare(
                 "INSERT INTO tblSongComponents (SongId, Type, Number, SortOrder, LinesJson)
                  VALUES (?, ?, ?, ?, ?)"
@@ -555,8 +556,11 @@ switch ($action) {
                 foreach ($song['adaptors']    ?? [] as $v) { if (is_string($v) && $v !== '') { $stmtAdaptor->bind_param('ss', $songId, $v);    $stmtAdaptor->execute();    $regNames[$v] = true; } }
                 foreach ($song['translators'] ?? [] as $v) { if (is_string($v) && $v !== '') { $stmtTranslator->bind_param('ss', $songId, $v); $stmtTranslator->execute(); $regNames[$v] = true; } }
                 foreach (array_keys($regNames) as $regName) {
-                    $stmtRegistry->bind_param('s', $regName);
-                    $stmtRegistry->execute();
+                    /* registerCreditPersonByName handles the lookup-
+                       or-insert with a slug — same end-state as the
+                       old `INSERT IGNORE (Name)` but no silent
+                       no-op on the orphan empty-Slug collision. */
+                    registerCreditPersonByName($db, $regName);
                 }
 
                 /* Components */
@@ -1487,32 +1491,26 @@ switch ($action) {
                Name-only INSERT IGNORE path. */
             if (!empty($regParts)) {
                 $partsCols = creditPeopleNamePartsColumnsExist($db);
-                /* Defensive two-step (INSERT IGNORE → targeted UPDATE
-                   by Name) instead of ON DUPLICATE KEY UPDATE.
-                   migrate-credit-people-slug.php declares
-                   `Slug VARCHAR(255) NOT NULL DEFAULT ''` with a
-                   UNIQUE index. If an orphan empty-Slug row exists
-                   in the registry (we've seen one in the wild), an
-                   INSERT that omits Slug collides on uk_Slug and
-                   ODKU would target THAT orphan row, overwriting
-                   FirstNames/Surname/Suffix with the new person's
-                   parts — silent corruption. INSERT IGNORE turns
-                   the slug collision into a no-op, then the
-                   targeted UPDATE-by-Name only ever touches a row
-                   whose Name actually matches. The full slug-on-
-                   every-insert fix lives in a follow-up audit PR. */
-                $stmtRegistry = $db->prepare('INSERT IGNORE INTO tblCreditPeople (Name) VALUES (?)');
-                foreach (array_keys($regParts) as $regName) {
-                    $stmtRegistry->bind_param('s', $regName);
-                    $stmtRegistry->execute();
+                /* Route every auto-promote through the shared registry
+                   helper. It computes a collision-safe Slug for the
+                   new row and idempotently no-ops when Name already
+                   exists — which means the orphan empty-Slug row
+                   that the IGNORE+UPDATE hotfix had to dodge can't
+                   block legit promotes anymore once
+                   migrate-credit-people-slug-rebackfill.php has run. */
+                foreach ($regParts as $regName => $p) {
+                    registerCreditPersonByName($db, $regName, $partsCols ? $p : null);
                 }
-                $stmtRegistry->close();
 
                 if ($partsCols) {
-                    /* Backfill structured parts only when the
-                       registry row currently has them empty —
-                       same "never overwrite a curated value"
-                       guarantee as the ODKU clause we replaced. */
+                    /* Existing registry rows may already exist
+                       without FirstNames/Surname/Suffix populated;
+                       backfill those (only when currently empty)
+                       so a song-save also enriches pre-existing
+                       Name-only registry rows. The helper above
+                       only sets parts for BRAND NEW inserts; this
+                       handles the existing-row case. Never
+                       overwrites a curated value. */
                     $stmtParts = $db->prepare(
                         'UPDATE tblCreditPeople
                             SET FirstNames = COALESCE(NULLIF(FirstNames, ""), ?),

--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -1887,9 +1887,32 @@ switch ($action) {
 
         $totalAdded = 0;
         $totalRemoved = 0;
+        $missingSongs   = []; /* IDs the client sent that aren't in tblSongs (FK would fail) */
+        $alreadyTagged  = []; /* (songId, tagName) pairs the request was a no-op for (duplicate PK) */
         try {
             $db = getDbMysqli();
             $db->begin_transaction();
+
+            /* Pre-validate songIds against tblSongs so a missing row
+               surfaces as a real diagnostic instead of being
+               silently swallowed by INSERT IGNORE downstream
+               (which would just bump affected_rows=0 and trigger the
+               misleading "Save the song first" toast even when the
+               song WAS saved but its persisted SongId differs from
+               the editor's local copy). #960-follow-up */
+            if (!empty($songIds)) {
+                $place      = implode(',', array_fill(0, count($songIds), '?'));
+                $checkStmt  = $db->prepare("SELECT SongId FROM tblSongs WHERE SongId IN ($place)");
+                $checkStmt->bind_param(str_repeat('s', count($songIds)), ...$songIds);
+                $checkStmt->execute();
+                $found = [];
+                $res   = $checkStmt->get_result();
+                while ($r = $res->fetch_assoc()) { $found[$r['SongId']] = true; }
+                $checkStmt->close();
+                foreach ($songIds as $sid) {
+                    if (!isset($found[$sid])) { $missingSongs[] = $sid; }
+                }
+            }
 
             /* Resolve / create tag rows for each ADD name. Keep a map of
                Name -> Id so we can insert mapping rows. The
@@ -1914,17 +1937,36 @@ switch ($action) {
                 $stmt->close();
             }
 
-            /* Insert mapping rows (ignore duplicates). */
+            /* Insert mapping rows (ignore duplicates). Skip songIds
+               we already know are missing from tblSongs — INSERT
+               IGNORE would just no-op on them and inflate the false
+               "tag couldn't be applied" hit. TaggedBy is bound as a
+               nullable INT (not 0) so a request from a session with
+               no resolved user id doesn't trip fk_TagMap_User on
+               servers where Id=0 doesn't exist. */
             if (!empty($addIds) && !empty($songIds)) {
-                $userId = (int)($currentUser['id'] ?? 0);
-                $stmt = $db->prepare(
+                $userId    = isset($currentUser['id']) ? (int)$currentUser['id'] : null;
+                $stmt      = $db->prepare(
                     'INSERT IGNORE INTO tblSongTagMap (SongId, TagId, TaggedBy) VALUES (?, ?, ?)'
                 );
+                /* Reverse-lookup so a 0-affected-rows result can be
+                   reported back to the client as "this song already
+                   has this tag" instead of the generic save-first
+                   toast. */
+                $tagNameById = array_flip($addIds);
                 foreach ($songIds as $sid) {
+                    if (in_array($sid, $missingSongs, true)) continue;
                     foreach ($addIds as $tagId) {
                         $stmt->bind_param('sii', $sid, $tagId, $userId);
                         $stmt->execute();
-                        $totalAdded += $db->affected_rows > 0 ? 1 : 0;
+                        if ($db->affected_rows > 0) {
+                            $totalAdded++;
+                        } else {
+                            $alreadyTagged[] = [
+                                'songId'  => $sid,
+                                'tagName' => $tagNameById[$tagId] ?? (string)$tagId,
+                            ];
+                        }
                     }
                 }
                 $stmt->close();
@@ -1968,6 +2010,14 @@ switch ($action) {
                 'songsAffected' => count($songIds),
                 'added'         => $totalAdded,
                 'removed'       => $totalRemoved,
+                /* #960-follow-up — diagnostics so the client can
+                   tell apart the three "0 added" failure modes
+                   (song missing in DB / already tagged / nothing
+                   asked for) instead of falling back to a generic
+                   "Save the song first" toast. Empty arrays when
+                   nothing went wrong. */
+                'missingSongs'  => $missingSongs,
+                'alreadyTagged' => $alreadyTagged,
             ]);
         } catch (\Throwable $e) {
             if (isset($db) && $db instanceof mysqli) {

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -2050,11 +2050,33 @@ function addSongTag(song, tagName) {
             loadSongTags(song);
             showToast('Added tag "' + tagName + '".', 'success');
         } else if (data && data.added === 0) {
-            showToast(
-                'Tag couldn\'t be applied. Save the song first, then re-add — ' +
-                'tags need a saved song to attach to.',
-                'warning'
-            );
+            /* Tell apart the three "0 added" failure modes using the
+               server's new diagnostic fields (#960 follow-up). */
+            var missing = Array.isArray(data.missingSongs)  ? data.missingSongs  : [];
+            var dupes   = Array.isArray(data.alreadyTagged) ? data.alreadyTagged : [];
+            if (missing.length > 0) {
+                showToast(
+                    'Tag couldn\'t be applied — this song isn\'t in the catalogue (id: "' +
+                    missing[0] + '"). If you just added the song, click Save first; ' +
+                    'otherwise refresh the editor to pick up the persisted id.',
+                    'warning'
+                );
+            } else if (dupes.length > 0) {
+                /* Refresh the tag list — the assigned-tags panel is
+                   showing a stale view; the tag actually IS attached. */
+                delete song.tags;
+                loadSongTags(song);
+                showToast(
+                    'Tag "' + tagName + '" was already attached — refreshed the list to show it.',
+                    'info'
+                );
+            } else {
+                showToast(
+                    'Tag couldn\'t be applied (server returned 0 added). ' +
+                    'Check the network tab for details.',
+                    'warning'
+                );
+            }
         } else {
             showToast((data && data.error) || 'Failed to add tag.', 'danger');
         }

--- a/appWeb/public_html/manage/notifications.php
+++ b/appWeb/public_html/manage/notifications.php
@@ -162,7 +162,14 @@ if (($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'POST') {
                     'INSERT INTO tblNotifications (UserId, Type, Title, Body, ActionUrl)
                      VALUES (?, ?, ?, ?, ?)'
                 );
-                $actionUrlForBind = $actionUrl !== '' ? $actionUrl : null;
+                /* tblNotifications.ActionUrl is NOT NULL DEFAULT '' —
+                   binding NULL on a blank optional field threw
+                   `Column 'ActionUrl' cannot be null` and the request
+                   500'd (blank white screen the user reported). The
+                   schema accepts '' to mean "no deep link"; consumers
+                   already treat empty strings as no-link, so swap
+                   the NULL fallback for ''. */
+                $actionUrlForBind = $actionUrl !== '' ? $actionUrl : '';
                 $count = 0;
                 foreach ($recipients as $uid) {
                     $stmt->bind_param('issss', $uid, $type, $title, $body, $actionUrlForBind);

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -209,6 +209,7 @@ $friendlyTitles = [
     'credit-people-flags'              => 'Credit People Flags (#584, #585)',
     'song-artists'                     => 'Songs Artist credit (#587)',
     'credit-people-slug'               => 'Credit People Slug + public page (#588)',
+    'credit-people-slug-rebackfill'    => 'Credit People Slug re-backfill (audit follow-up)',
     'credit-people-name-parts'         => 'Credit People Structured Name (FirstNames / Surname / Suffix) (#934)',
     'catalogues'                       => 'Catalogues — many-to-many song grouping (#941)',
     'backfill-works-from-iswc'         => 'Backfill Works from existing ISWCs (#942)',
@@ -285,6 +286,7 @@ $scriptMap = [
     'credit-people-flags' => 'migrate-credit-people-flags.php',
     'song-artists'  => 'migrate-song-artists.php',
     'credit-people-slug' => 'migrate-credit-people-slug.php',
+    'credit-people-slug-rebackfill' => 'migrate-credit-people-slug-rebackfill.php',
     'credit-people-name-parts' => 'migrate-credit-people-name-parts.php',
     'catalogues' => 'migrate-catalogues.php',
     'backfill-works-from-iswc' => 'backfill-works-from-iswc.php',
@@ -345,6 +347,7 @@ $migrationOrder = [
     'credit-people-flags',
     'song-artists',
     'credit-people-slug',
+    'credit-people-slug-rebackfill',
     'credit-people-name-parts',
     'catalogues',
     'backfill-works-from-iswc',
@@ -479,6 +482,20 @@ $migrationCards = [
                   . ' bio, lifespan, external links, and a discography grouped by role'
                   . ' across the six song-credit tables. Idempotent — safe to re-run.',
         'button' => 'Run Credit People Slug Migration',
+    ],
+    'credit-people-slug-rebackfill' => [
+        'title'  => 'Credit People Slug re-backfill (audit follow-up)',
+        'body'   => 'Data-fix counterpart to the slug-on-every-insert sweep across the eight'
+                  . ' <code>INSERT INTO tblCreditPeople</code> call sites. Several admin paths'
+                  . ' (Add Person, Rename / Merge auto-register, the editor save_song auto-promote)'
+                  . ' historically omitted <code>Slug</code> from the INSERT — the column\'s'
+                  . ' <code>NOT NULL DEFAULT \'\'</code> declaration meant the first such row landed'
+                  . ' with <code>Slug=\'\'</code> and every subsequent INSERT tripped the UNIQUE'
+                  . ' <code>uk_Slug</code> constraint. This migration finds any registry row whose'
+                  . ' <code>Slug</code> is empty / NULL and assigns a collision-safe slug computed'
+                  . ' from <code>Name</code>. Idempotent — re-running only touches rows that still'
+                  . ' need a slug.',
+        'button' => 'Re-backfill Empty Slugs',
     ],
     'backfill-works-from-iswc' => [
         'title'  => 'Backfill Works from existing ISWCs (#942)',
@@ -1027,6 +1044,17 @@ $migrationProbes = [
     'credit-people-flags'                => static fn(\mysqli $db) => !_migProbe_columnExists($db, 'tblCreditPeople', 'IsSpecialCase'),
     'song-artists'                       => static fn(\mysqli $db) => !_migProbe_tableExists($db, 'tblSongArtists'),
     'credit-people-slug'                 => static fn(\mysqli $db) => !_migProbe_columnExists($db, 'tblCreditPeople', 'Slug'),
+    /* Pending whenever any registry row still has an empty / NULL
+       Slug — e.g. the orphan row that triggered the "Duplicate entry
+       '' for uk_Slug" reports. Re-runnable: as call-site INSERTs
+       are corrected the probe self-clears. */
+    'credit-people-slug-rebackfill'      => static function (\mysqli $db): bool {
+        if (!_migProbe_columnExists($db, 'tblCreditPeople', 'Slug')) return false;
+        $res = $db->query("SELECT 1 FROM tblCreditPeople WHERE Slug = '' OR Slug IS NULL LIMIT 1");
+        $needs = $res && $res->fetch_row() !== null;
+        if ($res) $res->close();
+        return $needs;
+    },
     'credit-people-name-parts'           => static fn(\mysqli $db) => !_migProbe_columnExists($db, 'tblCreditPeople', 'Surname'),
     'catalogues'                         => static fn(\mysqli $db) => !_migProbe_tableExists($db, 'tblCatalogues'),
     /* #942 — pending whenever any ISWC-tagged song doesn't have a

--- a/appWeb/public_html/manage/works.php
+++ b/appWeb/public_html/manage/works.php
@@ -881,12 +881,40 @@ if ($hasSchema) {
     </div>
 
     <script>
-    (function () {
+    /* The inline page script runs BEFORE admin-footer.php loads
+       Bootstrap JS (#974 follow-up — symptom: Edit / Delete pencil/
+       trash buttons "do nothing"). Eagerly calling
+       bootstrap.Modal.getOrCreateInstance() threw ReferenceError
+       on Bootstrap-not-loaded-yet and aborted the IIFE, which meant
+       window.openWorkEditModal never got assigned and clicking the
+       inline-onclick handler silently failed.
+
+       Two fixes layered for defence-in-depth:
+       1. Wrap the IIFE in DOMContentLoaded so it runs after the
+          rest of the page (including admin-footer's <script src>)
+          is parsed.
+       2. Lazy-instantiate the modals via getOrCreateInstance INSIDE
+          openWorkEditModal / openWorkDeleteModal so even if Bootstrap
+          loads async / defers, the call happens at click-time
+          (guaranteed to be after page-load). */
+    document.addEventListener('DOMContentLoaded', function () {
         const modalEl   = document.getElementById('workEditModal');
         const delModal  = document.getElementById('workDeleteModal');
         if (!modalEl) return;
-        const editModal = bootstrap.Modal.getOrCreateInstance(modalEl);
-        const deleteModal = bootstrap.Modal.getOrCreateInstance(delModal);
+        let editModal = null;
+        let deleteModal = null;
+        function ensureModal(el, slot) {
+            if (slot === 'edit'   && editModal)   return editModal;
+            if (slot === 'delete' && deleteModal) return deleteModal;
+            if (typeof bootstrap === 'undefined' || !bootstrap.Modal) {
+                console.error('[works] Bootstrap JS not loaded yet; modal cannot open.');
+                return null;
+            }
+            const inst = bootstrap.Modal.getOrCreateInstance(el);
+            if (slot === 'edit')   editModal   = inst;
+            if (slot === 'delete') deleteModal = inst;
+            return inst;
+        }
         const tbody = document.getElementById('edit-work-members-tbody');
         const linkRowsEl = document.getElementById('edit-work-ext-links-rows');
         const addLinkBtn = document.getElementById('edit-work-ext-link-add-btn');
@@ -1100,14 +1128,16 @@ if ($hasSchema) {
             if (sugBox) { sugBox.style.display = 'none'; sugBox.innerHTML = ''; }
             if (search) search.value = '';
 
-            editModal.show();
+            const inst = ensureModal(modalEl, 'edit');
+            if (inst) inst.show();
         };
         window.openWorkDeleteModal = function (row) {
             document.getElementById('delete-work-id').value = row.id;
             document.getElementById('delete-work-name-label').textContent = row.title || '';
-            deleteModal.show();
+            const inst = ensureModal(delModal, 'delete');
+            if (inst) inst.show();
         };
-    })();
+    });
     </script>
 
     <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>


### PR DESCRIPTION
## Summary
Bundle of 6 self-contained fixes from the admin-surfaces audit, in chronological order:

| # | Commit | Surface | Symptom user saw |
|---|--------|---------|------------------|
| 1 | db2a80b2 | Song Editor → Tags tab | "Tag couldn't be applied. Save the song first" toast firing on already-saved songs (e.g. HAOLD / Psalty). |
| 2 | a78e4137 | Credit People + Notifications | Manual Add Person erroring `Duplicate entry '' for uk_Slug`; **/manage/notifications** broadcast Submit → blank white screen when Action URL left blank (the field that's labelled optional). |
| 3 | 652028d7 | /manage/works | Edit (pencil) + Delete (trash) buttons on each row "do nothing". |
| 4 | 0319fbae | Song Editor → Save | A song with an ISWC didn't auto-create a matching Work — the only Work-creation path was the batch backfill. |
| 5 | bfb9a754 | Home → Recently Viewed | A newly-created song in the non-official Psalty songbook never appeared in Recently Viewed despite being viewed multiple times. |
| 6 | 29835fa5 | Home → Song of the Day | With "English + Afrikaans" filter active, SoTD surfaced a Croatian HAC song. |

## Why
Each commit message explains its root cause in detail. Common themes:
- **Schema vs application drift** — `NOT NULL DEFAULT ''` columns being insert'd as `NULL` (Notifications) and `''` UNIQUE collisions piling up unnoticed (Credit People Slug).
- **Validation regex tighter than the canonical ID format** — the `song_view` recorder rejected the synthetic `song-<ts>-<rand>` IDs used in non-official songbooks; bulk_tag's similar regex was correct (32-char alnum/dash) but the toast didn't tell the user which of the three "0 added" failure modes applied.
- **Load-order race** — the Works inline `<script>` ran before `admin-footer.php` loaded Bootstrap JS, so the eager `bootstrap.Modal.getOrCreateInstance()` threw and aborted the IIFE before assigning `window.openWorkEditModal`. Fix wraps in `DOMContentLoaded` + lazy modal init.
- **Data-quality bleed-through into UX** — SoTD trusted per-song `language` even when the songbook itself was authoritative; now prefers `songbook.languages` when unambiguous.

## Migrations added
- `migrate-credit-people-slug-rebackfill.php` — finds any registry row with empty/NULL Slug and assigns a collision-safe slug. Registered in `setup-database.php` (titles, scriptMap, order, cards, probes). Idempotent — its probe self-clears once every row has a slug.

## Shared helpers added
- `includes/credit_people_helpers.php`:
  - `slugifyCreditPersonName()` — byte-equal to the migration-time slugify.
  - `generateUniqueCreditPersonSlug()` — collision-safe; returns `''` on pre-migration installs.
  - `registerCreditPersonByName()` — the canonical "lookup-or-insert by Name" used everywhere the registry needs to grow from a song-credit auto-promote.

## Open follow-ups (NOT in this PR)
- Data backfill that recomputes `tblSongs.Language` from `tblSongbooks.Language` for any single-language songbook (HAC, KMNZ, etc.) — would clean up the SoTD root cause; this PR's fix is the application-side defence.
- Comprehensive admin-surfaces audit — manual sweep of Song Editor / Songbooks / Songbook Series / Catalogues / External-Link Types for other dead buttons. Carrying on in subsequent commits / PR.
- Swagger UI for the REST API, gated to curator/editor/admin/global-admin.

## Test plan
- [ ] **Tags**: open the Psalty song that was previously failing, add a brand-new tag → success toast. Refresh, confirm tag persists.
- [ ] **Credit People**: from /manage/credit-people, click "Add to registry" on a song-only-credited person → row appears, no duplicate-slug error.
- [ ] **Notifications**: Compose a broadcast with Action URL blank → success flash, no blank screen.
- [ ] **Works**: from /manage/works, click Edit on any row → modal opens and prefills. Click Delete → confirmation modal opens.
- [ ] **ISWC**: open Song Editor, add an ISWC to a song, save → /manage/works shows a new auto-created Work tied to that ISWC.
- [ ] **Recently Viewed**: view a Psalty song (synthetic `song-…` ID) twice → reappears at the top of Recently Viewed on the home page.
- [ ] **SoTD**: with EN+AF filter active, refresh the home page repeatedly → SoTD always lands on an EN or AF (or untagged) song.

🤖 Generated with [Claude Code](https://claude.com/claude-code)