### PR TITLE
fix(song-system): server-backed song delete (#1289) + OPcache-reset for stale live runtime (#1290)

### DIFF
--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -5132,33 +5132,55 @@ function deleteSong() {
     }
 
     /* Find the song to show its title in the confirmation dialog. */
-    var song = findSongById(currentSongId);
+    var song  = findSongById(currentSongId);
     var title = song ? song.title : currentSongId;
 
     /* Ask for confirmation. */
-    if (!confirm('Delete "' + title + '"? This cannot be undone.')) {
+    if (!confirm('Delete "' + title + '"?\n\nThis permanently removes the song and ALL its data (components, lyric lines, credits, links, media) from the database. This cannot be undone.')) {
         return;
     }
 
-    /* Remove the song from the array. */
-    songData.songs = songData.songs.filter(function (s) {
-        return s.id !== currentSongId;
-    });
-    rebuildSongIndex();   /* keep the O(1) id index in sync (#1180-A1) */
+    var idToDelete = currentSongId;
 
-    /* Remove from modified set if present. */
-    modifiedSongIds.delete(currentSongId);
+    /* SERVER-BACKED delete (#1200 / #1290). The legacy implementation only
+       filtered the in-memory songData.songs array and toasted "deleted" — the
+       DB row was never touched, so the song reappeared on reload (and still
+       loaded in Song View). We now POST delete_song to the v2 API (cascade
+       delete + CSRF) and ONLY mutate local state + toast once the server
+       confirms. On failure nothing is removed locally and the error is shown,
+       so the toast can never lie again. */
+    var btn = document.getElementById('btn-delete-song');
+    if (btn) { btn.disabled = true; }
 
-    /* Clear the selection. */
-    currentSongId = null;
-
-    /* Refresh UI. */
-    clearEditForm();
-    renderSongList();
-    updateStatusBar();
-
-    /* Notify. */
-    showToast('Song deleted.', 'info');
+    ed2EnrichApi('delete_song', { songId: idToDelete })
+        .then(function (res) {
+            /* Server confirmed the cascade delete — sync local state now. */
+            songData.songs = songData.songs.filter(function (s) { return s.id !== idToDelete; });
+            rebuildSongIndex();           /* keep the O(1) id index in sync (#1180-A1) */
+            modifiedSongIds.delete(idToDelete);
+            if (currentSongId === idToDelete) {
+                currentSongId = null;
+                clearEditForm();
+            }
+            renderSongList();
+            updateStatusBar();
+            var n = (res && typeof res.deleted === 'number') ? res.deleted : null;
+            showToast(
+                'Deleted "' + title + '" from the database'
+                    + (n !== null ? ' (' + n + ' row' + (n === 1 ? '' : 's') + ' removed).' : '.'),
+                'success'
+            );
+        })
+        .catch(function (err) {
+            showToast(
+                'Delete failed: ' + (err && err.message ? err.message : 'unknown error')
+                    + '. The song was NOT removed.',
+                'danger'
+            );
+        })
+        .finally(function () {
+            if (btn) { btn.disabled = false; }
+        });
 }
 
 /* ========================================================================

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -274,6 +274,7 @@ $friendlyTitles = [
     'drop-legacy'                      => 'Drop Legacy Tables',
     'apply-all-migrations'             => 'Apply All Pending Migrations',
     'verify-cutover'                   => 'Verify Lyrics-Cutover Gate (#1235)',
+    'opcache-reset'                    => 'Reset PHP OPcache (runtime code cache)',
     /* Per-migration cards (label = card title minus the legacy
        alphabetic prefix; #816 standardised this on the issue
        number as the primary identifier). */
@@ -1073,6 +1074,42 @@ if ($action !== '') {
                 }
             }
         }
+    } elseif ($action === 'opcache-reset') {
+        /* #1290 — diagnose + reset the PHP OPcache. Stale compiled bytecode is the
+           leading cause of "deployed code isn't running" on shared hosting — e.g.
+           the songs_json 's.SongbookName' flood, where the column is dropped + the
+           repo SongData.php is correct (b.Name JOIN), but the live runtime executes
+           an OLD compiled copy. Resetting forces every PHP file to recompile from
+           disk on the next request. */
+        if (!function_exists('opcache_get_status')) {
+            echo "OPcache is NOT available on this PHP runtime (opcache_get_status missing).\n";
+            echo "Nothing to reset — if stale code persists, it's a deploy-upload issue, not OPcache.\n";
+            $actionSuccess = false;
+        } else {
+            $cfg    = function_exists('opcache_get_configuration') ? @opcache_get_configuration() : [];
+            $status = @opcache_get_status(false);
+            $vt     = $cfg['directives']['opcache.validate_timestamps'] ?? null;
+            $freq   = $cfg['directives']['opcache.revalidate_freq']     ?? null;
+            echo "=== OPcache status (before reset) ===\n";
+            echo "  enabled:             " . (($status && !empty($status['opcache_enabled'])) ? 'yes' : 'no') . "\n";
+            echo "  validate_timestamps: " . ($vt === null ? 'unknown'
+                : ($vt ? 'on (changed files auto-reload)'
+                       : 'OFF — never auto-reloads; deployed changes stay STALE until a reset')) . "\n";
+            echo "  revalidate_freq:     " . ($freq === null ? 'unknown' : ((int)$freq) . 's') . "\n";
+            if ($status && isset($status['opcache_statistics']['num_cached_scripts'])) {
+                echo "  cached scripts:      " . (int)$status['opcache_statistics']['num_cached_scripts'] . "\n";
+            }
+            $reset = function_exists('opcache_reset') ? @opcache_reset() : false;
+            clearstatcache(true);
+            echo "\n" . ($reset
+                ? "  ✓ OPcache reset — every PHP file recompiles from disk on the next request.\n"
+                : "  ✗ opcache_reset() returned false (disabled or restricted on this host).\n");
+            $actionSuccess = (bool)$reset;
+            echo "\nNow reload the public site (or wait for the next crawler hit) and re-check the Activity\n";
+            echo "Log. If the 'Unknown column s.SongbookName' errors STOP, stale OPcache was the cause\n";
+            echo "(the deployed code is already correct). If they persist, the deploy didn't upload the\n";
+            echo "current SongData.php — tell me and we'll fix the deploy itself.\n";
+        }
     } else {
         $scriptName = $scriptMap[$action] ?? null;
         if ($scriptName === null) {
@@ -1767,6 +1804,28 @@ if ($hasCredentials && defined('DB_HOST')) {
                         </p>
                         <a href="?action=cleanup" class="btn btn-outline-secondary btn-action <?= $hasCredentials ? '' : 'disabled' ?>">
                             Run Cleanup
+                        </a>
+                    </div>
+                </div>
+            </div>
+
+            <!-- #1290 — reset the PHP runtime code cache. The fix for "deployed code
+                 isn't running" on shared hosting (stale OPcache). -->
+            <div class="col-md-6">
+                <div class="card bg-dark border-secondary h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">
+                            <i class="bi bi-cpu me-1" aria-hidden="true"></i>
+                            Reset PHP OPcache
+                        </h5>
+                        <p class="card-text text-secondary small">
+                            Forces every PHP file to recompile from disk. Use after a deploy when the
+                            live site runs <strong>stale code</strong> (e.g. errors that reference a
+                            column already dropped). Reports the OPcache status — incl.
+                            <code>validate_timestamps</code> — before resetting. No DB needed.
+                        </p>
+                        <a href="?action=opcache-reset" class="btn btn-outline-warning btn-action">
+                            Reset OPcache
                         </a>
                     </div>
                 </div>


### PR DESCRIPTION
Two production-critical fixes. Targets **alpha**.

## #1289 — Song deletion no longer lies (`editor.js`)
The old Song Editor's `deleteSong()` was **client-only**: it filtered the in-memory `songData.songs` array and toasted *"Song deleted"* while the **DB kept the row**, so the song reappeared on reload + still loaded in Song View. (This is the bug that originally surfaced the "parts still on old JSON/SQLite" concern.) #1200 added the server `delete_song` endpoint + wired the *v2* editor but **left the old `editor.js` unwired.**
Now `deleteSong()` POSTs `delete_song` to the v2 API (`ed2EnrichApi` — cascade + CSRF + transaction, returns `{ok, deleted}`) and **only** mutates local state + toasts on confirmed success. On failure it shows the error and removes nothing — **the toast can never lie again.** `editor.js` is static JS, so this deploys cleanly regardless of #1290.

## #1290 — `songs_json`/sitemap flood `Unknown column s.SongbookName` = stale live runtime
Root-caused (verified):
- The DB-direct rewrite (#1010) **dropped** the denormalised `tblSongs.SongbookName` and switched every query to `JOIN tblSongbooks → b.Name AS songbookName`; the current repo `SongData.php` has **zero** `s.SongbookName` in SQL.
- Live DB confirms via **SQL Diagnostics**: `SHOW COLUMNS FROM tblSongs LIKE 'SongbookName'` → **0 rows** (column correctly dropped).
- The require path is the fresh `public_html/includes/SongData.php` (not the #1250 sibling-tree). So the live **runtime is executing OLD compiled PHP** (stale OPcache) that still references the dropped column. **This likely also explains why #1289's server fix + the rest of the rewrite aren't effective on live.**

Fix: a Global-Admin **"Reset PHP OPcache"** card on `/manage/setup-database` that reports OPcache status (incl. `validate_timestamps`) then `opcache_reset()` + `clearstatcache(true)` — so a CLI-less shared-host operator can bust deployed-but-stale code from the web. **After reset the `s.SongbookName` errors should stop** (the code is already correct), and the deletion endpoint should become effective too. If they persist, the deploy didn't upload the current file → a separate deploy fix.

## Testing
`php -l` clean (`setup-database.php`); `node --check` clean (`editor.js`). **Post-deploy:** click **Reset PHP OPcache** (Operations), then (a) re-check the Activity Log for `s.SongbookName` (should stop), and (b) retry deleting "Here to Stay" in the editor — it should now fail loudly or succeed truthfully against the DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)