### PR TITLE
feat(credit-people): AKA / alias names for searchability (MusicBrainz-style)

### DIFF
--- a/appWeb/.sql/migrate-credit-people-aliases.php
+++ b/appWeb/.sql/migrate-credit-people-aliases.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Credit People AKA / Alias names (#claude/credit-people-aliases)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Adds tblCreditPersonAliases so curators can record alternative names
+ * for a credit-person to assist searchability. Mirrors the MusicBrainz
+ * alias model in slimmed-down form:
+ *
+ *   - One row per (CreditPersonId, Name) — UNIQUE enforces no dupes.
+ *   - Type ENUM classifies the alias (legal, artist, pseudonym, nickname,
+ *     maiden, search-hint, misspelling, other).
+ *   - Optional Locale tag (IETF BCP 47) for transliterations:
+ *     "John Doe" (en) ↔ "ジョン・ドウ" (ja).
+ *   - SortName (optional) for surname-first display where useful.
+ *   - IsPrimary lets a curator mark one alias per locale as the
+ *     preferred display form.
+ *
+ * SEARCH IMPACT:
+ *   Site search, credit-people admin search, and the editor's
+ *   typeahead all UNION this table into their LIKE / FULLTEXT queries
+ *   so a user typing the alias name finds the canonical person.
+ *
+ * PUBLIC SURFACE:
+ *   /people/<slug> renders aliases under the bio header + emits
+ *   JSON-LD alternateName.
+ *
+ * BULK IMPORT:
+ *   The bulk-import parser detects "Smith (a.k.a. Jones)" /
+ *   "Smith / Jones" / "Smith (Jones)" patterns in incoming credit
+ *   strings and creates aliases automatically.
+ *
+ * Idempotent — uses CREATE TABLE IF NOT EXISTS. Re-runs no-op.
+ *
+ * @migration-adds tblCreditPersonAliases
+ *
+ * USAGE:
+ *   CLI: php appWeb/.sql/migrate-credit-people-aliases.php
+ *   Web: /manage/setup-database → "Credit People Aliases"
+ *        (entry point requires global_admin)
+ */
+
+if (PHP_SAPI === 'cli') {
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = true;
+} else {
+    if (!defined('IHYMNS_SETUP_DASHBOARD')) {
+        if (!function_exists('isAuthenticated')) {
+            require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+        }
+        if (!isAuthenticated()) {
+            http_response_code(401);
+            exit('Authentication required.');
+        }
+        $u = getCurrentUser();
+        if (!$u || $u['role'] !== 'global_admin') {
+            http_response_code(403);
+            exit('Global admin required.');
+        }
+    }
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = false;
+}
+
+function _migCpAlias_out(string $line): void
+{
+    global $isCli;
+    echo $line . ($isCli ? "\n" : "<br>\n");
+    if ($isCli) flush();
+}
+
+function _migCpAlias_tableExists(\mysqli $db, string $table): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? LIMIT 1'
+    );
+    $stmt->bind_param('s', $table);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+_migCpAlias_out('Credit People Aliases migration starting…');
+
+$mysqli = getDbMysqli();
+if (!$mysqli) {
+    throw new \RuntimeException('Could not connect to database.');
+}
+
+if (!_migCpAlias_tableExists($mysqli, 'tblCreditPeople')) {
+    _migCpAlias_out('[skip] tblCreditPeople not present — run migrate-credit-people.php (#545) first.');
+    return;
+}
+
+if (_migCpAlias_tableExists($mysqli, 'tblCreditPersonAliases')) {
+    _migCpAlias_out('[skip] tblCreditPersonAliases already present.');
+} else {
+    $sql = "CREATE TABLE tblCreditPersonAliases (
+        Id              INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+        CreditPersonId  INT UNSIGNED NOT NULL,
+        Name            VARCHAR(255) NOT NULL COMMENT 'Display form of the alias',
+        SortName        VARCHAR(255) NULL COMMENT 'Surname-first sortable form; NULL = derive from Name',
+        Type            ENUM('legal','artist','pseudonym','nickname','maiden','search-hint','misspelling','other')
+                                     NOT NULL DEFAULT 'other'
+                                     COMMENT 'MusicBrainz-style alias classification',
+        Locale          VARCHAR(35)  NULL COMMENT 'Optional IETF BCP 47 tag for transliterations (ja, ru-Latn, zh-Hans, …)',
+        IsPrimary       TINYINT(1)   NOT NULL DEFAULT 0 COMMENT '1 = preferred display form in this Locale',
+        SortOrder       INT UNSIGNED NOT NULL DEFAULT 0,
+        Note            VARCHAR(255) NULL,
+        CreatedAt       TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        UpdatedAt       TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+        UNIQUE KEY uq_person_name (CreditPersonId, Name),
+        INDEX idx_person (CreditPersonId),
+        INDEX idx_name   (Name),
+        INDEX idx_type   (Type),
+
+        CONSTRAINT fk_alias_person
+            FOREIGN KEY (CreditPersonId) REFERENCES tblCreditPeople(Id) ON DELETE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
+
+    if (!$mysqli->query($sql)) {
+        throw new \RuntimeException('CREATE TABLE tblCreditPersonAliases failed: ' . $mysqli->error);
+    }
+    _migCpAlias_out('[add ] tblCreditPersonAliases.');
+}
+
+_migCpAlias_out('Credit People Aliases migration finished.');

--- a/appWeb/.sql/schema.sql
+++ b/appWeb/.sql/schema.sql
@@ -1778,6 +1778,40 @@ CREATE TABLE IF NOT EXISTS tblCreditPersonExternalLinks (
 
 
 -- ----------------------------------------------------------------------------
+-- tblCreditPersonAliases — AKA / alternative names for searchability.
+-- MusicBrainz-style alias model: one row per (person, name) with a Type
+-- classification, optional Locale tag for transliterations, and an
+-- IsPrimary flag for the preferred display form within a locale.
+-- Searched alongside Name in site search + admin filter + editor
+-- typeahead. /people/<slug> renders aliases under the bio header and
+-- emits JSON-LD alternateName.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS tblCreditPersonAliases (
+    Id              INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    CreditPersonId  INT UNSIGNED NOT NULL,
+    Name            VARCHAR(255) NOT NULL COMMENT 'Display form of the alias',
+    SortName        VARCHAR(255) NULL COMMENT 'Surname-first sortable form; NULL = derive from Name',
+    Type            ENUM('legal','artist','pseudonym','nickname','maiden','search-hint','misspelling','other')
+                                 NOT NULL DEFAULT 'other'
+                                 COMMENT 'MusicBrainz-style alias classification',
+    Locale          VARCHAR(35)  NULL COMMENT 'Optional IETF BCP 47 tag for transliterations (ja, ru-Latn, zh-Hans, …)',
+    IsPrimary       TINYINT(1)   NOT NULL DEFAULT 0 COMMENT '1 = preferred display form in this Locale',
+    SortOrder       INT UNSIGNED NOT NULL DEFAULT 0,
+    Note            VARCHAR(255) NULL,
+    CreatedAt       TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UpdatedAt       TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    UNIQUE KEY uq_person_name (CreditPersonId, Name),
+    INDEX idx_person (CreditPersonId),
+    INDEX idx_name   (Name),
+    INDEX idx_type   (Type),
+
+    CONSTRAINT fk_alias_person
+        FOREIGN KEY (CreditPersonId) REFERENCES tblCreditPeople(Id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+-- ----------------------------------------------------------------------------
 -- tblSongAlternativeTitles (#832) — multiple "also known as" titles per song.
 -- ----------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS tblSongAlternativeTitles (

--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -9449,8 +9449,9 @@ if ($action !== null) {
             $deathPlace  = trim((string)($body['death_place']  ?? '')) ?: null;
             $deathDate   = trim((string)($body['death_date']   ?? '')) ?: null;
             $notes       = $notesRaw !== '' ? $notesRaw : null;
-            $links       = normaliseCreditPersonLinks($body['links'] ?? null);
-            $ipi         = normaliseCreditPersonIpi($body['ipi']     ?? null);
+            $links       = normaliseCreditPersonLinks($body['links']   ?? null);
+            $ipi         = normaliseCreditPersonIpi($body['ipi']       ?? null);
+            $aliases     = normaliseCreditPersonAliases($body['aliases'] ?? null);
             $isSpecialCase = !empty($body['is_special_case']) ? 1 : 0;
             $isGroup       = !empty($body['is_group'])        ? 1 : 0;
             /* Mutually exclusive in the UI; if both arrive we prefer
@@ -9561,6 +9562,11 @@ if ($action !== null) {
                         }
                         $ipiStmt->close();
                     }
+                    /* AKA / alias names — schema-tolerant: replaceCreditPersonAliases
+                       no-ops cleanly on installs where the aliases table isn't present. */
+                    if ($aliases) {
+                        replaceCreditPersonAliases($db, $newId, $aliases);
+                    }
                     $db->commit();
                 } catch (\Throwable $txErr) {
                     $db->rollback();
@@ -9568,16 +9574,17 @@ if ($action !== null) {
                 }
 
                 logActivity('api.admin.credit_person.add', 'credit_person', (string)$newId, [
-                    'name'       => $name,
-                    'fields'     => array_filter([
+                    'name'        => $name,
+                    'fields'      => array_filter([
                         'birth_place' => $birthPlace,
                         'birth_date'  => $birthDate,
                         'death_place' => $deathPlace,
                         'death_date'  => $deathDate,
                         'notes'       => $notes,
                     ], static fn($v) => $v !== null),
-                    'link_count' => count($links),
-                    'ipi_count'  => count($ipi),
+                    'link_count'  => count($links),
+                    'ipi_count'   => count($ipi),
+                    'alias_count' => count($aliases),
                 ]);
 
                 sendJson([
@@ -9623,8 +9630,9 @@ if ($action !== null) {
             $deathPlace  = trim((string)($body['death_place']  ?? '')) ?: null;
             $deathDate   = trim((string)($body['death_date']   ?? '')) ?: null;
             $notes       = $notesRaw !== '' ? $notesRaw : null;
-            $links       = normaliseCreditPersonLinks($body['links'] ?? null);
-            $ipi         = normaliseCreditPersonIpi($body['ipi']     ?? null);
+            $links       = normaliseCreditPersonLinks($body['links']   ?? null);
+            $ipi         = normaliseCreditPersonIpi($body['ipi']       ?? null);
+            $aliases     = normaliseCreditPersonAliases($body['aliases'] ?? null);
             $isSpecialCase = !empty($body['is_special_case']) ? 1 : 0;
             $isGroup       = !empty($body['is_group'])        ? 1 : 0;
             if ($isSpecialCase && $isGroup) { $isGroup = 0; }
@@ -9724,6 +9732,11 @@ if ($action !== null) {
                         }
                         $ipiStmt->close();
                     }
+                    /* Replace the alias set unconditionally — the curator's
+                       submitted list is the new truth, an empty list deletes
+                       all aliases. Schema-tolerant on installs where the
+                       table is absent (helper no-ops). */
+                    replaceCreditPersonAliases($db, $id, $aliases);
                     $db->commit();
                 } catch (\Throwable $txErr) {
                     $db->rollback();
@@ -9745,11 +9758,12 @@ if ($action !== null) {
                 }
 
                 logActivity('api.admin.credit_person.update', 'credit_person', (string)$id, [
-                    'name'       => $name,
-                    'fields'     => $changed,
-                    'before'     => array_intersect_key($beforeRow, array_flip($changed)),
-                    'after'      => array_intersect_key($afterRow,  array_flip($changed)),
-                    'link_count' => count($links),
+                    'name'        => $name,
+                    'fields'      => $changed,
+                    'before'      => array_intersect_key($beforeRow, array_flip($changed)),
+                    'after'       => array_intersect_key($afterRow,  array_flip($changed)),
+                    'link_count'  => count($links),
+                    'alias_count' => count($aliases),
                     'ipi_count'  => count($ipi),
                 ]);
 

--- a/appWeb/public_html/includes/credit_people_helpers.php
+++ b/appWeb/public_html/includes/credit_people_helpers.php
@@ -429,3 +429,275 @@ function creditPeopleFlagsColumnsExist(\mysqli $db): bool
     }
     return $cached;
 }
+
+
+/* =========================================================================
+ * CREDIT PERSON ALIASES (AKA names)
+ *
+ * Shared helpers for the MusicBrainz-style alias model
+ * (tblCreditPersonAliases — see migrate-credit-people-aliases.php).
+ * Used by:
+ *   - /api.php's admin_credit_person_add / _update handlers
+ *   - /manage/credit-people.php form handler
+ *   - /people/<slug>'s public render (alias list + JSON-LD)
+ *   - bulk-import's "(a.k.a. …)" pattern detector
+ * ========================================================================= */
+
+const CREDIT_PERSON_ALIAS_TYPES = [
+    'legal'         => 'Legal name',
+    'artist'        => 'Artist / performing name',
+    'pseudonym'     => 'Pseudonym / pen name',
+    'nickname'      => 'Nickname',
+    'maiden'        => 'Maiden name',
+    'search-hint'   => 'Search hint',
+    'misspelling'   => 'Common misspelling',
+    'other'         => 'Other',
+];
+
+const CREDIT_PERSON_ALIAS_TYPE_KEYS = [
+    'legal','artist','pseudonym','nickname','maiden','search-hint','misspelling','other',
+];
+
+/**
+ * Schema-tolerant probe for the aliases table — returns false on installs
+ * that haven't run migrate-credit-people-aliases.php yet so consuming
+ * code can branch cheaply rather than throw on every load.
+ */
+function creditPeopleAliasesTableExists(\mysqli $db): bool
+{
+    static $cached = null;
+    if ($cached !== null) return $cached;
+    try {
+        $stmt = $db->prepare(
+            "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+              WHERE TABLE_SCHEMA = DATABASE()
+                AND TABLE_NAME   = 'tblCreditPersonAliases' LIMIT 1"
+        );
+        $stmt->execute();
+        $cached = $stmt->get_result()->fetch_row() !== null;
+        $stmt->close();
+    } catch (\Throwable $_e) {
+        $cached = false;
+    }
+    return $cached;
+}
+
+/**
+ * Normalise inbound alias payload (form-encoded or JSON-decoded) into
+ * a list of INSERT-ready row arrays. Drops rows with empty Name, clamps
+ * Type to the allow-list, defaults SortOrder to the input index.
+ *
+ * @param mixed $raw Form / JSON-decoded array; non-array → []
+ * @return list<array{name:string,sort_name:?string,type:string,locale:?string,is_primary:int,sort_order:int,note:?string}>
+ */
+function normaliseCreditPersonAliases(mixed $raw): array
+{
+    if (!is_array($raw)) return [];
+    $out  = [];
+    $seen = []; /* dedupe by (lower-cased) name within the request */
+    foreach ($raw as $i => $row) {
+        if (!is_array($row)) continue;
+        $name = trim((string)($row['name'] ?? ''));
+        if ($name === '') continue;
+        if (mb_strlen($name) > 255) $name = mb_substr($name, 0, 255);
+        $key = mb_strtolower($name);
+        if (isset($seen[$key])) continue;
+        $seen[$key] = true;
+
+        $type = trim((string)($row['type'] ?? 'other'));
+        if (!in_array($type, CREDIT_PERSON_ALIAS_TYPE_KEYS, true)) $type = 'other';
+
+        $sortName = trim((string)($row['sort_name'] ?? ''));
+        $locale   = trim((string)($row['locale']    ?? ''));
+        $note     = trim((string)($row['note']      ?? ''));
+
+        $out[] = [
+            'name'        => $name,
+            'sort_name'   => $sortName !== '' ? mb_substr($sortName, 0, 255) : null,
+            'type'        => $type,
+            'locale'      => $locale   !== '' ? mb_substr($locale, 0, 35)    : null,
+            'is_primary'  => !empty($row['is_primary']) ? 1 : 0,
+            'sort_order'  => (int)($row['sort_order'] ?? $i),
+            'note'        => $note     !== '' ? mb_substr($note, 0, 255)     : null,
+        ];
+    }
+    return $out;
+}
+
+/**
+ * Replace all rows in tblCreditPersonAliases for a credit person with
+ * the supplied set. Run inside the same transaction as the parent
+ * INSERT/UPDATE so a downstream failure rolls back cleanly. Schema-
+ * tolerant: silently no-ops on installs where the table is absent.
+ *
+ * @param list<array> $aliases  Output of normaliseCreditPersonAliases()
+ */
+function replaceCreditPersonAliases(\mysqli $db, int $creditPersonId, array $aliases): void
+{
+    if (!creditPeopleAliasesTableExists($db)) return;
+
+    $del = $db->prepare('DELETE FROM tblCreditPersonAliases WHERE CreditPersonId = ?');
+    $del->bind_param('i', $creditPersonId);
+    $del->execute();
+    $del->close();
+
+    if (!$aliases) return;
+
+    $ins = $db->prepare(
+        'INSERT INTO tblCreditPersonAliases
+             (CreditPersonId, Name, SortName, Type, Locale, IsPrimary, SortOrder, Note)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
+    );
+    foreach ($aliases as $a) {
+        $cpId      = $creditPersonId;
+        $name      = $a['name'];
+        $sortName  = $a['sort_name'];
+        $type      = $a['type'];
+        $locale    = $a['locale'];
+        $isPrimary = (int)$a['is_primary'];
+        $sortOrder = (int)$a['sort_order'];
+        $note      = $a['note'];
+        $ins->bind_param(
+            'issssiis',
+            $cpId, $name, $sortName, $type, $locale, $isPrimary, $sortOrder, $note
+        );
+        $ins->execute();
+    }
+    $ins->close();
+}
+
+/**
+ * Fetch every alias for one credit-person, ordered by IsPrimary DESC
+ * then SortOrder ASC then Id ASC so the curator's preferred display
+ * form is first.
+ *
+ * @return list<array{Id:int,Name:string,SortName:?string,Type:string,Locale:?string,IsPrimary:int,SortOrder:int,Note:?string}>
+ */
+function loadCreditPersonAliases(\mysqli $db, int $creditPersonId): array
+{
+    if (!creditPeopleAliasesTableExists($db)) return [];
+    $stmt = $db->prepare(
+        'SELECT Id, Name, SortName, Type, Locale, IsPrimary, SortOrder, Note
+           FROM tblCreditPersonAliases
+          WHERE CreditPersonId = ?
+       ORDER BY IsPrimary DESC, SortOrder ASC, Id ASC'
+    );
+    $stmt->bind_param('i', $creditPersonId);
+    $stmt->execute();
+    $out = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+    $stmt->close();
+    foreach ($out as &$r) {
+        $r['Id']        = (int)$r['Id'];
+        $r['IsPrimary'] = (int)$r['IsPrimary'];
+        $r['SortOrder'] = (int)$r['SortOrder'];
+    }
+    unset($r);
+    return $out;
+}
+
+/**
+ * Bulk-load aliases for many credit-people in one round-trip, grouped
+ * by CreditPersonId. Used by /manage/credit-people's list-view render
+ * so the page doesn't issue N queries when surfacing aliases inline.
+ *
+ * @param list<int> $personIds
+ * @return array<int, list<array>>  CreditPersonId → list of alias rows
+ */
+function loadCreditPersonAliasesBulk(\mysqli $db, array $personIds): array
+{
+    $personIds = array_values(array_filter(array_map('intval', $personIds), fn($v) => $v > 0));
+    if (!$personIds || !creditPeopleAliasesTableExists($db)) return [];
+    $placeholders = implode(',', array_fill(0, count($personIds), '?'));
+    $types        = str_repeat('i', count($personIds));
+    $stmt = $db->prepare(
+        "SELECT CreditPersonId, Id, Name, SortName, Type, Locale, IsPrimary, SortOrder, Note
+           FROM tblCreditPersonAliases
+          WHERE CreditPersonId IN ($placeholders)
+       ORDER BY CreditPersonId ASC, IsPrimary DESC, SortOrder ASC, Id ASC"
+    );
+    $stmt->bind_param($types, ...$personIds);
+    $stmt->execute();
+    $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+    $stmt->close();
+    $grouped = [];
+    foreach ($rows as $r) {
+        $pid = (int)$r['CreditPersonId'];
+        unset($r['CreditPersonId']);
+        $r['Id']        = (int)$r['Id'];
+        $r['IsPrimary'] = (int)$r['IsPrimary'];
+        $r['SortOrder'] = (int)$r['SortOrder'];
+        $grouped[$pid][] = $r;
+    }
+    return $grouped;
+}
+
+/**
+ * Detect alias patterns inside a free-text credit string, used by the
+ * bulk-import flow to auto-promote "a.k.a." annotations into proper
+ * alias rows. Recognises:
+ *
+ *   "Smith (a.k.a. Jones)"        → primary=Smith, alias=Jones
+ *   "Smith (aka Jones)"           → ditto
+ *   "Smith / Jones"               → primary=Smith, alias=Jones
+ *   "Smith (Jones)"               → primary=Smith, alias=Jones (parenthetical)
+ *   "Smith, also known as Jones"  → ditto
+ *
+ * Returns ['name' => <canonical>, 'aliases' => list<string>]. Pass-through
+ * for strings with no recognisable pattern: ['name' => $raw, 'aliases' => []].
+ *
+ * Conservative — only fires on patterns that are unambiguously
+ * alias markers. Bare parenthetical "(b. 1850)" is left alone (the
+ * Smith-and-Jones case is distinguished by the absence of digits /
+ * non-name characters inside the parens).
+ */
+function parseCreditPersonAliasHints(string $raw): array
+{
+    $raw = trim($raw);
+    if ($raw === '') return ['name' => '', 'aliases' => []];
+
+    $aliases = [];
+    $primary = $raw;
+
+    /* Pattern 1 — explicit a.k.a. / aka / also known as. The optional
+       trailing comma/period before the marker gets stripped from the
+       primary so "Smith, also known as Jones" lands as primary=Smith,
+       not "Smith," with a trailing comma. */
+    if (preg_match('/^(.+?)\s*[,.]?\s*(?:\(\s*)?(?:a\.?k\.?a\.?|also\s+known\s+as)\s+([^)]+?)\s*\)?\s*$/i', $raw, $m)) {
+        $primary = rtrim(trim($m[1]), " ,.");
+        $aliasText = trim($m[2]);
+        if ($aliasText !== '') {
+            /* Split on slash / semicolon / " or " so multiple aliases work. */
+            foreach (preg_split('/\s*(?:\/|;| or )\s*/i', $aliasText) as $a) {
+                $a = trim($a);
+                if ($a !== '' && $a !== $primary) $aliases[] = $a;
+            }
+        }
+        return ['name' => $primary, 'aliases' => $aliases];
+    }
+
+    /* Pattern 2 — parenthetical name without explicit marker.
+       Requires the parens to contain letter-only content (no digits,
+       no commas, no dates), and to look like a name (≥2 letters). */
+    if (preg_match('/^(.+?)\s*\(\s*([\p{L}][\p{L}\s\.\-\']+)\s*\)\s*$/u', $raw, $m)) {
+        $inner = trim($m[2]);
+        /* Reject biography-ish content. */
+        if (!preg_match('/\d|,|^b\.|^d\.|^born\b|^died\b/iu', $inner)) {
+            $primary   = trim($m[1]);
+            $aliases[] = $inner;
+            return ['name' => $primary, 'aliases' => $aliases];
+        }
+    }
+
+    /* Pattern 3 — "A / B" without slash being a date or path. Only
+       split when both sides look like person names (≥2 letters, no
+       digits, no slashes themselves). */
+    if (preg_match('/^([\p{L}][\p{L}\s\.\-\']+?)\s+\/\s+([\p{L}][\p{L}\s\.\-\']+)$/u', $raw, $m)) {
+        $left  = trim($m[1]);
+        $right = trim($m[2]);
+        if ($left !== '' && $right !== '' && $left !== $right) {
+            return ['name' => $left, 'aliases' => [$right]];
+        }
+    }
+
+    return ['name' => $raw, 'aliases' => []];
+}

--- a/appWeb/public_html/includes/pages/person.php
+++ b/appWeb/public_html/includes/pages/person.php
@@ -71,6 +71,22 @@ if ($personName === '') {
     $personName = _personSlugToName($personSlug);
 }
 
+/* AKA / aliases — pull every alternative name attached to this
+   registry row so the header card can render "Also known as: …" and
+   the JSON-LD block can emit alternateName. Schema-tolerant: returns
+   an empty array on installs that haven't run the aliases migration. */
+$personAliases = [];
+if ($person && isset($person['Id'])) {
+    if (!function_exists('loadCreditPersonAliases')) {
+        require_once dirname(__DIR__) . '/credit_people_helpers.php';
+    }
+    try {
+        $personAliases = loadCreditPersonAliases($db, (int)$person['Id']);
+    } catch (\Throwable $_e) {
+        $personAliases = [];
+    }
+}
+
 /* ---------------------------------------------------------------------- */
 /* 2. Discography by role — count + list across all six credit tables.    */
 /* ---------------------------------------------------------------------- */
@@ -298,6 +314,37 @@ foreach ($discography as $rk => $entry) {
                     <small class="text-muted fw-normal ms-1"><?= htmlspecialchars($lifespanText) ?></small>
                 <?php endif; ?>
             </h1>
+            <?php if (!empty($personAliases)):
+                /* AKA names render directly under the title so a visitor
+                   arriving via the canonical-name URL sees every name
+                   this person is also known as. Search-hint and
+                   misspelling rows are hidden — they exist to make the
+                   internal search match, not for public display. */
+                $publicAliases = array_filter(
+                    $personAliases,
+                    static fn(array $a): bool => !in_array($a['Type'], ['search-hint', 'misspelling'], true)
+                );
+            ?>
+                <?php if ($publicAliases): ?>
+                    <p class="text-muted small mb-1">
+                        <i class="fa-solid fa-arrows-left-right me-1" aria-hidden="true"></i>
+                        Also known as:
+                        <?php
+                            $rendered = array_map(static function (array $a): string {
+                                $name = htmlspecialchars((string)$a['Name']);
+                                /* Locale tag in <small> trailing the alias
+                                   so a transliteration like "ジョン・ドウ (ja)" reads
+                                   naturally. */
+                                if (!empty($a['Locale'])) {
+                                    $name .= ' <small class="text-muted">(' . htmlspecialchars((string)$a['Locale']) . ')</small>';
+                                }
+                                return $name;
+                            }, $publicAliases);
+                            echo implode(', ', $rendered);
+                        ?>
+                    </p>
+                <?php endif; ?>
+            <?php endif; ?>
             <?php if (!empty($rolesForBadges)): ?>
                 <p class="text-muted small mb-1">
                     <?= htmlspecialchars(implode(' &middot; ', $rolesForBadges)) ?>
@@ -471,5 +518,33 @@ foreach ($discography as $rk => $entry) {
             </div>
         </div>
     <?php endforeach; ?>
+
+    <?php
+        /* JSON-LD Person schema (#claude/credit-people-aliases-v2). Emit
+           an alternateName entry for every alias so search engines and
+           knowledge-graph consumers learn that "John Newton" and his
+           common variants ("J. Newton", "Newton, John") are the same
+           person. Search-hint / misspelling aliases are included here
+           too — schema.org alternateName is a non-display catalogue of
+           known synonyms, so search engines benefit from the broader
+           set the public header skipped. */
+        if ($person && (!empty($publicAliases) || !empty($personAliases))):
+            $ldNames = array_values(array_unique(array_map(
+                static fn(array $a): string => (string)$a['Name'],
+                $personAliases
+            )));
+            $ldType = ((int)($person['IsGroup'] ?? 0) === 1) ? 'MusicGroup' : 'Person';
+            $ld = [
+                '@context'      => 'https://schema.org',
+                '@type'         => $ldType,
+                'name'          => $personName,
+                'alternateName' => count($ldNames) === 1 ? $ldNames[0] : $ldNames,
+            ];
+    ?>
+        <script type="application/ld+json"><?= json_encode(
+            $ld,
+            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+        ) ?></script>
+    <?php endif; ?>
 
 </section>

--- a/appWeb/public_html/manage/credit-people.php
+++ b/appWeb/public_html/manage/credit-people.php
@@ -97,8 +97,10 @@ $logCreditPerson = static function (string $action, string $entityId, array $det
  * ---------------------------------------------------------------------- */
 $LINK_TYPE_CATALOGUE = CREDIT_PERSON_LINK_TYPE_CATALOGUE;
 $LINK_TYPE_KEYS      = CREDIT_PERSON_LINK_TYPE_KEYS;
+$ALIAS_TYPES         = CREDIT_PERSON_ALIAS_TYPES;
 $normaliseLinks      = static fn(mixed $raw): array => normaliseCreditPersonLinks($raw);
 $normaliseIpi        = static fn(mixed $raw): array => normaliseCreditPersonIpi($raw);
+$normaliseAliases    = static fn(mixed $raw): array => normaliseCreditPersonAliases($raw);
 
 /* Wrapper kept under the original snake_case private-prefix name so
    existing call sites in this file keep working without further
@@ -218,8 +220,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $deathPlace  = trim((string)($_POST['death_place']  ?? '')) ?: null;
                 $deathDate   = trim((string)($_POST['death_date']   ?? '')) ?: null;
                 $notes       = $notesRaw !== '' ? $notesRaw : null;
-                $links       = $normaliseLinks($_POST['links'] ?? null);
-                $ipi         = $normaliseIpi($_POST['ipi']     ?? null);
+                $links       = $normaliseLinks($_POST['links']     ?? null);
+                $ipi         = $normaliseIpi($_POST['ipi']         ?? null);
+                $aliases     = $normaliseAliases($_POST['aliases'] ?? null);
                 /* #584 / #585 — classification flags. The two are
                    mutually exclusive in the UI; if both arrive we
                    prefer special-case (it's the more constraining
@@ -377,6 +380,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         }
                         $ipiStmt->close();
                     }
+                    /* AKA / alias rows — schema-tolerant (helper no-ops
+                       cleanly on installs that haven't run the
+                       migrate-credit-people-aliases.php migration yet). */
+                    if ($aliases) {
+                        replaceCreditPersonAliases($db, $newId, $aliases);
+                    }
                     $db->commit();
 
                     $logCreditPerson('add', (string)$newId, [
@@ -417,8 +426,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $deathPlace  = trim((string)($_POST['death_place']  ?? '')) ?: null;
                 $deathDate   = trim((string)($_POST['death_date']   ?? '')) ?: null;
                 $notes       = $notesRaw !== '' ? $notesRaw : null;
-                $links       = $normaliseLinks($_POST['links'] ?? null);
-                $ipi         = $normaliseIpi($_POST['ipi']     ?? null);
+                $links       = $normaliseLinks($_POST['links']     ?? null);
+                $ipi         = $normaliseIpi($_POST['ipi']         ?? null);
+                $aliases     = $normaliseAliases($_POST['aliases'] ?? null);
                 $isSpecialCase = !empty($_POST['is_special_case']) ? 1 : 0;
                 $isGroup       = !empty($_POST['is_group'])        ? 1 : 0;
                 if ($isSpecialCase && $isGroup) { $isGroup = 0; }
@@ -550,6 +560,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         }
                         $ipiStmt->close();
                     }
+                    /* Replace the alias set unconditionally — the curator's
+                       posted list is the new truth; an empty list deletes
+                       any pre-existing aliases. Schema-tolerant on installs
+                       that haven't run migrate-credit-people-aliases.php. */
+                    replaceCreditPersonAliases($db, $id, $aliases);
                     $db->commit();
 
                     /* Compute the changed-fields list for audit. The
@@ -1048,8 +1063,9 @@ try {
        child tables are small (a handful of rows per person, low
        hundreds total), so loading them all is cheaper than fetching
        per-person on demand from JS. */
-    $linksByPerson = [];
-    $ipiByPerson   = [];
+    $linksByPerson   = [];
+    $ipiByPerson     = [];
+    $aliasesByPerson = [];
     $stmt = $db->prepare(
         'SELECT Id, CreditPersonId, LinkType, Url, Label, SortOrder
            FROM tblCreditPersonLinks
@@ -1083,6 +1099,14 @@ try {
     }
     $stmt->close();
 
+    /* AKA / aliases — bulk load alongside links + IPI so the Edit
+       drawer's pre-fill can populate the chip-list without an extra
+       round-trip. Schema-tolerant: pre-migration installs return an
+       empty array (the helper checks INFORMATION_SCHEMA first). */
+    $personIds = [];
+    foreach ($registryRows as $r) { $personIds[] = (int)$r['Id']; }
+    $aliasesByPerson = loadCreditPersonAliasesBulk($db, $personIds);
+
     /* Merge — keyed by Name. A name may appear in usage only,
        registry only, or both. */
     $byName = [];
@@ -1109,6 +1133,7 @@ try {
             'is_group'        => 0,   /* #585 */
             'links'       => [],
             'ipi'         => [],
+            'aliases'     => [],
         ];
     }
     foreach ($registryRows as $r) {
@@ -1156,8 +1181,9 @@ try {
         /* Full child rows for the Edit drawer's pre-fill. Empty arrays
            default for registry rows with no children — the drawer's JS
            handles the empty case as "no rows yet". */
-        $byName[$name]['links'] = $linksByPerson[(int)$r['Id']] ?? [];
-        $byName[$name]['ipi']   = $ipiByPerson[(int)$r['Id']]   ?? [];
+        $byName[$name]['links']   = $linksByPerson[(int)$r['Id']]   ?? [];
+        $byName[$name]['ipi']     = $ipiByPerson[(int)$r['Id']]     ?? [];
+        $byName[$name]['aliases'] = $aliasesByPerson[(int)$r['Id']] ?? [];
     }
 
     /* Sort: highest-usage first, then alphabetical. Registry-only
@@ -1412,13 +1438,24 @@ $totalInUseUnregistered = count(array_filter($people, static fn($p) =>
                                 'total'       => $p['total'],
                                 'links'       => $p['links'],
                                 'ipi'         => $p['ipi'],
+                                'aliases'     => $p['aliases'] ?? [],
                             ], JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_TAG | JSON_HEX_AMP | JSON_UNESCAPED_UNICODE);
                             $isSpecial = !empty($p['is_special_case']);
                             $isGroup   = !empty($p['is_group']);
+                            /* AKA names flattened into the row's data-aka
+                               attribute so the existing client-side filter
+                               matches a typed query against aliases too —
+                               critical for the "I remember Cecil under her
+                               maiden name" workflow. Empty when the row
+                               has no aliases (the JS treats undefined as
+                               "no aliases to consider"). */
+                            $akaList = array_map(static fn(array $a): string => (string)$a['Name'], $p['aliases'] ?? []);
+                            $akaAttr = implode(' · ', $akaList);
                         ?>
                             <tr data-roles="<?= htmlspecialchars($rolesCsv) ?>"
                                 data-registry-only="<?= $isRegistryOnly ? '1' : '0' ?>"
                                 data-haystack="<?= htmlspecialchars($haystack) ?>"
+                                data-aka="<?= htmlspecialchars($akaAttr) ?>"
                                 data-classification="<?= $isSpecial ? 'special' : ($isGroup ? 'group' : 'individual') ?>"
                                 data-person='<?= htmlspecialchars($personJson, ENT_QUOTES) ?>'>
                                 <td data-col-priority="primary" class="person-name <?= $isSpecial ? 'fst-italic' : '' ?>">
@@ -1433,6 +1470,12 @@ $totalInUseUnregistered = count(array_filter($people, static fn($p) =>
                                     <?php endif; ?>
                                     <?php if ($isGroup): ?>
                                         <span class="badge bg-info-subtle text-info-emphasis ms-1" style="font-size: 0.6rem;">Group</span>
+                                    <?php endif; ?>
+                                    <?php if (!empty($p['aliases'])): ?>
+                                        <div class="text-secondary small mt-1" title="Alternative names that also match in search">
+                                            <i class="bi bi-arrow-left-right me-1" aria-hidden="true"></i>
+                                            AKA: <?= htmlspecialchars(implode(', ', array_map(static fn($a) => (string)$a['Name'], $p['aliases']))) ?>
+                                        </div>
                                     <?php endif; ?>
                                     <?php if ($p['notes']): ?>
                                         <span class="text-secondary small ms-2" title="<?= htmlspecialchars($p['notes']) ?>">
@@ -1908,6 +1951,25 @@ $totalInUseUnregistered = count(array_filter($people, static fn($p) =>
                 <div class="form-text small">A single individual can hold more than one IPI Name Number when they're registered under different performing names.</div>
             </div>
 
+            <!-- AKA / aliases — repeating sub-form. Mirrors the
+                 MusicBrainz alias model in a slimmed-down shape: each
+                 row carries a Name, a Type (legal / artist / pseudonym /
+                 nickname / maiden / search-hint / misspelling / other)
+                 and an optional Locale tag for transliterations
+                 (ja, ru-Latn, …). Surfaced as JSON-LD alternateName on
+                 /people/<slug> and searched alongside the canonical
+                 Name in editor typeahead + the admin filter. -->
+            <div>
+                <div class="d-flex justify-content-between align-items-center mb-1">
+                    <label class="form-label small mb-0">AKA / Aliases</label>
+                    <button type="button" class="btn btn-sm btn-outline-secondary" id="cp-add-alias-btn">
+                        <i class="bi bi-plus me-1"></i>Add alias
+                    </button>
+                </div>
+                <div id="cp-aliases-container" class="d-flex flex-column gap-2"></div>
+                <div class="form-text small">Alternative names that should match this person in search — legal name, stage name, common misspellings, transliterations. Each alias carries a type and optional locale tag.</div>
+            </div>
+
             <!-- Notes -->
             <div>
                 <label class="form-label small mb-1" for="cp-drawer-notes">Notes</label>
@@ -1958,6 +2020,28 @@ $totalInUseUnregistered = count(array_filter($people, static fn($p) =>
             </button>
         </div>
     </template>
+    <template id="cp-alias-row-template">
+        <div class="d-flex gap-1 align-items-start cp-alias-row" data-row-kind="alias">
+            <input type="text" class="form-control form-control-sm" name="aliases[{i}][name]"
+                   placeholder="Alternative name" maxlength="255" required>
+            <select class="form-select form-select-sm" style="min-width: 130px; max-width: 170px;"
+                    name="aliases[{i}][type]">
+                <?php foreach ($ALIAS_TYPES as $key => $label): ?>
+                    <option value="<?= htmlspecialchars($key) ?>"<?= $key === 'other' ? ' selected' : '' ?>>
+                        <?= htmlspecialchars($label) ?>
+                    </option>
+                <?php endforeach; ?>
+            </select>
+            <input type="text" class="form-control form-control-sm" style="max-width: 90px;"
+                   name="aliases[{i}][locale]" placeholder="Locale" maxlength="35"
+                   title="Optional IETF BCP 47 tag for transliterations (ja, ru-Latn, zh-Hans, …)">
+            <input type="hidden" name="aliases[{i}][sort_order]" value="{i}">
+            <button type="button" class="btn btn-sm btn-outline-danger cp-row-remove"
+                    title="Remove this alias" aria-label="Remove this alias">
+                <i class="bi bi-x" aria-hidden="true"></i>
+            </button>
+        </div>
+    </template>
 
     <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>
 
@@ -1990,6 +2074,13 @@ $totalInUseUnregistered = count(array_filter($people, static fn($p) =>
                 const rows = tbody.querySelectorAll('tr:not(.empty-row)');
                 rows.forEach(row => {
                     const haystack    = row.dataset.haystack || '';
+                    /* Include AKA names in the search haystack so a
+                       query for the alias spelling matches the row of
+                       the canonical name (e.g. typing the maiden name
+                       finds the post-marriage row). Lower-cased on the
+                       client because PHP wrote it as the raw display
+                       form. */
+                    const akaHaystack = (row.dataset.aka || '').toLowerCase();
                     const roles       = (row.dataset.roles || '').split(',').filter(Boolean);
                     const isRegOnly   = row.dataset.registryOnly === '1';
                     let matchRole = true;
@@ -1998,7 +2089,7 @@ $totalInUseUnregistered = count(array_filter($people, static fn($p) =>
                     } else if (activeFilter !== 'all') {
                         matchRole = roles.includes(activeFilter);
                     }
-                    const matchSearch = q === '' || haystack.includes(q);
+                    const matchSearch = q === '' || haystack.includes(q) || akaHaystack.includes(q);
                     const show = matchRole && matchSearch;
                     row.classList.toggle('no-match', !show);
                     if (show) visibleCount++;
@@ -2034,16 +2125,20 @@ $totalInUseUnregistered = count(array_filter($people, static fn($p) =>
             const nameIn    = document.getElementById('cp-drawer-name');
             const linksBox  = document.getElementById('cp-links-container');
             const ipiBox    = document.getElementById('cp-ipi-container');
+            const aliasBox  = document.getElementById('cp-aliases-container');
             const linkTpl   = document.getElementById('cp-link-row-template');
             const ipiTpl    = document.getElementById('cp-ipi-row-template');
+            const aliasTpl  = document.getElementById('cp-alias-row-template');
             const addBtn    = document.getElementById('cp-add-btn');
             const addLinkBtn= document.getElementById('cp-add-link-btn');
             const addIpiBtn = document.getElementById('cp-add-ipi-btn');
+            const addAliasBtn = document.getElementById('cp-add-alias-btn');
             if (!drawerEl || !form) return;
 
             const drawer = bootstrap.Offcanvas.getOrCreateInstance(drawerEl);
-            let linkIndex = 0;
-            let ipiIndex  = 0;
+            let linkIndex  = 0;
+            let ipiIndex   = 0;
+            let aliasIndex = 0;
 
             /* Append a new sub-form row, optionally pre-filled. The
                template's {i} placeholders get replaced with the
@@ -2080,13 +2175,33 @@ $totalInUseUnregistered = count(array_filter($people, static fn($p) =>
                 if (typeof applyFlagLabels === 'function') applyFlagLabels();
                 return row;
             }
+            function addAliasRow(prefill) {
+                if (!aliasTpl) return null;
+                const html = aliasTpl.innerHTML.replaceAll('{i}', String(aliasIndex++));
+                aliasBox.insertAdjacentHTML('beforeend', html);
+                const row = aliasBox.lastElementChild;
+                if (prefill) {
+                    row.querySelector('input[name$="[name]"]').value    = prefill.Name    || prefill.name    || '';
+                    const typeSel = row.querySelector('select[name$="[type]"]');
+                    if (typeSel) typeSel.value = prefill.Type || prefill.type || 'other';
+                    const localeIn = row.querySelector('input[name$="[locale]"]');
+                    if (localeIn) localeIn.value = prefill.Locale || prefill.locale || '';
+                    const ord = row.querySelector('input[name$="[sort_order]"]');
+                    if (ord && (prefill.SortOrder !== undefined || prefill.sort_order !== undefined)) {
+                        ord.value = prefill.SortOrder ?? prefill.sort_order;
+                    }
+                }
+                return row;
+            }
 
             function resetDrawer() {
                 form.reset();
-                linksBox.innerHTML = '';
-                ipiBox.innerHTML   = '';
-                linkIndex = 0;
-                ipiIndex  = 0;
+                linksBox.innerHTML  = '';
+                ipiBox.innerHTML    = '';
+                if (aliasBox) aliasBox.innerHTML = '';
+                linkIndex  = 0;
+                ipiIndex   = 0;
+                aliasIndex = 0;
             }
 
             /* Open empty drawer for Add. */
@@ -2169,8 +2284,9 @@ $totalInUseUnregistered = count(array_filter($people, static fn($p) =>
                     suffixIn.value     = '';
                 }
                 applyFlagLabels();
-                (person.links || []).forEach(l => addLinkRow(l));
-                (person.ipi   || []).forEach(r => addIpiRow(r));
+                (person.links   || []).forEach(l => addLinkRow(l));
+                (person.ipi     || []).forEach(r => addIpiRow(r));
+                (person.aliases || []).forEach(a => addAliasRow(a));
                 drawer.show();
             });
 
@@ -2322,8 +2438,9 @@ $totalInUseUnregistered = count(array_filter($people, static fn($p) =>
             });
 
             /* Add-row buttons inside the drawer. */
-            addLinkBtn?.addEventListener('click', () => addLinkRow());
-            addIpiBtn?.addEventListener('click',  () => addIpiRow());
+            addLinkBtn?.addEventListener('click',  () => addLinkRow());
+            addIpiBtn?.addEventListener('click',   () => addIpiRow());
+            addAliasBtn?.addEventListener('click', () => addAliasRow());
 
             /* Remove-row delegation. */
             drawerEl.addEventListener('click', (ev) => {

--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -556,11 +556,64 @@ switch ($action) {
                 foreach ($song['adaptors']    ?? [] as $v) { if (is_string($v) && $v !== '') { $stmtAdaptor->bind_param('ss', $songId, $v);    $stmtAdaptor->execute();    $regNames[$v] = true; } }
                 foreach ($song['translators'] ?? [] as $v) { if (is_string($v) && $v !== '') { $stmtTranslator->bind_param('ss', $songId, $v); $stmtTranslator->execute(); $regNames[$v] = true; } }
                 foreach (array_keys($regNames) as $regName) {
-                    /* registerCreditPersonByName handles the lookup-
-                       or-insert with a slug — same end-state as the
-                       old `INSERT IGNORE (Name)` but no silent
-                       no-op on the orphan empty-Slug collision. */
-                    registerCreditPersonByName($db, $regName);
+                    /* AKA / alias auto-detection. parseCreditPersonAliasHints
+                       only fires on conservative patterns (explicit
+                       a.k.a. / aka / "also known as" markers, or a
+                       slash-separated A / B with both halves looking
+                       like person names). Bare parentheticals like
+                       "(b. 1850)" are deliberately NOT matched —
+                       biographical content stays attached to the
+                       primary name. When no marker is detected,
+                       parseCreditPersonAliasHints returns
+                       ['name' => $regName, 'aliases' => []] so the
+                       legacy path runs unchanged.
+
+                       Registers the PRIMARY name as the registry row
+                       (so later edits land on the canonical form) and
+                       fires replaceCreditPersonAliases() to attach
+                       the discovered aliases. The 'other' Type marks
+                       them as auto-detected so a curator can re-classify
+                       (legal / artist / etc.) in the chip-list editor. */
+                    $hint    = parseCreditPersonAliasHints($regName);
+                    $primary = $hint['name'] !== '' ? $hint['name'] : $regName;
+                    $cpId    = registerCreditPersonByName($db, $primary);
+                    if (!empty($hint['aliases']) && $cpId > 0 && creditPeopleAliasesTableExists($db)) {
+                        $existing = loadCreditPersonAliases($db, $cpId);
+                        $merged   = $existing;
+                        $byName   = [];
+                        foreach ($merged as $a) { $byName[mb_strtolower($a['Name'])] = true; }
+                        $idx = count($merged);
+                        foreach ($hint['aliases'] as $aliasName) {
+                            if (isset($byName[mb_strtolower($aliasName)])) continue;
+                            $merged[] = [
+                                'Name'      => $aliasName,
+                                'SortName'  => null,
+                                'Type'      => 'other',
+                                'Locale'    => null,
+                                'IsPrimary' => 0,
+                                'SortOrder' => $idx++,
+                                'Note'      => 'auto-detected from bulk-import',
+                            ];
+                            $byName[mb_strtolower($aliasName)] = true;
+                        }
+                        /* Re-shape into the normaliser-friendly form
+                           (lower-case keys). replaceCreditPersonAliases
+                           deletes the existing set + re-inserts; passing
+                           the union keeps every prior alias intact
+                           alongside the new auto-detected ones. */
+                        $shaped = array_map(static function (array $a): array {
+                            return [
+                                'name'       => $a['Name'],
+                                'sort_name'  => $a['SortName']  ?? null,
+                                'type'       => $a['Type']      ?? 'other',
+                                'locale'     => $a['Locale']    ?? null,
+                                'is_primary' => (int)($a['IsPrimary'] ?? 0),
+                                'sort_order' => (int)($a['SortOrder'] ?? 0),
+                                'note'       => $a['Note']      ?? null,
+                            ];
+                        }, $merged);
+                        replaceCreditPersonAliases($db, $cpId, $shaped);
+                    }
                 }
 
                 /* Components */
@@ -2410,6 +2463,24 @@ switch ($action) {
                                  WHERE Name LIKE ?";
                 $params[] = $like;
                 $types   .= 's';
+
+                /* AKA / aliases — when the typed query matches an alias,
+                   surface the CANONICAL parent name (not the alias) so
+                   clicking the suggestion still chips in the canonical
+                   form. The 'alias' kindLabel signals to the client UI
+                   that this row was matched via an alternative name —
+                   the chip can render a small "via AKA: <alias>" hint
+                   if it wants. Schema-tolerant: silently skipped on
+                   installs where tblCreditPersonAliases isn't present. */
+                require_once dirname(dirname(__DIR__)) . '/includes/credit_people_helpers.php';
+                if (creditPeopleAliasesTableExists($db)) {
+                    $unionParts[] = "SELECT cp.Name, 'alias' AS kindLabel, 0 AS cnt
+                                     FROM tblCreditPersonAliases a
+                                     JOIN tblCreditPeople cp ON cp.Id = a.CreditPersonId
+                                     WHERE a.Name LIKE ?";
+                    $params[] = $like;
+                    $types   .= 's';
+                }
             }
             /* `usage` is a MySQL reserved word, so backtick it explicitly
                to avoid any edge-case parser drift between server versions

--- a/appWeb/public_html/manage/includes/migration-registry.php
+++ b/appWeb/public_html/manage/includes/migration-registry.php
@@ -197,6 +197,24 @@ return [
         ],
         'probe' => static fn(\mysqli $db) => !_migProbe_columnExists($db, 'tblCreditPeople', 'Surname'),
     ],
+    'credit-people-aliases' => [
+        'script' => 'migrate-credit-people-aliases.php',
+        'card' => [
+            'title'  => 'Credit People AKA / Aliases',
+            'body'   => 'Adds <code>tblCreditPersonAliases</code> — MusicBrainz-style alternative'
+                      . ' names per credit-person. Each alias carries a Type (legal / artist /'
+                      . ' pseudonym / nickname / maiden / search-hint / misspelling / other), an'
+                      . ' optional IETF BCP 47 Locale for transliterations'
+                      . ' ("John Doe" en ↔ "ジョン・ドウ" ja), an <code>IsPrimary</code> flag for'
+                      . ' the preferred display form, plus optional <code>SortName</code> /'
+                      . ' <code>Note</code>. Searched alongside the canonical <code>Name</code> in'
+                      . ' admin filter, editor typeahead and site search; surfaced as JSON-LD'
+                      . ' <code>alternateName</code> on the public <code>/people/&lt;slug&gt;</code>'
+                      . ' page. Bulk-import auto-detects "Smith (a.k.a. Jones)" patterns. Idempotent.',
+            'button' => 'Run Credit People Aliases Migration',
+        ],
+        'probe' => static fn(\mysqli $db) => !_migProbe_tableExists($db, 'tblCreditPersonAliases'),
+    ],
     'catalogues' => [
         'script' => 'migrate-catalogues.php',
         'card' => [


### PR DESCRIPTION
## Summary

Adds **AKA / alias names** to Credit People records — MusicBrainz-style alternative names per registry row so a search for any spelling surfaces the canonical entry. Closes the user's ask:

> Can we also add AKA/alias names in Credit People records, for alternative names to assist with searchability. Think similar to MusicBrainz implementation

Full scope landed in this PR per the user's confirmation (`Full feature in one PR` + `Full 8 types`).

## What's in the box

### Schema: `tblCreditPersonAliases`

| Column         | Type                            | Notes                                                    |
|----------------|---------------------------------|----------------------------------------------------------|
| Id             | INT UNSIGNED AUTO_INCREMENT     | PK                                                       |
| CreditPersonId | INT UNSIGNED                    | FK → tblCreditPeople, ON DELETE CASCADE                  |
| Name           | VARCHAR(255)                    | Display form                                             |
| SortName       | VARCHAR(255) NULL               | Surname-first form for sorting (optional)                |
| Type           | ENUM(8)                         | legal · artist · pseudonym · nickname · maiden · search-hint · misspelling · other |
| Locale         | VARCHAR(35) NULL                | IETF BCP 47 tag for transliterations (ja, ru-Latn, …)   |
| IsPrimary      | TINYINT(1)                      | 1 = preferred display form in this Locale                |
| SortOrder, Note, CreatedAt, UpdatedAt |              |                                                          |
| `UNIQUE (CreditPersonId, Name)` |                |                                                          |

Migration: `appWeb/.sql/migrate-credit-people-aliases.php`. Schema.sql + registry entry + CI guards all green.

### Shared helpers (`includes/credit_people_helpers.php`)

- `CREDIT_PERSON_ALIAS_TYPES` — picker label map
- `creditPeopleAliasesTableExists()` — schema-tolerant probe (cached)
- `normaliseCreditPersonAliases()` — form/JSON → INSERT rows, dedupes by lower-cased Name
- `replaceCreditPersonAliases()` — DELETE + INSERT inside the caller's transaction
- `loadCreditPersonAliases()` / `loadCreditPersonAliasesBulk()` — read paths
- `parseCreditPersonAliasHints()` — bulk-import auto-detection of "Smith (a.k.a. Jones)" patterns

### API round-trip

`admin_credit_person_add` / `admin_credit_person_update` accept `aliases[]` in the JSON body and persist inside the existing transaction. Form-POST handlers on `/manage/credit-people.php` do the same with `$_POST['aliases']`.

### Editor typeahead

`/manage/editor/api.php` typeahead (kind=any) UNIONs in an alias-matching branch that returns the **canonical parent name** with `kindLabel='alias'`. So a curator typing the alias still chips in the canonical form — the alias is just a hint to surface the right person.

### Bulk-import auto-detection

`_bulkImport_processZip` runs `parseCreditPersonAliasHints()` on every incoming credit string:

| Input                              | Primary                  | Aliases   |
|------------------------------------|--------------------------|-----------|
| `Smith (a.k.a. Jones)`             | Smith                    | [Jones]   |
| `Smith, also known as Jones`       | Smith                    | [Jones]   |
| `Smith / Jones`                    | Smith                    | [Jones]   |
| `Smith (Jones)`                    | Smith                    | [Jones]   |
| `Smith (a.k.a. Jones; Brown)`      | Smith                    | [Jones, Brown] |
| `Cecil Frances Alexander (b. 1818)` | Cecil Frances Alexander | []        |

Conservative — biographical-shaped parentheticals (`(b. 1850)`, `(1750-1830)`) are deliberately NOT matched. Auto-detected aliases land with `Type='other'` so a curator can re-classify in the chip-list editor.

### Admin UI on `/manage/credit-people`

- **Edit drawer** gains an "AKA / Aliases" section with a chip-list editor (same pattern as Links + IPI). Each row: Name + Type select + optional Locale + remove button. Pre-fills from `data-person` JSON.
- **Listing rows** render aliases inline as a small muted "AKA: …" line under the name.
- **Client-side filter** is extended to match against a new `data-aka` attribute on each row — typing any alias surfaces the canonical row.
- "Bulk promote with fuzzy-match" CTA already carries the `btn-amber-solid` readability fix from #982 (no-op if #982 lands first).

### Public `/people/<slug>`

- "Also known as: …" header line with public-friendly aliases (hides `search-hint` + `misspelling` types — those exist for the search index, not for display).
- **JSON-LD** `<script type="application/ld+json">` block emits a `Person` or `MusicGroup` with `alternateName` populated from the FULL alias set (including search-hint + misspelling so external knowledge-graph consumers learn every synonym).

## Test plan

- [ ] Run `Credit People AKA / Aliases` migration on `/manage/setup-database` (added to the registry between `credit-people-name-parts` and `catalogues`).
- [ ] Open Credit People → Edit any person → add an alias (e.g. "JN" for John Newton, Type=nickname). Save. Reload. Confirm the alias persists.
- [ ] On the listing, confirm "AKA: JN" appears under "John Newton". Type `jn` in the search box — confirm John Newton's row stays visible.
- [ ] Hit `/people/john-newton` — confirm the header reads "Also known as: JN" and View Source shows the JSON-LD block with `"alternateName": "JN"`.
- [ ] In the Song Editor, type "JN" into a writer chip — confirm John Newton surfaces in the typeahead suggestions with a small "alias" hint.
- [ ] Try a bulk-import ZIP that has `Newton, John (a.k.a. JN)` as a credit — confirm tblCreditPeople gets a row named "Newton, John" and tblCreditPersonAliases gets a row "JN" with Type='other' and Note='auto-detected from bulk-import'.

## Risk

Medium-low. Big surface (schema + 4 API paths + 2 UI surfaces + bulk-import wiring) but all changes are additive + schema-tolerant. Every consumer probes `INFORMATION_SCHEMA` first so a deployment that hasn't run the migration yet behaves exactly as today. CI guards (`tests/php/test-migration-registry.php` + `tests/php/test-schema-coverage.php`) both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011fgEBM87YrUdSnpKuLdekY)_