### PR TITLE
feat(activity-log): microsecond-precision timestamps (TIMESTAMP(6) + NOW(6) + ms display) (#1287)

### DIFF
--- a/appWeb/.sql/migrate-activity-log-microtime.php
+++ b/appWeb/.sql/migrate-activity-log-microtime.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Activity Log: microsecond-precision CreatedAt (#1287)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Widen tblActivityLog.CreatedAt from second-granularity TIMESTAMP to TIMESTAMP(6)
+ * so logActivity()'s NOW(6) write captures sub-second time (forensics, latency,
+ * precise sequencing readable straight off the timestamp). Ordering is already
+ * deterministic via the Id tiebreaker (#1285); this adds timestamp ACCURACY.
+ *
+ * IDEMPOTENT — skips when DATETIME_PRECISION is already 6. Existing rows keep their
+ * value with a .000000 fraction; no data loss (precision increase).
+ *
+ * NOTE: changing a TIMESTAMP's fractional precision resizes the column, so this is a
+ * one-time table REWRITE. It's opt-in per-env (run from /manage/setup-database when
+ * ready); trivial at current scale and the activity-log retention prune (#535) keeps
+ * the table bounded. Requires MySQL >= 5.6.4 (fractional seconds).
+ *
+ * USAGE:
+ *   CLI:  php appWeb/.sql/migrate-activity-log-microtime.php
+ *   Web:  /manage/setup-database → "Activity Log: microsecond timestamps (#1287)"
+ *
+ * @requires PHP 8.1+ with mysqli
+ */
+
+$isCli = (php_sapi_name() === 'cli');
+if (!$isCli && !defined('IHYMNS_SETUP_DASHBOARD')) {
+    header('Content-Type: text/plain; charset=UTF-8');
+    header('X-Content-Type-Options: nosniff');
+    header('Cache-Control: no-store');
+}
+function _migALM_out(string $m): void { global $isCli; echo $m . ($isCli ? "\n" : "<br>\n"); if (!$isCli) flush(); }
+
+$credFile = dirname(__DIR__) . DIRECTORY_SEPARATOR . '.auth' . DIRECTORY_SEPARATOR . 'db_credentials.php';
+if (!file_exists($credFile)) { _migALM_out("ERROR: MySQL credentials not found. Run install.php first."); return; }
+require_once $credFile;
+
+_migALM_out("");
+_migALM_out("=== iHymns — Activity Log microsecond CreatedAt (#1287) ===");
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+try {
+    $mysql = new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME, (int)DB_PORT);
+    $mysql->set_charset(defined('DB_CHARSET') ? DB_CHARSET : 'utf8mb4');
+} catch (\mysqli_sql_exception $e) { _migALM_out("ERROR: MySQL connection failed: " . $e->getMessage()); return; }
+_migALM_out("Connected to MySQL: " . DB_NAME);
+
+try {
+    /* Idempotent: skip when CreatedAt is already TIMESTAMP(6). */
+    $res = $mysql->query(
+        "SELECT DATETIME_PRECISION FROM INFORMATION_SCHEMA.COLUMNS
+          WHERE TABLE_SCHEMA = DATABASE()
+            AND TABLE_NAME   = 'tblActivityLog'
+            AND COLUMN_NAME  = 'CreatedAt' LIMIT 1"
+    );
+    $row = $res ? $res->fetch_assoc() : null;
+    if ($res) { $res->close(); }
+
+    if ($row === null) {
+        _migALM_out("  [SKIP] tblActivityLog.CreatedAt not found (run Install first).");
+    } elseif ((int)($row['DATETIME_PRECISION'] ?? 0) >= 6) {
+        _migALM_out("  [SKIP] tblActivityLog.CreatedAt is already TIMESTAMP(6).");
+    } else {
+        _migALM_out("  Rewriting tblActivityLog.CreatedAt -> TIMESTAMP(6) (one-time; precision change resizes the column)...");
+        $mysql->query(
+            "ALTER TABLE tblActivityLog
+                MODIFY CreatedAt TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)"
+        );
+        _migALM_out("  [OK] tblActivityLog.CreatedAt is now TIMESTAMP(6) — new rows capture microseconds (logActivity writes NOW(6)).");
+    }
+    _migALM_out("Migration complete.");
+} catch (\Throwable $e) { _migALM_out("  [ERROR] " . $e->getMessage()); }
+$mysql->close();
+return;

--- a/appWeb/.sql/schema.sql
+++ b/appWeb/.sql/schema.sql
@@ -1383,7 +1383,7 @@ CREATE TABLE IF NOT EXISTS tblActivityLog (
     RequestPath     VARCHAR(512)    NULL DEFAULT NULL COMMENT 'Requested path (REQUEST_URI minus query) — which file/route was hit (#1207)',
     Referrer        VARCHAR(2048)   NULL DEFAULT NULL COMMENT 'HTTP Referer header — where the request came from (#1207)',
     Country         CHAR(2)         NULL DEFAULT NULL COMMENT 'ISO-3166-1 alpha-2 country resolved from IpAddress AT log time (snapshot; geo resolver #1208 populates it)',
-    CreatedAt       TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CreatedAt       TIMESTAMP(6)    NOT NULL DEFAULT CURRENT_TIMESTAMP(6) COMMENT 'Microsecond precision (#1287) — logActivity writes NOW(6); the Id PK is the tiebreaker for same-instant rows (#1285)',
 
     INDEX idx_User              (UserId),
     INDEX idx_Action            (Action),

--- a/appWeb/public_html/includes/activity_log.php
+++ b/appWeb/public_html/includes/activity_log.php
@@ -326,7 +326,10 @@ function logActivity(
 
         $placeholders = implode(', ', array_fill(0, count($cols), '?'));
         $stmt = $db->prepare(
-            'INSERT INTO tblActivityLog (' . implode(', ', $cols) . ', CreatedAt) VALUES (' . $placeholders . ', NOW())'
+            /* NOW(6) captures microsecond precision (#1287) when CreatedAt is
+               TIMESTAMP(6); on a pre-migration second-granularity column MySQL
+               just truncates the fraction, so this is safe before the migration. */
+            'INSERT INTO tblActivityLog (' . implode(', ', $cols) . ', CreatedAt) VALUES (' . $placeholders . ', NOW(6))'
         );
         /* #926 — bindParamSafe throws a context-named error if types/args ever
            drift; here they're built together so they can't, but keep the guard. */

--- a/appWeb/public_html/manage/activity-log.php
+++ b/appWeb/public_html/manage/activity-log.php
@@ -247,7 +247,13 @@ if (($_GET['export'] ?? '') === 'csv') {
     $res = $stmt->get_result();
     while ($row = $res->fetch_assoc()) {
         $ts        = (int)($row['CreatedAtTs'] ?? 0);
-        $createdUtc = $ts > 0 ? gmdate('Y-m-d\TH:i:s\Z', $ts) : '';
+        /* Sub-second fraction (#1287) — from the raw TIMESTAMP(6) string when present
+           (UNIX_TIMESTAMP is cast to int, so the fraction lives on the raw value). */
+        $frac = '';
+        if (preg_match('/\.(\d{1,6})/', (string)($row['CreatedAt'] ?? ''), $fm)) {
+            $frac = '.' . substr(str_pad($fm[1], 3, '0'), 0, 3);
+        }
+        $createdUtc = $ts > 0 ? gmdate('Y-m-d\TH:i:s', $ts) . $frac . 'Z' : '';
         $csvRow = [
             $row['Id'], $row['CreatedAt'], $createdUtc, $row['Username'] ?? '', $row['Action'],
             $row['EntityType'], $row['EntityId'], $row['Result'],
@@ -587,12 +593,21 @@ $buildQuery = function (array $overrides = []) {
                         $createdUtcStr = $createdTs > 0
                             ? gmdate('Y-m-d H:i:s', $createdTs)
                             : (string)$r['CreatedAt'];
+                        /* Sub-second fraction (#1287) — ms (3 digits) from the raw
+                           TIMESTAMP(6) value; empty on a pre-migration second column,
+                           so the cell renders identically until the column is widened. */
+                        $createdMs = '';
+                        if (preg_match('/\.(\d{1,6})/', (string)($r['CreatedAt'] ?? ''), $msMatch)) {
+                            $createdMs = substr(str_pad($msMatch[1], 3, '0'), 0, 3);
+                        }
+                        $createdUtcFull = $createdUtcStr . ($createdMs !== '' ? '.' . $createdMs : '');
                     ?>
                         <tr class="activity-row">
                             <td class="text-muted small activity-when"
                                 data-ts="<?= (int)$createdTs ?>"
-                                title="<?= htmlspecialchars($createdUtcStr, ENT_QUOTES, 'UTF-8') ?> UTC">
-                                <?= htmlspecialchars($createdUtcStr, ENT_QUOTES, 'UTF-8') ?> <span class="text-muted">UTC</span>
+                                data-ms="<?= htmlspecialchars($createdMs, ENT_QUOTES, 'UTF-8') ?>"
+                                title="<?= htmlspecialchars($createdUtcFull, ENT_QUOTES, 'UTF-8') ?> UTC">
+                                <?= htmlspecialchars($createdUtcStr, ENT_QUOTES, 'UTF-8') ?><?php if ($createdMs !== ''): ?><span class="text-muted">.<?= htmlspecialchars($createdMs, ENT_QUOTES, 'UTF-8') ?></span><?php endif; ?> <span class="text-muted">UTC</span>
                             </td>
                             <?php if ($hasObsCols): ?>
                             <td>
@@ -791,8 +806,13 @@ $buildQuery = function (array $overrides = []) {
                 var parts = fmt.formatToParts(d).reduce(function (acc, p) {
                     if (p.type !== 'literal') acc[p.type] = p.value; return acc;
                 }, {});
+                /* #1287 — re-append the sub-second fraction after the local-TZ
+                   reformat (the fraction is timezone-invariant). Empty on rows
+                   logged before the TIMESTAMP(6) migration. */
+                var ms = cell.getAttribute('data-ms') || '';
                 cell.textContent = parts.year + '-' + parts.month + '-' + parts.day
-                    + ' ' + parts.hour + ':' + parts.minute + ':' + parts.second;
+                    + ' ' + parts.hour + ':' + parts.minute + ':' + parts.second
+                    + (ms ? '.' + ms : '');
                 /* Hover title carries the resolved timezone name so
                    curators inspecting an entry can see the offset
                    they're looking at — useful when comparing logs

--- a/appWeb/public_html/manage/includes/migration-registry.php
+++ b/appWeb/public_html/manage/includes/migration-registry.php
@@ -2121,4 +2121,31 @@ return [
         'probe' => static fn(\mysqli $db) =>
             _migProbe_columnExists($db, 'tblSongComponents', 'LinesJson'),
     ],
+
+    'activity-log-microtime' => [
+        'script' => 'migrate-activity-log-microtime.php',
+        'card' => [
+            'title'  => 'Activity Log: microsecond timestamps (#1287)',
+            'body'   => 'Widens <code>tblActivityLog.CreatedAt</code> to'
+                      . ' <code>TIMESTAMP(6)</code> so log entries capture sub-second'
+                      . ' time (<code>logActivity</code> writes <code>NOW(6)</code>) —'
+                      . ' forensics / latency / precise sequencing. Idempotent;'
+                      . ' one-time column rewrite (opt-in per env).',
+            'button' => 'Run Activity-Log Microtime Migration',
+        ],
+        /* Pending until CreatedAt is TIMESTAMP(6); self-clears once the precision is
+           6. Table-absent (fresh install pre-Install) reports not-pending. */
+        'probe' => static function (\mysqli $db): bool {
+            $r = $db->query(
+                "SELECT DATETIME_PRECISION FROM INFORMATION_SCHEMA.COLUMNS
+                  WHERE TABLE_SCHEMA = DATABASE()
+                    AND TABLE_NAME   = 'tblActivityLog'
+                    AND COLUMN_NAME  = 'CreatedAt' LIMIT 1"
+            );
+            $row = $r ? $r->fetch_assoc() : null;
+            if ($r) { $r->close(); }
+            if ($row === null) { return false; }
+            return (int)($row['DATETIME_PRECISION'] ?? 0) < 6;
+        },
+    ],
 ];


### PR DESCRIPTION
Closes #1287. Targets **alpha**.

You were right that millisecond precision is better for logging *accuracy* — and it turned out the timestamp wasn't even *captured* to sub-second (`logActivity` wrote `CreatedAt` with second-precision `NOW()`). This adds genuine microsecond capture + display. It's **complementary** to #1285 (which fixed *ordering* via the `Id` tiebreaker — kept): that's *which row first*; this is *when, exactly*.

## Change (coordinated)
- **Column** — `tblActivityLog.CreatedAt` → **`TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6)`** (`schema.sql` + idempotent migration `migrate-activity-log-microtime.php` + registry entry with a precision-probe).
- **Write** — `logActivity` INSERT `NOW()` → **`NOW(6)`** (DB-side time, no app/DB clock skew).
- **Display** — the page "When" cell renders the fraction (a `data-ms` attribute the JS re-appends *after* the local-timezone reformat, since the fraction is timezone-invariant; the no-JS server fallback shows it too), and the CSV `CreatedAtUtc` carries ms (the raw `CreatedAt` CSV column already carries full µs).

## Risk / rollout
- The column change is a **one-time table rewrite** (precision change resizes the column), so it's an **opt-in migration you run per-env** from `/manage/setup-database` — not auto-applied. Trivial at current scale; retention prune (#535) bounds the table. **No data loss** (existing rows keep `.000000`).
- **Degrades gracefully:** until you run the migration, the fraction is empty and every cell + export renders exactly as today. `NOW(6)` on a still-second column just truncates — safe to deploy before the ALTER.

## Why this over the `Id`-only approach
`Id` guarantees correct *order* but tells you nothing about *when*. Sub-second `CreatedAt` is the actual time — and `NOW(6)` from the DB avoids the clock-skew a PHP-supplied timestamp would introduce.

## Testing
`php -l` clean (4 files); `test-schema-coverage` + `test-migration-registry` + `test-component-json-guard` green. Post-deploy: run the migration card, then a new log row shows e.g. `13:58:31.123`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)