### PR TITLE
feat(#1181): catalogue + series colour pickers + series→songbook resolution

### DIFF
--- a/appWeb/public_html/includes/SongData.php
+++ b/appWeb/public_html/includes/SongData.php
@@ -317,6 +317,15 @@ class SongData
                 $_b['alternativeNames'] = $altNamesMap[(string)$_b['id']]  ?? [];
                 $_b['links']            = $linksMap[(string)$_b['id']]     ?? [];
 
+                /* #1181 — effective badge colour: own → first member series
+                   that defines a colour → theme default. Lets a series share
+                   ONE colour across all its songbooks (mirrors getSongbook()). */
+                if (($_b['colour'] ?? '') === '') {
+                    foreach ($_b['series'] as $_ser) {
+                        if (!empty($_ser['colour'])) { $_b['colour'] = $_ser['colour']; break; }
+                    }
+                }
+
                 /* #857 — union of: (a) the songbook's own primary
                    subtag, and (b) every distinct primary subtag
                    carried by songs within it. Drives the "Show
@@ -540,6 +549,7 @@ class SongData
                                s.Id           AS sid,
                                s.Name         AS sname,
                                s.Slug         AS sslug,
+                               s.Colour       AS scolour,
                                m.SortOrder    AS sortOrder
                           FROM tblSongbookSeriesMembership m
                           JOIN tblSongbookSeries s ON s.Id = m.SeriesId
@@ -557,6 +567,7 @@ class SongData
                                s.Id           AS sid,
                                s.Name         AS sname,
                                s.Slug         AS sslug,
+                               s.Colour       AS scolour,
                                m.SortOrder    AS sortOrder
                           FROM tblSongbookSeriesMembership m
                           JOIN tblSongbookSeries s ON s.Id = m.SeriesId
@@ -574,9 +585,10 @@ class SongData
                 $abbr = (string)$row['abbr'];
                 if (!isset($out[$abbr])) $out[$abbr] = [];
                 $out[$abbr][] = [
-                    'id'   => (int)$row['sid'],
-                    'name' => (string)$row['sname'],
-                    'slug' => (string)$row['sslug'],
+                    'id'     => (int)$row['sid'],
+                    'name'   => (string)$row['sname'],
+                    'slug'   => (string)$row['sslug'],
+                    'colour' => (string)($row['scolour'] ?? ''),  // #1181 — series badge colour
                 ];
             }
             $stmt->close();
@@ -1170,6 +1182,14 @@ class SongData
         $row['compilers']        = $compilersMap[(string)$row['id']] ?? [];
         $row['alternativeNames'] = $altNamesMap[(string)$row['id']]  ?? [];
         $row['links']            = $linksMap[(string)$row['id']]     ?? [];
+        /* #1181 — effective badge colour resolves own → first member series
+           that defines a colour → theme default (empty). So a series can give
+           ONE shared colour to all its songbooks without each being set. */
+        if (($row['colour'] ?? '') === '') {
+            foreach ($row['series'] as $ser) {
+                if (!empty($ser['colour'])) { $row['colour'] = $ser['colour']; break; }
+            }
+        }
         return $row;
     }
 

--- a/appWeb/public_html/manage/catalogues.php
+++ b/appWeb/public_html/manage/catalogues.php
@@ -138,6 +138,11 @@ if ($hasSchema && $_SERVER['REQUEST_METHOD'] === 'POST') {
                 $slug = $slugRaw !== '' ? $slugFor($slugRaw) : $slugFor($title);
                 if ($slug === '')                                        { $error = 'Slug could not be derived — provide one explicitly.'; break; }
                 if (mb_strlen($slug) > 255)                              { $error = 'Slug must be 255 characters or fewer.'; break; }
+                /* #1181 — optional badge colour (blank = theme default; validated hex). */
+                $colour = strtoupper(trim((string)($_POST['colour'] ?? '')));
+                if ($colour !== '' && !preg_match('/^#[0-9A-F]{6}$/', $colour)) {
+                    $error = 'Colour must be a #RRGGBB hex value or left blank.'; break;
+                }
 
                 $stmt = $db->prepare('SELECT Id FROM tblCatalogues WHERE Slug = ?');
                 $stmt->bind_param('s', $slug);
@@ -147,11 +152,11 @@ if ($hasSchema && $_SERVER['REQUEST_METHOD'] === 'POST') {
                 if ($exists) { $error = "A catalogue with slug '{$slug}' already exists."; break; }
 
                 $stmt = $db->prepare(
-                    'INSERT INTO tblCatalogues (Slug, Title, Description, SortOrder, Visibility)
-                     VALUES (?, ?, ?, ?, ?)'
+                    'INSERT INTO tblCatalogues (Slug, Title, Description, SortOrder, Visibility, Colour)
+                     VALUES (?, ?, ?, ?, ?, ?)'
                 );
-                $stmt->bind_param('sssis',
-                    $slug, $title, $description, $sortOrder, $visibility);
+                $stmt->bind_param('sssiss',
+                    $slug, $title, $description, $sortOrder, $visibility, $colour);
                 $stmt->execute();
                 $newId = (int)$db->insert_id;
                 $stmt->close();
@@ -175,12 +180,18 @@ if ($hasSchema && $_SERVER['REQUEST_METHOD'] === 'POST') {
                     $error = 'Invalid visibility.'; break;
                 }
 
+                /* #1181 — optional badge colour (blank = theme default; validated hex). */
+                $colour = strtoupper(trim((string)($_POST['colour'] ?? '')));
+                if ($colour !== '' && !preg_match('/^#[0-9A-F]{6}$/', $colour)) {
+                    $error = 'Colour must be a #RRGGBB hex value or left blank.'; break;
+                }
+
                 $stmt = $db->prepare(
                     'UPDATE tblCatalogues
-                        SET Title = ?, Description = ?, SortOrder = ?, Visibility = ?
+                        SET Title = ?, Description = ?, SortOrder = ?, Visibility = ?, Colour = ?
                       WHERE Id = ?'
                 );
-                $stmt->bind_param('ssisi', $title, $description, $sortOrder, $visibility, $id);
+                $stmt->bind_param('ssissi', $title, $description, $sortOrder, $visibility, $colour, $id);
                 $stmt->execute();
                 $stmt->close();
 
@@ -274,7 +285,7 @@ if ($hasSchema) {
     try {
         $stmt = $db->prepare(
             'SELECT c.Id, c.Slug, c.Title, c.Description, c.SortOrder, c.Visibility,
-                    c.CreatedAt, c.UpdatedAt,
+                    c.Colour, c.CreatedAt, c.UpdatedAt,
                     (SELECT COUNT(*) FROM tblCatalogueSongs cs WHERE cs.CatalogueId = c.Id) AS SongCount
                FROM tblCatalogues c
               ORDER BY c.SortOrder ASC, c.Title ASC'
@@ -382,6 +393,18 @@ if ($hasSchema && !empty($catalogues)) {
                         <option value="admin_only">Admin only</option>
                     </select>
                 </div>
+                <div class="col-md-3">
+                    <!-- #1181 — optional catalogue badge colour; swatch writes its
+                         hex into the text field (the submitted value). Blank = default. -->
+                    <label class="form-label small mb-0">Colour <small class="text-muted">(optional)</small></label>
+                    <div class="input-group input-group-sm">
+                        <input type="color" class="form-control form-control-color" value="#888888"
+                               title="Pick a colour" aria-label="Catalogue colour swatch"
+                               oninput="this.nextElementSibling.value = this.value.toUpperCase()">
+                        <input type="text" name="colour" class="form-control" maxlength="7"
+                               pattern="#?[0-9A-Fa-f]{6}" placeholder="#RRGGBB — blank = default">
+                    </div>
+                </div>
                 <div class="col-12">
                     <button type="submit" class="btn btn-sm btn-info">
                         <i class="bi bi-plus me-1"></i>Create catalogue
@@ -467,6 +490,19 @@ if ($hasSchema && !empty($catalogues)) {
                                                     <option value="<?= $v ?>" <?= $c['Visibility'] === $v ? 'selected' : '' ?>><?= $v ?></option>
                                                 <?php endforeach; ?>
                                             </select>
+                                        </div>
+                                        <div class="col-md-3">
+                                            <!-- #1181 — catalogue badge colour (blank = default). -->
+                                            <label class="form-label small mb-0">Colour</label>
+                                            <div class="input-group input-group-sm">
+                                                <input type="color" class="form-control form-control-color"
+                                                       value="<?= htmlspecialchars(($c['Colour'] ?? '') !== '' ? (string)$c['Colour'] : '#888888') ?>"
+                                                       title="Pick a colour" aria-label="Catalogue colour swatch"
+                                                       oninput="this.nextElementSibling.value = this.value.toUpperCase()">
+                                                <input type="text" name="colour" class="form-control"
+                                                       value="<?= htmlspecialchars((string)($c['Colour'] ?? '')) ?>"
+                                                       maxlength="7" pattern="#?[0-9A-Fa-f]{6}" placeholder="#RRGGBB">
+                                            </div>
                                         </div>
                                         <div class="col-md-3 text-end">
                                             <button type="submit" class="btn btn-sm btn-info">

--- a/appWeb/public_html/manage/songbook-series.php
+++ b/appWeb/public_html/manage/songbook-series.php
@@ -163,6 +163,12 @@ if ($hasSchema && ($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'POST') {
                 $name        = mb_substr($name, 0, 120);
                 $slug        = mb_substr($slug, 0, 120);
                 $description = mb_substr($description, 0, 255);
+                /* #1181 — optional shared series colour. Blank = theme default;
+                   otherwise a validated #RRGGBB hex (never interpolated). */
+                $colour = strtoupper(trim((string)($_POST['colour'] ?? '')));
+                if ($colour !== '' && !preg_match('/^#[0-9A-F]{6}$/', $colour)) {
+                    $error = 'Colour must be a #RRGGBB hex value or left blank.'; break;
+                }
 
                 /* UNIQUE on Slug → check before insert for a friendly error. */
                 $stmt = $db->prepare('SELECT Id FROM tblSongbookSeries WHERE Slug = ?');
@@ -173,9 +179,9 @@ if ($hasSchema && ($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'POST') {
                 if ($exists) { $error = "Slug '{$slug}' already taken — pick another."; break; }
 
                 $stmt = $db->prepare(
-                    'INSERT INTO tblSongbookSeries (Name, Slug, Description) VALUES (?, ?, ?)'
+                    'INSERT INTO tblSongbookSeries (Name, Slug, Description, Colour) VALUES (?, ?, ?, ?)'
                 );
-                $stmt->bind_param('sss', $name, $slug, $description);
+                $stmt->bind_param('ssss', $name, $slug, $description, $colour);
                 $stmt->execute();
                 $newId = (int)$db->insert_id;
                 $stmt->close();
@@ -200,6 +206,11 @@ if ($hasSchema && ($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'POST') {
                 $name        = mb_substr($name, 0, 120);
                 $slug        = mb_substr($slug, 0, 120);
                 $description = mb_substr($description, 0, 255);
+                /* #1181 — optional shared series colour (blank = theme default). */
+                $colour = strtoupper(trim((string)($_POST['colour'] ?? '')));
+                if ($colour !== '' && !preg_match('/^#[0-9A-F]{6}$/', $colour)) {
+                    $error = 'Colour must be a #RRGGBB hex value or left blank.'; break;
+                }
 
                 /* Pull the before-row for the audit log + collision check. */
                 $stmt = $db->prepare('SELECT Name, Slug, Description FROM tblSongbookSeries WHERE Id = ?');
@@ -236,10 +247,10 @@ if ($hasSchema && ($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'POST') {
                 try {
                     $stmt = $db->prepare(
                         'UPDATE tblSongbookSeries
-                            SET Name = ?, Slug = ?, Description = ?
+                            SET Name = ?, Slug = ?, Description = ?, Colour = ?
                           WHERE Id = ?'
                     );
-                    $stmt->bind_param('sssi', $name, $slug, $description, $id);
+                    $stmt->bind_param('ssssi', $name, $slug, $description, $colour, $id);
                     $stmt->execute();
                     $stmt->close();
 
@@ -350,7 +361,7 @@ $rows = [];
 if ($hasSchema) {
     try {
         $stmt = $db->prepare(
-            'SELECT s.Id, s.Name, s.Slug, s.Description, s.CreatedAt,
+            'SELECT s.Id, s.Name, s.Slug, s.Description, s.Colour, s.CreatedAt,
                     (SELECT COUNT(*) FROM tblSongbookSeriesMembership m WHERE m.SeriesId = s.Id) AS MemberCount
                FROM tblSongbookSeries s
               ORDER BY s.Name ASC'
@@ -465,6 +476,7 @@ if ($hasSchema) {
                                 'name'        => (string)$r['Name'],
                                 'slug'        => (string)$r['Slug'],
                                 'description' => (string)$r['Description'],
+                                'colour'      => (string)($r['Colour'] ?? ''),  // #1181
                                 'members'     => $members,
                             ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
                             $deleteJson = json_encode([
@@ -504,14 +516,14 @@ if ($hasSchema) {
             <input type="hidden" name="action" value="create">
             <h2 class="h6 mb-3"><i class="bi bi-plus-circle me-2"></i>Add a series</h2>
             <div class="row g-2">
-                <div class="col-sm-5">
+                <div class="col-sm-4">
                     <label class="form-label small">Name</label>
                     <input type="text" name="name" id="create-name"
                            class="form-control form-control-sm"
                            maxlength="120" required
                            placeholder="e.g. Songs of Fellowship">
                 </div>
-                <div class="col-sm-3">
+                <div class="col-sm-2">
                     <label class="form-label small">Slug
                         <small class="text-muted">(auto)</small>
                     </label>
@@ -520,12 +532,26 @@ if ($hasSchema) {
                            maxlength="120" pattern="[a-z0-9-]+"
                            placeholder="songs-of-fellowship">
                 </div>
-                <div class="col-sm-4">
+                <div class="col-sm-3">
                     <label class="form-label small">Description (optional)</label>
                     <input type="text" name="description"
                            class="form-control form-control-sm"
                            maxlength="255"
                            placeholder="Brief context for curators">
+                </div>
+                <div class="col-sm-3">
+                    <!-- #1181 — optional shared series colour; the swatch writes
+                         its hex into the text field (the submitted value). Blank
+                         text = theme default. Auto-contrast (#1179) keeps it readable. -->
+                    <label class="form-label small">Colour <small class="text-muted">(optional, shared)</small></label>
+                    <div class="input-group input-group-sm">
+                        <input type="color" class="form-control form-control-color" value="#888888"
+                               title="Pick a colour" aria-label="Series colour swatch"
+                               oninput="this.nextElementSibling.value = this.value.toUpperCase()">
+                        <input type="text" name="colour" id="create-colour"
+                               class="form-control" maxlength="7" pattern="#?[0-9A-Fa-f]{6}"
+                               placeholder="#RRGGBB — blank = default">
+                    </div>
                 </div>
             </div>
             <button type="submit" class="btn btn-amber btn-sm mt-3">
@@ -566,6 +592,19 @@ if ($hasSchema) {
                                 <label class="form-label">Description (optional)</label>
                                 <input type="text" name="description" id="edit-description"
                                        class="form-control" maxlength="255">
+                            </div>
+                            <div class="mb-3">
+                                <!-- #1181 — shared series colour. All member songbooks
+                                     inherit it (own songbook colour still wins). -->
+                                <label class="form-label">Colour <small class="text-muted">(optional — shared by all member songbooks)</small></label>
+                                <div class="input-group" style="max-width:18rem">
+                                    <input type="color" class="form-control form-control-color" id="edit-colour-swatch"
+                                           value="#888888" title="Pick a colour" aria-label="Series colour swatch"
+                                           oninput="document.getElementById('edit-colour').value = this.value.toUpperCase()">
+                                    <input type="text" name="colour" id="edit-colour"
+                                           class="form-control" maxlength="7" pattern="#?[0-9A-Fa-f]{6}"
+                                           placeholder="#RRGGBB — blank = theme default">
+                                </div>
                             </div>
 
                             <hr>
@@ -789,6 +828,11 @@ if ($hasSchema) {
             document.getElementById('edit-name').value         = row.name || '';
             document.getElementById('edit-slug').value         = row.slug || '';
             document.getElementById('edit-description').value  = row.description || '';
+            /* #1181 — shared series colour into the text field + swatch. */
+            var _ec = document.getElementById('edit-colour');
+            var _es = document.getElementById('edit-colour-swatch');
+            if (_ec) { _ec.value = row.colour || ''; }
+            if (_es && row.colour && /^#[0-9A-Fa-f]{6}$/.test(row.colour)) { _es.value = row.colour; }
             document.getElementById('edit-title-label').textContent = row.name || '';
             const tbody = document.getElementById('edit-members-tbody');
             tbody.innerHTML = '';


### PR DESCRIPTION
Second piece of **#1181** (builds on the schema foundation #1191) — makes the colours **settable** and **flow**.

## Resolution (the core ask) — `SongData.php`
A songbook's **effective** badge colour now resolves **own → first member series with a colour → theme default**, at the single data-layer point so every consumer benefits (song-page accent, songbook lists, badges):
- `_songbookSeriesMap()` also selects `s.Colour`;
- `getSongbook()` + `getSongbooks()` apply the fallback.

So **a series gives ONE shared colour to all its member songbooks** without each being set individually — exactly what you asked for.

## Curation
- **`songbook-series.php`** — Colour on create + update (inline `#RRGGBB` validation, blank = default, **bound, never interpolated**); a colour picker (native swatch synced to a hex field) in the create form + edit modal, pre-filled from the row payload + the list SELECT.
- **`catalogues.php`** — same Colour field on create + the inline edit row.

Auto-contrast (#1179) keeps any colour readable.

## Verified
✅ `php -l` clean (all three). ✅ Against a **real local MySQL**: the new Colour `INSERT`/`UPDATE` + the `_songbookSeriesMap` JOIN with `s.Colour` all execute (`series=#FFAA00`, `catalogue=#445566`).

> ⚠️ **Needs a visual check on alpha**: the `/manage/catalogues` + `/manage/songbook-series` colour pickers — I can't run `/manage/*` headless, so the form/swatch UX wants a real-browser glance. The data paths + SQL are validated.

Closes the curation+resolution part of #1181.

🤖 Generated with [Claude Code](https://claude.com/claude-code)