### PR TITLE
feat(song): Content-Language + hreflang alternates; extract getSongTranslations (#1206)

### DIFF
--- a/appWeb/public_html/includes/SongData.php
+++ b/appWeb/public_html/includes/SongData.php
@@ -263,6 +263,69 @@ class SongData
      *
      * @return array List of songbook objects (id, name, songCount)
      */
+    /**
+     * Other-language versions of a song (#281) — the translation cluster: songs
+     * THIS one translates to (outward), the source it translates FROM (inward),
+     * and that source's other translations (siblings). Used by the song page's
+     * language picker AND the song page's hreflang alternates (#1206). Wrapped so
+     * a missing table / DB hiccup yields an empty list, never a fatal.
+     *
+     * @return array<int, array<string, mixed>> rows: song_id, target_language,
+     *         language_name, native_name, text_direction, translator, verified
+     */
+    public function getSongTranslations(string $songId): array
+    {
+        if ($songId === '' || $this->jsonMode || !($this->db instanceof \mysqli)) {
+            return [];
+        }
+        try {
+            $sql = '
+                /* Outward — this song has translations to other languages */
+                SELECT t.TranslatedSongId AS song_id, t.TargetLanguage AS target_language,
+                       l.Name AS language_name, l.NativeName AS native_name,
+                       l.TextDirection AS text_direction, t.Translator AS translator, t.Verified AS verified
+                  FROM tblSongTranslations t
+                  JOIN tblLanguages l ON l.Code = t.TargetLanguage
+                 WHERE t.SourceSongId = ? AND l.IsActive = 1
+                UNION
+                /* Inward — this song IS a translation; surface the source. */
+                SELECT src.SongId AS song_id, srcLang.Code AS target_language,
+                       srcLang.Name AS language_name, srcLang.NativeName AS native_name,
+                       srcLang.TextDirection AS text_direction, "" AS translator, 1 AS verified
+                  FROM tblSongTranslations selfT
+                  JOIN tblSongs src ON src.SongId = selfT.SourceSongId
+                  JOIN tblLanguages srcLang ON srcLang.Code = src.Language
+                 WHERE selfT.TranslatedSongId = ? AND srcLang.IsActive = 1
+                UNION
+                /* Siblings — the source\'s OTHER translations. */
+                SELECT sibling.TranslatedSongId AS song_id, sibling.TargetLanguage AS target_language,
+                       l2.Name AS language_name, l2.NativeName AS native_name,
+                       l2.TextDirection AS text_direction, sibling.Translator AS translator, sibling.Verified AS verified
+                  FROM tblSongTranslations selfT2
+                  JOIN tblSongTranslations sibling
+                       ON sibling.SourceSongId = selfT2.SourceSongId
+                      AND sibling.TranslatedSongId <> selfT2.TranslatedSongId
+                  JOIN tblLanguages l2 ON l2.Code = sibling.TargetLanguage
+                 WHERE selfT2.TranslatedSongId = ? AND l2.IsActive = 1
+            ';
+            $stmt = $this->db->prepare($sql);
+            if ($stmt === false) {
+                return [];
+            }
+            $stmt->bind_param('sss', $songId, $songId, $songId);
+            $stmt->execute();
+            $res = $stmt->get_result();
+            $rows = [];
+            while ($row = $res->fetch_assoc()) {
+                $rows[] = $row;
+            }
+            $stmt->close();
+            return $rows;
+        } catch (\Throwable $_e) {
+            return [];   // missing table / DB hiccup → no alternates, never fatal
+        }
+    }
+
     public function getSongbooks(): array
     {
         if ($this->jsonMode) {

--- a/appWeb/public_html/includes/pages/song.php
+++ b/appWeb/public_html/includes/pages/song.php
@@ -161,62 +161,15 @@ if (function_exists('getAppSetting') && getAppSetting('content_gating_enabled', 
  * Wrapped in try/catch so a missing table during early setup or a
  * DB hiccup simply hides the picker rather than blanking the page.
  * =================================================================== */
+/* #1206 — the cluster query now lives in SongData::getSongTranslations() so the
+   song page picker AND the hreflang alternates (emitted in index.php's <head>)
+   share ONE definition (modularity rule). Still wrapped so a hiccup hides the
+   picker rather than blanking the page. */
 $translations = [];
 try {
-    require_once __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'db_mysql.php';
-    $translationsDb = getDbMysqli();
-    $sql = '
-        /* Outward — this song has translations to other languages */
-        SELECT t.TranslatedSongId  AS song_id,
-               t.TargetLanguage    AS target_language,
-               l.Name              AS language_name,
-               l.NativeName        AS native_name,
-               l.TextDirection     AS text_direction,
-               t.Translator        AS translator,
-               t.Verified          AS verified
-          FROM tblSongTranslations t
-          JOIN tblLanguages l ON l.Code = t.TargetLanguage
-         WHERE t.SourceSongId = ? AND l.IsActive = 1
-        UNION
-        /* Inward — this song IS a translation of another; surface the
-           source plus any siblings (other translations of that source). */
-        SELECT src.SongId          AS song_id,
-               srcLang.Code        AS target_language,
-               srcLang.Name        AS language_name,
-               srcLang.NativeName  AS native_name,
-               srcLang.TextDirection AS text_direction,
-               ""                  AS translator,
-               1                   AS verified
-          FROM tblSongTranslations selfT
-          JOIN tblSongs src            ON src.SongId = selfT.SourceSongId
-          JOIN tblLanguages srcLang    ON srcLang.Code = src.Language
-         WHERE selfT.TranslatedSongId = ? AND srcLang.IsActive = 1
-        UNION
-        SELECT sibling.TranslatedSongId AS song_id,
-               sibling.TargetLanguage   AS target_language,
-               l2.Name                  AS language_name,
-               l2.NativeName            AS native_name,
-               l2.TextDirection         AS text_direction,
-               sibling.Translator       AS translator,
-               sibling.Verified         AS verified
-          FROM tblSongTranslations selfT2
-          JOIN tblSongTranslations sibling
-               ON sibling.SourceSongId = selfT2.SourceSongId
-              AND sibling.TranslatedSongId <> selfT2.TranslatedSongId
-          JOIN tblLanguages l2 ON l2.Code = sibling.TargetLanguage
-         WHERE selfT2.TranslatedSongId = ? AND l2.IsActive = 1
-    ';
-    $stmt = $translationsDb->prepare($sql);
-    if ($stmt !== false) {
-        $sid = (string)($song['id'] ?? '');
-        $stmt->bind_param('sss', $sid, $sid, $sid);
-        $stmt->execute();
-        $res = $stmt->get_result();
-        while ($row = $res->fetch_assoc()) $translations[] = $row;
-        $stmt->close();
-    }
+    require_once __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'SongData.php';
+    $translations = (new SongData())->getSongTranslations((string)($song['id'] ?? ''));
 } catch (\Throwable $_e) {
-    /* No translations infrastructure — picker stays hidden. */
     $translations = [];
 }
 

--- a/appWeb/public_html/index.php
+++ b/appWeb/public_html/index.php
@@ -193,6 +193,11 @@ $cspDirectives = [
 
 header("Content-Security-Policy: " . implode('; ', $cspDirectives));
 
+/* #1206 — declare the page's primary (UI) language. The actual content languages
+   on a song page are carried per-component via lang/dir tags (#858/#1205); this
+   header + <html lang> stay the UI language by design. */
+header('Content-Language: ' . $locale);
+
 /* =========================================================================
  * OPEN GRAPH META TAGS — Dynamic per-page social sharing previews
  *
@@ -224,6 +229,11 @@ $jsonLdScripts   = [];
 $breadcrumbItems = [];
 $pageType        = 'home'; /* 'home', 'song', 'songbook', or 'other' */
 
+/* #1206 — hreflang alternates for a song's translation cluster. Filled in the
+   song route below (empty for every other page); emitted in <head>. */
+$hreflangLinks    = [];
+$hreflangSongLang = '';
+
 /* Detect specific page routes for customised OG tags */
 try {
     $songData = new SongData();
@@ -233,6 +243,27 @@ try {
         $ogSong = $songData->getSongById($matches[1]);
         if ($ogSong !== null) {
             $pageType = 'song';
+
+            /* #1206 — translation-cluster hreflang alternates (SEO: marks these
+               as language variants of one work). Only when the song has
+               other-language versions. Self + each alternate (+ x-default in the
+               head). Shares SongData::getSongTranslations() with the picker. */
+            $hreflangSongLang = trim((string)($ogSong['language'] ?? ''));
+            $_cluster = $songData->getSongTranslations($matches[1]);
+            if (!empty($_cluster)) {
+                $_seen = [];
+                if ($hreflangSongLang !== '') {
+                    $hreflangLinks[$hreflangSongLang] = $canonicalUrl;   // self
+                    $_seen[strtolower($hreflangSongLang)] = true;
+                }
+                foreach ($_cluster as $_c) {
+                    $_lang = trim((string)($_c['target_language'] ?? ''));
+                    $_sid  = (string)($_c['song_id'] ?? '');
+                    if ($_lang === '' || $_sid === '' || isset($_seen[strtolower($_lang)])) { continue; }
+                    $hreflangLinks[$_lang] = getCanonicalUrl('/song/' . rawurlencode($_sid));
+                    $_seen[strtolower($_lang)] = true;
+                }
+            }
             $ogTitle = htmlspecialchars($ogSong['title']) . ' — '
                      . htmlspecialchars($ogSong['songbookName'])
                      . ' #' . (int)$ogSong['number'];
@@ -633,6 +664,14 @@ if (!empty($breadcrumbItems)) {
 
     <!-- Canonical URL — prevents duplicate content for search engines -->
     <link rel="canonical" href="<?= htmlspecialchars($canonicalUrl) ?>">
+<?php /* #1206 — hreflang alternates: language variants of this song (only when a
+         translation cluster exists). x-default points at the current page. */ ?>
+<?php foreach ($hreflangLinks as $_hl => $_hurl): ?>
+    <link rel="alternate" hreflang="<?= htmlspecialchars($_hl, ENT_QUOTES, 'UTF-8') ?>" href="<?= htmlspecialchars($_hurl, ENT_QUOTES, 'UTF-8') ?>">
+<?php endforeach; ?>
+<?php if (!empty($hreflangLinks)): ?>
+    <link rel="alternate" hreflang="x-default" href="<?= htmlspecialchars($canonicalUrl, ENT_QUOTES, 'UTF-8') ?>">
+<?php endif; ?>
 
     <!-- Open Graph Protocol (Facebook, LinkedIn, Slack, Discord, etc.) -->
     <meta property="og:type" content="<?= htmlspecialchars($ogType) ?>">


### PR DESCRIPTION
The remaining public-song-page SEO/a11y pieces for #1206.

- **Content-Language** header = the UI locale (matches `<html lang>`, per the page=UI / blocks=content model), set right after CSP.
- **hreflang alternates** for a song's translation cluster (#281), emitted in `<head>` only when the song has other-language versions: **self + each alternate (`target_language` → `/song/<id>`) + x-default**, deduped by language — so search engines serve the right language variant.
- **Modularity:** the ~58-line cluster query moves out of `song.php` into **`SongData::getSongTranslations()`**, now shared by the picker **and** the head hreflang build (one definition). `song.php` just calls it; its later cross-book block still re-fetches `$translationsDb` via its existing `if (!isset())` guard — verified, no regression.

`$hreflangLinks` is initialised before the route + head (safe on every page). Head output `htmlspecialchars`-escaped; ids `rawurlencode`d. `php -l` clean.

### Remaining #1206
Per-**line** language tagging (needs the read layer to return line objects). Per-component lang/dir (render #858/#1205) + the editor input (#1213) are done.

Self-reviewed (the public page is high-traffic): faithful query extraction, bound params, guards, header placement, hreflang init/build/escape, and the `$translationsDb` re-fetch regression check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)