### PR TITLE
feat(lyrics): P1a — tblLyricLines mirror (chord/note columns + full backfill) (#1235)

### DIFF
--- a/appWeb/.sql/migrate-lyric-lines-mirror.php
+++ b/appWeb/.sql/migrate-lyric-lines-mirror.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — tblLyricLines mirror: per-line chord/note columns + full backfill (#1235 P1)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE (lyric-line normalisation, Phase 1 — Option 1):
+ *   1. Add the two per-line homes Option 1 still needs on `tblLyricLines`:
+ *      - ChordsJson (the line's chords, mirrored from tblSongComponents.ChordsJson[i])
+ *      - Note       (the line's presenter/slide note, from tblSongComponents.NotesJson[i])
+ *      Everything else Option 1 needs (PartType/PartNumber/SortOrder/LineText/
+ *      LanguageCode/timing/MetaJson) already exists on the table.
+ *   2. BACKFILL the whole catalogue into `tblLyricLines` from the authoritative
+ *      `tblSongComponents` — IN PLACE, no re-import — so the normalised mirror is
+ *      complete (an earlier `migrate-normalize-lyrics.php` populated line text +
+ *      part identity but NOT chords/notes; this reprojects everything via the one
+ *      shared projector, `lyricLinesProjectSong()`).
+ *
+ * P1 keeps `tblSongComponents` authoritative + reads unchanged; this mirror is
+ * kept live by the transitional dual-write (P1b). Strictly additive + idempotent
+ * (CREATE/ADD gated; the projection is delete + reinsert per song, re-runnable).
+ *
+ * @migration-adds tblLyricLines.ChordsJson
+ * @migration-adds tblLyricLines.Note
+ *
+ * USAGE:
+ *   Web:  /manage/setup-database → "Lyric-lines mirror (chords/notes + backfill)"
+ *   CLI:  php appWeb/.sql/migrate-lyric-lines-mirror.php
+ */
+
+$isCli = (PHP_SAPI === 'cli');
+if (!defined('IHYMNS_SETUP_DASHBOARD') && !function_exists('getDbMysqli')) {
+    require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+}
+require_once dirname(__DIR__) . '/public_html/includes/lyric_lines_sync.php';
+
+function _migLLMirror_out(string $msg): void
+{
+    global $isCli;
+    echo $msg . ($isCli ? "\n" : "<br>\n");
+    if (!$isCli) { @flush(); }
+}
+
+/** Add a column to tblLyricLines only if absent (idempotent). */
+function _migLLMirror_addCol(mysqli $db, string $col, string $ddl): void
+{
+    $res = $db->query("SHOW COLUMNS FROM tblLyricLines LIKE '" . $db->real_escape_string($col) . "'");
+    if ($res && $res->num_rows > 0) {
+        _migLLMirror_out("  [SKIP] tblLyricLines.{$col} already present.");
+        return;
+    }
+    $db->query("ALTER TABLE tblLyricLines ADD COLUMN {$ddl}");
+    _migLLMirror_out("  [OK] Added tblLyricLines.{$col}.");
+}
+
+$db = function_exists('getDbMysqli') ? getDbMysqli() : null;
+if (!($db instanceof mysqli)) {
+    _migLLMirror_out('ERROR: could not connect to database.');
+    if ($isCli) { exit(1); }
+    return;
+}
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+_migLLMirror_out('=== iHymns — tblLyricLines mirror: chord/note columns + backfill (#1235 P1) ===');
+
+try {
+    /* ---- Step 1: per-line chord + note columns (DDL byte-identical to schema.sql) ---- */
+    _migLLMirror_out('--- Step 1: per-line chord + note columns ---');
+    _migLLMirror_addCol(
+        $db,
+        'ChordsJson',
+        "ChordsJson JSON NULL DEFAULT NULL COMMENT 'Per-line chords mirrored from tblSongComponents.ChordsJson[i] (null/string/array); #1235 P1 normalisation' AFTER MetaJson"
+    );
+    _migLLMirror_addCol(
+        $db,
+        'Note',
+        "Note TEXT NULL DEFAULT NULL COMMENT 'Per-line presenter/slide note mirrored from tblSongComponents.NotesJson[i]; #1235 P1 normalisation' AFTER ChordsJson"
+    );
+
+    /* ---- Step 2: backfill the whole catalogue (in place, no re-import) ---- */
+    _migLLMirror_out('--- Step 2: backfilling tblLyricLines from tblSongComponents ---');
+    if (function_exists('set_time_limit')) { @set_time_limit(0); }
+
+    /* Collect SongIds up front (buffered) so projection queries can run on the
+       same connection without a "commands out of sync". */
+    $songIds = [];
+    $res = $db->query("SELECT SongId FROM tblSongs");
+    while ($res && ($r = $res->fetch_row())) { $songIds[] = (string)$r[0]; }
+    if ($res) { $res->close(); }
+
+    $songs = 0;
+    $lines = 0;
+    $batch = 0;
+    $db->begin_transaction();
+    foreach ($songIds as $sid) {
+        $lines += lyricLinesProjectSong($db, $sid);
+        $songs++;
+        if (++$batch >= 200) {
+            $db->commit();
+            $db->begin_transaction();
+            $batch = 0;
+            _migLLMirror_out("  ... {$songs} songs / {$lines} lines");
+        }
+    }
+    $db->commit();
+
+    _migLLMirror_out('');
+    _migLLMirror_out("Backfill complete — {$songs} songs, {$lines} lines mirrored into tblLyricLines.");
+    _migLLMirror_out('tblSongComponents stays authoritative; reads unchanged (P1).');
+} catch (\Throwable $e) {
+    /* Roll back the open backfill batch (no-op/harmless if the failure was in the
+       DDL step before any transaction began). */
+    @$db->rollback();
+    _migLLMirror_out('  [ERROR] ' . $e->getMessage());
+    if ($isCli) { exit(1); }
+    return;
+}
+
+return;

--- a/appWeb/.sql/schema.sql
+++ b/appWeb/.sql/schema.sql
@@ -593,6 +593,8 @@ CREATE TABLE IF NOT EXISTS tblLyricLines (
     LanguageCode  VARCHAR(35)     NULL DEFAULT NULL COMMENT 'Per-line language override (IETF tag); NULL = song default',
     IsInstrumental TINYINT(1)     NOT NULL DEFAULT 0,
     MetaJson      JSON            NULL DEFAULT NULL COMMENT 'Lossless TTML line attrs (ttm:role, ttm:agent, itunes:song-part, background-vocal) (#141)',
+    ChordsJson    JSON            NULL DEFAULT NULL COMMENT 'Per-line chords mirrored from tblSongComponents.ChordsJson[i] (null/string/array); #1235 P1 normalisation',
+    Note          TEXT            NULL DEFAULT NULL COMMENT 'Per-line presenter/slide note mirrored from tblSongComponents.NotesJson[i]; #1235 P1 normalisation',
     CreatedAt     TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UpdatedAt     TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 

--- a/appWeb/public_html/includes/lyric_lines_sync.php
+++ b/appWeb/public_html/includes/lyric_lines_sync.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — tblLyricLines mirror/sync helper (#1235 P1, lyric-line normalisation)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * Projects a song's CURRENTLY-AUTHORITATIVE `tblSongComponents`
+ * (LinesJson / ChordsJson / NotesJson + Type/Number/Language) into the
+ * normalised `tblLyricLines` mirror that #1235 is making the single source of
+ * truth (Option 1 — part identity lives ON the line).
+ *
+ * PHASE 1 (now): `tblSongComponents` stays authoritative; `tblLyricLines` is a
+ * kept-in-sync MIRROR (the backfill migration + a transitional dual-write on
+ * every component write). PUBLIC READS ARE UNCHANGED. The projection here is a
+ * naive whole-song delete + reinsert — correct + simple while nothing depends on
+ * line `Id` stability yet (timings / translations / annotations only attach in
+ * P3). P2 flips reads to `tblLyricLines` and replaces this with an Id-preserving
+ * diff so per-line enrichment survives an edit.
+ *
+ * ONE projection function, reused by the backfill migration AND every editor /
+ * import write path — so the two can never diverge (the modularity rule).
+ *
+ * Requires getDbMysqli() (includes/db_mysql.php). The DB layer runs mysqli under
+ * MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT, so failing statements throw.
+ */
+
+if (basename($_SERVER['SCRIPT_FILENAME'] ?? '') === basename(__FILE__)) {
+    http_response_code(403);
+    exit('Access denied.');
+}
+
+/**
+ * Is the P1 mirror schema present (the per-line chord/note columns added by
+ * migrate-lyric-lines-mirror.php)? Dual-write callers MUST skip when this is
+ * false — migrations are not auto-applied, so an un-migrated install keeps
+ * working on `tblSongComponents` alone rather than throwing on a missing column.
+ * Memoised per request.
+ */
+function lyricLinesSyncReady(\mysqli $db): bool
+{
+    static $ready = null;
+    if ($ready !== null) {
+        return $ready;
+    }
+    try {
+        /* Require BOTH per-line columns — a half-applied migration (ChordsJson
+           added, Note not) must NOT report ready, or the dual-write would throw
+           on the missing Note column. */
+        $r = $db->query(
+            "SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+              WHERE TABLE_SCHEMA = DATABASE()
+                AND TABLE_NAME   = 'tblLyricLines'
+                AND COLUMN_NAME  IN ('ChordsJson', 'Note')"
+        );
+        $row   = $r ? $r->fetch_row() : null;
+        $ready = ($row !== null && (int)$row[0] >= 2);
+        if ($r) { $r->close(); }
+    } catch (\Throwable $_e) {
+        $ready = false;
+    }
+    return $ready;
+}
+
+/**
+ * Find (or create) the primary `tblLyrics` version row for a song — the
+ * `Source = 'ihymns'` canonical version, unique per song via uq_song_source —
+ * and return its Id. Idempotent: re-runs return the existing row.
+ */
+function lyricLinesEnsurePrimaryVersion(\mysqli $db, string $songId): int
+{
+    $sel = $db->prepare(
+        "SELECT Id FROM tblLyrics WHERE SongId = ? AND Source = 'ihymns' LIMIT 1"
+    );
+    $sel->bind_param('s', $songId);
+    $sel->execute();
+    $row = $sel->get_result()->fetch_row();
+    $sel->close();
+    if ($row !== null) {
+        return (int)$row[0];
+    }
+    /* No 'ihymns' version yet — create the canonical primary one. Approved so it
+       renders once reads switch in P2; the (SongId,'ihymns') unique makes this
+       race-safe-ish (a duplicate INSERT would throw and the caller retries). */
+    $ins = $db->prepare(
+        "INSERT INTO tblLyrics (SongId, Source, FormatVersion, IsPrimary, Status)
+         VALUES (?, 'ihymns', '1.0', 1, 'approved')"
+    );
+    $ins->bind_param('s', $songId);
+    $ins->execute();
+    $id = (int)$db->insert_id;
+    $ins->close();
+    return $id;
+}
+
+/**
+ * Project ALL of a song's components into `tblLyricLines` (the primary version):
+ * wipe the version's existing lines, then reinsert one row per lyric line in
+ * global order, carrying part identity (Type → PartType, Number → PartNumber),
+ * the per-line chord (ChordsJson[i]) and presenter note (NotesJson[i]), and the
+ * per-component language override (#858). Returns the line count written.
+ *
+ * Naive whole-song replace (P1). Idempotent — safe to call on every component
+ * write and to re-run in the backfill. No-op-safe to call only when
+ * lyricLinesSyncReady() is true (the columns exist).
+ *
+ * @param \mysqli $db
+ * @param string  $songId
+ * @return int  number of lines written
+ */
+function lyricLinesProjectSong(\mysqli $db, string $songId): int
+{
+    $lyricsId = lyricLinesEnsurePrimaryVersion($db, $songId);
+
+    /* Replace the whole version's lines (P1 naive reproject). */
+    $del = $db->prepare("DELETE FROM tblLyricLines WHERE LyricsId = ?");
+    $del->bind_param('i', $lyricsId);
+    $del->execute();
+    $del->close();
+
+    /* Authoritative source: the song's components, in display order. */
+    $cs = $db->prepare(
+        "SELECT Id, Type, Number, Language, LinesJson, ChordsJson, NotesJson
+           FROM tblSongComponents
+          WHERE SongId = ?
+          ORDER BY SortOrder, Id"
+    );
+    $cs->bind_param('s', $songId);
+    $cs->execute();
+    $comps = $cs->get_result()->fetch_all(MYSQLI_ASSOC);
+    $cs->close();
+
+    $ins = $db->prepare(
+        "INSERT INTO tblLyricLines
+            (LyricsId, ComponentId, PartType, PartNumber, SortOrder,
+             LineText, ChordsJson, Note, LanguageCode, IsInstrumental)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    );
+
+    $sort  = 0;   // global line order within the version
+    $count = 0;
+    foreach ($comps as $c) {
+        $compId     = (int)$c['Id'];
+        $partType   = (string)$c['Type'];
+        $number     = (int)$c['Number'];
+        $partNumber = $number > 0 ? $number : null;          // 0 (e.g. a lone Chorus) => NULL
+        $lang       = ($c['Language'] !== null && $c['Language'] !== '') ? (string)$c['Language'] : null;
+
+        $lines  = json_decode((string)$c['LinesJson'], true);
+        if (!is_array($lines)) { $lines = []; }
+        $chords = ($c['ChordsJson'] !== null) ? json_decode((string)$c['ChordsJson'], true) : null;
+        $notes  = ($c['NotesJson']  !== null) ? json_decode((string)$c['NotesJson'],  true) : null;
+
+        foreach ($lines as $i => $line) {
+            $text   = (string)$line;
+            $isInst = (trim($text) === '') ? 1 : 0;
+            /* Per-line chord = the parallel array's element (null / string /
+               array of strings) re-encoded as JSON; null when absent. */
+            $chordVal = (is_array($chords) && array_key_exists($i, $chords) && $chords[$i] !== null)
+                ? json_encode($chords[$i], JSON_UNESCAPED_UNICODE)
+                : null;
+            $noteVal  = (is_array($notes) && array_key_exists($i, $notes) && $notes[$i] !== null && $notes[$i] !== '')
+                ? (string)$notes[$i]
+                : null;
+
+            $ins->bind_param(
+                'iisiissssi',
+                $lyricsId, $compId, $partType, $partNumber, $sort,
+                $text, $chordVal, $noteVal, $lang, $isInst
+            );
+            $ins->execute();
+            $sort++;
+            $count++;
+        }
+    }
+    $ins->close();
+    return $count;
+}

--- a/appWeb/public_html/manage/includes/migration-registry.php
+++ b/appWeb/public_html/manage/includes/migration-registry.php
@@ -1414,6 +1414,26 @@ return [
             !_migProbe_columnExists($db, 'tblNotifications', 'Environment')
             || !_migProbe_columnExists($db, 'tblNotifications', 'ExpiresAt'),
     ],
+    'lyric-lines-mirror' => [
+        'script' => 'migrate-lyric-lines-mirror.php',
+        'card' => [
+            'title'  => 'Lyric-lines mirror: chords/notes + backfill (#1235 P1)',
+            'body'   => 'Lyric-line normalisation Phase 1 (Option 1). Adds the two per-line homes'
+                      . ' <code>tblLyricLines</code> still needed — <code>ChordsJson</code> +'
+                      . ' <code>Note</code> — then backfills the WHOLE catalogue into'
+                      . ' <code>tblLyricLines</code> from the authoritative <code>tblSongComponents</code>'
+                      . ' (line text + part identity + chords + notes + per-component language),'
+                      . ' <strong>in place, no re-import</strong>. <code>tblSongComponents</code> stays'
+                      . ' authoritative + reads are unchanged; the mirror is the future single source of'
+                      . ' truth. Additive + idempotent (delete + reinsert per song) — safe to re-run.',
+            'button' => 'Run Lyric-lines Mirror Migration',
+        ],
+        /* Pending until BOTH per-line columns exist; self-clears once they land.
+           (The backfill is idempotent, so re-running after an edit is safe.) */
+        'probe' => static fn(\mysqli $db) =>
+            !_migProbe_columnExists($db, 'tblLyricLines', 'ChordsJson')
+            || !_migProbe_columnExists($db, 'tblLyricLines', 'Note'),
+    ],
 
     /* ---- iLyricsDB alignment, pre-deploy (#1044 / #1045 / #1046) ----------
        Shape-readiness so the iHymns DB can become the shared iLyricsDB core


### PR DESCRIPTION
First slice of the **lyric-line normalisation epic** (#1235, **Option 1** — `tblLyricLines` as the single source of truth, decided 2026-06-10). **P1a is the safe foundation: `tblSongComponents` stays authoritative and public reads are UNCHANGED.**

- **`includes/lyric_lines_sync.php`** — the ONE shared projector reused by the backfill *and* the upcoming dual-write (so they can't diverge): `lyricLinesProjectSong()` (wipe + reinsert a song's lines in global `SortOrder`, carrying part identity + per-line chord/note + language), `lyricLinesEnsurePrimaryVersion()`, `lyricLinesSyncReady()`.
- **Schema** — `tblLyricLines` gains `ChordsJson` (JSON) + `Note` (TEXT), the two per-line homes Option 1 still needed (mirrored byte-identically in `schema.sql`).
- **`migrate-lyric-lines-mirror.php`** — adds the columns, then backfills the **whole catalogue** from `tblSongComponents` **in place (no re-import)**, batched + idempotent; registered with an OR-probe on both columns.

**Adversarially reviewed** (1 blocker fixed — sync-ready now requires *both* columns; bind string / chord-note index alignment / global SortOrder / idempotency / DDL parity all confirmed). CI migration-registry + schema-coverage **pass**; `php -l` clean.

**Owner action:** Apply-all on each env to add the columns + backfill. **Next:** P1b wires the dual-write into the four component-write paths; P2 flips reads + the Id-preserving editor diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)