### PR TITLE
feat(observability): Activity-Log the verify-cutover gate + setup-database runs (#1282)

### DIFF
--- a/.claude/lyrics-soak-web-runbook.md
+++ b/.claude/lyrics-soak-web-runbook.md
@@ -1,0 +1,62 @@
+# Lyrics-cutover SOAK — web runbook (#1235 P4)
+
+> How the **web-only** owner runs the #1235 cutover verification soak entirely from
+> **/manage/setup-database** (no CLI — shared DreamHost; see the operator-web-only
+> constraint). The gate is `appWeb/.sql/verify-lyrics-cutover.php`, surfaced as the
+> **"Verify Lyrics-Cutover Gate (#1235)"** card (web runner #1280). Companions:
+> `lyrics-cutover-promotion-checklist.md`, `lyrics-cutover-dress-rehearsal.md`,
+> `lyrics-normalisation-strategy.md` §11.
+
+## Prereqs (done 2026-06-18)
+- Track-A migrations applied on alpha via **Apply all** (`component-line-languages`,
+  `lyric-lines-parttypeslug`; `song-part-types` + `lyric-lines-mirror` were already
+  applied). Only the manual `retire-component-lines-json` drop remains pending.
+- **Guardrail for the whole cutover:** edit lyrics on **alpha only**. A lyric edit on
+  beta/production (pre-cutover code) writes `LinesJson` only and orphans `tblLyricLines`,
+  breaking parity.
+
+## The card buttons
+`Smoke test` (first 50, no sentinel) · `--phase=pre` (full baseline + sentinel) ·
+`--phase=soak` · `--phase=pre-drop` (confirm-gated, drop-day) · `--phase=post-drop`.
+A **complete** run ends with `== GREEN — phase <p> passed ==` (or `RED`); `pre`/`pre-drop`
+also print `sentinel: lyrics_cutover_gate written (green)`. No trailer ⇒ the request was
+truncated by a host timeout — nothing was armed, just re-run.
+
+## Step 1 — Smoke test (safe path check)
+Click **Smoke test**. Expect all 10 gates `[PASS]`, `songs:50`,
+`sentinel: NOT written (--limit run …)` (correct), `== GREEN — phase pre passed ==`,
+badge **Complete**. RED here (real divergence in 50 songs) ⇒ stop, capture output.
+
+## Step 2 — Full baseline (`--phase=pre`, once)
+Click **Run --phase=pre**. Full corpus (~16,083 songs), ~1–3 min, leave tab open.
+Success = `== GREEN — phase pre passed ==` **and** `sentinel: lyrics_cutover_gate written (green)`.
+(2026-06-18: GREEN on the full corpus — 16,083 songs / 70,132 components / 291,634 lines,
+all 10 gates incl. G2 byte-identical; fingerprint `corpusSha256 30ec02…9bcc`.) Not destructive;
+`pre` does NOT arm the drop (only `pre-drop` + `confirm=1` can).
+
+## Step 3 — Soak (`--phase=soak`, recurring)
+Run periodically through the window. **The meaningful test:** make real edits in the alpha
+Song Editor (verse/chorus/**chords**/**per-line language**/**revision restore**/**import**),
+then run `--phase=soak`. Expect a **different** fingerprint (content changed — fine) but every
+gate, especially **G2**, still `[PASS]`. A `phase=soak` sentinel CANNOT arm the drop.
+⚠ If `G2`/`G1`/`G3`/`G8` ever flips `[FAIL]` after an edit → that's the bug the soak exists to
+catch; stop and capture the output.
+
+### Automated nightly soak (DreamHost panel cron)
+Set up 2026-06-18 by the owner. Command shape (no interactive shell needed):
+`php <dev.ihymns.app web root>/.sql/verify-lyrics-cutover.php --phase=soak`
+(`.sql/` is the sibling of the web root; the script is dual-mode CLI/web). The cron's STDOUT
+goes to DreamHost cron email — but every run ALSO writes an **Activity-Log row** (#1282), so a
+RED soak is visible at **/manage/activity-log** (`action=setup.verify_cutover`, `result=failure`)
+without checking email.
+
+## Observability (#1282)
+Every verify-gate run (cron + web) and every setup-database migration/ops run logs to the
+Activity Log with status + error. To check soak health in-app: `/manage/activity-log` → filter
+`action=setup.verify_cutover` → any `failure` row's details list the failing gates.
+
+## Exit criteria → promotion
+Ready for the alpha→beta→main promotion (then the gated drop) when: `pre` baseline GREEN + sentinel
+written (✅); several `soak` runs GREEN **including after real edits**; alpha song pages render
+correctly. Then: promote the full stack to beta+prod (so all 3 shared-DB envs are drop-safe), then
+run `pre-drop` inside a 3-env maintenance freeze and the gated `retire-component-lines-json` drop ONCE.

--- a/appWeb/.sql/verify-lyrics-cutover.php
+++ b/appWeb/.sql/verify-lyrics-cutover.php
@@ -101,6 +101,19 @@ if (!function_exists('lyricLinesAssembleComponents') || !function_exists('getDbM
     exit(2);
 }
 
+/* Activity Log (#1282) — OPTIONAL/best-effort: every run (CLI cron + web) leaves a
+   queryable row so a RED soak surfaces in /manage/activity-log without trawling cron
+   email. Already loaded by the dashboard (via auth.php); load it for the CLI path. A
+   missing activity_log.php must NOT abort the gate, so this is not in the guard above. */
+if (!function_exists('logActivity')) {
+    foreach ([
+        ($docRoot !== '' ? $docRoot . '/includes/activity_log.php' : null),
+        dirname(__DIR__) . '/public_html/includes/activity_log.php',
+    ] as $cand) {
+        if ($cand !== null && is_file($cand)) { require_once $cand; break; }
+    }
+}
+
 /* ---- args ---- (CLI: getopt; web: ?phase= only — the smoke/sample flags are CLI-only) */
 if ($LCV_WEB) {
     $phase       = (string)($_GET['phase'] ?? 'pre');
@@ -130,6 +143,7 @@ if (!($db instanceof mysqli)) {
     exit(2);
 }
 mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+$vcStart = microtime(true);   /* for the Activity-Log durationMs (#1282) */
 
 /* ---- output helpers ---- */
 $failuresNdjson = [];   // collected NDJSON lines (CLI stderr only)
@@ -450,6 +464,32 @@ if ($allGreen && $limit === 0) {
     out('  sentinel: lyrics_cutover_gate written (green).');
 } elseif ($allGreen) {
     out('  sentinel: NOT written (--limit run is not a full-corpus proof).');
+}
+
+/* Activity Log (#1282) — record every run's outcome (CLI cron + web) so an
+   unattended soak going RED is visible in /manage/activity-log without cron email.
+   Best-effort: logActivity never throws + is absent only if activity_log didn't load. */
+if (function_exists('logActivity')) {
+    $vcFailedGates = [];
+    foreach ($gates as $vcGid => $vcG) {
+        if (!$vcG['pass']) { $vcFailedGates[$vcGid] = $vcG['fails']; }
+    }
+    logActivity(
+        'setup.verify_cutover',
+        'database',
+        $phase,
+        [
+            'result'      => $allGreen ? 'green' : 'red',
+            'mode'        => $LCV_WEB ? 'web' : 'cli',
+            'limit'       => $limit,
+            'failedGates' => $vcFailedGates,
+            'fingerprint' => $fingerprint,
+            'sentinel'    => ($allGreen && $limit === 0) ? 'written' : 'not-written',
+        ],
+        $allGreen ? 'success' : 'failure',
+        null,
+        (int) round((microtime(true) - $vcStart) * 1000)
+    );
 }
 
 if ($asJson) {

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -711,6 +711,18 @@ if ($action !== '') {
         echo "---\n";
         echo $migOutput;
 
+        /* Activity Log (#1282) — per-run status for the JS per-card / bulk-runner
+           path (the bulk runner runs PENDING migrations only, so low volume).
+           Covers migrations + the install/migrate/users/cleanup/backup ops. */
+        if (function_exists('logActivity')) {
+            $logDetails = ['script' => $scriptName, 'elapsedMs' => (int)$elapsed, 'via' => 'ajax'];
+            if (!$migOk) {
+                $logDetails['error'] = $migErr;
+                if ($migErrFile !== '') { $logDetails['at'] = basename($migErrFile) . ':' . $migErrLine; }
+            }
+            logActivity('setup.run', 'database', $action, $logDetails, $migOk ? 'success' : 'error', null, (int)$elapsed);
+        }
+
         $pageRenderedCleanly = true;
         exit;
     }
@@ -968,6 +980,9 @@ if ($action !== '') {
                             $firstFailLine    = 0;
                         }
                         echo "\n  ✗ {$migAction} ran but is STILL PENDING after {$elapsed} ms — its objects were NOT created (the script swallowed an error above). Stopping so you can resolve it.\n";
+                        if (function_exists('logActivity')) {
+                            logActivity('setup.run', 'database', $migAction, ['script' => $migScript, 'bulk' => true, 'reason' => 'ran but probe still PENDING'], 'error', null, (int)$elapsed);
+                        }
                         break;
                     }
                     $totalRan++;
@@ -987,6 +1002,9 @@ if ($action !== '') {
                         echo "    File: " . htmlspecialchars(basename($e->getFile())) . ":" . $e->getLine() . "\n";
                     }
                     echo "\n  Stopping the bulk run so you can resolve this before continuing.\n";
+                    if (function_exists('logActivity')) {
+                        logActivity('setup.run', 'database', $migAction, ['script' => $migScript, 'bulk' => true, 'error' => $e->getMessage(), 'at' => basename((string)$e->getFile()) . ':' . $e->getLine()], 'error');
+                    }
                     break;
                 }
             }
@@ -1008,6 +1026,12 @@ if ($action !== '') {
                 echo ", {$totalFailed} failed";
             }
             echo " in {$totalElapsed} ms.\n";
+            /* Activity Log (#1282) — one summary row per Apply-all (per-migration
+               FAILURE rows are logged inline above; successes are not logged
+               individually to avoid ~95 no-op rows per click). */
+            if (function_exists('logActivity')) {
+                logActivity('setup.apply_all', 'database', '', ['ran' => $totalRan, 'failed' => $totalFailed, 'firstFailStep' => $firstFailStep], $totalFailed > 0 ? 'failure' : 'success', null, (int)$totalElapsed);
+            }
         }
     } elseif ($action === 'verify-cutover') {
         /* #1235 lyrics-cutover GATE runner — the WEB path for the verification
@@ -1055,6 +1079,7 @@ if ($action !== '') {
             if (!file_exists($scriptPath)) {
                 echo "ERROR: Script not found: {$scriptName}\n";
             } else {
+                $singleErr = null;
                 try {
                     /* Run the script in an isolated scope via an anonymous function.
                      * The scripts detect $isCli and adapt output accordingly.
@@ -1086,10 +1111,18 @@ if ($action !== '') {
                     }
                 } catch (\Throwable $e) {
                     $actionSuccess = false;
+                    $singleErr = $e->getMessage();
                     echo "\nERROR: " . htmlspecialchars($e->getMessage()) . "\n";
                     if ($e->getFile()) {
                         echo "File: " . htmlspecialchars(basename($e->getFile())) . ":" . $e->getLine() . "\n";
                     }
+                }
+                /* Activity Log (#1282) — per-run status for the no-JS single-action path
+                   (migrations + install/migrate/users/cleanup/backup/restore). */
+                if (function_exists('logActivity')) {
+                    $d = ['script' => $scriptName, 'via' => 'no-js'];
+                    if ($singleErr !== null) { $d['error'] = $singleErr; }
+                    logActivity('setup.run', 'database', $action, $d, $actionSuccess ? 'success' : 'error');
                 }
             }
         }


### PR DESCRIPTION
Closes #1282. Targets **alpha**.

Now that the #1235 soak runs **unattended via a DreamHost cron**, a RED result must surface **in-app** (the operator is web-only — no cron-email habit). This writes `tblActivityLog` rows for the verify gate and all DB-setup runs, visible at **/manage/activity-log**.

## What
- **`verify-lyrics-cutover.php`** — guarded-load `activity_log.php` (for the CLI/cron path; the dashboard already has it via `auth.php`) + **one `logActivity()` at the report tail**. Every run (cron + web) logs `action=setup.verify_cutover`, `entityId=<phase>`, `result=success|failure`, `details={result, mode, limit, failedGates, fingerprint, sentinel, durationMs}`. **A RED soak is now a queryable `failure` row** — filter `/manage/activity-log` by `action=setup.verify_cutover`.
- **`setup-database.php`** — log migration/ops runs:
  - **text-fast-path** (JS per-card + bulk-runner — runs *pending only*, low volume): per-run `setup.run`.
  - **no-JS Apply-all loop**: per-**failure** `setup.run` rows + one `setup.apply_all` **summary** (successes aren't logged individually — would be ~95 no-op rows per click).
  - **no-JS single-action** (incl. install/migrate/users/cleanup/backup/restore): per-run `setup.run`.
  - `verify-cutover` **self-logs**, so the dashboard handler doesn't double-log it.
- **`.claude/lyrics-soak-web-runbook.md`** — the web-only soak procedure (smoke → pre → soak), the cron line, and this observability.

## Design notes
- `logActivity()` is **best-effort** (never throws; internal try/catch; per-request flood cap 200 — we add ≤ a handful per request) and resolves **`UserId=NULL` for the cron/system actor**, so cron rows are attributed to "system" and web rows to the signed-in admin.
- Apply-all logs **summary + failures** rather than every success — running ~95 idempotent migrations would otherwise spam the audit log each click. Single/JS-per-card runs (pending-only) do log per-run.

## Security / safety
No new input or output surface — `logActivity` is the existing audited writer (prepared statements, IP/UA/request-id resolved internally). Additive + best-effort: a logging hiccup can't break a migration run, a soak, or the page. Action keys ≤ 50 chars.

## Testing
`php -l` clean (both files); `test-schema-coverage` + `test-migration-registry` + `test-component-json-guard` green. Self-reviewed: every `logActivity` site is `function_exists`-guarded with in-scope variables, no double-logging. **Runtime check after deploy:** run a `--phase=soak` (or the cron), then confirm a `setup.verify_cutover` row appears at `/manage/activity-log`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)