### PR TITLE
fix(places): Composition Origin HTTP 500 — wrong deploy-path in require_once

### DIFF
--- a/appWeb/public_html/manage/places-api.php
+++ b/appWeb/public_html/manage/places-api.php
@@ -46,8 +46,15 @@ if (!$currentUser || !hasRole($currentUser['role'], 'editor')) {
     exit;
 }
 
-require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'public_html' . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
-require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'public_html' . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'places.php';
+/* These were dirname(__DIR__, 2) . '/public_html/includes/…' — which assumes a
+   NESTED public_html and only resolved in the repo (appWeb/public_html/). On the
+   deployed server public_html IS the web root, so that path doesn't exist and the
+   require_once threw a FATAL at load — BEFORE the try/catch below — surfacing as a
+   bare HTTP 500 on every Composition-Origin lookup (#1180). Use the same proven
+   one-level pattern as the auth.php require above (dirname(__DIR__)/includes/…),
+   which resolves on BOTH layouts. */
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'places.php';
 
 /* =========================================================================
  * Configuration


### PR DESCRIPTION
**The "HTTP 500 still persists" was the clue.** My detail-surfacing (#1194) couldn't help because the 500 is a **fatal in `require_once`, *before* the try/catch** — not a caught exception.

## Root cause
`places-api.php` loaded `db_mysql.php` + `places.php` via:
```php
dirname(__DIR__, 2) . '/public_html/includes/…'
```
That assumes a **nested** `public_html` and only resolves in the repo (`appWeb/public_html/`). On the **deployed** server `public_html` *is* the web root, so the path doesn't exist → `require_once` **fatal at load** → bare HTTP 500 on every Composition-Origin lookup.

Tell-tale: the `auth.php` require two lines up already uses the *correct* `dirname(__DIR__) . '/includes/…'` (one level), which is why the page loaded + auth passed but the geocoder didn't.

## Fix
Match auth.php's proven pattern — `dirname(__DIR__) . '/includes/…'` — which resolves on **both** layouts. Same class of bug as the NormalizedTitle migration deploy-path fix.

Once deployed, Composition Origin should return real suggestions (or "No matching places" if the geocoder's reachable but has nothing). `php -l` clean.

> Follow-up: a couple of other `/manage` files have the same nested-`public_html` smell (`request-a-song.php:179`, some `setup-database.php` JS paths) — mostly non-fatal (filemtime cache-bust), but worth an audit. Tracking separately.