### PR TITLE
fix(migration): make canonicalise-existing-isni self-contained

### DIFF
--- a/appWeb/.sql/migrate-canonicalise-existing-isni.php
+++ b/appWeb/.sql/migrate-canonicalise-existing-isni.php
@@ -35,9 +35,6 @@ if (PHP_SAPI === 'cli') {
     if (!function_exists('getDbMysqli')) {
         require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
     }
-    if (!function_exists('canonicaliseIsni')) {
-        require_once dirname(__DIR__) . '/public_html/includes/credit_people_helpers.php';
-    }
     $isCli = true;
 } else {
     if (!defined('IHYMNS_SETUP_DASHBOARD')) {
@@ -57,10 +54,27 @@ if (PHP_SAPI === 'cli') {
     if (!function_exists('getDbMysqli')) {
         require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
     }
-    if (!function_exists('canonicaliseIsni')) {
-        require_once dirname(__DIR__) . '/public_html/includes/credit_people_helpers.php';
-    }
     $isCli = false;
+}
+
+/**
+ * Self-contained mirror of canonicaliseIsni() from credit_people_helpers.php
+ * (#991). Migrations stay self-contained — like _migCpName_* in
+ * migrate-credit-people-name-parts.php — so a one-shot data fix never
+ * depends on which unrelated includes happen to be deployed alongside.
+ * Kept under a migration-scoped name to avoid any chance of clashing
+ * with the global helper if both end up loaded in the same request.
+ */
+function _migIsniCanon_canonicalise(string $raw): string
+{
+    $clean = preg_replace('/[^0-9X]/', '', strtoupper($raw)) ?? '';
+    if (preg_match('/^\d{15}[0-9X]$/', $clean) === 1) {
+        return substr($clean, 0, 4) . ' '
+             . substr($clean, 4, 4) . ' '
+             . substr($clean, 8, 4) . ' '
+             . substr($clean, 12, 4);
+    }
+    return $clean;
 }
 
 function _migIsniCanon_out(string $line): void
@@ -117,7 +131,7 @@ $delStmt = $mysqli->prepare('DELETE FROM tblCreditPersonIdentifiers WHERE Id = ?
 foreach ($rows as $r) {
     $id          = (int)$r['Id'];
     $currentVal  = (string)$r['IdentifierValue'];
-    $canonical   = canonicaliseIsni($currentVal);
+    $canonical   = _migIsniCanon_canonicalise($currentVal);
     if ($canonical === $currentVal) {
         $skipped++;
         continue;


### PR DESCRIPTION
## Summary

- The "Canonicalise Existing ISNI Rows" card in `/manage/setup-database` was crashing with `Failed opening required '…/appWeb/public_html/includes/credit_people_helpers.php'` at `migrate-canonicalise-existing-isni.php:61`.
- Root cause: the migration lives in `appWeb/.sql/` (a separate deploy target from `appWeb/public_html/`) and was reaching across the deploy boundary via `require_once dirname(__DIR__) . '/public_html/includes/credit_people_helpers.php'` to use `canonicaliseIsni()`. Any path / deploy-ordering mismatch between the two trees leaves the require unresolvable and the migration crashes before running any SQL.
- Fix: inline the canonicalisation step under a migration-scoped name `_migIsniCanon_canonicalise()` so the script no longer reaches into `public_html/includes/`. This matches the established pattern in `migrate-credit-people-name-parts.php`, which inlines `decomposePersonName` as `_migCpName_*` for the same reason — a one-shot data migration shouldn't depend on which unrelated includes are deployed alongside it.
- Behaviour is byte-for-byte identical to the canonical helper: same `preg_replace`, same 16-char regroup into `NNNN NNNN NNNN NNNX`, same fallback (cleaned uppercased string) for non-conforming inputs.

## Test plan

- [x] `php -l appWeb/.sql/migrate-canonicalise-existing-isni.php` — clean
- [x] `tests/php/test-migration-registry.php` — PASS (55 entries)
- [x] `tests/php/test-schema-coverage.php` — PASS
- [x] Smoke-tested `_migIsniCanon_canonicalise()` against 8 inputs (bare 16-digit, hyphen-separated, space-separated, colon-separated, lowercase `x` checksum, whitespace-padded, garbage, short) — every output matches the canonical helper exactly
- [ ] After deploy: open `/manage/setup-database` as a global admin and click "Run ISNI Canonicalisation Migration" — should print the `[done] N row(s) canonicalised, M already canonical` summary instead of the require error
- [ ] Probe in registry should drive the pending counter to zero once the migration completes (any remaining `tblCreditPersonIdentifiers.IdentifierValue` for `IdentifierType='isni'` not matching `'^[0-9]{4} [0-9]{4} [0-9]{4} [0-9]{3}[0-9X]$'` would keep it pending)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VYYhsREsyZXpHUurWzAGG9)_