### PR TITLE
docs(claude): session handoff for 2026-05-15

### DIFF
--- a/.claude/sessions/2026-05-15-HANDOFF.md
+++ b/.claude/sessions/2026-05-15-HANDOFF.md
@@ -1,0 +1,266 @@
+# Session Handoff — 2026-05-15
+
+A new Claude Code session should read this file first when picking up where the previous session left off. The previous session was wrapped early because the chat-side image processor hit a pixel-dimension cap and was unable to process screenshots reliably. Code state is clean; what's queued and what's blocked is captured below.
+
+---
+
+## 1. MEMORY — durable facts learned this session
+
+**Catalogue state (alpha, dev.ihymns.app, v0.110.0)**
+- 17,305 songs loaded post-import.
+- Songbooks `HA` (Spanish, 527 songs) and `HASD` (Portuguese, 610 songs) imported from the SDA-Hymnal scrape this session.
+- Renamed companions `HAOLD` (614 songs) and `HASDOLD` (610 songs) preserve the older CIS-imported versions.
+- All 10 non-English SDA hymnals now complete: HA 527, NHA 613, HASD 610, HL 654, IA 568, HAC 490, PJ 490, HP 300, HJP 340, PES 490 → **5,082 non-English hymns**.
+
+**SDA scrape rate-limit profile**
+- HASD (`hinarioadventista.com`) and IA (`innarioavventista.com`) cap each session at ~50 hymns then return 500 + "Still rate limited — stopping" with `Exit=0`.
+- Wall lifts after ~1.5h. A cloud routine at `0 */2 * * *` cadence (`trig_01Y16QzoocEwUAvNegbV4GnC`) was scheduled to drip these. **DISABLE it now** that both songbooks are complete — otherwise it'll fire forever no-ops.
+- The local approach (run `python3 .importers/scrapers/SDAHymnals_SDAHymnal.org.py --site <hasd|ia> --output "SourceSongData/_SDAHymnalExportNEW"` per VPN-rotation) ended up doing the work.
+
+**Songbook rename → SongId prefix is now self-consistent**
+- PR #997 added `tblSongs.SongId` re-prefix to the `/manage/songbooks` rename flow when "rename song refs" is ticked.
+- PR #997's first migration approach had a child-first FK violation bug; PR #998 fixed it by ALTERing the 4 child FKs (`fk_link_song`, `fk_alt_song`, `fk_media_song`, `fk_work_song_song`) to `ON UPDATE CASCADE`, leaving the rewrite as a single parent UPDATE.
+- PR #999 (hotfix to #998) split the FK ALTER into separate DROP + ADD statements to dodge MySQL's "duplicate constraint name" check on combined ALTERs.
+- After running `migrate-songid-prefix-fixup.php`, **1,886 stale-prefix rows were re-prefixed** (HA-* → HAOLD-*, HASD-* → HASDOLD-*). HA / HASD namespaces now free.
+
+**Auto-maintenance hook (PR #998)** — fires on every songbook write + bulk import
+- New `appWeb/public_html/includes/songbook_maintenance.php` exposes `songbookMaintenanceRun($db, $context)` which combines cache regen + stale-prefix probe-and-fixup.
+- Wired into: songbooks.php create / update / reorder / delete / cascade-delete / auto-colour / manifest-apply; editor/api.php's 4 bulk-import variants.
+- BUT — until this session's observability commit (ddde5930 on `claude/fix-songbook-visibility-and-button-contrast`), the success-path activity log entry was missing, so the hook was firing invisibly. **PR with that fix is open on the same branch as PR #1001 (btn-info contrast)** — observability commit is the second one on that branch.
+
+**btn-info dark-mode contrast** — PR #1001 (OPEN) on branch `claude/fix-songbook-visibility-and-button-contrast`.
+- Bootstrap's default `btn-info` (dark text on cyan) renders illegibly in admin dark mode.
+- CSS override in `admin.css` forces white text on `#0aa6c4` across all states.
+- Affects 5 admin buttons (setup-database x2, catalogues x3) — no markup changes.
+
+**`/manage/tags` theme inheritance** — committed (ddde5930) on same branch as #1001
+- Was the last admin page hard-coding its own Bootstrap+CSS includes instead of going through `head-libs.php`.
+- Now uses `head-libs.php` so `admin-theme-init.php` runs → page obeys Light/Dark/CVD/System preference.
+
+**User-corrected facts**
+- The Public *Browse by Theme* screenshot looked like it had duplicates (Worship / Worssship / Thankful / Thankfulness) but `/manage/tags` shows clean data. **No actual duplicate rows in tblSongTags.** Don't trust the public screenshot blindly — it was probably a curated cropped image, not a faithful reflection of DB state.
+
+**HA visibility on public `/songbooks/`** — **STILL UNRESOLVED at session end**
+- `/manage/songbooks` shows HA with 527 songs.
+- Public `/songbooks/` skips HA, shows HAOLD (614) only.
+- Hard reload (Cmd+Shift+R), service worker unregister, manual cache regen — none of these revealed HA.
+- The public page filter is just `($book['songCount'] ?? 0) > 0` at [includes/pages/songbooks.php:48](appWeb/public_html/includes/pages/songbooks.php#L48). No `isOfficial` filter.
+- **Next-session diagnostic**: hit `https://dev.ihymns.app/api?action=songbooks` and inspect the HA entry. If `songCount` is correct → render-side bug. If 0 → tblSongbooks.SongCount is stale (SongCount triggers didn't fire on import). If missing entirely → SQL-side filter we haven't found.
+
+---
+
+## 2. CONTEXT — in-flight work and what's queued
+
+**Pushed but not yet merged**
+| PR | Branch | What | Status |
+|---|---|---|---|
+| #1001 | `claude/fix-songbook-visibility-and-button-contrast` | btn-info contrast fix + observability commit (cache regen success log + tags.php theme) | OPEN |
+| THIS PR | `claude/session-handoff-2026-05-15` | This handoff doc + auto-memory updates | OPEN (to alpha) |
+
+**Already merged this session** (in chronological order to alpha)
+- PR #997 — songbooks rename re-prefixes SongId (had FK bug)
+- PR #998 — ALTER 4 FKs to ON UPDATE CASCADE + new `songbook_maintenance.php` helper + wired into all write paths
+- PR #999 — split FK ALTER into separate DROP + ADD (MySQL quirk hotfix)
+
+**Queued — high priority, not started**
+
+1. **Service Worker network-first redesign** *(user-flagged urgent this session)*
+   - Current SW is cache-first, which means online users get stale content until they manually unregister the SW.
+   - User wants: when network is available, always fetch fresh; cache only for offline fallback.
+   - File: `appWeb/public_html/sw.js` (or wherever the SW lives — grep for `registerServiceWorker` to find).
+   - Strategy: switch the catalogue/HTML fetch routes to "network-first with cache fallback"; keep "cache-first" only for static assets that have hashed filenames.
+
+2. **`/manage/diagnostics` page** *(user agreed to build it this session)*
+   - Purpose: give Claude a structured way to run SELECT queries against the catalogue without holding credentials.
+   - Design agreed:
+     - Server-enforced SELECT-only: regex rejects anything not `^\s*(SELECT|SHOW|EXPLAIN|DESCRIBE)\b`.
+     - Whitelist of tables: only `tbl*`; `information_schema.*` allowed selectively for column probes; reject `mysql.*`, `performance_schema.*`.
+     - Hard row cap (1,000 max).
+     - Audit row per query → `tblActivityLog` with `Action='diagnostics.query'`, query text, row count, duration.
+     - New entitlement `view_diagnostics` (defaults to `global_admin`).
+     - Quick-paste shortcuts: pre-written queries (find songbook by abbr, mismatched-prefix rows, tag usage histogram, recent activity log entries).
+   - Files to create: `appWeb/public_html/manage/diagnostics.php`, registry entry in `appWeb/public_html/manage/includes/admin-links.php`, new entitlement in `appWeb/public_html/includes/entitlements.php`.
+
+3. **HA visibility deep-dive** *(blocked on diagnostic output)*
+   - Either run `/api?action=songbooks` and grep for `"id":"HA"`, OR build `/manage/diagnostics` first and run `SELECT Abbreviation, Name, SongCount, IsOfficial, Language FROM tblSongbooks WHERE Abbreviation IN ('HA', 'HAOLD');` through it.
+
+4. **"Merge obvious duplicates" auto-button on `/manage/tags`** *(user-requested this session)*
+   - Find tags whose normalized slugs are exact-prefix matches or Levenshtein ≤ 1 of each other.
+   - Offer one-click merge of the longer-named one into the shorter (or curator picks the survivor).
+   - Pattern to follow: the existing per-row Merge button already does pair-wise merge; this is an automation layer on top.
+
+5. **Recently Viewed broken** *(user reported this session)*
+   - Home page shows only old "Recently Viewed" entries (SDAH/MP/CH songs), not recent visits to new songs.
+   - Suspect: localStorage scoping. The SongId rename migration (HA-* → HAOLD-*) may have orphaned half the entries — the keys in localStorage now point at rows that don't exist under their old IDs.
+   - Files to check: `appWeb/public_html/js/modules/recently-viewed.js` (or similar — grep for `recently_viewed`), `appWeb/public_html/includes/pages/home.php`.
+
+6. **Browse-by-Theme scale redesign** *(user flagged for scale)*
+   - Current flat-chip layout fine for ~30 tags but breaks at 100+.
+   - Suggested redesign: category grouping (Seasonal / Doctrinal / Pastoral / Praise) with a "more…" expander per group, OR a search-as-you-type dropdown.
+   - Also worth promoting tags with high song-count first.
+
+**Queued — lower priority**
+
+7. **Disable the SDA scrape cron routine `trig_01Y16QzoocEwUAvNegbV4GnC`** — both songbooks complete; routine will idle-fire forever otherwise. URL: https://claude.ai/code/routines/trig_01Y16QzoocEwUAvNegbV4GnC
+
+---
+
+## 3. HISTORY — what happened this session, chronologically
+
+1. **Session opened with SDA scrape audit** — counted on-disk files vs expected hymn totals. HASD had 100/610, IA had 100/653 (later corrected to 568); both walls hit ~50 hymns/session.
+2. **VPN-rotation drip**: user manually triggered scrapes per VPN-rotation across ~8 turns. Final: HASD 610/610, IA 568/568.
+3. **Cloud routine scheduled** for safety net (90m → rounded to 2h cron). User chose cloud schedule despite the gitignore caveat — routine commits scraped files via `git add -f` to `claude/sda-scrape-hasd-ia`.
+4. **Bulk-import attempted** — user dropped `_SDAHymnalExportNEW.zip` into `/manage/editor`. Toast: "Imported 0 new (5,128 already in DB)" — every HA-*/HASD-* SongId already taken by the renamed-to-HAOLD/HASDOLD orphan rows.
+5. **PR #997** — fixed the rename flow to re-prefix SongIds. Multi-table approach. Had a hidden FK bug (children-first UPDATEs trip the FK constraint because the parent SongId doesn't yet exist).
+6. **PR #998** — proper fix: ALTER the 4 non-cascading child FKs to add `ON UPDATE CASCADE`, then a single parent UPDATE. Plus new `songbook_maintenance.php` helper wired into every songbook write path AND all 4 bulk-import variants.
+7. **PR #999** — hotfix. MySQL/MariaDB tripped "Duplicate foreign key constraint name 'fk_link_song'" on the combined `DROP + ADD` ALTER because it validates the new constraint name BEFORE the in-statement DROP registers. Split into two separate ALTERs.
+8. **Migration ran cleanly** — 1,886 rows re-prefixed. HA and HASD namespaces freed.
+9. **Re-import succeeded** — 1,137 new songs imported (HA 527 + HASD 610). Visible on `/manage/songbooks`.
+10. **But `/songbooks/` public still hid HA.** Diagnostics: hard-reload, SW unregister, manual cache regen — all fruitless. Activity log query revealed only manual data_health.manual regen events — `songsCacheRegenerateBestEffort` wasn't logging on success, so the auto-maintenance hook was invisible.
+11. **Started observability batch** — committed `tags.php` theme inheritance fix + `songs_cache.php` success-path activity log on the existing `claude/fix-songbook-visibility-and-button-contrast` branch (PR #1001 grows from 1 commit to 2).
+12. **Pivoted to session handoff** — user reported image-processing issues and asked for clean session wrap.
+
+---
+
+## 4. PROMPTS — pre-baked prompts to resume each open task
+
+Copy any of these into the next Claude Code session to pick up immediately.
+
+### Resume → Service Worker network-first redesign (TOP PRIORITY)
+
+```
+Continue from .claude/sessions/2026-05-15-HANDOFF.md.
+
+The user's #1 complaint is that the PWA service worker serves stale
+content even when the user is online. Make the SW network-first
+for catalogue HTML / JSON routes, cache-first only for hashed
+static assets.
+
+Steps:
+1. Grep for `registerServiceWorker` and `sw.js` to find the SW
+   file. Inspect its current fetch handler.
+2. Inventory which URL patterns are cached and with what strategy
+   today. Common ones: `/`, `/api?action=songs_json`, `/songbook/*`,
+   `/song/*`, `/css/*`, `/js/*`, `/vendor/*`.
+3. Switch HTML + dynamic-JSON routes to network-first. Fallback to
+   cache only when fetch fails (offline). Keep cache-first for
+   immutable hashed assets.
+4. Bump the SW version so existing installs invalidate.
+5. Test plan: stub-online → load /songbooks → confirm fresh data;
+   stub-offline → load /songbooks → confirm cached fallback works.
+
+Open as a focused PR against alpha.
+```
+
+### Resume → Build `/manage/diagnostics`
+
+```
+Continue from .claude/sessions/2026-05-15-HANDOFF.md.
+
+Build the curated SQL diagnostics page agreed last session. Spec:
+
+File: appWeb/public_html/manage/diagnostics.php
+
+Auth: new entitlement `view_diagnostics` defaulting to global_admin
+(see includes/entitlements.php). Register in admin-links.php under
+the Operations group.
+
+Behaviour:
+- Textarea for SELECT statement
+- Server regex: `^\s*(SELECT|SHOW|EXPLAIN|DESCRIBE)\b` — reject otherwise.
+- Whitelist parse: reject if query references `mysql.*`,
+  `performance_schema.*`. Allow `information_schema.*` (read-only
+  by definition).
+- Inject a LIMIT 1000 if absent.
+- Render result as a Bootstrap table.
+- Write a tblActivityLog row per query: Action='diagnostics.query',
+  Details = JSON {query, rows, duration_ms}.
+- Quick-paste buttons for common forensics:
+  * "Find songbook by abbreviation"
+  * "Songs with stale SongId prefix"
+  * "Recent songs_cache.regenerated events"
+  * "Tag usage histogram"
+  * "Active sessions / users"
+
+Open as a focused PR against alpha.
+```
+
+### Resume → HA visibility diagnosis
+
+```
+Continue from .claude/sessions/2026-05-15-HANDOFF.md.
+
+HA songbook still missing from public /songbooks/ on dev.ihymns.app
+despite cache regen + service worker unregister.
+
+If /manage/diagnostics doesn't yet exist, ask the user to hit
+`https://dev.ihymns.app/api?action=songbooks` directly and paste
+the JSON entry where `"id": "HA"` (or "missing" if not there).
+
+Three possible outcomes:
+- Present with correct songCount → bug is in page render filter
+  at includes/pages/songbooks.php:48. Investigate why the filter
+  rejects HA.
+- Present but songCount=0 → tblSongbooks.SongCount is stale.
+  SongCount triggers (migrate-songcount-triggers.php / #793) may
+  not have fired on bulk-import. Force recompute via
+  /manage/data-health → Recompute song counts (if button exists)
+  or a one-off UPDATE tblSongbooks SET SongCount = (subquery).
+- Missing entirely → some SQL-side filter we haven't found.
+  Inspect SongData::getSongbooks() at includes/SongData.php:292.
+```
+
+### Resume → Merge obvious duplicate tags (small feature)
+
+```
+Continue from .claude/sessions/2026-05-15-HANDOFF.md.
+
+Add a "Merge obvious duplicates" auto-button to /manage/tags.
+Algorithm:
+1. SELECT Id, Name, Slug, (SELECT COUNT(*) FROM tblSongTagMap m
+   WHERE m.TagId = t.Id) AS usage FROM tblSongTags t.
+2. Build clusters where slug-A is a Levenshtein-≤1 transform of
+   slug-B (likely typos like Worship/Worssship/Thankful/Thankfulness).
+3. Within each cluster, propose the most-used tag as survivor.
+4. Present as a confirm-list modal: each row shows the suggested
+   merge and a checkbox; default ticked.
+5. On confirm, reuse the existing pair-wise merge code path
+   (already exists per the page's per-row Merge button).
+
+Open as a focused PR against alpha.
+```
+
+### Resume → Recently Viewed broken
+
+```
+Continue from .claude/sessions/2026-05-15-HANDOFF.md.
+
+Home page "Recently Viewed" only shows old songs (SDAH/MP/CH),
+none of the songs viewed this session. Suspect localStorage
+scoping issue post-rename.
+
+Investigate:
+1. grep for `recently_viewed` or `recentlyViewed` in
+   appWeb/public_html/js/.
+2. Find where SongIds are written to / read from localStorage.
+3. Check whether the renamed SongIds (HAOLD-* formerly HA-*) get
+   silently dropped because the SongId in localStorage doesn't
+   resolve to a current row.
+4. If so, either:
+   (a) Migrate the localStorage entries on first load by
+       querying /api?action=songids_translate for stale ids.
+   (b) Or accept the data loss but bump a localStorage version
+       key to wipe and start fresh.
+
+Open as a focused PR against alpha.
+```
+
+---
+
+## 5. Useful current state for orientation
+
+**Local working tree at handoff time**: clean (any in-flight changes from this session were committed to `claude/fix-songbook-visibility-and-button-contrast`).
+
+**Alpha tip**: `2ad86a4b` (PR #998 merge) → `fc5cb0d5` (PR #999) — both merged ~09:00–09:30 BST 2026-05-15.
+
+**Recent activity-log query** (user-run) on `tblActivityLog WHERE Action LIKE 'songs_cache.%' OR Details LIKE '%songbook_maint%' ORDER BY CreatedAt DESC LIMIT 10` returned 3 rows, all `songs_cache.regenerated` with `context: "data_health.manual"`. The observability commit on `claude/fix-songbook-visibility-and-button-contrast` will start filling in the auto-hook contexts (`bulk_import_zip.sync` etc.) — re-run the same query after PR #1001 merges to confirm the hook is now visible.


### PR DESCRIPTION
## Why

The previous session was wrapped early because the chat-side image processor hit a pixel-dimension cap and stopped processing screenshots reliably. Committing a comprehensive handoff doc so a new session can pick up cleanly from a fresh checkout (preserves state across machines + sessions).

## What

One new file: `.claude/sessions/2026-05-15-HANDOFF.md`.

Structure: four sections per user request.

| Section | Contents |
|---|---|
| **MEMORY** | Durable facts learned this session — rename → SongId self-consistency now via FK cascade (#997/#998/#999); auto-maintenance hook fires on every songbook write; HA visibility on public `/songbooks/` STILL UNRESOLVED; ~10 non-English SDA hymnals scraped to completion (5,082 hymns). |
| **CONTEXT** | In-flight + queued work — PR #1001 open with btn-info contrast + observability commit; service worker network-first queued as top priority; `/manage/diagnostics` (curated SELECT-only queries) queued; HA deep-dive blocked on diagnostic output; merge-obvious-duplicate-tags / Recently-Viewed / Browse-by-Theme follow-ups. |
| **HISTORY** | Chronological log of this session — VPN-rotation scrape sessions, PR #997 (rename re-prefix; FK bug), PR #998 (ALTER FKs + auto-maintenance helper), PR #999 (DROP/ADD split hotfix), bulk-import succeeds, HA invisible on public, diagnostic gap revealed in activity log. |
| **PROMPTS** | Pre-baked resume prompts for each open task — copy verbatim into the next session to pick up immediately. |

## Note

No code changes in this PR — pure documentation. Sister PR #1001 (`claude/fix-songbook-visibility-and-button-contrast`) carries the in-flight observability fixes (btn-info dark-mode contrast + cache regen success log + tags.php theme inheritance). Both can merge independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)