### PR TITLE
fix+feat: NormalizedTitle migration path + sidebar infinite-scroll + export polish (PP7)

### DIFF
--- a/appWeb/.sql/migrate-song-normalized-title.php
+++ b/appWeb/.sql/migrate-song-normalized-title.php
@@ -57,16 +57,32 @@ if (!file_exists($credFile)) {
 }
 require_once $credFile;
 
-/* The canonical title normalizer the backfill (and write paths) use. */
-$normHelper = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'public_html'
-            . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'title_normalize.php';
-if (!file_exists($normHelper)) {
-    _migNormTitle_output("ERROR: title_normalize.php not found at {$normHelper}.");
+/* The canonical title normalizer the backfill (and write paths) use. The
+   DEPLOYED layout can differ from the repo: on the live server `public_html` is
+   the web root, so `includes/` sits WITHOUT the `public_html/` path segment.
+   The migration was hard-coding the repo path, failing `file_exists`, and
+   RETURNING EARLY before the ALTER — so the column never landed and the card
+   stayed "pending" while the run clocked ~1 ms (the #1162/#1165 saga's last
+   thread). Resolve the normalizer across the known layouts so it works either
+   way. */
+$ds = DIRECTORY_SEPARATOR;
+$normCandidates = [
+    dirname(__DIR__) . $ds . 'public_html' . $ds . 'includes' . $ds . 'title_normalize.php',
+    dirname(__DIR__) . $ds . 'includes' . $ds . 'title_normalize.php',
+    __DIR__ . $ds . '..' . $ds . 'public_html' . $ds . 'includes' . $ds . 'title_normalize.php',
+    __DIR__ . $ds . '..' . $ds . 'includes' . $ds . 'title_normalize.php',
+];
+$normHelper = null;
+foreach ($normCandidates as $cand) {
+    if (is_file($cand)) { $normHelper = $cand; break; }
+}
+if ($normHelper === null) {
+    _migNormTitle_output("ERROR: title_normalize.php not found. Tried: " . implode(' | ', $normCandidates));
     return;
 }
 require_once $normHelper;
 if (!function_exists('ihymns_normalize_title')) {
-    _migNormTitle_output("ERROR: ihymns_normalize_title() unavailable after include.");
+    _migNormTitle_output("ERROR: ihymns_normalize_title() unavailable after including {$normHelper}.");
     return;
 }
 

--- a/appWeb/public_html/includes/pages/song.php
+++ b/appWeb/public_html/includes/pages/song.php
@@ -767,12 +767,13 @@ try {
                         Export
                     </button>
                     <ul class="dropdown-menu dropdown-menu-end song-export-menu">
-                        <li><button type="button" class="dropdown-item" data-export-format="openSong">OpenSong (.xml)</button></li>
-                        <li><button type="button" class="dropdown-item" data-export-format="openLyrics">OpenLyrics / OpenLP (.xml)</button></li>
-                        <li><button type="button" class="dropdown-item" data-export-format="proPresenter6">ProPresenter 6 (.pro6)</button></li>
-                        <li><button type="button" class="dropdown-item" data-export-format="videoPsalm">VideoPsalm (.json)</button></li>
-                        <li><button type="button" class="dropdown-item" data-export-format="freeShow">FreeShow (.show)</button></li>
-                        <li><button type="button" class="dropdown-item" data-export-format="proclaim">Proclaim (.txt)</button></li>
+                        <li><button type="button" class="dropdown-item" data-export-format="openSong">OpenSong</button></li>
+                        <li><button type="button" class="dropdown-item" data-export-format="openLyrics">OpenLyrics / OpenLP</button></li>
+                        <li><button type="button" class="dropdown-item" data-export-format="proPresenter6">ProPresenter 6</button></li>
+                        <li><button type="button" class="dropdown-item" data-export-format="proPresenter7">ProPresenter 7+</button></li>
+                        <li><button type="button" class="dropdown-item" data-export-format="videoPsalm">VideoPsalm</button></li>
+                        <li><button type="button" class="dropdown-item" data-export-format="freeShow">FreeShow</button></li>
+                        <li><button type="button" class="dropdown-item" data-export-format="proclaim">Proclaim</button></li>
                     </ul>
                 </div>
 

--- a/appWeb/public_html/includes/pages/songbook.php
+++ b/appWeb/public_html/includes/pages/songbook.php
@@ -149,12 +149,13 @@ if ($book === null) {
                     Export
                 </button>
                 <ul class="dropdown-menu dropdown-menu-end songbook-export-menu">
-                    <li><button type="button" class="dropdown-item" data-export-format="openSong">OpenSong (.zip)</button></li>
-                    <li><button type="button" class="dropdown-item" data-export-format="openLyrics">OpenLyrics / OpenLP (.zip)</button></li>
-                    <li><button type="button" class="dropdown-item" data-export-format="proPresenter6">ProPresenter 6 (.zip)</button></li>
-                    <li><button type="button" class="dropdown-item" data-export-format="videoPsalm">VideoPsalm (.json)</button></li>
-                    <li><button type="button" class="dropdown-item" data-export-format="freeShow">FreeShow (.zip)</button></li>
-                    <li><button type="button" class="dropdown-item" data-export-format="proclaim">Proclaim (.zip)</button></li>
+                    <li><button type="button" class="dropdown-item" data-export-format="openSong">OpenSong</button></li>
+                    <li><button type="button" class="dropdown-item" data-export-format="openLyrics">OpenLyrics / OpenLP</button></li>
+                    <li><button type="button" class="dropdown-item" data-export-format="proPresenter6">ProPresenter 6</button></li>
+                    <li><button type="button" class="dropdown-item" data-export-format="proPresenter7">ProPresenter 7+</button></li>
+                    <li><button type="button" class="dropdown-item" data-export-format="videoPsalm">VideoPsalm</button></li>
+                    <li><button type="button" class="dropdown-item" data-export-format="freeShow">FreeShow</button></li>
+                    <li><button type="button" class="dropdown-item" data-export-format="proclaim">Proclaim</button></li>
                 </ul>
             </div>
         </div>

--- a/appWeb/public_html/js/modules/export-ui.js
+++ b/appWeb/public_html/js/modules/export-ui.js
@@ -34,6 +34,24 @@ function loadExportLibs() {
     return _libsPromise;
 }
 
+/* ProPresenter 7+ (.pro, #887) is a separate exporter (window.iHymnsProPresenter)
+   that encodes a binary protobuf, so it needs protobufjs loaded + init() first —
+   unlike the format-export.js formats. Single-song only (no exportSongbook). */
+let _pp7Promise = null;
+function loadPP7() {
+    if (_pp7Promise) { return _pp7Promise; }
+    _pp7Promise = loadScript('/manage/editor/vendor/protobuf.min.js')
+        .then(() => loadScript('/manage/editor/propresenter-export.js'))
+        .then(() => {
+            if (!window.iHymnsProPresenter || typeof window.iHymnsProPresenter.init !== 'function') {
+                throw new Error('ProPresenter 7 exporter unavailable');
+            }
+            return window.iHymnsProPresenter.init({ protobuf: window.protobuf });
+        })
+        .catch((err) => { _pp7Promise = null; throw err; });
+    return _pp7Promise;
+}
+
 function loadScript(src) {
     return new Promise((resolve, reject) => {
         if (document.querySelector('script[data-export-lib="' + src + '"]')) { resolve(); return; }
@@ -74,11 +92,16 @@ export function initSongExport(songId) {
             const fmtKey = item.dataset.exportFormat;
             try {
                 toast('Preparing export…', 'info');
+                const data = await fetchJson('/api?action=song_data&id=' + encodeURIComponent(songId));
+                if (!data || !data.song) { throw new Error('song not found'); }
+                if (fmtKey === 'proPresenter7') {
+                    await loadPP7();
+                    window.iHymnsProPresenter.exportSong(data.song, {});
+                    return;
+                }
                 await loadExportLibs();
                 const fmt = window.iHymnsFormatExport && window.iHymnsFormatExport[fmtKey];
                 if (!fmt || typeof fmt.exportSong !== 'function') { throw new Error('format unavailable'); }
-                const data = await fetchJson('/api?action=song_data&id=' + encodeURIComponent(songId));
-                if (!data || !data.song) { throw new Error('song not found'); }
                 fmt.exportSong(data.song, {});
             } catch (err) {
                 toast('Export failed: ' + (err && err.message ? err.message : 'unknown error'), 'danger');
@@ -101,9 +124,6 @@ export function initSongbookExport(abbr) {
             const fmtKey = item.dataset.exportFormat;
             try {
                 toast('Preparing songbook export…', 'info');
-                await loadExportLibs();
-                const fmt = window.iHymnsFormatExport && window.iHymnsFormatExport[fmtKey];
-                if (!fmt || typeof fmt.exportSongbook !== 'function') { throw new Error('format unavailable'); }
                 const data = await fetchJson('/api?action=songbook_export&abbr=' + encodeURIComponent(abbr));
                 const songs = data && data.songs;
                 if (!Array.isArray(songs) || !songs.length) { throw new Error('no songs to export'); }
@@ -111,6 +131,18 @@ export function initSongbookExport(abbr) {
                     name:         (data.songbook && (data.songbook.name || data.songbook.id)) || abbr,
                     abbreviation: (data.songbook && (data.songbook.id || data.songbook.abbreviation)) || abbr,
                 };
+                if (fmtKey === 'proPresenter7') {
+                    /* PP7 exports a whole songbook as a .probundle (#887). */
+                    await loadPP7();
+                    await window.iHymnsProPresenter.exportAllAsBundle(songs, {
+                        songbookAbbrev: meta.abbreviation,
+                        songbookName:   meta.name,
+                    });
+                    return;
+                }
+                await loadExportLibs();
+                const fmt = window.iHymnsFormatExport && window.iHymnsFormatExport[fmtKey];
+                if (!fmt || typeof fmt.exportSongbook !== 'function') { throw new Error('format unavailable'); }
                 fmt.exportSongbook(songs, meta);
             } catch (err) {
                 toast('Songbook export failed: ' + (err && err.message ? err.message : 'unknown error'), 'danger');

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -280,10 +280,9 @@ function renderSongList(filter) {
     /* Read the songbook filter dropdown value. */
     var songbookFilter = filter !== undefined ? filter : getSelectedSongbookFilter();
 
-    /* Count how many songs pass the filters (for the badge). */
-    var visibleCount = 0;
-
-    /* Sort songs according to the current sort mode (#251). */
+    /* Build the FULL filtered + sorted list. Search + songbook filters run over
+       the WHOLE corpus — only the DOM RENDER is incremental. The result is kept
+       on the module so the scroll handler can append more rows on demand. */
     var sortedSongs = songData.songs.slice().sort(function (a, b) {
         if (currentSortMode === 'title') {
             return (a.title || '').localeCompare(b.title || '', undefined, { sensitivity: 'base' });
@@ -297,97 +296,128 @@ function renderSongList(filter) {
         return 0;
     });
 
-    /* Iterate over sorted songs. */
-    sortedSongs.forEach(function (song) {
-        /* ---- Songbook filter ---- */
-        if (songbookFilter && song.songbook !== songbookFilter) {
-            return; // skip songs not in the selected songbook
-        }
-
-        /* ---- Text search filter ---- */
+    _sidebarVisible = sortedSongs.filter(function (song) {
+        if (songbookFilter && song.songbook !== songbookFilter) { return false; }
         if (searchTerm) {
-            /* Match against title and number (both lowercased). */
             var titleMatch  = (song.title  || '').toLowerCase().indexOf(searchTerm) !== -1;
             var numberMatch = String(song.number || '').toLowerCase().indexOf(searchTerm) !== -1;
-            if (!titleMatch && !numberMatch) {
-                return; // skip songs that don't match the search
-            }
+            if (!titleMatch && !numberMatch) { return false; }
         }
-
-        /* This song passed all filters — render it. */
-        visibleCount++;
-
-        /* Create the list-group-item element. */
-        var li = document.createElement('a');
-        li.href = '#';
-        li.className = 'list-group-item list-group-item-action d-flex justify-content-between align-items-center';
-
-        /* Multi-select mode (#399): prepend a checkbox that mirrors
-           the selected state and clicking it toggles selection without
-           navigating to the song. */
-        if (window._selectMode) {
-            var cb = document.createElement('input');
-            cb.type = 'checkbox';
-            cb.className = 'form-check-input me-2 flex-shrink-0';
-            cb.dataset.songId = song.id;
-            cb.checked = window._selectedIds && window._selectedIds.has(song.id);
-            cb.addEventListener('click', function (e) {
-                e.stopPropagation();
-            });
-            cb.addEventListener('change', function () {
-                if (!window._selectedIds) window._selectedIds = new Set();
-                if (cb.checked) window._selectedIds.add(song.id);
-                else window._selectedIds.delete(song.id);
-                updateBulkActionsBar();
-            });
-            li.appendChild(cb);
-        }
-
-        /* Highlight the currently selected song. */
-        if (song.id === currentSongId) {
-            li.classList.add('active');
-        }
-
-        /* Build the display text: "number - Title Case Title" (#249). */
-        var label = document.createElement('span');
-        label.textContent = (song.number || '?') + ' - ' + toTitleCase(song.title || 'Untitled');
-
-        /* Right-side badges: songbook abbreviation + modified indicator (#249). */
-        var badges = document.createElement('span');
-        badges.className = 'd-flex align-items-center gap-1 flex-shrink-0';
-        if (modifiedSongIds.has(song.id)) {
-            var modBadge = document.createElement('span');
-            modBadge.className = 'badge bg-warning text-dark';
-            modBadge.style.fontSize = '0.65rem';
-            modBadge.textContent = 'modified';
-            badges.appendChild(modBadge);
-        }
-        if (song.songbook) {
-            var sbBadge = document.createElement('span');
-            sbBadge.className = 'badge rounded-pill';
-            sbBadge.style.cssText = 'background-color: rgba(245,158,11,0.15); color: #f59e0b; font-size: 0.65rem; font-weight: 600;';
-            sbBadge.textContent = song.songbook;
-            badges.appendChild(sbBadge);
-        }
-
-        li.appendChild(label);
-        li.appendChild(badges);
-
-        /* When the user clicks this item, load the song into the editor. */
-        li.addEventListener('click', function (e) {
-            e.preventDefault(); // prevent default anchor behaviour
-            selectSong(song.id);
-        });
-
-        /* Add the item to the list. */
-        listEl.appendChild(li);
+        return true;
     });
+    _sidebarRendered = 0;
 
-    /* Update the song-count badge in the sidebar header. */
+    /* Infinite scroll (#1180-B1): bind once. As the user nears the bottom of the
+       sidebar we append the next batch, so the editor never builds all ~16k rows
+       up front (the slow-open / slow-Edit cause) yet the WHOLE filtered list is
+       reachable by scrolling — and search/filter still span the full corpus. */
+    if (!_sidebarScrollBound) {
+        _sidebarScrollBound = true;
+        listEl.addEventListener('scroll', function () {
+            if (_sidebarRendered >= _sidebarVisible.length) { return; }
+            if (listEl.scrollTop + listEl.clientHeight >= listEl.scrollHeight - 300) {
+                renderSidebarBatch();
+            }
+        });
+    }
+
+    renderSidebarBatch();   /* first batch */
+
+    /* If the first batch is shorter than the viewport, keep loading until it
+       fills (so there is something to scroll on, and the scroll handler can fire). */
+    var _fillGuard = 0;
+    while (_sidebarRendered < _sidebarVisible.length
+           && listEl.clientHeight > 0
+           && listEl.scrollHeight <= listEl.clientHeight + 4
+           && _fillGuard++ < 80) {
+        renderSidebarBatch();
+    }
+
+    /* Update the song-count badge in the sidebar header (full match count). */
     var countEl = document.getElementById('song-count');
     if (countEl) {
-        countEl.textContent = visibleCount + ' / ' + songData.songs.length;
+        countEl.textContent = _sidebarVisible.length + ' / ' + songData.songs.length;
     }
+}
+
+/* Sidebar incremental-render state (#1180-B1). */
+var SIDEBAR_BATCH       = 200;   /* rows built per batch */
+var _sidebarVisible     = [];    /* the full filtered+sorted song list */
+var _sidebarRendered    = 0;     /* how many rows are currently in the DOM */
+var _sidebarScrollBound = false;
+
+/* Append the next batch of sidebar rows from _sidebarVisible (#1180-B1). */
+function renderSidebarBatch() {
+    var listEl = document.getElementById('song-list');
+    if (!listEl) { return; }
+    var end  = Math.min(_sidebarRendered + SIDEBAR_BATCH, _sidebarVisible.length);
+    var frag = document.createDocumentFragment();
+    for (var i = _sidebarRendered; i < end; i++) {
+        frag.appendChild(buildSongListRow(_sidebarVisible[i]));
+    }
+    listEl.appendChild(frag);
+    _sidebarRendered = end;
+}
+
+/* Build one sidebar row <a> for a song — extracted so the initial render and the
+   scroll-loaded batches share identical markup + behaviour (#1180-B1). */
+function buildSongListRow(song) {
+    var li = document.createElement('a');
+    li.href = '#';
+    li.className = 'list-group-item list-group-item-action d-flex justify-content-between align-items-center';
+
+    /* Multi-select mode (#399): a checkbox that toggles selection without
+       navigating to the song. */
+    if (window._selectMode) {
+        var cb = document.createElement('input');
+        cb.type = 'checkbox';
+        cb.className = 'form-check-input me-2 flex-shrink-0';
+        cb.dataset.songId = song.id;
+        cb.checked = window._selectedIds && window._selectedIds.has(song.id);
+        cb.addEventListener('click', function (e) { e.stopPropagation(); });
+        cb.addEventListener('change', function () {
+            if (!window._selectedIds) window._selectedIds = new Set();
+            if (cb.checked) window._selectedIds.add(song.id);
+            else window._selectedIds.delete(song.id);
+            updateBulkActionsBar();
+        });
+        li.appendChild(cb);
+    }
+
+    /* Highlight the currently selected song. */
+    if (song.id === currentSongId) { li.classList.add('active'); }
+
+    /* "number - Title Case Title" (#249). */
+    var label = document.createElement('span');
+    label.textContent = (song.number || '?') + ' - ' + toTitleCase(song.title || 'Untitled');
+
+    /* Right-side badges: modified indicator + songbook abbreviation (#249). */
+    var badges = document.createElement('span');
+    badges.className = 'd-flex align-items-center gap-1 flex-shrink-0';
+    if (modifiedSongIds.has(song.id)) {
+        var modBadge = document.createElement('span');
+        modBadge.className = 'badge bg-warning text-dark';
+        modBadge.style.fontSize = '0.65rem';
+        modBadge.textContent = 'modified';
+        badges.appendChild(modBadge);
+    }
+    if (song.songbook) {
+        var sbBadge = document.createElement('span');
+        sbBadge.className = 'badge rounded-pill';
+        sbBadge.style.cssText = 'background-color: rgba(245,158,11,0.15); color: #f59e0b; font-size: 0.65rem; font-weight: 600;';
+        sbBadge.textContent = song.songbook;
+        badges.appendChild(sbBadge);
+    }
+
+    li.appendChild(label);
+    li.appendChild(badges);
+
+    /* Clicking a row loads the song into the editor. */
+    li.addEventListener('click', function (e) {
+        e.preventDefault();
+        selectSong(song.id);
+    });
+    return li;
 }
 
 /**


### PR DESCRIPTION
From the latest alpha testing.

## 🔴 NormalizedTitle migration stays "pending" (the 1-of-4 that wouldn't clear)
It ran in **~1 ms** = early-return before the ALTER: the migration hard-coded the **repo** path to `title_normalize.php`, which doesn't resolve on the **deployed** layout (where `public_html` is the web root), so it bailed and never added the column. Now it resolves the normalizer across the known layouts. *(Re-run "Apply all" after deploy → it should finally go to zero.)*

## ⚡ Sidebar infinite-scroll (#1180-B1) — fixes the 5s Edit-button delay
The editor built **all ~16k song rows** up front (the slow open + the slow `?song=` deep-link). Now:
- **search + filter still span the FULL corpus** — only the *render* is incremental;
- the first **200** rows paint instantly; more **load as you scroll** (so the whole filtered list is reachable, no hard cap);
- so clicking **Edit** on a song no longer waits for the entire sidebar to build.

## 📦 Export polish (#1166 / #887)
- **Dropped the `(.ext)` suffixes** from the dropdown labels (too technical).
- **Added ProPresenter 7+** — single-song (`.pro`, binary protobuf, lazy-loaded) **and whole-songbook (`.probundle`)** via `exportAllAsBundle`. In both song + songbook views.

> **App icons:** the actual app logos next to each format need brand assets (and a trademark call) — tracked as a follow-up rather than shipping mismatched generic icons.

`php -l` + `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)