### PR TITLE
docs(claude): session checkpoint 2026-06-12 — lyrics #1235 P1+P2a done, resume from P3

### DIFF
--- a/.claude/lyrics-normalisation-strategy.md
+++ b/.claude/lyrics-normalisation-strategy.md
@@ -1,8 +1,28 @@
-# Lyrics & song-info storage normalisation — strategy (DRAFT)
+# Lyrics & song-info storage normalisation — strategy
 
-> Status: **DRAFT for owner review.** No code, no branches, no migrations until the
-> model + phasing below are approved. Companion to the #1200 Song Editor rewrite.
-> Tracking epic: **#1235**. Author: pairing session 2026-06-10.
+> Status: **APPROVED + IN BUILD.** Owner chose **Option C (pure normalisation)** —
+> `tblLyricLines` is the single source of truth; part identity on the line;
+> components derived; JSON arrays retired. Tracking epic: **#1235**.
+> Companion to the #1200 Song Editor rewrite. Author: pairing 2026-06-10..12.
+
+## 0. Progress & RESUME POINT (2026-06-12)
+
+**Phase 1 + the read-switch are DONE and verified on alpha. Resume from P3.**
+
+| Phase | What | Status |
+|---|---|---|
+| **P1a** #1247 | `includes/lyric_lines_sync.php` (the ONE shared projector `lyricLinesProjectSong()` + `lyricLinesEnsurePrimaryVersion()` + `lyricLinesSyncReady()`); `tblLyricLines` += `ChordsJson`+`Note`; `migrate-lyric-lines-mirror.php` backfilled the whole catalogue | ✅ **verified: 16,081 songs / 291,478 lines, Query-2 parity = 0** |
+| **P1b** #1251 | transitional dual-write — guarded `lyricLinesProjectSong()` at the end of `ed2_rebuildLyricsText` (all api2.php editor paths) + legacy `api.php` save_song + `song_importers.php` + `lyrics_ingest.php createSong` | ✅ verified (edit keeps mirror in sync) |
+| **P2a** #1252 | read-switch — `SongData::_getComponents`/`_getComponentsMap` source line TEXT from `tblLyricLines` (JOIN component for metadata), **byte-identical output**, per-component `LinesJson` fallback guarded by `_hasLyricLinesMirror()` + a **line-count check** | ✅ verified visually on 6 songs (3 official + 2 unofficial books + editor) |
+| **P2b** (the Id-preserving diff) | replace the naive whole-song reproject so line `Id`s survive edits | ⏳ **COUPLE WITH P3** — its only value is keeping P3 enrichment from orphaning; harmless to defer (nothing references line `Id`s yet; P2a keeps them internal) |
+| **P3** ← RESUME HERE | per-line **translations / annotations / language** first-class (`tblLyricLineTranslations` / `tblLyricLineAnnotations` / `tblLyricLines.LanguageCode`), expose `lineIds[]` in the read output (**update `data/songs.schema.json`** — it is `additionalProperties:false`, which is why P2a withheld `lineIds`), + the **Id-preserving diff** (P2b), + the full **BCP 47 picker #1253** | TODO |
+| **P4** | drop `LinesJson` / `ChordsJson` / `NotesJson` after a verify gate | TODO |
+
+**Key facts for the resumer:**
+- The shared projector is `appWeb/public_html/includes/lyric_lines_sync.php` — reuse it; never re-fork. `_mirrorLinesByComponent[Map]()` in `SongData.php` already fetch each line's `Id` internally (P3 just exposes them).
+- **DEPLOY GOTCHA (cost us hours):** a `.sql/` migration that `require`s a NEW `public_html/includes/` file must resolve it **`DOCUMENT_ROOT`-first**, not `dirname(__DIR__)/public_html` — the sibling tree on the server is stale for brand-new includes. Pattern is in `migrate-lyric-lines-mirror.php`. Also: the SFTP deploy now content-compares (no `--only-newer`) + has a `timeout-minutes` cap (PRs #1249/#1250). Codified in `project-rules.md`.
+- **#1243 (musical metadata — Key/Tempo/Time-sig/Capo)** is the sibling `ArrangementJson`-vs-table split-brain; same Option-C treatment, plan together.
+- Sibling owner-decision still open: **beta→main promotion** (fixes live-prod songs_json/sitemap 500s) — independent of the lyrics epic.
 
 ## 1. Why this exists
 

--- a/.claude/project-rules.md
+++ b/.claude/project-rules.md
@@ -298,3 +298,25 @@ Setlists, favourites (+ their `Tags`), custom tags, and view-history sync to MyS
 ### 15.3 Maintenance mode + DB-down = themed 503 (never stale)
 
 `includes/maintenance.php` gates `index.php` + `api.php`. The `/manage/*` entry point, `app_status`, and `auth_*` are **structurally exempt** so an admin can never lock themselves out. `isDbConnectionFailure()` (in `db_mysql.php`) converts an unreachable DB into the same themed 503. The service worker caches only 2xx, so a 503 page is never cached → clean recovery once the DB/maintenance flag clears. Error surfaces render through `includes/error_page.php` (theme-aware, PWA-offline-capable).
+
+## 16. Deploy + migration include-path gotchas (2026-06, lyrics-mirror saga)
+
+### 16.1 A `.sql/` migration requiring a NEW `public_html/includes/` file MUST resolve it `DOCUMENT_ROOT`-first
+
+`appWeb/.sql/migrate-*.php` scripts compute paths to `public_html/includes/` helpers. The intuitive `dirname(__DIR__) . '/public_html/includes/foo.php'` (treating `.sql/` and `public_html/` as siblings) **works for long-lived files like `db_mysql.php` but silently 500s on a brand-new include** — on the server the SERVED web docroot is a *different tree* from that sibling path, and the sibling carries old files but not the newest ones. This cost hours on `migrate-lyric-lines-mirror.php` (`Failed opening required …/public_html/includes/lyric_lines_sync.php`, even though the deploy DID upload it).
+
+**Pattern (use this for any migration that requires a new public_html include):** try the live docroot first, sibling as the CLI fallback, error clearly if neither exists:
+
+```php
+$cands = [];
+$dr = rtrim((string)($_SERVER['DOCUMENT_ROOT'] ?? ''), '/');
+if ($dr !== '') { $cands[] = $dr . '/includes/foo.php'; }
+$cands[] = dirname(__DIR__) . '/public_html/includes/foo.php';
+foreach ($cands as $c) { if (is_file($c)) { require_once $c; $found = true; break; } }
+```
+
+(`db_mysql.php`-only migrations can keep the simple sibling path — it happens to be present in the stale tree. The hazard is specifically NEW includes.)
+
+### 16.2 The SFTP deploy content-compares; new files no longer silently strand
+
+`deploy.yml`'s normal path used `--only-newer`, which — because `actions/checkout` stamps every file with the checkout mtime — **silently skipped files** whose remote copy had a later (prior-deploy) mtime. It stranded `lyric_lines_sync.php` (and #919/#920 before it). Now the normal path **content-compares** (size+content); `[deploy all]` in the commit/PR-title still forces a full sweep; the deploy job has a `timeout-minutes: 20` cap + `~/.lftprc` net timeouts so a stalled mirror can't hang the 6h Actions ceiling (it did, twice). When you add a NEW file a deploy must pick up, a `[deploy all]` PR title is the belt-and-braces guarantee.

--- a/.claude/sessions/2026-06-12-HANDOFF.md
+++ b/.claude/sessions/2026-06-12-HANDOFF.md
@@ -1,0 +1,49 @@
+# Session handoff — 2026-06-10 → 2026-06-12
+
+> Clean checkpoint. Everything below is **merged to `alpha`, CI-green, and verified**
+> where noted. **Resume point: the lyrics epic from Phase 3** — see
+> `.claude/lyrics-normalisation-strategy.md` §0.
+
+## TL;DR resume
+
+Start a new session on **#1235 P3** (per-line translations / annotations / language +
+the Id-preserving diff + the BCP 47 picker #1253). The mirror is live, complete, and
+the read path is switched — all verified on alpha. Nothing is half-broken.
+
+## What shipped (by topic)
+
+**Lyrics normalisation epic #1235 (the headline work) — Option C chosen:**
+- P1a #1247 — shared projector `includes/lyric_lines_sync.php` + `tblLyricLines.ChordsJson`/`Note` + whole-catalogue backfill (`migrate-lyric-lines-mirror.php`). Verified parity = 0 (16,081 songs / 291,478 lines).
+- P1b #1251 — transitional dual-write across **all** component-write paths (api2.php via `ed2_rebuildLyricsText`, legacy api.php `save_song`, importers, `lyrics_ingest createSong`).
+- P2a #1252 — read-switch: `SongData` sources line text from `tblLyricLines`, **byte-identical** output, count-checked `LinesJson` fallback. Verified visually on 6 songs.
+- Strategy doc `.claude/lyrics-normalisation-strategy.md` (#1239/#1241/#1242) — §0 is the resume map.
+- **P2b is intentionally coupled with P3** (its only value is Id-stability for P3 enrichment; harmless to defer).
+
+**Per-environment + ops:**
+- #1234 per-environment maintenance mode + WordPress-style admin bypass; new canonical `includes/environment.php::ihymns_environment()`.
+- #1236 recently-viewed cross-device sync (the feature was built — WS-G #1019 — only the `tblSongHistory` migration was missing).
+- #1238 notifications: per-env scope + per-notification expiry.
+- #1237 recently-viewed "0" badge → book glyph.
+- #1232 duplicate-detection `cmp.Body`→`LinesJson` 500 fix.
+
+**CI / deploy hardening (PRs #1249/#1250 — see "lessons"):**
+- 3 genuinely-missing favicons regenerated; deploy `--only-newer` → content-compare; SFTP 6h-hang → `timeout-minutes` + lftp timeouts; `activityLogEnvironment()` consolidated to `ihymns_environment()`.
+
+## Open owner DECISIONS / ACTIONS (none block a P3 resume)
+
+- **beta→main promotion** — still the highest *external* impact: stops the live-production `songs_json`/sitemap 500s (old prod code vs the shared DB). Independent of lyrics.
+- **#1243** musical metadata (Key/Tempo/Time-sig/Capo) — sibling `ArrangementJson` split-brain; plan with the lyrics epic.
+- **#1253** full BCP 47 (script+region) per-component/line language picker — folds into P3.
+- `MAXMIND_LICENSE_KEY` for #1208's local geo provider; editor Phase-5 cutover.
+
+## Hard-won lessons (now codified in `project-rules.md`)
+
+1. **`.sql/` migration requiring a NEW `public_html/includes/` file → resolve it `DOCUMENT_ROOT`-first**, not via the `dirname(__DIR__)/public_html` sibling (stale on the server for new files). This 500'd `migrate-lyric-lines-mirror` for hours.
+2. The SFTP deploy silently stranded new files via `--only-newer` (CI checkout mtimes) — fixed to content-compare; a `[deploy all]` PR title forces a full sync.
+3. A two-pass repo-integrity audit after the rapid PRs was **clean** (no race casualties) bar the 3 favicons.
+
+## Verification state
+
+- `tblLyricLines` parity (Query 2) = **0 rows** on alpha after the mirror migration.
+- P2a render verified on 6 songs (official + unofficial books + editor).
+- All migrations applied on alpha; deploy pipeline healthy.


### PR DESCRIPTION
Clean-checkpoint of the 2026-06-10→12 session so a new session resumes from the lyrics epic's **Phase 3**.

- **strategy doc** §0 — progress/resume table (P1a #1247 / P1b #1251 / P2a #1252 done + verified; P2b coupled with P3; P3 = resume; the `songs.schema.json`/`lineIds` note).
- **sessions/2026-06-12-HANDOFF.md** — full handoff (shipped-by-topic, open owner decisions, deploy lessons, verification state).
- **project-rules.md §16** — codify the deploy gotchas (`.sql` migration → `DOCUMENT_ROOT`-first for new includes; content-compare deploy + `timeout-minutes` + `[deploy all]`).

Docs only; auto-memory updated device-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)