### PR TITLE
Queued features A+B+C: Maintenance UX (#1301) · Activity-Log infinite-scroll (#1302) · Email M365/Google (#1303)

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ git clone https://github.com/MWBMPartners/iHymns.wiki.git
 
 ## License
 
-Copyright (c) 2026 MWBM Partners Ltd. All rights reserved.
+Copyright © 2026 MWBM Partners Ltd. All rights reserved.
 
 This software is proprietary. Unauthorized copying, modification, or distribution is strictly prohibited.
 

--- a/appWeb/public_html/includes/EmailService.php
+++ b/appWeb/public_html/includes/EmailService.php
@@ -25,9 +25,18 @@ declare(strict_types=1);
  *   - sendgrid : SendGrid v3 REST API
  *   - mailgun  : Mailgun v3 REST API (auto-detects EU / US region)
  *   - ses      : AWS SES SendEmail (SigV4-signed POST, no AWS SDK)
- *   - smtp     : NOT YET IMPLEMENTED (#898 follow-up). Returns a
- *                structured failure so the caller surfaces a real 500
- *                rather than silently dropping the email.
+ *   - smtp     : Self-contained SMTP-AUTH client (no PHPMailer / Composer).
+ *                Speaks ESMTP over a raw socket with STARTTLS or implicit
+ *                SSL/TLS, AUTH LOGIN, and an RFC 5322 MIME multipart body.
+ *                Supports Microsoft 365 (smtp.office365.com) and Google
+ *                Workspace (smtp.gmail.com) via the provider presets in
+ *                /manage/configuration.php, plus DELEGATE / "send-as"
+ *                sending where the From / Sender address differs from the
+ *                SMTP AUTH login (the login mailbox must be granted
+ *                Send-As on the delegate mailbox in the provider's admin
+ *                console — see the configuration.php setup guides). OAuth2
+ *                (and the eventual MailerMatt service) is the future path;
+ *                today it is SMTP-AUTH + an app password + delegate. (feature C)
  *   - log      : developer-only "send to PHP error_log" mode. Sanitises
  *                the log line — never writes the magic-link token, the
  *                6-digit code, or the verification token. The raw
@@ -190,15 +199,10 @@ final class EmailService
             case 'ses':
                 return self::sendViaSes($to, $subject, $bodyHtml, $bodyText, $cfg);
             case 'smtp':
-                /* Documented as TODO in #898 — see configuration.php
-                   instructions panel. Returning a structured failure
-                   makes the caller surface a real 500 rather than
-                   silently dropping the email. */
-                return EmailSendResult::failure(
-                    'smtp',
-                    'smtp_provider_not_yet_implemented',
-                    'NotImplemented'
-                );
+                /* feature C — real SMTP-AUTH client with STARTTLS / implicit
+                   SSL, AUTH LOGIN, and delegate ("send-as") From support.
+                   Supersedes the #898 "not yet implemented" stub. */
+                return self::sendViaSmtp($to, $subject, $bodyHtml, $bodyText, $cfg);
             default:
                 return EmailSendResult::failure(
                     (string)$service,
@@ -415,6 +419,286 @@ final class EmailService
     }
 
     /* -------------------------------------------------------------------
+     * Driver: SMTP (feature C — self-contained ESMTP client)
+     * -----------------------------------------------------------------
+     * Speaks ESMTP over a raw socket so the repo stays Composer-free,
+     * mirroring the no-SDK approach of the SES driver. Supports:
+     *   - STARTTLS (port 587, the Microsoft 365 / Google Workspace default)
+     *     and implicit SSL/TLS (port 465).
+     *   - AUTH LOGIN with the SMTP username + password.
+     *   - DELEGATE / "send-as" sending: the MAIL FROM envelope sender and
+     *     the From: header use email_smtp_from_address (the delegate
+     *     mailbox) when set, while authentication still uses email_smtp_user
+     *     (the login mailbox). The provider must have granted the login
+     *     mailbox Send-As permission on the delegate mailbox — that's an
+     *     admin-console step, documented in configuration.php.
+     *
+     * NOTE: the SMTP password is read here and written ONLY into the
+     * AUTH LOGIN exchange on the encrypted socket — it is never logged,
+     * never echoed, never placed in the activity-log row.
+     * ----------------------------------------------------------------- */
+    private static function sendViaSmtp(string $to, string $subject, string $bodyHtml, string $bodyText, array $cfg): EmailSendResult
+    {
+        $host   = trim((string)($cfg['email_smtp_host'] ?? ''));
+        $port   = (int)($cfg['email_smtp_port'] ?? 0);
+        $user   = (string)($cfg['email_smtp_user'] ?? '');
+        $pass   = (string)($cfg['email_smtp_pass'] ?? '');
+        $secure = (string)($cfg['email_smtp_secure'] ?? 'tls');
+        /* fromAddress() already prefers the delegate / send-as address
+           (email_smtp_from_address → falls back to email_from_address). */
+        $from   = self::fromAddress($cfg);
+
+        if ($host === '' || $port <= 0 || $user === '' || $pass === '' || $from['email'] === '') {
+            return EmailSendResult::failure('smtp', 'missing_host_port_credentials_or_from', 'NotConfigured');
+        }
+        if (!function_exists('fsockopen') && !function_exists('stream_socket_client')) {
+            return EmailSendResult::failure('smtp', 'no_socket_transport_available', 'TransportError');
+        }
+
+        /* Implicit-SSL connects to an already-TLS socket (port 465);
+           STARTTLS and "none" connect in cleartext and (for tls) upgrade
+           after EHLO. */
+        $useImplicitSsl = ($secure === 'ssl');
+        $useStartTls    = ($secure === 'tls');
+        $transport      = $useImplicitSsl ? 'ssl://' : '';
+
+        $errno  = 0;
+        $errstr = '';
+        $timeout = 15;
+        /* @ suppresses the connection-warning so a refused/timed-out
+           connection becomes a clean structured failure instead of a
+           PHP warning leaking host details into the output. */
+        $fp = @stream_socket_client(
+            $transport . $host . ':' . $port,
+            $errno,
+            $errstr,
+            $timeout,
+            STREAM_CLIENT_CONNECT
+        );
+        if ($fp === false) {
+            return EmailSendResult::failure(
+                'smtp',
+                'connect_failed:' . self::sanitiseForLog($errstr !== '' ? $errstr : ('errno_' . $errno), 80),
+                'TransportError'
+            );
+        }
+        stream_set_timeout($fp, $timeout);
+
+        /* RFC 5321 conversation. Each helper reads the multi-line reply
+           and asserts the leading 3-digit code is in the accepted set;
+           any deviation aborts and closes the socket. */
+        $fail = static function (string $why, ?string $detail = null) use ($fp): EmailSendResult {
+            @fclose($fp);
+            $msg = $detail !== null ? ($why . ':' . self::sanitiseForLog($detail, 120)) : $why;
+            return EmailSendResult::failure('smtp', $msg, 'ProviderError');
+        };
+
+        $ehloName = self::smtpEhloName($from['email']);
+
+        $greet = self::smtpRead($fp);
+        if (substr($greet, 0, 1) !== '2') {
+            return $fail('no_greeting', $greet);
+        }
+
+        self::smtpWrite($fp, 'EHLO ' . $ehloName);
+        $ehlo = self::smtpRead($fp);
+        if (substr($ehlo, 0, 1) !== '2') {
+            return $fail('ehlo_rejected', $ehlo);
+        }
+
+        if ($useStartTls) {
+            self::smtpWrite($fp, 'STARTTLS');
+            $tls = self::smtpRead($fp);
+            if (substr($tls, 0, 1) !== '2') {
+                return $fail('starttls_rejected', $tls);
+            }
+            /* Negotiate TLS on the existing socket. Use the modern "any
+               TLS" crypto-method constant so 1.2 / 1.3 are both allowed. */
+            $cryptoOk = @stream_socket_enable_crypto(
+                $fp,
+                true,
+                STREAM_CRYPTO_METHOD_TLS_CLIENT
+            );
+            if ($cryptoOk !== true) {
+                return $fail('starttls_handshake_failed', null);
+            }
+            /* RFC 3207: re-issue EHLO over the now-encrypted channel. */
+            self::smtpWrite($fp, 'EHLO ' . $ehloName);
+            $ehlo2 = self::smtpRead($fp);
+            if (substr($ehlo2, 0, 1) !== '2') {
+                return $fail('ehlo_after_tls_rejected', $ehlo2);
+            }
+        }
+
+        /* AUTH LOGIN — username + password base64-encoded, each on its
+           own line after the server's 334 challenge. The password leaves
+           this process only here, over the (TLS) socket. */
+        self::smtpWrite($fp, 'AUTH LOGIN');
+        $authChallenge = self::smtpRead($fp);
+        if (substr($authChallenge, 0, 3) !== '334') {
+            return $fail('auth_login_unsupported', $authChallenge);
+        }
+        self::smtpWrite($fp, base64_encode($user));
+        $userChallenge = self::smtpRead($fp);
+        if (substr($userChallenge, 0, 3) !== '334') {
+            return $fail('auth_username_rejected', $userChallenge);
+        }
+        self::smtpWrite($fp, base64_encode($pass));
+        $authResult = self::smtpRead($fp);
+        if (substr($authResult, 0, 3) !== '235') {
+            /* 535 here = bad credentials / SMTP-AUTH disabled / app
+               password required. We surface the SERVER's text but never
+               the password itself. */
+            return $fail('auth_failed', $authResult);
+        }
+
+        /* Envelope. MAIL FROM is the delegate address when send-as is
+           configured; some providers (M365) require it to match an
+           address the login mailbox is authorised to send as. */
+        self::smtpWrite($fp, 'MAIL FROM:<' . self::smtpAddr($from['email']) . '>');
+        $mailFrom = self::smtpRead($fp);
+        if (substr($mailFrom, 0, 1) !== '2') {
+            return $fail('mail_from_rejected', $mailFrom);
+        }
+        self::smtpWrite($fp, 'RCPT TO:<' . self::smtpAddr($to) . '>');
+        $rcptTo = self::smtpRead($fp);
+        if (substr($rcptTo, 0, 1) !== '2') {
+            return $fail('rcpt_to_rejected', $rcptTo);
+        }
+
+        self::smtpWrite($fp, 'DATA');
+        $dataPrompt = self::smtpRead($fp);
+        if (substr($dataPrompt, 0, 3) !== '354') {
+            return $fail('data_rejected', $dataPrompt);
+        }
+
+        $message = self::smtpBuildMessage($from, $to, $subject, $bodyHtml, $bodyText);
+        /* Dot-stuffing (RFC 5321 §4.5.2): a line that is just "." would
+           terminate DATA prematurely, so any leading dot is doubled. */
+        $message = preg_replace('/^\./m', '..', $message) ?? $message;
+        /* Terminate DATA with CRLF.CRLF. */
+        self::smtpWriteRaw($fp, $message . "\r\n.\r\n");
+        $sent = self::smtpRead($fp);
+        if (substr($sent, 0, 1) !== '2') {
+            return $fail('message_rejected', $sent);
+        }
+
+        /* Best-effort polite close; the message is already accepted. */
+        self::smtpWrite($fp, 'QUIT');
+        @fclose($fp);
+
+        /* Pull the queue id out of the 250 acceptance line if present
+           (e.g. "250 2.0.0 OK <id>") so admins can cross-reference. */
+        $msgId = null;
+        if (preg_match('/queued as ([A-Za-z0-9]+)/i', $sent, $m)) {
+            $msgId = $m[1];
+        }
+        return EmailSendResult::success('smtp', $msgId);
+    }
+
+    /** Send one SMTP command line terminated with CRLF. */
+    private static function smtpWrite($fp, string $line): void
+    {
+        self::smtpWriteRaw($fp, $line . "\r\n");
+    }
+
+    /** Write a raw payload to the socket. */
+    private static function smtpWriteRaw($fp, string $data): void
+    {
+        @fwrite($fp, $data);
+    }
+
+    /**
+     * Read a (possibly multi-line) SMTP reply. Continuation lines have a
+     * hyphen after the 3-digit code ("250-..."); the final line has a
+     * space ("250 ..."). Returns the full block so callers inspect the
+     * leading code via substr().
+     */
+    private static function smtpRead($fp): string
+    {
+        $data = '';
+        while (!feof($fp)) {
+            $line = fgets($fp, 1024);
+            if ($line === false) {
+                break;
+            }
+            $data .= $line;
+            /* 4th char is a space on the last line of a reply. */
+            if (strlen($line) >= 4 && $line[3] === ' ') {
+                break;
+            }
+            $info = stream_get_meta_data($fp);
+            if (!empty($info['timed_out'])) {
+                break;
+            }
+        }
+        return $data;
+    }
+
+    /**
+     * Strip CR/LF from an address before it goes into a MAIL FROM /
+     * RCPT TO command or a header — prevents SMTP command / header
+     * injection via a crafted address.
+     */
+    private static function smtpAddr(string $addr): string
+    {
+        return str_replace(["\r", "\n"], '', trim($addr));
+    }
+
+    /**
+     * Derive the EHLO hostname. RFC 5321 wants a FQDN; the From domain is
+     * a reasonable, non-leaking choice (falls back to a literal).
+     */
+    private static function smtpEhloName(string $fromEmail): string
+    {
+        $at = strrpos($fromEmail, '@');
+        $domain = $at !== false ? substr($fromEmail, $at + 1) : '';
+        $domain = preg_replace('/[^A-Za-z0-9.\-]/', '', $domain) ?? '';
+        return $domain !== '' ? $domain : 'localhost';
+    }
+
+    /**
+     * Build the RFC 5322 message: headers + multipart/alternative body
+     * (text + HTML). All header values are CRLF-stripped so neither the
+     * subject nor the From name can inject extra headers.
+     */
+    private static function smtpBuildMessage(array $from, string $to, string $subject, string $bodyHtml, string $bodyText): string
+    {
+        $headerSafe = static fn (string $v): string => str_replace(["\r", "\n"], '', $v);
+
+        $fromHeader = self::formatFrom($from);
+        $boundary   = 'ihymns_' . bin2hex(random_bytes(16));
+        $date       = gmdate('r');
+        $messageId  = '<' . bin2hex(random_bytes(16)) . '@' . self::smtpEhloName($from['email']) . '>';
+        if ($bodyText === '') {
+            $bodyText = trim(strip_tags($bodyHtml));
+        }
+
+        $headers = [
+            'Date: ' . $date,
+            'From: ' . $headerSafe($fromHeader),
+            'To: <' . self::smtpAddr($to) . '>',
+            'Subject: ' . $headerSafe($subject),
+            'Message-ID: ' . $messageId,
+            'MIME-Version: 1.0',
+            'Content-Type: multipart/alternative; boundary="' . $boundary . '"',
+        ];
+
+        $crlf = "\r\n";
+        $body = '--' . $boundary . $crlf
+              . 'Content-Type: text/plain; charset=UTF-8' . $crlf
+              . 'Content-Transfer-Encoding: 8bit' . $crlf . $crlf
+              . $bodyText . $crlf . $crlf
+              . '--' . $boundary . $crlf
+              . 'Content-Type: text/html; charset=UTF-8' . $crlf
+              . 'Content-Transfer-Encoding: 8bit' . $crlf . $crlf
+              . $bodyHtml . $crlf . $crlf
+              . '--' . $boundary . '--' . $crlf;
+
+        return implode($crlf, $headers) . $crlf . $crlf . $body;
+    }
+
+    /* -------------------------------------------------------------------
      * Internal helpers
      * ----------------------------------------------------------------- */
 
@@ -467,6 +751,11 @@ final class EmailService
             'email_from_address', 'email_from_name',
             'email_smtp_host', 'email_smtp_port', 'email_smtp_user',
             'email_smtp_pass', 'email_smtp_secure',
+            /* feature C — SMTP provider preset + delegate / send-as From.
+               The preset only pre-fills host/port/secure in the UI; the
+               delegate address overrides the From / Sender at send time. */
+            'email_smtp_preset',
+            'email_smtp_from_address', 'email_smtp_from_name',
             'email_sendgrid_api_key',
             'email_mailgun_api_key', 'email_mailgun_domain',
             'email_ses_region', 'email_ses_access_key', 'email_ses_secret_key',
@@ -492,11 +781,37 @@ final class EmailService
         return self::$settings = $out;
     }
 
+    /**
+     * Resolve the effective From / Sender.
+     *
+     * feature C — DELEGATE / "send-as": when an SMTP delegate address is
+     * configured (email_smtp_from_address), it overrides the generic
+     * email_from_address so the message is sent on behalf of the
+     * delegated mailbox while AUTH still uses email_smtp_user. The
+     * delegate name (email_smtp_from_name) falls back to the generic
+     * From name. If no delegate is set, behaviour is identical to the
+     * pre-feature-C path (generic From for every provider).
+     *
+     * The delegate keys are SMTP-specific in the UI, but reading them
+     * here is harmless for the API providers (they have no delegate
+     * fields, so the keys are empty and we fall through to the generic
+     * From) and keeps the resolution in one place.
+     */
     private static function fromAddress(array $cfg): array
     {
+        $delegate = trim((string)($cfg['email_smtp_from_address'] ?? ''));
+        $email = ($delegate !== '' && filter_var($delegate, FILTER_VALIDATE_EMAIL))
+            ? $delegate
+            : (string)($cfg['email_from_address'] ?? '');
+
+        $delegateName = trim((string)($cfg['email_smtp_from_name'] ?? ''));
+        $name = $delegateName !== ''
+            ? $delegateName
+            : (string)($cfg['email_from_name'] ?? 'iHymns');
+
         return [
-            'email' => (string)($cfg['email_from_address'] ?? ''),
-            'name'  => (string)($cfg['email_from_name']    ?? 'iHymns'),
+            'email' => $email,
+            'name'  => $name,
         ];
     }
 

--- a/appWeb/public_html/includes/error_page.php
+++ b/appWeb/public_html/includes/error_page.php
@@ -101,6 +101,11 @@ body{font-family:system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;background
 .ep-btn-primary{background:linear-gradient(135deg,var(--ep-accent),var(--ep-accent2));color:#fff}
 .ep-btn-ghost{background:transparent;color:var(--ep-text);border-color:var(--ep-border)}
 .ep-btn:focus-visible{outline:3px solid var(--ep-accent);outline-offset:2px}
+/* SR-only helper (Bootstrap's .visually-hidden equivalent) — this page is
+   self-contained and does not load Bootstrap, so define it inline for the
+   aria-live announcements callers inject via extraBody. */
+.visually-hidden{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;
+ overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
 </style>
 CSS;
 }
@@ -115,7 +120,11 @@ CSS;
  *   detail?:string (already-safe-to-show text; caller gates by env),
  *   retryAfter?:int, noStatusCode?:bool,
  *   actions?:list<array{label:string,href:string,primary?:bool}>,
- *   extraHead?:string, extraBody?:string
+ *   extraHead?:string, extraBody?:string,
+ *   extraBodyAfter?:string (markup placed AFTER </main>, before </body> — for
+ *     content that must sit OUTSIDE the main's role="alert" assertive live
+ *     region, e.g. a separate aria-live="polite" announcement that must not be
+ *     double-announced by the alert)
  * }
  */
 function renderErrorPage(int $status, array $opts = []): void
@@ -143,7 +152,20 @@ function renderErrorPage(int $status, array $opts = []): void
     $actionsHtml = '';
     foreach ($actions as $a) {
         $cls = !empty($a['primary']) ? 'ep-btn ep-btn-primary' : 'ep-btn ep-btn-ghost';
+        /* Optional leading icon. Only the self-contained-safe 'padlock' is
+           supported (no Font Awesome on this page); it renders two inline
+           glyphs — a CLOSED lock shown at rest and an OPEN lock revealed on
+           hover/focus by the caller's CSS (.mtn-lock-closed / .mtn-lock-open),
+           giving the "signing in unlocks the site" affordance. */
+        $iconHtml = '';
+        if (($a['icon'] ?? '') === 'padlock') {
+            $iconHtml = '<span class="mtn-lock" aria-hidden="true">'
+                      . '<span class="mtn-lock-closed">&#128274;</span>'   /* 🔒 closed */
+                      . '<span class="mtn-lock-open">&#128275;</span>'      /* 🔓 open   */
+                      . '</span> ';
+        }
         $actionsHtml .= '<a class="' . $cls . '" href="' . htmlspecialchars((string)$a['href'], ENT_QUOTES, 'UTF-8') . '">'
+                      . $iconHtml
                       . htmlspecialchars((string)$a['label'], ENT_QUOTES, 'UTF-8') . '</a>';
     }
     $detailHtml = ($detail !== null && $detail !== '')
@@ -151,7 +173,11 @@ function renderErrorPage(int $status, array $opts = []): void
         : '';
 
     echo '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8">'
-       . '<meta name="viewport" content="width=device-width,initial-scale=1">'
+       /* viewport-fit=cover is REQUIRED for env(safe-area-inset-*) to resolve
+          to non-zero inside an installed iOS PWA — without it the standalone
+          safe-area padding block in maintenancePageExtraHead() is a no-op
+          (env() stays 0 in the default contain mode). #1276 feature A. */
+       . '<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">'
        . '<meta name="robots" content="noindex">'
        . '<title>iHymns &mdash; ' . $eTitle . '</title>'
        . errorPageThemeScript()
@@ -165,7 +191,9 @@ function renderErrorPage(int $status, array $opts = []): void
        . $detailHtml
        . '<div class="ep-actions">' . $actionsHtml . '</div>'
        . ($opts['extraBody'] ?? '')
-       . '</main></body></html>';
+       . '</main>'
+       . ($opts['extraBodyAfter'] ?? '')   /* outside the role="alert" main */
+       . '</body></html>';
 }
 
 /**

--- a/appWeb/public_html/includes/maintenance.php
+++ b/appWeb/public_html/includes/maintenance.php
@@ -120,6 +120,33 @@ function maintenanceMessage(): string
         : "iHymns is undergoing scheduled maintenance. We'll be back shortly — please check again in a few minutes.";
 }
 
+/* Auto-refresh interval bounds for the maintenance 503 page (#1276 feature A).
+   30s floor keeps a stuck-on-maintenance browser from hammering the origin;
+   3600s (1h) ceiling keeps the page from sitting stale forever. */
+const MAINTENANCE_REFRESH_DEFAULT = 300;
+const MAINTENANCE_REFRESH_MIN     = 30;
+const MAINTENANCE_REFRESH_MAX      = 3600;
+
+/**
+ * Admin-configured auto-refresh interval (seconds) for the maintenance 503
+ * page, read from the per-env `maintenance_refresh_seconds_<env>` setting.
+ * Parsed to an int, clamped to [MIN, MAX], and falls back to the default on
+ * ANY DB/parse error — getAppSetting() already returns the default string on
+ * a DB outage, and a non-numeric / out-of-range stored value can never push
+ * the timer below the floor. The maintenance page must never throw, so this
+ * is total: every code path returns a sane positive integer.
+ */
+function maintenanceRefreshSeconds(): int
+{
+    $raw = getAppSetting(maintenanceSettingKey('maintenance_refresh_seconds'), (string)MAINTENANCE_REFRESH_DEFAULT);
+    /* filter_var returns false on a non-numeric / empty value → default. */
+    $n = filter_var((string)$raw, FILTER_VALIDATE_INT);
+    if ($n === false) {
+        return MAINTENANCE_REFRESH_DEFAULT;
+    }
+    return max(MAINTENANCE_REFRESH_MIN, min(MAINTENANCE_REFRESH_MAX, (int)$n));
+}
+
 /** Shared 503 headers for maintenance + DB-down responses. */
 function maintenanceSend503Headers(): void
 {
@@ -145,14 +172,152 @@ function renderMaintenancePageHtml(): void
        maintenance page respects the user's light / dark / high-contrast / CVD
        theme instead of the old hardcoded-dark flash. */
     require_once __DIR__ . DIRECTORY_SEPARATOR . 'error_page.php';
+
+    /* Admin-configurable auto-refresh interval (seconds), DB-safe + clamped. */
+    $refreshSeconds = maintenanceRefreshSeconds();
+
     renderErrorPage(503, [
         'title'      => 'Under maintenance',
         'message'    => maintenanceMessage(),
         'emoji'      => '&#128295;',
         'code'       => '',                /* show the wrench + title, not "503" */
-        'retryAfter' => 120,
-        'actions'    => [['label' => 'Try again', 'href' => '/', 'primary' => true]],
+        'retryAfter' => $refreshSeconds,   /* HTTP Retry-After mirrors the JS timer */
+        'actions'    => [
+            /* Padlock-to-login: a logged-out admin can sign in here then
+               bypass maintenance. /manage is a SEPARATE entry point served
+               directly by .htaccess (RewriteRule ^manage/ - [L]) so it is
+               always reachable during maintenance — confirmed in the file
+               header above. The padlock icon is CLOSED at rest and OPENS on
+               hover/focus (CSS swap of the two glyphs), an affordance hint
+               that this unlocks the live site for an admin. */
+            ['label' => 'Admin sign-in', 'href' => '/manage/login', 'icon' => 'padlock'],
+            ['label' => 'Try again',     'href' => '/',             'primary' => true],
+        ],
+        'extraHead'      => maintenancePageExtraHead(),
+        'extraBody'      => maintenancePageExtraBody($refreshSeconds),
+        /* The single aria-live="polite" announcement, placed OUTSIDE the
+           <main role="alert"> so the assertive alert can't double-announce it. */
+        'extraBodyAfter' => maintenancePageExtraBodyAfter($refreshSeconds),
     ]);
+}
+
+/**
+ * Inline CSS for the maintenance-page extras (countdown widget + padlock
+ * affordance + standalone-PWA safe-area). Self-contained — appended to the
+ * error page's own <style> via the renderer's extraHead, so it paints with
+ * no dependency on app.css. All animation is gated behind
+ * prefers-reduced-motion so it stops dead when the user asks for less motion.
+ */
+function maintenancePageExtraHead(): string
+{
+    return <<<'CSS'
+<style>
+/* Standalone-PWA safe area: when the maintenance page is loaded inside an
+   installed PWA, env(safe-area-inset-*) clears the iPhone Dynamic Island /
+   notch and the rounded landscape corners. 0px fallback = no-op in a normal
+   browser tab. */
+@media (display-mode: standalone){
+  body{
+    padding-top:max(1.5rem,env(safe-area-inset-top,0px));
+    padding-bottom:max(1.5rem,env(safe-area-inset-bottom,0px));
+    padding-left:max(1.5rem,env(safe-area-inset-left,0px));
+    padding-right:max(1.5rem,env(safe-area-inset-right,0px));
+  }
+}
+/* Corner countdown chip — small, semi-transparent, pinned to a page corner
+   and clearing any notch in standalone mode. */
+.mtn-countdown{
+  position:fixed;
+  top:calc(0.75rem + env(safe-area-inset-top,0px));
+  right:calc(0.75rem + env(safe-area-inset-right,0px));
+  display:inline-flex;align-items:center;gap:.4rem;
+  padding:.35rem .7rem;border-radius:50px;
+  font-size:.8rem;font-weight:600;line-height:1;
+  background:var(--ep-card);color:var(--ep-muted);
+  border:1px solid var(--ep-border);
+  opacity:.6;                       /* semi-transparent at rest */
+  box-shadow:0 2px 8px rgba(0,0,0,.06);
+  transition:opacity .3s ease;
+}
+.mtn-countdown:hover{opacity:.95}
+/* Subtle pulse on the dot so the eye reads it as a live timer. Disabled
+   below for reduced-motion. */
+.mtn-countdown-dot{
+  width:.5rem;height:.5rem;border-radius:50%;
+  background:var(--ep-accent);
+  animation:mtn-pulse 2s ease-in-out infinite;
+}
+@keyframes mtn-pulse{0%,100%{opacity:.4}50%{opacity:1}}
+/* Padlock affordance: show the CLOSED lock at rest, swap to the OPEN lock on
+   hover/focus of the button, hinting that signing in unlocks the site. */
+.ep-btn .mtn-lock-open{display:none}
+.ep-btn:hover .mtn-lock-closed,
+.ep-btn:focus-visible .mtn-lock-closed{display:none}
+.ep-btn:hover .mtn-lock-open,
+.ep-btn:focus-visible .mtn-lock-open{display:inline}
+.mtn-lock{font-style:normal}
+@media (prefers-reduced-motion: reduce){
+  /* No pulse, no opacity transition — static, calm indicator. */
+  .mtn-countdown{transition:none;opacity:.85}
+  .mtn-countdown-dot{animation:none;opacity:1}
+}
+</style>
+CSS;
+}
+
+/**
+ * The countdown widget markup + the auto-refresh timer script, appended to the
+ * page body via the renderer's extraBody. A single setTimeout drives the hard
+ * reload at exactly $refreshSeconds; a 1-second setInterval updates the visible
+ * countdown so it stays in sync with that one timer (NOT a meta-refresh — that
+ * would fire independently and the countdown could never line up).
+ *
+ * Accessibility: the visible countdown chip is ENTIRELY aria-hidden (its dot
+ * and per-second numeric tick never reach a screen reader, so no once-a-second
+ * spam). The single aria-live="polite" announcement is NOT emitted here — it is
+ * returned by maintenancePageExtraBodyAfter() and placed by the renderer OUTSIDE
+ * the <main role="alert"> (via the extraBodyAfter hook) so the assertive alert
+ * cannot double-announce it. There is now exactly ONE live region on the page
+ * (no nested / overlapping polite-inside-status-inside-alert stack).
+ *
+ * @param int $refreshSeconds Already clamped to [30, 3600] by the caller.
+ */
+function maintenancePageExtraBody(int $refreshSeconds): string
+{
+    /* (int) cast belt-and-braces — the value is interpolated into JS, so it
+       must be a bare integer literal and nothing else. */
+    $n = (int)$refreshSeconds;
+    /* The visible chip is fully aria-hidden (no role="status" — that role was an
+       implicit polite live region nested inside the explicit polite span AND
+       inside <main role="alert">, the overlap this fix removes). */
+    return '<div class="mtn-countdown" aria-hidden="true">'
+         . '<span class="mtn-countdown-dot"></span>'
+         . '<span>Refreshing in <strong id="mtn-secs">' . $n . '</strong>s</span>'
+         . '</div>'
+         . '<script>(function(){'
+         . 'var n=' . $n . ',el=document.getElementById("mtn-secs"),left=n;'
+         . '/* One hard reload at the interval; the SW serves cache on a 503 so this is cheap. */'
+         . 'setTimeout(function(){location.reload();},n*1000);'
+         . '/* Visible tick — chip is aria-hidden so it never reaches the SR. */'
+         . 'var iv=setInterval(function(){left-=1;if(left<0)left=0;if(el)el.textContent=left;'
+         . 'if(left<=0)clearInterval(iv);},1000);'
+         . '})();</script>';
+}
+
+/**
+ * The ONE screen-reader announcement for the auto-refresh, placed by the
+ * renderer AFTER </main> (extraBodyAfter) — i.e. OUTSIDE the assertive
+ * <main role="alert"> — so it is announced once by the polite region alone and
+ * is never double-announced by the alert. Announced once on load; the visible
+ * per-second tick is aria-hidden (in maintenancePageExtraBody()).
+ *
+ * @param int $refreshSeconds Already clamped to [30, 3600] by the caller.
+ */
+function maintenancePageExtraBodyAfter(int $refreshSeconds): string
+{
+    $n = (int)$refreshSeconds;
+    return '<div class="visually-hidden" aria-live="polite">This page refreshes automatically every '
+         . $n . ' seconds.</div>';
 }
 
 /**

--- a/appWeb/public_html/js/modules/pwa.js
+++ b/appWeb/public_html/js/modules/pwa.js
@@ -33,6 +33,17 @@ export class PWA {
 
         /** @type {string} localStorage key for banner dismissal */
         this.dismissKey = STORAGE_PWA_BANNER_DISMISSED;
+
+        /**
+         * @type {boolean} When the app is in maintenance mode we suppress the
+         * install banner — a new visitor gets the full server-side maintenance
+         * 503 page (which never loads this module), but a returning, NOT-yet-
+         * installed user can still load the cached SPA shell during an outage;
+         * prompting them to install mid-maintenance is poor UX and collides
+         * with the maintenance banner app.js raises. Set true once
+         * _ensureAppStatus() reports maintenance. (#1276 feature A)
+         */
+        this._maintenanceSuppressed = false;
     }
 
     /**
@@ -50,6 +61,23 @@ export class PWA {
         const alreadyInstalled = await this._isAlreadyInstalled();
         if (alreadyInstalled) {
             return;
+        }
+
+        /* Suppress the install banner during maintenance (#1276 feature A).
+           app_status is a cached, lightweight fetch shared with the auth modal
+           and the maintenance banner; if maintenance is on we set the flag so
+           the show* methods below bail. Best-effort — a failed/late status
+           fetch leaves the banner enabled (the server-side 503 page is the
+           real safety net for new visitors). Awaited here so the flag is set
+           before beforeinstallprompt or the platform banners can fire. */
+        try {
+            const status = await this.app?.userAuth?._ensureAppStatus?.();
+            if (status && status.maintenance) {
+                this._maintenanceSuppressed = true;
+            }
+        } catch (_e) { /* status unavailable — leave banner enabled */ }
+        if (this._maintenanceSuppressed) {
+            return;   /* don't even wire the install listeners during maintenance */
         }
 
         /* Capture the beforeinstallprompt event (Chrome, Edge, Samsung on Android/desktop) */
@@ -164,6 +192,7 @@ export class PWA {
      * @param {Function} [opts.buttonAction] Click handler for the button
      */
     showPlatformBanner(opts) {
+        if (this._maintenanceSuppressed) return;   /* #1276 — no install prompt during maintenance */
         if (localStorage.getItem(this.dismissKey)) return;
 
         const banner = document.getElementById('pwa-install-banner');
@@ -210,6 +239,7 @@ export class PWA {
      * Populates the empty banner HTML with default install content.
      */
     showInstallBanner() {
+        if (this._maintenanceSuppressed) return;   /* #1276 — no install prompt during maintenance */
         if (localStorage.getItem(this.dismissKey)) return;
 
         const banner = document.getElementById('pwa-install-banner');

--- a/appWeb/public_html/manage/activity-log.php
+++ b/appWeb/public_html/manage/activity-log.php
@@ -48,6 +48,27 @@ try {
    so the query still compiles. Reused by the CSV export + the main SELECT. */
 $obsColsSql = $hasObsCols ? ', a.Environment, a.RequestPath, a.Referrer, a.Country' : '';
 
+/* Proxy/VPN columns (migrate-activity-log-proxy-vpn.php) — probed ONCE here so
+   the CSV export, the paginated SELECT, AND the #1302 infinite-scroll fragment
+   endpoint can all share the same flag + SELECT tail rather than re-probing
+   INFORMATION_SCHEMA three times. Pre-migration deploys skip the columns so the
+   SELECT still compiles. */
+$hasProxyCols = false;
+try {
+    $probe = $db->prepare(
+        "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+          WHERE TABLE_SCHEMA = DATABASE()
+            AND TABLE_NAME   = 'tblActivityLog'
+            AND COLUMN_NAME  = 'ProxyVpnIndicator' LIMIT 1"
+    );
+    $probe->execute();
+    $hasProxyCols = (bool)$probe->get_result()->fetch_row();
+    $probe->close();
+} catch (\Throwable $_e) { /* pre-migration deploy → stays false */ }
+$proxyColsSql = $hasProxyCols
+    ? ', a.IpProxyChain, a.ProxyVpnIndicator, a.ProxyVpnDetail'
+    : '';
+
 /* #1208 — render an ISO-3166-1 alpha-2 country code as its flag emoji (two
    Unicode regional-indicator letters). No image assets; empty for blank/invalid
    codes. The geo resolver (#1208) populates tblActivityLog.Country. */
@@ -183,6 +204,341 @@ if ($hasObsCols && in_array($filterEnv, ['alpha', 'beta', 'production'], true)) 
 }
 $whereSql = 'WHERE ' . implode(' AND ', $where);
 
+$pageSize = 50;
+
+$resultBadgeClass = [
+    'success' => 'bg-success',
+    'failure' => 'bg-warning text-dark',
+    'error'   => 'bg-danger',
+];
+
+/* Helper for keeping all current filters when generating the
+   "next page" / "export csv" links — saves writing them out
+   manually at every callsite. Defined up here (rather than after the
+   main query) so the #1302 fragment endpoint below can reuse it. */
+$buildQuery = function (array $overrides = []) {
+    $merged = array_filter(array_merge([
+        'action'      => $_GET['action']      ?? '',
+        'user'        => $_GET['user']        ?? '',
+        'result'      => $_GET['result']      ?? '',
+        'entity_type' => $_GET['entity_type'] ?? '',
+        'entity_id'   => $_GET['entity_id']   ?? '',
+        'request_id'  => $_GET['request_id']  ?? '',
+        'days'        => $_GET['days']        ?? '',
+        'q'           => $_GET['q']           ?? '',
+        'env'         => $_GET['env']          ?? '',
+        'page'        => $_GET['page']        ?? '',
+    ], $overrides), fn($v) => $v !== '' && $v !== null);
+    return http_build_query($merged);
+};
+
+/* #1302 — fetch ONE page of activity rows by OFFSET. Used by the full-page
+   render AND the no-JS ?page= fallback so there's exactly ONE OFFSET-paginated
+   query (same WHERE / $params / $types, same ORDER, same LIMIT/OFFSET). The page
+   number is the only thing that varies; $pageSize is fixed and the OFFSET is
+   computed from a bound-safe integer cast, so no filter value is ever
+   interpolated into SQL. Returns [$rows, $total].
+
+   NOTE: OFFSET pagination is provably unstable on tblActivityLog — the table is
+   append-heavy and self-logging, so rows inserted between two fetches shift the
+   window and the same row reappears at the next page's seam. That's why the
+   JS infinite-scroll path uses $fetchActivityKeyset() (SEEK pagination) below
+   instead of this. This OFFSET path is retained ONLY as the no-JS fallback,
+   where each ?page= load is a fresh independent snapshot and a one-row seam
+   overlap is immaterial. */
+$fetchActivityPage = function (int $pageNum) use ($db, $whereSql, $params, $types, $pageSize, $proxyColsSql, $obsColsSql): array {
+    $pageNum = max(1, $pageNum);
+    $offsetN = ($pageNum - 1) * $pageSize;
+
+    $countStmt = $db->prepare(
+        'SELECT COUNT(*)
+           FROM tblActivityLog a
+           LEFT JOIN tblUsers u ON u.Id = a.UserId ' . $whereSql
+    );
+    $countStmt->bind_param($types, ...$params);
+    $countStmt->execute();
+    $cRow = $countStmt->get_result()->fetch_row();
+    $totalN = (int)($cRow[0] ?? 0);
+    $countStmt->close();
+
+    /* #805 — UNIX_TIMESTAMP(a.CreatedAt) feeds the unambiguous-UTC cell + the
+       data-ts attribute the JS converter reads. LIMIT/OFFSET use (int)-cast
+       constants only — never a bound user value. */
+    $stmt = $db->prepare(
+        'SELECT a.Id, a.CreatedAt, UNIX_TIMESTAMP(a.CreatedAt) AS CreatedAtTs,
+                a.Action, a.EntityType, a.EntityId, a.Result,
+                a.Details, a.IpAddress' . $proxyColsSql . $obsColsSql . ', a.UserAgent, a.RequestId, a.Method,
+                a.DurationMs, u.Username
+           FROM tblActivityLog a
+           LEFT JOIN tblUsers u ON u.Id = a.UserId
+           ' . $whereSql . '
+           ORDER BY a.CreatedAt DESC, a.Id DESC
+           LIMIT ' . (int)$pageSize . ' OFFSET ' . (int)$offsetN
+    );
+    $stmt->bind_param($types, ...$params);
+    $stmt->execute();
+    $pageRows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+    $stmt->close();
+
+    return [$pageRows, $totalN];
+};
+
+/* #1302 — fetch ONE page of activity rows by KEYSET (SEEK) for the JS
+   infinite-scroll fragment path. The client carries the last-appended row's
+   (CreatedAt, Id) forward as an opaque cursor; we add an extra
+   `(a.CreatedAt < ? OR (a.CreatedAt = ? AND a.Id < ?))` predicate that selects
+   strictly OLDER rows than the cursor, REUSING the existing filter binds. Because
+   the seek is relative to a fixed anchor row (not an absolute OFFSET), rows
+   inserted between fetches never shift the window — so the page-boundary
+   duplicate that OFFSET pagination produces on this append-heavy, self-logging
+   table cannot occur (the MAJOR finding). ALL values are bound via bind_param;
+   the cursor strings/int are appended to a COPY of $params/$types so the shared
+   filter binds stay untouched for the OFFSET path + COUNT + CSV export.
+
+   $cursorTs is the raw TIMESTAMP(6) string from the cursor row's data-created
+   (compared against a.CreatedAt for sub-second-exact seeking); $cursorId is the
+   tie-breaker. With neither supplied the first keyset page is returned (no seek
+   predicate), so an initial fragment fetch with no cursor still works. Returns
+   just $rows — there is no $total for a keyset page; end-of-data is "fewer rows
+   than $pageSize came back" (handled by the caller). */
+$fetchActivityKeyset = function (string $cursorTs, int $cursorId) use ($db, $whereSql, $params, $types, $pageSize, $proxyColsSql, $obsColsSql): array {
+    /* Copy the shared filter binds, then append the seek binds so the canonical
+       $params/$types (reused by COUNT, OFFSET SELECT, CSV) are never mutated. */
+    $kParams = $params;
+    $kTypes  = $types;
+    $seekSql = '';
+    if ($cursorTs !== '' && $cursorId > 0) {
+        $seekSql  = ' AND (a.CreatedAt < ? OR (a.CreatedAt = ? AND a.Id < ?))';
+        $kParams[] = $cursorTs;   // a.CreatedAt < ?
+        $kParams[] = $cursorTs;   // a.CreatedAt = ?
+        $kParams[] = $cursorId;   // a.Id < ?
+        $kTypes   .= 'ssi';
+    }
+
+    $stmt = $db->prepare(
+        'SELECT a.Id, a.CreatedAt, UNIX_TIMESTAMP(a.CreatedAt) AS CreatedAtTs,
+                a.Action, a.EntityType, a.EntityId, a.Result,
+                a.Details, a.IpAddress' . $proxyColsSql . $obsColsSql . ', a.UserAgent, a.RequestId, a.Method,
+                a.DurationMs, u.Username
+           FROM tblActivityLog a
+           LEFT JOIN tblUsers u ON u.Id = a.UserId
+           ' . $whereSql . $seekSql . '
+           ORDER BY a.CreatedAt DESC, a.Id DESC
+           LIMIT ' . (int)$pageSize
+    );
+    $stmt->bind_param($kTypes, ...$kParams);
+    $stmt->execute();
+    $pageRows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+    $stmt->close();
+
+    return $pageRows;
+};
+
+/* #1302 — render the <tr> markup for a set of rows. The full-page table body
+   and the infinite-scroll fragment endpoint BOTH call this, so the row markup
+   (badges, geo-flags, TZ data attributes, proxy/VPN indicator, expandable
+   detail row) lives in exactly ONE place — no divergent client-side rebuild
+   of the row HTML. Echoes directly (used inside output buffering by the
+   fragment endpoint, inline by the page). */
+$renderActivityRows = function (array $rowsToRender) use ($hasObsCols, $resultBadgeClass, $buildQuery): void {
+    foreach ($rowsToRender as $r):
+        $detailsRaw = $r['Details'];
+        $detailsArr = $detailsRaw !== null ? json_decode((string)$detailsRaw, true) : null;
+        $detailsPretty = $detailsArr !== null
+            ? json_encode($detailsArr, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)
+            : '';
+        /* #805 — render the cell text as UTC built from UNIX_TIMESTAMP via
+           gmdate() so the value is correct regardless of MySQL session TZ or
+           PHP date.timezone. The data-ts attribute carries the Unix seconds
+           for the JS converter to format in the visitor's local TZ. */
+        $createdTs    = (int)($r['CreatedAtTs'] ?? 0);
+        $createdUtcStr = $createdTs > 0
+            ? gmdate('Y-m-d H:i:s', $createdTs)
+            : (string)$r['CreatedAt'];
+        /* Sub-second fraction (#1287) — ms (3 digits) from the raw TIMESTAMP(6)
+           value; empty on a pre-migration second column. */
+        $createdMs = '';
+        if (preg_match('/\.(\d{1,6})/', (string)($r['CreatedAt'] ?? ''), $msMatch)) {
+            $createdMs = substr(str_pad($msMatch[1], 3, '0'), 0, 3);
+        }
+        $createdUtcFull = $createdUtcStr . ($createdMs !== '' ? '.' . $createdMs : '');
+        /* #1302 keyset — the raw TIMESTAMP(6) string is the cursor's CreatedAt
+           half (the seek query compares against a.CreatedAt, NOT the int Unix
+           seconds, so sub-second precision is preserved and the comparison is
+           byte-for-byte identical to what MySQL stored). The Id is the
+           tie-breaker. Both are emitted on the row so the client can carry the
+           last-seen (CreatedAt, Id) forward as an opaque cursor AND skip any
+           row id it already has appended (belt-and-braces against a seam dup). */
+        $rowId        = (int)($r['Id'] ?? 0);
+        $rowCreatedAt = (string)($r['CreatedAt'] ?? '');
+    ?>
+        <tr class="activity-row"
+            data-row-id="<?= $rowId ?>"
+            data-created="<?= htmlspecialchars($rowCreatedAt, ENT_QUOTES, 'UTF-8') ?>">
+            <td class="text-muted small activity-when"
+                data-ts="<?= (int)$createdTs ?>"
+                data-ms="<?= htmlspecialchars($createdMs, ENT_QUOTES, 'UTF-8') ?>"
+                title="<?= htmlspecialchars($createdUtcFull, ENT_QUOTES, 'UTF-8') ?> UTC">
+                <?= htmlspecialchars($createdUtcStr, ENT_QUOTES, 'UTF-8') ?><?php if ($createdMs !== ''): ?><span class="text-muted">.<?= htmlspecialchars($createdMs, ENT_QUOTES, 'UTF-8') ?></span><?php endif; ?> <span class="text-muted">UTC</span>
+            </td>
+            <?php if ($hasObsCols): ?>
+            <td>
+                <?php
+                $env = (string)($r['Environment'] ?? '');
+                if ($env !== ''):
+                    $envCls = match ($env) {
+                        'production' => 'bg-success',
+                        'beta'       => 'bg-info text-dark',
+                        'alpha'      => 'bg-secondary',
+                        default      => 'bg-dark border',
+                    };
+                ?>
+                    <span class="badge <?= $envCls ?>"><?= htmlspecialchars($env, ENT_QUOTES, 'UTF-8') ?></span>
+                <?php endif; ?>
+            </td>
+            <?php endif; ?>
+            <td>
+                <?php if (!empty($r['Username'])): ?>
+                    <span><?= htmlspecialchars((string)$r['Username'], ENT_QUOTES, 'UTF-8') ?></span>
+                <?php else: ?>
+                    <em class="text-muted">— anon —</em>
+                <?php endif; ?>
+            </td>
+            <td class="activity-action">
+                <?= htmlspecialchars((string)$r['Action'], ENT_QUOTES, 'UTF-8') ?>
+            </td>
+            <td class="small">
+                <?php if ($r['EntityType'] !== '' || $r['EntityId'] !== ''): ?>
+                    <code><?= htmlspecialchars((string)$r['EntityType'], ENT_QUOTES, 'UTF-8') ?></code>
+                    <span class="text-muted">/</span>
+                    <code><?= htmlspecialchars((string)$r['EntityId'], ENT_QUOTES, 'UTF-8') ?></code>
+                <?php endif; ?>
+            </td>
+            <?php if ($hasObsCols): ?>
+            <td class="small text-muted">
+                <?php $rp = (string)($r['RequestPath'] ?? ''); if ($rp !== ''): ?>
+                    <a class="text-decoration-none"
+                       href="?<?= htmlspecialchars($buildQuery(['q' => $rp]), ENT_QUOTES, 'UTF-8') ?>"
+                       title="Filter to hits on this path">
+                        <code class="d-inline-block text-truncate" style="max-width: 18rem; vertical-align: bottom;"><?= htmlspecialchars($rp, ENT_QUOTES, 'UTF-8') ?></code>
+                    </a>
+                <?php endif; ?>
+            </td>
+            <?php endif; ?>
+            <td>
+                <span class="badge <?= $resultBadgeClass[$r['Result']] ?? 'bg-secondary' ?>">
+                    <?= htmlspecialchars((string)$r['Result'], ENT_QUOTES, 'UTF-8') ?>
+                </span>
+            </td>
+            <td class="text-muted small">
+                <?php
+                /* #1208 — every IP gets a .geo-flag span (filled
+                   server-side from the Country snapshot; empty
+                   ones are backfilled async by the script below). */
+                if ($hasObsCols):
+                    $cc = (string)($r['Country'] ?? '');
+                ?><span class="geo-flag" data-ip="<?= htmlspecialchars((string)$r['IpAddress'], ENT_QUOTES, 'UTF-8') ?>"<?php if ($cc !== ''): ?> title="<?= htmlspecialchars($cc, ENT_QUOTES, 'UTF-8') ?>"<?php endif; ?>><?= _activityFlagEmoji($cc) ?></span> <?php endif; ?><?= htmlspecialchars((string)$r['IpAddress'], ENT_QUOTES, 'UTF-8') ?>
+                <?php
+                /* Proxy/VPN indicator badge — shown inline under
+                   the IP when classification is something other
+                   than 'none'. Pre-migration deploys (column not
+                   selected) skip the badge entirely. */
+                $pind = (string)($r['ProxyVpnIndicator'] ?? '');
+                if ($pind !== '' && $pind !== 'none'):
+                    $pcls = match ($pind) {
+                        'vpn', 'tor'    => 'bg-warning text-dark',
+                        'datacentre',
+                        'proxy'         => 'bg-secondary',
+                        'cloudflare',
+                        'xff'           => 'bg-info text-dark',
+                        default          => 'bg-secondary',
+                    };
+                    $ptitle = trim((string)($r['IpProxyChain'] ?? ''));
+                ?>
+                    <br>
+                    <span class="badge <?= $pcls ?>"
+                          title="<?= htmlspecialchars($ptitle !== '' ? "Proxy chain: $ptitle" : '', ENT_QUOTES, 'UTF-8') ?>">
+                        <?= htmlspecialchars($pind, ENT_QUOTES, 'UTF-8') ?>
+                    </span>
+                <?php endif; ?>
+            </td>
+            <td>
+                <a class="request-id-pill"
+                   href="?<?= htmlspecialchars($buildQuery(['request_id' => $r['RequestId']]), ENT_QUOTES, 'UTF-8') ?>"
+                   title="Show every row from this HTTP request">
+                    <?= htmlspecialchars(substr((string)$r['RequestId'], 0, 8), ENT_QUOTES, 'UTF-8') ?>
+                </a>
+            </td>
+        </tr>
+        <?php if ($detailsPretty !== '' || ($r['UserAgent'] ?? '') !== '' || $r['DurationMs'] !== null): ?>
+        <tr class="activity-row">
+            <td colspan="<?= $hasObsCols ? 9 : 7 ?>" class="bg-black-soft border-0 py-2">
+                <div class="small text-muted mb-1">
+                    <?php if ($r['Method'] !== ''): ?>
+                        <code><?= htmlspecialchars((string)$r['Method'], ENT_QUOTES, 'UTF-8') ?></code>
+                    <?php endif; ?>
+                    <?php if ($r['DurationMs'] !== null): ?>
+                        · <?= (int)$r['DurationMs'] ?> ms
+                    <?php endif; ?>
+                    <?php if (!empty($r['UserAgent'])): ?>
+                        <?php /* Render the full UA inline (no 80-char substr cap)
+                                 — long UAs wrap to a second line via the
+                                 .activity-ua wrapper class. (#721) */ ?>
+                        · UA: <span class="activity-ua" title="<?= htmlspecialchars((string)$r['UserAgent'], ENT_QUOTES, 'UTF-8') ?>">
+                            <?= htmlspecialchars((string)$r['UserAgent'], ENT_QUOTES, 'UTF-8') ?>
+                        </span>
+                    <?php endif; ?>
+                    <?php if ($hasObsCols && !empty($r['Referrer'])): ?>
+                        <br>· Referrer: <span class="activity-ua"><?= htmlspecialchars((string)$r['Referrer'], ENT_QUOTES, 'UTF-8') ?></span>
+                    <?php endif; ?>
+                </div>
+                <?php if ($detailsPretty !== ''): ?>
+                    <div class="activity-details"><?= htmlspecialchars($detailsPretty, ENT_QUOTES, 'UTF-8') ?></div>
+                <?php endif; ?>
+            </td>
+        </tr>
+        <?php endif; ?>
+    <?php endforeach;
+};
+
+/* #1302 — infinite-scroll fragment endpoint. Returns ONLY the <tr> rows OLDER
+   than the supplied keyset cursor (same bound filters + ALL active filters as
+   the full view), so the client IntersectionObserver can append the next batch
+   without a reload. KEYSET (SEEK), not OFFSET — see $fetchActivityKeyset above
+   for why (page-boundary duplicates on this append-heavy table). The existing
+   ?page=N OFFSET pagination remains the complete no-JS fallback. Read-only GET;
+   the admin gate at the top of the file already applies.
+
+   Cursor: `cursor_ts` = the last appended row's data-created (raw TIMESTAMP(6)
+   string); `cursor_id` = its data-row-id. Both arrive only from rows this same
+   endpoint (or the initial page) emitted, and both are bound — never
+   interpolated. With neither present the first keyset batch is returned. */
+if (($_GET['action'] ?? '') === 'next-page') {
+    header('Content-Type: text/html; charset=UTF-8');
+    header('Cache-Control: no-store');
+    $cursorTs = trim((string)($_GET['cursor_ts'] ?? ''));
+    $cursorId = (int)($_GET['cursor_id'] ?? 0);
+    try {
+        $fpRows = $fetchActivityKeyset($cursorTs, $cursorId);
+    } catch (\Throwable $e) {
+        error_log('[manage/activity-log.php#next-page] ' . $e->getMessage());
+        http_response_code(503);
+        echo '<!-- activity-log fragment error -->';
+        exit;
+    }
+    /* "Fewer rows than a full page" => this was the last batch; tell the client
+       so it stops observing. A 200 with an EMPTY <tbody> (zero rows) is also a
+       valid end-of-data signal the client treats the same way (MINOR finding:
+       no tight-loop). */
+    $fpAtEnd = count($fpRows) < $pageSize ? 1 : 0;
+    echo '<tbody data-activity-fragment="1"'
+        . ' data-row-count="' . count($fpRows) . '"'
+        . ' data-at-end="' . $fpAtEnd . '">';
+    $renderActivityRows($fpRows);
+    echo '</tbody>';
+    exit;
+}
+
 /* CSV export — same filters, but streams every matching row to
    the browser instead of paginating. Capped at 10 000 rows so an
    accidental "everything" export doesn't OOM the worker. */
@@ -198,22 +554,10 @@ if (($_GET['export'] ?? '') === 'csv') {
        up. The legacy `CreatedAt` column is preserved for back-compat
        with any existing report tooling but should be considered
        deprecated — `CreatedAtUtc` is the new canonical value. */
-    /* New columns from migrate-activity-log-proxy-vpn.php — schema-
-       probe before SELECTing them so a pre-migration deploy keeps
-       exporting cleanly with the legacy header set. */
-    $hasProxyCols = false;
-    try {
-        $probe = $db->prepare(
-            "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
-              WHERE TABLE_SCHEMA = DATABASE()
-                AND TABLE_NAME   = 'tblActivityLog'
-                AND COLUMN_NAME  = 'ProxyVpnIndicator' LIMIT 1"
-        );
-        $probe->execute();
-        $hasProxyCols = (bool)$probe->get_result()->fetch_row();
-        $probe->close();
-    } catch (\Throwable $_e) { /* fall through to legacy export */ }
-
+    /* New columns from migrate-activity-log-proxy-vpn.php — $hasProxyCols was
+       probed once near the top of the file (shared with the paginated SELECT +
+       the #1302 fragment endpoint), so a pre-migration deploy keeps exporting
+       cleanly with the legacy header set. */
     $headerRow = [
         'Id', 'CreatedAt', 'CreatedAtUtc', 'Username', 'Action', 'EntityType', 'EntityId',
         'Result', 'IpAddress', 'UserAgent', 'RequestId', 'Method', 'DurationMs', 'Details',
@@ -228,9 +572,6 @@ if (($_GET['export'] ?? '') === 'csv') {
         $headerRow[] = 'Country';
     }
     fputcsv($out, $headerRow);
-    $proxyColsSql = $hasProxyCols
-        ? ', a.IpProxyChain, a.ProxyVpnIndicator, a.ProxyVpnDetail'
-        : '';
     $stmt = $db->prepare(
         'SELECT a.Id, a.CreatedAt, UNIX_TIMESTAMP(a.CreatedAt) AS CreatedAtTs,
                 u.Username, a.Action, a.EntityType, a.EntityId,
@@ -282,66 +623,14 @@ if (($_GET['export'] ?? '') === 'csv') {
     exit;
 }
 
-/* Paginated list query for the UI. */
-$pageSize = 50;
-$page     = max(1, (int)($_GET['page'] ?? 1));
-$offset   = ($page - 1) * $pageSize;
-
+/* Paginated list query for the UI — delegates to the shared $fetchActivityPage
+   closure so the full page and the #1302 fragment endpoint run the identical
+   bound query. */
+$page  = max(1, (int)($_GET['page'] ?? 1));
 $total = 0;
 $rows  = [];
 try {
-    $countStmt = $db->prepare(
-        'SELECT COUNT(*)
-           FROM tblActivityLog a
-           LEFT JOIN tblUsers u ON u.Id = a.UserId ' . $whereSql
-    );
-    $countStmt->bind_param($types, ...$params);
-    $countStmt->execute();
-    $row = $countStmt->get_result()->fetch_row();
-    $total = (int)($row[0] ?? 0);
-    $countStmt->close();
-
-    /* #805 — also pull UNIX_TIMESTAMP(a.CreatedAt) so the cell can
-       render an unambiguous UTC value AND carry the seconds-since-epoch
-       as a data attribute for the JS converter below. The raw
-       a.CreatedAt comes back in MySQL's session timezone (`SYSTEM` by
-       default = OS), so suffixing 'Z' on the string would lie when the
-       server isn't in UTC. UNIX_TIMESTAMP() is always UTC seconds and
-       side-steps that whole class of bug. */
-    /* Schema-probe for the proxy/VPN columns added by
-       migrate-activity-log-proxy-vpn.php. Pre-migration deploys
-       skip them entirely so the SELECT compiles. */
-    $hasProxyCols = false;
-    try {
-        $probe = $db->prepare(
-            "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
-              WHERE TABLE_SCHEMA = DATABASE()
-                AND TABLE_NAME   = 'tblActivityLog'
-                AND COLUMN_NAME  = 'ProxyVpnIndicator' LIMIT 1"
-        );
-        $probe->execute();
-        $hasProxyCols = (bool)$probe->get_result()->fetch_row();
-        $probe->close();
-    } catch (\Throwable $_e) { /* fall through */ }
-    $proxyColsSql = $hasProxyCols
-        ? ', a.IpProxyChain, a.ProxyVpnIndicator, a.ProxyVpnDetail'
-        : '';
-
-    $stmt = $db->prepare(
-        'SELECT a.Id, a.CreatedAt, UNIX_TIMESTAMP(a.CreatedAt) AS CreatedAtTs,
-                a.Action, a.EntityType, a.EntityId, a.Result,
-                a.Details, a.IpAddress' . $proxyColsSql . $obsColsSql . ', a.UserAgent, a.RequestId, a.Method,
-                a.DurationMs, u.Username
-           FROM tblActivityLog a
-           LEFT JOIN tblUsers u ON u.Id = a.UserId
-           ' . $whereSql . '
-           ORDER BY a.CreatedAt DESC, a.Id DESC
-           LIMIT ' . (int)$pageSize . ' OFFSET ' . (int)$offset
-    );
-    $stmt->bind_param($types, ...$params);
-    $stmt->execute();
-    $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
-    $stmt->close();
+    [$rows, $total] = $fetchActivityPage($page);
 } catch (\Throwable $e) {
     error_log('[manage/activity-log.php] ' . $e->getMessage());
     /* If the Activity Log viewer itself can't load, recording an
@@ -374,30 +663,8 @@ try {
     $stmt->close();
 } catch (\Throwable $_e) { /* empty list is fine */ }
 
-$resultBadgeClass = [
-    'success' => 'bg-success',
-    'failure' => 'bg-warning text-dark',
-    'error'   => 'bg-danger',
-];
-
-/* Helper for keeping all current filters when generating the
-   "next page" / "export csv" links — saves writing them out
-   manually at every callsite. */
-$buildQuery = function (array $overrides = []) {
-    $merged = array_filter(array_merge([
-        'action'      => $_GET['action']      ?? '',
-        'user'        => $_GET['user']        ?? '',
-        'result'      => $_GET['result']      ?? '',
-        'entity_type' => $_GET['entity_type'] ?? '',
-        'entity_id'   => $_GET['entity_id']   ?? '',
-        'request_id'  => $_GET['request_id']  ?? '',
-        'days'        => $_GET['days']        ?? '',
-        'q'           => $_GET['q']           ?? '',
-        'env'         => $_GET['env']          ?? '',
-        'page'        => $_GET['page']        ?? '',
-    ], $overrides), fn($v) => $v !== '' && $v !== null);
-    return http_build_query($merged);
-};
+/* $resultBadgeClass + $buildQuery were defined earlier (before the fragment
+   endpoint) so the shared render closure could reuse them. */
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -542,10 +809,22 @@ $buildQuery = function (array $overrides = []) {
             </div>
         </form>
 
-        <p class="text-secondary small mb-2">
-            <?= number_format($total) ?> entr<?= $total === 1 ? 'y' : 'ies' ?> match —
-            page <?= $page ?> of <?= $totalPages ?>.
-        </p>
+        <div class="d-flex align-items-center justify-content-between flex-wrap gap-2 mb-2">
+            <p class="text-secondary small mb-0">
+                <?= number_format($total) ?> entr<?= $total === 1 ? 'y' : 'ies' ?> match —
+                <span data-activity-pagelabel>page <?= $page ?> of <?= $totalPages ?></span>.
+            </p>
+            <?php /* #1302 — infinite-scroll opt-in. Hidden for no-JS users (the
+                     enhancement script un-hides it); the ?page= pagination below
+                     stays as the complete fallback either way. The choice is
+                     remembered in localStorage so it survives reloads. */ ?>
+            <div class="form-check form-switch small mb-0" data-activity-scroll-toggle hidden>
+                <input class="form-check-input" type="checkbox" role="switch" id="activity-infinite-scroll">
+                <label class="form-check-label text-secondary" for="activity-infinite-scroll">
+                    Infinite scroll
+                </label>
+            </div>
+        </div>
 
         <?php if (empty($rows)): ?>
             <div class="alert alert-info py-2" role="status">
@@ -553,7 +832,10 @@ $buildQuery = function (array $overrides = []) {
             </div>
         <?php else: ?>
             <div class="table-responsive">
-                <table class="table table-sm table-dark table-hover align-middle cp-sortable">
+                <table class="table table-sm table-dark table-hover align-middle cp-sortable"
+                       data-activity-table
+                       data-page="<?= (int)$page ?>"
+                       data-total-pages="<?= (int)$totalPages ?>">
                     <thead>
                         <tr>
                             <?php /* Header label flips between (local) and (UTC) at runtime
@@ -572,170 +854,50 @@ $buildQuery = function (array $overrides = []) {
                             <th style="width: 5rem;"  data-sort-key="req"    data-sort-type="text">Req</th>
                         </tr>
                     </thead>
-                    <tbody>
-                    <?php foreach ($rows as $r):
-                        $detailsRaw = $r['Details'];
-                        $detailsArr = $detailsRaw !== null ? json_decode((string)$detailsRaw, true) : null;
-                        $detailsPretty = $detailsArr !== null
-                            ? json_encode($detailsArr, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)
-                            : '';
-                        $rowId = (int)$r['Id'];
-                        /* #805 — render the cell text as UTC built from
-                           UNIX_TIMESTAMP via gmdate() so the value is
-                           correct regardless of MySQL session TZ or
-                           PHP date.timezone. The data-ts attribute
-                           carries the Unix seconds for the JS converter
-                           to format in the visitor's local TZ. The
-                           " UTC" suffix is dropped by the JS once it
-                           replaces the cell, so visitors see "(local)"
-                           cells without the redundant suffix. */
-                        $createdTs    = (int)($r['CreatedAtTs'] ?? 0);
-                        $createdUtcStr = $createdTs > 0
-                            ? gmdate('Y-m-d H:i:s', $createdTs)
-                            : (string)$r['CreatedAt'];
-                        /* Sub-second fraction (#1287) — ms (3 digits) from the raw
-                           TIMESTAMP(6) value; empty on a pre-migration second column,
-                           so the cell renders identically until the column is widened. */
-                        $createdMs = '';
-                        if (preg_match('/\.(\d{1,6})/', (string)($r['CreatedAt'] ?? ''), $msMatch)) {
-                            $createdMs = substr(str_pad($msMatch[1], 3, '0'), 0, 3);
-                        }
-                        $createdUtcFull = $createdUtcStr . ($createdMs !== '' ? '.' . $createdMs : '');
-                    ?>
-                        <tr class="activity-row">
-                            <td class="text-muted small activity-when"
-                                data-ts="<?= (int)$createdTs ?>"
-                                data-ms="<?= htmlspecialchars($createdMs, ENT_QUOTES, 'UTF-8') ?>"
-                                title="<?= htmlspecialchars($createdUtcFull, ENT_QUOTES, 'UTF-8') ?> UTC">
-                                <?= htmlspecialchars($createdUtcStr, ENT_QUOTES, 'UTF-8') ?><?php if ($createdMs !== ''): ?><span class="text-muted">.<?= htmlspecialchars($createdMs, ENT_QUOTES, 'UTF-8') ?></span><?php endif; ?> <span class="text-muted">UTC</span>
-                            </td>
-                            <?php if ($hasObsCols): ?>
-                            <td>
-                                <?php
-                                $env = (string)($r['Environment'] ?? '');
-                                if ($env !== ''):
-                                    $envCls = match ($env) {
-                                        'production' => 'bg-success',
-                                        'beta'       => 'bg-info text-dark',
-                                        'alpha'      => 'bg-secondary',
-                                        default      => 'bg-dark border',
-                                    };
-                                ?>
-                                    <span class="badge <?= $envCls ?>"><?= htmlspecialchars($env, ENT_QUOTES, 'UTF-8') ?></span>
-                                <?php endif; ?>
-                            </td>
-                            <?php endif; ?>
-                            <td>
-                                <?php if (!empty($r['Username'])): ?>
-                                    <span><?= htmlspecialchars((string)$r['Username'], ENT_QUOTES, 'UTF-8') ?></span>
-                                <?php else: ?>
-                                    <em class="text-muted">— anon —</em>
-                                <?php endif; ?>
-                            </td>
-                            <td class="activity-action">
-                                <?= htmlspecialchars((string)$r['Action'], ENT_QUOTES, 'UTF-8') ?>
-                            </td>
-                            <td class="small">
-                                <?php if ($r['EntityType'] !== '' || $r['EntityId'] !== ''): ?>
-                                    <code><?= htmlspecialchars((string)$r['EntityType'], ENT_QUOTES, 'UTF-8') ?></code>
-                                    <span class="text-muted">/</span>
-                                    <code><?= htmlspecialchars((string)$r['EntityId'], ENT_QUOTES, 'UTF-8') ?></code>
-                                <?php endif; ?>
-                            </td>
-                            <?php if ($hasObsCols): ?>
-                            <td class="small text-muted">
-                                <?php $rp = (string)($r['RequestPath'] ?? ''); if ($rp !== ''): ?>
-                                    <a class="text-decoration-none"
-                                       href="?<?= htmlspecialchars($buildQuery(['q' => $rp]), ENT_QUOTES, 'UTF-8') ?>"
-                                       title="Filter to hits on this path">
-                                        <code class="d-inline-block text-truncate" style="max-width: 18rem; vertical-align: bottom;"><?= htmlspecialchars($rp, ENT_QUOTES, 'UTF-8') ?></code>
-                                    </a>
-                                <?php endif; ?>
-                            </td>
-                            <?php endif; ?>
-                            <td>
-                                <span class="badge <?= $resultBadgeClass[$r['Result']] ?? 'bg-secondary' ?>">
-                                    <?= htmlspecialchars((string)$r['Result'], ENT_QUOTES, 'UTF-8') ?>
-                                </span>
-                            </td>
-                            <td class="text-muted small">
-                                <?php
-                                /* #1208 — every IP gets a .geo-flag span (filled
-                                   server-side from the Country snapshot; empty
-                                   ones are backfilled async by the script below). */
-                                if ($hasObsCols):
-                                    $cc = (string)($r['Country'] ?? '');
-                                ?><span class="geo-flag" data-ip="<?= htmlspecialchars((string)$r['IpAddress'], ENT_QUOTES, 'UTF-8') ?>"<?php if ($cc !== ''): ?> title="<?= htmlspecialchars($cc, ENT_QUOTES, 'UTF-8') ?>"<?php endif; ?>><?= _activityFlagEmoji($cc) ?></span> <?php endif; ?><?= htmlspecialchars((string)$r['IpAddress'], ENT_QUOTES, 'UTF-8') ?>
-                                <?php
-                                /* Proxy/VPN indicator badge — shown inline under
-                                   the IP when classification is something other
-                                   than 'none'. Pre-migration deploys (column not
-                                   selected) skip the badge entirely. */
-                                $pind = (string)($r['ProxyVpnIndicator'] ?? '');
-                                if ($pind !== '' && $pind !== 'none'):
-                                    $pcls = match ($pind) {
-                                        'vpn', 'tor'    => 'bg-warning text-dark',
-                                        'datacentre',
-                                        'proxy'         => 'bg-secondary',
-                                        'cloudflare',
-                                        'xff'           => 'bg-info text-dark',
-                                        default          => 'bg-secondary',
-                                    };
-                                    $ptitle = trim((string)($r['IpProxyChain'] ?? ''));
-                                ?>
-                                    <br>
-                                    <span class="badge <?= $pcls ?>"
-                                          title="<?= htmlspecialchars($ptitle !== '' ? "Proxy chain: $ptitle" : '', ENT_QUOTES, 'UTF-8') ?>">
-                                        <?= htmlspecialchars($pind, ENT_QUOTES, 'UTF-8') ?>
-                                    </span>
-                                <?php endif; ?>
-                            </td>
-                            <td>
-                                <a class="request-id-pill"
-                                   href="?<?= htmlspecialchars($buildQuery(['request_id' => $r['RequestId']]), ENT_QUOTES, 'UTF-8') ?>"
-                                   title="Show every row from this HTTP request">
-                                    <?= htmlspecialchars(substr((string)$r['RequestId'], 0, 8), ENT_QUOTES, 'UTF-8') ?>
-                                </a>
-                            </td>
-                        </tr>
-                        <?php if ($detailsPretty !== '' || ($r['UserAgent'] ?? '') !== '' || $r['DurationMs'] !== null): ?>
-                        <tr class="activity-row">
-                            <td colspan="<?= $hasObsCols ? 9 : 7 ?>" class="bg-black-soft border-0 py-2">
-                                <div class="small text-muted mb-1">
-                                    <?php if ($r['Method'] !== ''): ?>
-                                        <code><?= htmlspecialchars((string)$r['Method'], ENT_QUOTES, 'UTF-8') ?></code>
-                                    <?php endif; ?>
-                                    <?php if ($r['DurationMs'] !== null): ?>
-                                        · <?= (int)$r['DurationMs'] ?> ms
-                                    <?php endif; ?>
-                                    <?php if (!empty($r['UserAgent'])): ?>
-                                        <?php /* Render the full UA inline (no 80-char substr cap)
-                                                 — long UAs wrap to a second line via the
-                                                 .activity-ua wrapper class, which uses
-                                                 word-break:break-word + max-width:100% so
-                                                 long unbroken tokens still wrap rather than
-                                                 overflow the row. (#721) */ ?>
-                                        · UA: <span class="activity-ua" title="<?= htmlspecialchars((string)$r['UserAgent'], ENT_QUOTES, 'UTF-8') ?>">
-                                            <?= htmlspecialchars((string)$r['UserAgent'], ENT_QUOTES, 'UTF-8') ?>
-                                        </span>
-                                    <?php endif; ?>
-                                    <?php if ($hasObsCols && !empty($r['Referrer'])): ?>
-                                        <br>· Referrer: <span class="activity-ua"><?= htmlspecialchars((string)$r['Referrer'], ENT_QUOTES, 'UTF-8') ?></span>
-                                    <?php endif; ?>
-                                </div>
-                                <?php if ($detailsPretty !== ''): ?>
-                                    <div class="activity-details"><?= htmlspecialchars($detailsPretty, ENT_QUOTES, 'UTF-8') ?></div>
-                                <?php endif; ?>
-                            </td>
-                        </tr>
-                        <?php endif; ?>
-                    <?php endforeach; ?>
+                    <tbody data-activity-rows>
+                    <?php /* #1302 — rows rendered via the shared $renderActivityRows
+                             closure so the full page and the infinite-scroll
+                             fragment endpoint emit byte-identical markup. */ ?>
+                    <?php $renderActivityRows($rows); ?>
                     </tbody>
                 </table>
             </div>
 
+            <?php /* #1302 — infinite-scroll status line. The sentinel the
+                     IntersectionObserver watches lives here (a div, not a <tr>,
+                     so it sits outside the table semantics and never confuses a
+                     screen-reader's row count). The VISIBLE status text gives
+                     sighted users feedback; it is NOT a scroll-only instruction
+                     (a focusable "Load more" button below is the keyboard/AT
+                     trigger, so the message names the button, not "scroll").
+
+                     a11y (MINOR #3): the polite live region is a SEPARATE,
+                     ALWAYS-RENDERED .visually-hidden node — never `hidden`. A
+                     region with the `hidden` attribute is removed from the
+                     accessibility tree, so the FIRST mutation can be missed
+                     (the region must already be in the tree when its text
+                     changes for the announcement to fire). We mutate its text;
+                     we never toggle its presence.
+                     https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions */ ?>
+            <div class="activity-scroll-status text-secondary small mt-2"
+                 data-activity-scroll-status hidden></div>
+            <div class="visually-hidden" role="status" aria-live="polite"
+                 data-activity-scroll-announce></div>
+
+            <?php /* #1302 — focusable, non-scroll trigger (MINOR #2). Hidden for
+                     no-JS users; the enhancement reveals it only when infinite
+                     scroll is active so keyboard / AT users have a button they
+                     can Tab to and activate instead of relying on a scroll
+                     gesture an IntersectionObserver can't detect. */ ?>
+            <div class="mt-2" data-activity-loadmore-wrap hidden>
+                <button type="button" class="btn btn-sm btn-outline-secondary" data-activity-loadmore>
+                    <i class="bi bi-arrow-down-circle me-1"></i>Load more
+                </button>
+            </div>
+            <div data-activity-sentinel aria-hidden="true"></div>
+
             <?php if ($totalPages > 1): ?>
-            <nav aria-label="Activity log pagination" class="mt-3">
+            <nav aria-label="Activity log pagination" class="mt-3" data-activity-pagination>
                 <ul class="pagination pagination-sm">
                     <li class="page-item <?= $page <= 1 ? 'disabled' : '' ?>">
                         <a class="page-link"
@@ -758,16 +920,6 @@ $buildQuery = function (array $overrides = []) {
         <?php endif; ?>
     </div>
 
-    <!-- Visitor-local time conversion (#805, replaces #721 / #723).
-         Each .activity-when cell carries data-ts="<unix-seconds-utc>";
-         this script multiplies by 1000, builds a Date, formats via the
-         browser's Intl.DateTimeFormat in the visitor's resolved
-         timezone, and replaces the cell's text. The fallback (cell
-         text rendered server-side as `YYYY-MM-DD HH:MM:SS UTC` from
-         gmdate(UNIX_TIMESTAMP)) stays in place if Intl is unavailable
-         OR the visitor's TZ can't be resolved — so the column is
-         always either visitor-local or unambiguous UTC, never silently
-         server-local-pretending-to-be-anything-else. -->
     <style>
         .activity-ua {
             display: inline-block;
@@ -777,101 +929,395 @@ $buildQuery = function (array $overrides = []) {
         }
     </style>
     <script>
+    /* #1302 — the visitor-TZ converter + the geo backfill are now exposed on a
+       small shared namespace so the infinite-scroll script can re-run BOTH over
+       just-appended rows (a `root` element scopes each to a row subtree;
+       defaults to document for the initial page render). The behaviour for the
+       initial render is unchanged — these are the same two routines, factored
+       into reusable functions. */
     (function () {
+        var NS = (window.iHymnsActivityLog = window.iHymnsActivityLog || {});
+
+        /* ---- Visitor-local time conversion (#805, replaces #721 / #723). ----
+           Each .activity-when cell carries data-ts="<unix-seconds-utc>". We
+           multiply by 1000, build a Date, format via Intl.DateTimeFormat in the
+           visitor's resolved timezone, and replace the cell's text. The
+           server-rendered "YYYY-MM-DD HH:MM:SS UTC" fallback stays if Intl is
+           unavailable OR the TZ can't be resolved. */
+        var visitorTz = '';
+        var fmt = null;
         try {
-            if (typeof Intl === 'undefined' || !Intl.DateTimeFormat) return;
-            /* Resolve the visitor's TZ explicitly so we can fall back
-               to UTC display if it comes back empty (some locked-down
-               browser configs return ''). */
-            var resolved = Intl.DateTimeFormat().resolvedOptions();
-            var visitorTz = resolved && resolved.timeZone ? resolved.timeZone : '';
-            if (!visitorTz) return; /* fall back to server-rendered UTC */
-            var fmt = new Intl.DateTimeFormat(undefined, {
-                year:    'numeric', month:  '2-digit', day:    '2-digit',
-                hour:    '2-digit', minute: '2-digit', second: '2-digit',
-                hour12:  false,
-                timeZone: visitorTz,
-            });
-            var cells = document.querySelectorAll('.activity-when[data-ts]');
-            if (!cells.length) return;
-            cells.forEach(function (cell) {
+            if (typeof Intl !== 'undefined' && Intl.DateTimeFormat) {
+                var resolved = Intl.DateTimeFormat().resolvedOptions();
+                visitorTz = (resolved && resolved.timeZone) ? resolved.timeZone : '';
+                if (visitorTz) {
+                    fmt = new Intl.DateTimeFormat(undefined, {
+                        year:    'numeric', month:  '2-digit', day:    '2-digit',
+                        hour:    '2-digit', minute: '2-digit', second: '2-digit',
+                        hour12:  false,
+                        timeZone: visitorTz,
+                    });
+                }
+            }
+        } catch (_e) { fmt = null; }
+
+        NS.localiseTimes = function (root) {
+            if (!fmt) return; /* fall back to server-rendered UTC */
+            var scope = root || document;
+            var cells = scope.querySelectorAll('.activity-when[data-ts]');
+            Array.prototype.forEach.call(cells, function (cell) {
+                if (cell.getAttribute('data-tz-done')) return; /* idempotent re-runs */
                 var ts = parseInt(cell.getAttribute('data-ts') || '0', 10);
                 if (!ts) return;
                 var d = new Date(ts * 1000);
                 if (isNaN(d.getTime())) return;
-                /* Reformat to "YYYY-MM-DD HH:MM:SS" — matches the
-                   table's existing visual cadence; some locales would
-                   otherwise produce "30/04/2026, 14:53:42" which jars
-                   in a tabular layout. */
+                /* Reformat to "YYYY-MM-DD HH:MM:SS" — matches the table's visual
+                   cadence; some locales would otherwise produce
+                   "30/04/2026, 14:53:42" which jars in a tabular layout. */
                 var parts = fmt.formatToParts(d).reduce(function (acc, p) {
                     if (p.type !== 'literal') acc[p.type] = p.value; return acc;
                 }, {});
-                /* #1287 — re-append the sub-second fraction after the local-TZ
-                   reformat (the fraction is timezone-invariant). Empty on rows
-                   logged before the TIMESTAMP(6) migration. */
+                /* #1287 — re-append the sub-second fraction (timezone-invariant). */
                 var ms = cell.getAttribute('data-ms') || '';
                 cell.textContent = parts.year + '-' + parts.month + '-' + parts.day
                     + ' ' + parts.hour + ':' + parts.minute + ':' + parts.second
                     + (ms ? '.' + ms : '');
-                /* Hover title carries the resolved timezone name so
-                   curators inspecting an entry can see the offset
-                   they're looking at — useful when comparing logs
-                   across teammates in different regions. */
                 cell.setAttribute('title', cell.textContent + ' (' + visitorTz + ')');
+                cell.setAttribute('data-tz-done', '1');
             });
-            /* #1207 — keep the header short ("When (local)") so it doesn't wrap;
-               surface the actual timezone in the blurb instead. */
+        };
+
+        /* ---- #1208 async country flags. ---- Collect IPs whose flag isn't
+           rendered yet, resolve them via the CSRF-guarded geo backfill endpoint,
+           inject the flag emoji. The page never waits on this; flags pop in as
+           the lookups return. */
+        function flagEmoji(cc) {
+            cc = (cc || '').toUpperCase();
+            if (!/^[A-Z]{2}$/.test(cc)) { return ''; }
+            return String.fromCodePoint(0x1F1E6 + cc.charCodeAt(0) - 65, 0x1F1E6 + cc.charCodeAt(1) - 65);
+        }
+        NS.backfillFlags = function (root) {
+            try {
+                var meta = document.querySelector('meta[name="csrf-token"]');
+                var csrf = meta ? (meta.getAttribute('content') || '') : '';
+                /* #1302 — `root` may be a single element / document (initial
+                   render) OR an array / NodeList of elements (the just-appended
+                   rows, scoped per MINOR #5). Normalise to a list of scopes and
+                   gather the unresolved .geo-flag nodes across them in ONE pass,
+                   so an appended batch is still ONE POST — not one per row. */
+                var scopes;
+                if (!root) {
+                    scopes = [document];
+                } else if (root.nodeType) {
+                    scopes = [root];
+                } else {
+                    scopes = Array.prototype.slice.call(root);
+                }
+                var pending = [];
+                scopes.forEach(function (scope) {
+                    if (!scope || !scope.querySelectorAll) { return; }
+                    Array.prototype.forEach.call(scope.querySelectorAll('.geo-flag'), function (el) {
+                        if (el.textContent.trim() === '' && el.getAttribute('data-ip')) { pending.push(el); }
+                    });
+                });
+                if (!pending.length) { return; }
+                var ips = [];
+                pending.forEach(function (el) {
+                    var ip = el.getAttribute('data-ip');
+                    if (ip && ips.indexOf(ip) === -1) { ips.push(ip); }
+                });
+                ips = ips.slice(0, 25);   /* server caps at 25/call too */
+                if (!ips.length) { return; }
+                fetch('/manage/activity-log.php?action=geo', {
+                    method: 'POST',
+                    credentials: 'same-origin',
+                    headers: {
+                        'Content-Type': 'application/x-www-form-urlencoded',
+                        'X-Requested-With': 'XMLHttpRequest',
+                        'X-CSRF-Token': csrf,
+                    },
+                    body: 'ips=' + encodeURIComponent(ips.join(',')),
+                }).then(function (r) { return r.ok ? r.json() : null; }).then(function (j) {
+                    if (!j || !j.countries) { return; }
+                    pending.forEach(function (el) {
+                        var code = j.countries[el.getAttribute('data-ip')];
+                        if (code && /^[A-Za-z]{2}$/.test(code)) {   // defense-in-depth: validate before DOM
+                            var fl = flagEmoji(code);
+                            if (fl) { el.textContent = fl; el.setAttribute('title', code.toUpperCase()); }
+                        }
+                    });
+                }).catch(function () { /* fail-soft — no flags, page still fine */ });
+            } catch (_e) { /* fail-soft */ }
+        };
+
+        /* Initial-render pass (same effect as before #1302). */
+        try { NS.localiseTimes(document); } catch (_e) {}
+        try { NS.backfillFlags(document); } catch (_e) {}
+
+        /* #1207 — keep the header short ("When (local)"); surface the actual
+           timezone in the blurb instead. Done once, not per row. */
+        if (fmt && visitorTz) {
             var header = document.getElementById('activity-when-header');
             if (header) header.textContent = 'When (local)';
             var tzLabel = document.querySelector('[data-activity-tz]');
             if (tzLabel) tzLabel.textContent = visitorTz;
-        } catch (_e) { /* fail-soft — server-rendered UTC stays */ }
+        }
     })();
     </script>
 
-    <!-- #1208 — async country flags. Collect IPs whose flag isn't rendered yet,
-         resolve them via the geo backfill endpoint, inject the flag emoji. The
-         page never waits on this; flags pop in as the lookups return. -->
+    <!-- #1302 — Activity-Log infinite scroll (PROGRESSIVE ENHANCEMENT).
+         An IntersectionObserver watches a sentinel below the table; when it
+         scrolls into view the next BATCH is fetched from the ?action=next-page
+         fragment endpoint and its rows are appended to the tbody. The fetch uses
+         KEYSET (SEEK) pagination, NOT OFFSET: the client carries the last
+         appended row's (data-created, data-row-id) forward as an opaque cursor,
+         so rows inserted between fetches never cause a page-boundary duplicate
+         on this append-heavy, self-logging table. As belt-and-braces, the client
+         also tracks every row id it has appended and skips any the server
+         returns again. OPT-IN via a remembered toggle. Accessibility: a focusable
+         "Load more" button is the non-scroll trigger (keyboard / AT users don't
+         rely on a scroll gesture); the no-JS ?page= pagination stays reachable;
+         each batch + end-of-log are announced via an always-rendered
+         .visually-hidden role="status" aria-live="polite" region (never `hidden`,
+         so the first announce isn't lost). -->
     <script>
     (function () {
-        try {
-            var meta = document.querySelector('meta[name="csrf-token"]');
-            var csrf = meta ? (meta.getAttribute('content') || '') : '';
-            var pending = Array.prototype.slice.call(document.querySelectorAll('.geo-flag'))
-                .filter(function (el) { return el.textContent.trim() === '' && el.getAttribute('data-ip'); });
-            if (!pending.length) { return; }
-            var ips = [];
-            pending.forEach(function (el) {
-                var ip = el.getAttribute('data-ip');
-                if (ip && ips.indexOf(ip) === -1) { ips.push(ip); }
-            });
-            ips = ips.slice(0, 25);
-            if (!ips.length) { return; }
-            function flagEmoji(cc) {
-                cc = (cc || '').toUpperCase();
-                if (!/^[A-Z]{2}$/.test(cc)) { return ''; }
-                return String.fromCodePoint(0x1F1E6 + cc.charCodeAt(0) - 65, 0x1F1E6 + cc.charCodeAt(1) - 65);
+        var NS = window.iHymnsActivityLog || {};
+        var table = document.querySelector('[data-activity-table]');
+        var tbody = table ? table.querySelector('[data-activity-rows]') : null;
+        var sentinel = document.querySelector('[data-activity-sentinel]');
+        var statusEl = document.querySelector('[data-activity-scroll-status]');
+        var announceEl = document.querySelector('[data-activity-scroll-announce]');
+        var toggleWrap = document.querySelector('[data-activity-scroll-toggle]');
+        var toggle = document.getElementById('activity-infinite-scroll');
+        var pagination = document.querySelector('[data-activity-pagination]');
+        var pageLabel = document.querySelector('[data-activity-pagelabel]');
+        var loadMoreWrap = document.querySelector('[data-activity-loadmore-wrap]');
+        var loadMoreBtn = document.querySelector('[data-activity-loadmore]');
+
+        /* Bail to the no-JS pagination if the browser lacks the APIs we need or
+           the table is absent (e.g. the empty-results state). */
+        if (!table || !tbody || !sentinel || !toggle || !toggleWrap
+            || typeof IntersectionObserver === 'undefined'
+            || typeof fetch === 'undefined'
+            || typeof URLSearchParams === 'undefined') {
+            return;
+        }
+
+        var STORAGE_KEY = 'ihymns_activity_infinite_scroll';
+        var loading = false;
+        /* Seed end-of-data from the server's initial page-count: if the first
+           render already held every matching row (one page), there's nothing to
+           seek for and we never fire a fetch. Keyset takes over from there. */
+        var initialTotalPages = parseInt(table.getAttribute('data-total-pages') || '1', 10) || 1;
+        var reachedEnd = initialTotalPages <= 1;
+        var observer = null;
+        var loadedCount = tbody.querySelectorAll('tr.activity-row[data-row-id]').length;
+
+        /* Belt-and-braces de-dup: every row id already present in the DOM. Even
+           though keyset pagination should never re-emit a row, a row id the
+           server returns that's already here is skipped on append. */
+        var seenIds = Object.create(null);
+        Array.prototype.forEach.call(
+            tbody.querySelectorAll('tr.activity-row[data-row-id]'),
+            function (tr) { seenIds[tr.getAttribute('data-row-id')] = true; }
+        );
+
+        /* The keyset cursor = the last appended primary row's (data-created,
+           data-row-id). Re-derived from the DOM after every append so we always
+           seek from the genuinely oldest row currently shown. Returns null when
+           there are no rows (nothing to seek from). */
+        function readCursor() {
+            var rows = tbody.querySelectorAll('tr.activity-row[data-row-id]');
+            if (!rows.length) { return null; }
+            var last = rows[rows.length - 1];
+            return {
+                ts: last.getAttribute('data-created') || '',
+                id: last.getAttribute('data-row-id') || '',
+            };
+        }
+
+        /* The toggle is hidden for no-JS users; reveal it now that JS is live —
+           but only when there's actually more than one page to scroll through
+           (otherwise infinite scroll is a no-op). */
+        if (!reachedEnd) {
+            toggleWrap.removeAttribute('hidden');
+        }
+
+        /* Visible (sighted) status. The polite live region is mutated separately
+           via announce() so AT hears the same text without us toggling the
+           region's presence (which would drop the first announce). */
+        function setStatus(msg) {
+            if (statusEl) {
+                if (msg) {
+                    statusEl.textContent = msg;
+                    statusEl.removeAttribute('hidden');
+                } else {
+                    statusEl.textContent = '';
+                    statusEl.setAttribute('hidden', '');
+                }
             }
-            fetch('/manage/activity-log.php?action=geo', {
-                method: 'POST',
+        }
+        /* Mutate (never replace/hide) the always-rendered live region. */
+        function announce(msg) {
+            if (announceEl) { announceEl.textContent = msg || ''; }
+        }
+
+        /* Re-run the shared TZ + geo enhancements over ONLY the appended rows so
+           new timestamps localise and new IP flags backfill, exactly like the
+           initial page. TZ-localise is per row; geo backfill is ONE call scoped
+           to the appended rows ARRAY (MINOR #5) — not the whole tbody — so flags
+           resolved on a previous batch are never re-scanned, and the batch is
+           still a single geo POST rather than one per row. */
+        function enhanceAppendedRows(rows) {
+            rows.forEach(function (tr) {
+                try { if (NS.localiseTimes) NS.localiseTimes(tr); } catch (_e) {}
+            });
+            try { if (NS.backfillFlags) NS.backfillFlags(rows); } catch (_e) {}
+        }
+
+        function finish(endMsg) {
+            reachedEnd = true;
+            setStatus(endMsg);
+            announce(endMsg);
+            if (observer) { observer.disconnect(); }
+            if (loadMoreWrap) { loadMoreWrap.setAttribute('hidden', ''); }
+        }
+
+        function loadNextPage() {
+            if (loading || reachedEnd) { return; }
+            var cursor = readCursor();
+            if (!cursor || !cursor.id) {
+                /* No anchor row to seek from — nothing more we can fetch. */
+                finish('End of log — all entries loaded.');
+                return;
+            }
+            loading = true;
+            setStatus('Loading more…');
+            if (loadMoreBtn) { loadMoreBtn.disabled = true; }
+            var params = new URLSearchParams(window.location.search);
+            params.set('action', 'next-page');
+            params.set('cursor_ts', cursor.ts);
+            params.set('cursor_id', cursor.id);
+            /* page/export have no meaning for the keyset fragment — strip them. */
+            params.delete('page');
+            params.delete('export');
+
+            fetch(window.location.pathname + '?' + params.toString(), {
                 credentials: 'same-origin',
-                headers: {
-                    'Content-Type': 'application/x-www-form-urlencoded',
-                    'X-Requested-With': 'XMLHttpRequest',
-                    'X-CSRF-Token': csrf,
-                },
-                body: 'ips=' + encodeURIComponent(ips.join(',')),
-            }).then(function (r) { return r.ok ? r.json() : null; }).then(function (j) {
-                if (!j || !j.countries) { return; }
-                pending.forEach(function (el) {
-                    var code = j.countries[el.getAttribute('data-ip')];
-                    if (code && /^[A-Za-z]{2}$/.test(code)) {   // defense-in-depth: validate before DOM
-                        var fl = flagEmoji(code);
-                        if (fl) { el.textContent = fl; el.setAttribute('title', code.toUpperCase()); }
+                headers: { 'X-Requested-With': 'XMLHttpRequest' },
+            }).then(function (r) {
+                if (!r.ok) { throw new Error('HTTP ' + r.status); }
+                return r.text();
+            }).then(function (html) {
+                loading = false;
+                if (loadMoreBtn) { loadMoreBtn.disabled = false; }
+                /* Parse the returned <tbody> fragment in a detached table so the
+                   <tr> rows are valid (a bare <tr> in a <div> would be dropped by
+                   the HTML parser). */
+                var tmp = document.createElement('table');
+                tmp.innerHTML = html;
+                var frag = tmp.querySelector('[data-activity-fragment]');
+                /* MINOR #4: a 200 with NO fragment wrapper at all is treated as
+                   end-of-data (not retried), removing the latent tight-loop where
+                   an empty-but-OK body would re-arm the observer forever. */
+                if (!frag) {
+                    finish('End of log — all entries loaded.');
+                    return;
+                }
+                var allRows = Array.prototype.slice.call(frag.children);
+                /* Skip any row id already in the DOM (belt-and-braces dedup). */
+                var newRows = allRows.filter(function (tr) {
+                    if (tr.nodeType !== 1) { return false; }
+                    var id = tr.getAttribute && tr.getAttribute('data-row-id');
+                    if (id) {
+                        if (seenIds[id]) { return false; }
+                        seenIds[id] = true;
                     }
+                    return true;
                 });
-            }).catch(function () { /* fail-soft — no flags, page still fine */ });
-        } catch (_e) { /* fail-soft */ }
+                var atEnd = frag.getAttribute('data-at-end') === '1';
+                if (newRows.length) {
+                    /* Append into the live tbody, then enhance ONLY these rows
+                       (TZ-localise + geo-backfill scoped per row subtree). */
+                    newRows.forEach(function (tr) { tbody.appendChild(tr); });
+                    loadedCount += newRows.filter(function (tr) {
+                        return tr.classList && tr.classList.contains('activity-row')
+                            && tr.getAttribute('data-row-id');
+                    }).length;
+                    enhanceAppendedRows(newRows);
+                    if (pageLabel) {
+                        pageLabel.textContent = loadedCount + ' entr'
+                            + (loadedCount === 1 ? 'y' : 'ies') + ' loaded';
+                    }
+                }
+                /* End-of-data when the server says so OR it returned no usable
+                   rows (covers a full page of pure duplicates, which keyset makes
+                   essentially impossible but we still guard). */
+                if (atEnd || allRows.length === 0) {
+                    finish('End of log — all entries loaded.');
+                } else {
+                    setStatus('Scroll down or use “Load more” to load more.');
+                }
+            }).catch(function () {
+                /* Network / server error — stop trying and leave the no-JS
+                   pagination + Load more visible as a manual fallback. */
+                loading = false;
+                if (loadMoreBtn) { loadMoreBtn.disabled = false; }
+                var msg = 'Could not load more — use the page links below.';
+                setStatus(msg);
+                announce(msg);
+                if (pagination) { pagination.removeAttribute('hidden'); }
+                if (observer) { observer.disconnect(); }
+            });
+        }
+
+        function activate() {
+            /* The Prev/Next pagination is hidden while infinite scroll is active,
+               BUT keyboard / AT users are NOT left without a non-scroll trigger:
+               the focusable "Load more" button (revealed just below) replaces it
+               1:1 as a Tab-reachable, Enter/Space-activatable control. An
+               IntersectionObserver alone can't be driven by keyboard, so this
+               button is the accessibility fallback (MINOR #2). */
+            if (pagination) { pagination.setAttribute('hidden', ''); }
+            if (loadMoreWrap && !reachedEnd) { loadMoreWrap.removeAttribute('hidden'); }
+            if (!observer) {
+                /* rootMargin pre-fetches the next batch ~400px before the sentinel
+                   reaches the viewport, so the append feels seamless. */
+                observer = new IntersectionObserver(function (entries) {
+                    entries.forEach(function (entry) {
+                        if (entry.isIntersecting) { loadNextPage(); }
+                    });
+                }, { rootMargin: '400px' });
+            }
+            observer.observe(sentinel);
+            if (!reachedEnd) { setStatus('Scroll down or use “Load more” to load more.'); }
+        }
+
+        function deactivate() {
+            if (observer) { observer.disconnect(); }
+            if (pagination) { pagination.removeAttribute('hidden'); }
+            if (loadMoreWrap) { loadMoreWrap.setAttribute('hidden', ''); }
+            setStatus('');
+        }
+
+        /* The focusable button is the keyboard/AT trigger (MINOR #2). */
+        if (loadMoreBtn) {
+            loadMoreBtn.addEventListener('click', function () { loadNextPage(); });
+        }
+
+        /* Persisted preference (default OFF — the user asked for it as an
+           OPTION). Restore it, then react to changes. */
+        var saved = null;
+        try { saved = window.localStorage.getItem(STORAGE_KEY); } catch (_e) {}
+        if (saved === '1') { toggle.checked = true; }
+
+        toggle.addEventListener('change', function () {
+            try { window.localStorage.setItem(STORAGE_KEY, toggle.checked ? '1' : '0'); } catch (_e) {}
+            if (toggle.checked) { activate(); } else { deactivate(); }
+        });
+
+        if (toggle.checked) { activate(); }
     })();
     </script>
 

--- a/appWeb/public_html/manage/configuration.php
+++ b/appWeb/public_html/manage/configuration.php
@@ -18,8 +18,11 @@ declare(strict_types=1);
  * timestamp X" without writing the password into the log).
  *
  * Real send-mechanism landed in #898 via includes/EmailService.php
- * (SendGrid / Mailgun / SES drivers; SMTP driver is a documented TODO
- * — admins should pick one of the API providers in the meantime).
+ * (SendGrid / Mailgun / SES drivers). feature C adds a working SMTP-AUTH
+ * driver with provider presets (Microsoft 365 priority, Google Workspace)
+ * and DELEGATE / "send-as" support — the From / Sender mailbox can differ
+ * from the SMTP login when the provider has granted Send-As. OAuth2 /
+ * MailerMatt is the eventual path; today it is SMTP-AUTH + app password.
  * The "Send test email" button posts to test_email and renders the
  * EmailSendResult inline so admins can verify provider config without
  * triggering a real auth flow.
@@ -59,11 +62,20 @@ $EMAIL_SETTINGS = [
     'email_service'             => ['Email service',             'select', false, null],
     'email_from_address'        => ['From address',              'email',  false, ['smtp','sendgrid','mailgun','ses']],
     'email_from_name'           => ['From name',                 'text',   false, ['smtp','sendgrid','mailgun','ses']],
+    /* feature C — SMTP provider preset (pre-fills host/port/secure in the
+       UI; constrained server-side to the $SMTP_PRESETS keys). */
+    'email_smtp_preset'         => ['SMTP provider preset',      'select', false, ['smtp']],
     'email_smtp_host'           => ['SMTP host',                 'text',   false, ['smtp']],
     'email_smtp_port'           => ['SMTP port',                 'number', false, ['smtp']],
     'email_smtp_user'           => ['SMTP username',             'text',   false, ['smtp']],
     'email_smtp_pass'           => ['SMTP password',             'password', true, ['smtp']],
     'email_smtp_secure'         => ['SMTP encryption',           'select', false, ['smtp']],
+    /* feature C — delegate / send-as. Optional; validated as an email in
+       the save handler. When set, mail is sent FROM this mailbox while
+       AUTH still uses the SMTP username above (the login mailbox must be
+       granted Send-As on it in the provider's admin console). */
+    'email_smtp_from_address'   => ['Send-as / From address (delegate)', 'email', false, ['smtp']],
+    'email_smtp_from_name'      => ['Send-as display name',      'text',   false, ['smtp']],
     'email_sendgrid_api_key'    => ['SendGrid API key',          'password', true, ['sendgrid']],
     'email_mailgun_api_key'     => ['Mailgun API key',           'password', true, ['mailgun']],
     'email_mailgun_domain'      => ['Mailgun domain',            'text',   false, ['mailgun']],
@@ -74,7 +86,7 @@ $EMAIL_SETTINGS = [
 
 $EMAIL_SERVICE_OPTIONS = [
     'none'     => 'None — email login disabled',
-    'smtp'     => 'SMTP — not yet implemented (#898 follow-up)',
+    'smtp'     => 'SMTP (incl. Microsoft 365 / Google Workspace)',
     'sendgrid' => 'SendGrid',
     'mailgun'  => 'Mailgun',
     'ses'      => 'AWS SES',
@@ -84,6 +96,22 @@ $SMTP_SECURE_OPTIONS = [
     'tls'  => 'STARTTLS (port 587)',
     'ssl'  => 'SSL/TLS implicit (port 465)',
     'none' => 'None (port 25 — not recommended)',
+];
+
+/* ----------------------------------------------------------------------
+ * feature C — SMTP provider presets. Selecting one pre-fills host / port /
+ * encryption in the UI (client-side JS, below). 'custom' leaves the manual
+ * fields as-is. The value is stored only as a hint for the next page load;
+ * the authoritative connection details are the host/port/secure fields.
+ *
+ * The host/port/secure here are also the SINGLE source of truth the JS
+ * reads, so adding a provider is a one-line change. (Microsoft 365 is the
+ * priority target; Google Workspace second.)
+ * ---------------------------------------------------------------------- */
+$SMTP_PRESETS = [
+    'custom'    => ['label' => 'Custom / manual',                 'host' => '',                  'port' => '',    'secure' => ''],
+    'office365' => ['label' => 'Microsoft 365 (Exchange Online)', 'host' => 'smtp.office365.com', 'port' => '587', 'secure' => 'tls'],
+    'gmail'     => ['label' => 'Google Workspace / Gmail',        'host' => 'smtp.gmail.com',     'port' => '587', 'secure' => 'tls'],
 ];
 
 /* ----------------------------------------------------------------------
@@ -141,6 +169,20 @@ if (($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'POST') {
                     }
                     if ($key === 'email_smtp_secure' && !isset($SMTP_SECURE_OPTIONS[$value])) {
                         $value = 'tls';
+                    }
+                    /* feature C — preset constrained to the known keys;
+                       anything else (incl. a tampered POST) → 'custom'. */
+                    if ($key === 'email_smtp_preset' && !isset($SMTP_PRESETS[$value])) {
+                        $value = 'custom';
+                    }
+                    /* feature C — delegate / send-as address. Empty is
+                       allowed (means "no delegate, use the generic From");
+                       a non-empty value MUST be a syntactically valid email
+                       or the save is rejected, so a bad address can never
+                       reach the From / MAIL FROM in EmailService. */
+                    if ($key === 'email_smtp_from_address' && $value !== ''
+                        && !filter_var($value, FILTER_VALIDATE_EMAIL)) {
+                        throw new \RuntimeException('Send-as / From address is not a valid email address.');
                     }
                     /* Empty password fields mean "leave existing value"
                        (the form doesn't echo current secrets back, so
@@ -236,15 +278,26 @@ if (($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'POST') {
                 $mmVal    = ((string)($_POST['maintenance_mode'] ?? '0')) === '1' ? '1' : '0';
                 $msgVal   = mb_substr(trim((string)($_POST['maintenance_message'] ?? '')), 0, 500);
                 $allowVal = ((string)($_POST['maintenance_allow_admins'] ?? '0')) === '1' ? '1' : '0';
+                /* Auto-refresh interval for the maintenance 503 page (#1276
+                   feature A). Coerce to int and clamp to the same [30, 3600]
+                   range maintenanceRefreshSeconds() enforces on read, so a
+                   hand-edited or out-of-range POST can never store a value the
+                   page would have to defend against again. */
+                require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'maintenance.php';
+                $refreshIn  = filter_var((string)($_POST['maintenance_refresh_seconds'] ?? ''), FILTER_VALIDATE_INT);
+                $refreshVal = $refreshIn === false
+                    ? MAINTENANCE_REFRESH_DEFAULT
+                    : max(MAINTENANCE_REFRESH_MIN, min(MAINTENANCE_REFRESH_MAX, (int)$refreshIn));
                 $saveSetting($db, 'maintenance_mode_' . $env, $mmVal);
                 $saveSetting($db, 'maintenance_message_' . $env, $msgVal);
                 $saveSetting($db, 'maintenance_allow_admins_' . $env, $allowVal);
+                $saveSetting($db, 'maintenance_refresh_seconds_' . $env, (string)$refreshVal);
                 if (function_exists('logActivity')) {
                     logActivity(
                         'app_setting.update',
                         'app_setting',
                         'maintenance_mode_' . $env,
-                        ['keys' => ['maintenance_mode_' . $env, 'maintenance_message_' . $env, 'maintenance_allow_admins_' . $env], 'enabled' => $mmVal === '1'],
+                        ['keys' => ['maintenance_mode_' . $env, 'maintenance_message_' . $env, 'maintenance_allow_admins_' . $env, 'maintenance_refresh_seconds_' . $env], 'enabled' => $mmVal === '1'],
                         'success'
                     );
                 }
@@ -269,10 +322,16 @@ $maintenanceSettings = $loadSettings($db, [
     'maintenance_mode_' . $envCurrent,
     'maintenance_message_' . $envCurrent,
     'maintenance_allow_admins_' . $envCurrent,
+    'maintenance_refresh_seconds_' . $envCurrent,
 ]);
 $maintenanceOn       = ($maintenanceSettings['maintenance_mode_' . $envCurrent] ?? '0') === '1';
 $maintenanceMsg      = (string)($maintenanceSettings['maintenance_message_' . $envCurrent] ?? '');
 $maintenanceAllowAdm = ($maintenanceSettings['maintenance_allow_admins_' . $envCurrent] ?? '0') === '1';
+/* Auto-refresh interval (#1276). Reuse maintenanceRefreshSeconds() so the
+   form's displayed value is the SAME clamped value the 503 page would use —
+   no drift between what the admin sees and what visitors get. */
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'maintenance.php';
+$maintenanceRefresh  = maintenanceRefreshSeconds();
 
 require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-favicon.php';
 ?>
@@ -362,6 +421,21 @@ require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head
                               maxlength="500"
                               placeholder="We&rsquo;ll be back shortly &mdash; scheduled maintenance in progress."><?= htmlspecialchars($maintenanceMsg, ENT_QUOTES, 'UTF-8') ?></textarea>
                 </div>
+                <div class="mb-3">
+                    <label for="maintenance_refresh_seconds" class="form-label">
+                        Auto-refresh interval (seconds)
+                    </label>
+                    <input type="number" name="maintenance_refresh_seconds" id="maintenance_refresh_seconds"
+                           class="form-control" style="max-width: 12rem;"
+                           min="<?= MAINTENANCE_REFRESH_MIN ?>" max="<?= MAINTENANCE_REFRESH_MAX ?>" step="1"
+                           value="<?= (int)$maintenanceRefresh ?>">
+                    <div class="form-text">
+                        How often the maintenance page reloads itself to check if the site is back
+                        (a corner countdown shows the time remaining). Clamped to
+                        <?= MAINTENANCE_REFRESH_MIN ?>&ndash;<?= MAINTENANCE_REFRESH_MAX ?> seconds; default
+                        <?= MAINTENANCE_REFRESH_DEFAULT ?>.
+                    </div>
+                </div>
                 <!-- hidden 0 so an unchecked box still posts a value -->
                 <input type="hidden" name="maintenance_allow_admins" value="0">
                 <div class="form-check mb-3">
@@ -398,6 +472,14 @@ require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head
                 <strong>None</strong>, the Sign In modal hides the email-login
                 option and falls back to password-only mode (#766 / PR #767).
             </p>
+
+            <?php /* feature C — preset host/port/secure data for the JS,
+                     emitted as a JSON island so the script reads ONE source.
+                     json_encode with JSON_HEX_* hardens against an XSS via a
+                     future preset label containing < or ". */ ?>
+            <script type="application/json" data-smtp-presets>
+                <?= json_encode($SMTP_PRESETS, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>
+            </script>
 
             <form method="post" id="email-form">
                 <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8') ?>">
@@ -441,6 +523,31 @@ require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head
                 <div class="email-fields" data-provider-show="smtp">
                     <hr class="text-secondary">
                     <h3 class="h6 mb-3"><i class="bi bi-server me-1"></i>SMTP server</h3>
+
+                    <!-- feature C — provider preset. Pre-fills host / port /
+                         encryption client-side from $SMTP_PRESETS (see the
+                         data-smtp-presets script JSON below). -->
+                    <div class="row g-3 mb-3">
+                        <div class="col-md-6">
+                            <label for="email_smtp_preset" class="form-label">Provider preset</label>
+                            <select name="email_smtp_preset" id="email_smtp_preset"
+                                    class="form-select" data-smtp-preset>
+                                <?php
+                                    $smtpPreset = $currentSettings['email_smtp_preset'] ?? 'custom';
+                                    foreach ($SMTP_PRESETS as $pVal => $pCfg):
+                                ?>
+                                    <option value="<?= htmlspecialchars($pVal, ENT_QUOTES, 'UTF-8') ?>" <?= $smtpPreset === $pVal ? 'selected' : '' ?>>
+                                        <?= htmlspecialchars($pCfg['label'], ENT_QUOTES, 'UTF-8') ?>
+                                    </option>
+                                <?php endforeach; ?>
+                            </select>
+                            <div class="form-text">
+                                Pre-fills host, port and encryption for common providers.
+                                Choose <strong>Custom / manual</strong> to enter them yourself.
+                            </div>
+                        </div>
+                    </div>
+
                     <div class="row g-3 mb-3">
                         <div class="col-md-6">
                             <label for="email_smtp_host" class="form-label">SMTP host</label>
@@ -487,6 +594,35 @@ require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head
                             <input type="password" name="email_smtp_pass" id="email_smtp_pass"
                                    class="form-control" autocomplete="new-password"
                                    placeholder="<?= !empty($currentSettings['email_smtp_pass']) ? '••••••••' : 'Enter password' ?>">
+                        </div>
+                    </div>
+
+                    <!-- feature C — delegate / send-as. Optional: when set,
+                         mail is sent FROM this mailbox while AUTH stays on the
+                         username above. Requires Send-As granted on the
+                         delegate mailbox in the provider's admin console. -->
+                    <div class="row g-3 mb-3">
+                        <div class="col-12">
+                            <div class="form-text mb-1">
+                                <i class="bi bi-person-badge me-1"></i><strong>Send on behalf of a different mailbox (optional).</strong>
+                                Leave blank to send as the username above. To send as a shared / delegate
+                                mailbox, the username must be granted <em>Send As</em> on it in your provider's
+                                admin console (see the setup guide below).
+                            </div>
+                        </div>
+                        <div class="col-md-6">
+                            <label for="email_smtp_from_address" class="form-label">Send-as / From address</label>
+                            <input type="email" name="email_smtp_from_address" id="email_smtp_from_address"
+                                   class="form-control"
+                                   value="<?= htmlspecialchars($currentSettings['email_smtp_from_address'] ?? '', ENT_QUOTES, 'UTF-8') ?>"
+                                   placeholder="noreply@yourdomain.com">
+                        </div>
+                        <div class="col-md-6">
+                            <label for="email_smtp_from_name" class="form-label">Send-as display name</label>
+                            <input type="text" name="email_smtp_from_name" id="email_smtp_from_name"
+                                   class="form-control"
+                                   value="<?= htmlspecialchars($currentSettings['email_smtp_from_name'] ?? '', ENT_QUOTES, 'UTF-8') ?>"
+                                   placeholder="iHymns">
                         </div>
                     </div>
                 </div>
@@ -602,31 +738,108 @@ require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head
         </div>
         <div class="card-body">
             <div class="accordion" id="email-instructions">
-                <!-- SMTP -->
+                <!-- Microsoft 365 (priority) -->
+                <div class="accordion-item bg-dark">
+                    <h3 class="accordion-header">
+                        <button class="accordion-button collapsed bg-dark text-light" type="button"
+                                data-bs-toggle="collapse" data-bs-target="#instr-m365">
+                            <i class="bi bi-microsoft me-2"></i>SMTP — Microsoft 365 (recommended)
+                        </button>
+                    </h3>
+                    <div id="instr-m365" class="accordion-collapse collapse" data-bs-parent="#email-instructions">
+                        <div class="accordion-body small">
+                            <p>Pick provider <strong>SMTP</strong>, then preset <strong>Microsoft 365</strong> — that fills
+                               host <code>smtp.office365.com</code>, port <code>587</code>, encryption <code>STARTTLS</code>.</p>
+                            <ol class="mb-2">
+                                <li><strong>Enable SMTP AUTH on the sending mailbox.</strong> In the
+                                    <a href="https://admin.microsoft.com" target="_blank" rel="noopener">Microsoft 365 admin centre</a> →
+                                    <em>Users → Active users → (the mailbox) → Mail → Manage email apps</em>, tick
+                                    <em>Authenticated SMTP</em>. SMTP AUTH is off by default on most tenants.</li>
+                                <li><strong>Create an app password.</strong> M365 requires MFA, and basic SMTP can't do an
+                                    interactive MFA prompt, so generate an app password for the mailbox at
+                                    <a href="https://mysignins.microsoft.com/security-info" target="_blank" rel="noopener">My Sign-Ins → Security info → Add → App password</a>.
+                                    Use that as the SMTP <strong>password</strong> here (your normal password will be rejected).</li>
+                                <li><strong>Username</strong> = the mailbox you authenticate as (e.g. <code>automation@yourtenant.com</code>).</li>
+                                <li><strong>Send-as a different mailbox (optional).</strong> To send from, say,
+                                    <code>noreply@yourtenant.com</code> while authenticating as <code>automation@…</code>,
+                                    grant the automation account <em>Send As</em> on the target in the
+                                    <a href="https://admin.exchange.microsoft.com" target="_blank" rel="noopener">Exchange admin centre</a> →
+                                    <em>Recipients → Mailboxes → (target) → Delegation → Send as</em>, then put the target
+                                    address in <strong>Send-as / From address</strong> above.</li>
+                                <li><strong>Save</strong>, then <strong>Send test email</strong> to confirm.</li>
+                            </ol>
+                            <p class="text-secondary mb-0"><strong>If Send test fails:</strong>
+                               <em>auth_failed</em> → SMTP AUTH not enabled, or you used the account password instead of an app password.
+                               <em>mail_from_rejected</em> / <em>rcpt</em> with a 550 → the Send-as address isn't authorised for the login mailbox.</p>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Google Workspace -->
+                <div class="accordion-item bg-dark">
+                    <h3 class="accordion-header">
+                        <button class="accordion-button collapsed bg-dark text-light" type="button"
+                                data-bs-toggle="collapse" data-bs-target="#instr-gws">
+                            <i class="bi bi-google me-2"></i>SMTP — Google Workspace / Gmail
+                        </button>
+                    </h3>
+                    <div id="instr-gws" class="accordion-collapse collapse" data-bs-parent="#email-instructions">
+                        <div class="accordion-body small">
+                            <p>Pick provider <strong>SMTP</strong>, then preset <strong>Google Workspace / Gmail</strong> — that fills
+                               host <code>smtp.gmail.com</code>, port <code>587</code>, encryption <code>STARTTLS</code>.</p>
+                            <ol class="mb-2">
+                                <li><strong>Turn on 2-Step Verification</strong> on the sending account (required before
+                                    you can create an app password).</li>
+                                <li><strong>Create an app password</strong> at
+                                    <a href="https://myaccount.google.com/apppasswords" target="_blank" rel="noopener">myaccount.google.com/apppasswords</a>
+                                    and use it as the SMTP <strong>password</strong> here. A normal account password is rejected
+                                    over SMTP.</li>
+                                <li><strong>Username</strong> = the full Google Workspace address (e.g. <code>automation@yourdomain.com</code>).</li>
+                                <li><strong>Allow SMTP for the org (if needed).</strong> A Workspace admin can confirm SMTP
+                                    sending is permitted in the
+                                    <a href="https://admin.google.com" target="_blank" rel="noopener">Google Admin console</a>
+                                    (<em>Apps → Google Workspace → Gmail → End User Access</em>); some tenants block app passwords entirely.</li>
+                                <li><strong>Send-as a different address (optional).</strong> Gmail can send as an alias or a
+                                    delegated address only if it's been added under
+                                    <a href="https://mail.google.com/mail/u/0/#settings/accounts" target="_blank" rel="noopener">Gmail Settings → Accounts → Send mail as</a>
+                                    (verified), or granted to the account in the Admin console. Put that address in
+                                    <strong>Send-as / From address</strong> above; unverified send-as addresses are silently
+                                    rewritten by Gmail to the login address.</li>
+                                <li><strong>Save</strong>, then <strong>Send test email</strong>.</li>
+                            </ol>
+                            <p class="text-secondary mb-0"><strong>If Send test fails with</strong> <em>auth_failed</em>:
+                               2-Step Verification / app password isn't set up, or the org blocks app passwords.</p>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Custom SMTP + future-direction note -->
                 <div class="accordion-item bg-dark">
                     <h3 class="accordion-header">
                         <button class="accordion-button collapsed bg-dark text-light" type="button"
                                 data-bs-toggle="collapse" data-bs-target="#instr-smtp">
-                            <i class="bi bi-server me-2"></i>SMTP — any provider with SMTP relay
+                            <i class="bi bi-server me-2"></i>SMTP — any other provider (custom)
                         </button>
                     </h3>
                     <div id="instr-smtp" class="accordion-collapse collapse" data-bs-parent="#email-instructions">
                         <div class="accordion-body small">
-                            <p>SMTP is the most portable option — works with any provider that exposes a relay endpoint.</p>
-                            <ol class="mb-2">
-                                <li><strong>Pick a provider</strong> and grab its SMTP details. Common ones:
-                                    <ul>
-                                        <li><strong>Gmail / Google Workspace</strong> — host <code>smtp.gmail.com</code>, port <code>587</code>, encryption <code>STARTTLS</code>. Username = your Google address, password = an <a href="https://myaccount.google.com/apppasswords" target="_blank" rel="noopener">App Password</a> (regular password is rejected). Requires 2FA on the account.</li>
-                                        <li><strong>Microsoft 365</strong> — host <code>smtp.office365.com</code>, port <code>587</code>, <code>STARTTLS</code>. Same account credentials; admin must enable SMTP AUTH on the mailbox.</li>
-                                        <li><strong>Zoho Mail</strong> — host <code>smtp.zoho.com</code>, port <code>587</code> (TLS) or <code>465</code> (SSL).</li>
-                                        <li><strong>Fastmail</strong> — host <code>smtp.fastmail.com</code>, port <code>465</code>, <code>SSL/TLS</code>. Use an app-specific password.</li>
-                                        <li><strong>Mailgun SMTP relay</strong> — host <code>smtp.mailgun.org</code>, port <code>587</code>. Username + password are listed under <em>Sending → Domain settings → SMTP credentials</em> for each domain.</li>
-                                    </ul>
-                                </li>
-                                <li><strong>Set the From address</strong> to a mailbox the provider allows you to send from (usually a domain you own + verified).</li>
-                                <li><strong>Save configuration</strong> here. Use <strong>Send test email</strong> to verify — note: SMTP driver is not yet implemented (#898 follow-up); pick SendGrid, Mailgun, or AWS SES for a working transactional provider in the meantime.</li>
-                            </ol>
-                            <p class="text-secondary mb-0"><strong>Tip:</strong> if Send test fails with <em>auth failed</em>, the username/password is wrong or the provider hasn't enabled SMTP for the account. If it fails with <em>relay denied</em>, the From address isn't verified for that account.</p>
+                            <p>SMTP works with any provider that exposes an authenticated relay endpoint. Choose the
+                               <strong>Custom / manual</strong> preset and enter the details by hand:</p>
+                            <ul class="mb-2">
+                                <li><strong>Zoho Mail</strong> — host <code>smtp.zoho.com</code>, port <code>587</code> (STARTTLS) or <code>465</code> (SSL).</li>
+                                <li><strong>Fastmail</strong> — host <code>smtp.fastmail.com</code>, port <code>465</code>, <code>SSL/TLS</code>. Use an app-specific password.</li>
+                                <li><strong>Mailgun SMTP relay</strong> — host <code>smtp.mailgun.org</code>, port <code>587</code>. Credentials are under <em>Sending → Domain settings → SMTP credentials</em>.</li>
+                            </ul>
+                            <p class="mb-2">Set the <strong>From address</strong> to a mailbox the provider lets you send from.
+                               Use the optional <strong>Send-as / From address</strong> when the message should appear from a
+                               delegate mailbox the login account is authorised to send as.</p>
+                            <p class="text-secondary mb-2"><strong>Tip:</strong> if Send test fails with <em>auth_failed</em>,
+                               the username / password is wrong or the provider hasn't enabled SMTP AUTH. <em>mail_from_rejected</em>
+                               / <em>relay denied</em> means the From / Send-as address isn't authorised for that login.</p>
+                            <p class="text-info mb-0"><i class="bi bi-info-circle me-1"></i><strong>Future direction:</strong>
+                               this uses SMTP AUTH with an app password + delegate today. OAuth2 sign-in (and the planned
+                               <em>MailerMatt</em> delivery service) is the eventual path — not built yet; SMTP AUTH is the
+                               supported mechanism for now.</p>
                         </div>
                     </div>
                 </div>
@@ -744,6 +957,39 @@ require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head
     };
     providerSel.addEventListener('change', apply);
     apply();
+})();
+
+(function () {
+    'use strict';
+    /* feature C — SMTP provider preset. Selecting Microsoft 365 or Google
+       Workspace fills the host / port / encryption fields from the JSON
+       island so admins don't memorise endpoints. 'Custom / manual' leaves
+       the fields untouched. The fields stay editable after pre-fill — the
+       preset is a convenience, not a lock. */
+    const presetSel = document.querySelector('[data-smtp-preset]');
+    const dataEl    = document.querySelector('[data-smtp-presets]');
+    if (!presetSel || !dataEl) return;
+
+    let presets = {};
+    try {
+        presets = JSON.parse(dataEl.textContent || '{}');
+    } catch (e) {
+        return; /* malformed JSON — leave manual entry working */
+    }
+
+    const hostEl   = document.getElementById('email_smtp_host');
+    const portEl   = document.getElementById('email_smtp_port');
+    const secureEl = document.getElementById('email_smtp_secure');
+
+    presetSel.addEventListener('change', () => {
+        const cfg = presets[presetSel.value];
+        /* 'custom' (and any unknown key) has empty host/port/secure — skip
+           so we never wipe what the admin already typed. */
+        if (!cfg || !cfg.host) return;
+        if (hostEl)   hostEl.value = cfg.host;
+        if (portEl)   portEl.value = cfg.port;
+        if (secureEl && cfg.secure) secureEl.value = cfg.secure;
+    });
 })();
 </script>
 </body>


### PR DESCRIPTION
Targets **alpha**. Three independent queued features, bundled per the owner's request for efficiency — atomic per-feature commits (each individually revertable), plus the README © tidy-up. Built + adversarially reviewed by multi-agent workflows; the reviewer-required fixes are applied and re-verified.

### A — Maintenance UX — #1301 (`maintenance.php`, `error_page.php`, `pwa.js`, `configuration.php`)
Admin-configurable auto-refresh (per-env `maintenance_refresh_seconds_<env>`, default 300s, DB-safe, clamp 30–3600) + a semi-transparent animated corner countdown (prefers-reduced-motion; aria-hidden tick + one polite announce outside the `role=alert` main); a **padlock→login** (closed→open on hover) reachable during maintenance; PWA install-banner suppression during maintenance; and iOS **safe-area** (`viewport-fit=cover` + `env(safe-area-inset-*)` under `display-mode: standalone`) so it clears the Dynamic Island. Maintenance gate + admin bypass untouched.
- *Review-fix applied:* the safe-area block was a no-op without `viewport-fit=cover` → added (the major finding); ARIA live-region nesting simplified.

### B — Activity-Log infinite-scroll — #1302 (`activity-log.php`)
Opt-in infinite-scroll, progressive enhancement over `?page=` (no-JS fallback retained).
- *Review-fix applied (major):* switched from OFFSET to **keyset/seek pagination** (cursor = last `CreatedAt`+`Id`, all bound) — OFFSET on this append-heavy, self-logging table surfaced **duplicate rows at page seams**. Plus `data-row-id` dedup, focusable **Load-more**, always-rendered aria-live, end-of-data guard.

### C — Email M365 + Google Workspace — #1303 (`EmailService.php`, `configuration.php`)
Self-contained **ESMTP-AUTH driver** (no new deps), **provider presets** (M365 priority / Google Workspace / Custom), **delegate send-as** From, per-provider **setup guides**. Not MailerMatt (the eventual mechanism).

## Security review (pre-merge)
The email feature passed a dedicated adversarial **security** pass: no secret logged/echoed/rendered; existing credential storage + CSRF + `manage_configuration` gate preserved; SMTP **header/command injection** blocked (CRLF-stripped addresses/headers). One **deferred, parked** item: a low-utility, admin-gated **SMTP-host SSRF** (free-text host) → tracked as **#1304** (`for consideration`) with a "warn, don't block" proposal.

## Notes / out of scope
- Pre-existing inconsistency surfaced by the maintenance work: `/api?action=app_status` reads the **non**-env-suffixed `maintenance_mode` keys while the gate + admin UI use `maintenance_mode_<env>`. I kept the new PWA-banner suppression consistent with the *existing* app.js maintenance-banner mechanism (both read `status.maintenance`), so behaviour is internally consistent — but if you want `app_status` to honour per-env maintenance, happy to file/fix it separately.
- The two re-verify "minor" notes (keyset cursor is a server-stored literal; the infinite-scroll toggle hides on a single-page result) are intentional/cosmetic — no action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)