### PR TITLE
feat(editor): prefill new-song draft when opened from Missing Numbers

### DIFF
--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -4678,14 +4678,83 @@ function init() {
         /* After successful load, populate the songbook dropdown with real data. */
         populateSongbookFilterDropdown();
 
-        /* Deep-link support (#407): /manage/editor/?song=<SongId> opens
-           directly on that song when it exists in songData. Used by the
-           Edit button on the public song view. */
+        /* Deep-link support.
+
+           #407 — /manage/editor/?song=<SongId> opens directly on the
+                   named song when it exists in songData. Used by the
+                   Edit button on the public song view.
+
+           Missing-Numbers prefill — /manage/editor/?songbook=<ABBR>
+                   with either ?number=<N> or #number=<N> opens a
+                   blank new-song draft pre-filled with the songbook
+                   abbreviation, songbook display name, and the song
+                   number. Used by the "Open in editor" button on
+                   /manage/missing-numbers so the curator lands ready
+                   to type lyrics instead of facing an empty list and
+                   having to re-discover what to enter. */
         try {
-            var sid = new URLSearchParams(window.location.search).get('song');
+            var qs   = new URLSearchParams(window.location.search);
+            var hash = String(window.location.hash || '').replace(/^#/, '');
+            var sid  = qs.get('song');
             if (sid && Array.isArray(songData.songs)
                 && songData.songs.some(function (s) { return s.id === sid; })) {
                 selectSong(sid);
+                return;
+            }
+            var prefillBook = qs.get('songbook');
+            /* Number can arrive either as a query param (?number=N) or
+               as the legacy fragment (#number=N) the missing-numbers
+               page emits. Both shapes work. */
+            var prefillNum  = qs.get('number');
+            if (!prefillNum && hash.indexOf('number=') === 0) {
+                prefillNum = hash.slice('number='.length);
+            }
+            if (prefillBook && prefillNum && /^\d+$/.test(prefillNum)) {
+                var prefillNumInt = parseInt(prefillNum, 10);
+                /* If the (songbook, number) combo already exists in
+                   songData, jump to that song instead of creating a
+                   duplicate draft — protects against double-clicks
+                   on the missing-numbers link and from a curator
+                   navigating back to the editor with stale data. */
+                var existing = (Array.isArray(songData.songs) ? songData.songs : []).find(function (s) {
+                    return s.songbook === prefillBook
+                        && parseInt(s.number, 10) === prefillNumInt;
+                });
+                if (existing) {
+                    selectSong(existing.id);
+                    return;
+                }
+                /* Resolve the songbook display name from songData.songbooks
+                   so the new draft carries both abbreviation and full
+                   name (the editor displays the full name in the
+                   header chip; abbreviation drives the SongId). */
+                var bookRow = (Array.isArray(songData.songbooks) ? songData.songbooks : []).find(function (b) {
+                    return (b.id || b.abbreviation) === prefillBook;
+                });
+                var bookName = bookRow ? (bookRow.name || prefillBook) : prefillBook;
+
+                /* Spawn a draft via the same addNewSong() entry point
+                   the toolbar uses, then patch the songbook + number
+                   fields. addNewSong() runs selectSong() internally,
+                   so after the patches we mark the song modified +
+                   re-render so the sidebar label shows the new number
+                   instead of "New Song". */
+                addNewSong();
+                var draft = songData.songs[songData.songs.length - 1];
+                if (draft) {
+                    draft.songbook     = prefillBook;
+                    draft.songbookName = bookName;
+                    draft.number       = prefillNumInt;
+                    /* Title stays "New Song" — the curator types the
+                       real title themselves. Pre-filling a stub
+                       title would obscure what still needs entering. */
+                    if (typeof markModified === 'function') markModified(draft.id);
+                    if (typeof renderSongList === 'function') renderSongList();
+                    selectSong(draft.id);
+                    if (typeof showToast === 'function') {
+                        showToast('Pre-filled new song for ' + bookName + ' #' + prefillNumInt + ' — enter lyrics + metadata to save.', 'info');
+                    }
+                }
             }
         } catch (_e) { /* malformed URL — ignore */ }
     });


### PR DESCRIPTION
## Summary

User reported that clicking **"Open in editor"** next to a missing number on `/manage/missing-numbers` opened the Song Editor **blank** — the curator had to manually click *Add*, pick the songbook, and type the number before they could start entering lyrics. The link's URL already carried the right context (`/manage/editor/?songbook=<ABBR>#number=<N>`), but the editor's deep-link handler only knew about `?song=<SongId>` from #407 and silently ignored the missing-numbers shape.

## Fix

Extend the deep-link block in `editor.js`'s `initialise()` handler to recognise the `(?songbook, ?number | #number)` pair. Three behaviours:

1. **If the (songbook, number) combination already exists** in `songData` (curator double-clicked the link, or someone added the song between page-loads) — `selectSong()` into the existing row rather than creating a duplicate draft. Protects against a future *Save* trying to INSERT a second `tblSongs` row that would 500 on the SongId UNIQUE constraint.

2. **Otherwise**, spawn a draft via the same `addNewSong()` entry point the toolbar uses, then patch the songbook abbreviation, songbook display name (resolved via `songData.songbooks` lookup), and number fields. `markModified()` + `renderSongList()` refresh the sidebar so the new entry shows e.g. *"MP #13 — New Song"* instead of just *"New Song"*. A toast confirms the prefill.

3. **Title stays "New Song"** — the curator types the real title themselves. Pre-filling a stub title would hide what still needs entering and turn a happy-path workflow into a quiet error.

Both URL shapes work:
- `?songbook=MP&number=13`
- `?songbook=MP#number=13` (the legacy fragment the current `missing-numbers.php` template emits)

The number is parsed with `/^\d+$/` before `parseInt()` so a malformed fragment like `#number=abc` falls through to the existing no-op behaviour rather than seeding a draft with `NaN` as the number.

## Test plan

- [ ] Hit `/manage/missing-numbers`, expand Mission Praise (or any songbook with gaps), click **Open in editor** on `#13`. Expected: the editor opens, a new draft appears in the sidebar labelled around the lines of "MP #13 — New Song", the right-pane Songbook field shows "Mission Praise", and the Number field shows `13`. Toast: *"Pre-filled new song for Mission Praise #13 — enter lyrics + metadata to save."*
- [ ] On the same page click the same **Open in editor** link a second time. Expected: editor selects the existing draft instead of creating a second one (no toast on the second visit).
- [ ] Manually visit `/manage/editor/?songbook=MP&number=13` (query-only shape). Expected: same prefill as the fragment shape.
- [ ] Manually visit `/manage/editor/?songbook=MP#number=abc`. Expected: editor opens as if the URL had no params at all (no draft created, no toast).
- [ ] Confirm the existing `?song=<SongId>` deep-link still works for the public-page "Edit" button.

## Risk

Low. Pure client-side prefill — no backend / API / schema change. Reuses the existing `addNewSong()` seam so the draft is indistinguishable from a manually-created one once spawned. Existing `?song=` deep-link path is preserved untouched (handled before the new prefill branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011fgEBM87YrUdSnpKuLdekY)_