### PR TITLE
fix(activity-log): deterministic order for same-second rows (Id tiebreaker) (#1285)

### DIFF
--- a/appWeb/public_html/manage/activity-log.php
+++ b/appWeb/public_html/manage/activity-log.php
@@ -239,7 +239,7 @@ if (($_GET['export'] ?? '') === 'csv') {
            FROM tblActivityLog a
            LEFT JOIN tblUsers u ON u.Id = a.UserId
            ' . $whereSql . '
-           ORDER BY a.CreatedAt DESC
+           ORDER BY a.CreatedAt DESC, a.Id DESC
            LIMIT 10000'
     );
     $stmt->bind_param($types, ...$params);
@@ -329,7 +329,7 @@ try {
            FROM tblActivityLog a
            LEFT JOIN tblUsers u ON u.Id = a.UserId
            ' . $whereSql . '
-           ORDER BY a.CreatedAt DESC
+           ORDER BY a.CreatedAt DESC, a.Id DESC
            LIMIT ' . (int)$pageSize . ' OFFSET ' . (int)$offset
     );
     $stmt->bind_param($types, ...$params);


### PR DESCRIPTION
Closes #1285. Targets **alpha**.

`tblActivityLog.CreatedAt` is a second-granularity `TIMESTAMP`, and both Activity-Log queries sorted `ORDER BY a.CreatedAt DESC` **without a tiebreaker** — so rows written in the same second (e.g. a page's `request.success` + the `setup.verify_cutover` row from the *same* request) ordered arbitrarily and could flip between page loads. That's the "slightly off" order in the screenshot.

## Fix
Add **`, a.Id DESC`** to both sort sites (paginated page query + CSV export). `Id` is a monotonic `BIGINT AUTO_INCREMENT` = the true insertion order, so `CreatedAt DESC, Id DESC` is **deterministic + chronologically correct** (newest-inserted first) even within one second.

## Why this over millisecond timestamps
Millisecond display would need a `CreatedAt` → `TIMESTAMP(6)` migration and *still* tie on sub-ms. The `Id` tiebreaker is the authoritative insertion order, needs no schema change, and can never tie. (The displayed timestamp stays second-granularity — fine for humans; the *ordering* is now exact.)

2 lines changed; `php -l` clean.