### PR TITLE
fix(editor): rework increment — faster delete, draggable sidebar, place hint, sidebar count, #1178 guard (#1180)

### DIFF
--- a/appWeb/public_html/css/admin.css
+++ b/appWeb/public_html/css/admin.css
@@ -634,6 +634,30 @@ body:has(.navbar-admin) {
     display: flex;
     flex-direction: column;
     overflow: hidden;
+    position: relative;   /* anchor for the drag-to-resize handle (#1180) */
+}
+
+/* #1180 — draggable sidebar width on large displays. A thin grip pinned to the
+   sidebar's right edge; the inline script in editor/index.php handles the drag
+   and persists the chosen width to localStorage. Hidden on the ≤768px stacked
+   layout (a full-width sidebar has no width to give on a phone). */
+.sidebar-resize-handle {
+    position: absolute;
+    top: 0;
+    right: -1px;
+    width: 7px;
+    height: 100%;
+    cursor: col-resize;
+    z-index: 6;
+    background-color: transparent;
+    transition: background-color var(--transition-fast);
+}
+.sidebar-resize-handle:hover,
+.sidebar-resize-handle.dragging {
+    background-color: var(--accent-solid);
+}
+@media (max-width: 768px) {
+    .sidebar-resize-handle { display: none; }
 }
 
 .sidebar-header {

--- a/appWeb/public_html/js/modules/place-search.js
+++ b/appWeb/public_html/js/modules/place-search.js
@@ -159,6 +159,25 @@
             inputEl.setAttribute('aria-expanded', 'true');
         }
 
+        /* Show a single non-interactive info row in the panel. Used to
+           SURFACE a failed/empty lookup instead of silently showing nothing
+           (#1180) — a 404/401/blocked-geocoder used to leave the curator
+           typing into a dead field with no clue why no suggestions appeared. */
+        function renderHint(text) {
+            candidates = [];
+            highlight = -1;
+            panel.innerHTML = '';
+            const item = document.createElement('div');
+            item.style.padding = '0.4rem 0.6rem';
+            item.style.fontSize = '0.8rem';
+            item.style.opacity = '0.7';
+            item.textContent = text;
+            panel.appendChild(item);
+            positionPanel();
+            panel.style.display = 'block';
+            inputEl.setAttribute('aria-expanded', 'true');
+        }
+
         async function runSearch(query) {
             const requestId = ++currentRequest;
             const url = settings.endpoint + '?action=search&q=' + encodeURIComponent(query) + '&limit=' + settings.maxResults;
@@ -169,16 +188,25 @@
                     headers: { 'Accept': 'application/json' },
                 });
             } catch (_e) {
-                /* Network blip — leave the panel closed, the curator
-                   can retry by editing the input. */
+                if (requestId === currentRequest) renderHint('Place lookup unavailable (offline?). Your text is saved as typed.');
                 return;
             }
             if (requestId !== currentRequest) return; /* superseded */
-            if (!resp.ok) return;
+            if (!resp.ok) {
+                renderHint('Place lookup unavailable (HTTP ' + resp.status + '). Your text is saved as typed.');
+                return;
+            }
             const data = await resp.json().catch(() => null);
-            if (!data || !Array.isArray(data.results)) return;
+            if (!data || !Array.isArray(data.results)) {
+                renderHint('Place lookup returned no data. Your text is saved as typed.');
+                return;
+            }
             candidates = data.results;
             highlight = candidates.length ? 0 : -1;
+            if (!candidates.length) {
+                renderHint('No matching places — your text is saved as typed.');
+                return;
+            }
             renderPanel();
         }
 

--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -1162,6 +1162,45 @@ switch ($action) {
             }
         }
 
+        /* #1178 — strip all-BLANK components when the song has real lyrics. A
+           blank "Verse 1" (no non-empty line) left over from the accumulation
+           bug is junk once any filled component exists; never persist it. If
+           EVERY component is blank (a genuinely empty in-progress draft) they're
+           kept as-is so the Structure tab isn't emptied. Arrangement indices are
+           remapped through the same old→new map so they stay valid (mirrors the
+           exact-dup collapse above). */
+        if (is_array($song['components'] ?? null) && count($song['components']) > 0) {
+            $hasContent = false;
+            foreach ($song['components'] as $comp) {
+                foreach (($comp['lines'] ?? []) as $ln) {
+                    if (trim((string)$ln) !== '') { $hasContent = true; break 2; }
+                }
+            }
+            if ($hasContent) {
+                $keptComp = [];
+                $idxRemap = [];
+                foreach ($song['components'] as $oldIdx => $comp) {
+                    $blank = true;
+                    foreach (($comp['lines'] ?? []) as $ln) {
+                        if (trim((string)$ln) !== '') { $blank = false; break; }
+                    }
+                    if ($blank) { continue; }   /* drop the empty component */
+                    $idxRemap[$oldIdx] = count($keptComp);
+                    $keptComp[]        = $comp;
+                }
+                if (count($keptComp) !== count($song['components'])) {
+                    $song['components'] = $keptComp;
+                    if (is_array($song['arrangement'] ?? null)) {
+                        $remappedArr = [];
+                        foreach ($song['arrangement'] as $ai) {
+                            if (isset($idxRemap[$ai])) { $remappedArr[] = $idxRemap[$ai]; }
+                        }
+                        $song['arrangement'] = $remappedArr;
+                    }
+                }
+            }
+        }
+
         $componentCount = is_array($song['components'] ?? null) ? count($song['components']) : 0;
         $arrangementJson = _sanitiseArrangement($song['arrangement'] ?? null, $componentCount);
 

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -1320,10 +1320,13 @@ function removeComponent(song, index) {
     /* Mark as modified. */
     markModified(song.id);
 
-    /* Re-render. */
+    /* Re-render. The component cards + arrangement must rebuild now (the deleted
+       card has to disappear), but the PREVIEW is debounced (#1180) — rebuilding
+       the whole slide preview synchronously on every delete is what made a
+       single delete feel like it took seconds. */
     renderComponents(song);
     renderArrangement(song);
-    renderPreview(song);
+    schedulePreview(song);
 }
 
 /**

--- a/appWeb/public_html/manage/editor/index.php
+++ b/appWeb/public_html/manage/editor/index.php
@@ -214,6 +214,12 @@ try {
              ============================================================= -->
         <aside class="editor-sidebar">
 
+            <!-- #1180 — drag-to-resize grip (large displays only; CSS hides it
+                 ≤768px). Wired by the inline script near the foot of this file. -->
+            <div class="sidebar-resize-handle" id="sidebar-resize-handle"
+                 role="separator" aria-orientation="vertical"
+                 aria-label="Drag to resize the song list" title="Drag to resize"></div>
+
             <!-- Sidebar Header — Filter and search controls -->
             <div class="sidebar-header">
 
@@ -296,11 +302,12 @@ try {
             </div>
 
             <!-- Sidebar Footer — Song count + Add/Delete buttons -->
-            <div class="sidebar-footer d-flex align-items-center justify-content-between">
-                <span>
-                    <span id="song-count">0 songs</span>
-                    <span id="songCountFiltered" style="display: none;"> (showing <span id="filteredCount">0</span>)</span>
-                </span>
+            <div class="sidebar-footer d-flex align-items-center justify-content-center flex-wrap gap-2">
+                <!-- #1180 — the redundant "N / total" song-count was removed from
+                     here: the total already shows in the page footer ("N songs
+                     loaded"), and on the same flex row it crowded + mis-aligned
+                     the action buttons. editor.js still updates #song-count if
+                     present (guarded), so this is markup-only. -->
                 <span class="d-flex gap-1 flex-wrap">
                     <button type="button" class="btn btn-sm btn-outline-secondary" id="btn-select-mode"
                             title="Multi-select mode (#399)" aria-pressed="false">
@@ -1864,6 +1871,56 @@ try {
                 wirePlaceSearch();
             }
         })();
+    </script>
+    <!-- #1180 — drag-to-resize the song-list sidebar on large displays. The
+         chosen width persists to localStorage; clamped to [240px, 60vw]; only
+         active above the 768px stacked-layout breakpoint. -->
+    <script>
+    (function () {
+        var KEY = 'ihymns_editor_sidebar_w';
+        var sidebar = document.querySelector('.editor-sidebar');
+        var handle  = document.getElementById('sidebar-resize-handle');
+        if (!sidebar || !handle) { return; }
+        function isWide() { return window.matchMedia('(min-width: 769px)').matches; }
+        function clamp(w) { return Math.max(240, Math.min(w, Math.round(window.innerWidth * 0.6))); }
+        /* Restore a saved width (large displays only). */
+        try {
+            var saved = parseInt(window.localStorage.getItem(KEY), 10);
+            if (saved && isWide() && saved >= 240 && saved <= window.innerWidth * 0.6) {
+                sidebar.style.width = saved + 'px';
+                sidebar.style.maxWidth = 'none';
+            }
+        } catch (_e) { /* private mode — skip restore */ }
+        var dragging = false;
+        handle.addEventListener('mousedown', function (e) {
+            if (!isWide()) { return; }
+            dragging = true;
+            handle.classList.add('dragging');
+            document.body.style.userSelect = 'none';
+            document.body.style.cursor = 'col-resize';
+            e.preventDefault();
+        });
+        document.addEventListener('mousemove', function (e) {
+            if (!dragging) { return; }
+            var left = sidebar.getBoundingClientRect().left;
+            var w = clamp(e.clientX - left);
+            sidebar.style.width = w + 'px';
+            sidebar.style.maxWidth = 'none';
+        });
+        document.addEventListener('mouseup', function () {
+            if (!dragging) { return; }
+            dragging = false;
+            handle.classList.remove('dragging');
+            document.body.style.userSelect = '';
+            document.body.style.cursor = '';
+            try { window.localStorage.setItem(KEY, String(parseInt(sidebar.style.width, 10) || '')); } catch (_e) {}
+        });
+        /* If the viewport shrinks to the stacked layout, drop the inline width
+           so the ≤768px rules (full-width sidebar) take over cleanly. */
+        window.addEventListener('resize', function () {
+            if (!isWide()) { sidebar.style.width = ''; sidebar.style.maxWidth = ''; }
+        });
+    })();
     </script>
 
     <!-- #858 — pre-load tblLanguages once per page so the per-component


### PR DESCRIPTION
Addresses the latest batch of Song Editor complaints (part of the #1180 rework).

| Complaint | Fix |
|---|---|
| **"Deleting a component takes a few seconds"** | `removeComponent()` rebuilt the whole slide **preview synchronously** every delete — now debounced (`schedulePreview`). Cards + arrangement still update instantly. |
| **Sidebar "N / total" crowds + mis-aligns the buttons** | Removed from the sidebar footer (the total's already in the page footer). Markup-only. |
| **Want draggable sidebar width (not on phones)** | Drag-grip on the sidebar's right edge, **large displays only** (hidden ≤768px). Width **persists** to localStorage, clamped [240px, 60vw]. |
| **Composition Origin gives no suggestions** | The module + `/manage/places-api.php` (Photon→Nominatim) are correct, but it **failed silently** on 404/401/blocked-geocoder. Now shows a **hint** ("Place lookup unavailable… your text is saved as typed"). |
| **#1178 corruption residue** | `save_song` now also **strips all-blank components** when real lyrics exist (arrangement remapped), on top of the exact-dup collapse. |

## On the auto-save hypothesis + #1178 root cause
You asked whether auto-save could accumulate the duplicates. **Verified it can't**: every `save_song` does `ON DUPLICATE KEY UPDATE` on `tblSongs` by the **stable** SongId, then **DELETEs all child rows before re-INSERT** (api.php:1296) — each save overwrites the last. I also traced every client path (render/serialise/select/merge) — none append. The screenshot's progressive-snapshot duplicates are persisted from the original incident; being content-different they can't be auto-merged, so the **active client trigger still needs a live reproduction** (subagents rate-limited + I can't run the editor headless).

## Composition Origin — needs a prod check
If the hint shows "unavailable (HTTP …)", the shared host likely can't reach Photon/Nominatim (or the session cookie isn't valid on that path). A `curl -sI '/manage/places-api.php?action=search&q=cardiff'` from the server settles it.

`node --check` + `php -l` clean. The draggable sidebar + place hint want a real-browser glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)