### PR TITLE
feat(external-links): widen WorldCat, add SecondHandSongs + fix btn anchor styling

### DIFF
--- a/appWeb/.sql/migrate-external-link-patterns.php
+++ b/appWeb/.sql/migrate-external-link-patterns.php
@@ -234,6 +234,7 @@ $seedRows = [
     ['bandsintown',           'bandsintown.com',   null,        1, 75,  'Suffix match covers www.bandsintown.com'],
     ['genius',                'genius.com',        null,        1, 36,  'Suffix match covers www.genius.com — lyrics + annotations'],
     ['muzikum',               'muzikum.eu',        null,        1, 37,  'Lyrics + translations site'],
+    ['secondhandsongs',       'secondhandsongs.com', null,      1, 38,  'Database of cover versions, originals, releases'],
 ];
 
 /* Resolve slugs to LinkTypeIds in one query. */

--- a/appWeb/.sql/migrate-external-links.php
+++ b/appWeb/.sql/migrate-external-links.php
@@ -161,7 +161,7 @@ $seedTypes = [
     ['internet-archive',     'Internet Archive',     'read',        'songbook',             1, 'bi-archive',         30],
     ['open-library',         'Open Library',         'read',        'songbook',             1, 'bi-book-half',       31],
     ['archive-misc',         'Other archive',        'read',        'song,songbook,person', 1, 'bi-archive',         39],
-    ['oclc-worldcat',        'WorldCat / OCLC',      'authority',   'songbook',             0, 'bi-card-list',       40],
+    ['oclc-worldcat',        'WorldCat / OCLC',      'authority',   'song,songbook,person,work', 1, 'bi-card-list',       40],
     ['viaf',                 'VIAF authority',       'authority',   'songbook,person',      0, 'bi-card-list',       41],
     ['loc-name-authority',   'LoC name authority',   'authority',   'songbook,person',      0, 'bi-card-list',       42],
     ['find-a-grave',         'Find a Grave',         'authority',   'person',               0, 'bi-flower2',         43],
@@ -234,6 +234,7 @@ $seedTypes = [
     ['bandsintown',          'Bandsintown',          'information', 'person',               0, 'bi-ticket-perforated', 26],
     ['genius',               'Genius',               'information', 'song,person',          1, 'bi-file-text',       27],
     ['muzikum',              'Muzikum.eu',           'information', 'song,person',          1, 'bi-file-text',       28],
+    ['secondhandsongs',      'SecondHandSongs',      'information', 'song,songbook,person,work', 1, 'bi-music-note-list', 93],
     ['other',                'Other',                'other',       'song,songbook,person', 1, 'bi-link-45deg',      999],
 ];
 

--- a/appWeb/.sql/migrate-worldcat-and-secondhandsongs.php
+++ b/appWeb/.sql/migrate-worldcat-and-secondhandsongs.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — WorldCat Widening + SecondHandSongs Migration
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ *
+ *   (a) Widens the existing `oclc-worldcat` link type's AppliesTo from
+ *       'songbook' alone to 'song,songbook,person,work' so a curator can
+ *       attach a WorldCat / WorldCat Identities URL to a credit-person
+ *       (very common — every published author has one) or a song / work
+ *       (rare but useful for printed-music holdings). Also flips
+ *       AllowMultiple from 0 to 1 to match the other authority links.
+ *
+ *   (b) Adds SecondHandSongs (secondhandsongs.com) — the canonical
+ *       database of song originals / cover versions / releases. Crops up
+ *       repeatedly on MusicBrainz artist pages and is the cleanest way
+ *       to link a credit-person to their performance catalogue alongside
+ *       Discogs / MusicBrainz / AllMusic.
+ *
+ * The seed lists in `migrate-external-links.php` +
+ * `migrate-external-link-patterns.php` already cover these on a fresh
+ * install; this supplementary migration brings already-deployed installs
+ * in line via the dashboard.
+ *
+ * Idempotent: link types upsert by Slug (so re-running refreshes the
+ * widened AppliesTo / AllowMultiple values), patterns guard on
+ * (LinkTypeId, Host, PathPrefix) before inserting.
+ *
+ * USAGE:
+ *   CLI: php appWeb/.sql/migrate-worldcat-and-secondhandsongs.php
+ *   Web: /manage/setup-database → "WorldCat + SecondHandSongs Links"
+ */
+
+if (PHP_SAPI === 'cli') {
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = true;
+} else {
+    if (!defined('IHYMNS_SETUP_DASHBOARD')) {
+        if (!function_exists('isAuthenticated')) {
+            require_once dirname(__DIR__) . '/public_html/manage/includes/auth.php';
+        }
+        if (!isAuthenticated()) {
+            http_response_code(401);
+            exit('Authentication required.');
+        }
+        $u = getCurrentUser();
+        if (!$u || $u['role'] !== 'global_admin') {
+            http_response_code(403);
+            exit('Global admin required.');
+        }
+    }
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = false;
+}
+
+function _migWcShs_out(string $line): void
+{
+    global $isCli;
+    echo $line . ($isCli ? "\n" : "<br>\n");
+    if ($isCli) flush();
+}
+
+function _migWcShs_tableExists(\mysqli $db, string $table): bool
+{
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? LIMIT 1'
+    );
+    $stmt->bind_param('s', $table);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+_migWcShs_out('WorldCat + SecondHandSongs migration starting…');
+
+$mysqli = getDbMysqli();
+if (!$mysqli) {
+    throw new \RuntimeException('Could not connect to database.');
+}
+
+foreach (['tblExternalLinkTypes', 'tblExternalLinkPatterns'] as $required) {
+    if (!_migWcShs_tableExists($mysqli, $required)) {
+        _migWcShs_out("ERROR: {$required} not found. Run migrate-external-links.php"
+            . ' (#833) and migrate-external-link-patterns.php (#845) first.');
+        return;
+    }
+}
+
+/* ----------------------------------------------------------------------
+ * Step 1 — Upsert / widen link types
+ *
+ * Reusing the standard upsert keyed on Slug so the existing
+ * oclc-worldcat row's AppliesTo + AllowMultiple get refreshed without
+ * disturbing curator-controlled IsActive.
+ * ---------------------------------------------------------------------- */
+$seedTypes = [
+    /* slug, name, category, applies_to, allow_multiple, icon, order */
+    ['oclc-worldcat',   'WorldCat / OCLC', 'authority',   'song,songbook,person,work', 1, 'bi-card-list',        40],
+    ['secondhandsongs', 'SecondHandSongs', 'information', 'song,songbook,person,work', 1, 'bi-music-note-list',  93],
+];
+
+$upsert = $mysqli->prepare(
+    'INSERT INTO tblExternalLinkTypes
+         (Slug, Name, Category, AppliesTo, AllowMultiple, IconClass, DisplayOrder)
+     VALUES (?, ?, ?, ?, ?, ?, ?)
+     ON DUPLICATE KEY UPDATE
+         Name          = VALUES(Name),
+         Category      = VALUES(Category),
+         AppliesTo     = VALUES(AppliesTo),
+         AllowMultiple = VALUES(AllowMultiple),
+         IconClass     = VALUES(IconClass),
+         DisplayOrder  = VALUES(DisplayOrder)'
+);
+$typesAdded   = 0;
+$typesUpdated = 0;
+foreach ($seedTypes as $t) {
+    [$slug, $name, $cat, $appliesTo, $multi, $icon, $order] = $t;
+    $upsert->bind_param('ssssisi', $slug, $name, $cat, $appliesTo, $multi, $icon, $order);
+    @$upsert->execute();
+    $ar = $mysqli->affected_rows;
+    if ($ar === 1)      $typesAdded++;
+    elseif ($ar === 2)  $typesUpdated++;
+}
+$upsert->close();
+_migWcShs_out("[seed] {$typesAdded} link type" . ($typesAdded === 1 ? '' : 's')
+    . " inserted, {$typesUpdated} updated.");
+
+/* ----------------------------------------------------------------------
+ * Step 2 — Seed URL pattern for SecondHandSongs
+ *
+ * (WorldCat already has its pattern on worldcat.org seeded by #845;
+ * widening the type doesn't need a pattern change.)
+ * ---------------------------------------------------------------------- */
+$seedRows = [
+    ['secondhandsongs', 'secondhandsongs.com', null, 1, 38, 'Database of cover versions, originals, releases'],
+];
+
+$slugToId = [];
+$res = $mysqli->query('SELECT Id, Slug FROM tblExternalLinkTypes');
+while ($row = $res->fetch_assoc()) {
+    $slugToId[(string)$row['Slug']] = (int)$row['Id'];
+}
+$res->close();
+
+$insert = $mysqli->prepare(
+    'INSERT INTO tblExternalLinkPatterns
+         (LinkTypeId, Host, PathPrefix, MatchSubdomains, Priority, Note)
+     SELECT ?, ?, ?, ?, ?, ?
+       FROM DUAL
+      WHERE NOT EXISTS (
+            SELECT 1 FROM tblExternalLinkPatterns
+             WHERE LinkTypeId = ?
+               AND Host       = ?
+               AND COALESCE(PathPrefix, "") = COALESCE(?, "")
+      )'
+);
+
+$pInserted = 0;
+$pSkipped  = 0;
+$pMissing  = 0;
+foreach ($seedRows as $r) {
+    $slug    = (string)$r[0];
+    $host    = (string)$r[1];
+    $path    = $r[2] !== null ? (string)$r[2] : null;
+    $matchSd = (int)$r[3];
+    $prio    = (int)$r[4];
+    $note    = isset($r[5]) ? (string)$r[5] : null;
+
+    if (!isset($slugToId[$slug])) {
+        $pMissing++;
+        continue;
+    }
+    $typeId = $slugToId[$slug];
+
+    $insert->bind_param(
+        'issiisiss',
+        $typeId, $host, $path, $matchSd, $prio, $note,
+        $typeId, $host, $path
+    );
+    $insert->execute();
+    if ($mysqli->affected_rows > 0) $pInserted++;
+    else                            $pSkipped++;
+}
+$insert->close();
+
+_migWcShs_out("[seed] {$pInserted} pattern" . ($pInserted === 1 ? '' : 's')
+    . " inserted, {$pSkipped} already present"
+    . ($pMissing > 0 ? ", {$pMissing} skipped (link type missing)" : '')
+    . '.');
+
+_migWcShs_out('WorldCat + SecondHandSongs migration finished.');

--- a/appWeb/public_html/css/admin.css
+++ b/appWeb/public_html/css/admin.css
@@ -101,6 +101,24 @@ a:not(.btn):not(.nav-link):not(.dropdown-item):hover {
     color: var(--accent-end);
 }
 
+/* Anchors dressed up as buttons should render identically to their
+   <button> equivalents. The global `a { border-bottom: 1px dotted }`
+   rule in app.css §2.5 (#951) gives every <a> a muted underline; on
+   <a class="btn-…"> the underline collides visually with the button
+   border so the bulk-promote anchor on /manage/credit-people looked
+   subtly different from the <button>-tag "Add person" right next to
+   it. Pin every .btn anchor to a solid border-bottom matching the
+   rest of the button's border so the cascade lands on identical
+   pixels regardless of element type. */
+a.btn,
+a.btn:hover,
+a.btn:focus,
+a.btn:active {
+    border-bottom-style: solid;
+    border-bottom-color: inherit;
+    text-decoration: none;
+}
+
 /* Shared admin page container. Replaces the inline per-page
    `style="max-width: NNNNpx"` pattern — the hard caps meant every
    admin dashboard left 300–700 px of dead space on 1440–1920 desktops.

--- a/appWeb/public_html/js/modules/external-link-detect.js
+++ b/appWeb/public_html/js/modules/external-link-detect.js
@@ -126,6 +126,7 @@
         { slug: 'bandsintown',           hosts: ['bandsintown.com'] },
         { slug: 'genius',                hosts: ['genius.com'] },
         { slug: 'muzikum',               hosts: ['muzikum.eu'] },
+        { slug: 'secondhandsongs',       hosts: ['secondhandsongs.com'] },
     ];
 
     function lowerHost(h) { return (h || '').toLowerCase(); }

--- a/appWeb/public_html/manage/includes/migration-registry.php
+++ b/appWeb/public_html/manage/includes/migration-registry.php
@@ -966,6 +966,52 @@ return [
         'probe' => static fn(\mysqli $db) =>
             !_migProbe_tableExists($db, 'tblCreditPersonIdentifiers'),
     ],
+    'worldcat-and-secondhandsongs' => [
+        'script' => 'migrate-worldcat-and-secondhandsongs.php',
+        'card' => [
+            'title'  => 'WorldCat + SecondHandSongs Links',
+            'body'   => 'Widens the existing <code>oclc-worldcat</code> link type from'
+                      . ' <code>AppliesTo = \'songbook\'</code> to'
+                      . ' <code>song,songbook,person,work</code> so a curator can attach'
+                      . ' a WorldCat / WorldCat Identities URL to a credit-person (every'
+                      . ' published author has one) or a song / work. Adds the missing'
+                      . ' SecondHandSongs slug — the canonical database of song'
+                      . ' originals, cover versions and releases — with its'
+                      . ' <code>secondhandsongs.com</code> URL pattern.',
+            'button' => 'Run WorldCat + SecondHandSongs Migration',
+        ],
+        /* Pending when oclc-worldcat is still on its narrow AppliesTo OR when
+           the SecondHandSongs slug hasn't been seeded yet. Two checks because
+           a curator who runs the migration once shouldn't see it re-surface
+           if only one of the two changes is still pending. */
+        'probe' => static function (\mysqli $db): bool {
+            if (!_migProbe_tableExists($db, 'tblExternalLinkTypes')) {
+                return false;
+            }
+            /* SecondHandSongs slug check. */
+            $stmt = $db->prepare(
+                'SELECT 1 FROM tblExternalLinkTypes WHERE Slug = ? LIMIT 1'
+            );
+            $slug = 'secondhandsongs';
+            $stmt->bind_param('s', $slug);
+            $stmt->execute();
+            $hasShs = $stmt->get_result()->fetch_row() !== null;
+            $stmt->close();
+            if (!$hasShs) return true;
+            /* WorldCat widening check — pending while AppliesTo is still
+               just 'songbook' or hasn't been widened to include 'person'. */
+            $stmt = $db->prepare(
+                "SELECT 1 FROM tblExternalLinkTypes
+                  WHERE Slug = 'oclc-worldcat'
+                    AND NOT FIND_IN_SET('person', AppliesTo)
+                  LIMIT 1"
+            );
+            $stmt->execute();
+            $isNarrow = $stmt->get_result()->fetch_row() !== null;
+            $stmt->close();
+            return $isNarrow;
+        },
+    ],
     'canonicalise-existing-isni' => [
         'script' => 'migrate-canonicalise-existing-isni.php',
         'card' => [

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -242,6 +242,7 @@ $friendlyTitles = [
     'media-database-providers'         => 'Media Database Providers',
     'musicbrainz-style-links'          => 'MusicBrainz-Parity External Links',
     'credit-person-identifiers'        => 'Credit-Person Identifiers (IPI + ISNI)',
+    'worldcat-and-secondhandsongs'     => 'WorldCat + SecondHandSongs Links',
     'canonicalise-existing-isni'       => 'Canonicalise Existing ISNI Rows',
     'song-media'                       => 'Song Media Uploads (#853)',
     'song-component-language'          => 'Song Component Language Override (#858)',


### PR DESCRIPTION
## Summary

Three small fixes shaken out of curator feedback on `/manage/credit-people`:

### 1. WorldCat applies to person + song + work, not just songbook

The `oclc-worldcat` slug was seeded with `AppliesTo = 'songbook'` only (#833) — fine when the only WorldCat use case was hymnal holdings, but it meant the credit-person editor's dropdown never offered it even though the URL pattern on `worldcat.org` was already in `tblExternalLinkPatterns`. Curators with WorldCat Identities URLs (every published author has one) had nowhere to file them.

Widen `AppliesTo` to `song,songbook,person,work` and flip `AllowMultiple` from 0 to 1 (authors can have several WorldCat entries — older LCCN-based one plus the newer canonical entity).

### 2. SecondHandSongs as a first-class link type

The canonical DB of song originals / cover versions / releases — appears on every MusicBrainz artist page and is the natural complement to Discogs + AllMusic for performer catalogues.

| Slug | Host | Category | AppliesTo |
|---|---|---|---|
| `secondhandsongs` | `secondhandsongs.com` | information | song / songbook / person / work |

Three-place update per `.claude/CLAUDE.md` §11 / §12.

### 3. `<a class="btn">` no longer picks up the global dotted underline

The "Bulk promote with fuzzy-match" CTA on `/manage/credit-people` is an `<a>` styled as a button (carries an `href` to `/manage/credit-people-bulk-promote`). The global `a { border-bottom: 1px dotted }` rule from `app.css` §2.5 (#951) was bleeding onto its bottom edge — subtle but visible when sat next to the `<button class="btn-amber-solid">` "Add person" CTA in the same column.

Pin every `a.btn` to a solid `border-bottom` inheriting the rest of the button's border color in `admin.css`. The cascade now lands on identical pixels regardless of element type, so anchor-buttons and `<button>`s look the same everywhere.

## Supplementary migration

`migrate-worldcat-and-secondhandsongs.php` brings already-deployed alpha installs in line. The probe is two-part — pending when **either**:
- the SecondHandSongs slug is missing, **or**
- `oclc-worldcat.AppliesTo` doesn't yet include `'person'`

…so the dashboard counter converges to zero only when both changes have applied. Idempotent.

## CI

- `tests/php/test-migration-registry.php` — **55 entries** (up from 54), all assertions pass.
- `tests/php/test-schema-coverage.php` — pass (seeds + CSS only, no schema changes).
- `php -l` clean on all five edited PHP files; `node --check` clean on the JS module.

## Test plan

- [ ] Run `WorldCat + SecondHandSongs Links` from `/manage/setup-database` → counter decrements, dashboard reports both updates applied.
- [ ] Edit a credit person → External Links → dropdown now lists **WorldCat / OCLC** under Authority.
- [ ] Paste `https://www.worldcat.org/identities/lccn-n2004105278/` → chip flips to **WorldCat / OCLC**.
- [ ] Add a second WorldCat row on the same person (different URL) → saves cleanly (`AllowMultiple = 1`).
- [ ] Same modal, paste `https://secondhandsongs.com/artist/12345-chris-tomlin` → chip flips to **SecondHandSongs**.
- [ ] Edit a song → External Links → SecondHandSongs is also available (AppliesTo wide).
- [ ] Visually compare "Add person" (`<button>`) and "Bulk promote with fuzzy-match" (`<a>`) on `/manage/credit-people` → no dotted underline difference; pixel-identical button shape.

## Follow-up (separate PR)

Duplicate-link detection across every External Links editor surface (songs, songbooks, works, credit-people) with toast notification + auto-remove of the duplicate row. Coming next.

https://claude.ai/code/session_01V4qRuU2P28qe3Z7KT4o5WL

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4qRuU2P28qe3Z7KT4o5WL)_