### PR TITLE
fix(songbooks): rename now re-prefixes SongId + new fixup migration unblocks pre-patch renames

### DIFF
--- a/appWeb/.sql/migrate-songid-prefix-fixup.php
+++ b/appWeb/.sql/migrate-songid-prefix-fixup.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Re-prefix SongIds whose SongbookAbbr no longer matches
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * The /manage/songbooks rename flow used to update tblSongbooks.Abbreviation
+ * and (optionally) tblSongs.SongbookAbbr — but NOT the SongId itself. So
+ * after renaming a songbook (e.g. HA → HAOLD to free `HA` for a fresh
+ * scrape), the surviving rows looked like:
+ *
+ *     SongId = "HA-0001"          (untouched — still old prefix)
+ *     SongbookAbbr = "HAOLD"      (updated by the rename)
+ *
+ * A subsequent bulk-import of the new HA songbook would then collide on
+ * the PK when it tried to INSERT SongId='HA-0001'. The application-side
+ * rename code has been patched alongside this migration to also
+ * re-prefix the SongId, but rows that were renamed BEFORE the patch
+ * shipped still carry the stale prefix and need a one-shot data fix.
+ *
+ * Algorithm:
+ *   1. Find every (SongbookAbbr, oldPrefix) pair where:
+ *        - SongbookAbbr <> SUBSTRING_INDEX(SongId, '-', 1)
+ *        - i.e. the SongId's prefix (everything before the first `-`)
+ *          doesn't match the row's declared SongbookAbbr.
+ *   2. For each affected row, rewrite SongId = SongbookAbbr || '-' || <numeric tail>.
+ *   3. tblSongs has FKs to itself from many child tables. Most carry
+ *      ON UPDATE CASCADE so their SongId column refreshes automatically
+ *      — but four don't: tblSongExternalLinks, tblSongAlternativeTitles,
+ *      tblSongMedia, tblWorkSongs. We UPDATE those manually first,
+ *      then update tblSongs.SongId.
+ *
+ * Conservative:
+ *   - Only rewrites rows whose new SongId is FREE (no existing row with
+ *     the target ID). If the target SongId is already taken, the row is
+ *     left alone and reported in the output — a curator needs to merge
+ *     manually.
+ *   - Wrapped in a transaction; aborts cleanly on any error.
+ *
+ * Idempotent — re-running on an already-fixed catalogue is a no-op.
+ *
+ * @migration-updates tblSongs.SongId  (and child tables that lack
+ *                                       ON UPDATE CASCADE)
+ *
+ * USAGE:
+ *   Web:  /manage/setup-database → "Re-prefix SongIds"
+ *   CLI:  php appWeb/.sql/migrate-songid-prefix-fixup.php
+ */
+
+if (PHP_SAPI === 'cli') {
+    if (!function_exists('getDbMysqli')) {
+        require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+    }
+    $isCli = true;
+} else {
+    if (!defined('IHYMNS_SETUP_DASHBOARD')) {
+        if (!function_exists('getDbMysqli')) {
+            require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+        }
+    }
+    $isCli = false;
+}
+
+function _migSongIdPrefix_out(string $line): void
+{
+    if (PHP_SAPI === 'cli') {
+        echo $line . "\n";
+    } else {
+        echo htmlspecialchars($line, ENT_QUOTES) . "<br>\n";
+    }
+}
+
+_migSongIdPrefix_out('SongId prefix fixup starting…');
+
+$db = getDbMysqli();
+if (!$db) {
+    _migSongIdPrefix_out('ERROR: could not connect to database.');
+    if ($isCli) exit(1); else return;
+}
+
+/* Step 1 — find every row whose prefix is stale. */
+$rows = [];
+$res  = $db->query(
+    "SELECT SongId, SongbookAbbr
+       FROM tblSongs
+      WHERE SongbookAbbr <> ''
+        AND SongbookAbbr IS NOT NULL
+        AND SongbookAbbr <> SUBSTRING_INDEX(SongId, '-', 1)"
+);
+if (!$res) {
+    _migSongIdPrefix_out('ERROR: scan query failed: ' . $db->error);
+    if ($isCli) exit(1); else return;
+}
+while ($r = $res->fetch_assoc()) {
+    $rows[] = $r;
+}
+$res->close();
+
+if (empty($rows)) {
+    _migSongIdPrefix_out('[ok  ] no rows need re-prefixing — every SongId matches its SongbookAbbr.');
+    return;
+}
+
+_migSongIdPrefix_out('[scan] ' . count($rows) . ' row' . (count($rows) === 1 ? '' : 's') . ' have a stale SongId prefix.');
+
+/* Compute the proposed new SongId for each row and verify it's free
+   (no PK collision). Rows whose target ID is already taken can't be
+   fixed by a blind UPDATE — surface them for manual merge. */
+$proposed   = []; /* SongId → newSongId */
+$conflicts  = [];
+$takenStmt  = $db->prepare('SELECT 1 FROM tblSongs WHERE SongId = ? LIMIT 1');
+foreach ($rows as $r) {
+    $oldId    = (string)$r['SongId'];
+    $bookAbbr = (string)$r['SongbookAbbr'];
+    $dashPos  = strpos($oldId, '-');
+    /* Defensive: rows with no `-` in their SongId aren't safe to
+       reprefix automatically — they don't fit the abbr-number format.
+       Skip and let a curator resolve. */
+    if ($dashPos === false) {
+        $conflicts[] = ['old' => $oldId, 'new' => null, 'reason' => 'no `-` in SongId — non-standard format'];
+        continue;
+    }
+    $tail   = substr($oldId, $dashPos + 1);
+    $newId  = $bookAbbr . '-' . $tail;
+    if ($newId === $oldId) continue; /* shouldn't happen given the WHERE clause but safe */
+
+    $takenStmt->bind_param('s', $newId);
+    $takenStmt->execute();
+    $clash = $takenStmt->get_result()->fetch_row() !== null;
+    if ($clash) {
+        $conflicts[] = ['old' => $oldId, 'new' => $newId, 'reason' => 'target SongId already exists — manual merge needed'];
+        continue;
+    }
+    $proposed[$oldId] = $newId;
+}
+$takenStmt->close();
+
+if (!empty($conflicts)) {
+    _migSongIdPrefix_out('[warn] ' . count($conflicts) . ' row' . (count($conflicts) === 1 ? '' : 's')
+        . ' can\'t be re-prefixed automatically:');
+    foreach (array_slice($conflicts, 0, 20) as $c) {
+        $arrow = $c['new'] === null ? '' : ' → ' . $c['new'];
+        _migSongIdPrefix_out('       ' . $c['old'] . $arrow . '  (' . $c['reason'] . ')');
+    }
+    if (count($conflicts) > 20) {
+        _migSongIdPrefix_out('       … (' . (count($conflicts) - 20) . ' more)');
+    }
+}
+
+if (empty($proposed)) {
+    _migSongIdPrefix_out('[ok  ] no actionable rows after conflict filter.');
+    return;
+}
+
+_migSongIdPrefix_out('[fix ] re-prefixing ' . count($proposed) . ' row' . (count($proposed) === 1 ? '' : 's') . '…');
+
+/* Step 2 — do the updates inside a transaction. For each oldId →
+   newId pair: update the four non-cascading children first, then
+   tblSongs itself (the remaining ~14 children cascade via FK). */
+$db->begin_transaction();
+try {
+    $nonCascadingChildren = [
+        'tblSongExternalLinks',
+        'tblSongAlternativeTitles',
+        'tblSongMedia',
+        'tblWorkSongs',
+    ];
+    /* tblSongLinkSuggestions has two SongId columns (SongIdA + SongIdB)
+       and DOES carry ON UPDATE CASCADE, so it's handled automatically
+       by the tblSongs.SongId update below. tblTranslationMaps has the
+       same shape — also auto-cascades. */
+
+    $childStmts = [];
+    foreach ($nonCascadingChildren as $tbl) {
+        $childStmts[$tbl] = $db->prepare("UPDATE {$tbl} SET SongId = ? WHERE SongId = ?");
+    }
+    $parentStmt = $db->prepare('UPDATE tblSongs SET SongId = ? WHERE SongId = ?');
+
+    $applied = 0;
+    foreach ($proposed as $oldId => $newId) {
+        foreach ($childStmts as $tbl => $cs) {
+            $cs->bind_param('ss', $newId, $oldId);
+            $cs->execute();
+        }
+        $parentStmt->bind_param('ss', $newId, $oldId);
+        $parentStmt->execute();
+        if ($parentStmt->affected_rows > 0) {
+            $applied++;
+        }
+    }
+    foreach ($childStmts as $cs) { $cs->close(); }
+    $parentStmt->close();
+
+    $db->commit();
+    _migSongIdPrefix_out("[done] re-prefixed {$applied} SongId" . ($applied === 1 ? '' : 's') . '.');
+    if (!empty($conflicts)) {
+        _migSongIdPrefix_out('[note] ' . count($conflicts) . ' unresolved conflict' . (count($conflicts) === 1 ? '' : 's')
+            . ' — see list above; resolve manually (merge / delete / rename).');
+    }
+    _migSongIdPrefix_out('[note] regenerate the songs cache via /manage/data-health to refresh public reads.');
+} catch (\Throwable $e) {
+    $db->rollback();
+    _migSongIdPrefix_out('ERROR: rollback — ' . $e->getMessage());
+    if ($isCli) exit(1); else return;
+}

--- a/appWeb/public_html/manage/includes/migration-registry.php
+++ b/appWeb/public_html/manage/includes/migration-registry.php
@@ -451,6 +451,44 @@ return [
             }
         },
     ],
+    'songid-prefix-fixup' => [
+        'script' => 'migrate-songid-prefix-fixup.php',
+        'card' => [
+            'title'  => 'Re-prefix SongIds whose SongbookAbbr no longer matches',
+            'body'   => 'Before the songbook rename flow was patched to also re-prefix SongIds, renaming'
+                      . ' an abbreviation (e.g. <code>HA → HAOLD</code> to free <code>HA</code> for a fresh'
+                      . ' scrape) updated <code>tblSongs.SongbookAbbr</code> but left the SongIds carrying'
+                      . ' the OLD prefix (<code>HA-0001</code> staying as <code>HA-0001</code> even though'
+                      . ' the row now belongs to songbook <code>HAOLD</code>). A subsequent bulk-import of'
+                      . ' the original abbreviation then collides on the SongId primary key. This migration'
+                      . ' detects every row whose SongId prefix doesn\'t match its <code>SongbookAbbr</code>'
+                      . ' and rewrites the prefix (re-prefixing the four child tables that lack'
+                      . ' <code>ON UPDATE CASCADE</code> first, then <code>tblSongs.SongId</code>;'
+                      . ' the other ~14 child FKs cascade automatically). Rows whose target SongId is'
+                      . ' already taken are reported for manual merge rather than silently skipped.'
+                      . ' Re-runnable.',
+            'button' => 'Run SongId Prefix Fixup',
+        ],
+        'probe' => static function (\mysqli $db): bool {
+            try {
+                /* Pending whenever any row\'s SongId prefix disagrees with
+                   its declared SongbookAbbr. Self-clears once the migration
+                   has run. */
+                $res = $db->query(
+                    "SELECT 1 FROM tblSongs
+                      WHERE SongbookAbbr IS NOT NULL
+                        AND SongbookAbbr <> ''
+                        AND SongbookAbbr <> SUBSTRING_INDEX(SongId, '-', 1)
+                      LIMIT 1"
+                );
+                $needs = $res && $res->fetch_row() !== null;
+                if ($res) $res->close();
+                return $needs;
+            } catch (\Throwable $_e) {
+                return false;
+            }
+        },
+    ],
     'user-preferred-languages' => [
         'script' => 'migrate-user-preferred-languages.php',
         'card' => [

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -222,6 +222,7 @@ $friendlyTitles = [
     'bulk-import-jobs'                 => 'Bulk Import Jobs Tracking (#676)',
     'backfill-legacy-songbook-languages' => 'Backfill Legacy Songbook Languages (#735)',
     'backfill-song-language-from-songbook' => 'Backfill Song Language from Songbook (audit follow-up)',
+    'songid-prefix-fixup'                => 'Re-prefix SongIds after Songbook Rename',
     'user-preferred-languages'         => 'User Preferred Languages Column (#736)',
     'iana-language-subtag-registry'    => 'IETF BCP 47 Reference Data (#738)',
     'cldr-native-names'                => 'CLDR Native Names Overlay',

--- a/appWeb/public_html/manage/songbooks.php
+++ b/appWeb/public_html/manage/songbooks.php
@@ -1241,6 +1241,61 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                             $stmt->bind_param('ss', $newAbbr, $oldAbbr);
                             $stmt->execute();
                             $stmt->close();
+
+                            /* Also re-prefix the SongId itself so a future
+                               import of the original abbreviation (e.g.
+                               renaming HA → HAOLD to free `HA` for a fresh
+                               scrape) doesn't collide on the PK with the
+                               old HA-XXXX rows that survived the rename
+                               with their SongId prefix intact. The four
+                               child tables tblSongExternalLinks,
+                               tblSongAlternativeTitles, tblSongMedia, and
+                               tblWorkSongs have FKs to tblSongs.SongId
+                               WITHOUT `ON UPDATE CASCADE`, so they need
+                               explicit pre-updates; the other ~14 child
+                               tables cascade automatically. The match
+                               pattern is "<oldAbbr>-%" — anchored prefix
+                               + hyphen — so a SongId like HABA-0001 isn't
+                               accidentally rewritten when renaming HA. */
+                            $oldPrefix    = $oldAbbr . '-';
+                            $newPrefix    = $newAbbr . '-';
+                            $oldPrefixLen = strlen($oldPrefix);
+                            $likeOld      = $oldPrefix . '%';
+
+                            /* Step 1 — update child tables that lack
+                               ON UPDATE CASCADE. Order doesn't matter; each
+                               is independent. */
+                            foreach ([
+                                'tblSongExternalLinks',
+                                'tblSongAlternativeTitles',
+                                'tblSongMedia',
+                                'tblWorkSongs',
+                            ] as $childTbl) {
+                                $stmt = $db->prepare(
+                                    "UPDATE {$childTbl}
+                                        SET SongId = CONCAT(?, SUBSTRING(SongId, ? + 1))
+                                      WHERE SongId LIKE ?"
+                                );
+                                $stmt->bind_param('sis', $newPrefix, $oldPrefixLen, $likeOld);
+                                $stmt->execute();
+                                $stmt->close();
+                            }
+
+                            /* Step 2 — update tblSongs.SongId itself. The
+                               other ~14 child tables (Components, Writers,
+                               Composers, Arrangers, Adaptors, Translators,
+                               Artists, TagMap, History, Favorites, Keys,
+                               SongLinks, SongLinkSuggestions, Catalogues)
+                               cascade automatically via ON UPDATE CASCADE. */
+                            $stmt = $db->prepare(
+                                "UPDATE tblSongs
+                                    SET SongId = CONCAT(?, SUBSTRING(SongId, ? + 1))
+                                  WHERE SongbookAbbr = ?
+                                    AND SongId LIKE ?"
+                            );
+                            $stmt->bind_param('siss', $newPrefix, $oldPrefixLen, $newAbbr, $likeOld);
+                            $stmt->execute();
+                            $stmt->close();
                         }
                     }
 


### PR DESCRIPTION
## Summary

Two-part fix for the bulk-import failure observed after renaming `HA → HAOLD` and `HASD → HASDOLD` to free those abbreviations for the new SDA-Hymnal scrape:

1. **`/manage/songbooks` rename flow** now re-prefixes `tblSongs.SongId` when the abbreviation changes AND `rename_song_refs` is ticked — fixing the bug at source.
2. **`migrate-songid-prefix-fixup.php`** migration repairs catalogues whose rename happened BEFORE the patch shipped (i.e. your alpha right now). Detects every row whose `SongId` prefix doesn't match its `SongbookAbbr` and rewrites it. Idempotent + self-clearing probe.

## Why

The old rename code at [songbooks.php#L1234-L1245](appWeb/public_html/manage/songbooks.php#L1234-L1245) updated:
- `tblSongbooks.Abbreviation` ✓
- `tblSongs.SongbookAbbr` ✓ (when `rename_song_refs` is ticked)
- `tblSongs.SongId` ✗  **← bug**

So renaming `HA → HAOLD` produced surviving rows like `SongId='HA-0520', SongbookAbbr='HAOLD'` — and a subsequent bulk-import of the new `HA` collides on the SongId primary key.

## How the fix works

### Rename-flow patch

After the existing `SongbookAbbr` update, the patch:
1. UPDATEs the four child tables whose FK to `tblSongs.SongId` **lacks** `ON UPDATE CASCADE`:
   - `tblSongExternalLinks`
   - `tblSongAlternativeTitles`
   - `tblSongMedia`
   - `tblWorkSongs`
2. UPDATEs `tblSongs.SongId` itself. The remaining ~14 child tables (`tblSongComponents`, `tblSong{Writers,Composers,Arrangers,Adaptors,Translators,Artists}`, `tblSongTagMap`, `tblSongHistory`, `tblUserFavorites`, `tblSongKeys`, `tblSongLinks`, `tblSongLinkSuggestions`, `tblCatalogueSongs`, `tblTranslationMaps`) cascade automatically via their existing `ON UPDATE CASCADE`.

Match pattern is **anchored prefix** `<oldAbbr>-%` so renaming `HA` doesn't accidentally rewrite a SongId like `HABA-0001`.

### Fixup migration

`migrate-songid-prefix-fixup.php` does the same multi-step UPDATE, but driven by a SELECT that finds every row where the prefix is already stale:

```sql
SELECT SongId, SongbookAbbr
  FROM tblSongs
 WHERE SongbookAbbr <> SUBSTRING_INDEX(SongId, '-', 1)
```

Per-row, it computes the target SongId (`SongbookAbbr || '-' || tail`) and checks if it's already taken. If free → rewrite via the same 4-children + parent sequence used by the live rename flow. If taken → reported in the output for manual merge (curator's call) and skipped. Wrapped in a transaction; rolls back cleanly on error.

Probe self-clears: the card disappears from `/manage/setup-database`'s pending list once every row's prefix matches its `SongbookAbbr`.

## What to do after merge

1. Pull alpha locally.
2. `/manage/setup-database → Apply pending → "Re-prefix SongIds after Songbook Rename"` (single click).
   - Expected output: `[fix ] re-prefixing N rows…` followed by `[done] re-prefixed N SongIds`.
   - For your case: HAOLD-formerly-HA hymns get `HA-` → `HAOLD-`, and HASDOLD-formerly-HASD hymns get `HASD-` → `HASDOLD-`.
3. Regenerate the songs.json cache via `/manage/data-health → Regenerate songs.json cache`.
4. Re-run the SDA bulk-import ZIP. The `HA-XXXX` and `HASD-XXXX` SongId namespace is now free, so the new imports should land cleanly.

## Test plan

- [ ] `php -l` clean on all four touched files (verified).
- [ ] Local dry-run: rename a test songbook (with `rename_song_refs` ticked) → confirm every SongId, plus rows in all 18 child tables, gets the new prefix.
- [ ] Migration dry-run on a partly-renamed catalogue → confirm `[fix ]` line lists the right count + `[done]` matches.
- [ ] Conflict path: artificially create a target-SongId collision (insert a row with the target ID first) → confirm the migration reports it as `[warn]` and leaves both rows intact.
- [ ] After applying the migration + cache regen, re-run the SDA ZIP import → confirm HA and HASD songbooks populate cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)