### PR TITLE
feat(external-links): detect duplicate URLs + toast + auto-remove

### DIFF
--- a/appWeb/public_html/js/modules/external-link-dupe-detect.js
+++ b/appWeb/public_html/js/modules/external-link-dupe-detect.js
@@ -1,0 +1,145 @@
+/**
+ * iHymns — External-Link Duplicate Detection
+ *
+ * Detects when a curator pastes / types a URL that already exists in
+ * another row of the same external-links card-list, raises a toast,
+ * and removes the just-edited duplicate row. Shared across every
+ * surface that exposes an external-links editor — the canonical one
+ * (songs / songbooks / works via includes/partials/external-links-section.php
+ * + js/modules/external-links-editor.js) AND the credit-people inline
+ * editor (manage/credit-people.php's bespoke `cp-link-row` rows).
+ *
+ * Comparison is host + path only (no query, no hash, www. stripped,
+ * trailing slash trimmed, case-folded) so curators don't end up with
+ *   https://www.imdb.com/name/nm123/
+ *   https://IMDB.com/name/nm123
+ *   http://imdb.com/name/nm123/?ref=footer
+ * as three "different" rows pointing at the same resource.
+ *
+ * Exposed on `window.iHymnsExtLinkDupeDetect`:
+ *   normalise(url)              → canonical comparison key, or ''
+ *   attach(rowEl, opts)         → teardown fn
+ *
+ * `attach` listens for change / blur / paste on the row's URL input.
+ * A match against a sibling row triggers
+ *   1. window.iHymnsToast.show(...)
+ *   2. rowEl.remove()
+ * in that order — the toast then sticks even though the row is gone.
+ *
+ * Pre-fill on edit-modal load is safe: programmatic `.value = …`
+ * assignments don't fire change/blur, so two stored duplicates from
+ * before this feature shipped stay visible until the curator touches
+ * one — at which point the listener kicks in and resolves the dupe.
+ */
+
+(function () {
+    'use strict';
+
+    /**
+     * Normalise a URL string to a comparison key. Strategy:
+     *   - lowercase host, strip leading 'www.'
+     *   - keep path, lowercase it, drop trailing '/'
+     *   - drop query + hash (curators paste tracker-laden links all the
+     *     time — `?ref=`, `?utm_source=`, …, none of which alter what
+     *     the page actually is)
+     *   - non-URL input (malformed, relative): lowercased + trimmed
+     *     trailing slash so simple duplicate text is still caught
+     */
+    function normalise(url) {
+        if (typeof url !== 'string') return '';
+        var s = url.trim();
+        if (!s) return '';
+        try {
+            var u = new URL(s);
+            var host = (u.hostname || '').toLowerCase();
+            if (host.indexOf('www.') === 0) host = host.slice(4);
+            var path = (u.pathname || '/').toLowerCase().replace(/\/+$/, '') || '/';
+            return host + path;
+        } catch (_e) {
+            return s.toLowerCase().replace(/\/+$/, '');
+        }
+    }
+
+    /**
+     * Find a sibling row inside `container` whose URL field normalises
+     * to `target` (and isn't `excludeRow` itself). Returns the matching
+     * row element or null.
+     */
+    function findDuplicate(container, target, excludeRow, urlSelector, rowSelector) {
+        if (!container || !target) return null;
+        var rows = container.querySelectorAll(rowSelector);
+        for (var i = 0; i < rows.length; i++) {
+            var row = rows[i];
+            if (row === excludeRow) continue;
+            var input = row.querySelector(urlSelector);
+            if (!input) continue;
+            if (normalise(input.value) === target) return row;
+        }
+        return null;
+    }
+
+    /**
+     * Wire duplicate detection on a single row.
+     *
+     * @param {HTMLElement} rowEl
+     * @param {object} [opts]
+     * @param {string}   [opts.urlSelector]
+     *        CSS selector for the URL input inside the row + its
+     *        siblings. Default matches both the canonical
+     *        `name="ext_link_urls[]"` field used by the shared
+     *        partial / editor module AND the credit-people inline
+     *        `name="links[i][url]"` field.
+     * @param {string}   [opts.rowSelector]
+     *        Selector for sibling rows in the same container. Default
+     *        matches `.ihymns-ext-link-row` (shared) and `.cp-link-row`
+     *        (credit-people).
+     * @param {HTMLElement} [opts.container]
+     *        Override the container we search for duplicates within.
+     *        Defaults to rowEl.parentElement.
+     * @param {string}   [opts.toastMessage]
+     *        Override the default toast text.
+     * @returns {Function} teardown that detaches the listeners.
+     */
+    function attach(rowEl, opts) {
+        if (!rowEl) return function () {};
+        var settings = Object.assign({
+            urlSelector: 'input[type="url"], input[name="ext_link_urls[]"], input[name$="[url]"]',
+            rowSelector: '.ihymns-ext-link-row, .cp-link-row',
+            container:   rowEl.parentElement,
+            toastMessage: 'That URL is already in this list — duplicate removed.',
+        }, opts || {});
+        var urlInput = rowEl.querySelector(settings.urlSelector);
+        if (!urlInput) return function () {};
+
+        function check() {
+            var key = normalise(urlInput.value);
+            if (!key) return;
+            /* parentElement may have changed since attach time (drag-
+               reorder, container swap) — re-read each check. */
+            var container = settings.container || rowEl.parentElement;
+            var dupe = findDuplicate(container, key, rowEl, settings.urlSelector, settings.rowSelector);
+            if (!dupe) return;
+            if (window.iHymnsToast && typeof window.iHymnsToast.show === 'function') {
+                window.iHymnsToast.show(settings.toastMessage, 'warning');
+            }
+            rowEl.remove();
+        }
+
+        urlInput.addEventListener('change', check);
+        urlInput.addEventListener('blur',   check);
+        urlInput.addEventListener('paste', function () {
+            /* paste fires before the value updates */
+            setTimeout(check, 0);
+        });
+
+        return function teardown() {
+            urlInput.removeEventListener('change', check);
+            urlInput.removeEventListener('blur',   check);
+        };
+    }
+
+    window.iHymnsExtLinkDupeDetect = {
+        normalise: normalise,
+        attach:    attach,
+    };
+})();

--- a/appWeb/public_html/js/modules/external-links-editor.js
+++ b/appWeb/public_html/js/modules/external-links-editor.js
@@ -166,6 +166,15 @@
             window.iHymnsLinkDetect.attachAutoDetect(card);
         }
 
+        /* Duplicate-URL detection — if the curator pastes a URL that
+           matches another row in the same container, the dupe-detect
+           module fires a toast and auto-removes this just-added row.
+           Loaded globally via admin-footer.php so a no-op fallback
+           when the module isn't on the page keeps the editor working. */
+        if (window.iHymnsExtLinkDupeDetect && typeof window.iHymnsExtLinkDupeDetect.attach === 'function') {
+            window.iHymnsExtLinkDupeDetect.attach(card);
+        }
+
         return card;
     }
 

--- a/appWeb/public_html/js/modules/toast.js
+++ b/appWeb/public_html/js/modules/toast.js
@@ -1,0 +1,103 @@
+/**
+ * iHymns — Shared admin-side toast utility
+ *
+ * Single source of truth for non-blocking "your action was noticed"
+ * notifications across every admin surface. Before this module the
+ * codebase carried two independent implementations (editor/editor.js
+ * showToast(), js/app.js this.showToast()) and most admin pages had
+ * no toast at all — silent UX feedback was the norm.
+ *
+ * Exposed on `window.iHymnsToast`:
+ *   show(message, type, duration)  → bootstrap.Toast instance | null
+ *
+ * Parameters:
+ *   message  — plain text (rendered as textContent, no HTML injection risk)
+ *   type     — 'info' (default) | 'success' | 'warning' | 'error'
+ *              Maps to Bootstrap's text-bg-{info,success,warning,danger}.
+ *   duration — ms before autohide. 0 keeps the toast pinned. Default 4000.
+ *
+ * Container: looks up `#toast-container`. If absent (most admin pages
+ * don't ship one yet) it's lazily created and pinned bottom-right with
+ * a z-index that beats Bootstrap's modal backdrop (1090). Pages that
+ * already declare a #toast-container (notably manage/editor/index.php)
+ * keep using theirs unchanged.
+ *
+ * Falls back to console.warn() if Bootstrap's JS hasn't loaded yet —
+ * never throws.
+ */
+
+(function () {
+    'use strict';
+
+    function ensureContainer() {
+        var c = document.getElementById('toast-container');
+        if (c) return c;
+        c = document.createElement('div');
+        c.id = 'toast-container';
+        c.className = 'toast-container position-fixed bottom-0 end-0 p-3';
+        /* 11000 sits above Bootstrap's modal (1055) + modal-backdrop
+           (1050) so the toast remains visible when fired from an
+           open edit drawer. */
+        c.style.zIndex = '11000';
+        document.body.appendChild(c);
+        return c;
+    }
+
+    function variantClass(type) {
+        switch (type) {
+            case 'success': return 'text-bg-success';
+            case 'warning': return 'text-bg-warning';
+            case 'error':
+            case 'danger':  return 'text-bg-danger';
+            case 'info':
+            default:        return 'text-bg-info';
+        }
+    }
+
+    function show(message, type, duration) {
+        if (typeof bootstrap === 'undefined' || !bootstrap.Toast) {
+            /* JS bundle didn't load — degrade silently rather than
+               throwing, since callers (dedup detection, save handlers)
+               shouldn't crash a save flow over a missing notification. */
+            if (window && window.console) console.warn('[iHymnsToast]', message);
+            return null;
+        }
+        var container = ensureContainer();
+        var dur = (duration === 0) ? 0 : (Number(duration) || 4000);
+        var toastEl = document.createElement('div');
+        toastEl.className = 'toast align-items-center ' + variantClass(type) + ' border-0';
+        toastEl.setAttribute('role', 'alert');
+        toastEl.setAttribute('aria-live', 'polite');
+        toastEl.setAttribute('aria-atomic', 'true');
+
+        var flex = document.createElement('div');
+        flex.className = 'd-flex';
+
+        var body = document.createElement('div');
+        body.className = 'toast-body';
+        body.textContent = String(message == null ? '' : message);
+
+        var closeBtn = document.createElement('button');
+        closeBtn.type = 'button';
+        closeBtn.className = 'btn-close btn-close-white me-2 m-auto';
+        closeBtn.setAttribute('data-bs-dismiss', 'toast');
+        closeBtn.setAttribute('aria-label', 'Close');
+
+        flex.appendChild(body);
+        flex.appendChild(closeBtn);
+        toastEl.appendChild(flex);
+        container.appendChild(toastEl);
+
+        var instance = new bootstrap.Toast(toastEl, {
+            delay: dur > 0 ? dur : 0,
+            autohide: dur > 0,
+        });
+        toastEl.addEventListener('hidden.bs.toast', function () {
+            toastEl.remove();
+        });
+        instance.show();
+        return instance;
+    }
+
+    window.iHymnsToast = { show: show };
+})();

--- a/appWeb/public_html/manage/credit-people.php
+++ b/appWeb/public_html/manage/credit-people.php
@@ -2374,6 +2374,13 @@ $totalInUseUnregistered = count(array_filter($people, static fn($p) =>
                    with no translation map since the option values
                    are numeric registry ids. */
                 wireCpLinkRowAutoDetect(row);
+                /* Duplicate-URL detection — same shared module the
+                   songbooks / works / song-editor surfaces use. Fires
+                   a toast + auto-removes this row when its URL collides
+                   with another row's URL on the same person. */
+                if (window.iHymnsExtLinkDupeDetect && typeof window.iHymnsExtLinkDupeDetect.attach === 'function') {
+                    window.iHymnsExtLinkDupeDetect.attach(row, { container: linksBox });
+                }
                 return row;
             }
             function addIpiRow(prefill) {

--- a/appWeb/public_html/manage/includes/admin-footer.php
+++ b/appWeb/public_html/manage/includes/admin-footer.php
@@ -77,6 +77,20 @@ if (!empty($GLOBALS['_adminLayoutOpen'])):
 <?php endif; ?>
 
 <?php
+    /* Cross-page admin utilities — load AFTER Bootstrap so they can
+       use bootstrap.Toast. Loaded on every /manage/* page so any
+       surface that wants to fire a toast or wire duplicate-link
+       detection just calls into window.iHymnsToast /
+       window.iHymnsExtLinkDupeDetect without re-declaring the helper. */
+    $_toastModulePath = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'js' . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR . 'toast.js';
+    $_toastVersion = is_file($_toastModulePath) ? (string)filemtime($_toastModulePath) : '1';
+    $_dupeModulePath = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'js' . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR . 'external-link-dupe-detect.js';
+    $_dupeVersion = is_file($_dupeModulePath) ? (string)filemtime($_dupeModulePath) : '1';
+?>
+<script src="/js/modules/toast.js?v=<?= htmlspecialchars($_toastVersion, ENT_QUOTES) ?>"></script>
+<script src="/js/modules/external-link-dupe-detect.js?v=<?= htmlspecialchars($_dupeVersion, ENT_QUOTES) ?>"></script>
+
+<?php
     /* Persistent bulk-import progress widget (#676). Boots on every
        /manage/* page so a curator who started an import on
        /manage/editor and navigated to /manage/songbooks (or any


### PR DESCRIPTION
## Summary

Curators occasionally end up with several external-link rows pointing at the same resource — often after pasting a URL into a new row that another curator already filed under a slightly different surface spelling:

```
https://www.imdb.com/name/nm123/        ← canonical
https://IMDB.com/name/nm123             ← uppercased host
http://imdb.com/name/nm123/?ref=footer  ← tracker query
```

All three point at the same page; all three currently get stored as three rows.

This PR adds front-end duplicate detection. When the curator types or pastes into a URL field and the **normalised host + path** matches another row on the same record, the just-edited row is removed and a warning toast surfaces:

> That URL is already in this list — duplicate removed.

## Two new shared modules

Both loaded globally from `admin-footer.php` so every `/manage/*` page picks them up without per-page wiring.

### `js/modules/toast.js`

- `window.iHymnsToast.show(msg, type, duration)`
- Lazy-creates `#toast-container` if the page doesn't ship one (most admin pages don't; the song editor still uses its existing container).
- Maps `type` → Bootstrap `text-bg-{info, success, warning, danger}`.
- Degrades to `console.warn()` if Bootstrap JS hasn't loaded yet — never throws.

### `js/modules/external-link-dupe-detect.js`

- `window.iHymnsExtLinkDupeDetect.normalise(url)` → comparison key.
- `window.iHymnsExtLinkDupeDetect.attach(rowEl, opts)` → wires listeners.
- **Normalisation strategy**: lowercase host, strip leading `www.`, drop query + hash, trim trailing slashes, case-fold path. Malformed URLs pass through lowercased + trim-trailing-slashed so simple typed duplicates still collide.
- Listens on `change` / `blur` / `paste` of the row's URL input.
- Default selectors handle **both** the canonical `ext_link_urls[]` convention used by the shared partial/editor module AND the credit-people inline `links[i][url]` form.

## Wiring

- `js/modules/external-links-editor.js` — `attach()` called inside `buildRowEl`, so songbooks / works / song-editor surfaces pick up the new behaviour for free.
- `manage/credit-people.php` — `addLinkRow()` calls `attach()` with `container: linksBox` so it scopes correctly to the active drawer.

## Smoke-test results

`normalise()` against 10 input variations:

```
"https://www.imdb.com/name/nm123/"          -> "imdb.com/name/nm123"
"https://IMDB.com/name/nm123"               -> "imdb.com/name/nm123"
"http://imdb.com/name/nm123/?ref=footer"    -> "imdb.com/name/nm123"
"imdb.com/name/nm123"                       -> "imdb.com/name/nm123"
"https://www.imdb.com/name/nm123/#cast"     -> "imdb.com/name/nm123"
"https://example.com/path/"                 -> "example.com/path"
"https://example.com/path"                  -> "example.com/path"
""                                          -> ""
"   "                                       -> ""
"not a url"                                 -> "not a url"
```

All five IMDb spellings collapse to one key. ✓

## Behaviour notes

- **Pre-fill on edit-modal open is safe**: programmatic `element.value = …` doesn't fire `change` / `blur`, so two stored duplicates from before this feature shipped stay visible until the curator touches one — at which point the listener kicks in and resolves the dupe.
- **Both shared modules degrade gracefully**: if `iHymnsToast` or `iHymnsExtLinkDupeDetect` isn't on `window` (some legacy admin page bypasses the footer), the editor still works — just no toast / no dedup.
- **Server-side dedup is out of scope**: this is a front-end UX feature. If a curator finds a way to submit duplicates anyway (e.g. by curling the API directly), the existing save handlers still accept them. A future PR can add server-side `INSERT … ON DUPLICATE KEY UPDATE` semantics if that becomes a real problem.

## CI

- `php -l` clean on `admin-footer.php` + `credit-people.php`.
- `node --check` clean on all three JS modules.
- `tests/php/test-migration-registry.php` and `tests/php/test-schema-coverage.php` both pass — no DB / schema changes, feature is front-end-only.

## Test plan

- [ ] `/manage/credit-people` → edit any person → External Links → add two rows, paste the same URL into both → second row vanishes, toast appears bottom-right.
- [ ] Same modal, paste `https://www.example.com/foo/` into row A, then `https://example.com/foo` into row B → row B vanishes (www-prefix stripped on compare).
- [ ] Paste `https://example.com/foo` then `https://example.com/foo?ref=tracker` → second row vanishes (query stripped).
- [ ] Re-open a record that already has two stored duplicates → both still visible (pre-fill is silent); editing one of them re-triggers the check.
- [ ] `/manage/songbooks` edit modal → same dedup behaviour.
- [ ] `/manage/works` edit modal → same dedup behaviour.
- [ ] `/manage/editor` → song's External Links modal → same dedup behaviour.
- [ ] On any page, fire `window.iHymnsToast.show('test', 'success')` from the console → toast appears, auto-hides after 4s.

https://claude.ai/code/session_01V4qRuU2P28qe3Z7KT4o5WL

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4qRuU2P28qe3Z7KT4o5WL)_