### PR TITLE
fix(migrations): Signal probe drift + release v0.770.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **A multiplatform Christian lyrics application for worship enhancement**
 
-[![Version: 0.550.0 Alpha](https://img.shields.io/badge/Version-0.550.0%20Alpha-orange.svg)](#environments)
+[![Version: 0.770.0 Alpha](https://img.shields.io/badge/Version-0.770.0%20Alpha-orange.svg)](#environments)
 [![License: Proprietary](https://img.shields.io/badge/License-Proprietary-red.svg)](LICENSING.md)
 [![Security Policy](https://img.shields.io/badge/Security-Policy-brightgreen.svg)](SECURITY.md)
 [![Platform: Web](https://img.shields.io/badge/Platform-Web%20PWA-blue.svg)](#platforms)

--- a/appWeb/CHANGELOG.md
+++ b/appWeb/CHANGELOG.md
@@ -1,5 +1,27 @@
 # iHymns Web/PWA — Changelog
 
+## [0.770.0] — 2026-06-05
+
+DB-direct data-layer rewrite (epic #1010) landed on alpha (PR #1160) alongside the home-UX rethink, importers, and the security / accessibility / W3C audit fixes.
+
+### DB-direct reads & schema
+- Every read hits live MySQL; the whole-corpus `songs.json` file cache is decommissioned (#1020); a DB outage returns a themed 503 (#1021). One-pass forward-looking schema in the #1066 / #1088 / #1090 families (31 additive, dormant, idempotent migrations).
+
+### Home UX (#1147)
+- Compact searchable **language picker** (#1149), capped **Popular-Themes** strip with counts (#1148), customisable **home sections** via client-side hydration (#448).
+
+### Importers & catalogue
+- **MusicXML** notation parser (#1096), **PowerPoint .pptx** importer (#1095), manual per-line **chords** (#1094); smart song-correction flow (#1092); "why you can use this" rights panel (#1098).
+
+### Security / accessibility / compliance
+- Fixed a critical SQL-injection in the EasyWorship importer, a `.mxl` path-traversal, and 4 role→entitlement checks; Global Admin can no longer be locked out of the invite-only channel gate. WCAG 2.2 focus / aria-live / target-size fixes (#1151); W3C validity fixes incl. per-fragment (#1150).
+
+### Fixes
+- The song-link-confidence migration probe is now a multi-column OR-probe so a partial apply (Confidence added, Signal missing) re-applies instead of showing the card green (schema-audit drift fix).
+
+### Governance
+- Standing-tasks consistency convention (`.claude/standing-tasks.md`); new `SECURITY.md` + `LICENSING.md`.
+
 ## [0.550.0] — 2026-06-04
 
 Minor-version jump for the multi-format interchange + lyrics-ingest program. (iLyricsDB follows this version numbering until the backends merge.)

--- a/appWeb/public_html/includes/infoAppVer.php
+++ b/appWeb/public_html/includes/infoAppVer.php
@@ -79,7 +79,7 @@ $app["Application"]["Description"]["Keywords"] = "hymns, worship, lyrics, songbo
 /* Semantic version number (MAJOR.MINOR.PATCH) */
 /* Auto-bumped by the version-bump GitHub Action on push to beta */
 /* v1.x.x = Phase 1 (local JSON data), v2.x.x = Phase 2 (iLyrics dB) */
-$app["Application"]["Version"]["Number"] = "0.550.0";
+$app["Application"]["Version"]["Number"] = "0.770.0";
 
 /* Version name: human-readable release name (e.g., "Hymnal", NULL if unused) */
 $app["Application"]["Version"]["Name"] = NULL;

--- a/appWeb/public_html/manage/includes/migration-registry.php
+++ b/appWeb/public_html/manage/includes/migration-registry.php
@@ -1583,7 +1583,14 @@ return [
                       . ' matches ahead of fuzzy title guesses. Additive + idempotent.',
             'button' => 'Run Song-Link Confidence Migration',
         ],
-        'probe' => static fn(\mysqli $db) => !_migProbe_columnExists($db, 'tblSongLinkSuggestions', 'Confidence'),
+        /* Multi-column OR-probe (rule #19): pending until BOTH columns exist.
+           A single-column probe on 'Confidence' alone left the card green when
+           a partial apply added Confidence but not Signal — Apply-all then
+           never re-ran it to add the missing Signal (the addCol calls are each
+           idempotent, so a re-run safely adds only what's absent). */
+        'probe' => static fn(\mysqli $db) =>
+               !_migProbe_columnExists($db, 'tblSongLinkSuggestions', 'Confidence')
+            || !_migProbe_columnExists($db, 'tblSongLinkSuggestions', 'Signal'),
     ],
 
     'song-identity-map' => [


### PR DESCRIPTION
Two changes found during the alpha verify pass (follow-up to #1160).

## 1. Schema-drift fix — `tblSongLinkSuggestions.Signal`
The Schema Audit on alpha flagged `Signal` as **missing in DB** even though its migration card showed green. **Root cause:** the registry probe for `migrate-song-link-confidence.php` checked only the *first* column (`Confidence`), so a partial apply (Confidence added, Signal's ALTER interrupted/failed) marked the card applied — and Apply-all never re-ran it to add Signal. The migration's `addCol` calls are each idempotent, so a re-run safely adds only the absent column; the probe just needed to detect the partial state. Switched to the **multi-column OR-probe** pattern (rule #19; matches `song-identity-map`).

➡️ After this deploys, the **Song-Link Confidence** card re-appears as pending → "Apply all" adds the missing `Signal` column, clearing the audit.

## 2. Version bump → **v0.770.0**
Owner-requested bump for the DB-direct + v0.550-program work now on alpha. Updates `infoAppVer.php` (authoritative), the README badge, and adds the `[0.770.0]` CHANGELOG entry.

---
`php -l` clean; `test-migration-registry.php` passes.

**Note on `NormalizedTitle` (the other audit "missing"):** that one is correctly *pending* (single-column migration, not a probe bug) — it just needs **"Run NormalizedTitle Migration"** clicked directly; its ~16,695-row backfill is likely why Apply-all left it for a dedicated run (and it's re-runnable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)