### PR TITLE
fix(ui): person-page &middot; + role counts; quiet routine setlist-sync toast

### DIFF
--- a/appWeb/public_html/includes/pages/person.php
+++ b/appWeb/public_html/includes/pages/person.php
@@ -284,7 +284,12 @@ if (!$person && $totalSongs === 0) {
 /* ---------------------------------------------------------------------- */
 $rolesForBadges = [];
 foreach ($discography as $rk => $entry) {
-    $rolesForBadges[] = ucfirst($rk) . ' (' . count($entry['songs']) . ')';
+    /* Just the role name in the subtitle — the per-role song count is already
+       shown (in context) on each "As Writer (N)" / "As Composer (N)" section
+       header below, and surfacing both counts here read as a confusing
+       "24 + 25 ≠ 27" to users (the totals overlap when someone is both writer
+       and composer of a song). The distinct total is shown after the roles. */
+    $rolesForBadges[] = ucfirst($rk);
 }
 
 ?>
@@ -355,7 +360,10 @@ foreach ($discography as $rk => $entry) {
             <?php endif; ?>
             <?php if (!empty($rolesForBadges)): ?>
                 <p class="text-muted small mb-1">
-                    <?= htmlspecialchars(implode(' &middot; ', $rolesForBadges)) ?>
+                    <?= implode(' &middot; ', array_map(
+                        static fn(string $r): string => htmlspecialchars($r, ENT_QUOTES, 'UTF-8'),
+                        $rolesForBadges
+                    )) ?>
                     — <?= (int)$totalSongs ?> song<?= $totalSongs === 1 ? '' : 's' ?> total
                 </p>
             <?php endif; ?>

--- a/appWeb/public_html/js/modules/user-auth.js
+++ b/appWeb/public_html/js/modules/user-auth.js
@@ -1686,7 +1686,7 @@ export class UserAuth {
      * logout/account-switch mid-flight from repopulating the cache with the
      * old account's data (review #4).
      */
-    async triggerSetlistSync() {
+    async triggerSetlistSync(silent = false) {
         if (!this.app.setList) return false;
 
         const uid = this.getUser()?.id;
@@ -1701,7 +1701,14 @@ export class UserAuth {
         const final = this._unionSetlists(this.app.setList.getAll(), merged);
         this.app.setList.saveAll(final, { sync: false });
         this.app.setList._syncReady = true;
-        this.app.showToast(`Synced ${final.length} setlist${final.length !== 1 ? 's' : ''}`, 'success', 2000);
+        /* Only announce when the user did something deliberate (login, the
+           "Sync Now" button, a settings action). The automatic per-boot
+           reconcile passes silent=true so a routine reload doesn't pop a
+           "Synced N setlists" toast every time — favourites/tags already
+           reconcile silently on that path. */
+        if (!silent) {
+            this.app.showToast(`Synced ${final.length} setlist${final.length !== 1 ? 's' : ''}`, 'success', 2000);
+        }
         return true;
     }
 
@@ -1779,7 +1786,7 @@ export class UserAuth {
         let allOk = false;
         try {
             const results = await Promise.all([
-                this.triggerSetlistSync(),
+                this.triggerSetlistSync(true), /* silent — routine per-boot reconcile */
                 this.triggerFavoritesSync(),
                 this.triggerCustomTagsSync(),
             ]);


### PR DESCRIPTION
Three polish fixes spotted on the live alpha.

1. **`&middot;` rendered literally** on the person page — the entity was inside `htmlspecialchars()`, which escaped the `&`. Now escapes each role label and keeps the separator as a real entity → renders `·`.
2. **Dropped the confusing per-role counts** from the person subtitle (`Writer (24) · Composer (25)`). They duplicated the `As Writer (N)` section headers and read as a broken `24 + 25 ≠ 27` (totals overlap when someone is both writer & composer of a song). Subtitle is now `Writer · Composer — 27 songs total`; counts stay where they make sense (section headers).
3. **Quieted the routine setlist-sync toast.** The automatic per-boot reconcile popped "Synced N setlists" on every full reload (favourites/tags already reconcile silently there). Added a `silent` flag used only on the boot path — deliberate syncs (login / "Sync Now" / settings) still announce. The sync cadence is unchanged (once per app boot, for cross-device freshness).

`php -l` + `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)