### PR TITLE
feat(external-links): add 13 media-database providers (IMDb, TMDB, TheTVDB, …)

### DIFF
--- a/appWeb/.sql/migrate-external-link-patterns.php
+++ b/appWeb/.sql/migrate-external-link-patterns.php
@@ -196,6 +196,26 @@ $seedRows = [
 
     ['discogs',               'discogs.com',       null,        1, 160],
     ['goodreads-author',      'goodreads.com',     '/author/',  1, 170],
+
+    /* Media databases (film / TV / streaming / anime / games). Forward-
+       looking groundwork for iLyrics DB + MeedyaDB which will share the
+       iHymns external-link registry. Single bare-domain rule per
+       provider with MatchSubdomains = 1 so m.imdb.com, www.themoviedb.org,
+       etc. all match a single seed row. */
+    ['imdb',                  'imdb.com',          null,        1, 400, 'Suffix match covers m.imdb.com / www.imdb.com'],
+    ['tmdb',                  'themoviedb.org',    null,        1, 410, 'Suffix match covers www.themoviedb.org'],
+    ['thetvdb',               'thetvdb.com',       null,        1, 420, 'Suffix match covers www.thetvdb.com'],
+    ['letterboxd',            'letterboxd.com',    null,        1, 430],
+    ['rotten-tomatoes',       'rottentomatoes.com',null,        1, 440],
+    ['metacritic',            'metacritic.com',    null,        1, 450],
+    ['allmovie',              'allmovie.com',      null,        1, 460],
+    ['tvmaze',                'tvmaze.com',        null,        1, 470],
+    ['trakt',                 'trakt.tv',          null,        1, 480, 'Primary domain'],
+    ['justwatch',             'justwatch.com',     null,        1, 490, 'Suffix match covers per-country www.justwatch.com regional subdomains'],
+    ['myanimelist',           'myanimelist.net',   null,        1, 500],
+    ['anidb',                 'anidb.net',         null,        1, 510],
+    ['igdb',                  'igdb.com',          null,        1, 520, 'Internet Game Database'],
+
     ['linkedin',              'linkedin.com',      null,        1, 180],
     ['twitter-x',             'twitter.com',       null,        1, 190],
     ['twitter-x',             'x.com',             null,        1, 191],

--- a/appWeb/.sql/migrate-external-links.php
+++ b/appWeb/.sql/migrate-external-links.php
@@ -195,6 +195,25 @@ $seedTypes = [
     ['musicbrainz-recording','MusicBrainz recording','information', 'song',                 1, 'bi-music-note',      92],
     ['musicbrainz-artist',   'MusicBrainz artist',   'information', 'person',               0, 'bi-person-vcard',    93],
     ['goodreads-author',     'Goodreads author',     'information', 'person',               0, 'bi-book',            94],
+
+    /* Media databases — film / TV / streaming / anime / games. AppliesTo
+       deliberately wide (song,songbook,person,work) since iHymns data
+       is the seed for the upcoming iLyrics DB + MeedyaDB and these
+       providers want to live on every entity type. */
+    ['imdb',                 'IMDb',                 'information', 'song,songbook,person,work', 1, 'bi-film',           120],
+    ['tmdb',                 'The Movie DB (TMDB)',  'information', 'song,songbook,person,work', 1, 'bi-film',           121],
+    ['thetvdb',              'TheTVDB',              'information', 'song,songbook,person,work', 1, 'bi-tv',             122],
+    ['letterboxd',           'Letterboxd',           'information', 'song,songbook,person,work', 1, 'bi-film',           123],
+    ['rotten-tomatoes',      'Rotten Tomatoes',      'information', 'song,songbook,person,work', 1, 'bi-star',           124],
+    ['metacritic',           'Metacritic',           'information', 'song,songbook,person,work', 1, 'bi-star-half',      125],
+    ['allmovie',             'AllMovie',             'information', 'song,songbook,person,work', 1, 'bi-film',           126],
+    ['tvmaze',               'TVmaze',               'information', 'song,songbook,person,work', 1, 'bi-tv',             127],
+    ['trakt',                'Trakt',                'information', 'song,songbook,person,work', 1, 'bi-tv',             128],
+    ['justwatch',            'JustWatch',            'information', 'song,songbook,person,work', 1, 'bi-search',         129],
+    ['myanimelist',          'MyAnimeList',          'information', 'song,songbook,person,work', 1, 'bi-collection-play',130],
+    ['anidb',                'AniDB',                'information', 'song,songbook,person,work', 1, 'bi-collection-play',131],
+    ['igdb',                 'IGDB',                 'information', 'song,songbook,person,work', 1, 'bi-controller',     132],
+
     ['linkedin',             'LinkedIn',             'social',      'person',               0, 'bi-linkedin',        100],
     ['twitter-x',            'Twitter / X',          'social',      'person',               0, 'bi-twitter-x',       101],
     ['instagram',            'Instagram',            'social',      'person',               0, 'bi-instagram',       102],

--- a/appWeb/.sql/migrate-media-database-providers.php
+++ b/appWeb/.sql/migrate-media-database-providers.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Media Database Providers Migration
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Adds IMDB, The Movie DB (TMDB), TheTVDB, Letterboxd, Rotten Tomatoes,
+ * Metacritic, AllMovie, TVmaze, Trakt, JustWatch, MyAnimeList, AniDB
+ * and IGDB to the `tblExternalLinkTypes` registry (#833) and seeds the
+ * matching host patterns into `tblExternalLinkPatterns` (#845).
+ *
+ * Forward-looking: iHymns data + DB structure is the seed for the
+ * upcoming iLyrics DB + MeedyaDB, so these providers want to be on
+ * every entity type (song, songbook, person, work). AppliesTo is
+ * deliberately wide.
+ *
+ * The seed lists in `migrate-external-links.php` + `migrate-external-link-patterns.php`
+ * already cover these on a fresh install — this supplementary migration
+ * exists to bring already-deployed installs in line without re-running
+ * the bigger migrations (whose probes are satisfied as soon as the
+ * tables exist, so the dashboard wouldn't prompt to re-run them).
+ *
+ * Idempotent: link types upsert by Slug, patterns guard on
+ * (LinkTypeId, Host, PathPrefix) before inserting.
+ *
+ * USAGE:
+ *   CLI: php appWeb/.sql/migrate-media-database-providers.php
+ *   Web: /manage/setup-database → "Media Database Providers"
+ */
+
+if (PHP_SAPI === 'cli') {
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = true;
+} else {
+    if (!defined('IHYMNS_SETUP_DASHBOARD')) {
+        if (!function_exists('isAuthenticated')) {
+            require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+        }
+        if (!isAuthenticated()) {
+            http_response_code(401);
+            exit('Authentication required.');
+        }
+        $u = getCurrentUser();
+        if (!$u || $u['role'] !== 'global_admin') {
+            http_response_code(403);
+            exit('Global admin required.');
+        }
+    }
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = false;
+}
+
+function _migMediaDb_out(string $line): void
+{
+    global $isCli;
+    echo $line . ($isCli ? "\n" : "<br>\n");
+    if ($isCli) flush();
+}
+
+function _migMediaDb_tableExists(\mysqli $db, string $table): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? LIMIT 1'
+    );
+    $stmt->bind_param('s', $table);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+_migMediaDb_out('Media Database Providers migration starting…');
+
+$mysqli = getDbMysqli();
+if (!$mysqli) {
+    throw new \RuntimeException('Could not connect to database.');
+}
+
+foreach (['tblExternalLinkTypes', 'tblExternalLinkPatterns'] as $required) {
+    if (!_migMediaDb_tableExists($mysqli, $required)) {
+        _migMediaDb_out("ERROR: {$required} not found. Run migrate-external-links.php"
+            . ' (#833) and migrate-external-link-patterns.php (#845) first.');
+        return;
+    }
+}
+
+/* ----------------------------------------------------------------------
+ * Step 1 — Seed link types
+ *
+ * Mirrors the rows appended to migrate-external-links.php $seedTypes so
+ * fresh-install seed data and this supplementary migration converge on
+ * identical registry state. AppliesTo deliberately wide
+ * ('song,songbook,person,work') so these providers surface on every
+ * entity-editor surface.
+ * ---------------------------------------------------------------------- */
+$applies = 'song,songbook,person,work';
+$seedTypes = [
+    /* slug, name, category, applies_to, allow_multiple, icon, order */
+    ['imdb',            'IMDb',                 'information', $applies, 1, 'bi-film',            120],
+    ['tmdb',            'The Movie DB (TMDB)',  'information', $applies, 1, 'bi-film',            121],
+    ['thetvdb',         'TheTVDB',              'information', $applies, 1, 'bi-tv',              122],
+    ['letterboxd',      'Letterboxd',           'information', $applies, 1, 'bi-film',            123],
+    ['rotten-tomatoes', 'Rotten Tomatoes',      'information', $applies, 1, 'bi-star',            124],
+    ['metacritic',      'Metacritic',           'information', $applies, 1, 'bi-star-half',       125],
+    ['allmovie',        'AllMovie',             'information', $applies, 1, 'bi-film',            126],
+    ['tvmaze',          'TVmaze',               'information', $applies, 1, 'bi-tv',              127],
+    ['trakt',           'Trakt',                'information', $applies, 1, 'bi-tv',              128],
+    ['justwatch',       'JustWatch',            'information', $applies, 1, 'bi-search',          129],
+    ['myanimelist',     'MyAnimeList',          'information', $applies, 1, 'bi-collection-play', 130],
+    ['anidb',           'AniDB',                'information', $applies, 1, 'bi-collection-play', 131],
+    ['igdb',            'IGDB',                 'information', $applies, 1, 'bi-controller',      132],
+];
+
+$upsert = $mysqli->prepare(
+    'INSERT INTO tblExternalLinkTypes
+         (Slug, Name, Category, AppliesTo, AllowMultiple, IconClass, DisplayOrder)
+     VALUES (?, ?, ?, ?, ?, ?, ?)
+     ON DUPLICATE KEY UPDATE
+         Name          = VALUES(Name),
+         Category      = VALUES(Category),
+         AppliesTo     = VALUES(AppliesTo),
+         AllowMultiple = VALUES(AllowMultiple),
+         IconClass     = VALUES(IconClass),
+         DisplayOrder  = VALUES(DisplayOrder)'
+);
+$typesAdded   = 0;
+$typesUpdated = 0;
+foreach ($seedTypes as $t) {
+    [$slug, $name, $cat, $appliesTo, $multi, $icon, $order] = $t;
+    $upsert->bind_param('ssssisi', $slug, $name, $cat, $appliesTo, $multi, $icon, $order);
+    @$upsert->execute();
+    $ar = $mysqli->affected_rows;
+    if ($ar === 1)      $typesAdded++;
+    elseif ($ar === 2)  $typesUpdated++;
+}
+$upsert->close();
+_migMediaDb_out("[seed] {$typesAdded} link type" . ($typesAdded === 1 ? '' : 's')
+    . " inserted, {$typesUpdated} updated.");
+
+/* ----------------------------------------------------------------------
+ * Step 2 — Seed URL patterns
+ *
+ * Single bare-domain rule per provider with MatchSubdomains = 1 so
+ * m.imdb.com / www.themoviedb.org / per-country justwatch subdomains
+ * all match a single seed row. NOT EXISTS guard keeps the step idempotent.
+ * ---------------------------------------------------------------------- */
+$seedRows = [
+    /* [slug, host, path-prefix-or-null, match-subdomains, priority, note?] */
+    ['imdb',            'imdb.com',           null, 1, 400, 'Suffix match covers m.imdb.com / www.imdb.com'],
+    ['tmdb',            'themoviedb.org',     null, 1, 410, 'Suffix match covers www.themoviedb.org'],
+    ['thetvdb',         'thetvdb.com',        null, 1, 420, 'Suffix match covers www.thetvdb.com'],
+    ['letterboxd',      'letterboxd.com',     null, 1, 430],
+    ['rotten-tomatoes', 'rottentomatoes.com', null, 1, 440],
+    ['metacritic',      'metacritic.com',     null, 1, 450],
+    ['allmovie',        'allmovie.com',       null, 1, 460],
+    ['tvmaze',          'tvmaze.com',         null, 1, 470],
+    ['trakt',           'trakt.tv',           null, 1, 480, 'Primary domain'],
+    ['justwatch',       'justwatch.com',      null, 1, 490, 'Suffix match covers per-country www.justwatch.com regional subdomains'],
+    ['myanimelist',     'myanimelist.net',    null, 1, 500],
+    ['anidb',           'anidb.net',          null, 1, 510],
+    ['igdb',            'igdb.com',           null, 1, 520, 'Internet Game Database'],
+];
+
+$slugToId = [];
+$res = $mysqli->query('SELECT Id, Slug FROM tblExternalLinkTypes');
+while ($row = $res->fetch_assoc()) {
+    $slugToId[(string)$row['Slug']] = (int)$row['Id'];
+}
+$res->close();
+
+$insert = $mysqli->prepare(
+    'INSERT INTO tblExternalLinkPatterns
+         (LinkTypeId, Host, PathPrefix, MatchSubdomains, Priority, Note)
+     SELECT ?, ?, ?, ?, ?, ?
+       FROM DUAL
+      WHERE NOT EXISTS (
+            SELECT 1 FROM tblExternalLinkPatterns
+             WHERE LinkTypeId = ?
+               AND Host       = ?
+               AND COALESCE(PathPrefix, "") = COALESCE(?, "")
+      )'
+);
+
+$pInserted = 0;
+$pSkipped  = 0;
+$pMissing  = 0;
+foreach ($seedRows as $r) {
+    $slug    = (string)$r[0];
+    $host    = (string)$r[1];
+    $path    = $r[2] !== null ? (string)$r[2] : null;
+    $matchSd = (int)$r[3];
+    $prio    = (int)$r[4];
+    $note    = isset($r[5]) ? (string)$r[5] : null;
+
+    if (!isset($slugToId[$slug])) {
+        $pMissing++;
+        continue;
+    }
+    $typeId = $slugToId[$slug];
+
+    $insert->bind_param(
+        'issiisiss',
+        $typeId, $host, $path, $matchSd, $prio, $note,
+        $typeId, $host, $path
+    );
+    $insert->execute();
+    if ($mysqli->affected_rows > 0) $pInserted++;
+    else                            $pSkipped++;
+}
+$insert->close();
+
+_migMediaDb_out("[seed] {$pInserted} pattern" . ($pInserted === 1 ? '' : 's')
+    . " inserted, {$pSkipped} already present"
+    . ($pMissing > 0 ? ", {$pMissing} skipped (link type missing)" : '')
+    . '.');
+
+_migMediaDb_out('Media Database Providers migration finished.');

--- a/appWeb/public_html/js/modules/external-link-detect.js
+++ b/appWeb/public_html/js/modules/external-link-detect.js
@@ -94,6 +94,24 @@
 
         { slug: 'discogs',               hosts: ['discogs.com'] },
         { slug: 'goodreads-author',     hosts: ['goodreads.com'], pathPrefix: '/author/' },
+
+        /* Media databases — film / TV / streaming / anime / games.
+           Forward-looking groundwork for iLyrics DB + MeedyaDB which
+           will share the iHymns external-link registry. */
+        { slug: 'imdb',                  hosts: ['imdb.com'] },
+        { slug: 'tmdb',                  hosts: ['themoviedb.org'] },
+        { slug: 'thetvdb',               hosts: ['thetvdb.com'] },
+        { slug: 'letterboxd',            hosts: ['letterboxd.com'] },
+        { slug: 'rotten-tomatoes',       hosts: ['rottentomatoes.com'] },
+        { slug: 'metacritic',            hosts: ['metacritic.com'] },
+        { slug: 'allmovie',              hosts: ['allmovie.com'] },
+        { slug: 'tvmaze',                hosts: ['tvmaze.com'] },
+        { slug: 'trakt',                 hosts: ['trakt.tv'] },
+        { slug: 'justwatch',             hosts: ['justwatch.com'] },
+        { slug: 'myanimelist',           hosts: ['myanimelist.net'] },
+        { slug: 'anidb',                 hosts: ['anidb.net'] },
+        { slug: 'igdb',                  hosts: ['igdb.com'] },
+
         { slug: 'linkedin',              hosts: ['linkedin.com'] },
         { slug: 'twitter-x',             hosts: ['twitter.com', 'x.com'] },
         { slug: 'instagram',             hosts: ['instagram.com'] },

--- a/appWeb/public_html/manage/includes/migration-registry.php
+++ b/appWeb/public_html/manage/includes/migration-registry.php
@@ -880,6 +880,43 @@ return [
             return !$present;
         },
     ],
+    'media-database-providers' => [
+        'script' => 'migrate-media-database-providers.php',
+        'card' => [
+            'title'  => 'Media Database Providers',
+            'body'   => 'Adds IMDb, The Movie DB (TMDB), TheTVDB, Letterboxd,'
+                      . ' Rotten Tomatoes, Metacritic, AllMovie, TVmaze, Trakt,'
+                      . ' JustWatch, MyAnimeList, AniDB and IGDB to'
+                      . ' <code>tblExternalLinkTypes</code> (#833) with patterns'
+                      . ' in <code>tblExternalLinkPatterns</code> (#845). Forward-'
+                      . 'looking groundwork for iLyrics DB + MeedyaDB which will'
+                      . ' share the iHymns external-link registry —'
+                      . ' <code>AppliesTo</code> is deliberately wide'
+                      . ' (<code>song,songbook,person,work</code>) so these surface'
+                      . ' on every entity editor. Idempotent — link types upsert'
+                      . ' by Slug, patterns guard on (LinkTypeId, Host, PathPrefix)'
+                      . ' before inserting.',
+            'button' => 'Run Media Database Providers Migration',
+        ],
+        /* Pending when prerequisite registry tables exist AND the sentinel
+           'imdb' slug hasn't been seeded yet. Same single-sentinel pattern
+           as extra-streaming-platforms above. */
+        'probe' => static function (\mysqli $db): bool {
+            if (!_migProbe_tableExists($db, 'tblExternalLinkTypes')
+                || !_migProbe_tableExists($db, 'tblExternalLinkPatterns')) {
+                return false;
+            }
+            $stmt = $db->prepare(
+                'SELECT 1 FROM tblExternalLinkTypes WHERE Slug = ? LIMIT 1'
+            );
+            $sentinel = 'imdb';
+            $stmt->bind_param('s', $sentinel);
+            $stmt->execute();
+            $present = $stmt->get_result()->fetch_row() !== null;
+            $stmt->close();
+            return !$present;
+        },
+    ],
     'song-media' => [
         'script' => 'migrate-song-media.php',
         'card' => [

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -239,6 +239,7 @@ $friendlyTitles = [
     'works'                            => 'Works — composition grouping (#840)',
     'external-link-patterns'           => 'External-Link URL Patterns (#845)',
     'extra-streaming-platforms'        => 'Extra Streaming Platforms',
+    'media-database-providers'         => 'Media Database Providers',
     'song-media'                       => 'Song Media Uploads (#853)',
     'song-component-language'          => 'Song Component Language Override (#858)',
     'song-arrangement'                 => 'Song Arrangement Persistence (#892)',


### PR DESCRIPTION
## Summary

Extends the URL → provider auto-detector with film / TV / streaming / anime / video-game reference databases so a pasted media URL flips the provider chip on the songs / songbooks / works / credit-people external-links editor — and lays groundwork for the upcoming **iLyrics DB** and **MeedyaDB** which will fork from the iHymns schema.

**13 new providers** (all `information` category, multi-allowed):

| Slug | Host |
|---|---|
| `imdb` | imdb.com |
| `tmdb` | themoviedb.org |
| `thetvdb` | thetvdb.com |
| `letterboxd` | letterboxd.com |
| `rotten-tomatoes` | rottentomatoes.com |
| `metacritic` | metacritic.com |
| `allmovie` | allmovie.com |
| `tvmaze` | tvmaze.com |
| `trakt` | trakt.tv |
| `justwatch` | justwatch.com |
| `myanimelist` | myanimelist.net |
| `anidb` | anidb.net |
| `igdb` | igdb.com |

### Why `AppliesTo = song,songbook,person,work`

Wide deliberately. Two reasons:
1. Even inside iHymns there are composers with non-trivial film/TV credits (Andrew Lloyd Webber on `Pie Jesu`, John Rutter on TV soundtracks, etc.). A curator should be able to attach an IMDb link to a credit-person *or* to the work they composed.
2. When MeedyaDB / iLyrics DB fork this registry, they'll already have these provider rows pre-curated — no second-pass migration needed.

## Three-place update per `.claude/CLAUDE.md` §11 / §12

- **`js/modules/external-link-detect.js`** — 13 new entries in the fallback `RULES` list, single bare-domain rule per provider with suffix matching.
- **`appWeb/.sql/migrate-external-links.php`** — 13 new `$seedTypes` rows in the `'information'` block.
- **`appWeb/.sql/migrate-external-link-patterns.php`** — 13 new `$seedRows` (priority 400 – 520).

## Supplementary migration for already-deployed installs

`appWeb/.sql/migrate-media-database-providers.php` + `media-database-providers` entry in `manage/includes/migration-registry.php` carries just the new seed rows for existing installs. Probe pattern mirrors `extra-streaming-platforms` from #988:

- Returns `false` if `tblExternalLinkTypes` or `tblExternalLinkPatterns` is missing → migration stays hidden on fresh installs that need to run #833 / #845 first.
- Otherwise returns `true` iff the sentinel slug `imdb` is absent. Anchored to one slug so a curator deleting one of the new rows later can't keep the card stuck pending forever.

## CI

- `tests/php/test-migration-registry.php` — 51 entries (was 50), all assertions pass.
- `tests/php/test-schema-coverage.php` — pass (seeds only, no schema changes).
- `php -l` clean on all five edited PHP files; `node --check` clean on the JS module.

## Test plan

- [ ] On alpha, run the **Media Database Providers** card from `/manage/setup-database` → counter decrements by one, card flips to ✅
- [ ] Edit a credit person → External Links → paste `https://www.imdb.com/name/nm2970099/` → chip flips to **IMDb**
- [ ] Same modal, paste `https://www.themoviedb.org/person/12345-john-rutter` → chip flips to **The Movie DB (TMDB)**
- [ ] Edit a song → External Links → paste `https://www.thetvdb.com/series/the-chosen` → chip flips to **TheTVDB**
- [ ] Edit a songbook → External Links → paste `https://letterboxd.com/film/the-message/` → chip flips to **Letterboxd**
- [ ] Edit a work → External Links → paste `https://myanimelist.net/anime/1` → chip flips to **MyAnimeList**
- [ ] `/manage/external-link-types` shows 13 new rows + 13 new patterns

## Follow-up (separate PR)

The user has also asked for **ISNI** as a structured metadata field on Credit People (alongside the existing IPI Name Numbers), plus a handful of additional MusicBrainz-style external-link types from the reference screenshot — Myspace, AllMusic, Last.fm, Bandsintown, Genius, Muzikum.eu. These will land as a follow-up PR after this one ships.

https://claude.ai/code/session_01V4qRuU2P28qe3Z7KT4o5WL

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4qRuU2P28qe3Z7KT4o5WL)_