### PR TITLE
feat(activity-log): IP→country geolocation with flags (resolver + async backfill) (#1208)

### DIFF
--- a/appWeb/public_html/includes/activity_log.php
+++ b/appWeb/public_html/includes/activity_log.php
@@ -287,6 +287,18 @@ function logActivity(
                      ? substr((string)$_SERVER['HTTP_REFERER'], 0, 2048)
                      : null;
 
+        /* #1208 — country snapshot AT log time. Cache + MaxMind-local ONLY on the
+           write path (never an external API call — that would add network latency
+           to every request); a brand-new uncached IP stays NULL until the
+           activity-log viewer backfills it via the API chain. Resolution drift
+           over time is exactly why this is snapshotted on the row, not joined. */
+        $country = null;
+        if ($hasObsCols) {
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'ip_geolocation.php';
+            $geo = ihymnsGeoLookup($ip, false);
+            $country = $geo !== null ? $geo['code'] : null;
+        }
+
         /* Build the INSERT dynamically so the column list, placeholder count,
            type string and value list can NEVER drift apart (the #919/#923/#924
            bind-count saga that silently darkened the audit trail). All three are
@@ -303,9 +315,9 @@ function logActivity(
             array_push($values, $proxyChainTrim, $proxyIndTrim, $proxyDetailJson);
         }
         if ($hasObsCols) {
-            array_push($cols, 'Environment', 'RequestPath', 'Referrer');
-            $types .= 'sss';
-            array_push($values, $environment, $requestPath, $referrer);
+            array_push($cols, 'Environment', 'RequestPath', 'Referrer', 'Country');
+            $types .= 'ssss';
+            array_push($values, $environment, $requestPath, $referrer, $country);
         }
         array_push($cols, 'UserAgent', 'RequestId', 'Method', 'DurationMs');
         $types .= 'sssi';

--- a/appWeb/public_html/includes/ip_geolocation.php
+++ b/appWeb/public_html/includes/ip_geolocation.php
@@ -1,0 +1,262 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — IP → country geolocation (#1208)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * Resolves a client IP to an ISO-3166-1 alpha-2 country for the activity log
+ * (#1207's tblActivityLog.Country snapshot + the flag in the viewer). Layered so
+ * the hot write path never blocks on the network:
+ *
+ *   1. Per-request memo   — same IP resolved once per request.
+ *   2. DB cache           — tblIpReputation.{CountryCode,CountryName,GeoLookedUpAt}
+ *                           (90-day TTL). Shared across requests + environments.
+ *   3. MaxMind GeoLite2   — a LOCAL .mmdb lookup (fast, offline, no rate limit).
+ *                           Used on BOTH the write path + backfill when present.
+ *                           Seam only here — the reader + the db file land with
+ *                           the MaxMind follow-up; absent → this step is skipped.
+ *   4. External API chain — ip-api.com → ipwho.is → ipapi.co, fail-soft, SHORT
+ *                           timeout. ONLY when $allowExternal (never on the write
+ *                           path — the activity-log viewer backfills async).
+ *
+ * Private / reserved / invalid IPs resolve to null (no geo, not cached).
+ *
+ * @requires PHP 8.4+ — project targets 8.5.
+ */
+
+if (!function_exists('getDbMysqli')) {
+    require_once __DIR__ . DIRECTORY_SEPARATOR . 'db_mysql.php';
+}
+
+/** Cache freshness window for a resolved (or definitively-unknown) IP. */
+const IHYMNS_GEO_TTL_DAYS = 90;
+
+/** Path to the MaxMind GeoLite2-Country database, when the follow-up has
+ *  installed it (kept OUTSIDE the web root; the deploy/cron drops it here). */
+const IHYMNS_GEO_MMDB_PATH = __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR
+    . '..' . DIRECTORY_SEPARATOR . '.geoip' . DIRECTORY_SEPARATOR . 'GeoLite2-Country.mmdb';
+
+/**
+ * Resolve an IP to ['code' => 'GB', 'name' => 'United Kingdom', 'source' => …]
+ * or null. $allowExternal gates the network providers (false on the write path).
+ *
+ * @return array{code:string,name:string,source:string}|null
+ */
+function ihymnsGeoLookup(string $ip, bool $allowExternal = false): ?array
+{
+    static $memo = [];   // per-request memo (logActivity may fire many times)
+    $ip = trim($ip);
+    if ($ip === '') {
+        return null;
+    }
+    $memoKey = ($allowExternal ? 'x:' : 'c:') . $ip;
+    if (array_key_exists($memoKey, $memo)) {
+        return $memo[$memoKey];
+    }
+
+    /* Only public, routable IPs have a meaningful country. */
+    if (!filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
+        return $memo[$memoKey] = null;
+    }
+
+    $db = getDbMysqli();
+
+    /* 1/2 — DB cache (fresh within TTL). A non-null GeoLookedUpAt means we've
+       resolved (or definitively failed to) recently; trust it. */
+    $cached = ihymnsGeoCacheGet($db, $ip);
+    if ($cached !== null) {
+        return $memo[$memoKey] = ($cached['code'] !== '' ? $cached : null);
+    }
+
+    /* 3 — MaxMind local (always allowed — it's a fast file read). */
+    $hit = ihymnsGeoViaMaxmind($ip);
+    if ($hit !== null) {
+        ihymnsGeoCachePut($db, $ip, $hit['code'], $hit['name'], 'maxmind');
+        return $memo[$memoKey] = $hit;
+    }
+
+    /* 4 — external API chain (backfill / on-demand only). */
+    if ($allowExternal) {
+        $hit = ihymnsGeoViaApiChain($ip);
+        if ($hit !== null) {
+            ihymnsGeoCachePut($db, $ip, $hit['code'], $hit['name'], $hit['source']);
+            return $memo[$memoKey] = ['code' => $hit['code'], 'name' => $hit['name'], 'source' => $hit['source']];
+        }
+        /* All providers failed/timed out → DON'T cache (so a transient outage
+           retries next time), just return null for this request. */
+    }
+
+    return $memo[$memoKey] = null;
+}
+
+/**
+ * Read the geo cache for an IP. Returns ['code','name','source'] when a fresh
+ * row exists (code '' = "looked up, no country"), or null when absent/stale.
+ *
+ * @return array{code:string,name:string,source:string}|null
+ */
+function ihymnsGeoCacheGet(mysqli $db, string $ip): ?array
+{
+    try {
+        $stmt = $db->prepare(
+            'SELECT CountryCode, CountryName, GeoLookedUpAt
+               FROM tblIpReputation
+              WHERE IpAddress = ?
+                AND GeoLookedUpAt IS NOT NULL
+                AND GeoLookedUpAt > (NOW() - INTERVAL ? DAY)
+              LIMIT 1'
+        );
+        $ttl = IHYMNS_GEO_TTL_DAYS;
+        $stmt->bind_param('si', $ip, $ttl);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        if (!$row) {
+            return null;
+        }
+        return [
+            'code'   => (string)($row['CountryCode'] ?? ''),
+            'name'   => (string)($row['CountryName'] ?? ''),
+            'source' => 'cache',
+        ];
+    } catch (\Throwable $_e) {
+        return null;   // pre-migration / probe failure → treat as a miss
+    }
+}
+
+/**
+ * Upsert a geo result into tblIpReputation (IpAddress PK; other columns keep
+ * their defaults / existing proxy values). Best-effort.
+ */
+function ihymnsGeoCachePut(mysqli $db, string $ip, string $code, string $name, string $source): void
+{
+    try {
+        $code = strtoupper(substr($code, 0, 2));
+        $name = substr($name, 0, 100);
+        $src  = substr($source, 0, 50);
+        $stmt = $db->prepare(
+            'INSERT INTO tblIpReputation (IpAddress, CountryCode, CountryName, GeoLookedUpAt, Source)
+                 VALUES (?, ?, ?, NOW(), ?)
+             ON DUPLICATE KEY UPDATE
+                 CountryCode = VALUES(CountryCode),
+                 CountryName = VALUES(CountryName),
+                 GeoLookedUpAt = NOW()'
+        );
+        $stmt->bind_param('ssss', $ip, $code, $name, $src);
+        $stmt->execute();
+        $stmt->close();
+    } catch (\Throwable $_e) {
+        /* best-effort cache write */
+    }
+}
+
+/**
+ * MaxMind GeoLite2-Country local lookup. SEAM: returns null unless both the
+ * .mmdb file AND a reader are present (they land with the MaxMind follow-up).
+ * Supports the maxminddb PHP extension if installed; otherwise no-ops until a
+ * pure-PHP reader is vendored.
+ *
+ * @return array{code:string,name:string,source:string}|null
+ */
+function ihymnsGeoViaMaxmind(string $ip): ?array
+{
+    if (!is_file(IHYMNS_GEO_MMDB_PATH)) {
+        return null;
+    }
+    /* Native extension path (fastest); the pure-PHP reader vendor lands later. */
+    if (class_exists('\\MaxMind\\Db\\Reader')) {
+        try {
+            static $reader = null;
+            if ($reader === null) {
+                $reader = new \MaxMind\Db\Reader(IHYMNS_GEO_MMDB_PATH);
+            }
+            $rec = $reader->get($ip);
+            $code = is_array($rec) ? (string)($rec['country']['iso_code'] ?? '') : '';
+            if ($code === '') {
+                return null;
+            }
+            $name = is_array($rec) ? (string)($rec['country']['names']['en'] ?? $code) : $code;
+            return ['code' => strtoupper($code), 'name' => $name, 'source' => 'maxmind'];
+        } catch (\Throwable $_e) {
+            return null;
+        }
+    }
+    return null;
+}
+
+/**
+ * External provider chain — first success wins. Each provider is fail-soft with
+ * a short timeout so one slow/dead service can't stall a backfill.
+ *
+ * @return array{code:string,name:string,source:string}|null
+ */
+function ihymnsGeoViaApiChain(string $ip): ?array
+{
+    $providers = [
+        ['source' => 'ip-api',  'url' => 'http://ip-api.com/json/' . rawurlencode($ip) . '?fields=status,countryCode,country',
+         'code' => 'countryCode', 'name' => 'country',      'ok' => ['status' => 'success']],
+        ['source' => 'ipwho',   'url' => 'https://ipwho.is/' . rawurlencode($ip) . '?fields=success,country_code,country',
+         'code' => 'country_code', 'name' => 'country',     'ok' => ['success' => true]],
+        ['source' => 'ipapi',   'url' => 'https://ipapi.co/' . rawurlencode($ip) . '/json/',
+         'code' => 'country_code', 'name' => 'country_name', 'ok' => []],
+    ];
+    foreach ($providers as $p) {
+        $json = ihymnsGeoHttpGetJson($p['url']);
+        if ($json === null) {
+            continue;
+        }
+        foreach ($p['ok'] as $k => $v) {
+            if (($json[$k] ?? null) !== $v) {
+                continue 2;   // provider-level failure marker → next provider
+            }
+        }
+        $code = strtoupper((string)($json[$p['code']] ?? ''));
+        if (strlen($code) !== 2 || !ctype_alpha($code)) {
+            continue;
+        }
+        $name = (string)($json[$p['name']] ?? $code);
+        return ['code' => $code, 'name' => $name, 'source' => $p['source']];
+    }
+    return null;
+}
+
+/**
+ * Fail-soft JSON GET with a short timeout. Returns the decoded array or null.
+ */
+function ihymnsGeoHttpGetJson(string $url): ?array
+{
+    $body = null;
+    if (function_exists('curl_init')) {
+        $ch = curl_init($url);
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_CONNECTTIMEOUT => 2,
+            CURLOPT_TIMEOUT        => 3,
+            CURLOPT_USERAGENT      => 'iHymns-geo/1.0 (+https://ihymns.app)',
+            CURLOPT_FOLLOWLOCATION => false,
+        ]);
+        $resp = curl_exec($ch);
+        $httpCode = (int)curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+        if ($resp !== false && $httpCode >= 200 && $httpCode < 300) {
+            $body = (string)$resp;
+        }
+    } else {
+        $ctx = stream_context_create(['http' => [
+            'timeout' => 3,
+            'header'  => "User-Agent: iHymns-geo/1.0 (+https://ihymns.app)\r\n",
+        ]]);
+        $resp = @file_get_contents($url, false, $ctx);
+        if ($resp !== false) {
+            $body = (string)$resp;
+        }
+    }
+    if ($body === null || $body === '') {
+        return null;
+    }
+    $decoded = json_decode($body, true);
+    return is_array($decoded) ? $decoded : null;
+}

--- a/appWeb/public_html/manage/activity-log.php
+++ b/appWeb/public_html/manage/activity-log.php
@@ -61,6 +61,44 @@ function _activityFlagEmoji(string $cc): string
     return mb_chr($base + (ord($cc[0]) - 65), 'UTF-8') . mb_chr($base + (ord($cc[1]) - 65), 'UTF-8');
 }
 
+/* #1208 — async geo backfill endpoint. The viewer POSTs the IPs of rows that
+   have no country yet; we resolve them (cache → MaxMind → API chain), snapshot
+   the country onto matching tblActivityLog rows + the IP cache, and return
+   { ip: "GB" } so the page injects flags without a reload. CSRF-guarded (it
+   UPDATEs rows) + capped per call to respect free-API rate limits. Admin gate is
+   already enforced at the top of the page. */
+if ($hasObsCols && ($_GET['action'] ?? '') === 'geo') {
+    header('Content-Type: application/json');
+    $token = (string)($_SERVER['HTTP_X_CSRF_TOKEN'] ?? $_POST['csrf'] ?? '');
+    if (!validateCsrf($token)) {
+        http_response_code(403);
+        echo json_encode(['ok' => false, 'error' => 'csrf']);
+        exit;
+    }
+    $ipsRaw = (string)($_POST['ips'] ?? '');
+    $ips = array_values(array_unique(array_filter(array_map('trim', explode(',', $ipsRaw)))));
+    $ips = array_slice($ips, 0, 25);   // cap external lookups per call (rate limits)
+    require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'ip_geolocation.php';
+    $countries = [];
+    foreach ($ips as $oneIp) {
+        $geo = ihymnsGeoLookup($oneIp, true);   // allow external providers here
+        if ($geo !== null && $geo['code'] !== '') {
+            $countries[$oneIp] = $geo['code'];
+            /* Snapshot onto rows from this IP that have no country yet, so the
+               next view needs no lookup at all (the owner's "save the country on
+               the row" point). Bound; best-effort. */
+            try {
+                $u = $db->prepare("UPDATE tblActivityLog SET Country = ? WHERE IpAddress = ? AND (Country IS NULL OR Country = '')");
+                $u->bind_param('ss', $countries[$oneIp], $oneIp);
+                $u->execute();
+                $u->close();
+            } catch (\Throwable $_e) { /* best-effort backfill */ }
+        }
+    }
+    echo json_encode(['ok' => true, 'countries' => $countries]);
+    exit;
+}
+
 /* Filter parsing — every filter is optional. Defaults give the
    admin "last 24 h, every action, every user" landing view. */
 $filterAction     = trim((string)($_GET['action']      ?? ''));
@@ -361,6 +399,7 @@ $buildQuery = function (array $overrides = []) {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Activity Log — iHymns Admin</title>
+    <meta name="csrf-token" content="<?= htmlspecialchars(csrfToken(), ENT_QUOTES, 'UTF-8') ?>"><!-- #1208 geo backfill POST -->
     <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-libs.php'; ?>
     <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-favicon.php'; ?>
     <style>
@@ -606,11 +645,12 @@ $buildQuery = function (array $overrides = []) {
                             </td>
                             <td class="text-muted small">
                                 <?php
+                                /* #1208 — every IP gets a .geo-flag span (filled
+                                   server-side from the Country snapshot; empty
+                                   ones are backfilled async by the script below). */
                                 if ($hasObsCols):
                                     $cc = (string)($r['Country'] ?? '');
-                                    $flag = _activityFlagEmoji($cc);
-                                    if ($flag !== ''):
-                                ?><span title="<?= htmlspecialchars($cc, ENT_QUOTES, 'UTF-8') ?>" aria-label="<?= htmlspecialchars($cc, ENT_QUOTES, 'UTF-8') ?>"><?= $flag ?></span> <?php endif; endif; ?><?= htmlspecialchars((string)$r['IpAddress'], ENT_QUOTES, 'UTF-8') ?>
+                                ?><span class="geo-flag" data-ip="<?= htmlspecialchars((string)$r['IpAddress'], ENT_QUOTES, 'UTF-8') ?>"<?php if ($cc !== ''): ?> title="<?= htmlspecialchars($cc, ENT_QUOTES, 'UTF-8') ?>"<?php endif; ?>><?= _activityFlagEmoji($cc) ?></span> <?php endif; ?><?= htmlspecialchars((string)$r['IpAddress'], ENT_QUOTES, 'UTF-8') ?>
                                 <?php
                                 /* Proxy/VPN indicator badge — shown inline under
                                    the IP when classification is something other
@@ -766,6 +806,52 @@ $buildQuery = function (array $overrides = []) {
             var tzLabel = document.querySelector('[data-activity-tz]');
             if (tzLabel) tzLabel.textContent = visitorTz;
         } catch (_e) { /* fail-soft — server-rendered UTC stays */ }
+    })();
+    </script>
+
+    <!-- #1208 — async country flags. Collect IPs whose flag isn't rendered yet,
+         resolve them via the geo backfill endpoint, inject the flag emoji. The
+         page never waits on this; flags pop in as the lookups return. -->
+    <script>
+    (function () {
+        try {
+            var meta = document.querySelector('meta[name="csrf-token"]');
+            var csrf = meta ? (meta.getAttribute('content') || '') : '';
+            var pending = Array.prototype.slice.call(document.querySelectorAll('.geo-flag'))
+                .filter(function (el) { return el.textContent.trim() === '' && el.getAttribute('data-ip'); });
+            if (!pending.length) { return; }
+            var ips = [];
+            pending.forEach(function (el) {
+                var ip = el.getAttribute('data-ip');
+                if (ip && ips.indexOf(ip) === -1) { ips.push(ip); }
+            });
+            ips = ips.slice(0, 25);
+            if (!ips.length) { return; }
+            function flagEmoji(cc) {
+                cc = (cc || '').toUpperCase();
+                if (!/^[A-Z]{2}$/.test(cc)) { return ''; }
+                return String.fromCodePoint(0x1F1E6 + cc.charCodeAt(0) - 65, 0x1F1E6 + cc.charCodeAt(1) - 65);
+            }
+            fetch('/manage/activity-log.php?action=geo', {
+                method: 'POST',
+                credentials: 'same-origin',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                    'X-Requested-With': 'XMLHttpRequest',
+                    'X-CSRF-Token': csrf,
+                },
+                body: 'ips=' + encodeURIComponent(ips.join(',')),
+            }).then(function (r) { return r.ok ? r.json() : null; }).then(function (j) {
+                if (!j || !j.countries) { return; }
+                pending.forEach(function (el) {
+                    var code = j.countries[el.getAttribute('data-ip')];
+                    if (code && /^[A-Za-z]{2}$/.test(code)) {   // defense-in-depth: validate before DOM
+                        var fl = flagEmoji(code);
+                        if (fl) { el.textContent = fl; el.setAttribute('title', code.toUpperCase()); }
+                    }
+                });
+            }).catch(function () { /* fail-soft — no flags, page still fine */ });
+        } catch (_e) { /* fail-soft */ }
     })();
     </script>
 


### PR DESCRIPTION
Closes #1208 (the API/async phase). Fills the dormant `Country` column (#1207) and shows a flag next to each IP.

## Resolver — `includes/ip_geolocation.php` (new)
`ihymnsGeoLookup($ip, $allowExternal)`: per-request memo → DB cache (`tblIpReputation`, 90-day TTL) → **MaxMind GeoLite2 local seam** → (if `$allowExternal`) **API fallback chain** ip-api → ipwho.is → ipapi.co, fail-soft (3s timeout). Private/reserved/invalid IPs → null (uncached); all-providers-fail → null (uncached, so a transient outage retries). UPSERT deliberately leaves `Source` untouched (shared with the proxy/VPN resolver).

## Write path — `logActivity`
Snapshots `Country` **at log time**, resolving via **cache + MaxMind only** (never an external API on the hot path). New uncached IPs stay NULL until the viewer backfills. `Country` joins the dynamic-INSERT obs group — bind count verified across all four proxy×obs combos.

## Viewer — `activity-log.php`
Renders instantly, then async-backfills: a **CSRF-guarded, admin-gated, 25/call-capped** `POST ?action=geo` resolves unknown IPs, **snapshots `Country` onto matching rows** (bound UPDATE, only where empty — your "save it on the row" point), and returns a code map; JS injects flag emoji (built from the validated 2-letter code). Flag shows next to the IP.

## MaxMind (follow-up)
A clean seam — the reader + `.mmdb` + the scheduled download Action need `MAXMIND_LICENSE_KEY` and land next; the **API chain makes flags work immediately**, then MaxMind slots in as the fast local provider #1.

Reviewed (resolver / write-path bind-count / endpoint security); the one applied fix is JS title hardening. `php -l` clean; private-IP skip smoke-tested. Needs the #1207 migration applied on alpha first (Country column).

🤖 Generated with [Claude Code](https://claude.com/claude-code)