### PR TITLE
fix(credit-people): responsive sub-form rows on mobile + alias remove-button bug

### DIFF
--- a/appWeb/public_html/manage/credit-people.php
+++ b/appWeb/public_html/manage/credit-people.php
@@ -2028,37 +2028,56 @@ $totalInUseUnregistered = count(array_filter($people, static fn($p) =>
         $linkCatOrder = ['official','information','read','sheet-music','listen','watch','purchase','authority','social','other'];
     ?>
     <template id="cp-link-row-template">
-        <div class="d-flex gap-1 align-items-start cp-link-row" data-row-kind="link">
-            <select class="form-select form-select-sm" style="min-width: 160px; max-width: 200px;" name="links[{i}][type_id]">
-                <option value="">— pick a link type —</option>
-                <?php foreach ($linkCatOrder as $catKey): ?>
-                    <?php if (empty($linkOptionsByCat[$catKey])) continue; ?>
-                    <optgroup label="<?= htmlspecialchars($linkCatLabels[$catKey] ?? $catKey) ?>">
-                        <?php foreach ($linkOptionsByCat[$catKey] as $lt): ?>
-                            <option value="<?= (int)$lt['id'] ?>"><?= htmlspecialchars((string)$lt['name']) ?></option>
-                        <?php endforeach; ?>
-                    </optgroup>
-                <?php endforeach; ?>
-                <?php
-                    /* Catch-all for any category the labels map doesn't cover —
-                       guarantees a new registry category shows up rather than
-                       silently disappearing. */
-                    $leftoverCats = array_diff(array_keys($linkOptionsByCat), $linkCatOrder);
-                    foreach ($leftoverCats as $cat):
-                ?>
-                    <optgroup label="<?= htmlspecialchars($cat) ?>">
-                        <?php foreach ($linkOptionsByCat[$cat] as $lt): ?>
-                            <option value="<?= (int)$lt['id'] ?>"><?= htmlspecialchars((string)$lt['name']) ?></option>
-                        <?php endforeach; ?>
-                    </optgroup>
-                <?php endforeach; ?>
-            </select>
-            <input type="url" class="form-control form-control-sm" name="links[{i}][url]" placeholder="https://…" required>
-            <input type="text" class="form-control form-control-sm" style="max-width: 140px;" name="links[{i}][label]" placeholder="Label (optional)">
-            <input type="hidden" name="links[{i}][sort_order]" value="{i}">
-            <button type="button" class="btn btn-sm btn-outline-danger cp-row-remove" title="Remove this link" aria-label="Remove this link">
-                <i class="bi bi-x" aria-hidden="true"></i>
-            </button>
+        <div class="card bg-dark border-secondary cp-link-row" data-row-kind="link">
+            <div class="card-body py-2">
+                <div class="d-flex align-items-start gap-2">
+                    <div class="flex-grow-1">
+                        <div class="row g-2 mb-1">
+                            <div class="col-12 col-md-5">
+                                <select class="form-select form-select-sm" name="links[{i}][type_id]">
+                                    <option value="">— pick a link type —</option>
+                                    <?php foreach ($linkCatOrder as $catKey): ?>
+                                        <?php if (empty($linkOptionsByCat[$catKey])) continue; ?>
+                                        <optgroup label="<?= htmlspecialchars($linkCatLabels[$catKey] ?? $catKey) ?>">
+                                            <?php foreach ($linkOptionsByCat[$catKey] as $lt): ?>
+                                                <option value="<?= (int)$lt['id'] ?>"><?= htmlspecialchars((string)$lt['name']) ?></option>
+                                            <?php endforeach; ?>
+                                        </optgroup>
+                                    <?php endforeach; ?>
+                                    <?php
+                                        /* Catch-all for any category the labels map doesn't cover —
+                                           guarantees a new registry category shows up rather than
+                                           silently disappearing. */
+                                        $leftoverCats = array_diff(array_keys($linkOptionsByCat), $linkCatOrder);
+                                        foreach ($leftoverCats as $cat):
+                                    ?>
+                                        <optgroup label="<?= htmlspecialchars($cat) ?>">
+                                            <?php foreach ($linkOptionsByCat[$cat] as $lt): ?>
+                                                <option value="<?= (int)$lt['id'] ?>"><?= htmlspecialchars((string)$lt['name']) ?></option>
+                                            <?php endforeach; ?>
+                                        </optgroup>
+                                    <?php endforeach; ?>
+                                </select>
+                            </div>
+                            <div class="col-12 col-md-7">
+                                <input type="url" class="form-control form-control-sm"
+                                       name="links[{i}][url]" placeholder="https://…" required>
+                            </div>
+                        </div>
+                        <div class="row g-2">
+                            <div class="col-12">
+                                <input type="text" class="form-control form-control-sm"
+                                       name="links[{i}][label]" placeholder="Label (optional)">
+                            </div>
+                        </div>
+                        <input type="hidden" name="links[{i}][sort_order]" value="{i}">
+                    </div>
+                    <button type="button" class="btn btn-sm btn-outline-danger cp-row-remove"
+                            title="Remove this link" aria-label="Remove this link">
+                        <i class="bi bi-x" aria-hidden="true"></i>
+                    </button>
+                </div>
+            </div>
         </div>
     </template>
     <!-- Registry payload for the shared iHymnsLinkDetect module so the
@@ -2068,35 +2087,70 @@ $totalInUseUnregistered = count(array_filter($people, static fn($p) =>
         window._iHymnsLinkTypes = <?= json_encode($linkTypesForPerson, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?>;
     </script>
     <template id="cp-ipi-row-template">
-        <div class="d-flex gap-1 align-items-start cp-ipi-row" data-row-kind="ipi">
-            <input type="text" class="form-control form-control-sm" style="max-width: 140px;" name="ipi[{i}][number]" placeholder="IPI number" required>
-            <input type="text" class="form-control form-control-sm" style="max-width: 180px;" name="ipi[{i}][name_used]" placeholder="Name used (optional)">
-            <input type="text" class="form-control form-control-sm" name="ipi[{i}][notes]" placeholder="Notes (optional)">
-            <button type="button" class="btn btn-sm btn-outline-danger cp-row-remove" title="Remove this IPI" aria-label="Remove this IPI">
-                <i class="bi bi-x" aria-hidden="true"></i>
-            </button>
+        <div class="card bg-dark border-secondary cp-ipi-row" data-row-kind="ipi">
+            <div class="card-body py-2">
+                <div class="d-flex align-items-start gap-2">
+                    <div class="flex-grow-1">
+                        <div class="row g-2 mb-1">
+                            <div class="col-12 col-md-4">
+                                <input type="text" class="form-control form-control-sm"
+                                       name="ipi[{i}][number]" placeholder="IPI number" required>
+                            </div>
+                            <div class="col-12 col-md-8">
+                                <input type="text" class="form-control form-control-sm"
+                                       name="ipi[{i}][name_used]" placeholder="Name used (optional)">
+                            </div>
+                        </div>
+                        <div class="row g-2">
+                            <div class="col-12">
+                                <input type="text" class="form-control form-control-sm"
+                                       name="ipi[{i}][notes]" placeholder="Notes (optional)">
+                            </div>
+                        </div>
+                    </div>
+                    <button type="button" class="btn btn-sm btn-outline-danger cp-row-remove"
+                            title="Remove this IPI" aria-label="Remove this IPI">
+                        <i class="bi bi-x" aria-hidden="true"></i>
+                    </button>
+                </div>
+            </div>
         </div>
     </template>
     <template id="cp-alias-row-template">
-        <div class="d-flex gap-1 align-items-start cp-alias-row" data-row-kind="alias">
-            <input type="text" class="form-control form-control-sm" name="aliases[{i}][name]"
-                   placeholder="Alternative name" maxlength="255" required>
-            <select class="form-select form-select-sm" style="min-width: 130px; max-width: 170px;"
-                    name="aliases[{i}][type]">
-                <?php foreach ($ALIAS_TYPES as $key => $label): ?>
-                    <option value="<?= htmlspecialchars($key) ?>"<?= $key === 'other' ? ' selected' : '' ?>>
-                        <?= htmlspecialchars($label) ?>
-                    </option>
-                <?php endforeach; ?>
-            </select>
-            <input type="text" class="form-control form-control-sm" style="max-width: 90px;"
-                   name="aliases[{i}][locale]" placeholder="Locale" maxlength="35"
-                   title="Optional IETF BCP 47 tag for transliterations (ja, ru-Latn, zh-Hans, …)">
-            <input type="hidden" name="aliases[{i}][sort_order]" value="{i}">
-            <button type="button" class="btn btn-sm btn-outline-danger cp-row-remove"
-                    title="Remove this alias" aria-label="Remove this alias">
-                <i class="bi bi-x" aria-hidden="true"></i>
-            </button>
+        <div class="card bg-dark border-secondary cp-alias-row" data-row-kind="alias">
+            <div class="card-body py-2">
+                <div class="d-flex align-items-start gap-2">
+                    <div class="flex-grow-1">
+                        <div class="row g-2">
+                            <div class="col-12 col-md-5">
+                                <input type="text" class="form-control form-control-sm"
+                                       name="aliases[{i}][name]" placeholder="Alternative name"
+                                       maxlength="255" required>
+                            </div>
+                            <div class="col-12 col-md-4">
+                                <select class="form-select form-select-sm" name="aliases[{i}][type]">
+                                    <?php foreach ($ALIAS_TYPES as $key => $label): ?>
+                                        <option value="<?= htmlspecialchars($key) ?>"<?= $key === 'other' ? ' selected' : '' ?>>
+                                            <?= htmlspecialchars($label) ?>
+                                        </option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </div>
+                            <div class="col-12 col-md-3">
+                                <input type="text" class="form-control form-control-sm"
+                                       name="aliases[{i}][locale]" placeholder="Locale"
+                                       maxlength="35"
+                                       title="Optional IETF BCP 47 tag for transliterations (ja, ru-Latn, zh-Hans, …)">
+                            </div>
+                        </div>
+                        <input type="hidden" name="aliases[{i}][sort_order]" value="{i}">
+                    </div>
+                    <button type="button" class="btn btn-sm btn-outline-danger cp-row-remove"
+                            title="Remove this alias" aria-label="Remove this alias">
+                        <i class="bi bi-x" aria-hidden="true"></i>
+                    </button>
+                </div>
+            </div>
         </div>
     </template>
 
@@ -2522,7 +2576,7 @@ $totalInUseUnregistered = count(array_filter($people, static fn($p) =>
             drawerEl.addEventListener('click', (ev) => {
                 const remove = ev.target.closest('.cp-row-remove');
                 if (!remove) return;
-                const row = remove.closest('.cp-link-row, .cp-ipi-row');
+                const row = remove.closest('.cp-link-row, .cp-ipi-row, .cp-alias-row');
                 if (row) row.remove();
             });
         })();


### PR DESCRIPTION
## Summary

User reported (with screenshot) that the **Edit Person** drawer's External Links, IPI Numbers and AKA / Aliases sub-forms render with crushed inputs on narrow mobile widths — URL fields showing 1–2 visible characters etc. Asked to apply the same responsive treatment "across the iHymns site/application," so I did a thorough audit first.

## Audit results

| Surface | Pattern | Verdict |
|---|---|---|
| **credit-people drawer** — link / IPI / alias `<template>` rows | `d-flex gap-1 align-items-start` with bare sibling `<input>` / `<select>` and `style="max-width:140px"` inline | ❌ **CRAMPED — fix needed** |
| Songbook / work / song-editor external links | Shared `external-links-editor.js` already builds `<div class="row g-2">` + `col-md-N` | ✅ Already responsive |
| Songbook alt-names row | Vertical stack inside `flex-grow-1` | ✅ Already responsive |
| Song editor component cards (`editor.js renderComponents`) | `d-flex … flex-wrap` on header + `row g-2 col-md-N` on body | ✅ Already responsive |
| External-link-types pattern builder | `row g-2` + `col-md-N` | ✅ Already responsive |
| Org members / group members / role pickers | Single-input rows; hidden+visible fields only | ✅ Not cramped |
| Public-facing read views (favorites, settings, songbook, etc.) | `flex-grow-1` middle column, single-line items | ✅ Not form input — not relevant |
| Editor.js chip lists (translations, song-links, credits) | `flex-grow-1` content column | ✅ Not cramped |

**The credit-people drawer was the only place still using the hand-rolled cramped pattern.** Every other surface already follows the responsive convention (deliberately or accidentally). No other admin surface needs this fix.

## What this PR does

Rewrites the three credit-people `<template>` row builders using the same card + Bootstrap `row g-2 col-md-N` pattern the shared `external-links-editor.js` already uses on songbook / work / song. Below the `md` breakpoint (768 px) each input stacks full-width; at `md+` they lay out side-by-side as before. Visually consistent with how the other admin pages already render their card-list editors on a phone.

| Row | Wide (`md+`) | Narrow (`<md`) |
|---|---|---|
| **Link** | Type (5) \| URL (7), then Label (12) | each input stacks |
| **IPI** | Number (4) \| NameUsed (8), then Notes (12) | each input stacks |
| **Alias** | Name (5) \| Type (4) \| Locale (3) | each input stacks |

The wrapper container around the rows (`<div id="cp-links-container" class="d-flex flex-column gap-2">` etc.) was already vertically stacking, so no container change needed.

## Pre-existing bug bundled

The remove-row delegation listener at the drawer level only matched `.cp-link-row, .cp-ipi-row` in its `.closest()` selector, so clicking ✕ on an alias row never found its parent and did nothing. Added `.cp-alias-row` to the selector — aliases can now be removed from the drawer like the other two sub-forms.

## Note

I'd originally pushed this commit onto the `claude/credit-people-link-types-unify` branch before #986 merged, but the merge happened before the description update — so the commit was orphaned. This PR replays the same commit cleanly on top of current `alpha` (which already has the #986 unification merged).

## Test plan

- [ ] On a narrow viewport (≤ 768 px DevTools), open `/manage/credit-people` Edit drawer → External Links rows stack vertically (type, then URL, then label each on their own line).
- [ ] Same with IPI Numbers rows and AKA / Aliases rows.
- [ ] At `≥ md` (resize > 768 px), rows lay out side-by-side as before (no regression for desktop curators).
- [ ] Click ✕ on an AKA / Alias row — row removes (was broken; now fixed).
- [ ] Click ✕ on a link row + an IPI row — still works.
- [ ] Save with multiple links / IPIs / aliases → backend reads the `links[i][type_id]`, `ipi[i][number]`, `aliases[i][name]` POST shape correctly (no field-name regression).
- [ ] PHP lint: `php -l appWeb/public_html/manage/credit-people.php` clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_018jFVuXFjp6Wc4EPBMzR22U)_