### PR TITLE
fix(history): create tblSongHistory so Recently-Viewed syncs across devices (#1236)

### DIFF
--- a/appWeb/.sql/migrate-song-history.php
+++ b/appWeb/.sql/migrate-song-history.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Create tblSongHistory on existing installs (#1236)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * `tblSongHistory` (recently-viewed / most-popular) has long been declared in
+ * schema.sql, so FRESH installs get it — but **no migration ever created it for
+ * long-running installs** (alpha / beta / production predate the table). The
+ * result: the `song_history` API handler hits "table doesn't exist", returns
+ * `{ fallback: true }`, and the client silently falls back to per-device
+ * `localStorage` — so a signed-in user's Recently-Viewed list differs across
+ * devices. The client + API (#546 / #549 / WS-G #1019) are already built; only
+ * the table was missing on existing installs.
+ *
+ * This idempotent migration creates the table (DDL byte-identical to schema.sql)
+ * so the server-side, cross-device Recently-Viewed sync works.
+ *
+ * STRICTLY ADDITIVE + IDEMPOTENT (CREATE TABLE IF NOT EXISTS).
+ *
+ * @migration-adds tblSongHistory
+ *
+ * USAGE:
+ *   Web:  /manage/setup-database → "Recently-Viewed history table"
+ *   CLI:  php appWeb/.sql/migrate-song-history.php
+ */
+
+$isCli = (PHP_SAPI === 'cli');
+if (!defined('IHYMNS_SETUP_DASHBOARD') && !function_exists('getDbMysqli')) {
+    require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+}
+
+function _migSongHistory_out(string $msg): void
+{
+    global $isCli;
+    echo $msg . ($isCli ? "\n" : "<br>\n");
+    if (!$isCli) { @flush(); }
+}
+
+$db = function_exists('getDbMysqli') ? getDbMysqli() : null;
+if (!($db instanceof mysqli)) {
+    _migSongHistory_out('ERROR: could not connect to database.');
+    if ($isCli) { exit(1); }
+    return;
+}
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+_migSongHistory_out('=== iHymns — tblSongHistory (recently-viewed) for existing installs (#1236) ===');
+
+try {
+    $has = $db->query("SHOW TABLES LIKE 'tblSongHistory'");
+    if ($has && $has->num_rows > 0) {
+        _migSongHistory_out('  [SKIP] tblSongHistory already present.');
+    } else {
+        /* DDL byte-identical to appWeb/.sql/schema.sql (rule #19) so a migrated
+           install equals a fresh one. */
+        $db->query(
+            "CREATE TABLE IF NOT EXISTS tblSongHistory (
+    Id              BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    UserId          INT UNSIGNED    NULL COMMENT 'NULL for anonymous views',
+    SongId          VARCHAR(20)     NOT NULL,
+    ViewedAt        TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    INDEX idx_User      (UserId),
+    INDEX idx_Song      (SongId),
+    INDEX idx_ViewedAt  (ViewedAt),
+
+    CONSTRAINT fk_History_User
+        FOREIGN KEY (UserId) REFERENCES tblUsers(Id)
+        ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT fk_History_Song
+        FOREIGN KEY (SongId) REFERENCES tblSongs(SongId)
+        ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci"
+        );
+        _migSongHistory_out('  [OK] Created tblSongHistory.');
+    }
+    _migSongHistory_out('');
+    _migSongHistory_out('Migration complete — signed-in Recently-Viewed now syncs server-side across devices.');
+} catch (\Throwable $e) {
+    _migSongHistory_out('  [ERROR] ' . $e->getMessage());
+    if ($isCli) { exit(1); }
+    return;
+}
+
+return;

--- a/appWeb/public_html/manage/includes/migration-registry.php
+++ b/appWeb/public_html/manage/includes/migration-registry.php
@@ -1382,6 +1382,22 @@ return [
             !_migProbe_tableExists($db, 'tblUserCustomTags')
             || !_migProbe_columnExists($db, 'tblUserFavorites', 'Tags'),
     ],
+    'song-history-table' => [
+        'script' => 'migrate-song-history.php',
+        'card' => [
+            'title'  => 'Recently-Viewed history table (#1236)',
+            'body'   => 'Creates <code>tblSongHistory</code> on long-running installs that predate it'
+                      . ' (fresh installs already get it from schema.sql). Without the table the'
+                      . ' <code>song_history</code> API throws, returns <code>{ fallback: true }</code>,'
+                      . ' and the client silently falls back to per-device <code>localStorage</code> — so a'
+                      . ' signed-in user&rsquo;s Recently-Viewed list differs across devices. The client +'
+                      . ' API (#546 / #549 / WS-G #1019) are already built; this only adds the missing'
+                      . ' table. Additive + idempotent — safe to re-run.',
+            'button' => 'Run Recently-Viewed History Migration',
+        ],
+        /* Pending until the table exists; self-clears once it has been created. */
+        'probe' => static fn(\mysqli $db) => !_migProbe_tableExists($db, 'tblSongHistory'),
+    ],
 
     /* ---- iLyricsDB alignment, pre-deploy (#1044 / #1045 / #1046) ----------
        Shape-readiness so the iHymns DB can become the shared iLyricsDB core


### PR DESCRIPTION
Closes #1236.

**Root cause:** a signed-in user's Recently-Viewed list differed per device because the server-side sync silently fell back to localStorage. The `song_history` API queries **`tblSongHistory`**, which is in `schema.sql` (fresh installs get it) but **never had a migration** — so long-running installs (alpha/beta/prod) lack the table. The handler throws → returns `{ fallback: true }` → `history.js` falls back to per-device localStorage.

**The feature was already built (WS-G #1019):** the client does DB-first render → `backfillToServer()` (push local) → `_fetchServerHistory()` (pull) → `_unionByRecency` merge → mirror to cache. So logged-out = localStorage, logged-in = account-backed, **merge-on-login like setlists** — exactly as requested. Only the table was missing.

**Fix:** `migrate-song-history.php` (CREATE TABLE byte-identical to schema.sql, idempotent) + a registry entry so **Apply-all** creates it. No schema.sql change (already present). CI migration-registry + schema-coverage **pass**; `php -l` clean.

**Owner action:** run **Database Setup → Apply all** on each env to create the table. Important groundwork for the **native apps**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)