### PR TITLE
fix(songbook): hide "0" badge for unnumbered songs + share External Links UI

### DIFF
--- a/appWeb/public_html/includes/SongData.php
+++ b/appWeb/public_html/includes/SongData.php
@@ -1684,6 +1684,11 @@ class SongData
                a second per-song round-trip. Same bulk-loader pattern
                as writers / composers / etc. */
             $tagsMap = $this->_getTagsMap($songIds);
+            /* #833 — song-level external links bulked in so the Song
+               Editor (which reads from the corpus cache built off
+               exportAsJson → getSongs) surfaces existing links on load.
+               Pre-migration safe via the schema probe in the helper. */
+            $songLinksMap = $this->_externalLinksMap('song', $songIds);
             foreach ($songs as &$song) {
                 $sid = $song['id'];
                 $song['writers']     = $writersMap[$sid]     ?? [];
@@ -1694,6 +1699,7 @@ class SongData
                 $song['artists']     = $artistsMap[$sid]     ?? [];   /* #587 */
                 $song['components']  = $componentsMap[$sid]  ?? [];
                 $song['tags']        = $tagsMap[$sid]        ?? [];
+                $song['links']       = $songLinksMap[$sid]   ?? [];
             }
             unset($song);
         }

--- a/appWeb/public_html/includes/external_link_helpers.php
+++ b/appWeb/public_html/includes/external_link_helpers.php
@@ -95,3 +95,231 @@ function attachExternalLinkPatterns(\mysqli $db, array $types): array
     unset($t);
     return $types;
 }
+
+/**
+ * Load the active `tblExternalLinkTypes` registry for a given surface
+ * (songbook / work / song / credit-person / …) and attach URL → provider
+ * patterns. Returns a list shaped for `window._iHymnsLinkTypes` consumption
+ * by the shared `external-links-editor.js` module.
+ *
+ * Returns `[]` when the schema isn't live (pre-migration deployment) so
+ * callers can render the rest of their page without external-links UI.
+ *
+ * @param \mysqli $db
+ * @param string  $appliesTo  Value to test against tblExternalLinkTypes.AppliesTo
+ *                            via FIND_IN_SET. Common values: 'songbook',
+ *                            'work', 'song', 'credit-person'.
+ * @return list<array{id:int,slug:string,name:string,category:string,iconClass:string,allowMultiple:int,patterns:array}>
+ */
+function loadExternalLinkTypesFor(\mysqli $db, string $appliesTo): array
+{
+    try {
+        $probe = $db->query(
+            "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+              WHERE TABLE_SCHEMA = DATABASE()
+                AND TABLE_NAME   = 'tblExternalLinkTypes' LIMIT 1"
+        );
+        $hasTable = $probe && $probe->fetch_row() !== null;
+        if ($probe) $probe->close();
+    } catch (\Throwable $_e) {
+        $hasTable = false;
+    }
+    if (!$hasTable) return [];
+
+    $types = [];
+    try {
+        $stmt = $db->prepare(
+            "SELECT Id, Slug, Name, Category, IconClass, AllowMultiple, DisplayOrder
+               FROM tblExternalLinkTypes
+              WHERE COALESCE(IsActive, 1) = 1
+                AND FIND_IN_SET(?, AppliesTo) > 0
+              ORDER BY Category ASC, DisplayOrder ASC, Name ASC"
+        );
+        $stmt->bind_param('s', $appliesTo);
+        $stmt->execute();
+        $res = $stmt->get_result();
+        while ($row = $res->fetch_assoc()) {
+            $types[] = [
+                'id'            => (int)$row['Id'],
+                'slug'          => (string)$row['Slug'],
+                'name'          => (string)$row['Name'],
+                'category'      => (string)$row['Category'],
+                'iconClass'     => (string)($row['IconClass']  ?? ''),
+                'allowMultiple' => (int)($row['AllowMultiple'] ?? 0),
+            ];
+        }
+        $stmt->close();
+    } catch (\Throwable $e) {
+        error_log('[loadExternalLinkTypesFor] ' . $e->getMessage());
+        return [];
+    }
+
+    return attachExternalLinkPatterns($db, $types);
+}
+
+/**
+ * Save the per-row external-links sub-form posted from any admin edit
+ * surface using the canonical `ext_link_*[]` field naming. Runs inside
+ * the caller's transaction (caller is responsible for begin/commit so a
+ * downstream failure rolls back together with the parent UPDATE).
+ *
+ * Performs DELETE-then-INSERT against the surface's link table, mirroring
+ * the original songbook implementation (#833) which the songbook,
+ * work and song surfaces all converged on.
+ *
+ * @param \mysqli $db
+ * @param string  $table     Target link table — 'tblSongbookExternalLinks',
+ *                           'tblWorkExternalLinks', 'tblSongExternalLinks'.
+ * @param string  $fkColumn  FK column on $table that references the owning
+ *                           row — 'SongbookId', 'WorkId', 'SongId'.
+ * @param mixed   $fkValue   Owning row's PK value (int for the numeric
+ *                           surfaces, string for SongId).
+ * @param mixed   $rawTypeIds  $_POST['ext_link_type_ids']  (any shape — non-array → [])
+ * @param mixed   $rawUrls     $_POST['ext_link_urls']
+ * @param mixed   $rawNotes    $_POST['ext_link_notes']
+ * @param mixed   $rawVerified $_POST['ext_link_verified']
+ * @return int   Number of link rows inserted.
+ */
+function saveExternalLinksForRow(
+    \mysqli $db,
+    string  $table,
+    string  $fkColumn,
+    mixed   $fkValue,
+    mixed   $rawTypeIds,
+    mixed   $rawUrls,
+    mixed   $rawNotes,
+    mixed   $rawVerified
+): int {
+    $typeIds  = is_array($rawTypeIds)  ? $rawTypeIds  : [];
+    $urls     = is_array($rawUrls)     ? $rawUrls     : [];
+    $notes    = is_array($rawNotes)    ? $rawNotes    : [];
+    $verified = is_array($rawVerified) ? $rawVerified : [];
+
+    /* Whitelist the table + fk-column names — these come from the
+       caller, but we still guard against accidental mistypes leaking
+       into an unescaped SQL identifier position. */
+    $allowedTables = [
+        'tblSongbookExternalLinks' => 'SongbookId',
+        'tblWorkExternalLinks'     => 'WorkId',
+        'tblSongExternalLinks'     => 'SongId',
+    ];
+    if (!isset($allowedTables[$table]) || $allowedTables[$table] !== $fkColumn) {
+        throw new \InvalidArgumentException("Unknown external-links table/fk: $table/$fkColumn");
+    }
+
+    /* FK bind char — SongId is varchar in tblSongs, the rest are ints. */
+    $fkBindType = ($fkColumn === 'SongId') ? 's' : 'i';
+
+    $del = $db->prepare("DELETE FROM {$table} WHERE {$fkColumn} = ?");
+    if ($fkBindType === 's') {
+        $sv = (string)$fkValue;
+        $del->bind_param('s', $sv);
+    } else {
+        $iv = (int)$fkValue;
+        $del->bind_param('i', $iv);
+    }
+    $del->execute();
+    $del->close();
+
+    $inserted = 0;
+    $count    = max(count($typeIds), count($urls));
+    if ($count === 0) return 0;
+
+    $ins = $db->prepare(
+        "INSERT INTO {$table}
+            ({$fkColumn}, LinkTypeId, Url, Note, SortOrder, Verified)
+         VALUES (?, ?, ?, NULLIF(?, ''), ?, ?)"
+    );
+    for ($i = 0; $i < $count; $i++) {
+        $typeId = (int)($typeIds[$i] ?? 0);
+        $url    = trim((string)($urls[$i] ?? ''));
+        $note   = mb_substr(trim((string)($notes[$i] ?? '')), 0, 255);
+        $ver    = !empty($verified[$i]) ? 1 : 0;
+
+        if ($typeId <= 0 || $url === '') continue;
+        if (!preg_match('#^https?://#i', $url)) continue;
+        if (mb_strlen($url) > 2048) continue;
+
+        if ($fkBindType === 's') {
+            $sv = (string)$fkValue;
+            $ins->bind_param('sissii', $sv, $typeId, $url, $note, $i, $ver);
+        } else {
+            $iv = (int)$fkValue;
+            $ins->bind_param('iissii', $iv, $typeId, $url, $note, $i, $ver);
+        }
+        $ins->execute();
+        $inserted++;
+    }
+    $ins->close();
+    return $inserted;
+}
+
+/**
+ * Fetch the external links attached to one row across any of the
+ * tbl*ExternalLinks tables, shaped for the JS row-builder
+ * (`typeId / url / note / verified`). Used by the editor + admin
+ * modals to pre-fill the rows on load.
+ *
+ * @param \mysqli $db
+ * @param string  $table    'tblSongbookExternalLinks' | 'tblWorkExternalLinks' | 'tblSongExternalLinks'
+ * @param string  $fkColumn 'SongbookId' | 'WorkId' | 'SongId'
+ * @param mixed   $fkValue  Owning row's PK
+ * @return list<array{typeId:int,url:string,note:string,verified:int,sortOrder:int}>
+ */
+function loadExternalLinksForRow(
+    \mysqli $db,
+    string  $table,
+    string  $fkColumn,
+    mixed   $fkValue
+): array {
+    $allowedTables = [
+        'tblSongbookExternalLinks' => 'SongbookId',
+        'tblWorkExternalLinks'     => 'WorkId',
+        'tblSongExternalLinks'     => 'SongId',
+    ];
+    if (!isset($allowedTables[$table]) || $allowedTables[$table] !== $fkColumn) {
+        throw new \InvalidArgumentException("Unknown external-links table/fk: $table/$fkColumn");
+    }
+
+    try {
+        $probe = $db->query(
+            "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+              WHERE TABLE_SCHEMA = DATABASE()
+                AND TABLE_NAME   = '" . $table . "' LIMIT 1"
+        );
+        $exists = $probe && $probe->fetch_row() !== null;
+        if ($probe) $probe->close();
+    } catch (\Throwable $_e) {
+        $exists = false;
+    }
+    if (!$exists) return [];
+
+    $fkBindType = ($fkColumn === 'SongId') ? 's' : 'i';
+    $stmt = $db->prepare(
+        "SELECT LinkTypeId, Url, COALESCE(Note, '') AS Note, SortOrder, Verified
+           FROM {$table}
+          WHERE {$fkColumn} = ?
+       ORDER BY SortOrder ASC, LinkTypeId ASC"
+    );
+    if ($fkBindType === 's') {
+        $sv = (string)$fkValue;
+        $stmt->bind_param('s', $sv);
+    } else {
+        $iv = (int)$fkValue;
+        $stmt->bind_param('i', $iv);
+    }
+    $stmt->execute();
+    $res = $stmt->get_result();
+    $out = [];
+    while ($row = $res->fetch_assoc()) {
+        $out[] = [
+            'typeId'    => (int)$row['LinkTypeId'],
+            'url'       => (string)$row['Url'],
+            'note'      => (string)$row['Note'],
+            'verified'  => (int)$row['Verified'],
+            'sortOrder' => (int)$row['SortOrder'],
+        ];
+    }
+    $stmt->close();
+    return $out;
+}

--- a/appWeb/public_html/includes/pages/songbook.php
+++ b/appWeb/public_html/includes/pages/songbook.php
@@ -203,11 +203,17 @@ if ($book === null) {
                data-navigate="song"
                data-song-id="<?= htmlspecialchars($song['id']) ?>"
                role="listitem"
-               aria-label="Song <?= (int)$song['number'] ?>: <?= htmlspecialchars(toTitleCase($song['title'])) ?>">
-                <!-- Song number badge -->
-                <span class="song-number-badge" data-songbook="<?= htmlspecialchars($bookId) ?>" aria-hidden="true">
-                    <?= (int)$song['number'] ?>
-                </span>
+               aria-label="<?= isset($song['number']) && $song['number'] !== null ? 'Song ' . (int)$song['number'] . ': ' : '' ?><?= htmlspecialchars(toTitleCase($song['title'])) ?>">
+                <!-- Song number badge — left empty when the song has no
+                     songbook position (Number IS NULL, e.g. Misc or
+                     unofficial-songbook songs). The CSS rule
+                     `.song-number-badge:empty::before` then renders a
+                     book glyph as the fallback (#392). -->
+                <span class="song-number-badge" data-songbook="<?= htmlspecialchars($bookId) ?>" aria-hidden="true"><?php
+                    if (isset($song['number']) && $song['number'] !== null && (int)$song['number'] > 0) {
+                        echo (int)$song['number'];
+                    }
+                ?></span>
                 <!-- Song info -->
                 <div class="song-info flex-grow-1">
                     <span class="song-title"><?= htmlspecialchars(toTitleCase($song['title'])) ?><?php if (!empty($song['verified'])): ?><span class="verified-badge" title="Verified lyrics" aria-label="Verified lyrics"><svg viewBox="0 0 24 24" fill="none" aria-hidden="true"><circle cx="12" cy="12" r="10" fill="currentColor" opacity="0.15"/><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="1.5" fill="none"/><path d="M7.5 12.5L10.5 15.5L16.5 9" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg></span><?php endif; ?></span>

--- a/appWeb/public_html/js/modules/external-link-detect.js
+++ b/appWeb/public_html/js/modules/external-link-detect.js
@@ -183,15 +183,36 @@
      *
      * @param {HTMLElement} rowEl  The card containing both inputs.
      * @param {object} [opts]
-     * @param {boolean} [opts.respectManualChoice=true]
+     * @param {boolean}  [opts.respectManualChoice=true]
+     * @param {string}   [opts.urlSelector]    CSS selector for the URL input.
+     *                                          Default matches both the
+     *                                          canonical ext_link_urls[]
+     *                                          field and any <input type="url">.
+     * @param {string}   [opts.selectSelector] CSS selector for the provider
+     *                                          <select>. Default targets
+     *                                          ext_link_type_ids[].
+     * @param {function} [opts.slugLookup]     (slug, selectEl) => optionValue.
+     *                                          Override the default lookup
+     *                                          (which cross-references
+     *                                          window._iHymnsLinkTypes by id)
+     *                                          when the consuming surface
+     *                                          uses a different vocabulary.
      * @returns {Function} teardown that removes the listeners.
      */
     function attachAutoDetect(rowEl, opts) {
         if (!rowEl) return function () {};
-        var settings = Object.assign({ respectManualChoice: true }, opts || {});
-        var urlInput  = rowEl.querySelector('input[type="url"], input[name="ext_link_urls[]"]');
-        var providerSelect = rowEl.querySelector('select[name="ext_link_type_ids[]"]');
+        var settings = Object.assign({
+            respectManualChoice: true,
+            urlSelector:    'input[type="url"], input[name="ext_link_urls[]"]',
+            selectSelector: 'select[name="ext_link_type_ids[]"]',
+            slugLookup:     null,
+        }, opts || {});
+        var urlInput  = rowEl.querySelector(settings.urlSelector);
+        var providerSelect = rowEl.querySelector(settings.selectSelector);
         if (!urlInput || !providerSelect) return function () {};
+        var lookupFn = (typeof settings.slugLookup === 'function')
+            ? settings.slugLookup
+            : function (slug, sel) { return slugToOptionValue(sel, slug); };
 
         function onSelectChange() {
             /* Only stamp 'user picked' when the resulting value is a
@@ -206,7 +227,7 @@
             if (settings.respectManualChoice && providerSelect.dataset.userPicked === '1') return;
             var slug = detectFromUrl(urlInput.value);
             if (!slug) return;
-            var nextValue = slugToOptionValue(providerSelect, slug);
+            var nextValue = lookupFn(slug, providerSelect);
             if (!nextValue) return;
             if (providerSelect.value === nextValue) return;
             providerSelect.value = nextValue;

--- a/appWeb/public_html/js/modules/external-links-editor.js
+++ b/appWeb/public_html/js/modules/external-links-editor.js
@@ -1,0 +1,213 @@
+/**
+ * iHymns — Shared External-Links card-list editor
+ *
+ * Single source of truth for the per-row card editor that every admin
+ * surface uses to attach external links to a parent row (songbook, work,
+ * song, …). Before this module, songbooks.php and works.php carried
+ * ~100 near-identical lines each — diverging in trivial ways and
+ * skipping the auto-detect wiring on rows added post-load. Now both
+ * pages (and the song editor app) call `iHymnsExtLinksEditor.mount()`
+ * and the markup, behaviours, and auto-detect wiring are all defined
+ * here.
+ *
+ * Contract:
+ *   const editor = window.iHymnsExtLinksEditor.mount({
+ *       rowsEl,                       // <div> container that holds rows
+ *       addBtnEl,                     // <button> that adds a fresh row
+ *       types = window._iHymnsLinkTypes ?? [],
+ *       noteMaxLen = 255,
+ *       urlMaxLen  = 2048,
+ *       notePlaceholder = 'Optional note',
+ *   });
+ *
+ *   editor.addRow({ typeId, url, note, verified })   → HTMLElement
+ *   editor.setRows([{ typeId, url, … }, …])          → clears + repopulates
+ *   editor.clear()
+ *
+ * Field naming stays the canonical `ext_link_type_ids[]`,
+ * `ext_link_urls[]`, `ext_link_notes[]`, `ext_link_verified[]` so the
+ * server-side `saveExternalLinksForRow()` helper handles every surface
+ * the same way.
+ */
+
+(function () {
+    'use strict';
+
+    /* Category label/order map — same one previously duplicated across
+       songbooks.php and works.php. Kept in this module so a new category
+       in the DB needs adding here once, not in every consumer. */
+    var CAT_LABELS = {
+        'official':    'Official',
+        'information': 'Information',
+        'read':        'Read',
+        'sheet-music': 'Sheet music',
+        'listen':      'Listen',
+        'watch':       'Watch',
+        'purchase':    'Purchase',
+        'authority':   'Authority',
+        'social':      'Social',
+        'other':       'Other',
+    };
+    var CAT_ORDER = [
+        'official', 'information', 'read', 'sheet-music',
+        'listen', 'watch', 'purchase', 'authority', 'social', 'other',
+    ];
+
+    function escapeHtml(s) {
+        return String(s == null ? '' : s)
+            .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+    }
+
+    function groupByCategory(types) {
+        var byCat = {};
+        for (var i = 0; i < types.length; i++) {
+            var t   = types[i] || {};
+            var cat = t.category || 'other';
+            if (!byCat[cat]) byCat[cat] = [];
+            byCat[cat].push(t);
+        }
+        return byCat;
+    }
+
+    function buildSelectHtml(types, selectedId) {
+        var byCat = groupByCategory(types);
+        var html  = '<select class="form-select form-select-sm" name="ext_link_type_ids[]" required>';
+        html += '<option value="">— pick a link type —</option>';
+        for (var ci = 0; ci < CAT_ORDER.length; ci++) {
+            var cat = CAT_ORDER[ci];
+            if (!byCat[cat] || byCat[cat].length === 0) continue;
+            html += '<optgroup label="' + escapeHtml(CAT_LABELS[cat] || cat) + '">';
+            for (var ti = 0; ti < byCat[cat].length; ti++) {
+                var t = byCat[cat][ti];
+                var sel = (Number(selectedId) === Number(t.id)) ? ' selected' : '';
+                html += '<option value="' + Number(t.id) + '"' + sel + '>'
+                     +    escapeHtml(t.name)
+                     +  '</option>';
+            }
+            html += '</optgroup>';
+        }
+        /* If the DB has any category not in CAT_ORDER, dump it under a
+           catch-all "Other (uncategorised)" group so a curator can still
+           reach it without an explicit module update. */
+        var leftoverCats = Object.keys(byCat).filter(function (c) { return CAT_ORDER.indexOf(c) === -1; });
+        if (leftoverCats.length) {
+            html += '<optgroup label="Other (uncategorised)">';
+            for (var li = 0; li < leftoverCats.length; li++) {
+                var items = byCat[leftoverCats[li]];
+                for (var lj = 0; lj < items.length; lj++) {
+                    var t2 = items[lj];
+                    var sel2 = (Number(selectedId) === Number(t2.id)) ? ' selected' : '';
+                    html += '<option value="' + Number(t2.id) + '"' + sel2 + '>'
+                         +    escapeHtml(t2.name) + '</option>';
+                }
+            }
+            html += '</optgroup>';
+        }
+        html += '</select>';
+        return html;
+    }
+
+    function buildRowEl(types, data, opts) {
+        var url  = String(data && data.url  || '');
+        var note = String(data && data.note || '');
+        var ver  = data && data.verified ? 'checked' : '';
+        var notePh = opts.notePlaceholder || 'Optional note';
+        var urlMax = Number(opts.urlMaxLen) || 2048;
+        var noteMax = Number(opts.noteMaxLen) || 255;
+
+        var card = document.createElement('div');
+        card.className = 'card bg-dark border-secondary ihymns-ext-link-row';
+        card.innerHTML =
+            '<div class="card-body py-2">' +
+              '<div class="d-flex align-items-start gap-2">' +
+                '<i class="bi bi-grip-vertical text-muted mt-2" aria-hidden="true"></i>' +
+                '<div class="flex-grow-1">' +
+                  '<div class="row g-2 mb-1">' +
+                    '<div class="col-md-5">' + buildSelectHtml(types, data && data.typeId || 0) + '</div>' +
+                    '<div class="col-md-7">' +
+                      '<input type="url" class="form-control form-control-sm" ' +
+                              'name="ext_link_urls[]" required maxlength="' + urlMax + '" ' +
+                              'placeholder="https://…" value="' + escapeHtml(url) + '">' +
+                    '</div>' +
+                  '</div>' +
+                  '<div class="row g-2">' +
+                    '<div class="col-md-9">' +
+                      '<input type="text" class="form-control form-control-sm" ' +
+                              'name="ext_link_notes[]" maxlength="' + noteMax + '" ' +
+                              'placeholder="' + escapeHtml(notePh) + '" ' +
+                              'value="' + escapeHtml(note) + '">' +
+                    '</div>' +
+                    '<div class="col-md-3 d-flex align-items-center">' +
+                      '<div class="form-check small">' +
+                        '<input class="form-check-input" type="checkbox" ' +
+                                'name="ext_link_verified[]" value="1" ' + ver + '>' +
+                        '<label class="form-check-label">Verified</label>' +
+                      '</div>' +
+                    '</div>' +
+                  '</div>' +
+                '</div>' +
+                '<button type="button" class="btn btn-sm btn-outline-danger" ' +
+                        'data-action="remove-ext-link" title="Remove this link" aria-label="Remove this link">' +
+                  '<i class="bi bi-x-lg" aria-hidden="true"></i>' +
+                '</button>' +
+              '</div>' +
+            '</div>';
+
+        card.querySelector('[data-action=remove-ext-link]').addEventListener('click', function () {
+            card.remove();
+        });
+
+        /* Auto-detect provider from the pasted URL — the global
+           iHymnsLinkDetect module (#841) wires the row's URL input +
+           select together. Silently no-ops if the module didn't
+           load for some reason. */
+        if (window.iHymnsLinkDetect && typeof window.iHymnsLinkDetect.attachAutoDetect === 'function') {
+            window.iHymnsLinkDetect.attachAutoDetect(card);
+        }
+
+        return card;
+    }
+
+    /**
+     * Mount a card-list editor on the supplied container + add button.
+     * Returns a small handle the caller can use to add / replace rows.
+     */
+    function mount(config) {
+        var cfg = config || {};
+        var rowsEl   = cfg.rowsEl;
+        var addBtnEl = cfg.addBtnEl;
+        if (!rowsEl) throw new Error('iHymnsExtLinksEditor.mount(): missing rowsEl');
+
+        var types = Array.isArray(cfg.types) ? cfg.types
+                   : (Array.isArray(window._iHymnsLinkTypes) ? window._iHymnsLinkTypes : []);
+
+        var opts = {
+            notePlaceholder: cfg.notePlaceholder || 'Optional note',
+            urlMaxLen:       cfg.urlMaxLen,
+            noteMaxLen:      cfg.noteMaxLen,
+        };
+
+        function addRow(data) {
+            var card = buildRowEl(types, data || {}, opts);
+            rowsEl.appendChild(card);
+            return card;
+        }
+        function setRows(list) {
+            rowsEl.innerHTML = '';
+            (Array.isArray(list) ? list : []).forEach(function (r) { addRow(r); });
+        }
+        function clear() { rowsEl.innerHTML = ''; }
+
+        if (addBtnEl && !addBtnEl.dataset.ihymnsExtLinksBound) {
+            addBtnEl.addEventListener('click', function () {
+                addRow({ typeId: 0, url: '', note: '', verified: false });
+            });
+            addBtnEl.dataset.ihymnsExtLinksBound = '1';
+        }
+
+        return { addRow: addRow, setRows: setRows, clear: clear };
+    }
+
+    window.iHymnsExtLinksEditor = { mount: mount };
+})();

--- a/appWeb/public_html/manage/credit-people.php
+++ b/appWeb/public_html/manage/credit-people.php
@@ -2140,6 +2140,57 @@ $totalInUseUnregistered = count(array_filter($people, static fn($p) =>
             let ipiIndex   = 0;
             let aliasIndex = 0;
 
+            /* Translation map from the shared iHymnsLinkDetect slug
+               vocabulary (driven by tblExternalLinkTypes + the bundled
+               RULES array) to the credit-people-specific link-type keys
+               in CREDIT_PERSON_LINK_TYPE_CATALOGUE.
+
+               TODO (followup): unify credit-people storage onto
+               tblExternalLinkTypes so this map can disappear and the
+               same shared editor module can drive this surface too. */
+            const CP_DETECT_SLUG_TO_KEY = {
+                'wikipedia':            'wikipedia',
+                'wikidata':             'wikidata',
+                'musicbrainz-artist':   'musicbrainz',
+                'musicbrainz-work':     'musicbrainz',
+                'musicbrainz-recording':'musicbrainz',
+                'discogs':              'discogs',
+                'imslp':                'imslp',
+                'hymnary-org':          'hymnary',
+                'spotify':              'spotify',
+                'apple-music':          'apple_music',
+                'youtube-music':        'youtube_music',
+                'bandcamp':             'bandcamp',
+                'soundcloud':           'soundcloud',
+                'youtube':              'youtube',
+                'facebook':             'facebook',
+                'instagram':            'instagram',
+                'twitter-x':            'twitter',
+                'mastodon':             'mastodon',
+            };
+
+            /* Wire the credit-people link row to the shared
+               iHymnsLinkDetect module. The credit-people <select>
+               values ARE the credit-people key (e.g. 'apple_music'),
+               not a numeric tblExternalLinkTypes.Id, so the standard
+               slugToOptionValue helper doesn't fit — we pass a
+               slugLookup that walks our translation map and returns the
+               matching option value when present. */
+            function wireCpLinkRowAutoDetect(row) {
+                if (!window.iHymnsLinkDetect || typeof window.iHymnsLinkDetect.attachAutoDetect !== 'function') return;
+                window.iHymnsLinkDetect.attachAutoDetect(row, {
+                    selectSelector: 'select[name$="[type]"]',
+                    slugLookup: function (slug, selectEl) {
+                        const key = CP_DETECT_SLUG_TO_KEY[slug];
+                        if (!key || !selectEl) return '';
+                        for (let i = 0; i < selectEl.options.length; i++) {
+                            if (selectEl.options[i].value === key) return key;
+                        }
+                        return '';
+                    },
+                });
+            }
+
             /* Append a new sub-form row, optionally pre-filled. The
                template's {i} placeholders get replaced with the
                current per-kind index so PHP receives the rows as a
@@ -2158,6 +2209,10 @@ $totalInUseUnregistered = count(array_filter($people, static fn($p) =>
                     const ord = row.querySelector('input[name$="[sort_order]"]');
                     if (ord && prefill.sort_order !== undefined) ord.value = prefill.sort_order;
                 }
+                /* Auto-detect provider from the pasted URL — same
+                   global module the other admin surfaces use, with a
+                   per-page slug translation. */
+                wireCpLinkRowAutoDetect(row);
                 return row;
             }
             function addIpiRow(prefill) {

--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -1842,6 +1842,60 @@ switch ($action) {
                 }
             }
 
+            /* #833 — persist song-level external links when the client
+               opted into the new editor section by sending the
+               `externalLinks` key. The legacy / pre-#833 clients
+               (bulk-import path, older editor snapshots) omit the key
+               entirely and the existing rows stay untouched. The shared
+               saver expects four parallel arrays in the canonical
+               ext_link_*[] shape, so we unpack the JSON list of
+               {typeId, url, note, verified} into that shape inline. */
+            if (array_key_exists('externalLinks', $song)) {
+                try {
+                    require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'includes'
+                        . DIRECTORY_SEPARATOR . 'external_link_helpers.php';
+                    $extProbe = $db->query(
+                        "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+                          WHERE TABLE_SCHEMA = DATABASE()
+                            AND TABLE_NAME   = 'tblSongExternalLinks' LIMIT 1"
+                    );
+                    $hasExtTable = $extProbe && $extProbe->fetch_row() !== null;
+                    if ($extProbe) $extProbe->close();
+
+                    if ($hasExtTable) {
+                        $linkRows  = is_array($song['externalLinks']) ? $song['externalLinks'] : [];
+                        $typeIds   = [];
+                        $urls      = [];
+                        $notes     = [];
+                        $verified  = [];
+                        foreach ($linkRows as $row) {
+                            if (!is_array($row)) continue;
+                            $typeIds[]  = (int)($row['typeId'] ?? 0);
+                            $urls[]     = (string)($row['url'] ?? '');
+                            $notes[]    = (string)($row['note'] ?? '');
+                            $verified[] = !empty($row['verified']) ? '1' : '';
+                        }
+                        saveExternalLinksForRow(
+                            $db,
+                            'tblSongExternalLinks',
+                            'SongId',
+                            $songId,
+                            $typeIds,
+                            $urls,
+                            $notes,
+                            $verified
+                        );
+                    }
+                } catch (\Throwable $_e) {
+                    /* Match the Works-auto-link pattern — link
+                       reconciliation must not block the core save.
+                       The user's metadata edit is already committed
+                       below; a link write failure surfaces in
+                       error_log + audit but doesn't 500 the request. */
+                    error_log('[editor save_song] external-links reconcile failed: ' . $_e->getMessage());
+                }
+            }
+
             $db->commit();
 
             /* Refresh the on-disk songs cache so the editor's next

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -577,6 +577,16 @@ function selectSong(songId) {
         return;
     }
 
+    /* #833 — flush any pending External-Links DOM changes back into
+       the previously-open song before we navigate away. Without this
+       a user who edits links on song A and clicks song B in the
+       sidebar would lose the in-flight edits when the rows get
+       replaced. syncSongExternalLinksFromDom() reads the current
+       DOM state into the open song's `.links` and re-arms auto-save. */
+    if (typeof currentSongId !== 'undefined' && currentSongId && currentSongId !== songId) {
+        try { syncSongExternalLinksFromDom(); } catch (_e) { /* defensive — must not block navigation */ }
+    }
+
     /* Store the selection globally. */
     currentSongId = songId;
     updateHistoryButtonState();
@@ -647,6 +657,11 @@ function selectSong(songId) {
 
     /* Render the translations (cross-song link) panel (#352). */
     renderTranslations(song);
+
+    /* Render external website links (#833). Mounts the shared
+       /js/modules/external-links-editor.js card-list editor on the
+       Links tab and hydrates with song.links from the corpus cache. */
+    renderSongExternalLinks(song);
 
     /* Render cross-book counterparts (#807) and pull suggestions
        for the open song (#808). Both are async — the panels show
@@ -2379,6 +2394,115 @@ function initTranslationControls() {
 /* Latest fetch result kept in-memory so render-only re-runs don't refetch. */
 var songLinksCache = { songId: null, links: [] };
 
+/* ==========================================================================
+ *  SECTION — External website links per song (#833)
+ *
+ *  Backed by tblSongExternalLinks. Renders the shared editor module from
+ *  /js/modules/external-links-editor.js into the Links tab. We mount the
+ *  editor once (idempotent — repeat selectSong calls just re-hydrate the
+ *  rows), wire one delegated change listener that mirrors row state into
+ *  song.links so the save_song payload stays in sync with the form, and
+ *  flag the song as modified whenever a row is added / removed / edited.
+ * ========================================================================== */
+
+var _songExtLinksEditor = null;
+
+/**
+ * Capture the current external-links rows from the DOM. Used both for
+ * mirroring into the open song's `links` array on input/change events,
+ * and for the pre-switch capture in selectSong().
+ *
+ * @returns {Array<{typeId:number,url:string,note:string,verified:boolean}>}
+ */
+function captureSongExternalLinksFromDom() {
+    var rowsEl = document.getElementById('edit-song-ext-links-rows');
+    var out    = [];
+    if (!rowsEl) return out;
+    var rows = rowsEl.querySelectorAll('.ihymns-ext-link-row');
+    rows.forEach(function (card) {
+        var sel  = card.querySelector('select[name="ext_link_type_ids[]"]');
+        var url  = card.querySelector('input[name="ext_link_urls[]"]');
+        var note = card.querySelector('input[name="ext_link_notes[]"]');
+        var ver  = card.querySelector('input[name="ext_link_verified[]"]');
+        var typeId = Number(sel ? sel.value : 0);
+        var u      = String(url ? url.value : '').trim();
+        if (!typeId || !u) return;
+        out.push({
+            typeId:   typeId,
+            url:      u,
+            note:     String(note ? note.value : '').trim(),
+            verified: !!(ver && ver.checked),
+        });
+    });
+    return out;
+}
+
+/**
+ * Mirror the current DOM state into the open song's `.links` array and
+ * mark the song as modified so the auto-save flow ships the change.
+ */
+function syncSongExternalLinksFromDom() {
+    if (typeof currentSongId === 'undefined' || !currentSongId) return;
+    var song = (songData && songData.songs || []).find(function (s) { return s.id === currentSongId; });
+    if (!song) return;
+    song.links = captureSongExternalLinksFromDom();
+    if (typeof modifiedSongIds !== 'undefined' && modifiedSongIds && typeof modifiedSongIds.add === 'function') {
+        modifiedSongIds.add(currentSongId);
+    }
+    if (typeof scheduleAutoSave === 'function') scheduleAutoSave();
+    if (typeof updateStatusBar === 'function') updateStatusBar();
+}
+
+/**
+ * Render (mount + hydrate) the External Links section in the Links tab.
+ * The shared module owns the row template / Add / Remove / auto-detect;
+ * this function just feeds it the current song's saved links.
+ */
+function renderSongExternalLinks(song) {
+    var rowsEl = document.getElementById('edit-song-ext-links-rows');
+    var addBtn = document.getElementById('edit-song-ext-link-add-btn');
+    if (!rowsEl || !window.iHymnsExtLinksEditor) return;
+
+    if (!_songExtLinksEditor) {
+        _songExtLinksEditor = window.iHymnsExtLinksEditor.mount({
+            rowsEl:   rowsEl,
+            addBtnEl: addBtn,
+        });
+        /* Delegated change listener — every row built by the shared
+           module lives inside rowsEl, so one listener catches every
+           input / change. Each change mirrors back into the song
+           object and re-arms auto-save. */
+        rowsEl.addEventListener('input',  syncSongExternalLinksFromDom);
+        rowsEl.addEventListener('change', syncSongExternalLinksFromDom);
+        /* Add-row + Remove-row trigger DOM mutations rather than
+           input events on the existing inputs. Wrap the editor's
+           public addRow + a delegated click handler so the song
+           object stays in sync. */
+        if (addBtn) {
+            addBtn.addEventListener('click', function () {
+                /* Defer one tick so the new row's nodes exist when we capture. */
+                setTimeout(syncSongExternalLinksFromDom, 0);
+            });
+        }
+        rowsEl.addEventListener('click', function (ev) {
+            if (ev.target.closest('[data-action="remove-ext-link"]')) {
+                setTimeout(syncSongExternalLinksFromDom, 0);
+            }
+        });
+    }
+
+    var prefill = (Array.isArray(song.links) ? song.links : []).map(function (l) {
+        return {
+            typeId:   Number(l.typeId   || l.type_id   || 0),
+            url:      String(l.url      || ''),
+            note:     String(l.note     || ''),
+            verified: !!(l.verified),
+        };
+    });
+    _songExtLinksEditor.setRows(prefill);
+}
+
+
 /**
  * fetchSongLinks(songId, cb)
  * --------------------------
@@ -3976,6 +4100,30 @@ function serialiseSongForSave(song) {
     var creditKeys = ['writers', 'composers', 'arrangers', 'adaptors', 'translators', 'artists'];
     var out = {};
     Object.keys(song || {}).forEach(function (k) { out[k] = song[k]; });
+
+    /* #833 — for the currently-open song, prefer the live DOM state of
+       the External Links editor over the stale `song.links` value. The
+       'input' listener syncs them eagerly on every keystroke, but
+       capturing here too is cheap and protects against any race where
+       a save fires before the listener has flushed. Off-screen songs
+       send whatever was already in their `.links`. */
+    if (typeof currentSongId !== 'undefined' && song && song.id === currentSongId) {
+        try {
+            out.externalLinks = captureSongExternalLinksFromDom();
+        } catch (_e) {
+            out.externalLinks = Array.isArray(song.links) ? song.links : [];
+        }
+    } else {
+        out.externalLinks = Array.isArray(song.links) ? song.links.map(function (l) {
+            return {
+                typeId:   Number(l.typeId || l.type_id || 0),
+                url:      String(l.url    || ''),
+                note:     String(l.note   || ''),
+                verified: !!(l.verified),
+            };
+        }) : [];
+    }
+
     creditKeys.forEach(function (k) {
         if (!Array.isArray(out[k])) return;
         out[k] = out[k].map(function (entry) {

--- a/appWeb/public_html/manage/editor/index.php
+++ b/appWeb/public_html/manage/editor/index.php
@@ -24,6 +24,16 @@ require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEP
 requireEditor();
 
 $currentUser = getCurrentUser();
+
+/* External-link type registry for the Song-Editor Links tab (#833).
+   Empty array on pre-migration installs — the Links tab still
+   renders but the dropdown shows the empty-state hint. */
+require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'includes'
+    . DIRECTORY_SEPARATOR . 'external_link_helpers.php';
+$linkTypesForSong = [];
+try {
+    $linkTypesForSong = loadExternalLinkTypesFor(getDbMysqli(), 'song');
+} catch (\Throwable $_e) { /* probe failure → empty registry */ }
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -485,6 +495,24 @@ $currentUser = getCurrentUser();
                             aria-selected="false"
                         >
                             <i class="bi bi-people me-1"></i>Credits
+                        </button>
+                    </li>
+
+                    <!-- Links tab trigger (#833) — external website links
+                         (Hymnary.org, Wikipedia, YouTube performances, etc.)
+                         attached to this song via tblSongExternalLinks. -->
+                    <li class="nav-item" role="presentation">
+                        <button
+                            class="nav-link"
+                            id="tab-links"
+                            data-bs-toggle="tab"
+                            data-bs-target="#panel-links"
+                            type="button"
+                            role="tab"
+                            aria-controls="panel-links"
+                            aria-selected="false"
+                        >
+                            <i class="bi bi-link-45deg me-1"></i>Links
                         </button>
                     </li>
 
@@ -1110,6 +1138,59 @@ $currentUser = getCurrentUser();
 
 
                     <!-- -------------------------------------------------
+                         LINKS TAB PANEL (#833)
+                         External website links per song (Hymnary.org,
+                         Wikipedia, YouTube, Spotify, etc.) — same
+                         tblExternalLinkTypes-backed registry and shared
+                         row-builder module that powers the songbook
+                         + work admin pages. Auto-detect maps the
+                         pasted URL to the matching provider so the
+                         curator's dropdown selection is one less
+                         click in the common case.
+                         ------------------------------------------------- -->
+                    <div
+                        class="tab-pane fade"
+                        id="panel-links"
+                        role="tabpanel"
+                        aria-labelledby="tab-links"
+                    >
+                        <div class="form-section">
+                            <h6 class="section-title">
+                                <i class="bi bi-link-45deg me-1"></i>External links
+                            </h6>
+                            <div class="text-muted small mb-3">
+                                Hymnary.org · Internet Archive scans · Wikipedia ·
+                                YouTube performances · Spotify recordings · etc.
+                                Paste a URL — the provider dropdown auto-detects.
+                                <em>Verified</em> means a curator has eyeballed
+                                the URL and confirmed it's correct.
+                            </div>
+
+                            <?php
+                                /* Re-use the shared partial from manage/includes/partials.
+                                   The Song Editor lives one folder deeper than the rest
+                                   of /manage so the path resolves through the partial's
+                                   directory rather than the editor's own. */
+                                $containerId    = 'edit-song-ext-links-rows';
+                                $addBtnId       = 'edit-song-ext-link-add-btn';
+                                $heading        = 'External links';
+                                $helpText       = '';
+                                $useCardHeading = false;
+                                require dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes'
+                                    . DIRECTORY_SEPARATOR . 'partials'
+                                    . DIRECTORY_SEPARATOR . 'external-links-section.php';
+                            ?>
+
+                            <div class="form-text small mt-3" style="color: var(--ih-text-muted);">
+                                Save the song to persist link changes.
+                                Existing links are loaded automatically on song open.
+                            </div>
+                        </div>
+                    </div>
+                    <!-- END Links Tab Panel -->
+
+
+                    <!-- -------------------------------------------------
                          TAGS TAB PANEL (#496)
                          Per-song tag assignment. Chips show current tags
                          (× to remove). Autocomplete input searches
@@ -1455,6 +1536,18 @@ $currentUser = getCurrentUser();
             </div>
         </div>
     </div>
+
+    <!-- External-link provider auto-detect + shared card-list editor (#833 / #841).
+         Loaded before editor.js so the global module objects are
+         available when the editor mounts the Links tab. The Song
+         Editor has its own <head> (no head-libs.php), so we include
+         the scripts directly here. -->
+    <?php $_editorPublicRoot = dirname(__DIR__, 2); ?>
+    <script src="/js/modules/external-link-detect.js?v=<?= filemtime($_editorPublicRoot . '/js/modules/external-link-detect.js') ?>"></script>
+    <script src="/js/modules/external-links-editor.js?v=<?= filemtime($_editorPublicRoot . '/js/modules/external-links-editor.js') ?>"></script>
+    <script>
+        window._iHymnsLinkTypes = <?= json_encode($linkTypesForSong, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?>;
+    </script>
 
     <!-- Editor JavaScript — all interactive logic (loading, saving, editing, previewing)
          is handled in this separate file to keep concerns separated -->

--- a/appWeb/public_html/manage/includes/head-libs.php
+++ b/appWeb/public_html/manage/includes/head-libs.php
@@ -69,5 +69,8 @@ $_publicRoot = dirname(__DIR__, 2);
    constructs rows on initial page load. */
 $_extLinkDetectPath = $_publicRoot . '/js/modules/external-link-detect.js';
 $_extLinkDetectVer  = is_file($_extLinkDetectPath) ? (string)filemtime($_extLinkDetectPath) : '1';
+$_extLinkEditorPath = $_publicRoot . '/js/modules/external-links-editor.js';
+$_extLinkEditorVer  = is_file($_extLinkEditorPath) ? (string)filemtime($_extLinkEditorPath) : '1';
 ?>
     <script src="/js/modules/external-link-detect.js?v=<?= htmlspecialchars($_extLinkDetectVer, ENT_QUOTES) ?>"></script>
+    <script src="/js/modules/external-links-editor.js?v=<?= htmlspecialchars($_extLinkEditorVer, ENT_QUOTES) ?>"></script>

--- a/appWeb/public_html/manage/includes/partials/external-links-section.php
+++ b/appWeb/public_html/manage/includes/partials/external-links-section.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — External Links section partial
+ *
+ * Renders the heading + Add button + rows container that every admin
+ * edit modal uses to attach external links (tblExternalLinkTypes-backed)
+ * to its parent row. The caller is responsible for:
+ *
+ *   1. Calling `loadExternalLinkTypesFor($db, '<applies-to>')` and
+ *      emitting it as `window._iHymnsLinkTypes` before any consumer
+ *      script runs. The convention is to do that on the same page as
+ *      this partial so each admin surface ships its own slice of the
+ *      registry.
+ *   2. Wiring an `iHymnsExtLinksEditor.mount({ rowsEl, addBtnEl })`
+ *      call in the page's JS so the Add button + row builder come
+ *      alive. The container + button IDs are passed in via caller
+ *      variables ($containerId / $addBtnId) so a single page can
+ *      mount more than one editor without collisions.
+ *
+ * Caller contract:
+ *
+ *   <?php
+ *     $containerId = 'edit-ext-links-rows';
+ *     $addBtnId    = 'edit-ext-link-add-btn';
+ *     $heading     = 'External links';        // optional
+ *     $helpText    = '…';                     // optional
+ *     $useCardHeading = false;                // optional — when true,
+ *                                             //   wraps the heading in
+ *                                             //   <h6> instead of <label>
+ *     require __DIR__ . '/partials/external-links-section.php';
+ *   ?>
+ *
+ * Schema-gated callers should only render this partial when
+ * `tblExternalLinkTypes` exists — the partial itself doesn't probe.
+ */
+
+if (basename($_SERVER['SCRIPT_FILENAME'] ?? '') === basename(__FILE__)) {
+    http_response_code(403);
+    exit('Access denied.');
+}
+
+$containerId    = isset($containerId)    ? (string)$containerId    : 'ext-links-rows';
+$addBtnId       = isset($addBtnId)       ? (string)$addBtnId       : 'ext-link-add-btn';
+$heading        = isset($heading)        ? (string)$heading        : 'External links';
+$helpText       = isset($helpText)       ? (string)$helpText       : 'Provider auto-detects from the URL — paste a URL and the dropdown selects the matching provider automatically.';
+$useCardHeading = isset($useCardHeading) ? (bool)$useCardHeading   : false;
+
+/* Sanitise the IDs for HTML attribute use. The caller controls them,
+   but we still belt-and-braces in case they ever come from any
+   external source. */
+$safeContainerId = preg_replace('/[^A-Za-z0-9_-]/', '-', $containerId) ?? 'ext-links-rows';
+$safeAddBtnId    = preg_replace('/[^A-Za-z0-9_-]/', '-', $addBtnId)    ?? 'ext-link-add-btn';
+?>
+<div class="ihymns-ext-links-section">
+    <div class="d-flex justify-content-between align-items-baseline mb-2">
+        <?php if ($useCardHeading): ?>
+            <h6 class="mb-0"><i class="bi bi-link-45deg me-2" aria-hidden="true"></i><?= htmlspecialchars($heading, ENT_QUOTES, 'UTF-8') ?></h6>
+        <?php else: ?>
+            <label class="form-label mb-0"><i class="bi bi-link-45deg me-2" aria-hidden="true"></i><?= htmlspecialchars($heading, ENT_QUOTES, 'UTF-8') ?></label>
+        <?php endif; ?>
+        <button type="button"
+                class="btn btn-sm btn-outline-info"
+                id="<?= htmlspecialchars($safeAddBtnId, ENT_QUOTES, 'UTF-8') ?>">
+            <i class="bi bi-plus-lg me-1" aria-hidden="true"></i>Add link
+        </button>
+    </div>
+    <?php if ($helpText !== ''): ?>
+        <p class="form-text small mt-0 mb-2"><?= htmlspecialchars($helpText, ENT_QUOTES, 'UTF-8') ?></p>
+    <?php endif; ?>
+    <div id="<?= htmlspecialchars($safeContainerId, ENT_QUOTES, 'UTF-8') ?>" class="vstack gap-2"></div>
+</div>
+<?php
+/* Reset the caller-set vars so a second include on the same page picks
+   up its own values rather than the previous block's. */
+unset($containerId, $addBtnId, $heading, $helpText, $useCardHeading);

--- a/appWeb/public_html/manage/songbooks.php
+++ b/appWeb/public_html/manage/songbooks.php
@@ -1407,67 +1407,23 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         }
                     }
 
-                    /* #833 — reconcile external links. The edit modal posts
-                       four parallel arrays:
-                         ext_link_type_ids[]   tblExternalLinkTypes.Id
-                         ext_link_urls[]       URL
-                         ext_link_notes[]      optional Note
-                         ext_link_verified[]   '1'/''  per-row checkbox
-                       Position N in each array is the same link row;
-                       array index drives SortOrder. Empty / blank URLs
-                       are dropped before insert. DELETE-then-INSERT in
-                       the existing transaction.
+                    /* #833 — reconcile external links via the shared
+                       saver helper. DELETE-then-INSERT runs inside this
+                       transaction so any downstream failure rolls back
+                       cleanly with the parent UPDATE.
                        Schema-gated by $hasExtLinksSchema. */
                     $postedLinkCount = 0;
                     if ($hasExtLinksSchema) {
-                        $rawTypes    = $_POST['ext_link_type_ids']  ?? [];
-                        $rawUrls     = $_POST['ext_link_urls']      ?? [];
-                        $rawNotes    = $_POST['ext_link_notes']     ?? [];
-                        $rawVerified = $_POST['ext_link_verified']  ?? [];
-                        if (!is_array($rawTypes))    $rawTypes    = [];
-                        if (!is_array($rawUrls))     $rawUrls     = [];
-                        if (!is_array($rawNotes))    $rawNotes    = [];
-                        if (!is_array($rawVerified)) $rawVerified = [];
-
-                        $linkRows = [];
-                        foreach ($rawTypes as $idx => $rawTypeId) {
-                            $typeId = (int)$rawTypeId;
-                            $url    = trim((string)($rawUrls[$idx] ?? ''));
-                            if ($typeId <= 0 || $url === '')                  continue;
-                            if (!preg_match('#^https?://#i', $url))           continue;  /* must be http(s) */
-                            if (mb_strlen($url) > 2048)                       continue;
-                            $note = trim((string)($rawNotes[$idx] ?? ''));
-                            $verified = !empty($rawVerified[$idx]) ? 1 : 0;
-                            $linkRows[] = [
-                                'type_id'  => $typeId,
-                                'url'      => $url,
-                                'note'     => ($note !== '' ? mb_substr($note, 0, 255) : null),
-                                'verified' => $verified,
-                                'order'    => count($linkRows),
-                            ];
-                        }
-
-                        $stmt = $db->prepare('DELETE FROM tblSongbookExternalLinks WHERE SongbookId = ?');
-                        $stmt->bind_param('i', $id);
-                        $stmt->execute();
-                        $stmt->close();
-
-                        if ($linkRows) {
-                            $stmt = $db->prepare(
-                                'INSERT INTO tblSongbookExternalLinks
-                                     (SongbookId, LinkTypeId, Url, Note, SortOrder, Verified)
-                                  VALUES (?, ?, ?, ?, ?, ?)'
-                            );
-                            foreach ($linkRows as $r) {
-                                $stmt->bind_param(
-                                    'iissii',
-                                    $id, $r['type_id'], $r['url'], $r['note'], $r['order'], $r['verified']
-                                );
-                                $stmt->execute();
-                                $postedLinkCount++;
-                            }
-                            $stmt->close();
-                        }
+                        $postedLinkCount = saveExternalLinksForRow(
+                            $db,
+                            'tblSongbookExternalLinks',
+                            'SongbookId',
+                            $id,
+                            $_POST['ext_link_type_ids'] ?? [],
+                            $_POST['ext_link_urls']     ?? [],
+                            $_POST['ext_link_notes']    ?? [],
+                            $_POST['ext_link_verified'] ?? []
+                        );
                     }
 
                     $db->commit();
@@ -2184,30 +2140,10 @@ $linkTypesForSongbook = [];
 $sbLinksMap           = [];
 if ($hasExtLinksSchema) {
     try {
-        $res = $db->query(
-            "SELECT Id, Slug, Name, Category, IconClass, AllowMultiple, DisplayOrder
-               FROM tblExternalLinkTypes
-              WHERE COALESCE(IsActive, 1) = 1
-                AND FIND_IN_SET('songbook', AppliesTo) > 0
-              ORDER BY Category, DisplayOrder ASC, Name ASC"
-        );
-        if ($res) {
-            while ($row = $res->fetch_assoc()) {
-                $linkTypesForSongbook[] = [
-                    'id'             => (int)$row['Id'],
-                    'slug'           => (string)$row['Slug'],
-                    'name'           => (string)$row['Name'],
-                    'category'       => (string)$row['Category'],
-                    'icon_class'     => (string)($row['IconClass'] ?? ''),
-                    'allow_multiple' => (int)$row['AllowMultiple'],
-                ];
-            }
-            $res->close();
-        }
-        /* #845 — attach DB-driven URL → provider patterns so the JS
-           auto-detect module can read them via window._iHymnsLinkTypes
-           without a second AJAX round-trip. */
-        $linkTypesForSongbook = attachExternalLinkPatterns($db, $linkTypesForSongbook);
+        /* #841/#845 — shared loader returns the registry with URL →
+           provider patterns already attached, ready to ship as
+           window._iHymnsLinkTypes for the shared editor module. */
+        $linkTypesForSongbook = loadExternalLinkTypesFor($db, 'songbook');
 
         $res = $db->query(
             'SELECT el.SongbookId, el.LinkTypeId, el.Url, el.Note, el.SortOrder, el.Verified,
@@ -3393,29 +3329,18 @@ $csrf = csrfToken();
 
                         <?php if ($hasExtLinksSchema): ?>
                         <!-- #833 — External-links system.
-                             MusicBrainz-style typed links with multiple
-                             entries supported. Each row pairs a link
-                             type (FK → tblExternalLinkTypes) with a URL,
-                             an optional Note, and a Verified flag. -->
+                             Renders the shared partial; the row builder
+                             behaviour comes from /js/modules/external-links-editor.js. -->
                         <div class="mb-3" id="edit-ext-links-block">
-                            <label class="form-label">External links <span class="text-muted small">(optional)</span></label>
-                            <div class="form-text small mb-2">
-                                Hymnary.org · Internet Archive scans · Wikipedia ·
-                                Wikidata · YouTube performances · Spotify recordings ·
-                                etc. Multiple links of the same type are allowed
-                                where the type permits. Verified means a curator
-                                has eyeballed the URL and confirmed it's correct.
-                            </div>
-                            <div id="edit-ext-links-rows" class="vstack gap-2 mb-2"></div>
-                            <button type="button"
-                                    class="btn btn-sm btn-outline-info"
-                                    id="edit-ext-link-add-btn">
-                                <i class="bi bi-plus-lg me-1" aria-hidden="true"></i>Add link
-                            </button>
-                            <!-- Curated link-type registry (#833 seed list). Read at
-                                 page load + serialized inline as a JSON map so the
-                                 row-builder can populate the dropdown without an
-                                 extra AJAX round-trip. -->
+                            <?php
+                                $containerId = 'edit-ext-links-rows';
+                                $addBtnId    = 'edit-ext-link-add-btn';
+                                $heading     = 'External links';
+                                $helpText    = 'Hymnary.org · Internet Archive scans · Wikipedia · Wikidata · YouTube performances · Spotify recordings · etc. Provider auto-detects from the pasted URL. Multiple links of the same type are allowed where the type permits. Verified means a curator has eyeballed the URL and confirmed it\'s correct.';
+                                require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'partials' . DIRECTORY_SEPARATOR . 'external-links-section.php';
+                            ?>
+                            <!-- Curated link-type registry (#833 seed list). Pre-loaded so
+                                 the shared row-builder doesn't need an AJAX round-trip. -->
                             <script>
                                 window._iHymnsLinkTypes = <?= json_encode($linkTypesForSongbook, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?>;
                             </script>
@@ -3818,22 +3743,20 @@ $csrf = csrfToken();
             })();
 
             /* #833 — populate the external-links list from
-               row.external_links. Schema-gated container; clear +
-               repopulate on every modal-open. */
-            (function () {
-                const container = document.getElementById('edit-ext-links-rows');
-                if (!container || typeof window._iHymnsBuildExtLinkRow !== 'function') return;
-                container.innerHTML = '';
-                const links = Array.isArray(row.external_links) ? row.external_links : [];
-                links.forEach(l => {
-                    container.appendChild(window._iHymnsBuildExtLinkRow({
-                        typeId:   l.type_id || 0,
-                        url:      l.url || '',
-                        note:     l.note || '',
-                        verified: !!l.verified,
-                    }));
-                });
-            })();
+               row.external_links via the shared editor module.
+               Schema-gated container; clear + repopulate every open. */
+            if (window._iHymnsSongbookExtLinksEditor) {
+                window._iHymnsSongbookExtLinksEditor.setRows(
+                    (Array.isArray(row.external_links) ? row.external_links : []).map(function (l) {
+                        return {
+                            typeId:   l.type_id || 0,
+                            url:      l.url || '',
+                            note:     l.note || '',
+                            verified: !!l.verified,
+                        };
+                    })
+                );
+            }
 
             /* Stash the current row's abbreviation on the modal for the
                "Pick distinctive colour" button below — the button reads
@@ -4606,122 +4529,22 @@ $csrf = csrfToken();
     })();
     </script>
 
-    <!-- External-links card-list editor (#833). Each row carries:
-         - hidden ext_link_type_ids[]   (FK to tblExternalLinkTypes.Id)
-         - text   ext_link_urls[]
-         - text   ext_link_notes[]
-         - checkbox ext_link_verified[]
-         The link-type dropdown is grouped by Category and uses the
-         seeded list pre-loaded into window._iHymnsLinkTypes. -->
+    <!-- External-links card-list editor (#833) — now driven entirely by
+         /js/modules/external-links-editor.js. The shared module builds
+         the dropdown, wires Add/Remove, and attaches auto-detect to
+         every row. The previous ~120 lines of inline row-builder code
+         are now in the shared module. -->
     <script>
     (function () {
         const addBtn = document.getElementById('edit-ext-link-add-btn');
         const rowsEl = document.getElementById('edit-ext-links-rows');
         if (!addBtn || !rowsEl) return;  /* schema not live → block absent */
-
-        const types = Array.isArray(window._iHymnsLinkTypes) ? window._iHymnsLinkTypes : [];
-
-        /* Group types by Category for the <optgroup> structure. */
-        const byCat = {};
-        types.forEach(t => {
-            const cat = t.category || 'other';
-            if (!byCat[cat]) byCat[cat] = [];
-            byCat[cat].push(t);
+        if (!window.iHymnsExtLinksEditor) return;
+        window._iHymnsSongbookExtLinksEditor = window.iHymnsExtLinksEditor.mount({
+            rowsEl: rowsEl,
+            addBtnEl: addBtn,
+            notePlaceholder: "Optional note (e.g. '1900 first edition')",
         });
-        const catLabels = {
-            'official':    'Official',
-            'information': 'Information',
-            'read':        'Read',
-            'sheet-music': 'Sheet music',
-            'listen':      'Listen',
-            'watch':       'Watch',
-            'purchase':    'Purchase',
-            'authority':   'Authority',
-            'social':      'Social',
-            'other':       'Other',
-        };
-        const catOrder = ['official','information','read','sheet-music','listen','watch','purchase','authority','social','other'];
-
-        function buildSelect(selectedId) {
-            let html = '<select class="form-select form-select-sm" name="ext_link_type_ids[]" required>';
-            html += '<option value="">— pick a link type —</option>';
-            catOrder.forEach(cat => {
-                if (!byCat[cat] || byCat[cat].length === 0) return;
-                html += '<optgroup label="' + escapeHtml(catLabels[cat] || cat) + '">';
-                byCat[cat].forEach(t => {
-                    const sel = (Number(selectedId) === Number(t.id)) ? ' selected' : '';
-                    html += '<option value="' + Number(t.id) + '"' + sel + '>' + escapeHtml(t.name) + '</option>';
-                });
-                html += '</optgroup>';
-            });
-            html += '</select>';
-            return html;
-        }
-
-        window._iHymnsBuildExtLinkRow = function (data) {
-            const card = document.createElement('div');
-            card.className = 'card bg-dark border-secondary';
-            const url  = String(data.url || '');
-            const note = String(data.note || '');
-            const ver  = data.verified ? 'checked' : '';
-            card.innerHTML =
-                '<div class="card-body py-2">' +
-                  '<div class="d-flex align-items-start gap-2">' +
-                    '<i class="bi bi-grip-vertical text-muted mt-2" aria-hidden="true"></i>' +
-                    '<div class="flex-grow-1">' +
-                      '<div class="row g-2 mb-1">' +
-                        '<div class="col-md-5">' + buildSelect(data.typeId || 0) + '</div>' +
-                        '<div class="col-md-7">' +
-                          '<input type="url" class="form-control form-control-sm" ' +
-                                  'name="ext_link_urls[]" required maxlength="2048" ' +
-                                  'placeholder="https://…" value="' + escapeHtml(url) + '">' +
-                        '</div>' +
-                      '</div>' +
-                      '<div class="row g-2">' +
-                        '<div class="col-md-9">' +
-                          '<input type="text" class="form-control form-control-sm" ' +
-                                  'name="ext_link_notes[]" maxlength="255" ' +
-                                  'placeholder="Optional note (e.g. \'1900 first edition\')" ' +
-                                  'value="' + escapeHtml(note) + '">' +
-                        '</div>' +
-                        '<div class="col-md-3 d-flex align-items-center">' +
-                          '<div class="form-check small">' +
-                            '<input class="form-check-input" type="checkbox" ' +
-                                    'name="ext_link_verified[]" value="1" ' + ver + '>' +
-                            '<label class="form-check-label">Verified</label>' +
-                          '</div>' +
-                        '</div>' +
-                      '</div>' +
-                    '</div>' +
-                    '<button type="button" class="btn btn-sm btn-outline-danger" ' +
-                            'data-action="remove-ext-link" title="Remove this link">' +
-                      '<i class="bi bi-x-lg"></i>' +
-                    '</button>' +
-                  '</div>' +
-                '</div>';
-            card.querySelector('[data-action=remove-ext-link]')
-                .addEventListener('click', () => card.remove());
-            /* #841 — global URL → provider auto-detect. The module is
-               loaded by manage/includes/head-libs.php on every admin
-               page, so the wiring is the same one-liner here as in
-               every other edit modal. */
-            if (window.iHymnsLinkDetect && typeof window.iHymnsLinkDetect.attachAutoDetect === 'function') {
-                window.iHymnsLinkDetect.attachAutoDetect(card);
-            }
-            return card;
-        };
-
-        addBtn.addEventListener('click', () => {
-            rowsEl.appendChild(window._iHymnsBuildExtLinkRow({
-                typeId: 0, url: '', note: '', verified: false,
-            }));
-        });
-
-        function escapeHtml(s) {
-            return String(s)
-                .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-                .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
-        }
     })();
     </script>
 

--- a/appWeb/public_html/manage/works.php
+++ b/appWeb/public_html/manage/works.php
@@ -96,27 +96,9 @@ try {
     $hasExtLinksSchema = $r && $r->fetch_row() !== null;
     if ($r) $r->close();
     if ($hasExtLinksSchema) {
-        $res = $db->query(
-            "SELECT Id, Slug, Name, Category, IconClass
-               FROM tblExternalLinkTypes
-              WHERE COALESCE(IsActive, 1) = 1
-                AND FIND_IN_SET('work', AppliesTo) > 0
-              ORDER BY Category ASC, DisplayOrder ASC, Name ASC"
-        );
-        if ($res) {
-            while ($row = $res->fetch_assoc()) {
-                $linkTypesForWork[] = [
-                    'id'        => (int)$row['Id'],
-                    'slug'      => (string)$row['Slug'],
-                    'name'      => (string)$row['Name'],
-                    'category'  => (string)$row['Category'],
-                    'iconClass' => (string)($row['IconClass'] ?? ''),
-                ];
-            }
-            $res->close();
-        }
-        /* #845 — attach DB-driven URL → provider patterns. */
-        $linkTypesForWork = attachExternalLinkPatterns($db, $linkTypesForWork);
+        /* #841/#845 — shared loader returns the registry with URL →
+           provider patterns already attached. */
+        $linkTypesForWork = loadExternalLinkTypesFor($db, 'work');
     }
 } catch (\Throwable $_e) { /* probe failure → external-links UI silently absent */ }
 
@@ -314,16 +296,6 @@ if ($hasSchema && ($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'POST') {
                     $postedSongs
                 ))));
 
-                /* External-links reconciliation arrays (#833 pattern) */
-                $linkTypeIds  = $_POST['ext_link_type_ids'] ?? [];
-                $linkUrls     = $_POST['ext_link_urls']     ?? [];
-                $linkNotes    = $_POST['ext_link_notes']    ?? [];
-                $linkVerified = $_POST['ext_link_verified'] ?? [];
-                if (!is_array($linkTypeIds))  $linkTypeIds  = [];
-                if (!is_array($linkUrls))     $linkUrls     = [];
-                if (!is_array($linkNotes))    $linkNotes    = [];
-                if (!is_array($linkVerified)) $linkVerified = [];
-
                 $db->begin_transaction();
                 try {
                     $stmt = $db->prepare(
@@ -360,34 +332,19 @@ if ($hasSchema && ($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'POST') {
                         $stmt->close();
                     }
 
-                    /* External links — DELETE-then-INSERT, mirroring #833. */
+                    /* External links — delegated to the shared saver. */
+                    $insertedLinks = 0;
                     if ($hasExtLinksSchema) {
-                        $stmt = $db->prepare('DELETE FROM tblWorkExternalLinks WHERE WorkId = ?');
-                        $stmt->bind_param('i', $id);
-                        $stmt->execute();
-                        $stmt->close();
-
-                        $insertedLinks = 0;
-                        $count = max(count($linkTypeIds), count($linkUrls));
-                        for ($i = 0; $i < $count; $i++) {
-                            $typeId = (int)($linkTypeIds[$i] ?? 0);
-                            $url    = trim((string)($linkUrls[$i] ?? ''));
-                            $lnote  = mb_substr(trim((string)($linkNotes[$i] ?? '')), 0, 255);
-                            $ver    = !empty($linkVerified[$i]) ? 1 : 0;
-                            if ($typeId <= 0 || $url === '') continue;
-                            if (!preg_match('#^https?://#i', $url)) continue;
-                            if (mb_strlen($url) > 2048) continue;
-
-                            $stmt = $db->prepare(
-                                'INSERT INTO tblWorkExternalLinks
-                                     (WorkId, LinkTypeId, Url, Note, SortOrder, Verified)
-                                 VALUES (?, ?, ?, NULLIF(?, ""), ?, ?)'
-                            );
-                            $stmt->bind_param('iissii', $id, $typeId, $url, $lnote, $i, $ver);
-                            $stmt->execute();
-                            $stmt->close();
-                            $insertedLinks++;
-                        }
+                        $insertedLinks = saveExternalLinksForRow(
+                            $db,
+                            'tblWorkExternalLinks',
+                            'WorkId',
+                            $id,
+                            $_POST['ext_link_type_ids'] ?? [],
+                            $_POST['ext_link_urls']     ?? [],
+                            $_POST['ext_link_notes']    ?? [],
+                            $_POST['ext_link_verified'] ?? []
+                        );
                     }
 
                     $db->commit();
@@ -818,18 +775,14 @@ if ($hasSchema) {
 
                             <?php if ($hasExtLinksSchema): ?>
                             <hr>
-
-                            <div class="d-flex justify-content-between align-items-baseline mb-2">
-                                <h6 class="mb-0"><i class="bi bi-link-45deg me-2"></i>External links</h6>
-                                <button type="button" class="btn btn-outline-info btn-sm" id="edit-work-ext-link-add-btn">
-                                    <i class="bi bi-plus-lg me-1"></i>Add link
-                                </button>
-                            </div>
-                            <p class="form-text small mt-0 mb-2">
-                                Provider auto-detects from the URL — paste e.g. a YouTube link
-                                and the dropdown selects YouTube automatically.
-                            </p>
-                            <div id="edit-work-ext-links-rows" class="vstack gap-2"></div>
+                            <?php
+                                $containerId    = 'edit-work-ext-links-rows';
+                                $addBtnId       = 'edit-work-ext-link-add-btn';
+                                $heading        = 'External links';
+                                $helpText       = 'Provider auto-detects from the URL — paste e.g. a YouTube link and the dropdown selects YouTube automatically.';
+                                $useCardHeading = true;
+                                require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'partials' . DIRECTORY_SEPARATOR . 'external-links-section.php';
+                            ?>
                             <?php endif; ?>
                         </div>
                         <div class="modal-footer" style="border-color: var(--ih-border);">
@@ -949,89 +902,16 @@ if ($hasSchema) {
             });
         }
 
-        /* === External-links card builder, mirrors the songbooks page (#833) === */
-        function buildLinkSelect(selectedId) {
-            const types = Array.isArray(window._iHymnsLinkTypes) ? window._iHymnsLinkTypes : [];
-            const byCat = {};
-            types.forEach(t => {
-                const cat = t.category || 'other';
-                if (!byCat[cat]) byCat[cat] = [];
-                byCat[cat].push(t);
+        /* External-links editor — driven by the shared module
+           (#833 / #841). The row builder lives in
+           /js/modules/external-links-editor.js so songbooks, works
+           and the song editor never diverge again. */
+        let workLinksEditor = null;
+        if (linkRowsEl && window.iHymnsExtLinksEditor) {
+            workLinksEditor = window.iHymnsExtLinksEditor.mount({
+                rowsEl:   linkRowsEl,
+                addBtnEl: addLinkBtn,
             });
-            const catLabels = {
-                'official':'Official','information':'Information','read':'Read',
-                'sheet-music':'Sheet music','listen':'Listen','watch':'Watch',
-                'purchase':'Purchase','authority':'Authority','social':'Social','other':'Other',
-            };
-            const catOrder = ['official','information','read','sheet-music','listen','watch','purchase','authority','social','other'];
-            let html = '<select class="form-select form-select-sm" name="ext_link_type_ids[]" required>';
-            html += '<option value="">— pick a link type —</option>';
-            catOrder.forEach(cat => {
-                if (!byCat[cat] || !byCat[cat].length) return;
-                html += '<optgroup label="' + escapeHtml(catLabels[cat] || cat) + '">';
-                byCat[cat].forEach(t => {
-                    const sel = (Number(selectedId) === Number(t.id)) ? ' selected' : '';
-                    html += '<option value="' + Number(t.id) + '"' + sel + '>' + escapeHtml(t.name) + '</option>';
-                });
-                html += '</optgroup>';
-            });
-            html += '</select>';
-            return html;
-        }
-        function buildLinkRow(data) {
-            const card = document.createElement('div');
-            card.className = 'card bg-dark border-secondary';
-            const url  = String(data.url || '');
-            const note = String(data.note || '');
-            const ver  = data.verified ? 'checked' : '';
-            card.innerHTML =
-                '<div class="card-body py-2">' +
-                  '<div class="d-flex align-items-start gap-2">' +
-                    '<i class="bi bi-grip-vertical text-muted mt-2" aria-hidden="true"></i>' +
-                    '<div class="flex-grow-1">' +
-                      '<div class="row g-2 mb-1">' +
-                        '<div class="col-md-5">' + buildLinkSelect(data.typeId || 0) + '</div>' +
-                        '<div class="col-md-7">' +
-                          '<input type="url" class="form-control form-control-sm" ' +
-                                  'name="ext_link_urls[]" required maxlength="2048" ' +
-                                  'placeholder="https://…" value="' + escapeHtml(url) + '">' +
-                        '</div>' +
-                      '</div>' +
-                      '<div class="row g-2">' +
-                        '<div class="col-md-9">' +
-                          '<input type="text" class="form-control form-control-sm" ' +
-                                  'name="ext_link_notes[]" maxlength="255" ' +
-                                  'placeholder="Optional note" ' +
-                                  'value="' + escapeHtml(note) + '">' +
-                        '</div>' +
-                        '<div class="col-md-3 d-flex align-items-center">' +
-                          '<div class="form-check small">' +
-                            '<input class="form-check-input" type="checkbox" ' +
-                                    'name="ext_link_verified[]" value="1" ' + ver + '>' +
-                            '<label class="form-check-label">Verified</label>' +
-                          '</div>' +
-                        '</div>' +
-                      '</div>' +
-                    '</div>' +
-                    '<button type="button" class="btn btn-sm btn-outline-danger" ' +
-                            'data-action="remove-ext-link" title="Remove this link">' +
-                      '<i class="bi bi-x-lg"></i>' +
-                    '</button>' +
-                  '</div>' +
-                '</div>';
-            card.querySelector('[data-action=remove-ext-link]')
-                .addEventListener('click', () => card.remove());
-            /* Auto-detect provider from the pasted URL — global module
-               (#841) wires the row's URL input + select together. */
-            if (window.iHymnsLinkDetect && typeof window.iHymnsLinkDetect.attachAutoDetect === 'function') {
-                window.iHymnsLinkDetect.attachAutoDetect(card);
-            }
-            return card;
-        }
-        if (addLinkBtn) {
-            addLinkBtn.onclick = () => {
-                linkRowsEl.appendChild(buildLinkRow({ typeId: 0, url: '', note: '', verified: false }));
-            };
         }
 
         /* === Song typeahead === */
@@ -1116,13 +996,10 @@ if ($hasSchema) {
             tbody.innerHTML = (row.members || []).map(m => memberRowHtml(m)).join('');
             rebindRemoveButtons();
 
-            if (linkRowsEl) {
-                linkRowsEl.innerHTML = '';
-                (row.links || []).forEach(l => {
-                    linkRowsEl.appendChild(buildLinkRow({
-                        typeId: l.typeId, url: l.url, note: l.note, verified: l.verified,
-                    }));
-                });
+            if (workLinksEditor) {
+                workLinksEditor.setRows((row.links || []).map(l => ({
+                    typeId: l.typeId, url: l.url, note: l.note, verified: l.verified,
+                })));
             }
 
             if (sugBox) { sugBox.style.display = 'none'; sugBox.innerHTML = ''; }


### PR DESCRIPTION
## Summary

Three fixes plus a modularity refactor across every admin surface that owns external links.

### 1. Songbook list view — stop rendering "0" for unnumbered songs

Songs whose `Number` is `NULL` (Misc / unofficial-songbook entries) were rendering `0` inside the song-number badge because `pages/songbook.php` did `(int)$song['number']` and that collapses null to 0. The CSS already handles empty badges via `.song-number-badge:empty::before` (book glyph fallback, #392). Fix is purely in the view; the data layer was correct.

### 2. Credit People — link-type dropdown now auto-updates from pasted URL

The drawer's dropdown stayed on its default until the curator manually picked a provider, which contradicted the auto-detect UX that already worked on songbooks/works. Wired `iHymnsLinkDetect.attachAutoDetect()` into each credit-people link row via a small slug-translation map (the page uses its bespoke `CREDIT_PERSON_LINK_TYPE_CATALOGUE` slug vocabulary instead of numeric `tblExternalLinkTypes.Id`s, so a direct slug → option-value lookup is needed). `attachAutoDetect()` gained optional `urlSelector` / `selectSelector` / `slugLookup` opts so this surface can plug in without forking the module.

### 3. Song Editor — net-new External Links tab

`tblSongExternalLinks` has existed since #833 but had no admin UI; the public song page read it, nothing wrote it. Added a Links tab between Credits and Tags in the song editor, mounted on the same shared editor module the songbook + work admin pages use. Hydrates from `song.links` via the corpus cache, syncs DOM → in-memory song on every input so auto-save + manual save both ship the current state, and persists via `saveExternalLinksForRow()` inside `save_song`'s existing transaction.

`SongData::getSongs()` now bulk-loads `tblSongExternalLinks` so the corpus cache (which the editor reads from) carries each song's external links — pre-migration safe via the existing schema probe in `_externalLinksMap()`.

### 4. Shared codebase (modularity rule)

Before this PR, `songbooks.php` and `works.php` each carried ~120 lines of near-identical row-builder JS for their External Links sections, and the saver was inline. Extracted into:

- **`js/modules/external-links-editor.js`** — shared row builder. `mount({ rowsEl, addBtnEl })` returns `{ addRow, setRows, clear }`.
- **`manage/includes/partials/external-links-section.php`** — shared HTML partial (label + Add button + container).
- **`includes/external_link_helpers.php`** — `loadExternalLinkTypesFor()`, `saveExternalLinksForRow()`, `loadExternalLinksForRow()` helpers shared across the three surfaces.

`songbooks.php` shed ~200 lines, `works.php` shed ~90, and the song editor's new Links tab reuses the same wiring with no duplication.

## Follow-ups parked

- **Credit-people storage unification** — eventual migration moving `tblCreditPersonExternalLinks` onto numeric `LinkTypeId` FKs so credit-people can drop `CP_DETECT_SLUG_TO_KEY` and join the shared module fully. Tracking as a separate PR — DB migration is non-trivial.
- **Audit-log `external_link_count` on song save** — songbooks/works already log this; song editor's `save_song` doesn't. Small add coming next.
- **Corpus cache regen after deploy** — existing songs' links won't show up in the editor's Links tab until the cache rebuilds. Trigger from `/manage/data-health` once after deploy, or wait for the next per-song save to refresh.

## Test plan

- [ ] Songbook detail view: open an unofficial songbook (e.g. Psalty in the screenshot from the bug report) — songs with `Number IS NULL` render the book-glyph badge, not "0".
- [ ] Songbook detail view: open an official songbook (CP / MP / etc.) — numbered songs still show their number correctly.
- [ ] `/manage/songbooks` edit modal: Add link → row builder works, paste a Wikipedia URL → dropdown auto-selects Wikipedia.
- [ ] `/manage/works` edit modal: same paste-to-detect flow.
- [ ] `/manage/credit-people` Edit drawer: paste a YouTube URL into a link row → dropdown flips to "YouTube" without manual selection. Verify manual override still wins (data-user-picked respected).
- [ ] Song editor: open a song → Links tab shows any existing `tblSongExternalLinks` rows. Add a link, paste a URL, dropdown auto-detects, Save → row persists. Reload editor → row still there.
- [ ] Song editor: edit links on song A, switch to song B without saving, switch back → A's edited links still in the Links tab (sync-before-switch).
- [ ] PHP lint clean (`find appWeb -name '*.php' -exec php -l {} \;`) and JS syntax clean (`node --check`).


---
_Generated by [Claude Code](https://claude.ai/code/session_018jFVuXFjp6Wc4EPBMzR22U)_