### PR TITLE
feat: end-user export (#1166) + link-dedupe (#1177) + sheet-music download (#1182)

### DIFF
--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -709,6 +709,30 @@ if ($action !== null) {
             break;
 
         /* -----------------------------------------------------------------
+         * Public songbook export (#1166) — full records of ONE songbook's
+         * songs for the end-user export UI (js/modules/export-ui.js). DB-direct,
+         * scoped to one songbook (rule #17 — never the corpus); same shape the
+         * editor's songbook_export returns ({songs, songbook}). When content
+         * gating is enabled, export of copyrighted content is a gated action
+         * (#1141) — to wire here once gating ships; currently mirrors the public
+         * view (gating off → public-domain + open catalogue).
+         * ----------------------------------------------------------------- */
+        case 'songbook_export':
+            $abbr = isset($_GET['abbr']) ? strtoupper(trim((string)$_GET['abbr'])) : '';
+            if ($abbr === '' || !preg_match('/^[A-Z0-9]{1,20}$/', $abbr)) {
+                sendJson(['error' => 'A valid songbook abbreviation is required.'], 400);
+                break;
+            }
+            $sbSongs    = $songData->getSongs($abbr);
+            $sbSongbook = null;
+            foreach ($songData->getSongbooks() as $b) {
+                $bid = strtoupper((string)($b['id'] ?? $b['abbreviation'] ?? ''));
+                if ($bid === $abbr) { $sbSongbook = $b; break; }
+            }
+            sendJson(['songs' => $sbSongs, 'songbook' => $sbSongbook]);
+            break;
+
+        /* -----------------------------------------------------------------
          * Resolve songs by an industry identifier (#1103).
          * Params: type (iswc|isrc|upc|ccli) + value (required).
          * The type maps to a FIXED tblSongs column (allow-list — never user

--- a/appWeb/public_html/includes/pages/song.php
+++ b/appWeb/public_html/includes/pages/song.php
@@ -755,6 +755,27 @@ try {
                     Print
                 </button>
 
+                <!-- Export to a worship-presentation format (#1166). The dropdown
+                     items are wired by export-ui.js (initSongExport), which
+                     lazy-loads the export libs (format-export.js) on first use. -->
+                <div class="btn-group song-toolbar-btn">
+                    <button type="button"
+                            class="btn btn-sm btn-outline-secondary dropdown-toggle btn-export-song"
+                            data-bs-toggle="dropdown" aria-expanded="false"
+                            aria-label="Export this song to a worship-presentation format">
+                        <i class="fa-solid fa-file-export me-1" aria-hidden="true"></i>
+                        Export
+                    </button>
+                    <ul class="dropdown-menu dropdown-menu-end song-export-menu">
+                        <li><button type="button" class="dropdown-item" data-export-format="openSong">OpenSong (.xml)</button></li>
+                        <li><button type="button" class="dropdown-item" data-export-format="openLyrics">OpenLyrics / OpenLP (.xml)</button></li>
+                        <li><button type="button" class="dropdown-item" data-export-format="proPresenter6">ProPresenter 6 (.pro6)</button></li>
+                        <li><button type="button" class="dropdown-item" data-export-format="videoPsalm">VideoPsalm (.json)</button></li>
+                        <li><button type="button" class="dropdown-item" data-export-format="freeShow">FreeShow (.show)</button></li>
+                        <li><button type="button" class="dropdown-item" data-export-format="proclaim">Proclaim (.txt)</button></li>
+                    </ul>
+                </div>
+
                 <!-- Chord charts toggle (#299) -->
                 <button class="btn btn-sm btn-outline-secondary" id="btn-toggle-chords" style="display:none" title="Show/hide chord charts">
                     <i class="fa-solid fa-guitar me-1" aria-hidden="true"></i>Chords
@@ -1356,6 +1377,18 @@ try {
     </nav>
 
 </article>
+
+<!-- Export-to-format wiring (#1166). The SPA re-runs injected inline scripts,
+     so this binds the Export dropdown after the fragment loads. -->
+<script>
+(function () {
+    if (!document.querySelector('.btn-export-song')) { return; }
+    var songId = <?= json_encode($song['id'] ?? '', JSON_UNESCAPED_SLASHES) ?>;
+    import('/js/modules/export-ui.js')
+        .then(function (m) { m.initSongExport(songId); })
+        .catch(function () { /* export is best-effort; never block the page */ });
+})();
+</script>
 
 <!-- Presentation mode JS (#297) -->
 <script>

--- a/appWeb/public_html/includes/pages/songbook.php
+++ b/appWeb/public_html/includes/pages/songbook.php
@@ -137,8 +137,39 @@ if ($book === null) {
                 <i class="fa-solid fa-shuffle me-1" aria-hidden="true"></i>
                 Shuffle
             </button>
+            <!-- Export this whole songbook to a worship-presentation format
+                 (#1166). Wired by export-ui.js (initSongbookExport), which
+                 lazy-loads the export libs on first use. -->
+            <div class="btn-group">
+                <button type="button"
+                        class="btn btn-outline-secondary btn-sm dropdown-toggle btn-export-songbook"
+                        data-bs-toggle="dropdown" aria-expanded="false"
+                        aria-label="Export <?= htmlspecialchars($book['name']) ?> to a worship-presentation format">
+                    <i class="fa-solid fa-file-export me-1" aria-hidden="true"></i>
+                    Export
+                </button>
+                <ul class="dropdown-menu dropdown-menu-end songbook-export-menu">
+                    <li><button type="button" class="dropdown-item" data-export-format="openSong">OpenSong (.zip)</button></li>
+                    <li><button type="button" class="dropdown-item" data-export-format="openLyrics">OpenLyrics / OpenLP (.zip)</button></li>
+                    <li><button type="button" class="dropdown-item" data-export-format="proPresenter6">ProPresenter 6 (.zip)</button></li>
+                    <li><button type="button" class="dropdown-item" data-export-format="videoPsalm">VideoPsalm (.json)</button></li>
+                    <li><button type="button" class="dropdown-item" data-export-format="freeShow">FreeShow (.zip)</button></li>
+                    <li><button type="button" class="dropdown-item" data-export-format="proclaim">Proclaim (.zip)</button></li>
+                </ul>
+            </div>
         </div>
     </div>
+
+    <!-- Export wiring (#1166) — the SPA re-runs injected inline scripts. -->
+    <script>
+    (function () {
+        if (!document.querySelector('.btn-export-songbook')) { return; }
+        var abbr = <?= json_encode($book['id'] ?? '', JSON_UNESCAPED_SLASHES) ?>;
+        import('/js/modules/export-ui.js')
+            .then(function (m) { m.initSongbookExport(abbr); })
+            .catch(function () { /* best-effort */ });
+    })();
+    </script>
 
     <?php
         /* #833 — "Find this songbook elsewhere" panel. Reads from the

--- a/appWeb/public_html/js/modules/export-ui.js
+++ b/appWeb/public_html/js/modules/export-ui.js
@@ -1,0 +1,124 @@
+/* ==========================================================================
+ *  export-ui.js — End-user export of a song / songbook to worship-presentation
+ *  formats (#1166). Surfaces the editor's existing export machinery
+ *  (manage/editor/format-export.js → window.iHymnsFormatExport) to the PUBLIC
+ *  song + songbook views, so a curator can hand a file to ProPresenter / OpenLP
+ *  / VideoPsalm / FreeShow / OpenSong / Proclaim without opening the editor.
+ *
+ *  format-export.js is a plain global script (sets window.iHymnsFormatExport),
+ *  NOT an ES module, and depends on propresenter-export.js for the ZIP writer.
+ *  We load BOTH on demand (first export click) so pages that never export pay
+ *  nothing. Song data comes from the public ?action=song_data endpoint; whole
+ *  songbooks from ?action=songbook_export (both DB-direct, rule #17).
+ * ========================================================================== */
+
+/* The format keys exactly match window.iHymnsFormatExport's registry. */
+const FORMATS = [
+    { key: 'openSong',      label: 'OpenSong (.xml)' },
+    { key: 'openLyrics',    label: 'OpenLyrics / OpenLP (.xml)' },
+    { key: 'proPresenter6', label: 'ProPresenter 6 (.pro6)' },
+    { key: 'videoPsalm',    label: 'VideoPsalm (.json)' },
+    { key: 'freeShow',      label: 'FreeShow (.show)' },
+    { key: 'proclaim',      label: 'Proclaim (.txt)' },
+];
+
+let _libsPromise = null;
+
+/** Lazy-load the export libraries once (ProPresenter ZIP writer first). */
+function loadExportLibs() {
+    if (window.iHymnsFormatExport) { return Promise.resolve(); }
+    if (_libsPromise) { return _libsPromise; }
+    _libsPromise = loadScript('/manage/editor/propresenter-export.js')
+        .then(() => loadScript('/manage/editor/format-export.js'))
+        .catch((err) => { _libsPromise = null; throw err; });
+    return _libsPromise;
+}
+
+function loadScript(src) {
+    return new Promise((resolve, reject) => {
+        if (document.querySelector('script[data-export-lib="' + src + '"]')) { resolve(); return; }
+        const s = document.createElement('script');
+        s.src = src;
+        s.dataset.exportLib = src;
+        s.onload = () => resolve();
+        s.onerror = () => reject(new Error('Failed to load ' + src));
+        document.head.appendChild(s);
+    });
+}
+
+function toast(message, type) {
+    if (window.iHymnsApp && typeof window.iHymnsApp.showToast === 'function') {
+        window.iHymnsApp.showToast(message, type || 'info');
+    }
+}
+
+async function fetchJson(url) {
+    const r = await fetch(url, { credentials: 'same-origin', headers: { 'X-Requested-With': 'XMLHttpRequest' } });
+    if (!r.ok) { throw new Error('HTTP ' + r.status); }
+    return r.json();
+}
+
+/**
+ * Wire a song-view "Export ▾" dropdown. The dropdown markup (button +
+ * `.song-export-menu` with `[data-export-format]` items) lives in song.php;
+ * this binds the clicks.
+ * @param {string} songId
+ */
+export function initSongExport(songId) {
+    const menu = document.querySelector('.song-export-menu');
+    if (!menu || menu.dataset.wired === '1' || !songId) { return; }
+    menu.dataset.wired = '1';
+
+    menu.querySelectorAll('[data-export-format]').forEach((item) => {
+        item.addEventListener('click', async () => {
+            const fmtKey = item.dataset.exportFormat;
+            try {
+                toast('Preparing export…', 'info');
+                await loadExportLibs();
+                const fmt = window.iHymnsFormatExport && window.iHymnsFormatExport[fmtKey];
+                if (!fmt || typeof fmt.exportSong !== 'function') { throw new Error('format unavailable'); }
+                const data = await fetchJson('/api?action=song_data&id=' + encodeURIComponent(songId));
+                if (!data || !data.song) { throw new Error('song not found'); }
+                fmt.exportSong(data.song, {});
+            } catch (err) {
+                toast('Export failed: ' + (err && err.message ? err.message : 'unknown error'), 'danger');
+            }
+        });
+    });
+}
+
+/**
+ * Wire a songbook-view "Export songbook ▾" dropdown.
+ * @param {string} abbr  Songbook abbreviation (e.g. 'MP')
+ */
+export function initSongbookExport(abbr) {
+    const menu = document.querySelector('.songbook-export-menu');
+    if (!menu || menu.dataset.wired === '1' || !abbr) { return; }
+    menu.dataset.wired = '1';
+
+    menu.querySelectorAll('[data-export-format]').forEach((item) => {
+        item.addEventListener('click', async () => {
+            const fmtKey = item.dataset.exportFormat;
+            try {
+                toast('Preparing songbook export…', 'info');
+                await loadExportLibs();
+                const fmt = window.iHymnsFormatExport && window.iHymnsFormatExport[fmtKey];
+                if (!fmt || typeof fmt.exportSongbook !== 'function') { throw new Error('format unavailable'); }
+                const data = await fetchJson('/api?action=songbook_export&abbr=' + encodeURIComponent(abbr));
+                const songs = data && data.songs;
+                if (!Array.isArray(songs) || !songs.length) { throw new Error('no songs to export'); }
+                const meta = {
+                    name:         (data.songbook && (data.songbook.name || data.songbook.id)) || abbr,
+                    abbreviation: (data.songbook && (data.songbook.id || data.songbook.abbreviation)) || abbr,
+                };
+                fmt.exportSongbook(songs, meta);
+            } catch (err) {
+                toast('Songbook export failed: ' + (err && err.message ? err.message : 'unknown error'), 'danger');
+            }
+        });
+    });
+}
+
+/* Expose for the inline initialisers in song.php / songbook view (the SPA
+   re-runs injected inline scripts; they call these after the fragment loads). */
+window.iHymnsExportUi = { initSongExport, initSongbookExport };

--- a/appWeb/public_html/js/modules/external-link-dupe-detect.js
+++ b/appWeb/public_html/js/modules/external-link-dupe-detect.js
@@ -35,15 +35,48 @@
 (function () {
     'use strict';
 
+    /* Query params that NEVER change which resource a link points at — safe to
+       strip before comparing (so "same video + a tracker" still dedupes). The
+       identity-bearing params (e.g. YouTube `?v=`) are KEPT. (#1177) */
+    var TRACKING_PARAM = /^(?:utm_[a-z]+|ref|referrer|fbclid|gclid|dclid|msclkid|igshid|mc_[a-z]+|spm|si|feature|app|source|_hsenc|_hsmi|yclid)$/i;
+
+    /* Provider canonicalisers — collapse genuinely-equivalent forms of the SAME
+       resource to one key, so they ARE caught as duplicates, while DIFFERENT
+       resources on the same platform stay distinct. IDs are case-SENSITIVE
+       (YouTube/Spotify), so extract from the original-case path. */
+    function youtubeId(u, host, path) {
+        if (host === 'youtu.be') {
+            var m = path.match(/^\/([A-Za-z0-9_-]{6,})/);
+            return m ? m[1] : null;
+        }
+        if (host === 'youtube.com' || host === 'm.youtube.com'
+            || host === 'music.youtube.com' || host === 'youtube-nocookie.com') {
+            if (path === '/watch') { return u.searchParams.get('v') || null; }
+            var m2 = path.match(/^\/(?:shorts|embed|v|live)\/([A-Za-z0-9_-]{6,})/);
+            if (m2) return m2[1];
+        }
+        return null;
+    }
+    function spotifyId(host, path) {
+        if (host === 'open.spotify.com' || host === 'spotify.com') {
+            var m = path.match(/^\/(?:intl-[a-z]+\/)?(track|album|playlist|episode|show|artist)\/([A-Za-z0-9]+)/);
+            if (m) { return m[1] + '/' + m[2]; }
+        }
+        return null;
+    }
+
     /**
-     * Normalise a URL string to a comparison key. Strategy:
-     *   - lowercase host, strip leading 'www.'
-     *   - keep path, lowercase it, drop trailing '/'
-     *   - drop query + hash (curators paste tracker-laden links all the
-     *     time — `?ref=`, `?utm_source=`, …, none of which alter what
-     *     the page actually is)
-     *   - non-URL input (malformed, relative): lowercased + trimmed
-     *     trailing slash so simple duplicate text is still caught
+     * Normalise a URL string to a comparison key (#1177). Strategy:
+     *   - lowercase host, strip leading 'www.'; drop trailing '/'
+     *   - KEEP identity-bearing query params (strip only the tracking allowlist),
+     *     sorted for stability — so two DIFFERENT YouTube videos
+     *     (watch?v=A vs watch?v=B) are NO LONGER treated as the same link
+     *   - provider-aware canonicalisation so genuinely-equivalent forms still
+     *     dedupe (youtu.be/ID == youtube.com/watch?v=ID == /shorts/ID; Spotify
+     *     track/ID ignoring ?si)
+     *   - net: exact-same URL blocked; same platform, different resource allowed
+     *   - non-URL input (malformed, relative): lowercased + trimmed trailing
+     *     slash so simple duplicate text is still caught
      */
     function normalise(url) {
         if (typeof url !== 'string') return '';
@@ -53,8 +86,25 @@
             var u = new URL(s);
             var host = (u.hostname || '').toLowerCase();
             if (host.indexOf('www.') === 0) host = host.slice(4);
-            var path = (u.pathname || '/').toLowerCase().replace(/\/+$/, '') || '/';
-            return host + path;
+            /* Original-case path for case-sensitive provider IDs. */
+            var rawPath = (u.pathname || '/').replace(/\/+$/, '') || '/';
+
+            var yt = youtubeId(u, host, rawPath);
+            if (yt) { return 'youtube:' + yt; }
+            var sp = spotifyId(host, rawPath);
+            if (sp) { return 'spotify:' + sp; }
+
+            /* Generic: host + path + identity query (tracking stripped, sorted).
+               Keep param keys/values as-is apart from lowercasing the key — a
+               value can be a case-sensitive id. */
+            var params = [];
+            u.searchParams.forEach(function (v, k) {
+                if (TRACKING_PARAM.test(k)) { return; }
+                params.push(k.toLowerCase() + '=' + v);
+            });
+            params.sort();
+            var q = params.length ? '?' + params.join('&') : '';
+            return host + rawPath.toLowerCase() + q;
         } catch (_e) {
             return s.toLowerCase().replace(/\/+$/, '');
         }

--- a/appWeb/public_html/js/modules/sheet-music.js
+++ b/appWeb/public_html/js/modules/sheet-music.js
@@ -75,38 +75,68 @@ export class SheetMusic {
         this.currentSongId = songId;
         this.currentPage = 1;
 
-        /* Create and show the modal */
+        const url = this.app.config.musicBasePath + songId + '.pdf';
+
+        /* Build (but DON'T show yet) the modal so status updates have a target.
+           We only REVEAL the viewer once we know the PDF can actually render
+           inline; if PDF.js is unavailable or the document fails to open, we
+           DOWNLOAD it directly instead of popping a dead-end "Unable to display
+           sheet music" modal (#1182). */
         this.createModal(songId);
         this.bsModal = new bootstrap.Modal(this.modalEl);
-        this.bsModal.show();
 
-        /* Load PDF.js if not already loaded */
-        if (!this.pdfjsLoaded) {
-            this.updateStatus('Loading PDF viewer...');
-            const loaded = await this.loadPdfJs();
-            if (!loaded) {
-                this.updateStatus('PDF viewer unavailable.');
-                this.showDownloadFallback(songId);
-                this.isLoading = false;
-                return;
+        try {
+            if (!this.pdfjsLoaded) {
+                const loaded = await this.loadPdfJs();
+                if (!loaded) {
+                    this.downloadSheet(songId);
+                    this.isLoading = false;
+                    return;
+                }
             }
+            this.pdfDoc = await this.pdfjsLib.getDocument(url).promise;
+        } catch (err) {
+            console.warn('[SheetMusic] Inline view unavailable — downloading instead:', err);
+            this.downloadSheet(songId);
+            this.isLoading = false;
+            return;
         }
 
-        /* Fetch and render the PDF */
+        /* Renderable — reveal the viewer + draw the first page. */
+        this.bsModal.show();
         this.updateStatus('Loading sheet music...');
         try {
-            const url = this.app.config.musicBasePath + songId + '.pdf';
-            this.pdfDoc = await this.pdfjsLib.getDocument(url).promise;
             this.updatePageInfo();
             await this.renderPage(this.currentPage);
             this.enableControls(true);
             this.updateStatus('');
         } catch (err) {
-            console.error('[SheetMusic] Error loading PDF:', err);
-            this.updateStatus('Sheet music not available for this song.');
-            this.showDownloadFallback(songId);
+            /* Doc opened but a page failed to render (rare) — fall back to download. */
+            console.warn('[SheetMusic] Render failed — downloading instead:', err);
+            if (this.bsModal) { this.bsModal.hide(); }
+            this.downloadSheet(songId);
         } finally {
             this.isLoading = false;
+        }
+    }
+
+    /**
+     * Trigger a direct download of the song's sheet-music PDF (#1182) — used
+     * whenever the PDF can't be shown inline, so the Sheet Music button is never
+     * a dead end.
+     * @param {string} songId
+     */
+    downloadSheet(songId) {
+        const url = this.app.config.musicBasePath + songId + '.pdf';
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = songId + '.pdf';
+        a.rel = 'noopener';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        if (this.app && typeof this.app.showToast === 'function') {
+            this.app.showToast('Downloading sheet music…', 'info');
         }
     }
 


### PR DESCRIPTION
Three ready items from the alpha-testing batch.

## Export to formats — public song + songbook views (#1166)
The owner couldn't find an Export button in song view. New **`export-ui.js`** surfaces the editor's existing exporters (`window.iHymnsFormatExport`) to the public views, **lazy-loading** `format-export.js` (+ `propresenter-export.js`) on first click:
- **Song view** → "Export ▾" dropdown (OpenSong / OpenLyrics-OpenLP / ProPresenter 6 / VideoPsalm / FreeShow / Proclaim) → `?action=song_data` → `exportSong`.
- **Songbook view** → "Export ▾" → new **public `?action=songbook_export`** (DB-direct, one songbook) → `exportSongbook` (zip).
- Gated-content export remains a #1141 follow-up (mirrors the public view; gating is currently off).

## Link dedupe (#1177)
`normalise()` dropped the whole query → two different YouTube videos collapsed to one. Now **keeps identity query params** (strips only a tracking allowlist) + **provider canonicalisation** (`youtu.be/ID` ≡ `watch?v=ID` ≡ `/shorts/ID`; Spotify `track/ID` ignoring `?si`). Exact-same URL still blocked; **same platform, different resource now allowed**. One shared module → fixes songs/songbooks/credit-people/works editors at once.

## Sheet Music download (#1182)
The button no longer pops a dead-end "Unable to display" modal for un-renderable PDFs — it builds the modal but only **shows it once the PDF opens**; on any failure it **downloads the PDF directly**.

`php -l` + `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)