### PR TITLE
fix(schema-audit): kill phantom "all" / "which" columns + align per-table column widths

### DIFF
--- a/appWeb/public_html/css/admin.css
+++ b/appWeb/public_html/css/admin.css
@@ -1089,3 +1089,36 @@ body:has(.navbar-admin) .modal-content.bg-dark {
         display: none !important;
     }
 }
+
+/* ----------------------------------------------------------------------------
+   FIXED-WIDTH COLUMN ALIGNMENT
+
+   `<table class="table admin-table-fixed">` switches to a fixed-layout
+   table where every column width is honoured exactly as declared via
+   an inline `style="width: 200px"` on each <th>. Use this when a page
+   renders MULTIPLE sibling tables that share the same column structure
+   (Schema Audit's per-table reports, for example) and the default
+   content-driven sizing causes neighbouring tables to misalign with
+   each other.
+
+       <th style="width: 200px;">Column</th>
+       <th style="width: 120px;">Status</th>
+       <th>Notes</th>              <!-- no width = takes the remainder -->
+
+   Combined with `table-layout: fixed` this makes column widths
+   deterministic and identical across every table on the page; long
+   content overflows or wraps according to the cell's own styling
+   rather than stretching the column.
+---------------------------------------------------------------------------- */
+.admin-table-fixed {
+    table-layout: fixed;
+    width: 100%;
+}
+
+/* Long content (column names rendered in <code>) shouldn't blow out
+   the fixed column — wrap at word boundaries, fall back to character
+   wrapping for unbreakable strings. */
+.admin-table-fixed td code {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}

--- a/appWeb/public_html/includes/schema_audit.php
+++ b/appWeb/public_html/includes/schema_audit.php
@@ -87,6 +87,17 @@ function schemaAuditParseSchema(string $schemaSql): array
            declarations. (#722) */
         $body = preg_replace('/\/\*.*?\*\//s', '', $body);
 
+        /* Strip `--` line comments from the body BEFORE splitting at
+           commas. SQL `--` comments often contain prose with commas
+           ("VARCHAR(48), which silently truncated", "the defence is
+           single-use, all enforced by …"). Without this strip, the
+           comma inside the comment splits the segment, and whatever
+           word follows the comma in the comment becomes a phantom
+           column name (the column-extraction regex matches `^[A-Za-z_]
+           [A-Za-z0-9_]*\s+`). Pre-stripping `--` to end-of-line means
+           every comma in a comment vanishes alongside the comment. */
+        $body = preg_replace('/--[^\n]*/', '', $body);
+
         /* Split into top-level segments at commas, ignoring commas
            inside parentheses (so ENUM('success','failure','error')
            stays in one segment, not three). Each segment is exactly

--- a/appWeb/public_html/manage/schema-audit.php
+++ b/appWeb/public_html/manage/schema-audit.php
@@ -265,11 +265,11 @@ if ($audit !== null) {
                             <?= count($rows) ?> column<?= count($rows) === 1 ? '' : 's' ?>
                         </span>
                     </div>
-                    <table class="table table-sm align-middle mb-0">
+                    <table class="table table-sm align-middle mb-0 admin-table-fixed">
                         <thead>
                             <tr class="text-muted small">
-                                <th>Column</th>
-                                <th>Status</th>
+                                <th style="width: 200px;">Column</th>
+                                <th style="width: 120px;">Status</th>
                                 <th>Notes</th>
                             </tr>
                         </thead>


### PR DESCRIPTION
## Summary

Two issues surfaced when the curator opened `/manage/schema-audit` after #976 deployed.

### 1. Phantom "uncovered" columns

The audit reported **`tblEmailLoginTokens.all`** and **`tblPasswordResetTokens.which`** as uncovered. Neither is a real column — both are parser glitches like `tblSongbookCompilers.string` was in #976.

The schema.sql column-parser strips `--` line comments per-segment *after* splitting at commas. SQL `--` comments routinely contain prose with commas:

```sql
-- this column was VARCHAR(48), which silently truncated the 64-
                              ^
-- the defence is single-use, all enforced by tblEmailLoginTokens itself.
                            ^
```

The comma inside the comment splits the segment, and the next word (`which`, `all`) becomes a phantom column when the column-extraction regex matches `^[A-Za-z_]\w*\s+`.

**Fix**: strip `--` line comments from the body *before* the comma-split, alongside the existing pre-split strip of `/* … */` block comments. Verified locally — every table's column set now matches its `CREATE TABLE` definition exactly, no phantom entries left.

After this deploys, the audit page should report **0 uncovered** columns (down from 2).

### 2. Untidy column widths across the per-table cards

Each per-table card on Schema Audit renders its own `<table>` element, sizing columns to its own content. Tables with long column names (`ProxyVpnIndicator`) make the Column column wide; tables with short names (`Token`, `UserId`) leave it narrow. The resulting wall of misaligned tables looks chaotic (visible in screenshots provided).

**Fix**: new shared CSS class `.admin-table-fixed` in `admin.css`. Switches a table to `table-layout: fixed`; per-column widths declared inline on each `<th>`. Applied to schema-audit's per-table tables with:

| Column | Status  | Notes |
|--------|---------|-------|
| 200px  | 120px   | flex  |

Now every audit table aligns identically across the page. The class is **reusable** — any future admin page that renders multiple sibling tables sharing the same column shape can opt in with one extra class on each `<table>`.

## Test plan

- [ ] After deploy, hit `/manage/schema-audit` — confirm the banner reads "0 uncovered" (was "2 uncovered").
- [ ] Scroll the page — confirm every per-table card has its Column / Status / Notes columns aligned exactly.
- [ ] Spot-check a couple of cards with very short and very long column names — narrow ones shouldn't have a cramped Column header, wide ones shouldn't push Status off-screen.

## Risk

Low. Parser fix is a one-line `preg_replace` addition — strips content (comments) that should already have been treated as non-data. CSS change is a new class applied to one page; nothing else touches the class yet so no regression surface elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011fgEBM87YrUdSnpKuLdekY)_