### PR TITLE
ci: run PHP lint + tests on 8.4 and 8.5 (setup-php matrix)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -279,3 +279,73 @@ jobs:
           else
             echo "::warning::HTMLHint not available. Skipping HTML lint."
           fi
+
+  # ===========================================================================
+  # PHP forward-compat matrix (#1200) — actually runs the PHP lint + the PHP
+  # test suite on the SUPPORTED interpreter versions: 8.4 (backward-compat
+  # floor) and 8.5 (project target, per ProjectBrief). Catches syntax that only
+  # breaks on a newer PHP, on every push/PR (this workflow's existing triggers).
+  #
+  # Deliberately a SEPARATE job from `lint` (not a matrix ON `lint`): the `lint`
+  # job's name "Lint & Validate" is a REQUIRED status check on alpha branch
+  # protection. Adding a matrix would rename it to "Lint & Validate (8.4)" /
+  # "(8.5)", orphaning the required check and soft-locking auto-merge (see
+  # .claude/CLAUDE.md CI lesson #1). This job is additive + non-blocking until
+  # someone adds "PHP 8.4" / "PHP 8.5" to alpha's required checks in repo Settings.
+  # ===========================================================================
+  php-compat:
+    name: PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.4', '8.5']
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      # Same embedded-PHP-tag guard as the lint job — re-run per interpreter so
+      # a tag that only fatals on a newer PHP is still caught (#536 incident).
+      - name: Detect embedded PHP open tags in HTML comments / backticks
+        run: |
+          echo "Scanning .php files for literal '<?' inside backticks or HTML comments..."
+          MATCHES=$(grep -rnP '`[^`]*<\?|<!--[^>]*<\?' appWeb --include='*.php' || true)
+          if [ -n "$MATCHES" ]; then
+            echo "::error::Found literal PHP open tags inside HTML comments or backticks (see .claude/project-rules.md §9)."
+            echo "$MATCHES"
+            exit 1
+          fi
+          echo "OK: no embedded PHP tags inside HTML comments or backticks."
+
+      - name: Lint PHP (php -l) on PHP ${{ matrix.php }}
+        run: |
+          echo "Running php -l on all appWeb PHP under $(php -r 'echo PHP_VERSION;')..."
+          ERRORS=0
+          PHP_FILES=$(find appWeb/ -name '*.php' -type f 2>/dev/null || true)
+          if [ -z "$PHP_FILES" ]; then echo "No PHP files found."; exit 0; fi
+          while IFS= read -r file; do
+            if ! php -l "$file" 2>&1 | grep -q "No syntax errors"; then
+              echo "::error file=$file::PHP syntax error in $file"
+              php -l "$file"
+              ERRORS=$((ERRORS + 1))
+            fi
+          done <<< "$PHP_FILES"
+          if [ "$ERRORS" -gt 0 ]; then
+            echo "::error::$ERRORS PHP file(s) failed php -l on this interpreter."
+            exit 1
+          fi
+          echo "All PHP files parse cleanly on $(php -r 'echo PHP_VERSION;')."
+
+      - name: Migration registry sanity
+        run: php tests/php/test-migration-registry.php
+
+      - name: Schema-coverage drift guard
+        run: php tests/php/test-schema-coverage.php


### PR DESCRIPTION
## What

Adds a `php-compat` CI job that **actually runs** the PHP lint + test suite on **PHP 8.4** (backward-compat floor) and **PHP 8.5** (project target, per `ProjectBrief.md`) via a `shivammathur/setup-php` matrix. Previously CI only ran `php -l` on the runner's default PHP (~8.3).

Per-version it runs: the embedded-PHP-open-tag guard, `php -l` over all of `appWeb/`, and the two PHP test suites (`test-migration-registry.php`, `test-schema-coverage.php`).

## Why a separate job (not a matrix on `lint`)

`lint`'s job name **"Lint & Validate"** is a **required status check** on `alpha` branch protection. Adding a matrix would rename it to `Lint & Validate (8.4)`/`(8.5)`, orphaning the required check and soft-locking auto-merge — the exact trap documented in `.claude/CLAUDE.md` CI lesson #1. So `lint` is left **untouched** and `php-compat` is **additive + non-blocking**.

## To enforce it (optional, owner)

Add **`PHP 8.4`** and **`PHP 8.5`** to `alpha`'s required status checks: **Settings → Branches (or Rulesets) → required checks**. Until then it runs + reports on every PR but doesn't block.

## Notes
- `php -l` is parse-only — this catches *syntax* that breaks on a newer PHP, not runtime deprecations (those need execution; out of scope for lint).
- Follows the #1200 work which confirmed the editor PHP is already 8.4/8.5-clean (no implicit-nullable params, no 8.x-removed functions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)