### PR TITLE
fix(html): W3C validity residuals from the alpha verify pass (#1150)

### DIFF
--- a/appWeb/public_html/includes/pages/song.php
+++ b/appWeb/public_html/includes/pages/song.php
@@ -331,7 +331,7 @@ try {
                 </span>
                 <?php endif; ?>
                 <div class="flex-grow-1">
-                    <h1 class="h4 mb-1"><?= htmlspecialchars($songTitle) ?><?php if (!empty($song['verified'])): ?><span class="verified-badge" title="Verified lyrics" aria-label="Verified lyrics"><svg viewBox="0 0 24 24" fill="none" aria-hidden="true"><circle cx="12" cy="12" r="10" fill="currentColor" opacity="0.15"/><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="1.5" fill="none"/><path d="M7.5 12.5L10.5 15.5L16.5 9" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg></span><?php endif; ?></h1>
+                    <h1 class="h4 mb-1"><?= htmlspecialchars($songTitle) ?><?php if (!empty($song['verified'])): ?><span class="verified-badge" role="img" title="Verified lyrics" aria-label="Verified lyrics"><svg viewBox="0 0 24 24" fill="none" aria-hidden="true"><circle cx="12" cy="12" r="10" fill="currentColor" opacity="0.15"/><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="1.5" fill="none"/><path d="M7.5 12.5L10.5 15.5L16.5 9" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg></span><?php endif; ?></h1>
                     <?php
                         /* #832 — "Also known as …" line. Hidden when this
                            song has no alt titles (or pre-migration). Per-row

--- a/appWeb/public_html/includes/partials/songbook-language-filter.php
+++ b/appWeb/public_html/includes/partials/songbook-language-filter.php
@@ -147,6 +147,7 @@ $languageCount = count($languageList);
 ?>
 <div class="songbook-language-filter mb-3"
      data-songbook-language-filter
+     role="group"
      aria-label="Filter songbooks and songs by language">
     <div class="dropdown">
         <button type="button"
@@ -170,7 +171,7 @@ $languageCount = count($languageList);
             <div class="lang-filter-scroll" id="lang-filter-list">
                 <label class="lang-filter-row lang-filter-row--all d-flex align-items-center gap-2 px-3 py-2 mb-0">
                     <input type="checkbox" class="form-check-input m-0 flex-shrink-0 js-songbook-language-filter-all"
-                           id="songbook-language-filter-all" autocomplete="off" checked>
+                           id="songbook-language-filter-all" checked>
                     <span class="lang-filter-name fw-semibold">All languages</span>
                 </label>
                 <?php foreach ($languageList as $l): ?>
@@ -184,8 +185,7 @@ $languageCount = count($languageList);
                         <input type="checkbox" class="form-check-input m-0 flex-shrink-0 js-songbook-language-filter-option"
                                id="<?= $id ?>"
                                value="<?= htmlspecialchars($l['sub'], ENT_QUOTES, 'UTF-8') ?>"
-                               data-lang-name="<?= htmlspecialchars($l['name'], ENT_QUOTES, 'UTF-8') ?>"
-                               autocomplete="off">
+                               data-lang-name="<?= htmlspecialchars($l['name'], ENT_QUOTES, 'UTF-8') ?>">
                         <span class="d-flex flex-column lh-sm">
                             <span class="lang-filter-name"><?= htmlspecialchars($l['name'], ENT_QUOTES, 'UTF-8') ?></span>
                             <small class="text-muted lang-filter-meta">

--- a/appWeb/public_html/index.php
+++ b/appWeb/public_html/index.php
@@ -1004,6 +1004,7 @@ if (!empty($breadcrumbItems)) {
                         </button>
                         <div class="dropdown-menu dropdown-menu-end p-0"
                              id="header-notifications-panel"
+                             role="group"
                              aria-labelledby="header-notifications-btn"
                              style="width: 320px; max-width: 90vw;">
                             <div class="d-flex align-items-center justify-content-between px-3 py-2 border-bottom">


### PR DESCRIPTION
Follow-up to #1160. The post-deploy **per-fragment W3C validation** of alpha (which the stale-deploy shell check couldn't do) surfaced validity errors in the AJAX fragments. This clears the high-value, low-risk ones:

- **index.php** — notifications dropdown panel `<div aria-labelledby>` → `role="group"`.
- **songbook-language-filter.php** — removed invalid `autocomplete="off"` from the language `<input type=checkbox>` (~24 errors; JS re-syncs state from localStorage so it's behaviour-safe) + `role="group"` on the filter wrapper.
- **song.php** — verified-badge `<span aria-label>` → `role="img"`.

**Tracked on #1150 (need structural a11y fixes, not rushed):** the two `<h2 role="button">` collapse headers (button-in-heading disclosure pattern) and the `<select required>` placeholder-option.

Found by validating `dev.ihymns.app` after #1160 deployed. `php -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)