### PR TITLE
feat(song): tag title + lyric components with their own language/direction + v0.880.0

### DIFF
--- a/appWeb/CHANGELOG.md
+++ b/appWeb/CHANGELOG.md
@@ -1,5 +1,18 @@
 # iHymns Web/PWA — Changelog
 
+## [0.880.0] — 2026-06-09
+
+The Song Editor v2 rewrite (#1200) landed on alpha alongside dev-tooling and accuracy improvements.
+
+### Song Editor v2 (#1200)
+- Ground-up rewrite vs the MySQL backend: a clean, granular, CSRF-guarded `api2.php` + a hand-rolled reactive store, replacing the 5,800-line JSON-era `editor.js`. Sidebar (search · multi-select · resizable) → 7 tabs (Structure / Metadata / Credits / Links / Tags / Media / Preview) + Revisions → New / Delete → Paste & Reflow → Export (8 formats) → single-file + async ZIP import → credit-people autocomplete → Composition-origin place-picker → bulk Verify / Tag. Lives alongside the legacy editor pending cutover.
+
+### Lyrics language tagging (accuracy / SEO / a11y)
+- The song **title** and each lyric **component** now carry their own BCP 47 `lang` (script subtags pass through, e.g. `zh-Hans`) plus `dir="rtl"` for right-to-left scripts, while `<html lang>` stays the UI language. Multi-language songs tag each verse independently (#858 extended).
+
+### Dev tooling
+- Database Setup: an expandable list of **which** migrations are pending (incl. card-less ones) + per-item "Run & show output"; the bulk runner no longer auto-refreshes away the output log (#1200). CI now runs `php -l` + the PHP test suites on **PHP 8.4 and 8.5** (project targets 8.5, 8.4 floor).
+
 ## [0.770.0] — 2026-06-05
 
 DB-direct data-layer rewrite (epic #1010) landed on alpha (PR #1160) alongside the home-UX rethink, importers, and the security / accessibility / W3C audit fixes.

--- a/appWeb/public_html/includes/infoAppVer.php
+++ b/appWeb/public_html/includes/infoAppVer.php
@@ -79,7 +79,7 @@ $app["Application"]["Description"]["Keywords"] = "hymns, worship, lyrics, songbo
 /* Semantic version number (MAJOR.MINOR.PATCH) */
 /* Auto-bumped by the version-bump GitHub Action on push to beta */
 /* v1.x.x = Phase 1 (local JSON data), v2.x.x = Phase 2 (iLyrics dB) */
-$app["Application"]["Version"]["Number"] = "0.770.0";
+$app["Application"]["Version"]["Number"] = "0.880.0";
 
 /* Version name: human-readable release name (e.g., "Hymnal", NULL if unused) */
 $app["Application"]["Version"]["Name"] = NULL;

--- a/appWeb/public_html/includes/pages/song.php
+++ b/appWeb/public_html/includes/pages/song.php
@@ -105,6 +105,17 @@ $ccli        = $song['ccli']        ?? '';
 $hasAudio    = !empty($song['hasAudio']);
 $hasSheet    = !empty($song['hasSheetMusic']);
 $components  = $song['components'] ?? [];
+
+/* #1200 — song-language tagging. The page <html lang> stays the UI language;
+   song-language content (the TITLE here, and each lyric component below) carries
+   its OWN BCP 47 tag + dir for RTL scripts, so screen readers, browser
+   hyphenation, translators and search engines treat it correctly even when the
+   song's language differs from the UI. resolveLanguageMeta() resolves the
+   direction from tblLanguages (schema-probed + cached). Script subtags
+   (zh-Hans, sr-Cyrl, ja-Latn, …) pass straight through from the stored tag. */
+require_once __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'language_names.php';
+$songPrimaryLang = trim((string)($song['language'] ?? ''));
+$songLangDir     = $songPrimaryLang !== '' ? (resolveLanguageMeta($songPrimaryLang)['dir'] ?? 'ltr') : 'ltr';
 $lyricsPublicDomain = !empty($song['lyricsPublicDomain']);
 $musicPublicDomain  = !empty($song['musicPublicDomain']);
 $fullyPublicDomain  = $lyricsPublicDomain && $musicPublicDomain;
@@ -331,7 +342,7 @@ try {
                 </span>
                 <?php endif; ?>
                 <div class="flex-grow-1">
-                    <h1 class="h4 mb-1"><?= htmlspecialchars($songTitle) ?><?php if (!empty($song['verified'])): ?><span class="verified-badge" role="img" title="Verified lyrics" aria-label="Verified lyrics"><svg viewBox="0 0 24 24" fill="none" aria-hidden="true"><circle cx="12" cy="12" r="10" fill="currentColor" opacity="0.15"/><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="1.5" fill="none"/><path d="M7.5 12.5L10.5 15.5L16.5 9" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg></span><?php endif; ?></h1>
+                    <h1 class="h4 mb-1"<?php if ($songPrimaryLang !== ''): ?> lang="<?= htmlspecialchars($songPrimaryLang) ?>"<?php if ($songLangDir === 'rtl'): ?> dir="rtl"<?php endif; ?><?php endif; ?>><?= htmlspecialchars($songTitle) ?><?php if (!empty($song['verified'])): ?><span class="verified-badge" role="img" title="Verified lyrics" aria-label="Verified lyrics"><svg viewBox="0 0 24 24" fill="none" aria-hidden="true"><circle cx="12" cy="12" r="10" fill="currentColor" opacity="0.15"/><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="1.5" fill="none"/><path d="M7.5 12.5L10.5 15.5L16.5 9" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg></span><?php endif; ?></h1>
                     <?php
                         /* #832 — "Also known as …" line. Hidden when this
                            song has no alt titles (or pre-migration). Per-row
@@ -884,8 +895,9 @@ try {
                     require_once __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'language_names.php';
                 }
             ?>
+            <?php $effDir = resolveLanguageMeta($effectiveLang)['dir'] ?? 'ltr'; ?>
             <div class="lyric-component <?= $typeClass ?>"
-                 lang="<?= htmlspecialchars($effectiveLang) ?>"
+                 lang="<?= htmlspecialchars($effectiveLang) ?>"<?php if ($effDir === 'rtl'): ?> dir="rtl"<?php endif; ?>
                  role="group" aria-label="<?= htmlspecialchars($label) ?>">
                 <!-- Component type label -->
                 <div class="lyric-label" aria-hidden="true">


### PR DESCRIPTION
## What
Song-language content now carries its own BCP 47 `lang` (the page `<html lang>` stays the **UI** language, as intended):
- **Song title** → `lang="<song language>"` + `dir="rtl"` for RTL scripts (so a Swahili/Korean/Arabic title is announced + indexed in its real language on an English UI).
- **Lyric components** already emitted `lang` (#858); now also emit `dir="rtl"` for right-to-left scripts (Arabic/Hebrew/Persian/Urdu verses previously rendered LTR). Direction reuses `resolveLanguageMeta()` (`tblLanguages`, schema-probed + cached). Script subtags (`zh-Hans`, `sr-Cyrl`, `ja-Latn`) pass straight through; multi-language songs tag each verse independently.

Also bumps **0.770.0 → 0.880.0** + CHANGELOG (this batch: editor v2 #1200, dev-tooling, lyrics i18n).

## Not in this PR (tracked separately)
`Content-Language` header + `hreflang` alternates; per-LINE language tagging; a per-component language input in the v2 editor.

`php -l` clean. Public song page (`includes/pages/song.php`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)