### PR TITLE
fix: migration timeout (AFTER-clause rebuild) + 4 home/CVD bugs from alpha testing

### DIFF
--- a/appWeb/.sql/migrate-song-normalized-title.php
+++ b/appWeb/.sql/migrate-song-normalized-title.php
@@ -37,6 +37,13 @@ if (!$isCli && !defined('IHYMNS_SETUP_DASHBOARD')) {
     header('Cache-Control: no-store');
 }
 
+/* The backfill walks every song; on a large catalogue that can exceed a shared
+   host's default 30s limit. Lift PHP's cap and survive a curator navigating away
+   mid-run. (The setup dashboard sets these too; belt-and-braces for a direct run.) */
+@set_time_limit(0);
+@ini_set('max_execution_time', '0');
+@ignore_user_abort(true);
+
 function _migNormTitle_output(string $msg): void {
     global $isCli;
     echo $msg . ($isCli ? "\n" : "<br>\n");
@@ -85,11 +92,18 @@ try {
     if ($hasCol && $hasCol->num_rows > 0) {
         _migNormTitle_output("  [SKIP] tblSongs.NormalizedTitle already present.");
     } else {
+        /* NO positional `AFTER Title` clause: a positional add forces a full
+           table COPY/rebuild on MySQL 5.7 / pre-8.0.29, which on a wide table
+           (tblSongs has ~22 string columns + LyricsText) can exceed the host's
+           proxy timeout mid-rebuild and roll back — leaving the column missing
+           and the migration stuck "pending". Appending the column at the end is
+           an INSTANT, metadata-only op on MySQL 8.0.12+. The column's ordinal
+           position is cosmetic (it's an internal dedup fold); the Schema Audit
+           matches columns by name, not position, so fresh-vs-migrated stay OK. */
         $mysql->query(
             "ALTER TABLE tblSongs
                 ADD COLUMN NormalizedTitle VARCHAR(500) NOT NULL DEFAULT '' COLLATE utf8mb4_unicode_ci
-                    COMMENT 'App-maintained fold of Title via ihymns_normalize_title() for a fast indexed dedup/match pre-filter; exact compare still runs in PHP (#1066 Theme D)'
-                    AFTER Title"
+                    COMMENT 'App-maintained fold of Title via ihymns_normalize_title() for a fast indexed dedup/match pre-filter; exact compare still runs in PHP (#1066 Theme D)'"
         );
         _migNormTitle_output("  [OK] Added tblSongs.NormalizedTitle.");
     }

--- a/appWeb/public_html/css/accessibility.css
+++ b/appWeb/public_html/css/accessibility.css
@@ -108,22 +108,22 @@
  *   achromatopsia — Total colour blindness (monochromacy)
  * ========================================================================= */
 
-/* Protanopia: shift reds to be distinguishable */
-[data-ihymns-cvd="protanopia"] {
-    filter: url('#ihymns-cvd-protanopia');
-}
+/* Protanopia / Deuteranopia / Tritanopia: NO page-wide colour filter.
+ *
+ * The per-deficiency "correction" matrices (#ihymns-cvd-* in
+ * assets/cvd-filters.svg) were applied to the WHOLE page — but a static
+ * feColorMatrix that isn't strictly luminance-preserving DEGRADES contrast: it
+ * remapped the indigo-on-light theme to a near-unreadable yellow-on-white
+ * (reported on alpha). A page-wide hue remap is the wrong tool for *helping* a
+ * CVD user — it can't tell foreground from background. So we deliberately do
+ * NOT apply those filters. CVD distinction instead comes from non-colour cues
+ * (the songbook-badge border *patterns* below — solid / dashed / dotted /
+ * double — the robust, contrast-safe aid) on top of a base palette
+ * (indigo / teal / amber / pink) that is already reasonably CVD-distinguishable.
+ * A proper luminance-preserving daltonization is a tracked follow-up. */
 
-/* Deuteranopia: shift greens to be distinguishable */
-[data-ihymns-cvd="deuteranopia"] {
-    filter: url('#ihymns-cvd-deuteranopia');
-}
-
-/* Tritanopia: shift blues to be distinguishable */
-[data-ihymns-cvd="tritanopia"] {
-    filter: url('#ihymns-cvd-tritanopia');
-}
-
-/* Achromatopsia: full grayscale */
+/* Achromatopsia (total colour blindness): grayscale IS luminance-preserving, so
+   it keeps full contrast while dropping colour cues that could only mislead. */
 [data-ihymns-cvd="achromatopsia"] {
     filter: grayscale(100%);
 }

--- a/appWeb/public_html/css/app.css
+++ b/appWeb/public_html/css/app.css
@@ -1058,6 +1058,9 @@ body[data-page-transition="blur"] ::view-transition-new(root) {
 .footer-link {
     color: var(--text-muted);
     text-decoration: none;
+    /* Opt out of the global muted dotted-underline <a> default (Section 2.5):
+       footer links (Terms / Privacy) should be understated, not "obvious". */
+    border-bottom: none;
     transition: color var(--transition-fast);
 }
 

--- a/appWeb/public_html/js/modules/home-page.js
+++ b/appWeb/public_html/js/modules/home-page.js
@@ -157,11 +157,19 @@ function renderPopularRow(s, opts = {}) {
         ? `<span class="badge bg-secondary">${escapeHtml(String(views))}</span>`
         : '';
 
+    /* Suppress the number badge when there is no real number — collection /
+       unofficial songbooks (e.g. Misc) carry number 0, which otherwise rendered
+       a meaningless "0" in Recently Viewed. (Popular Songs from numbered books
+       are unaffected.) */
+    const numberBadge = number
+        ? `<span class="song-number-badge" data-songbook="${escapeHtml(book)}">${escapeHtml(String(number))}</span>`
+        : '';
+
     return `<a href="/song/${escapeHtml(id)}"
                data-navigate="song"
                data-song-id="${escapeHtml(id)}"
                class="list-group-item list-group-item-action song-list-item">
-                <span class="song-number-badge" data-songbook="${escapeHtml(book)}">${escapeHtml(String(number))}</span>
+                ${numberBadge}
                 <div class="song-info flex-grow-1">
                     <span class="song-title">${escapeHtml(title)}</span>
                     <small class="text-muted d-block">

--- a/appWeb/public_html/js/modules/router.js
+++ b/appWeb/public_html/js/modules/router.js
@@ -1143,6 +1143,10 @@ export class Router {
         if (recent.length < 2) return;
 
         const songbooks = this.config.songbooks || [];
+        /* Drop any recently-viewed songbooks that no longer exist (deleted) so a
+           badge never renders a 404-on-click link (e.g. a removed HAOLD). */
+        recent = recent.filter(id => songbooks.some(b => b.id === id));
+        if (recent.length === 0) return;
 
         const badges = recent.map(id => {
             const sb = songbooks.find(b => b.id === id);
@@ -1165,7 +1169,7 @@ export class Router {
             <div class="d-flex align-items-center gap-2 mb-1">
                 <small class="text-muted fw-semibold">
                     <i class="fa-solid fa-clock-rotate-left me-1" aria-hidden="true"></i>
-                    Recent
+                    Recently viewed songbooks
                 </small>
             </div>
             <div class="d-flex flex-wrap gap-2">${badges}</div>


### PR DESCRIPTION
Found during alpha testing.

## 🔴 Migrations stuck "pending" after Apply-all (the big one)
`migrate-song-normalized-title.php`'s `ALTER … ADD COLUMN … **AFTER Title**` forces a full table COPY/rebuild on MySQL 5.7 / pre-8.0.29. On the wide `tblSongs` (~22 string columns + `LyricsText`) that rebuild can exceed the host's proxy timeout mid-flight and **roll back** → column never added → card stays "pending". And because Apply-all **stops on the first hard failure**, it also blocked the Song-Link Confidence migration ordered behind it → **both** pending (matching the report). Fix: drop the positional clause (append = **INSTANT** on MySQL 8.0.12+), add `set_time_limit(0)`/`ignore_user_abort`. Position is cosmetic; the Schema Audit matches by name.

> ⚠️ **Please re-run after this deploys:** "Apply all" (or the two cards directly) → they should now complete, and Schema Audit should read **all-OK**. If a card *still* sticks, please paste the migration's printed output (the `[OK]`/`[ERROR]` lines) — that's the definitive diagnostic for any remaining cause (e.g. a row-size error).

## Home / CVD bugs
- **Recently Viewed showed "0"** as the number for collection songbooks (Misc) — now suppressed (matches numbered-book behaviour).
- **"Recent" songbooks strip listed a DELETED songbook (HAOLD)** → 404 on click. Now filtered against the live songbook set; header renamed to **"Recently viewed songbooks"**.
- **Footer links** (Terms/Privacy) had the global dotted underline → removed (understated).
- **Colour-blind mode was unreadable** — it applied page-wide `feColorMatrix` "correction" filters that *degrade* contrast (indigo → yellow-on-white). Removed them (kept luminance-safe grayscale for achromatopsia); CVD distinction now uses the contrast-safe songbook-badge border patterns. Proper daltonization tracked as a follow-up.

`php -l` + `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)