### PR TITLE
fix(editor): mint CSRF token before output — fixes delete_song 403 (#1293)

### DIFF
--- a/appWeb/public_html/manage/editor/index.php
+++ b/appWeb/public_html/manage/editor/index.php
@@ -25,6 +25,20 @@ requireEditor();
 
 $currentUser = getCurrentUser();
 
+/* CSRF token mint — MUST run BEFORE any HTML output (mirrors editor2.php:34).
+   csrfToken() calls initSession() → session_start(), so the session cookie
+   and the freshly-minted $_SESSION['csrf_token'] are committed to the response
+   headers + session store while we still own the output buffer. The old code
+   first called csrfToken() at the inline <script> ~1640 lines down, deep in the
+   HTML body; for a token-adopted session (ihymns_auth cookie, no prior PHP
+   session) that was the FIRST mint, and minting/persisting a brand-new token
+   that late made api2.php's validateCsrf() (X-CSRF-Token header) reject the
+   subsequent delete_song POST with a 403 "Invalid or missing CSRF token".
+   Establishing it here, before <!DOCTYPE>, gives the same early-mint guarantee
+   that makes the v2 editor's CSRF validate. The window.IHYMNS_EDITOR_CSRF emit
+   below now just re-reads this same session token. (delete_song 403 fix) */
+$editorCsrf = function_exists('csrfToken') ? csrfToken() : '';
+
 /* External-link type registry for the Song-Editor Links tab (#833).
    Empty array on pre-migration installs — the Links tab still
    renders but the dropdown shows the empty-state hint. */
@@ -1637,7 +1651,7 @@ try {
            translation/annotation editor POSTs to. The legacy load/save path
            (api.php) is session-only; api2.php's enrichment endpoints additionally
            validate this token via the X-CSRF-Token header. */
-        window.IHYMNS_EDITOR_CSRF = <?= json_encode(function_exists('csrfToken') ? csrfToken() : '') ?>;
+        window.IHYMNS_EDITOR_CSRF = <?= json_encode($editorCsrf) ?>;
         window.IHYMNS_EDITOR_API2 = '/manage/editor/api2';
     </script>
 


### PR DESCRIPTION
Targets **alpha**. Completes the deletion path opened by #1289 / #1291. Closes #1293.

## The bug
After #1291 made the old editor's `deleteSong()` server-backed, the delete reached the server but was rejected: `POST /manage/editor/api2?action=delete_song → 403 (Forbidden)` → *"Invalid or missing CSRF token. The song was NOT removed."* Persisted **after** an OPcache reset (so not stale code).

## Root cause (multi-agent trace, high confidence)
`index.php` minted its CSRF token **too late** — the first `csrfToken()` call was the inline `<script>` ~1600 lines into the HTML body. `csrfToken()` lazily mints `$_SESSION['csrf_token']` only on first call; for a **token-adopted session** (curator authed via the cross-subdomain `ihymns_auth` cookie, no prior PHP session ⇒ no existing `csrf_token`) that late first-mint made the embedded `window.IHYMNS_EDITOR_CSRF` unreliable against what `api2.php`'s `validateCsrf()` resumed ⇒ 403. The **v2 editor** never hit this because `editor2.php` mints `csrfToken()` **before `<!DOCTYPE>`**.

## Fix (minimal, mirrors v2)
Mint `$editorCsrf = csrfToken()` immediately after `getCurrentUser()`, **before any HTML output**; the line-1640 emit now re-reads `$editorCsrf` (no second mint). The `validateCsrf()` gate is **untouched** — the token now validates legitimately.

## Review
3 adversarial lenses — **fix-correctness** (token now validates incl. for `ihymns_auth`-adopted sessions), **no-regression** (v2 editor + other `ed2EnrichApi` callers unaffected; early mint is idempotent with the later read), **CSRF-security** (gate intact, still per-session `random_bytes` + `hash_equals`, no widened acceptance) — **all pass**.

## ⚠️ Deploy step
`index.php` is PHP under OPcache. After this merges + deploys, **run "Reset PHP OPcache"** on `/manage/setup-database` (until the auto-bust in #1292 is activated), then retest the "Here to Stay" delete — it should return **200** and remove the row. (Verify via a curator signed in through the main-app `ihymns_auth` cookie — the path that triggered the bug.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)