### PR TITLE
fix(duplicates): detection queried non-existent tblSongComponents.Body — use LinesJson

### DIFF
--- a/appWeb/public_html/includes/tools/build-song-link-suggestions.php
+++ b/appWeb/public_html/includes/tools/build-song-link-suggestions.php
@@ -115,10 +115,10 @@ $res = $db->query(
             s.Ccli,
             COALESCE(GROUP_CONCAT(DISTINCT w.Name SEPARATOR '|'), '') AS Writers,
             COALESCE(GROUP_CONCAT(DISTINCT c.Name SEPARATOR '|'), '') AS Composers,
-            (SELECT cmp.Body
+            (SELECT cmp.LinesJson
                FROM tblSongComponents cmp
               WHERE cmp.SongId = s.SongId
-              ORDER BY cmp.SortOrder ASC LIMIT 1) AS FirstComponentBody
+              ORDER BY cmp.SortOrder ASC LIMIT 1) AS FirstComponentLines
        FROM tblSongs s
        LEFT JOIN tblSongWriters   w ON w.SongId = s.SongId
        LEFT JOIN tblSongComposers c ON c.SongId = s.SongId
@@ -138,12 +138,16 @@ while ($row = $res->fetch_assoc()) {
     $normTitle = ihymns_sim_normalise($title);
     if ($normTitle === '') continue;
     $firstLine = '';
-    $body = (string)($row['FirstComponentBody'] ?? '');
-    if ($body !== '') {
-        /* First non-empty line of the first component. */
-        foreach (preg_split('/\r?\n/', $body) ?: [] as $ln) {
-            $ln = trim($ln);
-            if ($ln !== '') { $firstLine = $ln; break; }
+    /* The first component's lyrics live in LinesJson (a JSON array of lines),
+       not a `Body` column — decode it and take the first non-empty line. */
+    $linesJson = (string)($row['FirstComponentLines'] ?? '');
+    if ($linesJson !== '') {
+        $lines = json_decode($linesJson, true);
+        if (is_array($lines)) {
+            foreach ($lines as $ln) {
+                $ln = trim((string)$ln);
+                if ($ln !== '') { $firstLine = $ln; break; }
+            }
         }
     }
     $bagKey = (string)$row['Language'] . '|' . mb_substr($normTitle, 0, 1, 'UTF-8');

--- a/appWeb/public_html/manage/duplicate-songs.php
+++ b/appWeb/public_html/manage/duplicate-songs.php
@@ -592,8 +592,8 @@ foreach (array_chunk($candidateIds, 200) as $chunk) {
         "SELECT s.SongId,
                 COALESCE(GROUP_CONCAT(DISTINCT w.Name SEPARATOR '|'), '') AS Writers,
                 COALESCE(GROUP_CONCAT(DISTINCT c.Name SEPARATOR '|'), '') AS Composers,
-                (SELECT cmp.Body FROM tblSongComponents cmp
-                  WHERE cmp.SongId = s.SongId ORDER BY cmp.SortOrder ASC LIMIT 1) AS FirstBody,
+                (SELECT cmp.LinesJson FROM tblSongComponents cmp
+                  WHERE cmp.SongId = s.SongId ORDER BY cmp.SortOrder ASC LIMIT 1) AS FirstLines,
                 (SELECT COUNT(*) FROM tblLyrics l WHERE l.SongId = s.SongId) AS LyricsCount
            FROM tblSongs s
            LEFT JOIN tblSongWriters   w ON w.SongId = s.SongId
@@ -608,11 +608,16 @@ foreach (array_chunk($candidateIds, 200) as $chunk) {
         $sid = (string)$row['SongId'];
         /* First non-empty line of the first component = the strongest signal. */
         $firstLine = '';
-        $body = (string)($row['FirstBody'] ?? '');
-        if ($body !== '') {
-            foreach (preg_split('/\r?\n/', $body) ?: [] as $ln) {
-                $ln = trim($ln);
-                if ($ln !== '') { $firstLine = $ln; break; }
+        /* Lyrics live in LinesJson (a JSON array), not a `Body` column — decode
+           it and take the first non-empty line (the strongest dedup signal). */
+        $linesJson = (string)($row['FirstLines'] ?? '');
+        if ($linesJson !== '') {
+            $lines = json_decode($linesJson, true);
+            if (is_array($lines)) {
+                foreach ($lines as $ln) {
+                    $ln = trim((string)$ln);
+                    if ($ln !== '') { $firstLine = $ln; break; }
+                }
             }
         }
         $s = $songs[$sid] ?? [];


### PR DESCRIPTION
Fixes #1231.

**Symptom:** `/manage/duplicate-songs` 500s on load — *"Duplicate detection couldn't run … Unknown column 'cmp.Body'"* (the "apply a migration" hint is a red herring).

**Cause:** the first-lyric-line signal was read as `(SELECT cmp.Body FROM tblSongComponents cmp …)`, but `tblSongComponents` has **no `Body` column** — lyrics are in **`LinesJson`** (a JSON array). Two copies carried it:
- `includes/tools/build-song-link-suggestions.php` — the rebuild engine
- `manage/duplicate-songs.php` — the page's live scoring query (the one that 500s on load)

**Fix:** both `SELECT cmp.LinesJson` and `json_decode` it to take the first non-empty line, preserving the prior semantics. No schema/migration change — the column already exists. `php -l` clean.

Synced off the latest `origin/alpha` first (your #1216 shared-similarity refactor + Isrc/Iswc/Ccli) so the fix is against current code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)