### PR TITLE
fix(lyrics): resolve lyric_lines_sync.php via DOCUMENT_ROOT so the mirror migration runs (#1235) [deploy all]

### DIFF
--- a/appWeb/.sql/migrate-lyric-lines-mirror.php
+++ b/appWeb/.sql/migrate-lyric-lines-mirror.php
@@ -35,7 +35,31 @@ $isCli = (PHP_SAPI === 'cli');
 if (!defined('IHYMNS_SETUP_DASHBOARD') && !function_exists('getDbMysqli')) {
     require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
 }
-require_once dirname(__DIR__) . '/public_html/includes/lyric_lines_sync.php';
+
+/* Locate the shared projector ROBUSTLY. The naive `dirname(__DIR__)/public_html`
+   (sibling of .sql/) assumes the deploy keeps .sql and the SERVED public_html as
+   siblings — but on the server the live web docroot is a DIFFERENT tree from that
+   sibling path (the sibling carries long-lived files like db_mysql.php but NOT a
+   brand-new include), so a single hardcoded path 500s on "Failed opening
+   required". Try the live docroot (DOCUMENT_ROOT — where the dashboard runs and
+   the deploy lands) first, then the sibling for CLI. */
+$_llSyncCandidates = [];
+$_llDocRoot = rtrim((string)($_SERVER['DOCUMENT_ROOT'] ?? ''), '/');
+if ($_llDocRoot !== '') {
+    $_llSyncCandidates[] = $_llDocRoot . '/includes/lyric_lines_sync.php';
+}
+$_llSyncCandidates[] = dirname(__DIR__) . '/public_html/includes/lyric_lines_sync.php';
+$_llSyncPath = null;
+foreach ($_llSyncCandidates as $_cand) {
+    if (is_file($_cand)) { $_llSyncPath = $_cand; break; }
+}
+if ($_llSyncPath === null) {
+    echo 'ERROR: could not locate lyric_lines_sync.php (tried: '
+        . implode(' | ', $_llSyncCandidates) . ')' . ($isCli ? "\n" : "<br>\n");
+    if ($isCli) { exit(1); }
+    return;
+}
+require_once $_llSyncPath;
 
 function _migLLMirror_out(string $msg): void
 {


### PR DESCRIPTION
The `Lyric-lines-mirror` migration 500'd with `Failed opening required .../appWeb/public_html/includes/lyric_lines_sync.php`. The #1249 full-deploy log shows the file **was** transferred — so this is **not** a deploy strand but a **path-resolution bug**: the migration runs from `.../appWeb/.sql/` and computed the helper as `dirname(__DIR__)/public_html/includes/...`, assuming `.sql` and the **served** `public_html` are siblings. On the server the live docroot is a different tree from that sibling (which carries long-lived files like `db_mysql.php` — why peer migrations work — but not a brand-new include).

**Fix:** resolve the helper **DOCUMENT_ROOT-first** (live docroot, where the dashboard runs + the deploy lands), sibling path as CLI fallback, clear error if neither exists. The migration never got past this `require`, so its columns + backfill have not run — this unblocks them. `[deploy all]` forces the corrected migration to deploy. CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)