### PR TITLE
Quick-fixes bundle: editor padding (#1297) + destructive-op type-to-confirm (#1298) + model-tier standing rule (#1299)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -111,7 +111,7 @@ If an item can't be completed (network for a Wiki push, an owner decision for a 
 
 - `.claude/ProjectBrief.md` — current project state, versions, phase, database schema summary.
 - `.claude/ProjectOverview.md` — original multi-platform scoping.
-- `.claude/project-rules.md` — this file's detailed expansion (naming, data-access layers, error handling, i18n, test discipline).
+- `.claude/project-rules.md` — this file's detailed expansion (naming, data-access layers, error handling, i18n, test discipline). Includes §17 **model-tier selection**: match the model to task complexity — fast/cheap tier (`quick-edits`) for mechanical work, top tier (`deep-architect`) for hard reasoning / security / review, default model for standard implementation.
 
 ## 💾 Session continuity across devices
 

--- a/.claude/agents/deep-architect.md
+++ b/.claude/agents/deep-architect.md
@@ -1,0 +1,8 @@
+---
+name: deep-architect
+description: Use ONLY for genuinely hard reasoning — architecture decisions, subtle multi-file bugs, algorithm design, concurrency or data-model trade-offs, large cross-cutting refactors.
+model: claude-fable-5
+tools: Read, Edit, Bash, Grep, Glob
+---
+You handle complex reasoning. Weigh trade-offs explicitly and explain the
+decision before implementing. Prefer correctness over speed.

--- a/.claude/agents/quick-edits.md
+++ b/.claude/agents/quick-edits.md
@@ -1,0 +1,8 @@
+---
+name: quick-edits
+description: Use PROACTIVELY for mechanical, low-reasoning work — renames, formatting, import sorting, docstrings, boilerplate, simple find-and-replace across files, trivial config edits.
+model: claude-haiku-4-5
+tools: Read, Edit, Bash
+---
+You handle fast, mechanical changes. Make the edit, verify it builds or compiles
+if relevant, then stop. Do not redesign or refactor beyond what was asked.

--- a/.claude/project-rules.md
+++ b/.claude/project-rules.md
@@ -320,3 +320,22 @@ foreach ($cands as $c) { if (is_file($c)) { require_once $c; $found = true; brea
 ### 16.2 The SFTP deploy content-compares; new files no longer silently strand
 
 `deploy.yml`'s normal path used `--only-newer`, which — because `actions/checkout` stamps every file with the checkout mtime — **silently skipped files** whose remote copy had a later (prior-deploy) mtime. It stranded `lyric_lines_sync.php` (and #919/#920 before it). Now the normal path **content-compares** (size+content); `[deploy all]` in the commit/PR-title still forces a full sweep; the deploy job has a `timeout-minutes: 20` cap + `~/.lftprc` net timeouts so a stalled mirror can't hang the 6h Actions ceiling (it did, twice). When you add a NEW file a deploy must pick up, a `[deploy all]` PR title is the belt-and-braces guarantee.
+
+## 17. Model-tier selection — match the model to the task complexity
+
+**Standing rule:** when delegating to subagents (the Agent tool) or to a workflow stage, **match the model tier to the complexity of the work.** Don't default everything to the top tier (wasteful on cost + latency); don't hand hard reasoning to a weak tier (risky for correctness). Spread the work across the tiers available to you so each task runs on the cheapest model that can still do it well.
+
+The mapping:
+
+- **Fast / cheap tier (e.g. Haiku)** → mechanical, low-reasoning work: renames, formatting, import sorting, doc-blocks + comment annotation, boilerplate, simple find-and-replace, trivial config edits, simple `grep`/`glob` sweeps, syntax-only fixes.
+- **Mid tier (e.g. Sonnet)** → standard implementation: a self-contained feature, a single-page handler, a focused bugfix in code you already understand, writing tests against a clear spec.
+- **Top tier (e.g. Opus)** → genuinely hard reasoning: architecture + data-model decisions, subtle multi-file bugs, large cross-cutting refactors, adversarial review / verification, security-sensitive changes (auth, CSRF, SQL-binding, secrets), ambiguous trade-offs with no obvious right answer.
+
+The aim is cost/latency efficiency **without sacrificing quality where it matters**. **When unsure, prefer the more capable tier for anything correctness-critical** — a wrong auth check or a missed SQL-injection vector costs far more than the extra tokens. Tier-down only when the task is unambiguously mechanical.
+
+This repo already ships matching agent types as the natural vehicles — use them rather than reinventing the routing:
+
+- **`quick-edits`** (`.claude/agents/quick-edits.md`, fast/cheap tier) — the low-reasoning mechanical lane.
+- **`deep-architect`** (`.claude/agents/deep-architect.md`, top tier) — the hard-reasoning / review / security lane.
+
+Standard mid-tier implementation work needs no special agent — run it on the default model. Reserve the two named agents for the ends of the spectrum.

--- a/appWeb/public_html/css/admin.css
+++ b/appWeb/public_html/css/admin.css
@@ -676,6 +676,18 @@ body:has(.navbar-admin) {
 
 .song-list-container { flex: 1; overflow-y: auto; padding: 0; }
 
+/* Song-list rows are Bootstrap `.list-group-item`s appended straight into the
+   `padding:0` container by editor.js (buildSongListRow). Bootstrap's default
+   `padding-x: 1rem` left the row text out of line with the filter / search /
+   sort controls in `.sidebar-header` above (which are inset `0.75rem`). Pin the
+   rows' horizontal padding to that same `0.75rem` so the list text's left edge
+   aligns with the controls above (and keep the right side symmetric). Scoped to
+   `#song-list` so no other admin `.list-group-item` is touched. */
+#song-list .list-group-item {
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+}
+
 .song-list-item {
     padding: 0.5rem 0.75rem;
     border-bottom: 1px solid var(--card-border);

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -1988,14 +1988,20 @@ if ($hasCredentials && defined('DB_HOST')) {
                             </span>
                             <?php
                                 /* #1235 P4/C6 — a manual/destructive migration's run link carries
-                                   confirm=1 (the script refuses without it) + a confirm() dialog. */
+                                   confirm=1 (the script refuses without it) + a confirm() dialog.
+                                   #1298 — plus the type-to-confirm speed-bump (data attribute carries
+                                   the exact slug the operator must type). Layered on top of the
+                                   server-side confirm=1 / sentinel gate, never instead of it. */
                                 $_paManual  = !empty($migrationManual[$_pa]);
                                 $_paHref    = '?action=' . htmlspecialchars($_pa) . ($_paManual ? '&amp;confirm=1' : '');
                                 $_paOnclick = $_paManual
                                     ? ' onclick="return confirm(\'This is a DESTRUCTIVE, irreversible migration. It only proceeds behind the pre-drop verification gate. Continue?\');"'
                                     : '';
+                                $_paType    = $_paManual
+                                    ? ' data-type-to-confirm="' . htmlspecialchars($_pa, ENT_QUOTES) . '"'
+                                    : '';
                             ?>
-                            <a href="<?= $_paHref ?>"<?= $_paOnclick ?>
+                            <a href="<?= $_paHref ?>"<?= $_paOnclick ?><?= $_paType ?>
                                class="btn btn-sm <?= $_paManual ? 'btn-danger' : 'btn-outline-info' ?> flex-shrink-0 <?= $hasCredentials ? '' : 'disabled' ?>">
                                 Run &amp; show output
                             </a>
@@ -2136,11 +2142,20 @@ if ($hasCredentials && defined('DB_HOST')) {
                 $_renderCard = static function (string $migAction, array $card, bool $hasCreds, bool $isManual = false): void {
                     /* #1235 P4/C6 — a manual/destructive migration's run link carries confirm=1
                        (the script REFUSES a web run without it) + a JS confirm() dialog, mirroring
-                       the drop-legacy pattern; the button is danger-styled and the card flagged. */
+                       the drop-legacy pattern; the button is danger-styled and the card flagged.
+                       ADDITIONAL client speed-bump (#1298): the anchor also carries
+                       data-type-to-confirm="<slug>" so the shared inline JS forces the operator to
+                       type the exact migration slug before the destructive request fires. This is
+                       layered ON TOP of the server-side confirm=1 / sentinel gate — never instead. */
                     $href    = '?action=' . htmlspecialchars($migAction) . ($isManual ? '&amp;confirm=1' : '');
                     $btnClass = $isManual ? 'btn-danger' : 'btn-info';
                     $onclick = $isManual
                         ? ' onclick="return confirm(\'This is a DESTRUCTIVE, irreversible migration. It only proceeds if the pre-drop verification gate is green and &lt;24h old. Continue?\');"'
+                        : '';
+                    /* The required phrase IS the migration slug — shown to the operator in the
+                       prompt and matched case-sensitively. htmlspecialchars guards the attribute. */
+                    $typeToConfirm = $isManual
+                        ? ' data-type-to-confirm="' . htmlspecialchars($migAction, ENT_QUOTES) . '"'
                         : '';
                     ?>
                     <div class="col-md-6">
@@ -2151,7 +2166,7 @@ if ($hasCredentials && defined('DB_HOST')) {
                                     <span class="badge bg-danger mb-2">Manual &amp; destructive — NOT run by &ldquo;Apply all&rdquo;</span>
                                 <?php endif; ?>
                                 <p class="card-text text-secondary small"><?= $card['body'] ?></p>
-                                <a href="<?= $href ?>"<?= $onclick ?>
+                                <a href="<?= $href ?>"<?= $onclick ?><?= $typeToConfirm ?>
                                    class="btn <?= $btnClass ?> btn-action <?= $hasCreds ? '' : 'disabled' ?>">
                                     <?= htmlspecialchars($card['button']) ?>
                                 </a>
@@ -2461,6 +2476,7 @@ if ($hasCredentials && defined('DB_HOST')) {
                                 Preview
                             </a>
                             <a href="?action=drop-legacy&amp;confirm=1" class="btn btn-danger btn-sm <?= $hasCredentials ? '' : 'disabled' ?>"
+                               data-type-to-confirm="drop-legacy"
                                onclick="return confirm('This will DROP all tables in the database that are not defined in schema.sql.\n\nThis cannot be undone. Run a Backup first.\n\nContinue?')">
                                 Drop Them
                             </a>
@@ -2534,6 +2550,51 @@ if ($hasCredentials && defined('DB_HOST')) {
         <?php endif; ?>
     </p>
 </div>
+
+<script>
+/* Type-to-confirm speed-bump for DESTRUCTIVE / irreversible actions (#1298).
+
+   Any anchor tagged data-type-to-confirm="<phrase>" (the migration slug, e.g.
+   "retire-component-lines-json", or the "drop-legacy" action) forces the operator
+   to type that EXACT phrase before the request is allowed to fire. An exact,
+   case-sensitive match navigates; anything else cancels the click.
+
+   This is an ADDITIONAL client speed-bump only — it does NOT replace any
+   server-side guard. The destructive request still carries confirm=1 (the
+   migration / drop script refuses without it), the existing native confirm()
+   dialog still runs, the verifier-sentinel / parity preconditions still apply,
+   and the whole page is still behind the global_admin gate. We bind in the
+   CAPTURE phase so this runs BEFORE the anchor's inline onclick confirm(): on a
+   mismatch we preventDefault() + stopImmediatePropagation() so neither the inline
+   confirm nor the navigation proceeds. Vanilla JS, no dependencies. */
+(() => {
+    document.addEventListener('click', (ev) => {
+        const link = ev.target.closest('a[data-type-to-confirm]');
+        if (!link) return;
+        /* Respect the page's own disabled-state convention (no credentials). */
+        if (link.classList.contains('disabled')) return;
+
+        const phrase = link.getAttribute('data-type-to-confirm') || '';
+        if (phrase === '') return;
+
+        const typed = window.prompt(
+            'DESTRUCTIVE, irreversible action.\n\n' +
+            'To confirm, type the following EXACTLY (case-sensitive):\n\n' +
+            phrase
+        );
+
+        /* Exact, case-sensitive match required. Cancel / mismatch aborts the
+           click entirely — stopImmediatePropagation() prevents the inline
+           onclick confirm() from also running, preventDefault() blocks nav. */
+        if (typed !== phrase) {
+            ev.preventDefault();
+            ev.stopImmediatePropagation();
+        }
+        /* On an exact match we fall through: the inline onclick confirm()
+           (if any) runs next, then the browser follows the href. */
+    }, true /* capture */);
+})();
+</script>
 
 <script>
 /* IANA + CLDR live refresh button (#738).


### PR DESCRIPTION
Targets **alpha**. Three small, independent queued fixes — one review/deploy cycle, four atomic commits.

### 1. Editor sidebar padding — #1297 (`admin.css`)
Song-list rows were hard against the left edge, out of line with the search/sort controls above. `editor.js` builds rows as Bootstrap `.list-group-item` (default `padding-x: 1rem`) inside `.song-list-container{padding:0}`; the `.sidebar-header` controls are inset `0.75rem`. Scoped `#song-list .list-group-item { padding-left/right: 0.75rem }` aligns them. `#song-list` is unique to the editor → no other admin list affected.

### 2. Type-to-confirm on destructive Operations — #1298 (`setup-database.php`)
The irreversible actions — `retire-component-lines-json` (the `'manual'` migration that drops the `tblSongComponents` JSON columns) and `drop-legacy` (DROPs every non-schema table) — now require typing the **exact action phrase** before firing. Client-side capture-phase listener; exact case-sensitive match or it aborts (`preventDefault`+`stopImmediatePropagation`). **Purely additive** — every server-side guard (`confirm=1`, Stage-0 sentinel/parity, `global_admin`) is untouched; non-destructive actions (install/cleanup/backup/opcache-reset/deploy-forensics/verify-cutover/additive migrations) are **not** gated.

### 3. Model-tier standing rule — #1299 (`.claude/`)
`project-rules.md` §17 (+ `CLAUDE.md` pointer): match the model tier to task complexity when delegating — fast/cheap (`quick-edits`/Haiku) for mechanical work, mid (Sonnet/default) for standard implementation, top (`deep-architect`/Opus) for hard reasoning + review + security. Also tracks the two `.claude/agents/` definitions so §17's references resolve in version control (separate `chore` commit).

## Review
Built + adversarially reviewed by a multi-agent workflow: the type-to-confirm got a dedicated **safety/correctness** pass (**pass** — gates only destructive actions, preserves all server guards, no trivial bypass) and a **scope/lint** pass (editor CSS stays `#song-list`-scoped; `php -l` clean). The §17 placement fix from that review is applied.

Note: a cosmetic `README.md` `(c)`→`©` edit is intentionally **left uncommitted** (it's the owner's local change, not part of this bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)