### PR TITLE
feat(setup-db): show which migrations are pending + stop the post-apply auto-refresh

### DIFF
--- a/appWeb/public_html/js/modules/setup-bulk-runner.js
+++ b/appWeb/public_html/js/modules/setup-bulk-runner.js
@@ -160,16 +160,39 @@ async function runSequence(scope, triggerBtn, pending) {
         panel.querySelector('[data-bulk-status-badge]').className = 'badge bg-success';
         panel.querySelector('[data-bulk-status-badge]').textContent = 'Complete';
 
-        /* Re-render the dashboard so pending-vs-applied probes refresh
-           after a clean run. Small delay so the curator sees the
-           "Complete" state for a moment first. */
-        setTimeout(() => {
-            window.location.href = ENDPOINT;
-        }, 1200);
+        /* DON'T auto-redirect (#1200): a script can return STATUS: ok yet leave
+           its probe still reporting pending (e.g. it logged "[warn] manual merge
+           needed / skipped"). Yanking the page after 1.2s hid that output. Leave
+           the panel + log on screen and offer a manual refresh — the curator
+           expands the log, reads why anything's still pending, then reloads when
+           ready (the pending/applied partition re-runs on reload). */
+        addRefreshButton(panel);
     }
 
     triggerBtn.classList.remove('disabled');
     triggerBtn.removeAttribute('aria-disabled');
+}
+
+/**
+ * Append a "Refresh dashboard" button to the panel so the curator can read the
+ * output log before reloading (instead of being auto-redirected). Idempotent.
+ */
+function addRefreshButton(panel) {
+    if (panel.querySelector('[data-bulk-refresh]')) return;
+    const body = panel.querySelector('.card-body') || panel;
+    const wrap = document.createElement('div');
+    wrap.className = 'mt-3 d-flex align-items-center gap-2 flex-wrap';
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.dataset.bulkRefresh = '';
+    btn.className = 'btn btn-sm btn-primary';
+    btn.innerHTML = '<i class="bi bi-arrow-clockwise me-1" aria-hidden="true"></i>Refresh dashboard';
+    btn.addEventListener('click', () => { window.location.href = ENDPOINT; });
+    const note = document.createElement('span');
+    note.className = 'text-muted small';
+    note.textContent = 'Expand the log above to check nothing is still pending, then refresh to update the cards.';
+    wrap.append(btn, note);
+    body.appendChild(wrap);
 }
 
 /**

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -1333,6 +1333,54 @@ if ($hasCredentials && defined('DB_HOST')) {
             </a>
         </div>
 
+        <?php if (!empty($pendingActions)): ?>
+            <!-- ============================================================
+                 PENDING-MIGRATION LIST (#1200)
+                 Lists EVERY migration whose probe currently reports pending —
+                 including any that have NO card (so they're invisible in the
+                 grid AND skipped by the bulk runner, which both filter to
+                 isset($migrationCards[...])). A migration that runs but whose
+                 probe never flips, or one with no card, is exactly what keeps
+                 the counter stuck above zero. Each row has a "Run & show
+                 output" link: a single-migration run renders its full output
+                 INLINE (no auto-refresh), so the curator can read the
+                 "[warn] … manual merge / skipped" lines that explain why a
+                 probe stays pending.
+                 ============================================================ -->
+            <details class="mb-4">
+                <summary class="text-secondary small" style="cursor:pointer;">
+                    Show the <?= count($pendingActions) ?> pending migration<?= count($pendingActions) === 1 ? '' : 's' ?>
+                    (which, and why each is still pending)
+                </summary>
+                <ul class="list-group list-group-flush mt-2">
+                    <?php foreach ($pendingActions as $_pa): ?>
+                        <?php $_paCard = $migrationCards[$_pa] ?? null; ?>
+                        <li class="list-group-item bg-transparent d-flex justify-content-between align-items-center gap-2 flex-wrap">
+                            <span>
+                                <code class="text-info"><?= htmlspecialchars($_pa) ?></code>
+                                <?php if ($_paCard): ?>
+                                    <span class="ms-2"><?= htmlspecialchars(strip_tags((string)$_paCard['title'])) ?></span>
+                                <?php else: ?>
+                                    <span class="badge bg-warning text-dark ms-2">
+                                        no card — hidden from the grid &amp; skipped by &ldquo;Apply all&rdquo;
+                                    </span>
+                                <?php endif; ?>
+                            </span>
+                            <a href="?action=<?= htmlspecialchars($_pa) ?>"
+                               class="btn btn-sm btn-outline-info flex-shrink-0 <?= $hasCredentials ? '' : 'disabled' ?>">
+                                Run &amp; show output
+                            </a>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+                <p class="text-muted small mt-2 mb-0">
+                    A single-migration run shows its full output here without auto-refreshing, so you can read
+                    exactly what it did &mdash; including any <code>[warn]</code> lines (e.g. &ldquo;manual merge needed&rdquo;
+                    or &ldquo;skipped&rdquo;) that leave a probe reporting pending even though the script ran cleanly.
+                </p>
+            </details>
+        <?php endif; ?>
+
         <!-- ============================================================
              ACTION CARDS
              ============================================================ -->


### PR DESCRIPTION
## Why
When the "Apply all" counter sticks above zero, the dashboard gave no way to see **which** migration is pending or **why** — and the post-apply auto-refresh hid the output log before it could be read.

## Changes
1. **Expandable pending list** under the Apply-all banner — lists **every** migration whose probe reports pending, including any with **no card**. (Both the badge count and the bulk runner filter to `isset($migrationCards[...])`, so a card-less pending migration is invisible in the grid *and* skipped by "Apply all" — it sits pending forever with no way to see it.) Each row has a **"Run & show output"** link; a single-migration run renders its full output inline (no auto-refresh), exposing the `[warn] manual merge / skipped` lines that explain a stuck probe.
2. **No post-apply auto-redirect** — `setup-bulk-runner.js` redirected to the dashboard 1.2s after "Complete", hiding the log. It now keeps the panel + log on screen and adds a manual **"Refresh dashboard"** button. (The error path already stayed put.)

## Context
A migration script returning `STATUS: ok` does **not** guarantee its probe flipped to applied — e.g. `songid-prefix-fixup` leaves collision rows for manual merge, so "Complete — N ran" can still leave the counter > 0. These changes make the offending migration + its reason visible.

`php -l` + `node --check` clean. Admin-only page (`global_admin`-gated); list output is `htmlspecialchars`/`strip_tags`-escaped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)