### PR TITLE
Standard theme vocabulary + Collections rename (#1152, #1222, #1223)

### DIFF
--- a/appWeb/.sql/migrate-seed-theme-vocabulary.php
+++ b/appWeb/.sql/migrate-seed-theme-vocabulary.php
@@ -1,0 +1,352 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Seed standard CCLI / OpenLyrics theme vocabulary (#1152)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Adopt the standard CCLI / SongSelect theme taxonomy that the OpenLyrics
+ * project ships as themelist.txt (https://github.com/openlyrics/openlyrics),
+ * so iHymns' Browse-by-Theme is interoperable with the wider worship-software
+ * ecosystem and curators get a ready-made, professional vocabulary instead of
+ * ad-hoc free-text tags.
+ *
+ * Schema (strictly additive + idempotent, column existence guarded):
+ *   - tblSongTags.ParentId    self-FK → the 2-level "Parent / Child" hierarchy.
+ *   - tblSongTags.CcliThemeId  CCLI SongSelect theme number (dormant — themelist
+ *                              carries names only; populated later by import).
+ *   - tblSongTags.Source       provenance: 'curator' | 'ccli-openlyrics'.
+ *
+ * Data (idempotent upsert, re-runnable):
+ *   The themelist " / " hierarchy maps to parent → child. The LEAF is stored in
+ *   Name (never the slash-joined path — Name is VARCHAR(50)); the path lives via
+ *   ParentId. A leaf whose name already exists as a top-level theme
+ *   (Forgiveness / Grace / Love / Mercy / Righteousness all appear both flat and
+ *   under "God's Attributes") collapses to the single canonical node — it is NOT
+ *   duplicated and NOT re-parented (the canonical-vocabulary goal, #1222).
+ *   Any existing same-named curator tag is promoted to Source='ccli-openlyrics'.
+ *
+ * LICENCE: the theme *names* are short factual labels from the OpenLyrics
+ * themelist (the same taxonomy as CCLI SongSelect); seeding them is low-risk.
+ * Source recorded here per #1152's licensing note.
+ *
+ * @migration-adds tblSongTags.ParentId
+ * @migration-adds tblSongTags.CcliThemeId
+ * @migration-adds tblSongTags.Source
+ *
+ * USAGE:
+ *   CLI:  php appWeb/.sql/migrate-seed-theme-vocabulary.php
+ *   Web:  /manage/setup-database → "Standard Theme Vocabulary" button
+ *
+ * @requires PHP 8.1+ with mysqli
+ */
+
+$isCli = (php_sapi_name() === 'cli');
+if (!$isCli && !defined('IHYMNS_SETUP_DASHBOARD')) {
+    header('Content-Type: text/plain; charset=UTF-8');
+    header('X-Content-Type-Options: nosniff');
+    header('Cache-Control: no-store');
+}
+
+function _migThemes_output(string $msg): void {
+    global $isCli;
+    echo $msg . ($isCli ? "\n" : "<br>\n");
+    if (!$isCli) flush();
+}
+
+function _migThemes_addCol(\mysqli $db, string $table, string $col, string $ddl): void {
+    $r = $db->query("SHOW COLUMNS FROM {$table} LIKE '{$col}'");
+    if ($r && $r->num_rows > 0) { _migThemes_output("  [SKIP] {$table}.{$col} already present."); return; }
+    $db->query("ALTER TABLE {$table} ADD COLUMN {$ddl}");
+    _migThemes_output("  [OK] Added {$table}.{$col}.");
+}
+
+function _migThemes_addIdx(\mysqli $db, string $table, string $idx, string $cols): void {
+    $r = $db->query("SHOW INDEX FROM {$table} WHERE Key_name = '{$idx}'");
+    if ($r && $r->num_rows > 0) { _migThemes_output("  [SKIP] index {$idx} already present."); return; }
+    $db->query("ALTER TABLE {$table} ADD INDEX {$idx} ({$cols})");
+    _migThemes_output("  [OK] Added index {$idx}.");
+}
+
+function _migThemes_addFk(\mysqli $db, string $table, string $fk, string $ddl): void {
+    $r = $db->query(
+        "SELECT 1 FROM information_schema.TABLE_CONSTRAINTS
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '{$table}'
+            AND CONSTRAINT_NAME = '{$fk}' LIMIT 1"
+    );
+    if ($r && $r->num_rows > 0) { _migThemes_output("  [SKIP] FK {$fk} already present."); return; }
+    $db->query("ALTER TABLE {$table} ADD {$ddl}");
+    _migThemes_output("  [OK] Added FK {$fk}.");
+}
+
+/** URL-safe lowercase slug (apostrophes dropped, runs of non-alnum → single hyphen). */
+function _migThemes_slug(string $s): string {
+    $s = str_replace("'", '', strtolower($s));
+    $s = preg_replace('/[^a-z0-9]+/', '-', $s) ?? $s;
+    return trim($s, '-');
+}
+
+$credFile = dirname(__DIR__) . DIRECTORY_SEPARATOR . '.auth' . DIRECTORY_SEPARATOR . 'db_credentials.php';
+if (!file_exists($credFile)) {
+    _migThemes_output("ERROR: MySQL credentials not found. Run install.php first.");
+    return;
+}
+require_once $credFile;
+
+_migThemes_output("");
+_migThemes_output("=== iHymns — Standard Theme Vocabulary (CCLI / OpenLyrics) (#1152) ===");
+_migThemes_output("");
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+try {
+    $mysql = new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME, (int)DB_PORT);
+    $mysql->set_charset(defined('DB_CHARSET') ? DB_CHARSET : 'utf8mb4');
+} catch (\mysqli_sql_exception $e) {
+    _migThemes_output("ERROR: MySQL connection failed: " . $e->getMessage());
+    return;
+}
+_migThemes_output("Connected to MySQL: " . DB_NAME);
+
+/* The standard OpenLyrics / CCLI theme list (themelist.txt). One per line; a
+   " / " expresses a 2-level Parent / Child relationship. Verbatim labels. */
+$themelist = <<<'THEMES'
+Admonition
+Adoration
+Anointing
+Ascension
+Aspiration
+Assurance
+Atonement
+Benediction
+Beauty
+Blessing
+Blood
+Calvary
+Ceremony / Baby
+Ceremony / Baptism
+Ceremony / Funeral
+Ceremony / Wedding
+Challenge
+Character
+Children
+Christ
+Christian Life
+Church
+Cleansing
+Comfort
+Commitment
+Communion
+Compassion
+Confession
+Conquering
+Consecration
+Contentment
+Conversion
+Courage
+Creation
+Creator
+Cross
+Crucifixion
+Declaration
+Dedication
+Devotion
+Devotional
+Discipleship
+Encouragement
+Eternal Life
+Evangelism
+Faith
+Family
+Fellowship
+Forgiveness
+Freedom
+Giving
+God's Attributes / Faithfulness
+God's Attributes / Father
+God's Attributes / Forgiveness
+God's Attributes / Goodness
+God's Attributes / Grace
+God's Attributes / Greatness
+God's Attributes / His Name
+God's Attributes / Love
+God's Attributes / Majesty
+God's Attributes / Mercy
+God's Attributes / Power
+God's Attributes / Righteousness
+God's Attributes / Will
+God's Attributes / Wisdom
+God's Word
+Grace
+Guidance
+Healing
+Heaven
+Heritage
+Holiness
+Holy Spirit
+Hope
+Humility
+Jesus
+Jesus / Bread of Life
+Jesus / Friendship
+Jesus / Lamb of God
+Jesus / Life Of Jesus
+Jesus / Living Water
+Jesus / Lordship Of Jesus
+Jesus / Messiah
+Jesus / Name Of Jesus
+Jesus / The Light
+Joy
+Judgement
+Kingship
+Liberty
+Love
+Mercy
+Miracles
+Missions
+Nature
+Obedience
+Offering
+Peace
+Petition
+Praise
+Prayer
+Presence
+Processional
+Promise
+Protection
+Providence
+Provision
+Redemption
+Refuge
+Rejoice
+Renewal
+Repentance
+Resurrection
+Revival
+Righteousness
+Sacrifice
+Salvation
+Sanctification
+Savior
+Seasonal / Advent
+Seasonal / Christmas
+Seasonal / Easter
+Seasonal / Epiphany
+Seasonal / Harvest
+Seasonal / Lent
+Seasonal / Palm Sunday
+Seasonal / Patriotic
+Seasonal / Pentecost
+Second Coming
+Servanthood
+Service
+Stewardship
+Strength
+Testimony
+Thankfulness
+Tithes
+Trials
+Trust
+Truth
+Unity
+Victory
+Warfare
+Worship
+Youth
+Zion
+THEMES;
+
+try {
+    _migThemes_output("");
+    _migThemes_output("--- tblSongTags: hierarchy + provenance columns ---");
+    _migThemes_addCol($mysql, 'tblSongTags', 'ParentId',
+        "ParentId INT UNSIGNED NULL DEFAULT NULL COMMENT 'Self-FK to tblSongTags.Id for the 2-level CCLI/OpenLyrics theme hierarchy (#1152); NULL = top-level' AFTER Description");
+    _migThemes_addCol($mysql, 'tblSongTags', 'CcliThemeId',
+        "CcliThemeId INT UNSIGNED NULL DEFAULT NULL COMMENT 'CCLI SongSelect theme number for import id-match (#1152); NULL until known' AFTER ParentId");
+    _migThemes_addCol($mysql, 'tblSongTags', 'Source',
+        "Source VARCHAR(50) NOT NULL DEFAULT 'curator' COMMENT 'Provenance: curator | ccli-openlyrics (seeded standard vocab) (#1152)' AFTER CcliThemeId");
+    _migThemes_addIdx($mysql, 'tblSongTags', 'idx_ParentId', 'ParentId');
+    _migThemes_addIdx($mysql, 'tblSongTags', 'idx_Source', 'Source');
+    _migThemes_addFk($mysql, 'tblSongTags', 'fk_SongTags_Parent',
+        "CONSTRAINT fk_SongTags_Parent FOREIGN KEY (ParentId) REFERENCES tblSongTags(Id) ON DELETE SET NULL ON UPDATE CASCADE");
+
+    /* ---- Parse the themelist into top-level + child relations. ---- */
+    $topLevel = [];   // name => true (flat themes + implied parent categories)
+    $children = [];   // [parentName, leafName]
+    foreach (preg_split('/\r?\n/', $themelist) ?: [] as $line) {
+        $line = trim($line);
+        if ($line === '') { continue; }
+        if (str_contains($line, ' / ')) {
+            [$p, $leaf] = array_map('trim', explode(' / ', $line, 2));
+            $topLevel[$p] = true;       // ensure the parent category node exists
+            $children[]   = [$p, $leaf];
+        } else {
+            $topLevel[$line] = true;
+        }
+    }
+
+    _migThemes_output("");
+    _migThemes_output("--- Seeding " . count($topLevel) . " top-level + " . count($children) . " child theme(s) ---");
+
+    /* Phase 1 — upsert every top-level node; capture id (LAST_INSERT_ID trick
+       returns the existing row's id on a duplicate-key hit). Any existing
+       same-named curator tag is promoted to the standard vocabulary. */
+    $idOf = [];
+    $insTop = $mysql->prepare(
+        "INSERT INTO tblSongTags (Name, Slug, Source) VALUES (?, ?, 'ccli-openlyrics')
+         ON DUPLICATE KEY UPDATE Source = 'ccli-openlyrics', Id = LAST_INSERT_ID(Id)"
+    );
+    foreach (array_keys($topLevel) as $name) {
+        $slug = _migThemes_slug($name);
+        $insTop->bind_param('ss', $name, $slug);
+        $insTop->execute();
+        $idOf[$name] = (int)$mysql->insert_id;
+    }
+    $insTop->close();
+
+    /* Phase 2 — children. A leaf that already exists as a top-level theme
+       collapses to that single canonical node (promote, never duplicate /
+       re-parent). Otherwise insert under its parent. */
+    $insChild = $mysql->prepare(
+        "INSERT INTO tblSongTags (Name, Slug, Source, ParentId) VALUES (?, ?, 'ccli-openlyrics', ?)
+         ON DUPLICATE KEY UPDATE Source = 'ccli-openlyrics', Id = LAST_INSERT_ID(Id)"
+    );
+    $promote = $mysql->prepare(
+        "UPDATE tblSongTags SET Source = 'ccli-openlyrics' WHERE Name = ? AND Source = 'curator'"
+    );
+    $childCount = 0;
+    foreach ($children as [$p, $leaf]) {
+        if (isset($idOf[$leaf])) {           /* collision with a top-level theme */
+            $promote->bind_param('s', $leaf);
+            $promote->execute();
+            continue;
+        }
+        $parentId = $idOf[$p] ?? null;
+        $slug = _migThemes_slug($leaf);
+        $insChild->bind_param('ssi', $leaf, $slug, $parentId);
+        $insChild->execute();
+        $idOf[$leaf] = (int)$mysql->insert_id;
+        $childCount++;
+    }
+    $insChild->close();
+    $promote->close();
+
+    $std = $mysql->query("SELECT COUNT(*) AS n FROM tblSongTags WHERE Source = 'ccli-openlyrics'");
+    $stdN = $std ? (int)$std->fetch_assoc()['n'] : 0;
+    if ($std) { $std->close(); }
+
+    _migThemes_output("");
+    _migThemes_output("--- Summary ---");
+    _migThemes_output("  Standard theme nodes now present: {$stdN}.");
+    _migThemes_output("  Curators can still add custom themes; these are marked Source='ccli-openlyrics'.");
+    _migThemes_output("");
+    _migThemes_output("Migration complete.");
+} catch (\Throwable $e) {
+    _migThemes_output("  [ERROR] " . $e->getMessage());
+}
+
+$mysql->close();
+return;

--- a/appWeb/.sql/schema.sql
+++ b/appWeb/.sql/schema.sql
@@ -1735,9 +1735,17 @@ CREATE TABLE IF NOT EXISTS tblSongTags (
     Name            VARCHAR(50)     NOT NULL UNIQUE,
     Slug            VARCHAR(50)     NOT NULL UNIQUE COMMENT 'URL-safe lowercase version',
     Description     VARCHAR(255)    NOT NULL DEFAULT '',
+    ParentId        INT UNSIGNED    NULL DEFAULT NULL COMMENT 'Self-FK to tblSongTags.Id for the 2-level CCLI/OpenLyrics theme hierarchy (#1152); NULL = top-level',
+    CcliThemeId     INT UNSIGNED    NULL DEFAULT NULL COMMENT 'CCLI SongSelect theme number for import id-match (#1152); NULL until known',
+    Source          VARCHAR(50)     NOT NULL DEFAULT 'curator' COMMENT 'Provenance: curator | ccli-openlyrics (seeded standard vocab) (#1152)',
     CreatedAt       TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
-    INDEX idx_Slug  (Slug)
+    INDEX idx_Slug  (Slug),
+    INDEX idx_ParentId (ParentId),
+    INDEX idx_Source (Source),
+    CONSTRAINT fk_SongTags_Parent
+        FOREIGN KEY (ParentId) REFERENCES tblSongTags(Id)
+        ON DELETE SET NULL ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 

--- a/appWeb/public_html/manage/catalogues.php
+++ b/appWeb/public_html/manage/catalogues.php
@@ -164,7 +164,7 @@ if ($hasSchema && $_SERVER['REQUEST_METHOD'] === 'POST') {
                 logActivity('admin.catalogues.add', 'catalogue', (string)$newId, [
                     'slug' => $slug, 'title' => $title, 'visibility' => $visibility,
                 ]);
-                $success = "Catalogue '{$title}' created.";
+                $success = "Collection '{$title}' created.";
                 break;
             }
 
@@ -174,7 +174,7 @@ if ($hasSchema && $_SERVER['REQUEST_METHOD'] === 'POST') {
                 $description = trim((string)($_POST['description'] ?? '')) ?: null;
                 $visibility  = trim((string)($_POST['visibility']  ?? 'public'));
                 $sortOrder   = (int)($_POST['sort_order'] ?? 0);
-                if ($id <= 0)                                            { $error = 'Catalogue id missing.'; break; }
+                if ($id <= 0)                                            { $error = 'Collection id missing.'; break; }
                 if ($title === '')                                       { $error = 'Title is required.'; break; }
                 if (!in_array($visibility, ['public','curated','admin_only'], true)) {
                     $error = 'Invalid visibility.'; break;
@@ -198,19 +198,19 @@ if ($hasSchema && $_SERVER['REQUEST_METHOD'] === 'POST') {
                 logActivity('admin.catalogues.update', 'catalogue', (string)$id, [
                     'title' => $title, 'visibility' => $visibility,
                 ]);
-                $success = "Catalogue updated.";
+                $success = "Collection updated.";
                 break;
             }
 
             case 'delete': {
                 $id = (int)($_POST['id'] ?? 0);
-                if ($id <= 0) { $error = 'Catalogue id missing.'; break; }
+                if ($id <= 0) { $error = 'Collection id missing.'; break; }
                 $stmt = $db->prepare('SELECT Title FROM tblCatalogues WHERE Id = ?');
                 $stmt->bind_param('i', $id);
                 $stmt->execute();
                 $row = $stmt->get_result()->fetch_assoc();
                 $stmt->close();
-                if (!$row) { $error = 'Catalogue not found.'; break; }
+                if (!$row) { $error = 'Collection not found.'; break; }
                 $stmt = $db->prepare('DELETE FROM tblCatalogues WHERE Id = ?');
                 $stmt->bind_param('i', $id);
                 $stmt->execute();
@@ -219,7 +219,7 @@ if ($hasSchema && $_SERVER['REQUEST_METHOD'] === 'POST') {
                 logActivity('admin.catalogues.delete', 'catalogue', (string)$id, [
                     'title' => $row['Title'],
                 ]);
-                $success = "Catalogue '{$row['Title']}' deleted.";
+                $success = "Collection '{$row['Title']}' deleted.";
                 break;
             }
 
@@ -327,7 +327,7 @@ if ($hasSchema && !empty($catalogues)) {
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Catalogues — iHymns Admin</title>
+    <title>Collections — iHymns Admin</title>
     <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-libs.php'; ?>
     <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-favicon.php'; ?>
 </head>
@@ -337,10 +337,10 @@ if ($hasSchema && !empty($catalogues)) {
 <main class="container py-3">
 
     <h1 class="h4 mb-3">
-        <i class="bi bi-collection me-1" aria-hidden="true"></i>Catalogues
+        <i class="bi bi-collection me-1" aria-hidden="true"></i>Collections
     </h1>
     <p class="small text-muted mb-3">
-        A <strong>Catalogue</strong> is a free-form many-to-many grouping of songs that sits alongside
+        A <strong>Collection</strong> is a free-form many-to-many grouping of songs that sits alongside
         the Songbook hierarchy. Use it for thematic collections (Christmas, Easter), worship-leader
         curations (Modern, Traditional), denominational groupings, Public-Domain-only views — anything
         where one song should appear in many groupings without duplicating data.
@@ -357,13 +357,13 @@ if ($hasSchema && !empty($catalogues)) {
         <div class="alert alert-warning small">
             <i class="bi bi-database-gear me-1" aria-hidden="true"></i>
             The <code>tblCatalogues</code> table hasn't been created yet. Run the
-            <a href="/manage/setup-database">Catalogues migration</a> to enable this page.
+            <a href="/manage/setup-database">Collections migration</a> to enable this page.
         </div>
     <?php else: ?>
 
         <!-- Add catalogue form -->
         <div class="card-admin p-3 mb-3">
-            <h2 class="h6 mb-2"><i class="bi bi-plus-circle me-1" aria-hidden="true"></i>Add a catalogue</h2>
+            <h2 class="h6 mb-2"><i class="bi bi-plus-circle me-1" aria-hidden="true"></i>Add a collection</h2>
             <form method="POST" class="row g-2 align-items-end small">
                 <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
                 <input type="hidden" name="action" value="add">
@@ -399,7 +399,7 @@ if ($hasSchema && !empty($catalogues)) {
                     <label class="form-label small mb-0">Colour <small class="text-muted">(optional)</small></label>
                     <div class="input-group input-group-sm">
                         <input type="color" class="form-control form-control-color" value="#888888"
-                               title="Pick a colour" aria-label="Catalogue colour swatch"
+                               title="Pick a colour" aria-label="Collection colour swatch"
                                oninput="this.nextElementSibling.value = this.value.toUpperCase()">
                         <input type="text" name="colour" class="form-control" maxlength="7"
                                pattern="#?[0-9A-Fa-f]{6}" placeholder="#RRGGBB — blank = default">
@@ -415,7 +415,7 @@ if ($hasSchema && !empty($catalogues)) {
 
         <!-- Existing catalogues -->
         <?php if (empty($catalogues)): ?>
-            <div class="text-muted small">No catalogues yet — use the form above to create the first one.</div>
+            <div class="text-muted small">No collections yet — use the form above to create the first one.</div>
         <?php else: ?>
             <div class="card-admin p-0 mb-3">
                 <div class="table-responsive">
@@ -451,7 +451,7 @@ if ($hasSchema && !empty($catalogues)) {
                                         <i class="bi bi-music-note-list"></i>
                                     </button>
                                     <form method="POST" class="d-inline"
-                                          onsubmit="return confirm('Delete catalogue \'<?= htmlspecialchars($c['Title'], ENT_QUOTES) ?>\'? This unlinks every member song; the songs themselves are NOT deleted.');">
+                                          onsubmit="return confirm('Delete collection \'<?= htmlspecialchars($c['Title'], ENT_QUOTES) ?>\'? This unlinks every member song; the songs themselves are NOT deleted.');">
                                         <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
                                         <input type="hidden" name="action" value="delete">
                                         <input type="hidden" name="id"     value="<?= (int)$c['Id'] ?>">
@@ -497,7 +497,7 @@ if ($hasSchema && !empty($catalogues)) {
                                             <div class="input-group input-group-sm">
                                                 <input type="color" class="form-control form-control-color"
                                                        value="<?= htmlspecialchars(($c['Colour'] ?? '') !== '' ? (string)$c['Colour'] : '#888888') ?>"
-                                                       title="Pick a colour" aria-label="Catalogue colour swatch"
+                                                       title="Pick a colour" aria-label="Collection colour swatch"
                                                        oninput="this.nextElementSibling.value = this.value.toUpperCase()">
                                                 <input type="text" name="colour" class="form-control"
                                                        value="<?= htmlspecialchars((string)($c['Colour'] ?? '')) ?>"
@@ -518,7 +518,7 @@ if ($hasSchema && !empty($catalogues)) {
                                 <td colspan="6" class="bg-body-secondary">
                                     <h3 class="h6 mb-2"><i class="bi bi-music-note-list me-1"></i>Members of "<?= htmlspecialchars($c['Title']) ?>"</h3>
                                     <?php if (empty($members)): ?>
-                                        <p class="text-muted small mb-2">No songs in this catalogue yet — use the form below to add some.</p>
+                                        <p class="text-muted small mb-2">No songs in this collection yet — use the form below to add some.</p>
                                     <?php else: ?>
                                         <ul class="list-group list-group-flush small mb-2">
                                             <?php foreach ($members as $m): ?>
@@ -531,7 +531,7 @@ if ($hasSchema && !empty($catalogues)) {
                                                         <small class="text-muted ms-2">#<?= (int)$m['SongNumber'] ?></small>
                                                     </span>
                                                     <form method="POST" class="d-inline"
-                                                          onsubmit="return confirm('Remove this song from the catalogue?');">
+                                                          onsubmit="return confirm('Remove this song from the collection?');">
                                                         <input type="hidden" name="csrf_token"   value="<?= htmlspecialchars($csrf) ?>">
                                                         <input type="hidden" name="action"       value="remove_member">
                                                         <input type="hidden" name="catalogue_id" value="<?= (int)$c['Id'] ?>">

--- a/appWeb/public_html/manage/includes/admin-links.php
+++ b/appWeb/public_html/manage/includes/admin-links.php
@@ -53,7 +53,9 @@ $_adminLinks = [
     /* Catalogue — collection / metadata surfaces (#819) */
     ['songbooks',            '/manage/songbooks',              'bi-book',            'Songbooks',             'manage_songbooks',            'Catalogue'  ],
     ['songbook-series',      '/manage/songbook-series',        'bi-collection',      'Songbook Series',       'manage_songbooks',            'Catalogue'  ],
-    ['catalogues',           '/manage/catalogues',             'bi-collection-fill', 'Catalogues',            'manage_songbooks',            'Catalogue'  ],
+    /* User-facing label is "Collections" (#1223); the route + table + entitlement
+       stay 'catalogue(s)' internally (owner decision — keep tblCatalogues). */
+    ['catalogues',           '/manage/catalogues',             'bi-collection-fill', 'Collections',           'manage_songbooks',            'Catalogue'  ],
     ['works',                '/manage/works',                  'bi-diagram-3',       'Works',                 'manage_works',                'Catalogue'  ],
     ['external-link-types',  '/manage/external-link-types',    'bi-link-45deg',      'External-Link Types',   'manage_external_link_types',  'Catalogue'  ],
     ['credit-people',        '/manage/credit-people',          'bi-person-badge',    'Credit People',         'manage_credit_people',        'Catalogue'  ],

--- a/appWeb/public_html/manage/includes/migration-registry.php
+++ b/appWeb/public_html/manage/includes/migration-registry.php
@@ -1931,4 +1931,33 @@ return [
             !_migProbe_columnExists($db, 'tblCatalogues', 'Colour')
             || !_migProbe_columnExists($db, 'tblSongbookSeries', 'Colour'),
     ],
+
+    'theme-vocabulary' => [
+        'script' => 'migrate-seed-theme-vocabulary.php',
+        'card' => [
+            'title'  => 'Standard Theme Vocabulary (CCLI / OpenLyrics) (#1152)',
+            'body'   => 'Adds <code>tblSongTags.ParentId</code> (self-FK for the 2-level theme'
+                      . ' hierarchy), <code>CcliThemeId</code> and <code>Source</code>, then seeds'
+                      . ' the standard CCLI / OpenLyrics theme vocabulary'
+                      . ' (<code>themelist.txt</code>) marked <code>Source=ccli-openlyrics</code>.'
+                      . ' Curators keep adding custom tags; the seed gives Browse-by-Theme and the'
+                      . ' tag typeahead a professional, interoperable baseline. Idempotent — re-runs'
+                      . ' upsert by name, never duplicating.',
+            'button' => 'Run Standard Theme Vocabulary Migration',
+        ],
+        /* Multi-object OR-probe: pending until all three columns exist AND the
+           standard vocabulary has actually been seeded (a partial apply never
+           shows the card green). */
+        'probe' => static function (\mysqli $db): bool {
+            if (!_migProbe_columnExists($db, 'tblSongTags', 'ParentId'))    return true;
+            if (!_migProbe_columnExists($db, 'tblSongTags', 'CcliThemeId')) return true;
+            if (!_migProbe_columnExists($db, 'tblSongTags', 'Source'))      return true;
+            try {
+                $res = $db->query("SELECT 1 FROM tblSongTags WHERE Source = 'ccli-openlyrics' LIMIT 1");
+                $seeded = $res && $res->fetch_row() !== null;
+                if ($res) $res->close();
+                return !$seeded;   /* pending while nothing has been seeded */
+            } catch (\Throwable $_e) { return false; }
+        },
+    ],
 ];

--- a/appWeb/public_html/manage/tags.php
+++ b/appWeb/public_html/manage/tags.php
@@ -27,6 +27,8 @@ declare(strict_types=1);
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'config.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
+/* Shared fuzzy scorer for the canonicalisation suggestions (#1222). */
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'song_similarity.php';
 
 if (!isAuthenticated()) {
     header('Location: /manage/login');
@@ -362,6 +364,64 @@ if ($res) $res->close();
 $tagNameById = [];
 foreach ($allTagsForMerge as $t) { $tagNameById[(int)$t['Id']] = (string)$t['Name']; }
 
+/* ----------------------------------------------------------------------
+ * Canonicalisation suggestions (#1222) — fold curator-added tags whose
+ * spelling closely matches a seeded standard theme into that theme.
+ * Exact case/spacing/diacritic variants were already promoted at seed
+ * time (the upsert is collation-insensitive on Name); this catches the
+ * FUZZY remainder (typos: "Resurrection"/"Resurection", "Thankfulness"/
+ * "Thanksgiving"-ish). Curator-confirmed via the existing Merge action —
+ * never auto-applied. Skipped entirely until the migration has run.
+ * ---------------------------------------------------------------------- */
+$canonSuggestions = [];
+if ($hasThemeCols) {
+    $std = [];
+    $sr = $db->query("SELECT Id, Name FROM tblSongTags WHERE Source = 'ccli-openlyrics'");
+    while ($sr && ($row = $sr->fetch_assoc())) {
+        $std[] = ['id' => (int)$row['Id'], 'name' => (string)$row['Name'], 'norm' => ihymns_sim_normalise((string)$row['Name'])];
+    }
+    if ($sr) { $sr->close(); }
+
+    if ($std) {
+        /* Curator tags, most-used first; bounded so the pairwise pass stays cheap. */
+        $cr = $db->query(
+            "SELECT t.Id, t.Name, COUNT(m.TagId) AS UseCount
+               FROM tblSongTags t
+               LEFT JOIN tblSongTagMap m ON m.TagId = t.Id
+              WHERE t.Source <> 'ccli-openlyrics'
+              GROUP BY t.Id
+              ORDER BY UseCount DESC, t.Name ASC
+              LIMIT 300"
+        );
+        while ($cr && ($row = $cr->fetch_assoc())) {
+            $cn = ihymns_sim_normalise((string)$row['Name']);
+            if ($cn === '') { continue; }
+            $best = null; $bestScore = 0.0;
+            foreach ($std as $s) {
+                if ($s['norm'] === '') { continue; }
+                $score = ($cn === $s['norm']) ? 1.0 : ihymns_sim_text($cn, $s['norm']);
+                if ($score > $bestScore) { $bestScore = $score; $best = $s; }
+            }
+            /* >= 0.84 catches close spellings/typos; the strcasecmp guard is a
+               belt-and-braces no-op (the unique Name index already prevents a
+               curator row from ci-colliding with a standard one). */
+            if ($best && $bestScore >= 0.84 && strcasecmp((string)$row['Name'], $best['name']) !== 0) {
+                $canonSuggestions[] = [
+                    'curId'   => (int)$row['Id'],
+                    'curName' => (string)$row['Name'],
+                    'uses'    => (int)$row['UseCount'],
+                    'stdId'   => $best['id'],
+                    'stdName' => $best['name'],
+                    'score'   => $bestScore,
+                ];
+            }
+        }
+        if ($cr) { $cr->close(); }
+        usort($canonSuggestions, static fn($a, $b) => $b['score'] <=> $a['score']);
+        $canonSuggestions = array_slice($canonSuggestions, 0, 50);
+    }
+}
+
 require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-favicon.php';
 ?>
 <!DOCTYPE html>
@@ -418,6 +478,50 @@ require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head
     <p class="small text-secondary mb-2">
         <strong><?= count($rows) ?></strong> of <strong><?= number_format($totalRows) ?></strong> tag(s). Page <?= $pageNum ?>/<?= $totalPages ?>.
     </p>
+
+    <?php if (!empty($canonSuggestions)): ?>
+    <div class="card mb-3 border-info">
+        <div class="card-body py-2">
+            <h2 class="h6 mb-1"><i class="bi bi-magic me-1"></i>Canonicalisation suggestions (<?= count($canonSuggestions) ?>)</h2>
+            <p class="small text-secondary mb-2">
+                Curator tags whose spelling closely matches a
+                <span class="badge bg-info-subtle text-info-emphasis border border-info-subtle">standard</span>
+                theme. <strong>Fold</strong> re-points every song to the standard theme and removes the
+                variant (the existing Merge — irreversible). Review each before folding.
+            </p>
+            <div class="table-responsive">
+                <table class="table table-sm align-middle mb-0">
+                    <thead>
+                        <tr>
+                            <th>Variant tag</th><th class="text-end">Songs</th><th></th>
+                            <th>Standard theme</th><th>Match</th><th class="text-end">Action</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    <?php foreach ($canonSuggestions as $s): ?>
+                        <tr>
+                            <td><strong><?= htmlspecialchars($s['curName'], ENT_QUOTES, 'UTF-8') ?></strong></td>
+                            <td class="text-end"><?= number_format($s['uses']) ?></td>
+                            <td class="text-secondary">→</td>
+                            <td><?= htmlspecialchars($s['stdName'], ENT_QUOTES, 'UTF-8') ?></td>
+                            <td><span class="badge bg-secondary"><?= (int)round($s['score'] * 100) ?>%</span></td>
+                            <td class="text-end">
+                                <button class="btn btn-sm btn-outline-warning tag-canon-btn"
+                                        data-source="<?= (int)$s['curId'] ?>"
+                                        data-target="<?= (int)$s['stdId'] ?>"
+                                        data-source-name="<?= htmlspecialchars($s['curName'], ENT_QUOTES, 'UTF-8') ?>"
+                                        data-target-name="<?= htmlspecialchars($s['stdName'], ENT_QUOTES, 'UTF-8') ?>">
+                                    <i class="bi bi-arrow-down-up me-1"></i>Fold into standard
+                                </button>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+    <?php endif; ?>
 
     <div class="table-responsive">
         <table class="table table-dark table-striped table-hover align-middle cp-sortable">
@@ -648,6 +752,25 @@ require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head
         if (!r.ok) { alert(d?.error || 'Merge failed.'); return; }
         alert('Merged. Repointed ' + d.repointed + ' mapping(s); ' + d.conflicts + ' duplicate(s) collapsed.');
         window.location.reload();
+    });
+
+    /* Canonicalisation (#1222): fold a variant tag into its standard theme.
+       Reuses the merge action — source = variant (deleted), target = standard. */
+    document.querySelectorAll('.tag-canon-btn').forEach((btn) => {
+        btn.addEventListener('click', async () => {
+            if (!confirm('Fold "' + (btn.dataset.sourceName || '') + '" into the standard theme "'
+                + (btn.dataset.targetName || '') + '"? Every song is re-pointed to the standard theme and '
+                + 'the variant is deleted. This is irreversible.')) return;
+            btn.disabled = true;
+            const body = new URLSearchParams({
+                csrf_token: CSRF, action: 'merge',
+                source_id: btn.dataset.source, target_id: btn.dataset.target,
+            });
+            const r = await fetch(URL_, { method: 'POST', body, credentials: 'same-origin' });
+            const d = await r.json().catch(() => ({}));
+            if (!r.ok || !d.success) { btn.disabled = false; alert(d?.error || 'Fold failed.'); return; }
+            const row = btn.closest('tr'); if (row) row.remove();
+        });
     });
 })();
 </script>

--- a/appWeb/public_html/manage/tags.php
+++ b/appWeb/public_html/manage/tags.php
@@ -43,6 +43,13 @@ $activePage = 'tags';
 $db   = getDbMysqli();
 $csrf = csrfToken();
 
+/* #1152 — the standard-vocabulary columns (Source / ParentId / CcliThemeId)
+   land via migrate-seed-theme-vocabulary.php. Probe so this page degrades
+   gracefully on a long-running install that hasn't applied it yet. */
+$hasThemeCols = false;
+$probe = $db->query("SHOW COLUMNS FROM tblSongTags LIKE 'Source'");
+if ($probe) { $hasThemeCols = $probe->num_rows > 0; $probe->close(); }
+
 $logTag = static function (string $action, string $entityId, array $details, string $result = 'success'): void {
     if (function_exists('logActivity')) {
         try { logActivity('tag.' . $action, 'tag', $entityId, $details, $result); }
@@ -326,7 +333,10 @@ $totalPages = max(1, (int)ceil($totalRows / $pageSize));
 $pageNum    = min($pageNum, $totalPages);
 $offset     = ($pageNum - 1) * $pageSize;
 
-$listSql = 'SELECT t.Id, t.Name, t.Slug, t.Description, COUNT(m.TagId) AS UseCount
+/* Source + ParentId are functionally dependent on t.Id (PK) so they're safe
+   under ONLY_FULL_GROUP_BY; only select them once the migration has run. */
+$themeCols = $hasThemeCols ? ', t.Source AS Source, t.ParentId AS ParentId' : '';
+$listSql = 'SELECT t.Id, t.Name, t.Slug, t.Description, COUNT(m.TagId) AS UseCount' . $themeCols . '
             FROM tblSongTags t
             LEFT JOIN tblSongTagMap m ON m.TagId = t.Id'
          . $where
@@ -347,6 +357,10 @@ $stmt->close();
 $res = $db->query('SELECT Id, Name FROM tblSongTags ORDER BY Name ASC');
 $allTagsForMerge = $res ? $res->fetch_all(MYSQLI_ASSOC) : [];
 if ($res) $res->close();
+/* Id → Name map so the list can show a child theme's parent without a
+   GROUP BY-unfriendly self-join (#1152). */
+$tagNameById = [];
+foreach ($allTagsForMerge as $t) { $tagNameById[(int)$t['Id']] = (string)$t['Name']; }
 
 require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-favicon.php';
 ?>
@@ -376,8 +390,10 @@ require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head
             </h1>
             <p class="text-secondary small mb-0">
                 Curator-managed taxonomy that powers the public Browse-by-Theme home section and
-                <code>/tag/&lt;slug&gt;</code> listing pages. Use <strong>Merge</strong> to collapse
-                duplicate-meaning tags into one canonical row.
+                <code>/tag/&lt;slug&gt;</code> listing pages. Rows badged <span class="badge bg-info-subtle text-info-emphasis border border-info-subtle">standard</span>
+                are the seeded CCLI / OpenLyrics theme vocabulary (#1152) — the editor's tag typeahead autofills
+                from this list, so curators reuse the canonical spelling instead of re-typing variants. Use
+                <strong>Merge</strong> to fold a duplicate-meaning tag into its canonical row.
             </p>
         </div>
         <div class="d-flex gap-2">
@@ -419,7 +435,16 @@ require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head
                 <tr><td colspan="5" class="text-center text-secondary py-4">No tags match.</td></tr>
             <?php else: foreach ($rows as $r): ?>
                 <tr data-tag-id="<?= (int)$r['Id'] ?>">
-                    <td><strong><?= htmlspecialchars($r['Name'], ENT_QUOTES, 'UTF-8') ?></strong></td>
+                    <td>
+                        <strong><?= htmlspecialchars($r['Name'], ENT_QUOTES, 'UTF-8') ?></strong>
+                        <?php if (($r['Source'] ?? '') === 'ccli-openlyrics'): ?>
+                            <span class="badge bg-info-subtle text-info-emphasis border border-info-subtle ms-1"
+                                  title="Standard CCLI / OpenLyrics theme (#1152)">standard</span>
+                        <?php endif; ?>
+                        <?php $pid = (int)($r['ParentId'] ?? 0); if ($pid > 0 && isset($tagNameById[$pid])): ?>
+                            <div class="small text-muted"><i class="bi bi-diagram-2 me-1"></i>under <?= htmlspecialchars($tagNameById[$pid], ENT_QUOTES, 'UTF-8') ?></div>
+                        <?php endif; ?>
+                    </td>
                     <td><code><?= htmlspecialchars($r['Slug'], ENT_QUOTES, 'UTF-8') ?></code></td>
                     <td class="small text-secondary">
                         <?= $r['Description'] !== ''


### PR DESCRIPTION
## Standard theme vocabulary + Collections

**Base:** `claude/duplicate-songs-review-gb3hzn` (⚠️ **STACKED** — see below), ultimately → `alpha`.

> **Why stacked, not direct to `alpha`:** the #1222 canonicalisation panel `require`s `includes/song_similarity.php`, which is introduced by the **Duplicate &amp; Counterpart** PR (#1216) and is **not** on `alpha`. Merging this PR to `alpha` first would fatal-error `/manage/tags`. Basing it on the duplicate-songs branch keeps this PR's diff to just the 4 commits below; GitHub auto-retargets the base to `alpha` once the duplicate-songs PR merges. **➡️ Merge the Duplicate &amp; Counterpart PR first.**

### Commits
- **#1152** `f0fce7f` — seed the standard CCLI/OpenLyrics theme vocabulary (**144 themelist.txt lines → 142 canonical nodes**) + add `tblSongTags.ParentId` (self-FK hierarchy), `CcliThemeId`, `Source`. Migration + byte-identical `schema.sql` mirror + one `migration-registry` entry with a real multi-object OR-probe; idempotent, collisions collapse to the canonical node.
- **#1152** `98f6b30` — `/manage/tags` badges **standard** + shows parent hierarchy (column-probe-guarded). Autofill works for free — the editor's `tag_search` typeahead already reads `tblSongTags`.
- **#1222** `9f2e6f1` — fuzzy **"Canonicalisation suggestions"** panel (scored via the shared `song_similarity.php`); **"Fold into standard"** reuses the page's existing transactional Merge.
- **#1223** `2212ce4` — rename **Catalogue → "Collection"** across the admin UI (display-only; route/table/log-keys/entitlement stay `catalogue`).

### Testing
- `php -l` whole-tree clean; inline JS `node --check` clean.
- Schema-coverage (825 cols) + migration-registry CI guards green.
- ⚠️ Migration apply + the tags/collections pages want a live-DB alpha pass.

Closes #1152, #1222. Advances #1223 — the end-user "badge unofficial songbooks as Songbooks" surface remains (a frontend songbook-card change; `isOfficial` is already exposed).

https://claude.ai/code/session_01Aw9jFfwj5rxLcUxWZyGuCV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw9jFfwj5rxLcUxWZyGuCV)_