### PR TITLE
fix(editor): mobile responsivity — sidebar footer button cluster wrap (#1180)

### DIFF
--- a/appWeb/public_html/css/admin.css
+++ b/appWeb/public_html/css/admin.css
@@ -1010,6 +1010,19 @@ body:has(.navbar-admin) {
         max-width: none;
         max-height: 40vh;
     }
+    /* Sidebar footer: let the song-count + the action/export button cluster
+       WRAP instead of overflowing horizontally on the stacked/narrow layout
+       (#1180 mobile pass). */
+    .sidebar-footer {
+        flex-wrap: wrap;
+        gap: 0.4rem;
+        justify-content: center;
+        text-align: center;
+    }
+    .sidebar-footer > span.d-flex {
+        flex-wrap: wrap;
+        justify-content: center;
+    }
 }
 
 /* --------------------------------------------------------------------------
@@ -1053,6 +1066,15 @@ body:has(.navbar-admin) {
     /* Both flex groups (left nav, right actions) — tighten internal gap. */
     .navbar-editor > .d-flex {
         gap: 0.35rem !important;
+    }
+    /* Sidebar footer action/export buttons — pack tighter so the wrapped
+       cluster (#1180 mobile pass) needs fewer rows on a phone. */
+    .sidebar-footer .btn.btn-sm {
+        padding: 0.2rem 0.4rem;
+        font-size: 0.75rem;
+    }
+    .sidebar-footer .dropdown-toggle::after {
+        margin-left: 0.2rem;
     }
 }
 

--- a/appWeb/public_html/manage/editor/index.php
+++ b/appWeb/public_html/manage/editor/index.php
@@ -301,7 +301,7 @@ try {
                     <span id="song-count">0 songs</span>
                     <span id="songCountFiltered" style="display: none;"> (showing <span id="filteredCount">0</span>)</span>
                 </span>
-                <span class="d-flex gap-1">
+                <span class="d-flex gap-1 flex-wrap">
                     <button type="button" class="btn btn-sm btn-outline-secondary" id="btn-select-mode"
                             title="Multi-select mode (#399)" aria-pressed="false">
                         <i class="bi bi-check2-square me-1"></i>Select


### PR DESCRIPTION
The editor mobile-responsivity pass (#1180) — fixes the worst offender surfaced in testing.

## The problem
The sidebar footer packs the song-count + a cluster of action/export buttons (Select, Add, Delete, **Export ▾**, **ProPresenter ▾**, …) into a `justify-content-between` flex row with **no `flex-wrap`** — so on the stacked/narrow mobile layout the buttons **overflowed horizontally**.

## Fixes
- the action/export cluster gets **`flex-wrap`** (the markup omitted it; its sibling cluster already had it);
- on the **≤768px** stacked layout, `.sidebar-footer` itself **wraps + centres** so the count and button clusters drop onto their own rows;
- at **≤576px** the footer buttons pack tighter (padding/font) so the wrapped cluster uses fewer rows.

The top toolbar was already responsive (≤576px hides low-priority controls + wraps), and the component-card control rows use `col-md-*` (stack below 768px), so those were already fine. Deeper editor-surface tweaks (tab strip, on-phone editing ergonomics) stay tracked on **#1180**.

`php -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)