### PR TITLE
feat(import-export): ChordPro (.cho) export — WorshipTools/OnSong interop (#1264)

### DIFF
--- a/appWeb/public_html/includes/pages/song.php
+++ b/appWeb/public_html/includes/pages/song.php
@@ -738,6 +738,7 @@ try {
                         <li><button type="button" class="dropdown-item" data-export-format="videoPsalm">VideoPsalm</button></li>
                         <li><button type="button" class="dropdown-item" data-export-format="freeShow">FreeShow</button></li>
                         <li><button type="button" class="dropdown-item" data-export-format="proclaim">Proclaim</button></li>
+                        <li><button type="button" class="dropdown-item" data-export-format="chordPro">ChordPro</button></li>
                     </ul>
                 </div>
 

--- a/appWeb/public_html/js/modules/export-ui.js
+++ b/appWeb/public_html/js/modules/export-ui.js
@@ -20,6 +20,7 @@ const FORMATS = [
     { key: 'videoPsalm',    label: 'VideoPsalm (.json)' },
     { key: 'freeShow',      label: 'FreeShow (.show)' },
     { key: 'proclaim',      label: 'Proclaim (.txt)' },
+    { key: 'chordPro',      label: 'ChordPro (.cho)' },
 ];
 
 let _libsPromise = null;

--- a/appWeb/public_html/manage/editor/format-export.js
+++ b/appWeb/public_html/manage/editor/format-export.js
@@ -614,6 +614,77 @@
         return { filename: zipName, size: zip.length, count: files.length };
     }
 
+    /* ====================================================================
+     *  ChordPro (.cho) — #1264  (lyrics-only v1)
+     * ====================================================================
+     * ChordPro is the lingua franca chord-chart text format and the only
+     * format WorshipTools Presenter/Planning imports under six extensions
+     * (.chord/.cho/.crd/.chopro/.pro/.txt) — also read by OnSong, SongBeamer
+     * and Planning Center. This v1 emits the header directives WorshipTools
+     * documents plus section labels as {comment:} (the section directive
+     * WorshipTools confirms), with LYRICS ONLY. Inline [chord] markers are a
+     * follow-on once per-line chords are surfaced on the export read path
+     * (#299 / #1094) — they aren't in the export song-shape yet. A songbook
+     * exports as a zip of .cho files. */
+
+    function cpDirective(name, value) {
+        /* A ChordPro directive value cannot contain a brace or newline, so
+           collapse any to spaces; an empty value emits nothing. */
+        var v = String(value == null ? '' : value).replace(/[{}\r\n]+/g, ' ').trim();
+        return v ? ('{' + name + ': ' + v + '}\n') : '';
+    }
+
+    function buildChordPro(song, options) {
+        if (!song) { throw new Error('buildChordPro: song required'); }
+        var authors = [].concat(song.writers || [], song.composers || []).filter(Boolean).join(', ');
+        var out = '';
+        out += cpDirective('title', song.title || 'Untitled');
+        if (song.alternateTitle) { out += cpDirective('subtitle', song.alternateTitle); }
+        if (authors)             { out += cpDirective('artist', authors); }
+        if (song.key)            { out += cpDirective('key', song.key); }
+        if (song.capo)           { out += cpDirective('capo', song.capo); }
+        if (song.ccli)           { out += cpDirective('ccli', song.ccli); }
+        if (song.copyright)      { out += cpDirective('copyright', song.copyright); }
+        (song.components || []).forEach(function (comp) {
+            /* Section label as a {comment:} (e.g. "Verse 1", "Chorus") —
+               reuses the Proclaim label map so labelling stays consistent. */
+            out += '\n' + cpDirective('comment', pcLabel(comp));
+            (comp.lines || []).forEach(function (line) {
+                out += String(line == null ? '' : line) + '\n';
+            });
+        });
+        return out;
+    }
+
+    function exportSongChordPro(song, options) {
+        var txt = buildChordPro(song, options);
+        var filename = baseFilename(song) + '.cho';
+        download(txt, filename, 'text/plain');
+        return { filename: filename, size: txt.length };
+    }
+
+    function exportSongbookChordPro(songs, options) {
+        options = options || {};
+        if (!Array.isArray(songs) || !songs.length) {
+            throw new Error('exportSongbookChordPro: non-empty songs array required');
+        }
+        var enc = new TextEncoder();
+        var seen = Object.create(null);
+        var files = songs.map(function (song) {
+            var name = baseFilename(song) + '.cho';
+            if (seen[name]) { name = baseFilename(song) + ' (' + (seen[name]++) + ').cho'; }
+            else { seen[name] = 1; }
+            return { name: name, bytes: enc.encode(buildChordPro(song, options)) };
+        });
+        var zip = buildZip(files);
+        var stem = options.songbookName
+            ? sanitizeFilename(options.songbookName + (options.songbookAbbr ? ' (' + options.songbookAbbr + ')' : ''))
+            : (options.songbookAbbr ? sanitizeFilename(options.songbookAbbr) : 'ChordPro Export');
+        var zipName = stem + ' [ChordPro].zip';
+        download(zip, zipName, 'application/zip');
+        return { filename: zipName, size: zip.length, count: files.length };
+    }
+
     /* ---- public API ----------------------------------------------------- */
 
     var api = {
@@ -646,6 +717,11 @@
             build:           buildFreeShow,
             exportSong:      exportSongFreeShow,
             exportSongbook:  exportSongbookFreeShow
+        },
+        chordPro: {
+            build:           buildChordPro,
+            exportSong:      exportSongChordPro,
+            exportSongbook:  exportSongbookChordPro
         },
         _internal: { escapeXml: escapeXml, baseFilename: baseFilename, buildZip: buildZip, download: download }
     };

--- a/tests/test-chordpro-export.js
+++ b/tests/test-chordpro-export.js
@@ -1,0 +1,109 @@
+/**
+ * iHymns — ChordPro Export Unit Tests (#1264)
+ *
+ * Exercises the pure builder `chordPro.build(song)` exposed by
+ *   appWeb/public_html/manage/editor/format-export.js
+ *
+ * Scope: the lyrics-only v1 — header directives + {comment:} section labels +
+ * lyric lines. (Inline [chord] markers are a follow-on once per-line chords
+ * are surfaced on the export read path, #299/#1094.) Only `build` is tested:
+ * `exportSong*` call download()/the DOM, which doesn't exist under Node.
+ *
+ *   USAGE:  node tests/test-chordpro-export.js
+ *   Exit status 0 = all pass, 1 = at least one assertion failed.
+ */
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const require    = createRequire(import.meta.url);
+
+const FORMAT_EXPORT_PATH = path.resolve(
+    __dirname, '..',
+    'appWeb/public_html/manage/editor/format-export.js'
+);
+
+/* format-export.js is a plain global script: requiring it for side effect sets
+   globalThis.iHymnsFormatExport (the same contract the browser consumes).
+   buildChordPro is pure (no DOM), so it's directly testable. */
+require(FORMAT_EXPORT_PATH);
+const fmt = globalThis.iHymnsFormatExport;
+const buildChordPro = fmt.chordPro.build;
+
+let passed = 0, failed = 0;
+const failures = [];
+function test(name, fn) {
+    try { fn(); passed++; console.log(`  PASS  ${name}`); }
+    catch (err) { failed++; failures.push({ name, error: err.message }); console.log(`  FAIL  ${name}`); }
+}
+
+const SONG = {
+    title: 'Amazing Grace',
+    alternateTitle: 'New Britain',
+    writers: ['John Newton'],
+    composers: ['Trad.'],
+    key: 'G',
+    capo: 2,
+    ccli: '12345',
+    copyright: 'Public Domain',
+    components: [
+        { type: 'verse',  number: 1,    lines: ['Amazing grace how sweet the sound', 'That saved a wretch like me'] },
+        { type: 'chorus', number: null, lines: ['Praise God', 'Praise God'] },
+    ],
+};
+
+test('registry exposes chordPro.build', () => {
+    assert.equal(typeof buildChordPro, 'function');
+});
+
+test('emits the documented header directives', () => {
+    const out = buildChordPro(SONG);
+    assert.match(out, /\{title: Amazing Grace\}/);
+    assert.match(out, /\{subtitle: New Britain\}/);
+    assert.match(out, /\{artist: John Newton, Trad\.\}/);
+    assert.match(out, /\{key: G\}/);
+    assert.match(out, /\{capo: 2\}/);
+    assert.match(out, /\{ccli: 12345\}/);
+    assert.match(out, /\{copyright: Public Domain\}/);
+});
+
+test('labels sections as {comment:} (Verse 1 / Chorus)', () => {
+    const out = buildChordPro(SONG);
+    assert.match(out, /\{comment: Verse 1\}/);
+    assert.match(out, /\{comment: Chorus\}/);
+});
+
+test('includes the lyric lines verbatim', () => {
+    const out = buildChordPro(SONG);
+    assert.ok(out.includes('Amazing grace how sweet the sound'));
+    assert.ok(out.includes('That saved a wretch like me'));
+});
+
+test('omits absent metadata (no empty directives)', () => {
+    const out = buildChordPro({ title: 'Bare', components: [{ type: 'verse', number: 1, lines: ['x'] }] });
+    assert.match(out, /\{title: Bare\}/);
+    assert.ok(!/\{subtitle:/.test(out), 'no subtitle directive');
+    assert.ok(!/\{key:/.test(out),      'no key directive');
+    assert.ok(!/\{ccli:/.test(out),     'no ccli directive');
+    assert.ok(!/\{artist:/.test(out),   'no artist directive');
+});
+
+test('untitled fallback when title missing', () => {
+    assert.match(buildChordPro({ components: [] }), /\{title: Untitled\}/);
+});
+
+test('directive values strip braces/newlines (cannot break the directive)', () => {
+    const out = buildChordPro({ title: 'A{B}\nC', components: [] });
+    assert.match(out, /\{title: A B C\}/);
+    assert.ok(!out.includes('A{B}'), 'inner brace removed');
+});
+
+test('throws without a song', () => {
+    assert.throws(() => buildChordPro(null), /song required/);
+});
+
+console.log(`\nChordPro export: ${passed} passed, ${failed} failed`);
+if (failed) { failures.forEach(f => console.log(`  - ${f.name}: ${f.error}`)); process.exit(1); }


### PR DESCRIPTION
Part of #1264 (the WorshipTools interop request). Targets **alpha**.

ChordPro is the **only** format WorshipTools Presenter/Planning imports (six extensions: `.chord/.cho/.crd/.chopro/.pro/.txt`) and the lingua franca for OnSong/OpenSong/SongBeamer/Planning Center — so a ChordPro exporter is the realistic interop on-ramp (WorshipTools ships no native song format and essentially no export; see the research summarised on #1264).

## What
- **`format-export.js`** — `buildChordPro` / `exportSongChordPro` / `exportSongbookChordPro` + a `chordPro` registry entry, reusing the existing `pcLabel` / `baseFilename` / `buildZip` helpers (mirrors the Proclaim builder).
- **`export-ui.js` + `song.php`** — a "ChordPro" item on the public song-page export menu (single song `.cho`) and the songbook export (`.zip` of `.cho`).
- **`tests/test-chordpro-export.js`** — 8 unit tests over the pure `build` (header directives, `{comment:}` section labels, lyric lines, omitted-metadata, untitled fallback, brace/newline stripping, throw-without-song).

## Scope — lyrics-only v1 (deliberate)
Emits the header directives WorshipTools documents — `{title}/{subtitle}/{artist}/{key}/{capo}/{ccli}/{copyright}` — plus section labels as `{comment:}` (the section directive WorshipTools' docs confirm; `{soc}`/`[G]` are *not* confirmed, so they're avoided until validated against a live Planning import). **Inline `[chord]` markers are a follow-on**: per-line chords aren't surfaced on the export read-path yet (the shared keystone with #299/#1094). Adding chords later is purely additive to `buildChordPro`.

## Security notes (clean)
Client-side text-file builder. Output is a downloaded `.cho` (plain text, not HTML — no XSS). `cpDirective` strips `{`/`}`/newlines from directive values so a value can't break the directive. No SQL/auth/CSRF/network/secrets surface; `song.php` adds one static menu `<button>`.

## Testing
`node tests/test-chordpro-export.js` → 8/8 pass. Full `node --check` sweep across `appWeb` + `tests` green; `php -l` clean on `song.php`. Non-lyric/non-DB → no impact on the #1235 cutover soak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)