### PR TITLE
feat(lyrics): P1b — transitional dual-write keeps tblLyricLines mirror live (#1235) [deploy all]

### DIFF
--- a/appWeb/public_html/includes/lyrics_ingest.php
+++ b/appWeb/public_html/includes/lyrics_ingest.php
@@ -603,6 +603,13 @@ function lyricsIngest_createSong(\mysqli $db, array $payload, string $lyricsText
             $comp->close();
         }
 
+        /* #1235 P1b — mirror the provisional component into tblLyricLines (guarded;
+           no-op until the mirror columns exist). Inside the transaction. */
+        require_once __DIR__ . DIRECTORY_SEPARATOR . 'lyric_lines_sync.php';
+        if (lyricLinesSyncReady($db)) {
+            lyricLinesProjectSong($db, $songId);
+        }
+
         $db->commit();
         return $songId;
     } catch (\Throwable $e) {

--- a/appWeb/public_html/includes/song_importers.php
+++ b/appWeb/public_html/includes/song_importers.php
@@ -502,6 +502,14 @@ function _bulkImport_saveSong(\mysqli $db, array $song): array
         }
         $insComp->close();
 
+        /* #1235 P1b — mirror the imported components into tblLyricLines (guarded;
+           no-op until the mirror columns exist). Inside the import transaction so
+           it commits / rolls back atomically with the song. */
+        require_once __DIR__ . DIRECTORY_SEPARATOR . 'lyric_lines_sync.php';
+        if (lyricLinesSyncReady($db)) {
+            lyricLinesProjectSong($db, $songId);
+        }
+
         /* Revision audit row (#400). Same shape as save_song writes. */
         try {
             $editor = function_exists('getCurrentUser') ? getCurrentUser() : null;

--- a/appWeb/public_html/manage/editor/api.php
+++ b/appWeb/public_html/manage/editor/api.php
@@ -1689,6 +1689,16 @@ switch ($action) {
                 }
             }
 
+            /* #1235 P1b — keep the normalised tblLyricLines mirror in sync with the
+               components this legacy save just rewrote (guarded; no-op until the
+               mirror columns exist). Inside the transaction so it is atomic with the
+               save. The v2 editor (api2.php) does this via ed2_rebuildLyricsText; the
+               legacy path needs its own call until the editor cutover. */
+            require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'lyric_lines_sync.php';
+            if (lyricLinesSyncReady($db)) {
+                lyricLinesProjectSong($db, $songId);
+            }
+
             $db->commit();
 
             /* WS-J #1020: no songs.json cache to refresh — all reads are now

--- a/appWeb/public_html/manage/editor/api2.php
+++ b/appWeb/public_html/manage/editor/api2.php
@@ -80,6 +80,8 @@ require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_
    universal saver the legacy api.php uses (extracted to a shared include so v2
    reuses, never forks, them). Provides _bulkImport_process*() + _bulkImport_dedupeMode(). */
 require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'song_importers.php';
+/* #1235 P1b — the shared tblLyricLines projector (transitional dual-write). */
+require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'lyric_lines_sync.php';
 
 header('Content-Type: application/json; charset=UTF-8');
 header('X-Content-Type-Options: nosniff');
@@ -317,6 +319,16 @@ function ed2_rebuildLyricsText(\mysqli $db, string $songId): void {
     $u->bind_param('ss', $text, $songId);
     $u->execute();
     $u->close();
+
+    /* #1235 P1b — transitional dual-write. Every editor component change
+       (upsert / delete / reorder / components_replace / snapshot-restore) funnels
+       through here to rebuild the LyricsText mirror, so this is the ONE place to
+       also keep the normalised tblLyricLines mirror in sync. Guarded so it is a
+       no-op until the mirror columns exist (migrate-lyric-lines-mirror); naive
+       whole-song reproject (P2 swaps in the Id-preserving diff). */
+    if (lyricLinesSyncReady($db)) {
+        lyricLinesProjectSong($db, $songId);
+    }
 }
 
 /**


### PR DESCRIPTION
Completes **Phase 1** of #1235: the normalised `tblLyricLines` mirror now stays in sync with the authoritative `tblSongComponents` on **every** change — via the shared `lyricLinesProjectSong()`, guarded by `lyricLinesSyncReady()` (no-op until the mirror columns exist; idempotent whole-song reproject — P2 swaps in the Id-preserving diff). **Public reads still come from `tblSongComponents` — no behaviour change.**

**Coverage across ALL component-write paths** (adversarial review caught two gaps, both fixed):
- **api2.php** (v2 editor) — one call at the end of `ed2_rebuildLyricsText`, which every mutation (upsert / delete / reorder / replace / snapshot-restore) already funnels through.
- **api.php** (LEGACY editor `save_song`, still active until cutover) — its own guarded call before commit; without it a legacy save would silently drift the mirror (review **blocker**).
- **song_importers.php** (`_bulkImport_saveSong`) — inside the import transaction.
- **lyrics_ingest.php** (`createSong`) — the provisional TTML component, inside its transaction (review **major**).

All calls sit **inside the caller's transaction** (atomic; the projector does no begin/commit of its own). `delete_song` correctly does **not** project (cascade handles it). Reviewed; api2 paths + importer + transaction + delete safety confirmed. `php -l` clean on all four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)