### PR TITLE
fix(setup-database): songcount-triggers probe stuck pending on no-trigger hosts

### DIFF
--- a/appWeb/.sql/migrate-songcount-triggers.php
+++ b/appWeb/.sql/migrate-songcount-triggers.php
@@ -265,3 +265,29 @@ if (!$res) {
 _migSCTrig_out('');
 _migSCTrig_out('SongCount triggers migration finished (#793).');
 _migSCTrig_out('Future INSERT / UPDATE / DELETE on tblSongs will keep tblSongbooks.SongCount honest automatically.');
+
+/* Mark the migration as attempted so the dashboard's pending-probe can
+   flip "pending → applied" on hosts where CREATE TRIGGER was denied. The
+   trigger-presence probe alone leaves this card stuck pending forever on
+   hosts that disallow trigger creation (shared MySQL hosts pre-MySQL-8.0
+   typically require SUPER for CREATE TRIGGER, or deny it outright via
+   policy). The migration is idempotent + the recompute path runs every
+   time, so "attempted = applied" is the right semantics for the
+   dashboard. (#claude/fix-songcount-triggers-probe follow-up.) */
+$_sentinelStmt = $db->prepare(
+    'INSERT INTO tblAppSettings (SettingKey, SettingValue, Description)
+     VALUES (?, ?, ?)
+     ON DUPLICATE KEY UPDATE SettingValue = VALUES(SettingValue), Description = VALUES(Description)'
+);
+$_sentinelKey  = 'songcount_triggers_attempted';
+$_sentinelVal  = '1';
+$_sentinelDesc = 'SongCount triggers migration ran (#793). Value 1 regardless of '
+               . 'whether CREATE TRIGGER succeeded — recompute path runs on every '
+               . 'pass so the cache stays correct even when triggers are denied.';
+$_sentinelStmt->bind_param('sss', $_sentinelKey, $_sentinelVal, $_sentinelDesc);
+if (!$_sentinelStmt->execute()) {
+    _migSCTrig_out('[warn] could not set sentinel (' . $db->error . '); migration body still ran.');
+} else {
+    _migSCTrig_out('[mark] tblAppSettings.songcount_triggers_attempted = 1.');
+}
+$_sentinelStmt->close();

--- a/appWeb/public_html/manage/includes/migration-registry.php
+++ b/appWeb/public_html/manage/includes/migration-registry.php
@@ -626,7 +626,26 @@ return [
                       . ' recompute remains the safety net.',
             'button' => 'Run SongCount Triggers Migration',
         ],
-        'probe' => static fn(\mysqli $db) => !_migProbe_triggerExists($db, 'trg_songs_songcount_ai'),
+        /* Two-signal probe: applied when EITHER the AFTER INSERT trigger
+           exists OR the migration left its `songcount_triggers_attempted`
+           sentinel in tblAppSettings. The sentinel covers the host-disallows-
+           CREATE-TRIGGER case where the migration's friendly-skip path
+           (#815) runs the initial recompute but never installs the trigger
+           — pre-sentinel this card stayed pending forever even after
+           successful runs. */
+        'probe' => static function (\mysqli $db): bool {
+            if (_migProbe_triggerExists($db, 'trg_songs_songcount_ai')) return false;
+            try {
+                $stmt = $db->prepare(
+                    "SELECT SettingValue FROM tblAppSettings
+                      WHERE SettingKey = 'songcount_triggers_attempted' LIMIT 1"
+                );
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_row();
+                $stmt->close();
+                return !($row && (string)$row[0] === '1');
+            } catch (\Throwable $_e) { return true; }
+        },
     ],
     'songbook-compilers' => [
         'script' => 'migrate-songbook-compilers.php',


### PR DESCRIPTION
## Summary

After #976 deployed, the dashboard still showed **1 pending** even after running "Apply all pending migrations" repeatedly. The stuck card is **SongCount Triggers (#793)**.

## Root cause

Same regression class as the five always-true probes fixed in #976 — just hidden behind a real-looking condition.

The probe checked whether `trg_songs_songcount_ai` exists. The migration handles hosts that disallow `CREATE TRIGGER` (typical on shared MySQL pre-8.0, which needs the `SUPER` privilege) by logging a friendly skip via #815 and proceeding to run the initial recompute — but it never installs the trigger. So on those hosts the probe permanently reports pending.

The existing card body even acknowledged this: *"On hosts that disallow `CREATE TRIGGER` the migration logs a friendly skip cleanly (#815)"* — but the probe was never updated to detect the friendly-skip path.

## Fix

**Two-signal probe + sentinel write.**

1. `migrate-songcount-triggers.php` now writes `tblAppSettings.songcount_triggers_attempted = 1` at the end of the run, regardless of whether `CREATE TRIGGER` succeeded. The recompute path runs every time so "attempted = applied" is the right semantics for the dashboard. Same sentinel pattern used by `email-login-token-hashing` (#898 follow-up).

2. The probe now returns pending only when **both** the trigger is absent **and** the sentinel is unset. Hosts where `CREATE TRIGGER` is denied will see the card flip pending → applied on the first run; hosts where it succeeds keep the trigger-based signal as the primary detector.

```php
'probe' => static function (\mysqli $db): bool {
    if (_migProbe_triggerExists($db, 'trg_songs_songcount_ai')) return false;
    try {
        $stmt = $db->prepare(
            "SELECT SettingValue FROM tblAppSettings
              WHERE SettingKey = 'songcount_triggers_attempted' LIMIT 1"
        );
        $stmt->execute();
        $row = $stmt->get_result()->fetch_row();
        $stmt->close();
        return !($row && (string)$row[0] === '1');
    } catch (\Throwable $_e) { return true; }
},
```

## Test plan

- [ ] After deploy, hit `/manage/setup-database` and click "Apply all pending migrations" once.
- [ ] Reload — the card should flip from "1 pending" to "Schema fully up-to-date".
- [ ] Re-run "Apply all" — should report 0 migrations ran (or just no-op cleanly).
- [ ] Confirm SongCount Triggers card has moved into the "X migrations already applied — click to show" expander.

## Risk

Low. The migration write is `INSERT … ON DUPLICATE KEY UPDATE` so re-runs are safe. The probe's SELECT is wrapped in try/catch — any unexpected SQL error defaults to pending rather than masking a real problem. Behaviour on hosts where `CREATE TRIGGER` succeeded is unchanged (trigger-presence check fires first and short-circuits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011fgEBM87YrUdSnpKuLdekY)_