### PR TITLE
fix(credit-people): store ISNI in canonical &quot;NNNN NNNN NNNN NNNX&quot; form

### DIFF
--- a/appWeb/.sql/migrate-canonicalise-existing-isni.php
+++ b/appWeb/.sql/migrate-canonicalise-existing-isni.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Canonicalise Existing ISNI Rows Migration
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * The first ISNI rows in tblCreditPersonIdentifiers were stored as bare
+ * 16-character strings ("0000000121032683") because the previous version
+ * of normaliseCreditPersonIsni() stripped separators on save. Search +
+ * link-out + the UNIQUE constraint all work better when every ISNI is
+ * stored in the canonical ISO 27729 display form "NNNN NNNN NNNN NNNX".
+ *
+ * This migration re-formats every existing ISNI row through the same
+ * canonicaliseIsni() helper the runtime save path uses, so historic
+ * rows match the new convention. Idempotent: rows already in canonical
+ * form are no-ops; only changed rows get UPDATE'd.
+ *
+ * Race against UNIQUE: if two rows on the same person happen to
+ * canonicalise to the same string (e.g. one stored bare-digits, another
+ * with hyphens but representing the same ISNI), the second UPDATE will
+ * fail on uk_PersonIdValue. We catch the duplicate-key error and DELETE
+ * the redundant row instead so the curator ends up with the surviving
+ * canonical record.
+ *
+ * USAGE:
+ *   CLI: php appWeb/.sql/migrate-canonicalise-existing-isni.php
+ *   Web: /manage/setup-database → "Canonicalise Existing ISNI Rows"
+ */
+
+if (PHP_SAPI === 'cli') {
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    if (!function_exists('canonicaliseIsni')) {
+        require_once dirname(__DIR__) . '/public_html/includes/credit_people_helpers.php';
+    }
+    $isCli = true;
+} else {
+    if (!defined('IHYMNS_SETUP_DASHBOARD')) {
+        if (!function_exists('isAuthenticated')) {
+            require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+        }
+        if (!isAuthenticated()) {
+            http_response_code(401);
+            exit('Authentication required.');
+        }
+        $u = getCurrentUser();
+        if (!$u || $u['role'] !== 'global_admin') {
+            http_response_code(403);
+            exit('Global admin required.');
+        }
+    }
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    if (!function_exists('canonicaliseIsni')) {
+        require_once dirname(__DIR__) . '/public_html/includes/credit_people_helpers.php';
+    }
+    $isCli = false;
+}
+
+function _migIsniCanon_out(string $line): void
+{
+    global $isCli;
+    echo $line . ($isCli ? "\n" : "<br>\n");
+    if ($isCli) flush();
+}
+
+function _migIsniCanon_tableExists(\mysqli $db, string $table): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? LIMIT 1'
+    );
+    $stmt->bind_param('s', $table);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+_migIsniCanon_out('Canonicalise Existing ISNI Rows migration starting…');
+
+$mysqli = getDbMysqli();
+if (!$mysqli) {
+    throw new \RuntimeException('Could not connect to database.');
+}
+
+if (!_migIsniCanon_tableExists($mysqli, 'tblCreditPersonIdentifiers')) {
+    _migIsniCanon_out('[skip] tblCreditPersonIdentifiers not present — run'
+        . ' migrate-credit-person-identifiers.php first.');
+    return;
+}
+
+$stmt = $mysqli->prepare(
+    "SELECT Id, CreditPersonId, IdentifierValue
+       FROM tblCreditPersonIdentifiers
+      WHERE IdentifierType = 'isni'"
+);
+$stmt->execute();
+$rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+$stmt->close();
+
+$updated = 0;
+$skipped = 0;
+$deletedDupes = 0;
+
+$updStmt = $mysqli->prepare(
+    'UPDATE tblCreditPersonIdentifiers SET IdentifierValue = ? WHERE Id = ?'
+);
+$delStmt = $mysqli->prepare('DELETE FROM tblCreditPersonIdentifiers WHERE Id = ?');
+
+foreach ($rows as $r) {
+    $id          = (int)$r['Id'];
+    $currentVal  = (string)$r['IdentifierValue'];
+    $canonical   = canonicaliseIsni($currentVal);
+    if ($canonical === $currentVal) {
+        $skipped++;
+        continue;
+    }
+    $updStmt->bind_param('si', $canonical, $id);
+    if ($updStmt->execute()) {
+        $updated++;
+    } else {
+        /* Duplicate-key race: another row on the same person already
+           holds the canonical form. Drop this row instead so the
+           surviving record is the canonical one. */
+        if ($mysqli->errno === 1062) {
+            $delStmt->bind_param('i', $id);
+            $delStmt->execute();
+            $deletedDupes++;
+        } else {
+            throw new \RuntimeException('UPDATE failed: ' . $mysqli->error);
+        }
+    }
+}
+$updStmt->close();
+$delStmt->close();
+
+_migIsniCanon_out("[done] {$updated} row" . ($updated === 1 ? '' : 's')
+    . " canonicalised, {$skipped} already canonical"
+    . ($deletedDupes > 0 ? ", {$deletedDupes} duplicate" . ($deletedDupes === 1 ? '' : 's') . ' removed' : '')
+    . '.');
+_migIsniCanon_out('Canonicalise Existing ISNI Rows migration finished.');

--- a/appWeb/public_html/includes/credit_people_helpers.php
+++ b/appWeb/public_html/includes/credit_people_helpers.php
@@ -213,11 +213,19 @@ function normaliseCreditPersonIpi(mixed $raw): array
  * identically — the only thing that differs is the IdentifierType value
  * the caller binds when persisting.
  *
- * Light validation: trims hyphens / spaces and uppercases the trailing X
- * (ISNI checksum digit) since ISNI is a 16-character ID conventionally
- * displayed in groups of four separated by spaces or hyphens. Stored
- * representation is the bare digits/X so two equivalent renderings
- * collide on the UNIQUE constraint.
+ * ISNI canonical form is "NNNN NNNN NNNN NNNX" — 16 characters total
+ * (15 digits + a checksum that may be 'X' to encode value 10), grouped
+ * in four blocks separated by single spaces. We normalise to that form
+ * on save so search, link-out (https://isni.org/isni/<bare>), and the
+ * UNIQUE constraint all collide cleanly regardless of what the curator
+ * pasted ("0000-0001-2103-2683", "0000:0001:2103:2683", or just the
+ * 16 bare digits all land at "0000 0001 2103 2683").
+ *
+ * Inputs that don't normalise to the 16-char shape (typo, partial paste,
+ * deliberately weird format) are stored as the cleaned uppercased version
+ * with all separators stripped — the curator can spot the problem on
+ * re-open and fix it. UNIQUE still works because the same bad input
+ * normalises to the same cleaned string.
  *
  * @param mixed $raw Form / JSON-decoded array; non-array → []
  * @return list<array{number:string,name_used:?string,notes:?string}>
@@ -230,17 +238,37 @@ function normaliseCreditPersonIsni(mixed $raw): array
         if (!is_array($row)) continue;
         $raw_id = trim((string)($row['number'] ?? ''));
         if ($raw_id === '') continue;
-        /* Collapse separators + uppercase the X check character so
-           "0000 0001 2103 2683" and "0000-0001-2103-2683" both store
-           as 0000000121032683. */
-        $bare = strtoupper(preg_replace('/[\s\-]+/', '', $raw_id) ?? $raw_id);
         $out[] = [
-            'number'    => $bare,
+            'number'    => canonicaliseIsni($raw_id),
             'name_used' => trim((string)($row['name_used'] ?? '')) ?: null,
             'notes'     => trim((string)($row['notes']     ?? '')) ?: null,
         ];
     }
     return $out;
+}
+
+/**
+ * Format an ISNI input string in its canonical "NNNN NNNN NNNN NNNX"
+ * shape. Strips every non-[0-9X] character (handles spaces, hyphens,
+ * en/em-dashes, colons, dots, NBSP, …) and uppercases. A 16-character
+ * cleaned result that matches the ISNI pattern is regrouped into four
+ * space-separated blocks of four. Anything else is returned as the
+ * cleaned uppercased string so the UNIQUE constraint still collapses
+ * duplicate inputs that disagree only on separator style.
+ */
+function canonicaliseIsni(string $raw): string
+{
+    /* Uppercase first so the trailing X check-digit lands correctly,
+       then drop every non-[0-9X] character. This handles every
+       separator a curator might paste without enumerating them. */
+    $clean = preg_replace('/[^0-9X]/', '', strtoupper($raw)) ?? '';
+    if (preg_match('/^\d{15}[0-9X]$/', $clean) === 1) {
+        return substr($clean, 0, 4) . ' '
+             . substr($clean, 4, 4) . ' '
+             . substr($clean, 8, 4) . ' '
+             . substr($clean, 12, 4);
+    }
+    return $clean;
 }
 
 /**

--- a/appWeb/public_html/manage/credit-people.php
+++ b/appWeb/public_html/manage/credit-people.php
@@ -2007,7 +2007,7 @@ $totalInUseUnregistered = count(array_filter($people, static fn($p) =>
                     </button>
                 </div>
                 <div id="cp-isni-container" class="d-flex flex-column gap-2"></div>
-                <div class="form-text small">ISNI is a 16-digit ISO 27729 identifier (look it up at <a href="https://isni.org" target="_blank" rel="noopener">isni.org</a>). Spaces and hyphens are stripped on save — paste either "0000 0001 2103 2683" or "0000000121032683".</div>
+                <div class="form-text small">ISNI is a 16-character ISO 27729 identifier (look it up at <a href="https://isni.org" target="_blank" rel="noopener">isni.org</a>). Paste any separator style — "0000 0001 2103 2683", "0000-0001-2103-2683", or just "0000000121032683" — it's normalised to the canonical "NNNN NNNN NNNN NNNX" form on save.</div>
             </div>
 
             <!-- AKA / aliases — repeating sub-form. Mirrors the
@@ -2172,9 +2172,11 @@ $totalInUseUnregistered = count(array_filter($people, static fn($p) =>
                     <div class="flex-grow-1">
                         <div class="row g-2 mb-1">
                             <div class="col-12 col-md-4">
-                                <input type="text" class="form-control form-control-sm"
-                                       name="isni[{i}][number]" placeholder="ISNI (16 digits)"
-                                       pattern="[0-9 \-]{16,24}[0-9Xx]?" required>
+                                <input type="text" class="form-control form-control-sm cp-isni-number"
+                                       name="isni[{i}][number]" placeholder="0000 0000 0000 0000"
+                                       inputmode="numeric"
+                                       title="16 characters: 15 digits + checksum (digit or X). Spaces / hyphens accepted on input — stored canonically as four space-separated groups of four."
+                                       required>
                             </div>
                             <div class="col-12 col-md-8">
                                 <input type="text" class="form-control form-control-sm"
@@ -2389,14 +2391,44 @@ $totalInUseUnregistered = count(array_filter($people, static fn($p) =>
                 if (typeof applyFlagLabels === 'function') applyFlagLabels();
                 return row;
             }
+            /* Mirror of PHP's canonicaliseIsni() — strips every non-[0-9X]
+               character (any separator the curator paints with), upper-
+               cases, and regroups a 16-char result into "NNNN NNNN NNNN NNNX".
+               Non-16-char inputs stay as the cleaned string so the server-
+               side normaliser produces a matching value. */
+            function canonicaliseIsniJS(raw) {
+                const clean = (raw || '').toUpperCase().replace(/[^0-9X]/g, '');
+                if (/^\d{15}[0-9X]$/.test(clean)) {
+                    return clean.slice(0, 4) + ' '
+                         + clean.slice(4, 8) + ' '
+                         + clean.slice(8, 12) + ' '
+                         + clean.slice(12, 16);
+                }
+                return clean;
+            }
             function addIsniRow(prefill) {
                 const html = isniTpl.innerHTML.replaceAll('{i}', String(isniIndex++));
                 isniBox.insertAdjacentHTML('beforeend', html);
                 const row = isniBox.lastElementChild;
+                const numIn = row.querySelector('input.cp-isni-number');
                 if (prefill) {
-                    row.querySelector('input[name$="[number]"]').value    = prefill.number    || '';
+                    if (numIn) numIn.value = prefill.number || '';
                     row.querySelector('input[name$="[name_used]"]').value = prefill.name_used || '';
                     row.querySelector('input[name$="[notes]"]').value     = prefill.notes     || '';
+                }
+                /* Reformat on blur so the curator sees the canonical
+                   "NNNN NNNN NNNN NNNX" shape before submit — matches
+                   what the server-side normaliser will store. Live
+                   formatting (input event) would fight the cursor;
+                   blur is the standard pattern for credit-card-style
+                   masking. */
+                if (numIn) {
+                    numIn.addEventListener('blur', () => {
+                        const canonical = canonicaliseIsniJS(numIn.value);
+                        if (canonical && canonical !== numIn.value) {
+                            numIn.value = canonical;
+                        }
+                    });
                 }
                 if (typeof applyFlagLabels === 'function') applyFlagLabels();
                 return row;

--- a/appWeb/public_html/manage/includes/migration-registry.php
+++ b/appWeb/public_html/manage/includes/migration-registry.php
@@ -966,6 +966,42 @@ return [
         'probe' => static fn(\mysqli $db) =>
             !_migProbe_tableExists($db, 'tblCreditPersonIdentifiers'),
     ],
+    'canonicalise-existing-isni' => [
+        'script' => 'migrate-canonicalise-existing-isni.php',
+        'card' => [
+            'title'  => 'Canonicalise Existing ISNI Rows',
+            'body'   => 'Re-formats every existing ISNI row in'
+                      . ' <code>tblCreditPersonIdentifiers</code> through the same'
+                      . ' <code>canonicaliseIsni()</code> helper the runtime save path'
+                      . ' uses — turning bare-digit storage like'
+                      . ' <code>0000000121032683</code> into the canonical ISO 27729'
+                      . ' display form <code>0000 0001 2103 2683</code>. Search,'
+                      . ' link-out (<code>https://isni.org/isni/&lt;bare&gt;</code>)'
+                      . ' and the <code>uk_PersonIdValue</code> UNIQUE constraint all'
+                      . ' work better when every ISNI matches the same shape. Idempotent —'
+                      . ' rows already canonical are no-ops; duplicate-key races (same'
+                      . ' person, two stored renderings of the same ISNI) drop the'
+                      . ' redundant row in favour of the canonical one.',
+            'button' => 'Run ISNI Canonicalisation Migration',
+        ],
+        /* Pending when any ISNI row in the identifiers table isn\'t already
+           in canonical "NNNN NNNN NNNN NNNX" form. Gated on the prerequisite
+           table existing so this card stays hidden on fresh installs that
+           haven\'t run migrate-credit-person-identifiers yet. */
+        'probe' => static function (\mysqli $db): bool {
+            if (!_migProbe_tableExists($db, 'tblCreditPersonIdentifiers')) {
+                return false;
+            }
+            $sql = "SELECT 1 FROM tblCreditPersonIdentifiers
+                     WHERE IdentifierType = 'isni'
+                       AND IdentifierValue NOT REGEXP '^[0-9]{4} [0-9]{4} [0-9]{4} [0-9]{3}[0-9X]$'
+                     LIMIT 1";
+            $res = $db->query($sql);
+            $hasNonCanonical = $res && $res->fetch_row() !== null;
+            if ($res) $res->close();
+            return (bool)$hasNonCanonical;
+        },
+    ],
     'song-media' => [
         'script' => 'migrate-song-media.php',
         'card' => [

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -242,6 +242,7 @@ $friendlyTitles = [
     'media-database-providers'         => 'Media Database Providers',
     'musicbrainz-style-links'          => 'MusicBrainz-Parity External Links',
     'credit-person-identifiers'        => 'Credit-Person Identifiers (IPI + ISNI)',
+    'canonicalise-existing-isni'       => 'Canonicalise Existing ISNI Rows',
     'song-media'                       => 'Song Media Uploads (#853)',
     'song-component-language'          => 'Song Component Language Override (#858)',
     'song-arrangement'                 => 'Song Arrangement Persistence (#892)',


### PR DESCRIPTION
## Summary

Switch ISNI storage to the canonical ISO 27729 display form `NNNN NNNN NNNN NNNX` so search, link-out, and consistent rendering all collapse to one well-known shape.

**Before** (landed in #990): the save path stripped separators and stored the bare 16-char string `0000000121032683`. Worked for UNIQUE, but lost information at display time and forced every search / link-out site to re-format on the fly.

**Now**:
- Store `0000 0001 2103 2683` — four space-separated groups of four.
- The public link-out URL stays a single `str_replace` away (`https://isni.org/isni/` + bare digits).
- Every UI surface that renders an ISNI shows it identically without per-page formatting code.

## Changes

### `canonicaliseIsni()` helper (`credit_people_helpers.php`)

- Strips every non-`[0-9X]` character — handles space, hyphen, en/em-dash, colon, dot, NBSP, and anything else a curator might paste.
- Uppercases (so the checksum `X` lands in the right case).
- Regroups a valid 16-char result as `NNNN NNNN NNNN NNNX`.
- Non-16-char inputs are returned as the cleaned uppercased string so the curator can spot the problem when they re-open the editor (the UNIQUE constraint still collapses dupes).

`normaliseCreditPersonIsni()` now routes through this helper.

### Editor (`manage/credit-people.php`)

- Placeholder updated from `"ISNI (16 digits)"` to the canonical `"0000 0000 0000 0000"` so the expected shape is obvious.
- Help text rewritten to describe the normalisation explicitly.
- **Blur-time JS reformatter** (`canonicaliseIsniJS`) mirrors the PHP helper so the curator sees canonical shape **before** Save. Blur-only, not `input`-time, to avoid fighting the cursor (standard credit-card masking pattern).
- Old `pattern="…"` attribute removed — server canonicalisation makes browser pattern validation redundant and risks rejecting legitimate inputs that the server would accept.

### One-shot canonicalisation migration

`migrate-canonicalise-existing-isni.php` re-formats every existing ISNI row in `tblCreditPersonIdentifiers` through the same PHP helper. Idempotent; rows already canonical are no-ops. Handles the duplicate-key race (two rows on the same person canonicalising to the same string) by DELETE'ing the redundant row in favour of the surviving canonical one.

Probe: `IdentifierValue NOT REGEXP '^[0-9]{4} [0-9]{4} [0-9]{4} [0-9]{3}[0-9X]$'` — flags pending only when at least one ISNI row isn't canonical, drives to zero exactly when the corpus is fully canonical.

## Smoke-test results

`canonicaliseIsni()` against eight inputs:

```
[0000 0001 2103 2683]     -> 0000 0001 2103 2683
[0000-0001-2103-2683]     -> 0000 0001 2103 2683
[0000:0001:2103:2683]     -> 0000 0001 2103 2683
[0000000121032683]        -> 0000 0001 2103 2683
[0000 0001 2103 268X]     -> 0000 0001 2103 268X
[  0000-0001-2103-2683  ] -> 0000 0001 2103 2683    (whitespace-padded)
[abc123]                  -> 123                     (garbage → cleaned)
[000000012103268]         -> 000000012103268         (15 chars → cleaned)
```

## CI

- **54 registry entries** (up from 53).
- `tests/php/test-migration-registry.php` and `tests/php/test-schema-coverage.php` both pass.
- `php -l` clean across all five edited files.

## Test plan

- [ ] Run `Canonicalise Existing ISNI Rows` from `/manage/setup-database` → re-formats any bare-digit rows from yesterday's PR. Counter decrements; re-run is a no-op.
- [ ] Edit a person, add a new ISNI as `0000-0001-2103-2683`, tab out of the field → input reformats to `0000 0001 2103 2683` immediately.
- [ ] Paste `0000000121032683` (no separators) → tab out → same canonical form.
- [ ] Paste `0000:0001:2103:2683` (colons) → tab out → canonical form.
- [ ] Save → DB stores `0000 0001 2103 2683` regardless of input style.
- [ ] Re-open same person → ISNI field pre-fills with `0000 0001 2103 2683`.
- [ ] Try to add a duplicate ISNI on the same person (any separator style) → UNIQUE constraint catches it (editor's DELETE/INSERT pattern handles this cleanly).
- [ ] Paste a partial / malformed value (e.g. `abc123`) → tab out → shows `123` (cleaned); curator notices and corrects.

https://claude.ai/code/session_01V4qRuU2P28qe3Z7KT4o5WL

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4qRuU2P28qe3Z7KT4o5WL)_