### PR TITLE
fix(bulk-promote): Auto-resolve no longer points every row at same target (data-destruction risk)

### DIFF
--- a/appWeb/public_html/manage/credit-people-bulk-promote.php
+++ b/appWeb/public_html/manage/credit-people-bulk-promote.php
@@ -530,8 +530,30 @@ if (!empty($registryByName)) {
 
     <script>
     (function () {
+        /* Real fuzzy-match options carry a `data-score` attribute (set
+           on lines ~495-497 of the per-row render); the full-registry
+           fallback options below the divider do NOT. The bulk-promote
+           UX relies on this distinction so a row with zero real matches
+           can never silently auto-resolve into "whichever registry row
+           happens to be first alphabetically" — which is exactly the
+           data-destruction class of bug fixed in this commit. */
+        const isFuzzyMatchOption = (opt) =>
+            opt && opt.value && !opt.disabled && opt.hasAttribute('data-score');
+        const hasFuzzyMatch = (mergeSelect) => {
+            if (!mergeSelect) return false;
+            for (const opt of mergeSelect.options) {
+                if (isFuzzyMatchOption(opt)) return true;
+            }
+            return false;
+        };
+
         /* Toggle the merge-target select disabled state with the row's
-           action picker. */
+           action picker. Auto-picks the highest-scoring fuzzy match
+           when the row becomes a merge — but ONLY when a real fuzzy
+           match exists. Rows with no fuzzy match stay on the
+           "— pick target —" placeholder so the curator must consciously
+           pick a destination instead of accidentally inheriting the
+           first registry entry. (#claude/fix-bulk-promote-auto-resolve) */
         document.querySelectorAll('.row-action-select').forEach(sel => {
             const row = sel.closest('tr');
             const target = row?.querySelector('.row-merge-select');
@@ -539,9 +561,15 @@ if (!empty($registryByName)) {
                 if (!target) return;
                 target.disabled = (sel.value !== 'merge');
                 if (sel.value === 'merge' && !target.value) {
-                    /* Pre-pick the first option that isn't the placeholder. */
+                    /* Pre-pick only from real fuzzy matches, never from
+                       the registry-fallback list. If no fuzzy match
+                       exists, leave the placeholder — the curator's
+                       explicit choice is required. */
                     for (const opt of target.options) {
-                        if (opt.value && !opt.disabled) { target.value = opt.value; break; }
+                        if (isFuzzyMatchOption(opt)) {
+                            target.value = opt.value;
+                            break;
+                        }
                     }
                 }
             };
@@ -549,20 +577,43 @@ if (!empty($registryByName)) {
             sync();
         });
 
-        /* Bulk-action buttons. */
+        /* Bulk-action buttons.
+
+           "Auto-resolve flagged matches" should ONLY change rows that
+           have a flagged fuzzy match — not every row that happens to
+           have a non-empty merge dropdown (every row does, because the
+           full registry is always available as a fallback). Pre-fix,
+           the check was `merge.options.length > 1`, which caught
+           literally every row and then the sync() handler above
+           defaulted them all to the first non-placeholder option =
+           whichever person was first in registryOptions. That's the
+           "every candidate merged to Cecil Frances Alexander"
+           data-destruction bug the screenshot showed. */
         document.addEventListener('click', (ev) => {
             const btn = ev.target.closest('[data-action]');
             if (!btn) return;
             const action = btn.getAttribute('data-action');
             if (action === 'auto-resolve') {
+                let flipped = 0;
                 document.querySelectorAll('.row-action-select').forEach(sel => {
                     const row = sel.closest('tr');
                     const merge = row?.querySelector('.row-merge-select');
-                    if (merge && merge.options.length > 1) {
+                    if (hasFuzzyMatch(merge)) {
                         sel.value = 'merge';
                         sel.dispatchEvent(new Event('change'));
+                        flipped++;
                     }
                 });
+                /* Light-touch feedback so the curator knows when "no
+                   matches to auto-resolve" is the real answer instead
+                   of staring at an unchanged page. */
+                if (flipped === 0) {
+                    window.alert(
+                        'No candidate rows have a flagged fuzzy match to auto-resolve.\n\n'
+                        + 'Lower the Match threshold (or raise Min total uses) to surface '
+                        + 'more potential matches, or set the candidates individually.'
+                    );
+                }
             } else if (action === 'set-all') {
                 const value = btn.getAttribute('data-value');
                 document.querySelectorAll('.row-action-select').forEach(sel => {


### PR DESCRIPTION
## ⚠️ URGENT — data-destruction risk

Reported with a screenshot showing every candidate (Graham Kendrick, David Peacock, Phil Burt, Christopher Norton, Greg Leavers, Roland Fudge, Andy Silver, Christopher Hayward, Timothy Dudley-Smith, Chris Bowater, …) defaulting to **"Merge into existing… → Cecil Frances Humphreys Alexander"** after clicking **Auto-resolve flagged matches**, despite the *Best match* column reading **"no match"** on every row.

A curator who pressed **Promote selected** with that pre-filled state would have merged every selected candidate's song-credit rows into one wrong target — silently corrupting credits across hundreds of song-credit rows with no straightforward way to undo.

## Root cause

Two-part bug in the inline `<script>` at the bottom of `credit-people-bulk-promote.php`:

1. **Auto-resolve handler** (line 557) treated every row whose merge dropdown had `> 1 option` as a candidate to flip into "merge" mode. But every row's dropdown ALWAYS has many options because the full registry is rendered as a fallback after the fuzzy-match block. `merge.options.length > 1` matched literally every row.

2. **sync() handler** on `change` of the action select (line 541) auto-picked the first non-placeholder option in the merge dropdown when the action became "merge". For rows with zero fuzzy matches, that first option was whichever registry person sorted first in `$registryOptions` — *Cecil Frances Humphreys Alexander* on this curator's DB. Every flipped row inherited the same wrong default.

## Fix

Introduce an `isFuzzyMatchOption(opt)` predicate keyed off the `data-score` attribute — only present on real fuzzy-match options (set at the renderer on line 495), absent from the full-registry fallback options below the divider.

```js
const isFuzzyMatchOption = (opt) =>
    opt && opt.value && !opt.disabled && opt.hasAttribute('data-score');
```

Use it in both places:

- **Auto-resolve** now flips only rows whose merge dropdown contains at least one fuzzy-match option. Rows with no real match stay on "Register as new". If no row qualifies, a small alert explains why nothing changed and suggests lowering the threshold or raising *Min total uses*.

- **sync()** now auto-picks only from fuzzy-match options. A row with no fuzzy match stays on "— pick target —" so the curator must consciously pick a destination — they can no longer inherit whichever registry row sorted first.

## Test plan

- [ ] After deploy, hit `/manage/credit-people/bulk-promote`.
- [ ] On a page where the *Best match* column shows "no match" for every row (the screenshot scenario), click **Auto-resolve flagged matches**. Expected: an alert ("No candidate rows have a flagged fuzzy match…") and every row stays on **Register as new**. *Was: every row silently flipped to **Merge into existing → Cecil Frances Humphreys Alexander**.*
- [ ] On a page that DOES have fuzzy matches (lower the threshold to 0.5 if needed), click **Auto-resolve**. Expected: only the rows with fuzzy matches flip to Merge, each pre-selecting its own highest-scoring match. Rows without matches still stay on Register as new.
- [ ] Manually pick **Merge into existing…** on a row with no fuzzy match. Expected: dropdown stays on "— pick target —" forcing the curator to pick. *Was: dropdown silently auto-selected the first registry option.*

## Risk

Low. Pure UX-defaults fix — no schema change, no DB-handler change. The server-side `merge_to[]` handler already validates each target ID exists in `tblCreditPeople`, so this fix is defence-in-depth for the curator's review step.

## Out of scope (deferred to follow-up branches)

The user also flagged three UX issues on this same page in the preceding message — all real but lower-urgency than the data-destruction risk this PR addresses:

- **"Bulk promote with fuzzy-match"** button label not readable in dark mode.
- **Two dropdowns per row is confusing**: should be a single dropdown with "Register as new" as default and a few inline merge candidates as additional options.
- **Smarter merge suggestions** based on name similarity (Levenshtein / token-set distance already used elsewhere — surface the top 2-3 inline).

Happy to tackle these on a separate branch once this fix is merged — the URGENT fix shouldn't wait behind the broader UX rework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011fgEBM87YrUdSnpKuLdekY)_