### PR TITLE
feat(maintenance): per-environment maintenance mode + WordPress-style admin bypass (#1233)

### DIFF
--- a/appWeb/public_html/includes/environment.php
+++ b/appWeb/public_html/includes/environment.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — canonical deploy-environment detector (#1233)
+ *
+ * Returns 'alpha' | 'beta' | 'production'. All branches deploy from one source
+ * tree, so the environment is the SFTP *destination* directory — detected from
+ * DOCUMENT_ROOT / SCRIPT_FILENAME (mirrors infoAppVer.php's Development.Status
+ * logic), with a CI-injected `.env-channel` file as the fallback. Cached per
+ * request.
+ *
+ * This matters because all three environments share ONE database, so anything
+ * that must behave per-environment (e.g. per-env maintenance mode) keys off this
+ * rather than a single shared flag.
+ *
+ * @return string One of 'alpha', 'beta', 'production'.
+ */
+function ihymns_environment(): string
+{
+    static $env = null;
+    if ($env !== null) {
+        return $env;
+    }
+    $path = (string)($_SERVER['DOCUMENT_ROOT'] ?? $_SERVER['SCRIPT_FILENAME'] ?? '');
+    if (str_contains($path, 'public_html_dev')) {
+        return $env = 'alpha';
+    }
+    if (str_contains($path, 'public_html_beta')) {
+        return $env = 'beta';
+    }
+    /* CI/CD-injected channel file fallback (public_html/.env-channel). */
+    $channelFile = dirname(__DIR__) . DIRECTORY_SEPARATOR . '.env-channel';
+    if (is_file($channelFile)) {
+        $ch = trim((string)@file_get_contents($channelFile));
+        if ($ch === 'alpha') { return $env = 'alpha'; }
+        if ($ch === 'beta')  { return $env = 'beta'; }
+    }
+    return $env = 'production';
+}

--- a/appWeb/public_html/includes/maintenance.php
+++ b/appWeb/public_html/includes/maintenance.php
@@ -24,6 +24,16 @@ if (basename($_SERVER['SCRIPT_FILENAME'] ?? '') === basename(__FILE__)) {
     exit('Access denied.');
 }
 
+/* #1233 — maintenance mode is PER-ENVIRONMENT (alpha/beta/production share one
+   DB), so every flag is keyed by the current environment. */
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'environment.php';
+
+/** Env-suffixed settings key, e.g. maintenance_mode_alpha / _beta / _production. */
+function maintenanceSettingKey(string $base): string
+{
+    return $base . '_' . ihymns_environment();
+}
+
 /**
  * Read a tblAppSettings value, memoized per request. Returns $default on ANY
  * DB error so a maintenance/flag check never throws on a DB outage.
@@ -54,16 +64,57 @@ function getAppSetting(string $key, ?string $default = null): ?string
     return $cache[$key];
 }
 
-/** Is the site in admin-triggered maintenance mode? (false on a DB error.) */
+/** Is THIS environment in admin-triggered maintenance mode? (false on a DB error.) */
 function isMaintenanceMode(): bool
 {
-    return getAppSetting('maintenance_mode', '0') === '1';
+    return getAppSetting(maintenanceSettingKey('maintenance_mode'), '0') === '1';
+}
+
+/** May regular admins (not just global admins) bypass maintenance on THIS env?
+ *  Off by default — the global admin opts in per environment. (#1233) */
+function maintenanceAllowAdmins(): bool
+{
+    return getAppSetting(maintenanceSettingKey('maintenance_allow_admins'), '0') === '1';
+}
+
+/**
+ * Is the CURRENT request from a user allowed to bypass the maintenance page
+ * (WordPress-style "logged-in admins still see the live site")? Global admins
+ * always; regular admins only when this env's allow-admins flag is on. Everyone
+ * else (logged-out, regular users) is gated. Default-DENY on any uncertainty.
+ *
+ * Auth is loaded lazily here — only reached when maintenance is ON — so the
+ * normal (session-less) public hot path pays nothing. It reuses isAuthenticated()
+ * / getCurrentUser(), which resolve the cross-surface `ihymns_auth` API token
+ * (the /manage/ PHP-session cookie is path-scoped and never reaches the public
+ * site), so the bypass is the user's REAL authenticated identity, not spoofable.
+ */
+function maintenanceUserMayBypass(): bool
+{
+    try {
+        require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'manage'
+            . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+        if (!function_exists('isAuthenticated') || !isAuthenticated()) {
+            return false;
+        }
+        $user = function_exists('getCurrentUser') ? getCurrentUser() : null;
+        $role = is_array($user) ? (string)($user['role'] ?? '') : '';
+        if ($role === 'global_admin') {
+            return true;   // global admins always get through
+        }
+        if ($role === 'admin' && maintenanceAllowAdmins()) {
+            return true;   // regular admins only if the global admin enabled it for this env
+        }
+        return false;
+    } catch (\Throwable $_e) {
+        return false;      // any error → show the maintenance page (fail safe)
+    }
 }
 
 /** The admin-configured maintenance message, or a sensible default. */
 function maintenanceMessage(): string
 {
-    $msg = trim((string)getAppSetting('maintenance_message', ''));
+    $msg = trim((string)getAppSetting(maintenanceSettingKey('maintenance_message'), ''));
     return $msg !== ''
         ? $msg
         : "iHymns is undergoing scheduled maintenance. We'll be back shortly — please check again in a few minutes.";
@@ -114,6 +165,12 @@ function enforceMaintenanceForPublicSite(): void
     if (!isMaintenanceMode()) {
         return;
     }
+    if (maintenanceUserMayBypass()) {
+        /* Admin bypass — see the live site; index.php renders a "maintenance is
+           on" banner so the admin knows visitors are being gated. */
+        $GLOBALS['_ihymnsMaintenanceBypass'] = true;
+        return;
+    }
     renderMaintenancePageHtml();
     exit;
 }
@@ -137,6 +194,9 @@ function enforceMaintenanceForApi(): void
     $action = (string)($_GET['action'] ?? '');
     if ($action === 'app_status' || strncmp($action, 'auth_', 5) === 0) {
         return;
+    }
+    if (maintenanceUserMayBypass()) {
+        return;   // authenticated admin — let their API calls through during maintenance
     }
 
     maintenanceSend503Headers();

--- a/appWeb/public_html/index.php
+++ b/appWeb/public_html/index.php
@@ -863,6 +863,12 @@ if (!empty($breadcrumbItems)) {
 </head>
 
 <body class="d-flex flex-column min-vh-100">
+<?php if (!empty($GLOBALS['_ihymnsMaintenanceBypass'])): /* #1233 — admin is bypassing maintenance; make that obvious. Self-contained styles (no icon/CSS deps). */ ?>
+    <div role="status" style="position:sticky;top:0;z-index:1080;background:#ffc107;color:#000;text-align:center;padding:0.5rem 1rem;font-size:0.85rem;line-height:1.3;">
+        🔧 <strong>Maintenance mode is ON</strong> for this environment — visitors see a maintenance page; you have admin access.
+        <a href="/manage/configuration" style="color:#000;text-decoration:underline;font-weight:600;">Turn it off</a>.
+    </div>
+<?php endif; ?>
     <!-- ================================================================
          SKIP NAVIGATION LINK — Accessibility: allows keyboard users
          to skip directly to main content.

--- a/appWeb/public_html/manage/configuration.php
+++ b/appWeb/public_html/manage/configuration.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'config.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'environment.php'; // #1233 per-env maintenance
 
 if (!isAuthenticated()) {
     header('Location: /manage/login');
@@ -228,22 +229,28 @@ if (($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'POST') {
                into a 503 maintenance landing page; /manage stays reachable
                (separate entry point) so this can always be turned back off. */
             try {
-                $mmVal  = ((string)($_POST['maintenance_mode'] ?? '0')) === '1' ? '1' : '0';
-                $msgVal = mb_substr(trim((string)($_POST['maintenance_message'] ?? '')), 0, 500);
-                $saveSetting($db, 'maintenance_mode', $mmVal);
-                $saveSetting($db, 'maintenance_message', $msgVal);
+                /* #1233 — per-environment maintenance. The shared DB means each
+                   env keys its own flags; this form toggles the CURRENT env only.
+                   Manage another env from its own /manage. */
+                $env      = ihymns_environment();
+                $mmVal    = ((string)($_POST['maintenance_mode'] ?? '0')) === '1' ? '1' : '0';
+                $msgVal   = mb_substr(trim((string)($_POST['maintenance_message'] ?? '')), 0, 500);
+                $allowVal = ((string)($_POST['maintenance_allow_admins'] ?? '0')) === '1' ? '1' : '0';
+                $saveSetting($db, 'maintenance_mode_' . $env, $mmVal);
+                $saveSetting($db, 'maintenance_message_' . $env, $msgVal);
+                $saveSetting($db, 'maintenance_allow_admins_' . $env, $allowVal);
                 if (function_exists('logActivity')) {
                     logActivity(
                         'app_setting.update',
                         'app_setting',
-                        'maintenance_mode',
-                        ['keys' => ['maintenance_mode', 'maintenance_message'], 'enabled' => $mmVal === '1'],
+                        'maintenance_mode_' . $env,
+                        ['keys' => ['maintenance_mode_' . $env, 'maintenance_message_' . $env, 'maintenance_allow_admins_' . $env], 'enabled' => $mmVal === '1'],
                         'success'
                     );
                 }
                 $saveSuccess = $mmVal === '1'
-                    ? 'Maintenance mode is now ON — the public site shows a maintenance page; /manage stays open so you can turn it off.'
-                    : 'Maintenance mode is now OFF — the public site is live again.';
+                    ? ('Maintenance mode is now ON for ' . $env . ' — that environment\'s public site shows a maintenance page; /manage stays open so you can turn it off.')
+                    : ('Maintenance mode is now OFF for ' . $env . ' — its public site is live again.');
             } catch (\Throwable $e) {
                 error_log('[manage configuration save_maintenance] ' . $e->getMessage());
                 $saveError = 'Save failed: ' . $e->getMessage();
@@ -257,9 +264,15 @@ if (($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'POST') {
  * ---------------------------------------------------------------------- */
 $currentSettings    = $loadSettings($db, array_keys($EMAIL_SETTINGS));
 $currentService     = $currentSettings['email_service'] ?? 'none';
-$maintenanceSettings = $loadSettings($db, ['maintenance_mode', 'maintenance_message']);
-$maintenanceOn       = ($maintenanceSettings['maintenance_mode'] ?? '0') === '1';
-$maintenanceMsg      = (string)($maintenanceSettings['maintenance_message'] ?? '');
+$envCurrent          = ihymns_environment();   // #1233 — per-env maintenance keys
+$maintenanceSettings = $loadSettings($db, [
+    'maintenance_mode_' . $envCurrent,
+    'maintenance_message_' . $envCurrent,
+    'maintenance_allow_admins_' . $envCurrent,
+]);
+$maintenanceOn       = ($maintenanceSettings['maintenance_mode_' . $envCurrent] ?? '0') === '1';
+$maintenanceMsg      = (string)($maintenanceSettings['maintenance_message_' . $envCurrent] ?? '');
+$maintenanceAllowAdm = ($maintenanceSettings['maintenance_allow_admins_' . $envCurrent] ?? '0') === '1';
 
 require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-favicon.php';
 ?>
@@ -312,6 +325,7 @@ require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head
         <div class="card-header d-flex align-items-center justify-content-between">
             <h2 class="h5 mb-0">
                 <i class="bi bi-cone-striped me-2"></i>System maintenance
+                <span class="badge bg-secondary ms-1 text-uppercase"><?= htmlspecialchars($envCurrent, ENT_QUOTES, 'UTF-8') ?></span>
             </h2>
             <span class="badge <?= $maintenanceOn ? 'bg-danger' : 'bg-success' ?>">
                 <?= $maintenanceOn ? 'ON — public site in maintenance' : 'OFF — site is live' ?>
@@ -323,6 +337,14 @@ require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head
                 visitors. This admin area (<code>/manage</code>) and sign-in stay
                 available so you can turn it back off. Returning app users keep
                 their cached offline experience and see a maintenance banner.
+            </p>
+            <p class="small text-secondary mb-3">
+                <i class="bi bi-hdd-network me-1"></i><strong>Per-environment.</strong>
+                The three environments share one database, but each has its own flag —
+                this toggles <strong><?= htmlspecialchars($envCurrent, ENT_QUOTES, 'UTF-8') ?></strong>
+                only. Manage another environment from <em>its own</em> <code>/manage</code>.
+                <strong>Global admins</strong> always keep access to the live site while
+                maintenance is on; you can optionally extend that to regular admins below.
             </p>
             <form method="post">
                 <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8') ?>">
@@ -339,6 +361,16 @@ require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head
                     <textarea name="maintenance_message" id="maintenance_message" class="form-control" rows="2"
                               maxlength="500"
                               placeholder="We&rsquo;ll be back shortly &mdash; scheduled maintenance in progress."><?= htmlspecialchars($maintenanceMsg, ENT_QUOTES, 'UTF-8') ?></textarea>
+                </div>
+                <!-- hidden 0 so an unchecked box still posts a value -->
+                <input type="hidden" name="maintenance_allow_admins" value="0">
+                <div class="form-check mb-3">
+                    <input class="form-check-input" type="checkbox" id="maintenance_allow_admins"
+                           name="maintenance_allow_admins" value="1" <?= $maintenanceAllowAdm ? 'checked' : '' ?>>
+                    <label class="form-check-label" for="maintenance_allow_admins">
+                        Also let <strong>regular admins</strong> bypass maintenance on this environment
+                        <span class="text-secondary">(global admins always can)</span>
+                    </label>
                 </div>
                 <button type="submit" class="btn btn-primary">
                     <i class="bi bi-save me-1"></i>Save maintenance settings


### PR DESCRIPTION
Closes #1233.

**Problem:** maintenance mode was a single shared-DB flag, so toggling it took **all three environments down at once**, and a logged-in admin on the public site got the 503 too.

## Per-environment
New `includes/environment.php` (`ihymns_environment()`, mirrors `infoAppVer`'s deploy-path detection). All flags are env-keyed — `maintenance_mode_<env>` / `_message_<env>` / `_allow_admins_<env>` — so **production can be in maintenance while alpha/beta stay live**. The config panel toggles the current env (manage another from its own `/manage`).

## Admin bypass (WordPress-style)
`maintenanceUserMayBypass()` lets **global_admin** through **always**, **regular admins** only when this env's allow-admins flag is set, everyone else gated. It is:
- **Fail-safe** — any error → maintenance page (try/catch default-deny)
- **Non-spoofable** — real authenticated identity via the cross-surface `ihymns_auth` token (the `/manage` session cookie is path-scoped)
- **Zero hot-path cost** — auth loaded lazily, only when maintenance is on

A sticky banner tells a bypassing admin maintenance is on. Settings are `tblAppSettings` rows — **no migration**.

**Security-reviewed (8/8 positive):** non-spoofable, role logic correct, per-env isolation correct, CSRF enforced, output escaped, DB-down fails safe. `php -l` clean. Synced off latest alpha.