### PR TITLE
chore(claude): track auto-generated permission allowlist (.claude/settings.json)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(php -l appWeb/public_html/manage/diagnostics.php)",
+      "Bash(grep -rln \"bind_param\\\\|->query\\(\\\\|manage/\\\\|admin-links\\\\|SELECT.*\\\\$\" tests/php)",
+      "Bash(php tests/php/test-schema-coverage.php)",
+      "Bash(php tests/php/test-migration-registry.php)",
+      "Bash(awk '{print $1}')"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Tracks `.claude/settings.json` — the Claude Code **permission allowlist** auto-generated while building the SQL Diagnostics page (#1004 / PR #1005). `settings.json` is the repo-shared Claude Code settings file (`settings.local.json` is the per-developer one and stays untracked), so it's safe to commit.

Single-file change. Base branch: **alpha**.

### Why a separate PR

This commit was made on the diagnostics feature branch *after* PR #1005 had already been squash-merged into `alpha`, so it was stranded. Rather than re-open the old branch (whose commits aren't ancestors of the squashed merge — a PR from it would show all 7,400+ files again), this is a fresh branch off current `alpha` with just the one commit cherry-picked on top.

### Contents

The allow rules are narrow and session-specific:
- `Bash(php -l appWeb/public_html/manage/diagnostics.php)`
- the two PHP test harnesses (`test-schema-coverage.php`, `test-migration-registry.php`)
- a `grep` and an `awk '{print $1}'`

No secrets, no credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)