### PR TITLE
fix(migration): split FK alter into separate DROP + ADD statements (follow-up to #998)

### DIFF
--- a/appWeb/.sql/migrate-songid-prefix-fixup.php
+++ b/appWeb/.sql/migrate-songid-prefix-fixup.php
@@ -137,22 +137,32 @@ foreach ($cascadeTargets as [$tbl, $fk, $col]) {
         continue; /* already cascading — nothing to do */
     }
 
-    /* MySQL has no in-place "ALTER FK". The only path is DROP +
-       ADD inside the same ALTER TABLE statement so the FK is never
-       missing during the operation. ON DELETE CASCADE is preserved
-       (every one of these started with DELETE CASCADE already). */
-    $sql = "ALTER TABLE {$tbl}
-                DROP FOREIGN KEY {$fk},
-                ADD CONSTRAINT {$fk}
-                    FOREIGN KEY ({$col}) REFERENCES tblSongs(SongId)
-                    ON DELETE CASCADE ON UPDATE CASCADE";
-    if ($db->query($sql)) {
-        _migSongIdPrefix_out("[alt ] {$tbl}.{$fk} now ON UPDATE CASCADE.");
-        $altered++;
-    } else {
-        _migSongIdPrefix_out("ERROR: ALTER {$tbl}.{$fk} failed: " . $db->error);
+    /* MySQL has no in-place "ALTER FK". The path is DROP then ADD
+       — and these MUST be two SEPARATE ALTER TABLE statements,
+       not a single multi-action ALTER. MySQL/MariaDB validates the
+       new constraint name against the schema state at the START of
+       the statement, BEFORE the in-statement DROP registers, so a
+       combined `DROP FOREIGN KEY x, ADD CONSTRAINT x …` trips
+       "Duplicate foreign key constraint name 'x'". Two statements
+       avoid that — the brief window between them, where the FK is
+       absent, is safe for a maintenance migration (no concurrent
+       writes are expected). ON DELETE CASCADE is preserved (every
+       one of these started with DELETE CASCADE already). */
+    $sqlDrop = "ALTER TABLE {$tbl} DROP FOREIGN KEY {$fk}";
+    if (!$db->query($sqlDrop)) {
+        _migSongIdPrefix_out("ERROR: DROP {$tbl}.{$fk} failed: " . $db->error);
         if ($isCli) exit(1); else return;
     }
+    $sqlAdd = "ALTER TABLE {$tbl}
+                  ADD CONSTRAINT {$fk}
+                      FOREIGN KEY ({$col}) REFERENCES tblSongs(SongId)
+                      ON DELETE CASCADE ON UPDATE CASCADE";
+    if (!$db->query($sqlAdd)) {
+        _migSongIdPrefix_out("ERROR: ADD {$tbl}.{$fk} failed (FK left dropped — re-run the migration to retry): " . $db->error);
+        if ($isCli) exit(1); else return;
+    }
+    _migSongIdPrefix_out("[alt ] {$tbl}.{$fk} now ON UPDATE CASCADE.");
+    $altered++;
 }
 if ($altered === 0) {
     _migSongIdPrefix_out('[ok  ] all four child FKs already ON UPDATE CASCADE.');


### PR DESCRIPTION
## Hotfix to #998

The migration shipped in #998 trips a different MySQL/MariaDB quirk the moment it tries the ALTER:

```
ERROR: Duplicate foreign key constraint name 'fk_link_song'
File: migrate-songid-prefix-fixup.php:149
```

MySQL validates new FK constraint names against the schema state at the **start** of an `ALTER TABLE` statement, before the in-statement `DROP FOREIGN KEY` registers. So the combined form

```sql
ALTER TABLE tblSongExternalLinks
    DROP FOREIGN KEY fk_link_song,
    ADD CONSTRAINT fk_link_song …
```

complains about a duplicate name even though the same statement is also dropping it.

Fix: two separate `ALTER` statements per table.

```sql
ALTER TABLE tblSongExternalLinks DROP FOREIGN KEY fk_link_song;
ALTER TABLE tblSongExternalLinks ADD CONSTRAINT fk_link_song …;
```

Between the two, the FK is briefly absent. Safe in a maintenance migration where no concurrent writes are expected. If the ADD step fails (constraint redefinition typo etc.) the FK is left dropped — the error message tells the curator to re-run the migration, which will skip the already-altered FKs via the existing `INFORMATION_SCHEMA` probe and retry only the broken one. Idempotency holds.

## After merge

Re-run **`/manage/setup-database` → Re-prefix SongIds**. Expected output:

```
SongId prefix fixup starting…
[alt ] tblSongExternalLinks.fk_link_song now ON UPDATE CASCADE.
[alt ] tblSongAlternativeTitles.fk_alt_song now ON UPDATE CASCADE.
[alt ] tblSongMedia.fk_media_song now ON UPDATE CASCADE.
[alt ] tblWorkSongs.fk_work_song_song now ON UPDATE CASCADE.
[scan] 1886 rows have a stale SongId prefix.
[fix ] re-prefixing 1886 rows…
[done] re-prefixed 1886 SongIds.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)