### PR TITLE
fix(admin): footer links muted again, not accent-coloured (#1189)

### DIFF
--- a/appWeb/public_html/css/admin.css
+++ b/appWeb/public_html/css/admin.css
@@ -94,12 +94,17 @@ body.reduce-motion {
     animation: none !important;
 }
 
-a:not(.btn):not(.nav-link):not(.dropdown-item) {
+a:not(.btn):not(.nav-link):not(.dropdown-item):not(.footer-link) {
     color: var(--accent-solid);
 }
-a:not(.btn):not(.nav-link):not(.dropdown-item):hover {
+a:not(.btn):not(.nav-link):not(.dropdown-item):not(.footer-link):hover {
     color: var(--accent-end);
 }
+/* `.footer-link` (Terms / Privacy in the admin footer) is deliberately
+   EXCLUDED above so it keeps its understated app.css styling (muted, same
+   colour as the surrounding footer text) — the owner wants footer links
+   understated, NOT accent-coloured. This admin accent-link rule's high
+   specificity (a + three :not()s) was overriding .footer-link's colour. */
 
 /* Anchors dressed up as buttons should render identically to their
    <button> equivalents. The global `a { border-bottom: 1px dotted }`


### PR DESCRIPTION
Closes #1189. On `/manage/*` the footer links (Terms · Privacy) were accent-**coloured** instead of the understated muted colour you asked for — you only wanted the dotted-underline removed, not a colour change.

**Cause:** `admin.css` has `a:not(.btn):not(.nav-link):not(.dropdown-item) { color: var(--accent-solid) }` — specificity **0,3,1**, which beats `.footer-link` (**0,1,0**), so admin footer links got the accent colour. Removing the dotted underline just made that long-standing colouring more conspicuous.

**Fix:** exclude `.footer-link` from that rule, so footer links keep their muted `.footer-link` styling — the **same colour as the surrounding footer text**, no underline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)