### PR TITLE
feat(schema): Colour columns for Catalogues + Songbook Series (#1181 foundation)

### DIFF
--- a/appWeb/.sql/migrate-entity-colours.php
+++ b/appWeb/.sql/migrate-entity-colours.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Per-entity colour columns for Catalogues + Songbook Series (#1181)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Songbooks already carry a badge `Colour` (tblSongbooks.Colour). The owner
+ * wants the same for **Catalogues / Collections**, and for a **Songbook Series**
+ * to define ONE colour that all its member songbooks share. This migration adds
+ * the two colour columns; the resolution (a songbook's effective colour = its
+ * own Colour → else its series' Colour → else theme default) + the admin colour
+ * pickers land alongside it. The auto-contrast pass (#1179) means any chosen
+ * colour stays readable, so colours can vary widely.
+ *
+ * Both columns are VARCHAR(7) hex (#RRGGBB), empty = theme default — byte-for-byte
+ * the same shape as tblSongbooks.Colour so the existing validate/auto-pick helpers
+ * apply unchanged.
+ *
+ * STRICTLY ADDITIVE + IDEMPOTENT (column existence guarded).
+ *
+ * @migration-adds tblCatalogues.Colour
+ * @migration-adds tblSongbookSeries.Colour
+ *
+ * USAGE:
+ *   CLI:  php appWeb/.sql/migrate-entity-colours.php
+ *   Web:  /manage/setup-database → "Catalogue + Series colours" button
+ *
+ * @requires PHP 8.1+ with mysqli
+ */
+
+$isCli = (php_sapi_name() === 'cli');
+if (!$isCli && !defined('IHYMNS_SETUP_DASHBOARD')) {
+    header('Content-Type: text/plain; charset=UTF-8');
+    header('X-Content-Type-Options: nosniff');
+    header('Cache-Control: no-store');
+}
+
+function _migEntityColour_output(string $msg): void {
+    global $isCli;
+    echo $msg . ($isCli ? "\n" : "<br>\n");
+    if (!$isCli) flush();
+}
+
+function _migEntityColour_columnExists(\mysqli $db, string $table, string $column): bool {
+    $stmt = $db->prepare(
+        'SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ? LIMIT 1'
+    );
+    $stmt->bind_param('ss', $table, $column);
+    $stmt->execute();
+    $exists = (bool)$stmt->get_result()->fetch_row();
+    $stmt->close();
+    return $exists;
+}
+
+$credFile = dirname(__DIR__) . DIRECTORY_SEPARATOR . '.auth' . DIRECTORY_SEPARATOR . 'db_credentials.php';
+if (!file_exists($credFile)) {
+    _migEntityColour_output("ERROR: MySQL credentials not found. Run install.php first.");
+    return;
+}
+require_once $credFile;
+
+_migEntityColour_output("");
+_migEntityColour_output("=== iHymns — Catalogue + Songbook-Series colours (#1181) ===");
+_migEntityColour_output("");
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+try {
+    $mysql = new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME, (int)DB_PORT);
+    $mysql->set_charset(defined('DB_CHARSET') ? DB_CHARSET : 'utf8mb4');
+} catch (\mysqli_sql_exception $e) {
+    _migEntityColour_output("ERROR: MySQL connection failed: " . $e->getMessage());
+    return;
+}
+_migEntityColour_output("Connected to MySQL: " . DB_NAME);
+
+try {
+    /* tblCatalogues.Colour */
+    _migEntityColour_output("--- tblCatalogues.Colour ---");
+    if (_migEntityColour_columnExists($mysql, 'tblCatalogues', 'Colour')) {
+        _migEntityColour_output("  [SKIP] tblCatalogues.Colour already present.");
+    } else {
+        $mysql->query(
+            "ALTER TABLE tblCatalogues
+                ADD COLUMN Colour VARCHAR(7) NOT NULL DEFAULT ''
+                    COMMENT 'Badge colour hex #RRGGBB (empty = theme default) (#1181)'"
+        );
+        _migEntityColour_output("  [OK] Added tblCatalogues.Colour.");
+    }
+
+    /* tblSongbookSeries.Colour — inherited by all member songbooks. */
+    _migEntityColour_output("--- tblSongbookSeries.Colour ---");
+    if (_migEntityColour_columnExists($mysql, 'tblSongbookSeries', 'Colour')) {
+        _migEntityColour_output("  [SKIP] tblSongbookSeries.Colour already present.");
+    } else {
+        $mysql->query(
+            "ALTER TABLE tblSongbookSeries
+                ADD COLUMN Colour VARCHAR(7) NOT NULL DEFAULT ''
+                    COMMENT 'Badge colour hex #RRGGBB inherited by all member songbooks; empty = theme default (#1181)'"
+        );
+        _migEntityColour_output("  [OK] Added tblSongbookSeries.Colour.");
+    }
+
+    _migEntityColour_output("");
+    _migEntityColour_output("--- Summary ---");
+    _migEntityColour_output("  Catalogues + Songbook Series can now carry a badge colour. A songbook's");
+    _migEntityColour_output("  effective colour resolves own → series → theme default; the admin colour");
+    _migEntityColour_output("  pickers + the render resolution land alongside this migration (#1181).");
+    _migEntityColour_output("");
+    _migEntityColour_output("Migration complete.");
+} catch (\Throwable $e) {
+    _migEntityColour_output("  [ERROR] " . $e->getMessage());
+}
+
+$mysql->close();
+return;

--- a/appWeb/.sql/schema.sql
+++ b/appWeb/.sql/schema.sql
@@ -1978,6 +1978,7 @@ CREATE TABLE IF NOT EXISTS tblCatalogues (
     CreatedAt    DATETIME          NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UpdatedAt    DATETIME          NOT NULL DEFAULT CURRENT_TIMESTAMP
                                     ON UPDATE CURRENT_TIMESTAMP,
+    Colour       VARCHAR(7)        NOT NULL DEFAULT '' COMMENT 'Badge colour hex #RRGGBB (empty = theme default) (#1181)',
     UNIQUE KEY uk_Slug (Slug),
     INDEX idx_Visibility (Visibility),
     INDEX idx_SortOrder  (SortOrder)
@@ -2257,6 +2258,7 @@ CREATE TABLE IF NOT EXISTS tblSongbookSeries (
     Slug         VARCHAR(120)  NOT NULL UNIQUE
                  COMMENT 'URL-safe lowercase form for /series/<slug> public listing pages',
     CreatedAt    TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    Colour       VARCHAR(7)    NOT NULL DEFAULT '' COMMENT 'Badge colour hex #RRGGBB inherited by all member songbooks; empty = theme default (#1181)',
     KEY idx_Name (Name)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 

--- a/appWeb/public_html/manage/includes/migration-registry.php
+++ b/appWeb/public_html/manage/includes/migration-registry.php
@@ -1891,4 +1891,20 @@ return [
             || !_migProbe_tableExists($db, 'tblPresentationThemeTags')
             || !_migProbe_tableExists($db, 'tblPresentationFormatFidelity'),
     ],
+
+    'entity-colours' => [
+        'script' => 'migrate-entity-colours.php',
+        'card' => [
+            'title'  => 'Catalogue + Series colours (#1181)',
+            'body'   => 'Adds <code>tblCatalogues.Colour</code> + <code>tblSongbookSeries.Colour</code>'
+                      . ' (badge hex <code>#RRGGBB</code>, empty = theme default) so catalogues /'
+                      . ' collections carry a badge colour and a songbook series defines ONE colour its'
+                      . ' member songbooks share. Additive + idempotent.',
+            'button' => 'Run Entity Colours Migration',
+        ],
+        /* Pending until BOTH columns exist (multi-column OR-form). */
+        'probe' => static fn(\mysqli $db) =>
+            !_migProbe_columnExists($db, 'tblCatalogues', 'Colour')
+            || !_migProbe_columnExists($db, 'tblSongbookSeries', 'Colour'),
+    ],
 ];


### PR DESCRIPTION
First piece of **#1181** — the schema foundation for per-entity colours.

Songbooks already have a badge `Colour`. This adds the same to **Catalogues/Collections** and **Songbook Series**, enabling:
- a catalogue/collection with its own badge colour;
- a **series that defines ONE colour all its member songbooks share** (effective colour will resolve **own → series → theme default**).

The auto-contrast pass (#1179) keeps any chosen colour readable, so colours can vary widely.

## What's here
- `migrate-entity-colours.php` — `ALTER tblCatalogues + tblSongbookSeries ADD Colour VARCHAR(7)` (same shape as `tblSongbooks.Colour`, so the existing validate/auto-pick helpers apply). Additive + idempotent, `@migration-adds` doctag per column.
- byte-identical `schema.sql` mirror + one registry entry with a two-column OR-probe.

## Verified
✅ Applied `schema.sql` to a **real local MySQL** — clean, all three `Colour` columns present. ✅ `test-schema-coverage` + `test-migration-registry` + `php -l` green.

## Next #1181 pieces
Admin colour pickers on `/manage/catalogues` + `/manage/songbook-series` (reusing `validateSongbookColour` / the `pick_colour` pattern), then the **series→songbook colour resolution** at render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)