### PR TITLE
feat(live-follow): #1268 Phase 1 — dormant backend (StateRevision + broadcast API)

### DIFF
--- a/appWeb/.sql/cleanup.php
+++ b/appWeb/.sql/cleanup.php
@@ -142,6 +142,26 @@ try {
     echo "tblLoginAttempts:      ERROR — " . $e->getMessage() . "\n";
 }
 
+/* 4b. Expired Live-Follow sessions (#1268) — broadcast state is ephemeral:
+   drop rows past their ExpiresAt horizon, plus any deactivated session left
+   over from a prior day. ExpiresAt is written in UTC (UTC_TIMESTAMP()) by the
+   live_follow_* endpoints, so compare against the UTC $now built above. */
+try {
+    $stmt = $db->prepare(
+        'DELETE FROM tblLiveFollowSessions
+          WHERE ExpiresAt < ?
+             OR (IsActive = 0 AND UpdatedAt < DATE_SUB(UTC_TIMESTAMP(), INTERVAL 1 DAY))'
+    );
+    $stmt->bind_param('s', $now);
+    $stmt->execute();
+    $count = $stmt->affected_rows;
+    echo "tblLiveFollowSessions: $count stale session(s) deleted\n";
+    $totalDeleted += $count;
+    $stmt->close();
+} catch (\mysqli_sql_exception $e) {
+    echo "tblLiveFollowSessions: ERROR — " . $e->getMessage() . "\n";
+}
+
 /* 5. tblActivityLog retention prune (#535).
    Pruning is OPT-IN — the default retention is 0 (unset), meaning
    activity rows are kept indefinitely. Audit, compliance, and

--- a/appWeb/.sql/migrate-live-follow-revision.php
+++ b/appWeb/.sql/migrate-live-follow-revision.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Live-follow: add the StateRevision broadcast counter (#1268)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Adds a monotonic StateRevision counter to tblLiveFollowSessions. The host
+ * bumps it on every state write; followers short-poll with `?since=<n>` and the
+ * server returns a near-free "unchanged" until the revision advances — the key
+ * efficiency lever that lets the web/PWA Live Follow (#1268) scale on shared
+ * hosting without holding a worker open per follower (no SSE).
+ *
+ * STRICTLY ADDITIVE + IDEMPOTENT. Depends on tblLiveFollowSessions existing
+ * (run the "Live-follow sessions" migration first — #1090 P7).
+ *
+ * @migration-adds tblLiveFollowSessions.StateRevision
+ *
+ * USAGE:
+ *   CLI:  php appWeb/.sql/migrate-live-follow-revision.php
+ *   Web:  /manage/setup-database → "Live-follow: StateRevision" button
+ *
+ * @requires PHP 8.1+ with mysqli
+ */
+
+$isCli = (php_sapi_name() === 'cli');
+if (!$isCli && !defined('IHYMNS_SETUP_DASHBOARD')) {
+    header('Content-Type: text/plain; charset=UTF-8');
+    header('X-Content-Type-Options: nosniff');
+    header('Cache-Control: no-store');
+}
+function _migLFR_output(string $m): void { global $isCli; echo $m . ($isCli ? "\n" : "<br>\n"); if (!$isCli) flush(); }
+function _migLFR_tableExists(\mysqli $db, string $t): bool { $r = $db->query("SHOW TABLES LIKE '{$t}'"); return (bool)($r && $r->num_rows > 0); }
+function _migLFR_colExists(\mysqli $db, string $t, string $c): bool {
+    $r = $db->query("SHOW COLUMNS FROM `{$t}` LIKE '" . $db->real_escape_string($c) . "'");
+    return (bool)($r && $r->num_rows > 0);
+}
+
+$credFile = dirname(__DIR__) . DIRECTORY_SEPARATOR . '.auth' . DIRECTORY_SEPARATOR . 'db_credentials.php';
+if (!file_exists($credFile)) { _migLFR_output("ERROR: MySQL credentials not found. Run install.php first."); return; }
+require_once $credFile;
+
+_migLFR_output("");
+_migLFR_output("=== iHymns — Live-follow StateRevision (#1268) ===");
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+try {
+    $mysql = new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME, (int)DB_PORT);
+    $mysql->set_charset(defined('DB_CHARSET') ? DB_CHARSET : 'utf8mb4');
+} catch (\mysqli_sql_exception $e) { _migLFR_output("ERROR: MySQL connection failed: " . $e->getMessage()); return; }
+_migLFR_output("Connected to MySQL: " . DB_NAME);
+
+try {
+    if (!_migLFR_tableExists($mysql, 'tblLiveFollowSessions')) {
+        _migLFR_output("  [SKIP] tblLiveFollowSessions not present yet — run the Live-follow sessions migration first.");
+    } elseif (_migLFR_colExists($mysql, 'tblLiveFollowSessions', 'StateRevision')) {
+        _migLFR_output("  [SKIP] tblLiveFollowSessions.StateRevision already present.");
+    } else {
+        $mysql->query(
+            "ALTER TABLE tblLiveFollowSessions
+                ADD COLUMN StateRevision INT UNSIGNED NOT NULL DEFAULT 0
+                    COMMENT 'Monotonic broadcast revision; host bumps on each state write so followers poll cheaply with ?since='
+                AFTER StateJson"
+        );
+        _migLFR_output("  [OK] Added tblLiveFollowSessions.StateRevision.");
+    }
+    _migLFR_output("Migration complete.");
+} catch (\Throwable $e) { _migLFR_output("  [ERROR] " . $e->getMessage()); }
+$mysql->close();
+return;

--- a/appWeb/.sql/schema.sql
+++ b/appWeb/.sql/schema.sql
@@ -3004,6 +3004,7 @@ CREATE TABLE IF NOT EXISTS tblLiveFollowSessions (
     CurrentSongId        VARCHAR(20)  NULL DEFAULT NULL COMMENT 'FK to tblSongs — the song currently displayed',
     CurrentComponentIndex INT        NULL DEFAULT NULL COMMENT 'Index into the arrangement/component order being shown',
     StateJson            JSON         NULL DEFAULT NULL COMMENT 'Extra broadcast state (blank, theme, font-size hints)',
+    StateRevision        INT UNSIGNED NOT NULL DEFAULT 0 COMMENT 'Monotonic broadcast revision; host bumps on each state write so followers poll cheaply with ?since=',
     IsActive             TINYINT(1)   NOT NULL DEFAULT 1,
     StartedAt            DATETIME     NOT NULL,
     LastHeartbeatAt      DATETIME     NOT NULL,

--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -11518,6 +11518,293 @@ if ($action !== null) {
         }
 
         /* -----------------------------------------------------------------
+         * Live Follow (#1268) — web/PWA real-time multi-device follow.
+         * DB-relayed short-poll over tblLiveFollowSessions (no SSE — shared
+         * hosting can't hold a worker per follower). The host writes its
+         * current song/section/state and bumps StateRevision; followers poll
+         * with ?since=<rev> and get a near-free "unchanged" until it advances.
+         * Host endpoints require auth + ownership; join/poll are anonymous,
+         * scoped by the unguessable code. State-changing POSTs inherit the
+         * X-Requested-With CSRF guard at the top of this file.
+         * ----------------------------------------------------------------- */
+        case 'live_follow_create': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') { sendJson(['error' => 'POST method required.'], 405); break; }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser) { sendJson(['error' => 'Not authenticated.'], 401); break; }
+            $userId = (int)$authUser['Id'];
+            $liveIp = $_SERVER['REMOTE_ADDR'] ?? '';
+
+            /* 20 new sessions / hour / user is plenty for a worship leader. */
+            checkRateLimit('live_follow_create', $liveIp, 20, 3600, true, $userId);
+            recordRateLimitHit('live_follow_create', 'user:' . $userId);
+
+            $body = json_decode(file_get_contents('php://input'), true);
+            if (!is_array($body)) { $body = []; }
+
+            $setlistId = isset($body['setlistId'])
+                ? mb_substr(preg_replace('/[^a-zA-Z0-9_\-]/', '', (string)$body['setlistId']), 0, 100) : null;
+            if ($setlistId === '') { $setlistId = null; }
+            $songId = isset($body['songId']) ? _liveFollowCleanSongId((string)$body['songId']) : null;
+            if ($songId === '') { $songId = null; }
+            $componentIndex = (isset($body['componentIndex']) && $body['componentIndex'] !== null)
+                ? min(9999, max(0, (int)$body['componentIndex'])) : null;
+            $stateJson = _liveFollowCleanState($body['state'] ?? null);
+            $orgId = null; /* v1: org scoping deferred; the FK stays NULL (SET NULL-safe). */
+
+            $db = getDbMysqli();
+
+            /* Reject an unknown songId up front — the CurrentSongId FK would
+               otherwise throw 1452 under STRICT → an uncaught 500. */
+            if ($songId !== null) {
+                $chkSong = $db->prepare('SELECT 1 FROM tblSongs WHERE SongId = ? LIMIT 1');
+                $chkSong->bind_param('s', $songId);
+                $chkSong->execute();
+                $songOk = $chkSong->get_result()->fetch_row() !== null;
+                $chkSong->close();
+                if (!$songOk) { sendJson(['error' => 'Unknown song.'], 400); break; }
+            }
+
+            /* One active session per host — supersede any prior one. */
+            $deact = $db->prepare('UPDATE tblLiveFollowSessions SET IsActive = 0 WHERE HostUserId = ? AND IsActive = 1');
+            $deact->bind_param('i', $userId);
+            $deact->execute();
+            $deact->close();
+
+            /* Crockford-ish base32, no ambiguous glyphs (no I/L/O/U/0/1). */
+            $alphabet = 'ABCDEFGHJKMNPQRSTVWXYZ23456789';
+            $alphaMax = strlen($alphabet) - 1;
+            $code = '';
+            $inserted = false;
+            for ($attempt = 0; $attempt < 6 && !$inserted; $attempt++) {
+                $code = '';
+                for ($i = 0; $i < 6; $i++) { $code .= $alphabet[random_int(0, $alphaMax)]; }
+                try {
+                    $ins = $db->prepare(
+                        'INSERT INTO tblLiveFollowSessions
+                            (SessionCode, HostUserId, OrgId, SetlistId, CurrentSongId,
+                             CurrentComponentIndex, StateJson, IsActive, StartedAt,
+                             LastHeartbeatAt, ExpiresAt, StateRevision)
+                         VALUES (?, ?, ?, ?, ?, ?, ?, 1, UTC_TIMESTAMP(), UTC_TIMESTAMP(),
+                                 DATE_ADD(UTC_TIMESTAMP(), INTERVAL 4 HOUR), 0)'
+                    );
+                    $ins->bind_param('siissis', $code, $userId, $orgId, $setlistId, $songId, $componentIndex, $stateJson);
+                    $ins->execute();
+                    $ins->close();
+                    $inserted = true;
+                } catch (\mysqli_sql_exception $e) {
+                    /* uq_Code collision (errno 1062) — retry; anything else is real. */
+                    if ($e->getCode() !== 1062) { throw $e; }
+                }
+            }
+            if (!$inserted) { sendJson(['error' => 'Could not allocate a session code, please retry.'], 503); break; }
+
+            sendJson(['ok' => true, 'code' => $code, 'revision' => 0]);
+            break;
+        }
+
+        case 'live_follow_update': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') { sendJson(['error' => 'POST method required.'], 405); break; }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser) { sendJson(['error' => 'Not authenticated.'], 401); break; }
+            $userId = (int)$authUser['Id'];
+            $liveIp = $_SERVER['REMOTE_ADDR'] ?? '';
+
+            /* Generous: a fast operator + heartbeats stay well under 600/min. */
+            checkRateLimit('live_follow_update', $liveIp, 600, 60, true, $userId);
+            recordRateLimitHit('live_follow_update', 'user:' . $userId);
+
+            $body = json_decode(file_get_contents('php://input'), true);
+            if (!is_array($body)) { $body = []; }
+
+            $code = strtoupper(trim((string)($body['code'] ?? '')));
+            if (!preg_match('/^[A-Z0-9]{4,12}$/', $code)) { sendJson(['error' => 'Invalid session code.'], 400); break; }
+
+            /* The host broadcasts its FULL current context each update. */
+            $songId = isset($body['songId']) ? _liveFollowCleanSongId((string)$body['songId']) : '';
+            if ($songId === '') { sendJson(['error' => 'songId is required.'], 400); break; }
+            $componentIndex = (isset($body['componentIndex']) && $body['componentIndex'] !== null)
+                ? min(9999, max(0, (int)$body['componentIndex'])) : null;
+            $stateJson = _liveFollowCleanState($body['state'] ?? null);
+
+            $db = getDbMysqli();
+
+            /* Reject an unknown songId before the CurrentSongId FK throws 1452 → 500. */
+            $chkSong = $db->prepare('SELECT 1 FROM tblSongs WHERE SongId = ? LIMIT 1');
+            $chkSong->bind_param('s', $songId);
+            $chkSong->execute();
+            $songOk = $chkSong->get_result()->fetch_row() !== null;
+            $chkSong->close();
+            if (!$songOk) { sendJson(['error' => 'Unknown song.'], 400); break; }
+
+            $upd = $db->prepare(
+                'UPDATE tblLiveFollowSessions
+                    SET CurrentSongId = ?, CurrentComponentIndex = ?, StateJson = ?,
+                        LastHeartbeatAt = UTC_TIMESTAMP(),
+                        ExpiresAt = DATE_ADD(UTC_TIMESTAMP(), INTERVAL 4 HOUR),
+                        StateRevision = StateRevision + 1
+                  WHERE SessionCode = ? AND HostUserId = ? AND IsActive = 1'
+            );
+            $upd->bind_param('sissi', $songId, $componentIndex, $stateJson, $code, $userId);
+            $upd->execute();
+            $changed = $upd->affected_rows;
+            $upd->close();
+            if ($changed === 0) { sendJson(['ok' => false, 'error' => 'Session not found, not yours, or ended.'], 409); break; }
+
+            $sel = $db->prepare('SELECT StateRevision FROM tblLiveFollowSessions WHERE SessionCode = ? AND HostUserId = ?');
+            $sel->bind_param('si', $code, $userId);
+            $sel->execute();
+            $revRow = $sel->get_result()->fetch_row();
+            $rev = $revRow ? (int)$revRow[0] : 0;
+            $sel->close();
+
+            sendJson(['ok' => true, 'revision' => $rev]);
+            break;
+        }
+
+        case 'live_follow_heartbeat': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') { sendJson(['error' => 'POST method required.'], 405); break; }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser) { sendJson(['error' => 'Not authenticated.'], 401); break; }
+            $userId = (int)$authUser['Id'];
+
+            $body = json_decode(file_get_contents('php://input'), true);
+            if (!is_array($body)) { $body = []; }
+            $code = strtoupper(trim((string)($body['code'] ?? '')));
+            if (!preg_match('/^[A-Z0-9]{4,12}$/', $code)) { sendJson(['error' => 'Invalid session code.'], 400); break; }
+
+            $db = getDbMysqli();
+            /* Keepalive only — does NOT bump StateRevision (no state changed). */
+            $hb = $db->prepare(
+                'UPDATE tblLiveFollowSessions
+                    SET LastHeartbeatAt = UTC_TIMESTAMP(),
+                        ExpiresAt = DATE_ADD(UTC_TIMESTAMP(), INTERVAL 4 HOUR)
+                  WHERE SessionCode = ? AND HostUserId = ? AND IsActive = 1'
+            );
+            $hb->bind_param('si', $code, $userId);
+            $hb->execute();
+            $hb->close();
+
+            /* Liveness via existence, NOT affected_rows: two heartbeats in the
+               same second write identical timestamps, so affected_rows (changed
+               rows) would be 0 even though the session is fine. */
+            $chk = $db->prepare(
+                'SELECT 1 FROM tblLiveFollowSessions
+                  WHERE SessionCode = ? AND HostUserId = ? AND IsActive = 1'
+            );
+            $chk->bind_param('si', $code, $userId);
+            $chk->execute();
+            $alive = $chk->get_result()->fetch_row() !== null;
+            $chk->close();
+
+            sendJson(['ok' => $alive]);
+            break;
+        }
+
+        case 'live_follow_leave': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') { sendJson(['error' => 'POST method required.'], 405); break; }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser) { sendJson(['error' => 'Not authenticated.'], 401); break; }
+            $userId = (int)$authUser['Id'];
+
+            $body = json_decode(file_get_contents('php://input'), true);
+            if (!is_array($body)) { $body = []; }
+            $code = strtoupper(trim((string)($body['code'] ?? '')));
+            if (!preg_match('/^[A-Z0-9]{4,12}$/', $code)) { sendJson(['error' => 'Invalid session code.'], 400); break; }
+
+            $db = getDbMysqli();
+            $end = $db->prepare('UPDATE tblLiveFollowSessions SET IsActive = 0 WHERE SessionCode = ? AND HostUserId = ?');
+            $end->bind_param('si', $code, $userId);
+            $end->execute();
+            $end->close();
+
+            sendJson(['ok' => true]);
+            break;
+        }
+
+        case 'live_follow_join': {
+            $code = strtoupper(trim((string)($_GET['code'] ?? '')));
+            if (!preg_match('/^[A-Z0-9]{4,12}$/', $code)) { sendJson(['ok' => false, 'error' => 'Invalid session code.'], 400); break; }
+            $liveIp = $_SERVER['REMOTE_ADDR'] ?? '';
+
+            /* Join is infrequent (once per follower); a per-IP cap blunts code
+               enumeration without penalising a real congregation. */
+            checkRateLimit('live_follow_join', $liveIp, 60, 60, true);
+            recordRateLimitHit('live_follow_join', $liveIp);
+
+            $db = getDbMysqli();
+            $stmt = $db->prepare(
+                'SELECT s.CurrentSongId, s.CurrentComponentIndex, s.StateJson, s.StateRevision,
+                        u.DisplayName AS HostName
+                   FROM tblLiveFollowSessions s
+                   JOIN tblUsers u ON u.Id = s.HostUserId
+                  WHERE s.SessionCode = ? AND s.IsActive = 1
+                    AND s.LastHeartbeatAt > DATE_SUB(UTC_TIMESTAMP(), INTERVAL 90 SECOND)'
+            );
+            $stmt->bind_param('s', $code);
+            $stmt->execute();
+            $row = $stmt->get_result()->fetch_assoc();
+            $stmt->close();
+
+            /* Identical message for missing / expired / wrong code so liveness
+               can't be probed cheaply (combined with the rate limit). */
+            if (!$row) { sendJson(['ok' => false, 'error' => 'Session not found or ended.'], 404); break; }
+
+            sendJson([
+                'ok'              => true,
+                'code'            => $code,
+                'hostDisplayName' => (string)($row['HostName'] ?? ''),
+                'currentSongId'   => $row['CurrentSongId'],
+                'componentIndex'  => $row['CurrentComponentIndex'] !== null ? (int)$row['CurrentComponentIndex'] : null,
+                'state'           => $row['StateJson'] !== null ? json_decode($row['StateJson'], true) : null,
+                'revision'        => (int)$row['StateRevision'],
+            ]);
+            break;
+        }
+
+        case 'live_follow_poll': {
+            $code = strtoupper(trim((string)($_GET['code'] ?? '')));
+            if (!preg_match('/^[A-Z0-9]{4,12}$/', $code)) { sendJson(['active' => false], 400); break; }
+            $since = (int)($_GET['since'] ?? 0);
+            $liveIp = $_SERVER['REMOTE_ADDR'] ?? '';
+
+            /* Per-IP cap so `poll` can't serve as an un-throttled code-existence
+               oracle that sidesteps the join cap (a live vs unknown code give
+               different responses). Generous for legitimate ~2.5s polling from a
+               handful of devices. NOTE: a NAT-shared congregation polling at
+               scale needs the NAT-safe anti-enumeration design — a short-lived
+               join token gating poll + a per-session counter instead of per-IP
+               recording — which lands with the Phase-3 client (#1268). Dormant in
+               Phase 1 (no client polls yet). */
+            checkRateLimit('live_follow_poll', $liveIp, 600, 60, true);
+            recordRateLimitHit('live_follow_poll', $liveIp);
+            $db = getDbMysqli();
+            $stmt = $db->prepare(
+                'SELECT CurrentSongId, CurrentComponentIndex, StateJson, StateRevision,
+                        (IsActive = 1 AND LastHeartbeatAt > DATE_SUB(UTC_TIMESTAMP(), INTERVAL 90 SECOND)) AS Fresh
+                   FROM tblLiveFollowSessions
+                  WHERE SessionCode = ?'
+            );
+            $stmt->bind_param('s', $code);
+            $stmt->execute();
+            $row = $stmt->get_result()->fetch_assoc();
+            $stmt->close();
+
+            if (!$row || (int)$row['Fresh'] !== 1) { sendJson(['active' => false]); break; }
+
+            $rev = (int)$row['StateRevision'];
+            if ($rev <= $since) { sendJson(['changed' => false, 'revision' => $rev]); break; }
+
+            sendJson([
+                'changed'        => true,
+                'currentSongId'  => $row['CurrentSongId'],
+                'componentIndex' => $row['CurrentComponentIndex'] !== null ? (int)$row['CurrentComponentIndex'] : null,
+                'state'          => $row['StateJson'] !== null ? json_decode($row['StateJson'], true) : null,
+                'revision'       => $rev,
+            ]);
+            break;
+        }
+
+        /* -----------------------------------------------------------------
          * Unknown action
          * ----------------------------------------------------------------- */
         default:
@@ -11577,6 +11864,38 @@ function sendJson(array $data, int $statusCode = 200): void
     header('X-Content-Type-Options: nosniff');
     header('Cache-Control: no-cache, must-revalidate');
     echo json_encode($data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+}
+
+/**
+ * Live Follow (#1268) — sanitise a SongId from client input to the SongId
+ * charset (alnum + _ -) and the column width (VARCHAR(20)). Empty after
+ * cleaning ⇒ '' (caller treats as "no song").
+ */
+function _liveFollowCleanSongId(string $raw): string
+{
+    return mb_substr(preg_replace('/[^a-zA-Z0-9_\-]/', '', $raw), 0, 20);
+}
+
+/**
+ * Live Follow (#1268) — whitelist the broadcast StateJson. NEVER stores raw
+ * client JSON: only the known broadcast hints survive, each clamped to a safe
+ * range. Returns a compact JSON string, or null when nothing valid was sent.
+ */
+function _liveFollowCleanState($state): ?string
+{
+    if (!is_array($state)) { return null; }
+    $clean = [];
+    if (array_key_exists('blank', $state)) {
+        $clean['blank'] = (bool)$state['blank'];
+    }
+    if (array_key_exists('scrollPct', $state) && is_numeric($state['scrollPct'])) {
+        $clean['scrollPct'] = max(0.0, min(1.0, (float)$state['scrollPct']));
+    }
+    if (array_key_exists('transposeOffset', $state) && is_numeric($state['transposeOffset'])) {
+        $clean['transposeOffset'] = max(-12, min(12, (int)$state['transposeOffset']));
+    }
+    if (!$clean) { return null; }
+    return json_encode($clean, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
 }
 
 /**

--- a/appWeb/public_html/manage/includes/migration-registry.php
+++ b/appWeb/public_html/manage/includes/migration-registry.php
@@ -1836,6 +1836,20 @@ return [
         'probe' => static fn(\mysqli $db) => !_migProbe_tableExists($db, 'tblLiveFollowSessions'),
     ],
 
+    'live-follow-revision' => [
+        'script' => 'migrate-live-follow-revision.php',
+        'card' => [
+            'title'  => 'Live-follow: StateRevision (#1268)',
+            'body'   => 'Adds <code>tblLiveFollowSessions.StateRevision</code> — a'
+                      . ' monotonic broadcast counter so web/PWA Live-Follow'
+                      . ' followers short-poll cheaply (<code>?since=</code>) without'
+                      . ' holding a server connection open. Additive + idempotent;'
+                      . ' run the Live-follow sessions migration first.',
+            'button' => 'Run Live-Follow Revision Migration',
+        ],
+        'probe' => static fn(\mysqli $db) => !_migProbe_columnExists($db, 'tblLiveFollowSessions', 'StateRevision'),
+    ],
+
     'request-corrections' => [
         'script' => 'migrate-request-corrections.php',
         'card' => [


### PR DESCRIPTION
Part of #1268 (web/PWA Live Follow). **Phase 1 = the dormant backend only** (no UI). Targets **alpha**.

Real-time "the band's devices follow the worship leader's current slide." Transport is **DB-relayed short-poll** over the already-dormant `tblLiveFollowSessions` — **not SSE**, because shared DreamHost hosting can't hold a PHP worker open per follower (SSE would exhaust the FPM pool under a congregation). The host writes its current song/section/state and bumps a revision; followers poll `?since=<rev>` and get a near-free `{changed:false}` until it advances.

## What's in Phase 1
- **`migrate-live-follow-revision.php` + `schema.sql`** — additive `StateRevision INT UNSIGNED` counter (idempotent, column-exists guarded, byte-identical COMMENT). Registered in `migration-registry.php`; `cleanup.php` gets a prune block (expired/stale sessions).
- **`api.php`** — six `?action=` handlers:
  - `live_follow_create` / `update` / `heartbeat` / `leave` — **POST, authenticated, ownership-scoped** (`WHERE HostUserId = ?`); one active session per host.
  - `live_follow_join` / `poll` — **GET, anonymous**, scoped by an unguessable 6-char Crockford code.
  - Helpers `_liveFollowCleanSongId` / `_liveFollowCleanState` (the latter a **strict whitelist** — `blank`/`scrollPct`/`transposeOffset`, clamped; never stores raw client JSON).

## Security review (done before commit — fixes applied)
Adversarially reviewed; **no CRITICAL/HIGH**. Fixed in this PR: heartbeat liveness via an existence check (not `affected_rows`, which is 0 on same-second writes); a per-IP cap on `poll` so it can't be an un-throttled enumeration oracle bypassing the join cap; unknown `songId` → clean `400` instead of an FK-1452 `500`; `errno === 1062` collision retry (not a message substring); `componentIndex` upper clamp; update read-back null-guard; cleanup UTC consistency. Confirmed: all SQL prepared + `bind_param` (type-strings verified), authz enforced on every mutation, CSRF inherited from the global `X-Requested-With` guard, rate-limit check/record keys matched. The NAT-safe anti-enumeration design (a short-lived join token gating `poll` + a per-session counter) is noted in-code as **Phase-3** work (when the client + real polling exist).

## Safety
**Ships dormant** — no UI consumes these yet, the migration is additive + not auto-applied, and nothing touches the lyrics path, so **zero impact on the #1235 cutover soak**. Phases 2 (host control in `display.js`/`setlist.js`) and 3 (follower client) follow in separate PRs.

## Testing
`php -l` clean on all changed PHP; `test-schema-coverage` + `test-migration-registry` green (the `StateRevision` mirror + the flip-probe are verified). Endpoints are `curl`-testable once the migration is applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)