### PR TITLE
feat(notifications): per-environment scope + per-notification expiry (#1238)

### DIFF
--- a/appWeb/.sql/migrate-notification-scope-expiry.php
+++ b/appWeb/.sql/migrate-notification-scope-expiry.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Notifications: per-environment scope + expiry (#1238)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Adds two optional columns to tblNotifications so a broadcast can be scoped to a
+ * single environment and/or auto-expire:
+ *   1. Environment VARCHAR(16) NULL — NULL = all environments (the existing
+ *      system-wide behaviour); 'alpha' / 'beta' / 'production' = show only on
+ *      that environment (the three envs share one DB, so the client filters on
+ *      ihymns_environment(), the same detector #1233 introduced).
+ *   2. ExpiresAt   DATETIME NULL — NULL = never expires; a timestamp = the client
+ *      stops showing the notification after that moment.
+ *
+ * VARCHAR not ENUM for Environment (rule #20 — a growable vocab); DATETIME not
+ * TIMESTAMP for ExpiresAt (rule #20 — TTL convention). STRICTLY ADDITIVE +
+ * IDEMPOTENT (each ADD COLUMN gated on SHOW COLUMNS).
+ *
+ * @migration-adds tblNotifications.Environment
+ * @migration-adds tblNotifications.ExpiresAt
+ *
+ * USAGE:
+ *   Web:  /manage/setup-database → "Notification scope + expiry"
+ *   CLI:  php appWeb/.sql/migrate-notification-scope-expiry.php
+ */
+
+$isCli = (PHP_SAPI === 'cli');
+if (!defined('IHYMNS_SETUP_DASHBOARD') && !function_exists('getDbMysqli')) {
+    require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+}
+
+function _migNotifScope_out(string $msg): void
+{
+    global $isCli;
+    echo $msg . ($isCli ? "\n" : "<br>\n");
+    if (!$isCli) { @flush(); }
+}
+
+/** Add a column only if it isn't already present (idempotent). */
+function _migNotifScope_addCol(mysqli $db, string $col, string $ddl): void
+{
+    $res = $db->query("SHOW COLUMNS FROM tblNotifications LIKE '" . $db->real_escape_string($col) . "'");
+    if ($res && $res->num_rows > 0) {
+        _migNotifScope_out("  [SKIP] tblNotifications.{$col} already present.");
+        return;
+    }
+    $db->query("ALTER TABLE tblNotifications ADD COLUMN {$ddl}");
+    _migNotifScope_out("  [OK] Added tblNotifications.{$col}.");
+}
+
+$db = function_exists('getDbMysqli') ? getDbMysqli() : null;
+if (!($db instanceof mysqli)) {
+    _migNotifScope_out('ERROR: could not connect to database.');
+    if ($isCli) { exit(1); }
+    return;
+}
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+_migNotifScope_out('=== iHymns — Notifications scope + expiry (#1238) ===');
+
+try {
+    /* DDL byte-identical to appWeb/.sql/schema.sql (rule #19). */
+    _migNotifScope_addCol(
+        $db,
+        'Environment',
+        "Environment VARCHAR(16) NULL DEFAULT NULL COMMENT 'Target environment (#1238): NULL = all; alpha / beta / production = that env only' AFTER IsRead"
+    );
+    _migNotifScope_addCol(
+        $db,
+        'ExpiresAt',
+        "ExpiresAt DATETIME NULL DEFAULT NULL COMMENT 'Optional expiry (#1238): NULL = never; the client hides the notification after this moment' AFTER Environment"
+    );
+    _migNotifScope_out('');
+    _migNotifScope_out('Migration complete — notifications can now be environment-scoped and/or set to expire.');
+} catch (\Throwable $e) {
+    _migNotifScope_out('  [ERROR] ' . $e->getMessage());
+    if ($isCli) { exit(1); }
+    return;
+}
+
+return;

--- a/appWeb/.sql/schema.sql
+++ b/appWeb/.sql/schema.sql
@@ -1829,6 +1829,8 @@ CREATE TABLE IF NOT EXISTS tblNotifications (
     Body            TEXT            NOT NULL DEFAULT (''),
     ActionUrl       VARCHAR(500)    NOT NULL DEFAULT '' COMMENT 'Deep link (e.g., /song/CP-0001)',
     IsRead          TINYINT(1)      NOT NULL DEFAULT 0,
+    Environment     VARCHAR(16)     NULL DEFAULT NULL COMMENT 'Target environment (#1238): NULL = all; alpha / beta / production = that env only',
+    ExpiresAt       DATETIME        NULL DEFAULT NULL COMMENT 'Optional expiry (#1238): NULL = never; the client hides the notification after this moment',
     CreatedAt       TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
     INDEX idx_User          (UserId),

--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -7448,21 +7448,45 @@ if ($action !== null) {
             }
             try {
                 $db = getDbMysqli();
-                $stmt = $db->prepare(
-                    'SELECT Id AS id,
-                            Type AS type,
-                            Title AS title,
-                            Body AS body,
-                            ActionUrl AS action_url,
-                            IsRead AS is_read,
-                            CreatedAt AS created_at
-                       FROM tblNotifications
-                      WHERE UserId = ?
-                      ORDER BY IsRead ASC, CreatedAt DESC
-                      LIMIT 50'
-                );
                 $authUserId = (int)$authUser['Id'];
-                $stmt->bind_param('i', $authUserId);
+                /* #1238 — filter by environment scope + expiry, but ONLY if the
+                   columns exist (migrations aren't auto-applied; an un-migrated
+                   install must not 500 the bell). Probe once; degrade to the
+                   original unscoped query when absent. */
+                $notifHasScope = false;
+                $colRes = $db->query(
+                    "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+                      WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tblNotifications'
+                        AND COLUMN_NAME = 'Environment' LIMIT 1"
+                );
+                if ($colRes) { $notifHasScope = $colRes->num_rows > 0; $colRes->close(); }
+
+                if ($notifHasScope) {
+                    /* Show rows for ALL envs (Environment IS NULL) or THIS env, that
+                       are unexpired (ExpiresAt IS NULL or still in the future). */
+                    $stmt = $db->prepare(
+                        'SELECT Id AS id, Type AS type, Title AS title, Body AS body,
+                                ActionUrl AS action_url, IsRead AS is_read, CreatedAt AS created_at
+                           FROM tblNotifications
+                          WHERE UserId = ?
+                            AND (Environment IS NULL OR Environment = ?)
+                            AND (ExpiresAt IS NULL OR ExpiresAt > NOW())
+                          ORDER BY IsRead ASC, CreatedAt DESC
+                          LIMIT 50'
+                    );
+                    $env = ihymns_environment();
+                    $stmt->bind_param('is', $authUserId, $env);
+                } else {
+                    $stmt = $db->prepare(
+                        'SELECT Id AS id, Type AS type, Title AS title, Body AS body,
+                                ActionUrl AS action_url, IsRead AS is_read, CreatedAt AS created_at
+                           FROM tblNotifications
+                          WHERE UserId = ?
+                          ORDER BY IsRead ASC, CreatedAt DESC
+                          LIMIT 50'
+                    );
+                    $stmt->bind_param('i', $authUserId);
+                }
                 $stmt->execute();
                 $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
                 $stmt->close();

--- a/appWeb/public_html/manage/includes/migration-registry.php
+++ b/appWeb/public_html/manage/includes/migration-registry.php
@@ -1398,6 +1398,22 @@ return [
         /* Pending until the table exists; self-clears once it has been created. */
         'probe' => static fn(\mysqli $db) => !_migProbe_tableExists($db, 'tblSongHistory'),
     ],
+    'notification-scope-expiry' => [
+        'script' => 'migrate-notification-scope-expiry.php',
+        'card' => [
+            'title'  => 'Notification scope + expiry (#1238)',
+            'body'   => 'Adds <code>Environment</code> (NULL = all; alpha / beta / production = that env'
+                      . ' only — the three environments share one DB) and <code>ExpiresAt</code>'
+                      . ' (NULL = never) to <code>tblNotifications</code>, so an admin broadcast can'
+                      . ' target a single environment and/or auto-expire. Additive + idempotent —'
+                      . ' safe to re-run.',
+            'button' => 'Run Notification Scope + Expiry Migration',
+        ],
+        /* Pending until BOTH columns exist; self-clears once they have landed. */
+        'probe' => static fn(\mysqli $db) =>
+            !_migProbe_columnExists($db, 'tblNotifications', 'Environment')
+            || !_migProbe_columnExists($db, 'tblNotifications', 'ExpiresAt'),
+    ],
 
     /* ---- iLyricsDB alignment, pre-deploy (#1044 / #1045 / #1046) ----------
        Shape-readiness so the iHymns DB can become the shared iLyricsDB core

--- a/appWeb/public_html/manage/notifications.php
+++ b/appWeb/public_html/manage/notifications.php
@@ -44,6 +44,24 @@ $activePage = 'notifications';
 $db   = getDbMysqli();
 $csrf = csrfToken();
 
+/* #1238 — the Environment / ExpiresAt columns may not exist yet (migrations are
+   NOT auto-applied on deploy, per the house DB rules). Probe ONCE and degrade
+   gracefully: when absent, the compose/INSERT/list all behave as before (every
+   notification system-wide + never-expiring) instead of 500-ing on a missing
+   column. The "Notification scope + expiry" migration adds them. */
+$notifHasScope = false;
+try {
+    $r = $db->query(
+        "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tblNotifications'
+            AND COLUMN_NAME = 'Environment' LIMIT 1"
+    );
+    $notifHasScope = ($r && $r->num_rows > 0);
+    if ($r) { $r->close(); }
+} catch (\Throwable $_e) {
+    $notifHasScope = false;
+}
+
 /* ----------------------------------------------------------------------
  * POST handlers — compose / delete
  * ---------------------------------------------------------------------- */
@@ -71,6 +89,10 @@ if (($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'POST') {
             $body        = trim((string)($_POST['body']      ?? ''));
             $actionUrl   = trim((string)($_POST['action_url'] ?? ''));
             $type        = trim((string)($_POST['type']      ?? 'announcement'));
+            /* #1238 — optional environment scope + expiry. */
+            $environment = (string)($_POST['environment'] ?? '');      // '' = all environments
+            $expiresAtIn = trim((string)($_POST['expires_at'] ?? ''));  // '' = never expires
+            $expiresAtSql = '';
 
             /* Validate */
             $errs = [];
@@ -93,6 +115,21 @@ if (($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'POST') {
             $allowedTypes = ['announcement', 'maintenance', 'release', 'info'];
             if (!in_array($type, $allowedTypes, true)) {
                 $type = 'announcement';
+            }
+            /* #1238 — env scope must be one of the known environments (blank = all);
+               expiry, when given, must parse and be in the future. */
+            if (!in_array($environment, ['', 'alpha', 'beta', 'production'], true)) {
+                $errs[] = 'Invalid environment scope.';
+            }
+            if ($expiresAtIn !== '') {
+                $expTs = strtotime($expiresAtIn);
+                if ($expTs === false) {
+                    $errs[] = 'Expiry date/time is not valid.';
+                } elseif ($expTs <= time()) {
+                    $errs[] = 'Expiry must be in the future.';
+                } else {
+                    $expiresAtSql = date('Y-m-d H:i:s', $expTs);
+                }
             }
 
             /* Resolve recipients */
@@ -158,10 +195,20 @@ if (($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'POST') {
                    without dynamically generated SQL — at NOTIFY_BROADCAST_MAX
                    = 5000 the loop is fast enough (~< 1s on a typical host)
                    and stays auditable per-row. */
-                $stmt = $db->prepare(
-                    'INSERT INTO tblNotifications (UserId, Type, Title, Body, ActionUrl)
-                     VALUES (?, ?, ?, ?, ?)'
-                );
+                /* #1238 — include Environment + ExpiresAt only when the columns
+                   exist; otherwise fall back to the original 5-column INSERT so an
+                   un-migrated install still broadcasts (system-wide, never-expiring). */
+                if ($notifHasScope) {
+                    $stmt = $db->prepare(
+                        'INSERT INTO tblNotifications (UserId, Type, Title, Body, ActionUrl, Environment, ExpiresAt)
+                         VALUES (?, ?, ?, ?, ?, ?, ?)'
+                    );
+                } else {
+                    $stmt = $db->prepare(
+                        'INSERT INTO tblNotifications (UserId, Type, Title, Body, ActionUrl)
+                         VALUES (?, ?, ?, ?, ?)'
+                    );
+                }
                 /* tblNotifications.ActionUrl is NOT NULL DEFAULT '' —
                    binding NULL on a blank optional field threw
                    `Column 'ActionUrl' cannot be null` and the request
@@ -170,9 +217,16 @@ if (($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'POST') {
                    already treat empty strings as no-link, so swap
                    the NULL fallback for ''. */
                 $actionUrlForBind = $actionUrl !== '' ? $actionUrl : '';
+                /* NULL binds: blank env => all environments; blank expiry => never. */
+                $envForBind     = $environment !== '' ? $environment : null;
+                $expiresForBind = $expiresAtSql !== '' ? $expiresAtSql : null;
                 $count = 0;
                 foreach ($recipients as $uid) {
-                    $stmt->bind_param('issss', $uid, $type, $title, $body, $actionUrlForBind);
+                    if ($notifHasScope) {
+                        $stmt->bind_param('issssss', $uid, $type, $title, $body, $actionUrlForBind, $envForBind, $expiresForBind);
+                    } else {
+                        $stmt->bind_param('issss', $uid, $type, $title, $body, $actionUrlForBind);
+                    }
                     if (@$stmt->execute()) $count++;
                 }
                 $stmt->close();
@@ -576,6 +630,25 @@ require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head
                         <input type="text" name="action_url" class="form-control form-control-sm" placeholder="/manage/some-page  or  https://…">
                         <div class="form-text small">Local /-rooted path or absolute https://. Clicking the row in the bell sends the user here.</div>
                     </div>
+<?php if ($notifHasScope): /* #1238 — only when the columns exist (migration applied) */ ?>
+                    <div class="row g-2 mb-1">
+                        <div class="col-sm-6">
+                            <label class="form-label small">Environment <span class="text-muted">(optional)</span></label>
+                            <select name="environment" class="form-select form-select-sm">
+                                <option value="">All environments</option>
+                                <option value="alpha">Alpha only</option>
+                                <option value="beta">Beta only</option>
+                                <option value="production">Production only</option>
+                            </select>
+                            <div class="form-text small">The three environments share one database; scope a notice to just one.</div>
+                        </div>
+                        <div class="col-sm-6">
+                            <label class="form-label small">Expires <span class="text-muted">(optional)</span></label>
+                            <input type="datetime-local" name="expires_at" class="form-control form-control-sm">
+                            <div class="form-text small">Leave blank to never expire.</div>
+                        </div>
+                    </div>
+<?php endif; ?>
                 </div>
 
                 <div class="modal-footer">


### PR DESCRIPTION
Closes #1238.

Manage → Notifications could only broadcast **system-wide** and **never-expiring**. Two additions:

1. **Environment scope** — target **alpha / beta / production** (or all). The three envs share one DB, so the client read filters on `ihymns_environment()` (the #1233 detector): `WHERE Environment IS NULL OR Environment = <this env>`.
2. **Expiry** — optional `ExpiresAt`; the client hides the notification after it: `WHERE ExpiresAt IS NULL OR ExpiresAt > NOW()`.

**Schema:** `tblNotifications.Environment VARCHAR(16) NULL` + `ExpiresAt DATETIME NULL` (VARCHAR-not-ENUM + DATETIME-not-TIMESTAMP, rule #20), mirrored in `schema.sql`, with `migrate-notification-scope-expiry.php` + a registered OR-probe (rule #19).

**Safety:** both the compose INSERT and the client read **probe for the columns** and degrade gracefully when absent — migrations aren't auto-applied, so an un-migrated install keeps working (system-wide, never-expiring) rather than 500-ing the bell. The compose modal shows the env + expiry fields only once the columns exist.

**Follow-up (minor):** surface Environment/Expiry as columns in the admin list for at-a-glance verification.

CI migration-registry + schema-coverage **pass**; `php -l` clean. **Owner action:** Apply-all on each env to add the columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)