### PR TITLE
fix(deploy): auto-bust PHP OPcache after every deploy — stops stale-code deploys (#1290)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -553,6 +553,43 @@ jobs:
           echo ".sql deployed to ${SQL_PATH}"
 
       # ================================================================
+      # POST-DEPLOY: bust PHP OPcache (#1290)
+      # On this shared FPM host, OPcache can serve STALE bytecode across a
+      # deploy even with opcache.validate_timestamps=on, so freshly-uploaded
+      # PHP doesn't run until the cache is reset (this caused the songs_json
+      # 's.SongbookName' flood + the editor CSRF mismatch). Curl the token-
+      # guarded /opcache-bust.php so new code goes live immediately.
+      # No-op (logs a notice, never fails the deploy) until OPCACHE_BUST_KEY
+      # is set AND the matching ../.auth/opcache_bust_key.php exists on the host.
+      # ================================================================
+      - name: Bust PHP OPcache (post-deploy)
+        if: steps.changes.outputs.has_changes == 'true'
+        env:
+          OPCACHE_KEY: ${{ secrets.OPCACHE_BUST_KEY }}
+          CHANNEL: ${{ steps.target.outputs.channel }}
+        run: |
+          if [[ -z "$OPCACHE_KEY" ]]; then
+            echo "::notice::OPCACHE_BUST_KEY secret not set — skipping OPcache bust. Set it (and ../.auth/opcache_bust_key.php on the host) to enable automatic post-deploy cache busting (#1290)."
+            exit 0
+          fi
+          case "$CHANNEL" in
+            alpha) BASE="https://dev.ihymns.app" ;;
+            beta)  BASE="https://beta.ihymns.app" ;;
+            live)  BASE="https://ihymns.app" ;;
+            *)     echo "::notice::Unknown channel '$CHANNEL' — skipping OPcache bust."; exit 0 ;;
+          esac
+          echo "Busting OPcache at ${BASE}/opcache-bust.php"
+          HTTP=$(curl -fsS -o /tmp/opcache_resp.json -w '%{http_code}' \
+            -H "X-OPcache-Key: ${OPCACHE_KEY}" \
+            --max-time 30 "${BASE}/opcache-bust.php" || true)
+          echo "HTTP ${HTTP}"
+          cat /tmp/opcache_resp.json 2>/dev/null || true
+          echo
+          if [[ "$HTTP" != "200" ]]; then
+            echo "::warning::OPcache bust returned HTTP ${HTTP} (deploy still succeeded; new code may lag until the cache evicts). 503=key not configured on host; 403=key mismatch."
+          fi
+
+      # ================================================================
       # .auth/ DEPLOYMENT (#272)
       # Uploads appWeb/.auth/ (.htaccess, db_credentials.example.php)
       # as a sibling of public_html/. The real db_credentials.php is

--- a/appWeb/public_html/opcache-bust.php
+++ b/appWeb/public_html/opcache-bust.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * opcache-bust.php — token-guarded OPcache reset for post-deploy cache busting.
+ *
+ * #1290 — on this shared DreamHost FPM host, OPcache can serve STALE compiled
+ * bytecode across an SFTP deploy even with opcache.validate_timestamps=on: the
+ * freshly-uploaded file's mtime doesn't always change in a way FPM revalidates,
+ * so the deployed code does NOT run until the cache is reset. That single fault
+ * produced the songs_json/sitemap "Unknown column s.SongbookName" flood (DB
+ * column dropped + repo code correct, but stale bytecode still selected it) AND
+ * the editor's "Invalid or missing CSRF token" (the stale API ran old CSRF code
+ * that didn't match the fresh page's token). A manual reset on /manage/setup-
+ * database stopped both — so the deploy workflow now curls this endpoint after
+ * every SFTP mirror, making new code go live immediately.
+ *
+ * This file is intentionally STANDALONE — no includes, no DB, no session, no
+ * app bootstrap — so nothing can interfere with (or be interfered by) the reset.
+ *
+ * SECURITY
+ *   - Requires a shared secret, supplied via the `X-OPcache-Key` request header
+ *     (preferred) or `?key=`, matched with hash_equals() against the expected
+ *     key resolved from `IHYMNS_OPCACHE_KEY` (env) or `../.auth/opcache_bust_key.php`.
+ *   - SAFE BY DEFAULT: if no key is configured server-side, it returns 503 and
+ *     does nothing — the endpoint cannot be abused before it is set up.
+ *   - RATE-LIMITED: at most one reset per 5 seconds (temp-dir sentinel), so even
+ *     a leaked key cannot be used to hammer recompiles into a DoS.
+ *   - The only side effect is opcache_reset() + clearstatcache(). No user input
+ *     other than the key is read or echoed.
+ */
+
+declare(strict_types=1);
+
+header('Content-Type: application/json; charset=utf-8');
+header('Cache-Control: no-store');
+header('X-Robots-Tag: noindex');
+
+/* ---- Resolve the EXPECTED key: env first, then a .auth/ sibling file. ----
+   .auth/ is deployed as a sibling of public_html/, so from this file the path
+   is ../.auth/opcache_bust_key.php. That file must `return '<the-key>';`. */
+$expected = (string) (getenv('IHYMNS_OPCACHE_KEY') ?: '');
+if ($expected === '') {
+    $keyFile = dirname(__DIR__) . DIRECTORY_SEPARATOR . '.auth' . DIRECTORY_SEPARATOR . 'opcache_bust_key.php';
+    if (is_file($keyFile)) {
+        $v = require $keyFile;
+        if (is_string($v)) {
+            $expected = trim($v);
+        }
+    }
+}
+if ($expected === '') {
+    http_response_code(503);
+    echo json_encode(['ok' => false, 'error' => 'OPcache bust not configured.']);
+    exit;
+}
+
+/* ---- Compare the PROVIDED key (header preferred, query fallback). ---- */
+$provided = (string) ($_SERVER['HTTP_X_OPCACHE_KEY'] ?? ($_GET['key'] ?? ''));
+if ($provided === '' || !hash_equals($expected, $provided)) {
+    http_response_code(403);
+    echo json_encode(['ok' => false, 'error' => 'Forbidden.']);
+    exit;
+}
+
+/* ---- Rate-limit: skip if a reset happened in the last 5 seconds. ---- */
+$sentinel = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'ihymns_opcache_bust.ts';
+$now  = time();
+$last = is_file($sentinel) ? (int) @file_get_contents($sentinel) : 0;
+if ($now - $last < 5) {
+    echo json_encode(['ok' => true, 'reset' => false, 'note' => 'skipped (a reset ran <5s ago)']);
+    exit;
+}
+@file_put_contents($sentinel, (string) $now);
+
+/* ---- The actual bust. ---- */
+$available = function_exists('opcache_reset');
+$reset     = $available ? @opcache_reset() : false;
+clearstatcache(true);
+
+echo json_encode([
+    'ok'                => true,
+    'reset'             => (bool) $reset,
+    'opcache_available' => $available,
+]);


### PR DESCRIPTION
Targets **alpha**. The systemic follow-up to PR #1291.

## Confirmed root cause
The `songs_json`/sitemap **`Unknown column s.SongbookName`** flood was **stale PHP OPcache**, not a code bug:
- The column is correctly dropped (verified: `SHOW COLUMNS … → 0 rows`) and the repo `SongData.php` is correct (`b.Name` JOIN).
- On this shared DreamHost FPM host, OPcache served **stale compiled bytecode across the deploy even with `opcache.validate_timestamps: on` (revalidate 2s)** — the uploaded file's mtime didn't change in a way FPM revalidated.
- A **manual OPcache reset stopped the flood instantly**: last error in the log was `10:32:06Z`, reset ~`10:38Z`, **none since**. The same staleness explains the editor's *"Invalid or missing CSRF token"* (the stale API ran old CSRF code that didn't match the fresh page's token).

I was initially wrong that `validate_timestamps: on` rules OPcache out — the live evidence overrides the theory, so this **automates** the reset so it can't recur on any future deploy.

## What this does
- **`appWeb/public_html/opcache-bust.php`** — a **standalone** (no DB/session/app-bootstrap), **token-guarded**, **safe-by-default** (503 until a key is configured), **rate-limited** (1 reset / 5s) endpoint that runs `opcache_reset()` + `clearstatcache(true)`. Key matched with `hash_equals()` against `IHYMNS_OPCACHE_KEY` (env) **or** `../.auth/opcache_bust_key.php`.
- **`deploy.yml`** — a final **"Bust PHP OPcache"** step curls the endpoint per channel (alpha→`dev.ihymns.app`, beta→`beta.ihymns.app`, live→`ihymns.app`) after the SFTP mirror. **No-op + GitHub notice** until the secret + host key file exist; **never fails the deploy**; warns (doesn't fail) on non-200.

## Activation (one-time, owner action — see PR comment / chat)
Needs a `OPCACHE_BUST_KEY` GitHub secret **and** a matching `../.auth/opcache_bust_key.php` on each host. Until both exist it stays a safe no-op.

## Security notes (pre-PR review)
- Timing-safe key compare; safe-by-default (no key ⇒ 503, no reset); rate-limited against reset-hammering; `X-Robots-Tag: noindex`; **no secrets committed** (the `.auth` key file is created by the owner, not in this PR); no SQL/user-input beyond the key; the key is sent as a header and is not logged by the deploy step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)