### PR TITLE
fix(api): broken Log Request form + Missing-Numbers column alignment

### DIFF
--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -211,10 +211,53 @@ require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $xrw = $_SERVER['HTTP_X_REQUESTED_WITH'] ?? '';
     if ($xrw !== 'XMLHttpRequest') {
-        sendJson([
-            'error' => 'Cross-site POST blocked: missing or invalid X-Requested-With header.',
-        ], 403);
-        exit;
+        /* No-JS fallback path (#711). One public endpoint —
+           `?action=song_request_submit` — accepts a native HTML form
+           POST so the /request page still works when the page's
+           <script type="module"> never loads (CSP fail, SW cache miss,
+           syntax error). HTML <form> elements cannot set custom
+           headers, so they can never carry X-Requested-With; the
+           CSRF protection for this path is a same-origin check on
+           Origin / Referer instead. Browsers attach both headers
+           automatically and cannot be forged across origins, so a
+           cross-site CSRF attempt would carry a different host and
+           get rejected here.
+
+           This block intentionally allows ONLY song_request_submit —
+           every other POST endpoint stays on the strict
+           X-Requested-With requirement. If a new endpoint ever needs
+           a no-JS path, extend this allow-list explicitly. */
+        $action = (string)($_GET['action'] ?? '');
+        $noJsAllowedActions = ['song_request_submit'];
+        $passesSameOrigin = false;
+        if (in_array($action, $noJsAllowedActions, true)) {
+            $host    = (string)($_SERVER['HTTP_HOST'] ?? '');
+            $origin  = (string)($_SERVER['HTTP_ORIGIN']  ?? '');
+            $referer = (string)($_SERVER['HTTP_REFERER'] ?? '');
+            /* Extract host:port from Origin / Referer URLs and compare
+               to the request's Host header. parse_url() returns null
+               for the missing-field case, str-cast normalises that to
+               '' so an empty header doesn't accidentally match an
+               empty host. */
+            if ($origin !== '') {
+                $originHost = (string)parse_url($origin, PHP_URL_HOST);
+                $originPort = parse_url($origin, PHP_URL_PORT);
+                if ($originPort) $originHost .= ':' . $originPort;
+                $passesSameOrigin = ($originHost !== '' && strcasecmp($originHost, $host) === 0);
+            }
+            if (!$passesSameOrigin && $referer !== '') {
+                $refererHost = (string)parse_url($referer, PHP_URL_HOST);
+                $refererPort = parse_url($referer, PHP_URL_PORT);
+                if ($refererPort) $refererHost .= ':' . $refererPort;
+                $passesSameOrigin = ($refererHost !== '' && strcasecmp($refererHost, $host) === 0);
+            }
+        }
+        if (!$passesSameOrigin) {
+            sendJson([
+                'error' => 'Cross-site POST blocked: missing or invalid X-Requested-With header.',
+            ], 403);
+            exit;
+        }
     }
 }
 

--- a/appWeb/public_html/manage/missing-numbers.php
+++ b/appWeb/public_html/manage/missing-numbers.php
@@ -203,11 +203,11 @@ foreach ($reports as $r) {
                                     </div>
                                 <?php else: ?>
                                     <div class="table-responsive">
-                                        <table class="table table-sm align-middle mb-0 cp-sortable">
+                                        <table class="table table-sm align-middle mb-0 cp-sortable admin-table-fixed">
                                             <thead>
                                                 <tr>
-                                                    <th scope="col" data-sort-key="range" data-sort-type="text">Range</th>
-                                                    <th scope="col" class="text-end" data-sort-key="missing" data-sort-type="number">Missing</th>
+                                                    <th scope="col" style="width: 200px;" data-sort-key="range" data-sort-type="text">Range</th>
+                                                    <th scope="col" style="width: 100px;" class="text-end" data-sort-key="missing" data-sort-type="number">Missing</th>
                                                     <th scope="col">Action</th>
                                                 </tr>
                                             </thead>


### PR DESCRIPTION
## Summary

Two reports from `/manage/missing-numbers`:

### 1. "Log Request" workflow is broken

Clicking **Log request** on a missing-songbook-number opened `/request?songbook=MP&number=13`, the user filled the form and hit Send Request, and got back:

```json
{"error": "Cross-site POST blocked: missing or invalid X-Requested-With header."}
```

**Root cause**: the `/request` page's `<form>` has a no-JS fallback path (#711) that does a native HTML POST when the page's `<script type="module">` hasn't finished loading yet. HTML forms cannot set custom headers, so the `X-Requested-With: XMLHttpRequest` check at `api.php:211` rejected the request before it ever reached `song_request_submit`'s own handler — even though the endpoint explicitly accepts `application/x-www-form-urlencoded`. The no-JS path was dead on arrival.

**Fix**: when the X-Requested-With check fails on `?action=song_request_submit` (a narrow allow-list), fall back to a same-origin check on `Origin` / `Referer` headers. Browsers attach both automatically on form POSTs and cannot be forged across origins from a malicious site, so a real cross-site CSRF attempt would carry a mismatched host and still get rejected. Every other POST endpoint stays on the strict X-Requested-With requirement.

```php
$action = (string)($_GET['action'] ?? '');
$noJsAllowedActions = ['song_request_submit'];
$passesSameOrigin = false;
if (in_array($action, $noJsAllowedActions, true)) {
    // parse Origin then Referer, compare host[:port] against Host
}
if (!$passesSameOrigin) {
    sendJson(['error' => 'Cross-site POST blocked: …'], 403);
    exit;
}
```

Defence stack on `song_request_submit` after this lands:
- Same-origin check (this PR — Origin/Referer must match Host).
- Honeypot `website` field (existing — bots fill it; real users never see it).
- Endpoint-level rate limit (existing).

If a new endpoint ever needs a no-JS form path, the comment block at the top of the guard directs the contributor to extend the allow-list explicitly.

### 2. Missing-Numbers per-songbook table widths

Each songbook's expanded `<details>` rendered its own `<table>` sizing columns to its own content. Long ranges (`#1245–#1248`) stretched the Range column; short ranges (`#13`) compressed it; the Action column with two buttons varied too. Same fix as #978's schema-audit: tag the table with `.admin-table-fixed` (CSS class added in #978) and declare inline widths on the `<th>` elements:

| Range  | Missing | Action |
|--------|---------|--------|
| 200px  | 100px   | flex   |

Every songbook's expanded table now aligns identically.

## Scope note on "alignment across iHymns"

This PR addresses the two acutely visible cases the user pointed to. Most other manage tables render a single table per page where column widths are deterministic by definition — the cross-page inconsistency is genuine but cosmetic and would require a per-page width decision (different pages have different columns by content). The `.admin-table-fixed` class added in #978 is reusable on any page; happy to extend it to specific pages on request — name the pages and what columns you want fixed-width and I'll do it.

## Test plan

- [ ] Hit `/manage/missing-numbers`, expand Mission Praise, confirm the Range / Missing / Action columns line up uniformly across rows.
- [ ] Click "Log request" on any missing number — the form should open at `/request?songbook=MP&number=…` and submit cleanly. Either the JS path (JSON + X-Requested-With) or the no-JS fallback (form POST + same-origin) should succeed.
- [ ] After submit, you should see either the JSON success response or the server-rendered banner at `/request?submitted=1&id=…`.
- [ ] Verify other POST endpoints (anything `/api?action=…` that's not `song_request_submit`) still reject form POSTs without X-Requested-With — open one in a fresh tab via direct URL and confirm the 403.

## Risk

Low. The same-origin check is narrowly scoped to one endpoint; every other POST endpoint stays on the unchanged X-Requested-With contract. The alignment class on missing-numbers is purely additive CSS — no behaviour change beyond visual layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011fgEBM87YrUdSnpKuLdekY)_