### PR TITLE
feat(observability): log per-migration SUCCESS in the no-JS Apply-all loop (completes #1282)

### DIFF
--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -988,6 +988,13 @@ if ($action !== '') {
                     $totalRan++;
                     $verifiedNote = ($verifyPending === false) ? ' + verified' : '';  /* null = unverifiable */
                     echo "\n  ✓ {$migAction} completed{$verifiedNote} in {$elapsed} ms\n\n";
+                    /* Activity Log (#1282) — log EVERY migration run in the no-JS bulk
+                       path, success included, so the audit trail is complete in every
+                       path (the JS per-card runner already logs each). A no-JS Apply-all
+                       therefore writes one row per migration in $migrationOrder. */
+                    if (function_exists('logActivity')) {
+                        logActivity('setup.run', 'database', $migAction, ['script' => $migScript, 'bulk' => true, 'verified' => ($verifyPending === false)], 'success', null, (int)$elapsed);
+                    }
                 } catch (\Throwable $e) {
                     $totalFailed++;
                     $actionSuccess = false;
@@ -1026,9 +1033,8 @@ if ($action !== '') {
                 echo ", {$totalFailed} failed";
             }
             echo " in {$totalElapsed} ms.\n";
-            /* Activity Log (#1282) — one summary row per Apply-all (per-migration
-               FAILURE rows are logged inline above; successes are not logged
-               individually to avoid ~95 no-op rows per click). */
+            /* Activity Log (#1282) — one summary row per Apply-all, on top of the
+               per-migration rows (success + failure) logged inline above. */
             if (function_exists('logActivity')) {
                 logActivity('setup.apply_all', 'database', '', ['ran' => $totalRan, 'failed' => $totalFailed, 'firstFailStep' => $firstFailStep], $totalFailed > 0 ? 'failure' : 'success', null, (int)$totalElapsed);
             }


### PR DESCRIPTION
Follow-up to #1283 — completes **#1282** so **every migration run logs its status in every dashboard path**. Targets **alpha**.

#1283 already logged: the JS per-card / bulk-runner path (each run), single-action runs, and the verify gate. The only gap was the **no-JS "Apply all" loop**, which logged failures + a summary but skipped per-migration **successes** (to avoid ~95 no-op rows per click). Per the owner's direction — *"ensure ALL migration tasks are logged"* — completeness wins: the loop now also writes a `setup.run` **success** row per migration, alongside the existing per-failure rows and the `setup.apply_all` summary.

Still best-effort (`logActivity` never throws) and under the 200/request flood cap.

## Note on what's visible now
Migrations applied **before** #1283 deployed aren't retroactively logged. Going forward, every run logs. To see it immediately, re-run any single migration card's "Run & show output" — it logs a `setup.run` row even when the migration no-ops.

## Testing
`php -l` clean; `test-migration-registry` + `test-component-json-guard` green.