### PR TITLE
refactor(credit-people): unify link storage, responsive sub-form rows, song-audit count

### DIFF
--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -9449,7 +9449,7 @@ if ($action !== null) {
             $deathPlace  = trim((string)($body['death_place']  ?? '')) ?: null;
             $deathDate   = trim((string)($body['death_date']   ?? '')) ?: null;
             $notes       = $notesRaw !== '' ? $notesRaw : null;
-            $links       = normaliseCreditPersonLinks($body['links']   ?? null);
+            $rawLinks    = $body['links']   ?? null;
             $ipi         = normaliseCreditPersonIpi($body['ipi']       ?? null);
             $aliases     = normaliseCreditPersonAliases($body['aliases'] ?? null);
             $isSpecialCase = !empty($body['is_special_case']) ? 1 : 0;
@@ -9469,6 +9469,9 @@ if ($action !== null) {
 
             try {
                 $db = getDbMysqli();
+                /* #833 — link normaliser resolves slug ↔ registry id via
+                   tblExternalLinkTypes, so it needs the live mysqli. */
+                $links = normaliseCreditPersonLinks($db, $rawLinks);
 
                 $stmt = $db->prepare('SELECT Id FROM tblCreditPeople WHERE Name = ?');
                 $stmt->bind_param('s', $name);
@@ -9538,13 +9541,13 @@ if ($action !== null) {
 
                     if ($links) {
                         $linkStmt = $db->prepare(
-                            'INSERT INTO tblCreditPersonLinks
-                                (CreditPersonId, LinkType, Url, Label, SortOrder)
+                            'INSERT INTO tblCreditPersonExternalLinks
+                                (CreditPersonId, LinkTypeId, Url, Note, SortOrder)
                              VALUES (?, ?, ?, ?, ?)'
                         );
                         foreach ($links as $l) {
-                            $linkStmt->bind_param('isssi',
-                                $newId, $l['type'], $l['url'], $l['label'], $l['sort_order']);
+                            $linkStmt->bind_param('iissi',
+                                $newId, $l['type_id'], $l['url'], $l['label'], $l['sort_order']);
                             $linkStmt->execute();
                         }
                         $linkStmt->close();
@@ -9630,7 +9633,7 @@ if ($action !== null) {
             $deathPlace  = trim((string)($body['death_place']  ?? '')) ?: null;
             $deathDate   = trim((string)($body['death_date']   ?? '')) ?: null;
             $notes       = $notesRaw !== '' ? $notesRaw : null;
-            $links       = normaliseCreditPersonLinks($body['links']   ?? null);
+            $rawLinks    = $body['links']   ?? null;
             $ipi         = normaliseCreditPersonIpi($body['ipi']       ?? null);
             $aliases     = normaliseCreditPersonAliases($body['aliases'] ?? null);
             $isSpecialCase = !empty($body['is_special_case']) ? 1 : 0;
@@ -9648,6 +9651,9 @@ if ($action !== null) {
 
             try {
                 $db = getDbMysqli();
+                /* #833 — link normaliser resolves slug ↔ registry id via
+                   tblExternalLinkTypes, so it needs the live mysqli. */
+                $links = normaliseCreditPersonLinks($db, $rawLinks);
                 $stmt = $db->prepare(
                     'SELECT Name, Notes, BirthPlace, BirthDate, DeathPlace, DeathDate
                        FROM tblCreditPeople WHERE Id = ?'
@@ -9697,19 +9703,19 @@ if ($action !== null) {
                        diffing and the per-person row counts are small
                        (typically < 10 each). The child Ids change as a
                        side effect, but no other table references them. */
-                    $del = $db->prepare('DELETE FROM tblCreditPersonLinks WHERE CreditPersonId = ?');
+                    $del = $db->prepare('DELETE FROM tblCreditPersonExternalLinks WHERE CreditPersonId = ?');
                     $del->bind_param('i', $id);
                     $del->execute();
                     $del->close();
                     if ($links) {
                         $linkStmt = $db->prepare(
-                            'INSERT INTO tblCreditPersonLinks
-                                (CreditPersonId, LinkType, Url, Label, SortOrder)
+                            'INSERT INTO tblCreditPersonExternalLinks
+                                (CreditPersonId, LinkTypeId, Url, Note, SortOrder)
                              VALUES (?, ?, ?, ?, ?)'
                         );
                         foreach ($links as $l) {
-                            $linkStmt->bind_param('isssi',
-                                $id, $l['type'], $l['url'], $l['label'], $l['sort_order']);
+                            $linkStmt->bind_param('iissi',
+                                $id, $l['type_id'], $l['url'], $l['label'], $l['sort_order']);
                             $linkStmt->execute();
                         }
                         $linkStmt->close();
@@ -9959,7 +9965,7 @@ if ($action !== null) {
                        Anything not in keep_link_ids / keep_ipi_ids gets
                        dropped via the cascade when the source row is
                        deleted below. */
-                    $stmt = $db->prepare('SELECT Id FROM tblCreditPersonLinks WHERE CreditPersonId = ?');
+                    $stmt = $db->prepare('SELECT Id FROM tblCreditPersonExternalLinks WHERE CreditPersonId = ?');
                     $stmt->bind_param('i', $sourceId);
                     $stmt->execute();
                     $sourceLinkIds = array_column($stmt->get_result()->fetch_all(MYSQLI_ASSOC), 'Id');
@@ -9975,7 +9981,7 @@ if ($action !== null) {
                         $toMove = array_intersect($keepLinks, array_map('intval', $sourceLinkIds));
                         if ($toMove) {
                             $upd = $db->prepare(
-                                'UPDATE tblCreditPersonLinks SET CreditPersonId = ? WHERE Id = ? AND CreditPersonId = ?'
+                                'UPDATE tblCreditPersonExternalLinks SET CreditPersonId = ? WHERE Id = ? AND CreditPersonId = ?'
                             );
                             foreach ($toMove as $lid) {
                                 $upd->bind_param('iii', $targetId, $lid, $sourceId);

--- a/appWeb/public_html/includes/credit_people_helpers.php
+++ b/appWeb/public_html/includes/credit_people_helpers.php
@@ -8,12 +8,16 @@ declare(strict_types=1);
  * Single source of truth for the bits both /manage/credit-people.php
  * and the admin_credit_person_* API endpoints share:
  *
- *   - CREDIT_PERSON_LINK_TYPE_CATALOGUE — grouped catalogue of
- *     link-type keys for the per-person external-link sub-form (#586).
- *   - CREDIT_PERSON_LINK_TYPE_KEYS — flat lookup used by the validator.
+ *   - CREDIT_PERSON_LEGACY_SLUG_MAP — back-compat slug → registry-slug
+ *     coercion table for /api.php callers that still send the legacy
+ *     #586 vocabulary. The /manage/credit-people form moved to numeric
+ *     LinkTypeId values directly and no longer reads this map.
+ *   - resolveCreditPersonLinkTypeId() — single source of truth for
+ *     "given a numeric type_id OR a slug string, find the matching
+ *     tblExternalLinkTypes.Id row" used by every write path.
  *   - normaliseCreditPersonLinks() / normaliseCreditPersonIpi() —
- *     drop empty rows, coerce unknown link types to 'other', normalise
- *     the row shape into INSERT-ready arrays.
+ *     drop empty rows, resolve link-type slugs / numeric ids to
+ *     registry FKs, normalise the row shape into INSERT-ready arrays.
  *   - creditPeopleFlagsColumnsExist() — cached check for the
  *     IsSpecialCase / IsGroup columns from #584/#585. Lets the add /
  *     update paths gracefully no-op the flag writes on a partly-
@@ -29,71 +33,137 @@ if (basename($_SERVER['SCRIPT_FILENAME'] ?? '') === basename(__FILE__)) {
 }
 
 /**
- * Curated link-type registry (#586).
+ * Legacy slug → tblExternalLinkTypes.Slug map for credit-people.
  *
- * Adding a new provider: append it under its category. The picker
- * UI (built from this catalogue via <optgroup>) and the
- * normaliser's allowlist both update automatically. Legacy
- * LinkType values stored in the DB before #586 (e.g. 'official',
- * 'wikipedia') stay valid because they still appear under General.
+ * Preserved purely for backwards compatibility with /api.php
+ * admin_credit_person_add / _update callers that historically sent
+ * `links[].type` as a free-text slug string (the #586 catalogue
+ * vocabulary: 'apple_music', 'youtube_music', 'twitter', etc.).
+ * Mirrors the mapping table from migrate-backfill-credit-person-links.php
+ * so any external consumer can keep sending the old vocabulary
+ * while the storage layer moves to numeric LinkTypeId FKs.
+ *
+ * Anything not in the map resolves to 'other' — same fall-through
+ * the backfill migration applies.
  */
-if (!defined('IHYMNS_CREDIT_LINK_CATALOGUE_DEFINED')) {
-    define('IHYMNS_CREDIT_LINK_CATALOGUE_DEFINED', true);
-    define('CREDIT_PERSON_LINK_TYPE_CATALOGUE', [
-        'General' => [
-            'official'      => 'Official website',
-            'wikipedia'     => 'Wikipedia',
-            'wikidata'      => 'Wikidata',
-            'musicbrainz'   => 'MusicBrainz',
-            'discogs'       => 'Discogs',
-            'imslp'         => 'IMSLP',
-            'hymnary'       => 'Hymnary',
-        ],
-        'Music streaming / stores' => [
-            'spotify'       => 'Spotify',
-            'apple_music'   => 'Apple Music',
-            'youtube_music' => 'YouTube Music',
-            'amazon_music'  => 'Amazon Music',
-            'tidal'         => 'Tidal',
-            'qobuz'         => 'Qobuz',
-            'pandora'       => 'Pandora',
-            'bandcamp'      => 'Bandcamp',
-            'soundcloud'    => 'SoundCloud',
-        ],
-        'Social media' => [
-            'facebook'      => 'Facebook',
-            'instagram'     => 'Instagram',
-            'twitter'       => 'Twitter / X',
-            'tiktok'        => 'TikTok',
-            'youtube'       => 'YouTube',
-            'snapchat'      => 'Snapchat',
-            'threads'       => 'Threads',
-            'mastodon'      => 'Mastodon',
-        ],
-        'Other' => [
-            'other'         => 'Other (free text)',
-        ],
+if (!defined('IHYMNS_CREDIT_LINK_LEGACY_SLUG_MAP_DEFINED')) {
+    define('IHYMNS_CREDIT_LINK_LEGACY_SLUG_MAP_DEFINED', true);
+    define('CREDIT_PERSON_LEGACY_SLUG_MAP', [
+        /* Direct passes (the registry slug IS the form slug) */
+        'wikipedia'             => 'wikipedia',
+        'wikidata'              => 'wikidata',
+        'discogs'               => 'discogs',
+        'imslp'                 => 'imslp',
+        'viaf'                  => 'viaf',
+        'linkedin'              => 'linkedin',
+        'instagram'             => 'instagram',
+        'facebook'              => 'facebook',
+        'mastodon'              => 'mastodon',
+        'youtube'               => 'youtube',
+        'spotify'               => 'spotify',
+        'bandcamp'              => 'bandcamp',
+        'soundcloud'            => 'soundcloud',
+        /* Aliases the #586 catalogue used (and other common variants) */
+        'wiki'                  => 'wikipedia',
+        'petrucci'              => 'imslp',
+        'hymnary'               => 'hymnary-org',
+        'hymnary.org'           => 'hymnary-org',
+        'hymnary-org'           => 'hymnary-org',
+        'website'               => 'official-website',
+        'official'              => 'official-website',
+        'official-website'      => 'official-website',
+        'home'                  => 'official-website',
+        'homepage'              => 'official-website',
+        'musicbrainz'           => 'musicbrainz-artist',
+        'mb'                    => 'musicbrainz-artist',
+        'musicbrainz-artist'    => 'musicbrainz-artist',
+        'loc'                   => 'loc-name-authority',
+        'library-of-congress'   => 'loc-name-authority',
+        'loc-name-authority'    => 'loc-name-authority',
+        'findagrave'            => 'find-a-grave',
+        'find-a-grave'          => 'find-a-grave',
+        'goodreads'             => 'goodreads-author',
+        'goodreads-author'      => 'goodreads-author',
+        'twitter'               => 'twitter-x',
+        'x'                     => 'twitter-x',
+        'twitter-x'             => 'twitter-x',
+        'apple_music'           => 'apple-music',
+        'apple-music'           => 'apple-music',
+        'itunes'                => 'apple-music',
+        'youtube_music'         => 'youtube-music',
+        'youtube-music'         => 'youtube-music',
+        'archive.org'           => 'internet-archive',
+        'archive'               => 'internet-archive',
+        'internet-archive'      => 'internet-archive',
+        'cyber-hymnal'          => 'cyber-hymnal',
+        'cyberhymnal'           => 'cyber-hymnal',
     ]);
-    /* Flat lookup used by the normaliser's allowlist + by the JS-side
-       serialiser when it needs to validate keys client-side. */
-    define('CREDIT_PERSON_LINK_TYPE_KEYS',
-        array_keys(array_merge(...array_values(CREDIT_PERSON_LINK_TYPE_CATALOGUE))));
+}
+
+/**
+ * Resolve the `tblExternalLinkTypes.Id` for a credit-person link row.
+ *
+ * Accepts either a numeric `type_id` (preferred — the /manage/credit-people
+ * form uses the shared editor module so values are already registry
+ * IDs) or a legacy slug string (`type`) which gets coerced via
+ * CREDIT_PERSON_LEGACY_SLUG_MAP and looked up in the registry.
+ * Returns null when neither path resolves — the caller drops the
+ * row from the normaliser output, matching the pre-#833 behaviour
+ * where unknown types collapsed to 'other'.
+ */
+function resolveCreditPersonLinkTypeId(\mysqli $db, mixed $rawTypeId, mixed $rawSlug): ?int
+{
+    static $registryIds = null;
+    static $slugToId    = null;
+    if ($registryIds === null) {
+        $registryIds = [];
+        $slugToId    = [];
+        try {
+            $res = $db->query(
+                'SELECT Id, Slug FROM tblExternalLinkTypes WHERE COALESCE(IsActive, 1) = 1'
+            );
+            if ($res) {
+                while ($r = $res->fetch_assoc()) {
+                    $registryIds[(int)$r['Id']]     = true;
+                    $slugToId[(string)$r['Slug']]   = (int)$r['Id'];
+                }
+                $res->close();
+            }
+        } catch (\Throwable $_e) { /* leave maps empty — caller falls through */ }
+    }
+
+    /* New shape — caller already has a numeric id. Trust it provided
+       it exists in the active registry. */
+    $typeId = (int)($rawTypeId ?? 0);
+    if ($typeId > 0 && isset($registryIds[$typeId])) return $typeId;
+
+    /* Legacy shape — coerce the slug via the alias map, then look up. */
+    $slugIn = trim((string)($rawSlug ?? ''));
+    if ($slugIn === '') return null;
+    $resolved = CREDIT_PERSON_LEGACY_SLUG_MAP[mb_strtolower($slugIn)] ?? 'other';
+    return $slugToId[$resolved] ?? null;
 }
 
 /**
  * Normalise the per-person external-link sub-form. Drops empty rows
- * (no URL), coerces unknown types to 'other', and returns
- * INSERT-ready row arrays.
+ * (no URL), resolves either numeric `type_id` (new editor) or legacy
+ * `type` slug strings to a `tblExternalLinkTypes.Id`, and returns
+ * INSERT-ready row arrays shaped for `tblCreditPersonExternalLinks`.
  *
  * Accepts either the form-array shape from /manage/credit-people
- * (`links[i][type|url|label]`) or the JSON shape from /api.php
- * (`links[]: {type, url, label}`). The shape is identical once
- * decoded, so one normaliser covers both surfaces.
+ * (`links[i][type_id|type|url|label]`) or the JSON shape from
+ * /api.php (`links[]: {type_id|type, url, label}`).
  *
- * @param mixed $raw Form / JSON-decoded array; non-array → []
- * @return list<array{type:string,url:string,label:?string,sort_order:int}>
+ * Rows whose type can't be resolved to a registry id are dropped
+ * silently — same outcome the pre-#833 normaliser produced for
+ * unknown slug strings (it folded them into 'other'; here we
+ * require the 'other' row itself to exist in the registry).
+ *
+ * @param \mysqli $db   Needed to resolve slug → registry id.
+ * @param mixed   $raw  Form / JSON-decoded array; non-array → []
+ * @return list<array{type_id:int,url:string,label:?string,sort_order:int}>
  */
-function normaliseCreditPersonLinks(mixed $raw): array
+function normaliseCreditPersonLinks(\mysqli $db, mixed $raw): array
 {
     if (!is_array($raw)) return [];
     $out = [];
@@ -101,15 +171,10 @@ function normaliseCreditPersonLinks(mixed $raw): array
         if (!is_array($row)) continue;
         $url = trim((string)($row['url'] ?? ''));
         if ($url === '') continue;
-        $type = trim((string)($row['type'] ?? 'other'));
-        /* Unknown types collapse to 'other' rather than 500ing —
-           keeps a forward-compatible UI where a future picker
-           category gets dropped to a sane bucket on older servers. */
-        if (!in_array($type, CREDIT_PERSON_LINK_TYPE_KEYS, true)) {
-            $type = 'other';
-        }
+        $typeId = resolveCreditPersonLinkTypeId($db, $row['type_id'] ?? null, $row['type'] ?? null);
+        if ($typeId === null) continue;
         $out[] = [
-            'type'       => $type,
+            'type_id'    => $typeId,
             'url'        => $url,
             'label'      => trim((string)($row['label'] ?? '')) ?: null,
             'sort_order' => (int)($row['sort_order'] ?? $i),

--- a/appWeb/public_html/includes/external_link_helpers.php
+++ b/appWeb/public_html/includes/external_link_helpers.php
@@ -199,9 +199,10 @@ function saveExternalLinksForRow(
        caller, but we still guard against accidental mistypes leaking
        into an unescaped SQL identifier position. */
     $allowedTables = [
-        'tblSongbookExternalLinks' => 'SongbookId',
-        'tblWorkExternalLinks'     => 'WorkId',
-        'tblSongExternalLinks'     => 'SongId',
+        'tblSongbookExternalLinks'     => 'SongbookId',
+        'tblWorkExternalLinks'         => 'WorkId',
+        'tblSongExternalLinks'         => 'SongId',
+        'tblCreditPersonExternalLinks' => 'CreditPersonId',
     ];
     if (!isset($allowedTables[$table]) || $allowedTables[$table] !== $fkColumn) {
         throw new \InvalidArgumentException("Unknown external-links table/fk: $table/$fkColumn");
@@ -273,9 +274,10 @@ function loadExternalLinksForRow(
     mixed   $fkValue
 ): array {
     $allowedTables = [
-        'tblSongbookExternalLinks' => 'SongbookId',
-        'tblWorkExternalLinks'     => 'WorkId',
-        'tblSongExternalLinks'     => 'SongId',
+        'tblSongbookExternalLinks'     => 'SongbookId',
+        'tblWorkExternalLinks'         => 'WorkId',
+        'tblSongExternalLinks'         => 'SongId',
+        'tblCreditPersonExternalLinks' => 'CreditPersonId',
     ];
     if (!isset($allowedTables[$table]) || $allowedTables[$table] !== $fkColumn) {
         throw new \InvalidArgumentException("Unknown external-links table/fk: $table/$fkColumn");

--- a/appWeb/public_html/manage/credit-people.php
+++ b/appWeb/public_html/manage/credit-people.php
@@ -95,12 +95,16 @@ $logCreditPerson = static function (string $action, string $entityId, array $det
  * thin wrappers so the existing call sites below ($normaliseLinks,
  * $normaliseIpi, _cpFlagsColumnsExist) keep working unchanged.
  * ---------------------------------------------------------------------- */
-$LINK_TYPE_CATALOGUE = CREDIT_PERSON_LINK_TYPE_CATALOGUE;
-$LINK_TYPE_KEYS      = CREDIT_PERSON_LINK_TYPE_KEYS;
 $ALIAS_TYPES         = CREDIT_PERSON_ALIAS_TYPES;
-$normaliseLinks      = static fn(mixed $raw): array => normaliseCreditPersonLinks($raw);
+$normaliseLinks      = static fn(\mysqli $db, mixed $raw): array => normaliseCreditPersonLinks($db, $raw);
 $normaliseIpi        = static fn(mixed $raw): array => normaliseCreditPersonIpi($raw);
 $normaliseAliases    = static fn(mixed $raw): array => normaliseCreditPersonAliases($raw);
+
+/* External-link type registry — pulled inside each action handler
+   below from $linkTypesForPerson, populated near the page-render
+   section once $db is in scope. */
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes'
+    . DIRECTORY_SEPARATOR . 'external_link_helpers.php';
 
 /* Wrapper kept under the original snake_case private-prefix name so
    existing call sites in this file keep working without further
@@ -220,7 +224,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $deathPlace  = trim((string)($_POST['death_place']  ?? '')) ?: null;
                 $deathDate   = trim((string)($_POST['death_date']   ?? '')) ?: null;
                 $notes       = $notesRaw !== '' ? $notesRaw : null;
-                $links       = $normaliseLinks($_POST['links']     ?? null);
+                $links       = $normaliseLinks($db, $_POST['links']     ?? null);
                 $ipi         = $normaliseIpi($_POST['ipi']         ?? null);
                 $aliases     = $normaliseAliases($_POST['aliases'] ?? null);
                 /* #584 / #585 — classification flags. The two are
@@ -356,13 +360,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
                     if ($links) {
                         $linkStmt = $db->prepare(
-                            'INSERT INTO tblCreditPersonLinks
-                                (CreditPersonId, LinkType, Url, Label, SortOrder)
+                            'INSERT INTO tblCreditPersonExternalLinks
+                                (CreditPersonId, LinkTypeId, Url, Note, SortOrder)
                              VALUES (?, ?, ?, ?, ?)'
                         );
                         foreach ($links as $l) {
-                            $linkStmt->bind_param('isssi',
-                                $newId, $l['type'], $l['url'], $l['label'], $l['sort_order']);
+                            $linkStmt->bind_param('iissi',
+                                $newId, $l['type_id'], $l['url'], $l['label'], $l['sort_order']);
                             $linkStmt->execute();
                         }
                         $linkStmt->close();
@@ -426,7 +430,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $deathPlace  = trim((string)($_POST['death_place']  ?? '')) ?: null;
                 $deathDate   = trim((string)($_POST['death_date']   ?? '')) ?: null;
                 $notes       = $notesRaw !== '' ? $notesRaw : null;
-                $links       = $normaliseLinks($_POST['links']     ?? null);
+                $links       = $normaliseLinks($db, $_POST['links']     ?? null);
                 $ipi         = $normaliseIpi($_POST['ipi']         ?? null);
                 $aliases     = $normaliseAliases($_POST['aliases'] ?? null);
                 $isSpecialCase = !empty($_POST['is_special_case']) ? 1 : 0;
@@ -525,19 +529,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                        diffing and the per-person row counts are small
                        (typically < 10 each). The child Ids change as a
                        side effect, but no other table references them. */
-                    $del = $db->prepare('DELETE FROM tblCreditPersonLinks WHERE CreditPersonId = ?');
+                    $del = $db->prepare('DELETE FROM tblCreditPersonExternalLinks WHERE CreditPersonId = ?');
                     $del->bind_param('i', $id);
                     $del->execute();
                     $del->close();
                     if ($links) {
                         $linkStmt = $db->prepare(
-                            'INSERT INTO tblCreditPersonLinks
-                                (CreditPersonId, LinkType, Url, Label, SortOrder)
+                            'INSERT INTO tblCreditPersonExternalLinks
+                                (CreditPersonId, LinkTypeId, Url, Note, SortOrder)
                              VALUES (?, ?, ?, ?, ?)'
                         );
                         foreach ($links as $l) {
-                            $linkStmt->bind_param('isssi',
-                                $id, $l['type'], $l['url'], $l['label'], $l['sort_order']);
+                            $linkStmt->bind_param('iissi',
+                                $id, $l['type_id'], $l['url'], $l['label'], $l['sort_order']);
                             $linkStmt->execute();
                         }
                         $linkStmt->close();
@@ -798,7 +802,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
                     /* Count links currently on the source so we can report
                        kept-vs-dropped accurately. */
-                    $stmt = $db->prepare('SELECT Id FROM tblCreditPersonLinks WHERE CreditPersonId = ?');
+                    $stmt = $db->prepare('SELECT Id FROM tblCreditPersonExternalLinks WHERE CreditPersonId = ?');
                     $stmt->bind_param('i', $sourceId);
                     $stmt->execute();
                     $sourceLinkIds = array_column($stmt->get_result()->fetch_all(MYSQLI_ASSOC), 'Id');
@@ -817,7 +821,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         $toMove = array_intersect($keepLinks, array_map('intval', $sourceLinkIds));
                         if ($toMove) {
                             $upd = $db->prepare(
-                                'UPDATE tblCreditPersonLinks SET CreditPersonId = ? WHERE Id = ? AND CreditPersonId = ?'
+                                'UPDATE tblCreditPersonExternalLinks SET CreditPersonId = ? WHERE Id = ? AND CreditPersonId = ?'
                             );
                             foreach ($toMove as $lid) {
                                 $upd->bind_param('iii', $targetId, $lid, $sourceId);
@@ -1047,7 +1051,7 @@ try {
                p.DeathPlace,
                p.DeathDate,
                p.UpdatedAt,
-               (SELECT COUNT(*) FROM tblCreditPersonLinks l WHERE l.CreditPersonId = p.Id) AS LinkCount,
+               (SELECT COUNT(*) FROM tblCreditPersonExternalLinks l WHERE l.CreditPersonId = p.Id) AS LinkCount,
                (SELECT COUNT(*) FROM tblCreditPersonIPI   i WHERE i.CreditPersonId = p.Id) AS IPICount
                {$flagCols}
                {$namePartCols}
@@ -1067,21 +1071,27 @@ try {
     $ipiByPerson     = [];
     $aliasesByPerson = [];
     $stmt = $db->prepare(
-        'SELECT Id, CreditPersonId, LinkType, Url, Label, SortOrder
-           FROM tblCreditPersonLinks
+        'SELECT Id, CreditPersonId, LinkTypeId, Url, Note, SortOrder, Verified
+           FROM tblCreditPersonExternalLinks
           ORDER BY CreditPersonId ASC, SortOrder ASC, Id ASC'
     );
     $stmt->execute();
     foreach ($stmt->get_result()->fetch_all(MYSQLI_ASSOC) as $l) {
         $linksByPerson[(int)$l['CreditPersonId']][] = [
             'id'         => (int)$l['Id'],
-            'type'       => (string)$l['LinkType'],
+            'type_id'    => (int)$l['LinkTypeId'],
             'url'        => (string)$l['Url'],
-            'label'      => $l['Label'],
+            'label'      => $l['Note'],
             'sort_order' => (int)$l['SortOrder'],
+            'verified'   => (int)$l['Verified'],
         ];
     }
     $stmt->close();
+
+    /* #833 — load the registry for the edit drawer's link-type dropdown,
+       once per page. Powers window._iHymnsLinkTypes for the shared
+       editor module, and the inline <option> seed below. */
+    $linkTypesForPerson = loadExternalLinkTypesFor($db, 'person');
 
     $stmt = $db->prepare(
         'SELECT Id, CreditPersonId, IPINumber, NameUsed, Notes
@@ -1989,15 +1999,56 @@ $totalInUseUnregistered = count(array_filter($people, static fn($p) =>
     <!-- Templates for the repeating sub-form rows. {i} placeholder gets
          replaced by the JS with the row's array index so PHP receives
          them as $_POST['links'][i][...] and $_POST['ipi'][i][...]. -->
+    <?php
+        /* Build the link-type dropdown from the tblExternalLinkTypes
+           registry instead of the deprecated PHP catalogue (#586 →
+           unified into tblExternalLinkTypes). Grouped by Category for
+           the <optgroup>; the values are the numeric registry Ids so
+           the auto-detect module's default slugToOptionValue() lookup
+           (which cross-references window._iHymnsLinkTypes by id) does
+           the right thing without the per-page translation kludge. */
+        $linkOptionsByCat = [];
+        foreach ($linkTypesForPerson as $lt) {
+            $cat = (string)($lt['category'] ?? 'other');
+            if (!isset($linkOptionsByCat[$cat])) $linkOptionsByCat[$cat] = [];
+            $linkOptionsByCat[$cat][] = $lt;
+        }
+        $linkCatLabels = [
+            'official'    => 'Official',
+            'information' => 'Information',
+            'read'        => 'Read',
+            'sheet-music' => 'Sheet music',
+            'listen'      => 'Listen',
+            'watch'       => 'Watch',
+            'purchase'    => 'Purchase',
+            'authority'   => 'Authority',
+            'social'      => 'Social',
+            'other'       => 'Other',
+        ];
+        $linkCatOrder = ['official','information','read','sheet-music','listen','watch','purchase','authority','social','other'];
+    ?>
     <template id="cp-link-row-template">
         <div class="d-flex gap-1 align-items-start cp-link-row" data-row-kind="link">
-            <select class="form-select form-select-sm" style="min-width: 160px; max-width: 200px;" name="links[{i}][type]">
-                <?php foreach ($LINK_TYPE_CATALOGUE as $groupLabel => $items): ?>
-                    <optgroup label="<?= htmlspecialchars($groupLabel) ?>">
-                        <?php foreach ($items as $key => $label): ?>
-                            <option value="<?= htmlspecialchars($key) ?>"<?= $key === 'official' ? ' selected' : '' ?>>
-                                <?= htmlspecialchars($label) ?>
-                            </option>
+            <select class="form-select form-select-sm" style="min-width: 160px; max-width: 200px;" name="links[{i}][type_id]">
+                <option value="">— pick a link type —</option>
+                <?php foreach ($linkCatOrder as $catKey): ?>
+                    <?php if (empty($linkOptionsByCat[$catKey])) continue; ?>
+                    <optgroup label="<?= htmlspecialchars($linkCatLabels[$catKey] ?? $catKey) ?>">
+                        <?php foreach ($linkOptionsByCat[$catKey] as $lt): ?>
+                            <option value="<?= (int)$lt['id'] ?>"><?= htmlspecialchars((string)$lt['name']) ?></option>
+                        <?php endforeach; ?>
+                    </optgroup>
+                <?php endforeach; ?>
+                <?php
+                    /* Catch-all for any category the labels map doesn't cover —
+                       guarantees a new registry category shows up rather than
+                       silently disappearing. */
+                    $leftoverCats = array_diff(array_keys($linkOptionsByCat), $linkCatOrder);
+                    foreach ($leftoverCats as $cat):
+                ?>
+                    <optgroup label="<?= htmlspecialchars($cat) ?>">
+                        <?php foreach ($linkOptionsByCat[$cat] as $lt): ?>
+                            <option value="<?= (int)$lt['id'] ?>"><?= htmlspecialchars((string)$lt['name']) ?></option>
                         <?php endforeach; ?>
                     </optgroup>
                 <?php endforeach; ?>
@@ -2010,6 +2061,12 @@ $totalInUseUnregistered = count(array_filter($people, static fn($p) =>
             </button>
         </div>
     </template>
+    <!-- Registry payload for the shared iHymnsLinkDetect module so the
+         default slugToOptionValue lookup can resolve detected slugs
+         to the numeric option values in the template above. -->
+    <script>
+        window._iHymnsLinkTypes = <?= json_encode($linkTypesForPerson, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?>;
+    </script>
     <template id="cp-ipi-row-template">
         <div class="d-flex gap-1 align-items-start cp-ipi-row" data-row-kind="ipi">
             <input type="text" class="form-control form-control-sm" style="max-width: 140px;" name="ipi[{i}][number]" placeholder="IPI number" required>
@@ -2140,54 +2197,17 @@ $totalInUseUnregistered = count(array_filter($people, static fn($p) =>
             let ipiIndex   = 0;
             let aliasIndex = 0;
 
-            /* Translation map from the shared iHymnsLinkDetect slug
-               vocabulary (driven by tblExternalLinkTypes + the bundled
-               RULES array) to the credit-people-specific link-type keys
-               in CREDIT_PERSON_LINK_TYPE_CATALOGUE.
-
-               TODO (followup): unify credit-people storage onto
-               tblExternalLinkTypes so this map can disappear and the
-               same shared editor module can drive this surface too. */
-            const CP_DETECT_SLUG_TO_KEY = {
-                'wikipedia':            'wikipedia',
-                'wikidata':             'wikidata',
-                'musicbrainz-artist':   'musicbrainz',
-                'musicbrainz-work':     'musicbrainz',
-                'musicbrainz-recording':'musicbrainz',
-                'discogs':              'discogs',
-                'imslp':                'imslp',
-                'hymnary-org':          'hymnary',
-                'spotify':              'spotify',
-                'apple-music':          'apple_music',
-                'youtube-music':        'youtube_music',
-                'bandcamp':             'bandcamp',
-                'soundcloud':           'soundcloud',
-                'youtube':              'youtube',
-                'facebook':             'facebook',
-                'instagram':            'instagram',
-                'twitter-x':            'twitter',
-                'mastodon':             'mastodon',
-            };
-
-            /* Wire the credit-people link row to the shared
-               iHymnsLinkDetect module. The credit-people <select>
-               values ARE the credit-people key (e.g. 'apple_music'),
-               not a numeric tblExternalLinkTypes.Id, so the standard
-               slugToOptionValue helper doesn't fit — we pass a
-               slugLookup that walks our translation map and returns the
-               matching option value when present. */
+            /* Wire each credit-people link row to the shared
+               iHymnsLinkDetect module. The dropdown's option values
+               are now numeric tblExternalLinkTypes.Id (post-#833
+               unification), so the module's default slugToOptionValue
+               lookup (cross-referencing window._iHymnsLinkTypes by
+               id) Just Works — no per-page translation map needed
+               any more. */
             function wireCpLinkRowAutoDetect(row) {
                 if (!window.iHymnsLinkDetect || typeof window.iHymnsLinkDetect.attachAutoDetect !== 'function') return;
                 window.iHymnsLinkDetect.attachAutoDetect(row, {
-                    selectSelector: 'select[name$="[type]"]',
-                    slugLookup: function (slug, selectEl) {
-                        const key = CP_DETECT_SLUG_TO_KEY[slug];
-                        if (!key || !selectEl) return '';
-                        for (let i = 0; i < selectEl.options.length; i++) {
-                            if (selectEl.options[i].value === key) return key;
-                        }
-                        return '';
-                    },
+                    selectSelector: 'select[name$="[type_id]"]',
                 });
             }
 
@@ -2201,7 +2221,7 @@ $totalInUseUnregistered = count(array_filter($people, static fn($p) =>
                 const row = linksBox.lastElementChild;
                 if (prefill) {
                     const sel = row.querySelector('select');
-                    if (sel) sel.value = prefill.type || 'other';
+                    if (sel && prefill.type_id) sel.value = String(prefill.type_id);
                     const url = row.querySelector('input[type="url"]');
                     if (url) url.value = prefill.url || '';
                     const lbl = row.querySelector('input[name$="[label]"]');
@@ -2210,8 +2230,9 @@ $totalInUseUnregistered = count(array_filter($people, static fn($p) =>
                     if (ord && prefill.sort_order !== undefined) ord.value = prefill.sort_order;
                 }
                 /* Auto-detect provider from the pasted URL — same
-                   global module the other admin surfaces use, with a
-                   per-page slug translation. */
+                   shared module every other admin surface uses, now
+                   with no translation map since the option values
+                   are numeric registry ids. */
                 wireCpLinkRowAutoDetect(row);
                 return row;
             }

--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -1707,22 +1707,88 @@ switch ($action) {
                 error_log('[editor save_song] SongCount recompute failed: ' . $_e->getMessage());
             }
 
+            /* #833 — persist song-level external links when the client
+               opted into the new editor section by sending the
+               `externalLinks` key. The legacy / pre-#833 clients
+               (bulk-import path, older editor snapshots) omit the key
+               entirely and the existing rows stay untouched. The shared
+               saver expects four parallel arrays in the canonical
+               ext_link_*[] shape, so we unpack the JSON list of
+               {typeId, url, note, verified} into that shape inline.
+               Runs before the song.edit / song.create logActivity row
+               below so the inserted-link count can be folded into the
+               audit payload (mirroring the songbook / work surfaces'
+               external_link_count audit field). */
+            $externalLinkCount = null;
+            if (array_key_exists('externalLinks', $song)) {
+                try {
+                    require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'includes'
+                        . DIRECTORY_SEPARATOR . 'external_link_helpers.php';
+                    $extProbe = $db->query(
+                        "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+                          WHERE TABLE_SCHEMA = DATABASE()
+                            AND TABLE_NAME   = 'tblSongExternalLinks' LIMIT 1"
+                    );
+                    $hasExtTable = $extProbe && $extProbe->fetch_row() !== null;
+                    if ($extProbe) $extProbe->close();
+
+                    if ($hasExtTable) {
+                        $linkRows  = is_array($song['externalLinks']) ? $song['externalLinks'] : [];
+                        $typeIds   = [];
+                        $urls      = [];
+                        $notes     = [];
+                        $verified  = [];
+                        foreach ($linkRows as $row) {
+                            if (!is_array($row)) continue;
+                            $typeIds[]  = (int)($row['typeId'] ?? 0);
+                            $urls[]     = (string)($row['url'] ?? '');
+                            $notes[]    = (string)($row['note'] ?? '');
+                            $verified[] = !empty($row['verified']) ? '1' : '';
+                        }
+                        $externalLinkCount = saveExternalLinksForRow(
+                            $db,
+                            'tblSongExternalLinks',
+                            'SongId',
+                            $songId,
+                            $typeIds,
+                            $urls,
+                            $notes,
+                            $verified
+                        );
+                    }
+                } catch (\Throwable $_e) {
+                    /* Match the Works-auto-link pattern — link
+                       reconciliation must not block the core save.
+                       The user's metadata edit is already committed
+                       below; a link write failure surfaces in
+                       error_log + audit but doesn't 500 the request. */
+                    error_log('[editor save_song] external-links reconcile failed: ' . $_e->getMessage());
+                }
+            }
+
             /* Activity log (#535) — high-level "song.create" / "song.edit"
                row with a cross-link to the revisions row above so a
                timeline reader can drill into the full before/after diff
-               without bloating Details here. */
+               without bloating Details here. external_link_count is
+               null when the client didn't opt into the externalLinks
+               key (e.g. bulk-import path); otherwise it carries the
+               number of rows inserted by the reconcile above. */
             if (function_exists('logActivity')) {
+                $logDetails = [
+                    'title'         => $title,
+                    'songbook'      => $songbookAbbr,
+                    'number'        => $number,
+                    'verified'      => (bool)$verified,
+                    'revision_id'   => $revisionId,
+                ];
+                if ($externalLinkCount !== null) {
+                    $logDetails['external_link_count'] = $externalLinkCount;
+                }
                 logActivity(
                     $action === 'create' ? 'song.create' : 'song.edit',
                     'song',
                     $songId,
-                    [
-                        'title'         => $title,
-                        'songbook'      => $songbookAbbr,
-                        'number'        => $number,
-                        'verified'      => (bool)$verified,
-                        'revision_id'   => $revisionId,
-                    ]
+                    $logDetails
                 );
             }
 
@@ -1839,60 +1905,6 @@ switch ($action) {
                        core song save. The user's edit is already
                        captured in tblSongs + tblSongRevisions. */
                     error_log('[editor save_song] Works auto-link failed: ' . $_e->getMessage());
-                }
-            }
-
-            /* #833 — persist song-level external links when the client
-               opted into the new editor section by sending the
-               `externalLinks` key. The legacy / pre-#833 clients
-               (bulk-import path, older editor snapshots) omit the key
-               entirely and the existing rows stay untouched. The shared
-               saver expects four parallel arrays in the canonical
-               ext_link_*[] shape, so we unpack the JSON list of
-               {typeId, url, note, verified} into that shape inline. */
-            if (array_key_exists('externalLinks', $song)) {
-                try {
-                    require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'includes'
-                        . DIRECTORY_SEPARATOR . 'external_link_helpers.php';
-                    $extProbe = $db->query(
-                        "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
-                          WHERE TABLE_SCHEMA = DATABASE()
-                            AND TABLE_NAME   = 'tblSongExternalLinks' LIMIT 1"
-                    );
-                    $hasExtTable = $extProbe && $extProbe->fetch_row() !== null;
-                    if ($extProbe) $extProbe->close();
-
-                    if ($hasExtTable) {
-                        $linkRows  = is_array($song['externalLinks']) ? $song['externalLinks'] : [];
-                        $typeIds   = [];
-                        $urls      = [];
-                        $notes     = [];
-                        $verified  = [];
-                        foreach ($linkRows as $row) {
-                            if (!is_array($row)) continue;
-                            $typeIds[]  = (int)($row['typeId'] ?? 0);
-                            $urls[]     = (string)($row['url'] ?? '');
-                            $notes[]    = (string)($row['note'] ?? '');
-                            $verified[] = !empty($row['verified']) ? '1' : '';
-                        }
-                        saveExternalLinksForRow(
-                            $db,
-                            'tblSongExternalLinks',
-                            'SongId',
-                            $songId,
-                            $typeIds,
-                            $urls,
-                            $notes,
-                            $verified
-                        );
-                    }
-                } catch (\Throwable $_e) {
-                    /* Match the Works-auto-link pattern — link
-                       reconciliation must not block the core save.
-                       The user's metadata edit is already committed
-                       below; a link write failure surfaces in
-                       error_log + audit but doesn't 500 the request. */
-                    error_log('[editor save_song] external-links reconcile failed: ' . $_e->getMessage());
                 }
             }
 


### PR DESCRIPTION
Three follow-ups to PR #985, layered onto the same branch.

## 1. Song save audit log — include `external_link_count`

The songbook and work admin pages already log `external_link_count` on every save so a curator triaging tblActivityLog can tell at a glance whether a save changed link rows. The song editor's `save_song` handler was missing the field — link edits were invisible in the audit timeline even though the underlying reconcile fired correctly.

Reordered the external-links reconcile to run **before** the `song.create` / `song.edit` `logActivity` call so the inserted-link count is in scope when the audit row is built. The reconcile still runs inside the same transaction. The field is omitted (not 0) when the client didn't opt into the `externalLinks` key — keeps "no link write" distinguishable from "client cleared all links".

Commit: `feat(editor): include external_link_count in song save audit log`

## 2. Credit-people storage unification

Credit-people was the last admin surface still writing links to the legacy `tblCreditPersonLinks` table with free-text LinkType slug strings from the hardcoded `CREDIT_PERSON_LINK_TYPE_CATALOGUE`. The schema / public render had moved to `tblCreditPersonExternalLinks` + `tblExternalLinkTypes` FK since #833 — only the write path was lagging, so post-#833 curator edits sat in the legacy table until the backfill migration ran again. The auto-detect dropdown needed a per-page slug-translation map (`CP_DETECT_SLUG_TO_KEY`) because the two vocabularies had drifted.

This commit moves the credit-people write path onto the same `tblExternalLinkTypes`-backed storage every other surface uses:

- **Form save** (`/manage/credit-people.php`, actions `add` / `update_person` / `rename`) now writes to `tblCreditPersonExternalLinks` with numeric `LinkTypeId` FKs.
- **Form prefill** reads from the new table too, surfacing the curator's most recent edits without needing a backfill cycle.
- **`/api.php`** `admin_credit_person_add` / `_update` endpoints write to the new table on the same code path.
- The drawer's `<select>` is populated from the live registry (`loadExternalLinkTypesFor($db, 'person')`) grouped by Category, rather than the static `CREDIT_PERSON_LINK_TYPE_CATALOGUE`.
- **`CP_DETECT_SLUG_TO_KEY` is gone** — the dropdown's option values are now the same numeric registry IDs every other surface uses, so `iHymnsLinkDetect`'s default `slugToOptionValue()` (which cross-references `window._iHymnsLinkTypes` by id) Just Works.
- `saveExternalLinksForRow()` gains `tblCreditPersonExternalLinks ↔ CreditPersonId` in its allowlist so future writes can flow through the shared saver too.

**Back-compat preserved**: `/api.php` callers that historically sent legacy `type` slug strings (rather than `type_id` numeric) still work — the normaliser falls through to a slug → registry-id resolver that mirrors the backfill migration's mapping table (`apple_music` → `apple-music`, `twitter` → `twitter-x`, etc.). Unrecognised slugs collapse to `'other'` — same fallback the backfill applies.

The legacy `tblCreditPersonLinks` table is **NOT** dropped here — `index.php` and `pages/person.php` still keep their read-fallback against it for one release cycle (matching the policy from the backfill migration's docblock), so any pre-deploy edits that hadn't yet been backfilled stay visible on the public surface. A follow-up migration will retire the legacy table once we're confident the new system has been the canonical write path long enough.

Commit: `refactor(credit-people): unify external-link storage onto tblExternalLinkTypes`

## 3. Responsive credit-people sub-form rows (+ alias remove-button bug)

The credit-people drawer's three repeating sub-forms — **External Links**, **IPI Numbers**, **AKA / Aliases** — used a hand-rolled `d-flex gap-1` that pinned every input to one horizontal line. On narrow mobile widths the URL / Label / Name fields got crushed to one or two visible characters (reported by the user with a screenshot of editing Graham Kendrick).

Rewrites each template using the same card + Bootstrap `row g-2 col-md-N` pattern the shared `external-links-editor.js` already uses on the songbook / work / song surfaces. Below the `md` breakpoint each input stacks full-width; at `md+` they lay out side-by-side as before. Visually consistent with how the other admin pages already render their card-list editors on a phone.

| Row | Wide (`md+`) | Narrow (`<md`) |
|---|---|---|
| **Link** | Type (5) \| URL (7), then Label (12) | each input stacks |
| **IPI** | Number (4) \| NameUsed (8), then Notes (12) | each input stacks |
| **Alias** | Name (5) \| Type (4) \| Locale (3) | each input stacks |

The other admin surfaces (songbook, work, song editor) were already responsive — the shared `external-links-editor.js` module uses `col-md-N` cols so they stack below `md` without any changes here. Credit-people was the last bespoke pattern that hadn't picked up the same approach.

**Pre-existing bug fix bundled**: the remove-row delegation listener only matched `.cp-link-row, .cp-ipi-row` in its `.closest()` selector, so clicking ✕ on an alias row never found its parent and did nothing. Added `.cp-alias-row` to the selector.

Commit: `fix(credit-people): responsive sub-form rows + alias remove-button bug`

## ⚠️ Deploy note

Re-run `migrate-backfill-credit-person-links.php` before landing this so any post-initial-backfill edits in `tblCreditPersonLinks` get copied across into `tblCreditPersonExternalLinks`. The migration is idempotent (`INSERT WHERE NOT EXISTS`).

## Test plan

- [ ] Re-run `migrate-backfill-credit-person-links.php` from `/manage/setup-database` first.
- [ ] `/manage/credit-people` Edit drawer on a narrow viewport (≤ 768 px): External Links, IPI Numbers, AKA / Aliases sub-form rows stack vertically; on `≥ md` they lay out side-by-side.
- [ ] Click ✕ on an AKA / Alias row — it now removes (previously did nothing).
- [ ] Open an existing person with external links — drawer shows the same links as the public `/people/<slug>` page.
- [ ] Add a new link, paste a Wikipedia URL → dropdown auto-flips to Wikipedia (no per-page slug map any more).
- [ ] Save → public `/people/<slug>` page reflects the new link immediately.
- [ ] `/api/admin_credit_person_update` with legacy `links[].type` slug shape (e.g. `{"type":"apple_music","url":"..."}`) — still works (backwards compatibility).
- [ ] `/api/admin_credit_person_update` with new `links[].type_id` numeric shape — works.
- [ ] Rename action: links from the source person move to the target person (now via `UPDATE tblCreditPersonExternalLinks` rather than the legacy table).
- [ ] Song editor: save a song with linked external URLs — verify the activity log row carries `external_link_count` in its Details JSON.
- [ ] PHP lint clean on `appWeb/public_html/api.php`, `manage/credit-people.php`, `manage/editor/api.php`, the two helpers.
