### PR TITLE
feat(presentation): blank/black screen + pre-service countdown (#1273)

### DIFF
--- a/appWeb/public_html/css/app.css
+++ b/appWeb/public_html/css/app.css
@@ -2143,6 +2143,71 @@ body.presentation-active .scroll-to-top-btn {
     display: none !important;
 }
 
+/* --------------------------------------------------------------------------
+   Presentation utility slides (#1273): operator blank toggle + pre-service
+   countdown. Live-operation controls a worship presenter expects; purely
+   client-side over the existing overlay.
+   -------------------------------------------------------------------------- */
+
+/* Operator controls cluster in the presentation header (blank + countdown). */
+.presentation-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+.presentation-countdown-select {
+    width: auto;
+}
+
+/* Blank/black screen — black out everything between songs. The overlay goes
+   black and its direct children are hidden; the "B" key or Blank button (and
+   Escape to exit) still work because those are document-level key handlers. */
+.presentation-overlay.presentation-blank {
+    background: #000 !important;
+}
+.presentation-overlay.presentation-blank > .presentation-header,
+.presentation-overlay.presentation-blank > .presentation-lyrics,
+.presentation-overlay.presentation-blank > .presentation-countdown {
+    visibility: hidden;
+}
+
+/* Pre-service countdown — a large centred timer covering the slide. Tap it
+   (or pick "Countdown…") to dismiss. */
+.presentation-countdown {
+    position: fixed;
+    inset: 0;
+    z-index: 3;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    background: var(--bs-body-bg, #fff);
+    color: var(--bs-body-color, #000);
+    text-align: center;
+    cursor: pointer;
+}
+/* The [hidden] attribute would normally hide it, but our display:flex wins —
+   restore the intended hiding when the attribute is present. */
+.presentation-countdown[hidden] {
+    display: none;
+}
+.presentation-countdown-label {
+    font-size: 2rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    opacity: 0.75;
+}
+.presentation-countdown-time {
+    font-size: clamp(4rem, 22vw, 16rem);
+    font-weight: 800;
+    line-height: 1;
+    /* Tabular figures so the digits don't jitter as they count down. */
+    font-variant-numeric: tabular-nums;
+    font-feature-settings: "tnum" 1;
+}
+
 /* ==========================================================================
    QUICK-JUMP NUMBER INDICATOR (#96)
    ========================================================================== */

--- a/appWeb/public_html/js/app.js
+++ b/appWeb/public_html/js/app.js
@@ -516,6 +516,12 @@ class iHymnsApp {
                     /* Toggle presentation mode (#125) */
                     this.display.togglePresentationMode();
                     break;
+                case 'b':
+                case 'B':
+                    /* Blank/black the screen while presenting (#1273). No-ops
+                       elsewhere — toggleBlankScreen checks for the overlay. */
+                    this.display.toggleBlankScreen();
+                    break;
                 case 'l':
                 case 'L':
                     /* Navigate to set list page (#125) */

--- a/appWeb/public_html/js/modules/display.js
+++ b/appWeb/public_html/js/modules/display.js
@@ -27,6 +27,9 @@ export class Display {
         /** @type {boolean} Whether auto-scroll is active */
         this.autoScrollActive = false;
 
+        /** @type {number|null} setInterval id for the pre-service countdown (#1273) */
+        this.countdownTimer = null;
+
         /** Default display preferences */
         this.defaults = {
             fontSize: 1.0,          /* Multiplier: 0.5 – 5.0 */
@@ -517,13 +520,34 @@ export class Display {
                     ${songNum ? `<span class="presentation-number">${escapeHtml(songNum)}</span>` : ''}
                     <span>${escapeHtml(title)}</span>
                 </div>
-                <button type="button" class="btn btn-light btn-sm" id="presentation-close-btn"
-                        aria-label="Exit presentation mode">
-                    <i class="fa-solid fa-compress me-1" aria-hidden="true"></i> Exit
-                </button>
+                <div class="presentation-controls">
+                    <label class="visually-hidden" for="presentation-countdown-select">Pre-service countdown</label>
+                    <select class="form-select form-select-sm presentation-countdown-select"
+                            id="presentation-countdown-select" aria-label="Pre-service countdown">
+                        <option value="0">Countdown…</option>
+                        <option value="5">5 min</option>
+                        <option value="10">10 min</option>
+                        <option value="15">15 min</option>
+                        <option value="20">20 min</option>
+                    </select>
+                    <button type="button" class="btn btn-dark btn-sm" id="presentation-blank-btn"
+                            aria-pressed="false" aria-label="Blank the screen (press B)" title="Blank screen (B)">
+                        <i class="fa-solid fa-circle-half-stroke me-1" aria-hidden="true"></i> Blank
+                    </button>
+                    <button type="button" class="btn btn-light btn-sm" id="presentation-close-btn"
+                            aria-label="Exit presentation mode">
+                        <i class="fa-solid fa-compress me-1" aria-hidden="true"></i> Exit
+                    </button>
+                </div>
             </div>
             <div class="presentation-lyrics">
                 ${lyricsEl.innerHTML}
+            </div>
+            <div class="presentation-countdown" id="presentation-countdown" hidden
+                 title="Click to dismiss the countdown">
+                <div class="presentation-countdown-label">Service begins in</div>
+                <div class="presentation-countdown-time" id="presentation-countdown-time"
+                     role="timer" aria-live="off">0:00</div>
             </div>`;
 
         document.body.appendChild(overlay);
@@ -547,6 +571,29 @@ export class Display {
             this.exitPresentationMode();
         });
 
+        /* Blank/black screen toggle (#1273) — operator control; the "B" key
+           (wired in app.js) does the same hands-on-keyboard blackout. */
+        overlay.querySelector('#presentation-blank-btn')?.addEventListener('click', () => {
+            this.toggleBlankScreen();
+        });
+
+        /* Pre-service countdown (#1273) — picking a preset starts/replaces the
+           timer; the "Countdown…" option (value 0) clears it. */
+        overlay.querySelector('#presentation-countdown-select')?.addEventListener('change', (e) => {
+            const mins = parseInt(e.target.value, 10) || 0;
+            if (mins > 0) {
+                this.startCountdown(mins);
+            } else {
+                this.stopCountdown();
+            }
+        });
+
+        /* Tapping the countdown (e.g. on the projector/touch device) dismisses
+           it — Escape exits and "B" blanks regardless, via the key handlers. */
+        overlay.querySelector('#presentation-countdown')?.addEventListener('click', () => {
+            this.stopCountdown();
+        });
+
         /* Escape key to close */
         const escHandler = (e) => {
             if (e.key === 'Escape') {
@@ -566,12 +613,123 @@ export class Display {
 
     /** Exit presentation mode */
     exitPresentationMode() {
+        /* Clear any running pre-service countdown so its interval doesn't
+           keep firing after the overlay is gone (#1273). */
+        this.stopCountdown();
+
         document.body.classList.remove('presentation-active');
         document.getElementById('presentation-overlay')?.remove();
 
         if (document.fullscreenElement) {
             document.exitFullscreen().catch(() => {});
         }
+    }
+
+    /* =====================================================================
+     * PRESENTATION UTILITY SLIDES (#1273)
+     * Blank/black screen + a pre-service countdown — the live-operation
+     * controls worship presenters expect (ProPresenter / WorshipTools ship
+     * these). Pure client-side over the existing presentation overlay; no
+     * song data, no schema, no network.
+     * ===================================================================== */
+
+    /**
+     * Toggle the blank/black screen in presentation mode.
+     *
+     * ELI5: hides the words behind a black screen so the congregation sees
+     * nothing between songs, then brings them back.
+     *
+     * Detailed: flips the `presentation-blank` class on the overlay (CSS
+     * blacks it out and hides the header/lyrics/countdown) and mirrors the
+     * state into the Blank button's `aria-pressed`. No-ops when not in
+     * presentation mode, so the bound "B" key is harmless on other pages.
+     * MDN: https://developer.mozilla.org/en-US/docs/Web/API/Element/classList
+     */
+    toggleBlankScreen() {
+        const overlay = document.getElementById('presentation-overlay');
+        if (!overlay) return;
+
+        const blanked = overlay.classList.toggle('presentation-blank');
+
+        const btn = document.getElementById('presentation-blank-btn');
+        if (btn) btn.setAttribute('aria-pressed', blanked ? 'true' : 'false');
+    }
+
+    /**
+     * Start (or restart) a pre-service countdown overlay.
+     *
+     * ELI5: shows a big "Service begins in 5:00" timer that counts down to
+     * zero so people know when to be seated.
+     *
+     * Detailed: anchors on an absolute end timestamp (`Date.now() + minutes`)
+     * and recomputes the remaining seconds on every tick, so the display
+     * can't drift even when a tick is delayed or the tab is throttled. Ticks
+     * every 250ms for a crisp final second; on reaching zero it stops
+     * ticking but leaves "0:00" on screen. Replaces any prior run.
+     *
+     * @param {number} minutes Whole minutes to count down from (clamped 1–180).
+     */
+    startCountdown(minutes) {
+        const layer = document.getElementById('presentation-countdown');
+        const timeEl = document.getElementById('presentation-countdown-time');
+        if (!layer || !timeEl) return;
+
+        /* Clear any previous run first so presets replace cleanly. */
+        this.stopCountdown();
+
+        /* Clamp to a sane range so a stray value can't run away. */
+        const mins = Math.min(180, Math.max(1, Math.floor(minutes) || 0));
+        const endAt = Date.now() + mins * 60 * 1000;
+
+        const render = () => {
+            const remaining = Math.max(0, Math.round((endAt - Date.now()) / 1000));
+            timeEl.textContent = this._formatCountdown(remaining);
+            if (remaining <= 0 && this.countdownTimer) {
+                /* Reached zero — stop ticking but leave 0:00 displayed. */
+                clearInterval(this.countdownTimer);
+                this.countdownTimer = null;
+            }
+        };
+
+        layer.hidden = false;
+        render();
+        this.countdownTimer = setInterval(render, 250);
+    }
+
+    /**
+     * Stop the pre-service countdown and hide its overlay.
+     *
+     * ELI5: turns the countdown timer off.
+     *
+     * Detailed: clears the interval, hides the countdown layer, and resets
+     * the header `<select>` back to "Countdown…" so the control reflects the
+     * off state. Safe to call when nothing is running.
+     */
+    stopCountdown() {
+        if (this.countdownTimer) {
+            clearInterval(this.countdownTimer);
+            this.countdownTimer = null;
+        }
+        const layer = document.getElementById('presentation-countdown');
+        if (layer) layer.hidden = true;
+        const select = document.getElementById('presentation-countdown-select');
+        if (select) select.value = '0';
+    }
+
+    /**
+     * Format whole seconds as `M:SS` (or `H:MM:SS` past an hour).
+     * @param {number} totalSeconds
+     * @returns {string}
+     */
+    _formatCountdown(totalSeconds) {
+        const s = Math.max(0, totalSeconds);
+        const hours = Math.floor(s / 3600);
+        const mins = Math.floor((s % 3600) / 60);
+        const secs = s % 60;
+        const pad = (n) => String(n).padStart(2, '0');
+        return hours > 0
+            ? `${hours}:${pad(mins)}:${pad(secs)}`
+            : `${mins}:${pad(secs)}`;
     }
 
     /* =====================================================================


### PR DESCRIPTION
Closes #1273.

The one genuinely-shippable "easy win" from the 2026-06-14 WorshipTools / Planning-Center feature-comparison pass — live-operation controls on top of the existing fullscreen presentation overlay (#297). **Pure client-side; no PHP, no schema, no SQL/CSRF/auth/network surface.**

## What
- **Blank/black screen** — a header `Blank` button **and the `B` key** black out the screen between songs (the operator standard in ProPresenter/WorshipTools). `toggleBlankScreen()` no-ops when not presenting, so the key binding is harmless on other pages.
- **Pre-service countdown** — a header picker (5/10/15/20 min) shows a large, centred, **drift-free** `M:SS` timer (anchored on an absolute end timestamp, recomputed each tick so it can't drift when the tab is throttled); tap — or pick "Countdown…" — to dismiss. The interval is cleared on exit (`exitPresentationMode`/`cleanup`) so it never leaks.

## Files (+233 / −4)
- `js/modules/display.js` — `toggleBlankScreen()`, `startCountdown()`/`stopCountdown()`/`_formatCountdown()`, overlay markup + wiring, countdown cleared on exit.
- `js/app.js` — the `B` key in the global shortcut dispatcher (guarded like `p`/`s`; ignored in inputs and when shortcuts are disabled).
- `css/app.css` — `.presentation-controls`, `.presentation-blank`, `.presentation-countdown` (tabular-nums so digits don't jitter).

## Why not the sibling chart ideas
The other flagged "easy wins" — #1270 (two-column), #1271 (per-user capo overlay), #1265 (Nashville) — are **deferred**: they depend on **#299** rendering visible chords on the song page first (`song.php:745`'s chord toggle is currently `display:none`). Noted on each of those issues.

## Security notes (pre-PR review — clean)
No new untrusted input handling: the only input is the countdown `<select>`, `parseInt`'d and **clamped 1–180**; the timer text is computed numbers; title/song-number keep their existing `escapeHtml`. No `innerHTML` of user data, no SQL, no CSRF/auth surface, no secrets, no dangerous functions, no new deps.

## Testing
Full `node --check` sweep across `appWeb` green; manual checks: `B`/Blank toggles the blackout and mirrors `aria-pressed`; countdown counts down drift-free and clears on exit; exiting/Escape tears everything down. Targets **alpha** — non-lyric/non-DB, so it doesn't disturb the #1235 cutover soak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)