### PR TITLE
feat(activity-log): environment + path + referrer columns, env filter, TZ tidy (#1207)

### DIFF
--- a/appWeb/.sql/migrate-activity-log-observability.php
+++ b/appWeb/.sql/migrate-activity-log-observability.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Activity Log observability columns (#1207 + #1208)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * The activity log (tblActivityLog, #535) lives in the SHARED database, so it
+ * records requests from all three environments (alpha / beta / production) with
+ * no way to tell them apart. This migration adds the columns that let the log
+ * answer "which environment, which file, from where, and from what country":
+ *
+ *   tblActivityLog:
+ *     - Environment  VARCHAR(16)  — deploy env at log time (alpha|beta|production)
+ *     - RequestPath  VARCHAR(512) — requested path (REQUEST_URI minus query)
+ *     - Referrer     VARCHAR(2048)— HTTP Referer header (where the hit came from)
+ *     - Country      CHAR(2)      — ISO-3166-1 country resolved from the IP AT
+ *                                   log time (snapshot; geo→#1208 fills it)
+ *   tblIpReputation (per-IP cache, extends the proxy/VPN cache):
+ *     - CountryCode  CHAR(2)      — cached geo lookup result
+ *     - CountryName  VARCHAR(100)
+ *     - GeoLookedUpAt DATETIME    — cache freshness for the geo lookup
+ *
+ * One-pass forward-looking batch (house rule #20): the geo columns ship dormant
+ * now alongside #1207's columns so #1208 (the geo resolver) needs no second
+ * migration.
+ *
+ * STRICTLY ADDITIVE + IDEMPOTENT — every add is guarded by a column/index probe,
+ * so re-running on an already-migrated catalogue is a no-op.
+ *
+ * @migration-adds tblActivityLog.Environment
+ * @migration-adds tblActivityLog.RequestPath
+ * @migration-adds tblActivityLog.Referrer
+ * @migration-adds tblActivityLog.Country
+ * @migration-adds tblIpReputation.CountryCode
+ * @migration-adds tblIpReputation.CountryName
+ * @migration-adds tblIpReputation.GeoLookedUpAt
+ *
+ * USAGE:
+ *   Web:  /manage/setup-database → "Activity Log observability columns"
+ *   CLI:  php appWeb/.sql/migrate-activity-log-observability.php
+ */
+
+$isCli = (PHP_SAPI === 'cli');
+if (!defined('IHYMNS_SETUP_DASHBOARD') && !function_exists('getDbMysqli')) {
+    require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+}
+
+function _migAlObs_out(string $msg): void
+{
+    global $isCli;
+    echo $msg . ($isCli ? "\n" : "<br>\n");
+    if (!$isCli) { @flush(); }
+}
+
+$db = function_exists('getDbMysqli') ? getDbMysqli() : null;
+if (!($db instanceof mysqli)) {
+    _migAlObs_out('ERROR: could not connect to database.');
+    if ($isCli) { exit(1); }
+    return;
+}
+
+/** Add a column only when it's absent (idempotent). $ddl is the column
+ *  definition AFTER `ADD COLUMN <name> `. */
+function _migAlObs_addColumn(mysqli $db, string $table, string $col, string $ddl): void
+{
+    $res = $db->query("SHOW COLUMNS FROM `{$table}` LIKE '{$col}'");
+    if ($res && $res->num_rows > 0) {
+        _migAlObs_out("  [SKIP] {$table}.{$col} already present.");
+        return;
+    }
+    $db->query("ALTER TABLE `{$table}` ADD COLUMN `{$col}` {$ddl}");
+    _migAlObs_out("  [OK] Added {$table}.{$col}.");
+}
+
+/** Add an index only when it's absent (idempotent). */
+function _migAlObs_addIndex(mysqli $db, string $table, string $index, string $cols): void
+{
+    $res = $db->query("SHOW INDEX FROM `{$table}` WHERE Key_name = '{$index}'");
+    if ($res && $res->num_rows > 0) {
+        _migAlObs_out("  [SKIP] index {$table}.{$index} already present.");
+        return;
+    }
+    $db->query("ALTER TABLE `{$table}` ADD INDEX `{$index}` ({$cols})");
+    _migAlObs_out("  [OK] Added index {$table}.{$index}.");
+}
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+_migAlObs_out('=== iHymns — Activity Log observability columns (#1207 + #1208) ===');
+
+try {
+    _migAlObs_out('--- tblActivityLog ---');
+    _migAlObs_addColumn($db, 'tblActivityLog', 'Environment',
+        "VARCHAR(16) NULL DEFAULT NULL COMMENT 'Deploy environment at log time: alpha | beta | production (the DB is shared across all three) (#1207)'");
+    _migAlObs_addColumn($db, 'tblActivityLog', 'RequestPath',
+        "VARCHAR(512) NULL DEFAULT NULL COMMENT 'Requested path (REQUEST_URI minus query) — which file/route was hit (#1207)'");
+    _migAlObs_addColumn($db, 'tblActivityLog', 'Referrer',
+        "VARCHAR(2048) NULL DEFAULT NULL COMMENT 'HTTP Referer header — where the request came from (#1207)'");
+    _migAlObs_addColumn($db, 'tblActivityLog', 'Country',
+        "CHAR(2) NULL DEFAULT NULL COMMENT 'ISO-3166-1 alpha-2 country resolved from IpAddress AT log time (snapshot; geo resolver #1208 populates it)'");
+    _migAlObs_addIndex($db, 'tblActivityLog', 'idx_Environment', 'Environment');
+    _migAlObs_addIndex($db, 'tblActivityLog', 'idx_RequestPath', 'RequestPath(191)');
+    _migAlObs_addIndex($db, 'tblActivityLog', 'idx_Country', 'Country');
+
+    _migAlObs_out('--- tblIpReputation (geo cache, dormant until #1208) ---');
+    _migAlObs_addColumn($db, 'tblIpReputation', 'CountryCode',
+        "CHAR(2) NULL DEFAULT NULL COMMENT 'ISO-3166-1 alpha-2 from the geo lookup (#1208)'");
+    _migAlObs_addColumn($db, 'tblIpReputation', 'CountryName',
+        "VARCHAR(100) NULL DEFAULT NULL COMMENT 'Country display name from the geo lookup (#1208)'");
+    _migAlObs_addColumn($db, 'tblIpReputation', 'GeoLookedUpAt',
+        "DATETIME NULL DEFAULT NULL COMMENT 'When geo was last resolved for this IP — drives the cache TTL (#1208)'");
+
+    _migAlObs_out('');
+    _migAlObs_out('Migration complete.');
+} catch (\Throwable $e) {
+    _migAlObs_out('  [ERROR] ' . $e->getMessage());
+    if ($isCli) { exit(1); }
+    return;
+}
+
+return;

--- a/appWeb/.sql/schema.sql
+++ b/appWeb/.sql/schema.sql
@@ -1373,6 +1373,10 @@ CREATE TABLE IF NOT EXISTS tblActivityLog (
     RequestId       CHAR(16)        NOT NULL DEFAULT '' COMMENT 'Per-HTTP-request correlation ID; groups every row from one request (#535)',
     Method          VARCHAR(10)     NOT NULL DEFAULT '' COMMENT 'HTTP method (GET/POST/etc) for HTTP-driven events; blank for cron/system (#535)',
     DurationMs      INT UNSIGNED    NULL COMMENT 'Wall-clock duration of the logged operation in milliseconds (#535)',
+    Environment     VARCHAR(16)     NULL DEFAULT NULL COMMENT 'Deploy environment at log time: alpha | beta | production (the DB is shared across all three) (#1207)',
+    RequestPath     VARCHAR(512)    NULL DEFAULT NULL COMMENT 'Requested path (REQUEST_URI minus query) — which file/route was hit (#1207)',
+    Referrer        VARCHAR(2048)   NULL DEFAULT NULL COMMENT 'HTTP Referer header — where the request came from (#1207)',
+    Country         CHAR(2)         NULL DEFAULT NULL COMMENT 'ISO-3166-1 alpha-2 country resolved from IpAddress AT log time (snapshot; geo resolver #1208 populates it)',
     CreatedAt       TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
     INDEX idx_User              (UserId),
@@ -1382,6 +1386,9 @@ CREATE TABLE IF NOT EXISTS tblActivityLog (
     INDEX idx_Result            (Result),
     INDEX idx_RequestId         (RequestId),
     INDEX idx_ProxyVpnIndicator (ProxyVpnIndicator),
+    INDEX idx_Environment       (Environment),
+    INDEX idx_RequestPath       (RequestPath(191)),
+    INDEX idx_Country           (Country),
 
     CONSTRAINT fk_Log_User
         FOREIGN KEY (UserId) REFERENCES tblUsers(Id)
@@ -1411,6 +1418,9 @@ CREATE TABLE IF NOT EXISTS tblIpReputation (
                    COMMENT 'header | ipqs | maxmind | ipinfo | manual',
     LookedUpAt     TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     ExpiresAt      TIMESTAMP    NULL,
+    CountryCode    CHAR(2)      NULL DEFAULT NULL COMMENT 'ISO-3166-1 alpha-2 from the geo lookup (#1208)',
+    CountryName    VARCHAR(100) NULL DEFAULT NULL COMMENT 'Country display name from the geo lookup (#1208)',
+    GeoLookedUpAt  DATETIME     NULL DEFAULT NULL COMMENT 'When geo was last resolved for this IP — drives the cache TTL (#1208)',
 
     INDEX idx_Indicator (Indicator),
     INDEX idx_Expires   (ExpiresAt)

--- a/appWeb/public_html/includes/activity_log.php
+++ b/appWeb/public_html/includes/activity_log.php
@@ -248,28 +248,26 @@ function logActivity(
             }
         }
 
-        if ($hasProxyCols) {
-            $stmt = $db->prepare(
-                'INSERT INTO tblActivityLog
-                    (UserId, Action, EntityType, EntityId, Result, Details,
-                     IpAddress, IpProxyChain, ProxyVpnIndicator, ProxyVpnDetail,
-                     UserAgent, RequestId, Method, DurationMs, CreatedAt)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())'
-            );
-        } else {
-            $stmt = $db->prepare(
-                'INSERT INTO tblActivityLog
-                    (UserId, Action, EntityType, EntityId, Result, Details,
-                     IpAddress, UserAgent, RequestId, Method, DurationMs, CreatedAt)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())'
-            );
+        /* #1207 — probe for the observability columns (Environment / RequestPath
+           / Referrer) added by migrate-activity-log-observability.php. Degrade to
+           skipping the group on a pre-migration deploy. Probed once per process. */
+        static $hasObsCols = null;
+        if ($hasObsCols === null) {
+            try {
+                $obsProbe = $db->prepare(
+                    "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+                      WHERE TABLE_SCHEMA = DATABASE()
+                        AND TABLE_NAME   = 'tblActivityLog'
+                        AND COLUMN_NAME  = 'Environment' LIMIT 1"
+                );
+                $obsProbe->execute();
+                $hasObsCols = (bool)$obsProbe->get_result()->fetch_row();
+                $obsProbe->close();
+            } catch (\Throwable $_e) {
+                $hasObsCols = false;
+            }
         }
-        /* Types: UserId(i nullable), Action(s), EntityType(s), EntityId(s),
-           Result(s), Details(s nullable), IpAddress(s), [IpProxyChain(s nullable),
-           ProxyVpnIndicator(s nullable), ProxyVpnDetail(s nullable),]
-           UserAgent(s), RequestId(s), Method(s), DurationMs(i nullable).
-           mysqli passes NULL correctly when the bound variable is null even
-           with type 'i' or 's'. */
+
         $actionTrim   = substr($action,     0, 50);
         $entityTrim   = substr($entityType, 0, 50);
         $entityIdTrim = substr($entityId,   0, 50);
@@ -278,64 +276,48 @@ function logActivity(
         $proxyChainTrim = $proxyChain !== null ? substr($proxyChain, 0, 255) : null;
         $proxyIndTrim   = $proxyInd   !== null ? substr($proxyInd,   0, 50)  : null;
 
+        /* #1207 observability — environment, requested path, referrer. NULL on a
+           pre-migration deploy (the $hasObsCols probe degrades the column group). */
+        $environment = substr(activityLogEnvironment(), 0, 16);
+        $reqUriRaw   = (string)($_SERVER['REQUEST_URI'] ?? '');
+        $qPos        = strpos($reqUriRaw, '?');
+        $pathOnly    = $qPos === false ? $reqUriRaw : substr($reqUriRaw, 0, $qPos);
+        $requestPath = $pathOnly !== '' ? substr($pathOnly, 0, 512) : null;
+        $referrer    = isset($_SERVER['HTTP_REFERER']) && $_SERVER['HTTP_REFERER'] !== ''
+                     ? substr((string)$_SERVER['HTTP_REFERER'], 0, 2048)
+                     : null;
+
+        /* Build the INSERT dynamically so the column list, placeholder count,
+           type string and value list can NEVER drift apart (the #919/#923/#924
+           bind-count saga that silently darkened the audit trail). All three are
+           derived from ONE ordered set; optional column GROUPS are appended only
+           when their migration has run (probed once per process). CreatedAt is
+           NOW() (not a placeholder). */
+        $cols   = ['UserId', 'Action', 'EntityType', 'EntityId', 'Result', 'Details', 'IpAddress'];
+        $types  = 'issssss';
+        $values = [$resolvedUserId, $actionTrim, $entityTrim, $entityIdTrim, $result, $detailsJson, $ip];
+
         if ($hasProxyCols) {
-            /* 14 placeholders → 14 type chars: 1×'i' (UserId)
-               + 12×'s' (Action / EntityType / EntityId / Result /
-               Details / IpAddress / IpProxyChain / ProxyVpnIndicator /
-               ProxyVpnDetail / UserAgent / RequestId / Method)
-               + 1×'i' (DurationMs).
-               #923 — was previously `'isssssssssssssi'` (15 chars,
-               one extra 's'), which made bind_param throw
-               `Number of elements in type definition string
-               doesn't match number of bind variables`. The catch at
-               the bottom of this function swallows the throw to an
-               error_log line, so every logActivity() call after the
-               proxy/VPN migration ran landed silently in the file
-               log instead of tblActivityLog — the audit trail went
-               dark from #919 deploy until #924 shipped.
-               #926 — defensive `bindParamSafe()` from db_mysql.php
-               throws a context-named RuntimeException ("bind_param
-               mismatch in logActivity (post-#919) INSERT: …") if
-               the type string and arg count ever drift again,
-               instead of mysqli's generic message that originally
-               masked the regression. */
-            bindParamSafe(
-                'logActivity (post-#919) INSERT', $stmt,
-                'issssssssssssi',
-                $resolvedUserId,
-                $actionTrim,
-                $entityTrim,
-                $entityIdTrim,
-                $result,
-                $detailsJson,
-                $ip,
-                $proxyChainTrim,
-                $proxyIndTrim,
-                $proxyDetailJson,
-                $ua,
-                $rid,
-                $methodTrim,
-                $duration
-            );
-        } else {
-            /* #926 — same defensive helper for the legacy 11-col
-               INSERT (pre-migration deploys). */
-            bindParamSafe(
-                'logActivity (legacy) INSERT', $stmt,
-                'isssssssssi',
-                $resolvedUserId,
-                $actionTrim,
-                $entityTrim,
-                $entityIdTrim,
-                $result,
-                $detailsJson,
-                $ip,
-                $ua,
-                $rid,
-                $methodTrim,
-                $duration
-            );
+            array_push($cols, 'IpProxyChain', 'ProxyVpnIndicator', 'ProxyVpnDetail');
+            $types .= 'sss';
+            array_push($values, $proxyChainTrim, $proxyIndTrim, $proxyDetailJson);
         }
+        if ($hasObsCols) {
+            array_push($cols, 'Environment', 'RequestPath', 'Referrer');
+            $types .= 'sss';
+            array_push($values, $environment, $requestPath, $referrer);
+        }
+        array_push($cols, 'UserAgent', 'RequestId', 'Method', 'DurationMs');
+        $types .= 'sssi';
+        array_push($values, $ua, $rid, $methodTrim, $duration);
+
+        $placeholders = implode(', ', array_fill(0, count($cols), '?'));
+        $stmt = $db->prepare(
+            'INSERT INTO tblActivityLog (' . implode(', ', $cols) . ', CreatedAt) VALUES (' . $placeholders . ', NOW())'
+        );
+        /* #926 — bindParamSafe throws a context-named error if types/args ever
+           drift; here they're built together so they can't, but keep the guard. */
+        bindParamSafe('logActivity dynamic INSERT', $stmt, $types, ...$values);
         $stmt->execute();
         $stmt->close();
         activityLogWriteCount($count + 1);
@@ -344,6 +326,38 @@ function logActivity(
            One error_log so admins can spot a sustained outage. */
         error_log('[activity_log] write failed for "' . $action . '": ' . $e->getMessage());
     }
+}
+
+/**
+ * Resolve the deploy environment for activity-log labelling (#1207):
+ * 'alpha' | 'beta' | 'production'. Mirrors infoAppVer.php's canonical
+ * DOCUMENT_ROOT-based detection without pulling the whole $app array onto the
+ * write path. Cached per process. The shared DB serves all three environments,
+ * so this is what lets a log row say which one it came from.
+ *
+ * @return string One of 'alpha', 'beta', 'production'.
+ */
+function activityLogEnvironment(): string
+{
+    static $env = null;
+    if ($env !== null) {
+        return $env;
+    }
+    $path = (string)($_SERVER['DOCUMENT_ROOT'] ?? $_SERVER['SCRIPT_FILENAME'] ?? '');
+    if (str_contains($path, 'public_html_dev')) {
+        return $env = 'alpha';
+    }
+    if (str_contains($path, 'public_html_beta')) {
+        return $env = 'beta';
+    }
+    /* CI/CD-injected channel file fallback (mirrors infoAppVer.php). */
+    $channelFile = dirname(__DIR__) . DIRECTORY_SEPARATOR . '.env-channel';
+    if (is_file($channelFile)) {
+        $ch = trim((string)@file_get_contents($channelFile));
+        if ($ch === 'alpha') { return $env = 'alpha'; }
+        if ($ch === 'beta')  { return $env = 'beta'; }
+    }
+    return $env = 'production';
 }
 
 /**

--- a/appWeb/public_html/manage/activity-log.php
+++ b/appWeb/public_html/manage/activity-log.php
@@ -29,6 +29,38 @@ if (!$currentUser || !in_array(($currentUser['role'] ?? ''), ['admin', 'global_a
 $activePage = 'activity-log';
 $db = getDbMysqli();
 
+/* #1207 — do the observability columns (Environment / RequestPath / Referrer /
+   Country) exist yet? Probed once; gates the env filter, the path search, the
+   SELECT tail, and the display so a pre-migration deploy still renders. */
+$hasObsCols = false;
+try {
+    $obsProbe = $db->prepare(
+        "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+          WHERE TABLE_SCHEMA = DATABASE()
+            AND TABLE_NAME   = 'tblActivityLog'
+            AND COLUMN_NAME  = 'Environment' LIMIT 1"
+    );
+    $obsProbe->execute();
+    $hasObsCols = (bool)$obsProbe->get_result()->fetch_row();
+    $obsProbe->close();
+} catch (\Throwable $_e) { /* pre-migration deploy → stays false */ }
+/* SELECT tail for the observability columns — empty on a pre-migration deploy
+   so the query still compiles. Reused by the CSV export + the main SELECT. */
+$obsColsSql = $hasObsCols ? ', a.Environment, a.RequestPath, a.Referrer, a.Country' : '';
+
+/* #1208 — render an ISO-3166-1 alpha-2 country code as its flag emoji (two
+   Unicode regional-indicator letters). No image assets; empty for blank/invalid
+   codes. The geo resolver (#1208) populates tblActivityLog.Country. */
+function _activityFlagEmoji(string $cc): string
+{
+    $cc = strtoupper(trim($cc));
+    if (strlen($cc) !== 2 || !ctype_alpha($cc)) {
+        return '';
+    }
+    $base = 0x1F1E6; // 🇦 regional indicator A
+    return mb_chr($base + (ord($cc[0]) - 65), 'UTF-8') . mb_chr($base + (ord($cc[1]) - 65), 'UTF-8');
+}
+
 /* Filter parsing — every filter is optional. Defaults give the
    admin "last 24 h, every action, every user" landing view. */
 $filterAction     = trim((string)($_GET['action']      ?? ''));
@@ -40,6 +72,7 @@ $filterRequestId  = trim((string)($_GET['request_id']  ?? ''));
 $filterDays       = (int)($_GET['days'] ?? 1);
 if (!in_array($filterDays, [1, 7, 30, 90, 365], true)) { $filterDays = 1; }
 $filterSearch     = trim((string)($_GET['q'] ?? ''));
+$filterEnv        = trim((string)($_GET['env'] ?? ''));   /* #1207 — alpha | beta | production */
 
 $since = (new DateTime("-{$filterDays} days"))->format('Y-m-d H:i:s');
 
@@ -88,11 +121,27 @@ if ($filterRequestId !== '') {
     $types   .= 's';
 }
 if ($filterSearch !== '') {
-    $where[]  = '(a.Action LIKE ? OR a.EntityId LIKE ?)';
     $searchLike = '%' . $filterSearch . '%';
-    $params[] = $searchLike;
-    $params[] = $searchLike;
-    $types   .= 'ss';
+    /* #1207 — also search the requested path so "find every hit on /sitemap.xml"
+       works (only when the column exists). */
+    if ($hasObsCols) {
+        $where[]  = '(a.Action LIKE ? OR a.EntityId LIKE ? OR a.RequestPath LIKE ?)';
+        $params[] = $searchLike;
+        $params[] = $searchLike;
+        $params[] = $searchLike;
+        $types   .= 'sss';
+    } else {
+        $where[]  = '(a.Action LIKE ? OR a.EntityId LIKE ?)';
+        $params[] = $searchLike;
+        $params[] = $searchLike;
+        $types   .= 'ss';
+    }
+}
+/* #1207 — environment filter (the shared DB serves alpha / beta / production). */
+if ($hasObsCols && in_array($filterEnv, ['alpha', 'beta', 'production'], true)) {
+    $where[]  = 'a.Environment = ?';
+    $params[] = $filterEnv;
+    $types   .= 's';
 }
 $whereSql = 'WHERE ' . implode(' AND ', $where);
 
@@ -134,6 +183,12 @@ if (($_GET['export'] ?? '') === 'csv') {
     if ($hasProxyCols) {
         array_splice($headerRow, 9, 0, ['IpProxyChain', 'ProxyVpnIndicator', 'ProxyVpnDetail']);
     }
+    if ($hasObsCols) {
+        $headerRow[] = 'Environment';
+        $headerRow[] = 'RequestPath';
+        $headerRow[] = 'Referrer';
+        $headerRow[] = 'Country';
+    }
     fputcsv($out, $headerRow);
     $proxyColsSql = $hasProxyCols
         ? ', a.IpProxyChain, a.ProxyVpnIndicator, a.ProxyVpnDetail'
@@ -141,7 +196,7 @@ if (($_GET['export'] ?? '') === 'csv') {
     $stmt = $db->prepare(
         'SELECT a.Id, a.CreatedAt, UNIX_TIMESTAMP(a.CreatedAt) AS CreatedAtTs,
                 u.Username, a.Action, a.EntityType, a.EntityId,
-                a.Result, a.IpAddress' . $proxyColsSql . ', a.UserAgent, a.RequestId, a.Method,
+                a.Result, a.IpAddress' . $proxyColsSql . $obsColsSql . ', a.UserAgent, a.RequestId, a.Method,
                 a.DurationMs, a.Details
            FROM tblActivityLog a
            LEFT JOIN tblUsers u ON u.Id = a.UserId
@@ -170,6 +225,12 @@ if (($_GET['export'] ?? '') === 'csv') {
         $csvRow[] = $row['Method']     ?? '';
         $csvRow[] = $row['DurationMs'] ?? '';
         $csvRow[] = $row['Details']    ?? '';
+        if ($hasObsCols) {
+            $csvRow[] = $row['Environment'] ?? '';
+            $csvRow[] = $row['RequestPath'] ?? '';
+            $csvRow[] = $row['Referrer']    ?? '';
+            $csvRow[] = $row['Country']     ?? '';
+        }
         fputcsv($out, $csvRow);
     }
     $stmt->close();
@@ -225,7 +286,7 @@ try {
     $stmt = $db->prepare(
         'SELECT a.Id, a.CreatedAt, UNIX_TIMESTAMP(a.CreatedAt) AS CreatedAtTs,
                 a.Action, a.EntityType, a.EntityId, a.Result,
-                a.Details, a.IpAddress' . $proxyColsSql . ', a.UserAgent, a.RequestId, a.Method,
+                a.Details, a.IpAddress' . $proxyColsSql . $obsColsSql . ', a.UserAgent, a.RequestId, a.Method,
                 a.DurationMs, u.Username
            FROM tblActivityLog a
            LEFT JOIN tblUsers u ON u.Id = a.UserId
@@ -288,6 +349,7 @@ $buildQuery = function (array $overrides = []) {
         'request_id'  => $_GET['request_id']  ?? '',
         'days'        => $_GET['days']        ?? '',
         'q'           => $_GET['q']           ?? '',
+        'env'         => $_GET['env']          ?? '',
         'page'        => $_GET['page']        ?? '',
     ], $overrides), fn($v) => $v !== '' && $v !== null);
     return http_build_query($merged);
@@ -342,6 +404,13 @@ $buildQuery = function (array $overrides = []) {
             a positive integer (1..3650 days). Audit, compliance, and
             forensics tend to want long retention, so pruning is opt-in.
         </p>
+        <p class="text-secondary small mb-4">
+            <i class="bi bi-info-circle me-1"></i>All three environments
+            (alpha&nbsp;·&nbsp;beta&nbsp;·&nbsp;production) share one database, so this log
+            spans them all — use the <strong>Env</strong> column / filter to tell them apart.
+            The <strong>When</strong> column shows your <strong>local</strong> time
+            (<span data-activity-tz>detecting…</span>); CSV export is in UTC.
+        </p>
 
         <form method="GET" class="row g-2 mb-3 small">
             <div class="col-md-3">
@@ -371,6 +440,17 @@ $buildQuery = function (array $overrides = []) {
                     <option value="error"   <?= $filterResult === 'error'   ? 'selected' : '' ?>>error</option>
                 </select>
             </div>
+            <?php if ($hasObsCols): ?>
+            <div class="col-md-2">
+                <label class="form-label mb-1" for="filter-env">Env</label>
+                <select class="form-select form-select-sm" id="filter-env" name="env">
+                    <option value="">— any —</option>
+                    <option value="alpha"      <?= $filterEnv === 'alpha'      ? 'selected' : '' ?>>alpha</option>
+                    <option value="beta"       <?= $filterEnv === 'beta'       ? 'selected' : '' ?>>beta</option>
+                    <option value="production" <?= $filterEnv === 'production' ? 'selected' : '' ?>>production</option>
+                </select>
+            </div>
+            <?php endif; ?>
             <div class="col-md-2">
                 <label class="form-label mb-1" for="filter-entity-type">Entity</label>
                 <input class="form-control form-control-sm" id="filter-entity-type" type="text" name="entity_type"
@@ -437,9 +517,11 @@ $buildQuery = function (array $overrides = []) {
                                      the cells stay UTC and the header keeps its initial
                                      "(UTC)" suffix. (#723) */ ?>
                             <th style="width: 11rem;" id="activity-when-header" data-sort-key="when"   data-sort-type="text">When (UTC)</th>
+                            <?php if ($hasObsCols): ?><th style="width: 5rem;" data-sort-key="env" data-sort-type="text">Env</th><?php endif; ?>
                             <th style="width: 10rem;" data-sort-key="user"   data-sort-type="text">User</th>
                             <th data-sort-key="action" data-sort-type="text">Action</th>
                             <th data-sort-key="entity" data-sort-type="text">Entity</th>
+                            <?php if ($hasObsCols): ?><th data-sort-key="path" data-sort-type="text">Path</th><?php endif; ?>
                             <th style="width: 5rem;"  data-sort-key="result" data-sort-type="text">Result</th>
                             <th style="width: 9rem;"  data-sort-key="ip"     data-sort-type="text">IP</th>
                             <th style="width: 5rem;"  data-sort-key="req"    data-sort-type="text">Req</th>
@@ -473,6 +555,22 @@ $buildQuery = function (array $overrides = []) {
                                 title="<?= htmlspecialchars($createdUtcStr, ENT_QUOTES, 'UTF-8') ?> UTC">
                                 <?= htmlspecialchars($createdUtcStr, ENT_QUOTES, 'UTF-8') ?> <span class="text-muted">UTC</span>
                             </td>
+                            <?php if ($hasObsCols): ?>
+                            <td>
+                                <?php
+                                $env = (string)($r['Environment'] ?? '');
+                                if ($env !== ''):
+                                    $envCls = match ($env) {
+                                        'production' => 'bg-success',
+                                        'beta'       => 'bg-info text-dark',
+                                        'alpha'      => 'bg-secondary',
+                                        default      => 'bg-dark border',
+                                    };
+                                ?>
+                                    <span class="badge <?= $envCls ?>"><?= htmlspecialchars($env, ENT_QUOTES, 'UTF-8') ?></span>
+                                <?php endif; ?>
+                            </td>
+                            <?php endif; ?>
                             <td>
                                 <?php if (!empty($r['Username'])): ?>
                                     <span><?= htmlspecialchars((string)$r['Username'], ENT_QUOTES, 'UTF-8') ?></span>
@@ -490,13 +588,29 @@ $buildQuery = function (array $overrides = []) {
                                     <code><?= htmlspecialchars((string)$r['EntityId'], ENT_QUOTES, 'UTF-8') ?></code>
                                 <?php endif; ?>
                             </td>
+                            <?php if ($hasObsCols): ?>
+                            <td class="small text-muted">
+                                <?php $rp = (string)($r['RequestPath'] ?? ''); if ($rp !== ''): ?>
+                                    <a class="text-decoration-none"
+                                       href="?<?= htmlspecialchars($buildQuery(['q' => $rp]), ENT_QUOTES, 'UTF-8') ?>"
+                                       title="Filter to hits on this path">
+                                        <code class="d-inline-block text-truncate" style="max-width: 18rem; vertical-align: bottom;"><?= htmlspecialchars($rp, ENT_QUOTES, 'UTF-8') ?></code>
+                                    </a>
+                                <?php endif; ?>
+                            </td>
+                            <?php endif; ?>
                             <td>
                                 <span class="badge <?= $resultBadgeClass[$r['Result']] ?? 'bg-secondary' ?>">
                                     <?= htmlspecialchars((string)$r['Result'], ENT_QUOTES, 'UTF-8') ?>
                                 </span>
                             </td>
                             <td class="text-muted small">
-                                <?= htmlspecialchars((string)$r['IpAddress'], ENT_QUOTES, 'UTF-8') ?>
+                                <?php
+                                if ($hasObsCols):
+                                    $cc = (string)($r['Country'] ?? '');
+                                    $flag = _activityFlagEmoji($cc);
+                                    if ($flag !== ''):
+                                ?><span title="<?= htmlspecialchars($cc, ENT_QUOTES, 'UTF-8') ?>" aria-label="<?= htmlspecialchars($cc, ENT_QUOTES, 'UTF-8') ?>"><?= $flag ?></span> <?php endif; endif; ?><?= htmlspecialchars((string)$r['IpAddress'], ENT_QUOTES, 'UTF-8') ?>
                                 <?php
                                 /* Proxy/VPN indicator badge — shown inline under
                                    the IP when classification is something other
@@ -531,7 +645,7 @@ $buildQuery = function (array $overrides = []) {
                         </tr>
                         <?php if ($detailsPretty !== '' || ($r['UserAgent'] ?? '') !== '' || $r['DurationMs'] !== null): ?>
                         <tr class="activity-row">
-                            <td colspan="7" class="bg-black-soft border-0 py-2">
+                            <td colspan="<?= $hasObsCols ? 9 : 7 ?>" class="bg-black-soft border-0 py-2">
                                 <div class="small text-muted mb-1">
                                     <?php if ($r['Method'] !== ''): ?>
                                         <code><?= htmlspecialchars((string)$r['Method'], ENT_QUOTES, 'UTF-8') ?></code>
@@ -549,6 +663,9 @@ $buildQuery = function (array $overrides = []) {
                                         · UA: <span class="activity-ua" title="<?= htmlspecialchars((string)$r['UserAgent'], ENT_QUOTES, 'UTF-8') ?>">
                                             <?= htmlspecialchars((string)$r['UserAgent'], ENT_QUOTES, 'UTF-8') ?>
                                         </span>
+                                    <?php endif; ?>
+                                    <?php if ($hasObsCols && !empty($r['Referrer'])): ?>
+                                        <br>· Referrer: <span class="activity-ua"><?= htmlspecialchars((string)$r['Referrer'], ENT_QUOTES, 'UTF-8') ?></span>
                                     <?php endif; ?>
                                 </div>
                                 <?php if ($detailsPretty !== ''): ?>
@@ -642,8 +759,12 @@ $buildQuery = function (array $overrides = []) {
                    across teammates in different regions. */
                 cell.setAttribute('title', cell.textContent + ' (' + visitorTz + ')');
             });
+            /* #1207 — keep the header short ("When (local)") so it doesn't wrap;
+               surface the actual timezone in the blurb instead. */
             var header = document.getElementById('activity-when-header');
-            if (header) header.textContent = 'When (local — ' + visitorTz + ')';
+            if (header) header.textContent = 'When (local)';
+            var tzLabel = document.querySelector('[data-activity-tz]');
+            if (tzLabel) tzLabel.textContent = visitorTz;
         } catch (_e) { /* fail-soft — server-rendered UTC stays */ }
     })();
     </script>

--- a/appWeb/public_html/manage/includes/migration-registry.php
+++ b/appWeb/public_html/manage/includes/migration-registry.php
@@ -1573,6 +1573,30 @@ return [
         'probe' => static fn(\mysqli $db) => !_migProbe_columnExists($db, 'tblSongs', 'NormalizedTitle'),
     ],
 
+    'activity-log-observability' => [
+        'script' => 'migrate-activity-log-observability.php',
+        'card' => [
+            'title'  => 'Activity Log observability columns (#1207)',
+            'body'   => 'Adds <code>Environment</code> / <code>RequestPath</code> / '
+                      . '<code>Referrer</code> / <code>Country</code> to <code>tblActivityLog</code> '
+                      . '— the shared DB serves all three environments, so each row records which '
+                      . 'env / file / referrer / country it came from. Also adds dormant geo-cache '
+                      . 'columns to <code>tblIpReputation</code> for the IP→country resolver (#1208). '
+                      . 'Strictly additive + idempotent.',
+            'button' => 'Run Activity Log Observability Migration',
+        ],
+        /* OR-probe (rule #19): pending until EVERY added column exists, so a
+           partial apply re-applies instead of showing the card green. */
+        'probe' => static fn(\mysqli $db) =>
+               !_migProbe_columnExists($db, 'tblActivityLog', 'Environment')
+            || !_migProbe_columnExists($db, 'tblActivityLog', 'RequestPath')
+            || !_migProbe_columnExists($db, 'tblActivityLog', 'Referrer')
+            || !_migProbe_columnExists($db, 'tblActivityLog', 'Country')
+            || !_migProbe_columnExists($db, 'tblIpReputation', 'CountryCode')
+            || !_migProbe_columnExists($db, 'tblIpReputation', 'CountryName')
+            || !_migProbe_columnExists($db, 'tblIpReputation', 'GeoLookedUpAt'),
+    ],
+
     'song-link-confidence' => [
         'script' => 'migrate-song-link-confidence.php',
         'card' => [


### PR DESCRIPTION
Closes #1207 (the #1208 geo columns ship dormant here too).

The activity log lives in the **shared DB**, so it recorded all three environments indistinguishably. This adds the columns + UI to answer **which environment, which file, from where** — plus a tidy of the wrapping `When` header.

## Schema (one-pass; also lands #1208's dormant geo columns — house rule #20)
`migrate-activity-log-observability.php` adds `tblActivityLog.{Environment, RequestPath, Referrer, Country}` (+ indexes) and `tblIpReputation.{CountryCode, CountryName, GeoLookedUpAt}`. Additive + idempotent. `schema.sql` mirrored (schema-coverage CI passes); registry OR-probe stays pending until **all seven** columns exist.

## `logActivity()`
- Captures **Environment** (new `activityLogEnvironment()`, mirrors `infoAppVer`), **RequestPath** (`REQUEST_URI` minus query), **Referrer** (`HTTP_REFERER`). Probed once/process; degrades pre-migration.
- INSERT is now built **dynamically** (column list + placeholders + type string + values from one ordered source) — structurally killing the bind-count drift that previously darkened the audit trail (#919/#923/#924).

## Page
Env **badge column + filter**; **Path** column (+ search matches `RequestPath`); **Referrer** in the row detail; **country flag** next to the IP (renders once #1208 fills `Country`); CSV export gains the four columns. **Timezone** moved out of the `When` header (no wrap) into the blurb, noting the log spans all environments. All gated on one `$hasObsCols` probe so the table stays consistent pre/post-migration.

## After deploy
Re-run **Apply all** on Database Setup to apply the migration; then the Env/Path/Referrer columns populate going forward. (Country flags wait on #1208's resolver.)

Reviewed (dynamic INSERT / page SQL+XSS+gating / migration); the one finding (probe missing two columns) is fixed. `php -l` + both CI guards pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)