### PR TITLE
fix(schema): 2 stuck migrations — Signal reserved word + presentation CHECK/generated-col (#1172)

### DIFF
--- a/appWeb/.sql/migrate-presentation-themes.php
+++ b/appWeb/.sql/migrate-presentation-themes.php
@@ -242,10 +242,8 @@ try {
             ComponentId   INT UNSIGNED NULL DEFAULT NULL,
             DisplayRole   VARCHAR(30)  NULL DEFAULT NULL COMMENT 'NULL = applies to all display roles; else binds only that variant',
             Priority      INT NOT NULL DEFAULT 0 COMMENT 'Tie-break within a scope level',
-            AssignmentKey VARCHAR(180) AS (CONCAT_WS('|', AssignmentScope, IFNULL(OrgId,'-'), IFNULL(UserId,'-'), IFNULL(SongbookId,'-'), IFNULL(SongId,'-'), IFNULL(ArrangementId,'-'), IFNULL(ComponentId,'-'), IFNULL(DisplayRole,'*'))) STORED COMMENT 'Generated non-null cascade key; its UNIQUE enforces one theme per (scope,tenant,anchor,role) — NULL-leak-proof',
             CreatedAt   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
             UpdatedAt   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-            UNIQUE KEY uq_Assignment (AssignmentKey),
             INDEX idx_Theme (ThemeId),
             INDEX idx_Scope (AssignmentScope),
             INDEX idx_Org (OrgId),
@@ -257,17 +255,9 @@ try {
             CONSTRAINT fk_PresAssign_Songbook  FOREIGN KEY (SongbookId) REFERENCES tblSongbooks(Id) ON DELETE CASCADE ON UPDATE CASCADE,
             CONSTRAINT fk_PresAssign_Song      FOREIGN KEY (SongId) REFERENCES tblSongs(SongId) ON DELETE CASCADE ON UPDATE CASCADE,
             CONSTRAINT fk_PresAssign_Arr       FOREIGN KEY (ArrangementId) REFERENCES tblSongArrangements(Id) ON DELETE CASCADE ON UPDATE CASCADE,
-            CONSTRAINT fk_PresAssign_Component FOREIGN KEY (ComponentId) REFERENCES tblSongComponents(Id) ON DELETE CASCADE ON UPDATE CASCADE,
-            CONSTRAINT chk_PresAssign_Anchor CHECK (
-                (AssignmentScope = 'org_default'  AND OrgId IS NOT NULL AND UserId IS NULL AND SongbookId IS NULL AND SongId IS NULL AND ArrangementId IS NULL AND ComponentId IS NULL) OR
-                (AssignmentScope = 'user_default' AND UserId IS NOT NULL AND OrgId IS NULL AND SongbookId IS NULL AND SongId IS NULL AND ArrangementId IS NULL AND ComponentId IS NULL) OR
-                (AssignmentScope = 'songbook'     AND SongbookId IS NOT NULL AND SongId IS NULL AND ArrangementId IS NULL AND ComponentId IS NULL) OR
-                (AssignmentScope = 'song'         AND SongId IS NOT NULL AND SongbookId IS NULL AND ArrangementId IS NULL AND ComponentId IS NULL) OR
-                (AssignmentScope = 'arrangement'  AND ArrangementId IS NOT NULL AND SongbookId IS NULL AND SongId IS NULL AND ComponentId IS NULL) OR
-                (AssignmentScope = 'component'    AND ComponentId IS NOT NULL AND SongbookId IS NULL AND SongId IS NULL AND ArrangementId IS NULL)
-            )
+            CONSTRAINT fk_PresAssign_Component FOREIGN KEY (ComponentId) REFERENCES tblSongComponents(Id) ON DELETE CASCADE ON UPDATE CASCADE
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
-          COMMENT='Theme→scope cascade spine (org→songbook→song→arrangement→component) with org/user tenancy; one discriminated table, per-anchor typed FKs (#1168).'"
+          COMMENT='Theme→scope cascade spine (org→songbook→song→arrangement→component) with org/user tenancy; per-anchor typed FKs. Uniqueness + anchor-exclusivity are APP-enforced — a STORED generated key / CHECK cannot coexist with the FK CASCADE actions we need for cleanup (MySQL errors 3823/1215) (#1168).'"
     );
     _migPresTheme_output("  [OK] tblPresentationThemeAssignments ensured.");
 
@@ -288,11 +278,9 @@ try {
             LyricWordId BIGINT UNSIGNED NULL DEFAULT NULL COMMENT 'Optional per-WORD anchor → tblLyricWords.Id for per-word karaoke styling (rule #21)',
             LineIndex   INT UNSIGNED NULL DEFAULT NULL COMMENT 'Transitional fallback index into LinesJson when no tblLyricLines row exists yet',
             DisplayRole VARCHAR(30) NULL DEFAULT NULL COMMENT 'NULL = all roles',
-            OverrideKey VARCHAR(120) AS (CONCAT_WS('|', ComponentId, IFNULL(LyricsId,'-'), IFNULL(LyricLineId,'-'), IFNULL(LyricWordId,'-'), IFNULL(LineIndex,'-'), IFNULL(DisplayRole,'*'))) STORED COMMENT 'Generated non-null key; UNIQUE prevents duplicate patches (NULL-leak-proof)',
             StylePatchJson JSON NOT NULL COMMENT 'Sparse style patch {fontSizeScale,textColour,slideBreakAfter,highlightColour,foregroundMediaUrl,…} — STYLE ONLY, never lyric text',
             CreatedAt   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
             UpdatedAt   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-            UNIQUE KEY uq_Override (OverrideKey),
             INDEX idx_Component (ComponentId),
             INDEX idx_Line (LyricLineId),
             INDEX idx_Word (LyricWordId),

--- a/appWeb/.sql/migrate-song-link-confidence.php
+++ b/appWeb/.sql/migrate-song-link-confidence.php
@@ -87,11 +87,15 @@ try {
     _migLinkConf_output("--- tblSongLinkSuggestions: Confidence + Signal ---");
     _migLinkConf_addCol($mysql, 'tblSongLinkSuggestions', 'Confidence',
         "Confidence ENUM('high','medium','low') NOT NULL DEFAULT 'low' COMMENT 'Triage tier (#1066 Theme D)' AFTER Score");
+    /* `Signal` MUST be backtick-quoted — SIGNAL is a reserved word in MySQL 8
+       (SIGNAL/RESIGNAL), so an unquoted `ADD COLUMN Signal …` is a 1064 syntax
+       error. The migration swallowed that error (caught internally), so the
+       column was never added and the card stayed stuck pending. */
     _migLinkConf_addCol($mysql, 'tblSongLinkSuggestions', 'Signal',
-        "Signal VARCHAR(50) NOT NULL DEFAULT 'fuzzy' COMMENT 'Detection method: fuzzy | shared-isrc | shared-musicbrainz | shared-spotify | shared-genius (#1066 Theme D)' AFTER Confidence");
+        "`Signal` VARCHAR(50) NOT NULL DEFAULT 'fuzzy' COMMENT 'Detection method: fuzzy | shared-isrc | shared-musicbrainz | shared-spotify | shared-genius (#1066 Theme D)' AFTER Confidence");
 
     _migLinkConf_addIdx($mysql, 'tblSongLinkSuggestions', 'idx_Confidence', 'Confidence');
-    _migLinkConf_addIdx($mysql, 'tblSongLinkSuggestions', 'idx_Signal', 'Signal');
+    _migLinkConf_addIdx($mysql, 'tblSongLinkSuggestions', 'idx_Signal', '`Signal`');
 
     _migLinkConf_output("");
     _migLinkConf_output("--- Summary ---");

--- a/appWeb/.sql/schema.sql
+++ b/appWeb/.sql/schema.sql
@@ -1894,7 +1894,7 @@ CREATE TABLE IF NOT EXISTS tblSongLinkSuggestions (
     SongIdB         VARCHAR(20)  NOT NULL,
     Score           DECIMAL(4,3) NOT NULL COMMENT 'Composite similarity, 0.000-1.000',
     Confidence      ENUM('high','medium','low') NOT NULL DEFAULT 'low' COMMENT 'Triage tier so curators sort by confidence, not raw blend: strong-key match (ISRC/MBID) => high; fuzzy+author => medium; title-only => low (#1066 Theme D)',
-    Signal          VARCHAR(50)  NOT NULL DEFAULT 'fuzzy' COMMENT 'Detection method: fuzzy | shared-isrc | shared-musicbrainz | shared-spotify | shared-genius. VARCHAR (not ENUM) so a new signal type needs no ALTER (#1066 Theme D)',
+    `Signal`        VARCHAR(50)  NOT NULL DEFAULT 'fuzzy' COMMENT 'Detection method: fuzzy | shared-isrc | shared-musicbrainz | shared-spotify | shared-genius. VARCHAR (not ENUM) so a new signal type needs no ALTER (#1066 Theme D). Backtick-quoted — SIGNAL is a reserved word in MySQL 8',
     TitleScore      DECIMAL(4,3) NOT NULL DEFAULT 0.000,
     LyricsScore     DECIMAL(4,3) NOT NULL DEFAULT 0.000,
     AuthorsScore    DECIMAL(4,3) NOT NULL DEFAULT 0.000,
@@ -1902,7 +1902,7 @@ CREATE TABLE IF NOT EXISTS tblSongLinkSuggestions (
     UNIQUE KEY uk_pair (SongIdA, SongIdB),
     KEY idx_Score (Score),
     KEY idx_Confidence (Confidence),
-    KEY idx_Signal (Signal),
+    KEY idx_Signal (`Signal`),
     KEY idx_SongA (SongIdA),
     KEY idx_SongB (SongIdB),
     CONSTRAINT fk_SongLinkSugg_A FOREIGN KEY (SongIdA)
@@ -3309,10 +3309,8 @@ CREATE TABLE IF NOT EXISTS tblPresentationThemeAssignments (
     ComponentId   INT UNSIGNED NULL DEFAULT NULL,
     DisplayRole   VARCHAR(30)  NULL DEFAULT NULL COMMENT 'NULL = applies to all display roles; else binds only that variant',
     Priority      INT NOT NULL DEFAULT 0 COMMENT 'Tie-break within a scope level',
-    AssignmentKey VARCHAR(180) AS (CONCAT_WS('|', AssignmentScope, IFNULL(OrgId,'-'), IFNULL(UserId,'-'), IFNULL(SongbookId,'-'), IFNULL(SongId,'-'), IFNULL(ArrangementId,'-'), IFNULL(ComponentId,'-'), IFNULL(DisplayRole,'*'))) STORED COMMENT 'Generated non-null cascade key; its UNIQUE enforces one theme per (scope,tenant,anchor,role) — NULL-leak-proof',
     CreatedAt   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UpdatedAt   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    UNIQUE KEY uq_Assignment (AssignmentKey),
     INDEX idx_Theme (ThemeId),
     INDEX idx_Scope (AssignmentScope),
     INDEX idx_Org (OrgId),
@@ -3324,17 +3322,9 @@ CREATE TABLE IF NOT EXISTS tblPresentationThemeAssignments (
     CONSTRAINT fk_PresAssign_Songbook  FOREIGN KEY (SongbookId) REFERENCES tblSongbooks(Id) ON DELETE CASCADE ON UPDATE CASCADE,
     CONSTRAINT fk_PresAssign_Song      FOREIGN KEY (SongId) REFERENCES tblSongs(SongId) ON DELETE CASCADE ON UPDATE CASCADE,
     CONSTRAINT fk_PresAssign_Arr       FOREIGN KEY (ArrangementId) REFERENCES tblSongArrangements(Id) ON DELETE CASCADE ON UPDATE CASCADE,
-    CONSTRAINT fk_PresAssign_Component FOREIGN KEY (ComponentId) REFERENCES tblSongComponents(Id) ON DELETE CASCADE ON UPDATE CASCADE,
-    CONSTRAINT chk_PresAssign_Anchor CHECK (
-        (AssignmentScope = 'org_default'  AND OrgId IS NOT NULL AND UserId IS NULL AND SongbookId IS NULL AND SongId IS NULL AND ArrangementId IS NULL AND ComponentId IS NULL) OR
-        (AssignmentScope = 'user_default' AND UserId IS NOT NULL AND OrgId IS NULL AND SongbookId IS NULL AND SongId IS NULL AND ArrangementId IS NULL AND ComponentId IS NULL) OR
-        (AssignmentScope = 'songbook'     AND SongbookId IS NOT NULL AND SongId IS NULL AND ArrangementId IS NULL AND ComponentId IS NULL) OR
-        (AssignmentScope = 'song'         AND SongId IS NOT NULL AND SongbookId IS NULL AND ArrangementId IS NULL AND ComponentId IS NULL) OR
-        (AssignmentScope = 'arrangement'  AND ArrangementId IS NOT NULL AND SongbookId IS NULL AND SongId IS NULL AND ComponentId IS NULL) OR
-        (AssignmentScope = 'component'    AND ComponentId IS NOT NULL AND SongbookId IS NULL AND SongId IS NULL AND ArrangementId IS NULL)
-    )
+    CONSTRAINT fk_PresAssign_Component FOREIGN KEY (ComponentId) REFERENCES tblSongComponents(Id) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
-  COMMENT='Theme→scope cascade spine (org→songbook→song→arrangement→component) with org/user tenancy; one discriminated table, per-anchor typed FKs (#1168).';
+  COMMENT='Theme→scope cascade spine (org→songbook→song→arrangement→component) with org/user tenancy; per-anchor typed FKs. Uniqueness + anchor-exclusivity are APP-enforced — a STORED generated key / CHECK cannot coexist with the FK CASCADE actions we need for cleanup (MySQL errors 3823/1215) (#1168).';
 
 CREATE TABLE IF NOT EXISTS tblPresentationSlideOverrides (
     Id          INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
@@ -3344,11 +3334,9 @@ CREATE TABLE IF NOT EXISTS tblPresentationSlideOverrides (
     LyricWordId BIGINT UNSIGNED NULL DEFAULT NULL COMMENT 'Optional per-WORD anchor → tblLyricWords.Id for per-word karaoke styling (rule #21)',
     LineIndex   INT UNSIGNED NULL DEFAULT NULL COMMENT 'Transitional fallback index into LinesJson when no tblLyricLines row exists yet',
     DisplayRole VARCHAR(30) NULL DEFAULT NULL COMMENT 'NULL = all roles',
-    OverrideKey VARCHAR(120) AS (CONCAT_WS('|', ComponentId, IFNULL(LyricsId,'-'), IFNULL(LyricLineId,'-'), IFNULL(LyricWordId,'-'), IFNULL(LineIndex,'-'), IFNULL(DisplayRole,'*'))) STORED COMMENT 'Generated non-null key; UNIQUE prevents duplicate patches (NULL-leak-proof)',
     StylePatchJson JSON NOT NULL COMMENT 'Sparse style patch {fontSizeScale,textColour,slideBreakAfter,highlightColour,foregroundMediaUrl,…} — STYLE ONLY, never lyric text',
     CreatedAt   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UpdatedAt   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    UNIQUE KEY uq_Override (OverrideKey),
     INDEX idx_Component (ComponentId),
     INDEX idx_Line (LyricLineId),
     INDEX idx_Word (LyricWordId),


### PR DESCRIPTION
Reproduced the stuck migrations against a **real local MySQL** (our CI is static — it lints but never *executes* the DDL, which is exactly why these slipped through). Two of the three were definite DDL bugs that each script swallowed internally → reported "completed" while staying pending. (#1173 now also surfaces that; this fixes the actual causes.)

## 1. `tblSongLinkSuggestions.Signal` — reserved word (#1066)
`SIGNAL` is **reserved in MySQL 8** (SIGNAL/RESIGNAL), so the unquoted `ADD COLUMN Signal …` is a **1064 syntax error** → the column never landed → Song-Link Confidence stuck pending. #1162's probe fix couldn't help because the column genuinely couldn't be added. **Fix:** backtick-quote `` `Signal` `` in the migration (ADD COLUMN + index) and schema.sql (column + `idx_Signal`). No app SQL referenced it — it's been a dead column.

## 2. Presentation themes (#1171, just shipped)
- **Error 3823** — the assignment spine's `CHECK` referenced FK columns ("cannot be used in a check constraint … needed in a foreign key referential action").
- **Error 1215** — both the spine and slide-override tables had a **STORED generated key** whose source columns carry FK `CASCADE`; MySQL forbids that combination.

A generated column / CHECK **cannot coexist with the FK `CASCADE`** we want for cleanup, on any MySQL version. **Fix:** dropped the generated `AssignmentKey`/`OverrideKey` + their UNIQUE + the CHECK; kept the FK CASCADE + lookup indexes. Uniqueness + anchor-exclusivity move to **app enforcement** at write time (the table is dormant — nothing writes it yet, so no functional loss).

## Verification (against a real MySQL, not just lint)
- ✅ Full `schema.sql` applies with **zero** errors; all **8** presentation tables + the `Signal` column create.
- ✅ `test-schema-coverage` + `test-migration-registry` + `php -l` green.

After this deploys, re-running "Apply all" should clear these two; the third (NormalizedTitle) is the #1165 timeout fix — and #1173 will now show truthfully whether any remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)