### PR TITLE
Fix queued-feature follow-ups: editor delete CSRF (#1307) · maintenance banner overlap (#1308) · M365/Google providers (#1309)

### DIFF
--- a/appWeb/public_html/includes/EmailService.php
+++ b/appWeb/public_html/includes/EmailService.php
@@ -198,6 +198,12 @@ final class EmailService
                 return self::sendViaMailgun($to, $subject, $bodyHtml, $bodyText, $cfg);
             case 'ses':
                 return self::sendViaSes($to, $subject, $bodyHtml, $bodyText, $cfg);
+            case 'office365':
+            case 'gmail':
+                /* #1309 — Microsoft 365 / Google Workspace are first-class
+                   providers that ride the same SMTP-AUTH transport; sendViaSmtp
+                   defaults host/port/secure from the shared preset keyed by the
+                   service when the admin left them blank. */
             case 'smtp':
                 /* feature C — real SMTP-AUTH client with STARTTLS / implicit
                    SSL, AUTH LOGIN, and delegate ("send-as") From support.
@@ -444,6 +450,24 @@ final class EmailService
         $user   = (string)($cfg['email_smtp_user'] ?? '');
         $pass   = (string)($cfg['email_smtp_pass'] ?? '');
         $secure = (string)($cfg['email_smtp_secure'] ?? 'tls');
+
+        /* #1309 — when a first-class office365 / gmail provider is selected,
+           default the connection endpoint from the shared preset (keyed by the
+           service) for any field the admin left blank. The UI pre-fills these
+           too, but this guarantees a correct send even if the JS pre-fill never
+           ran (e.g. the value was saved before this field was filled). The
+           preset keys are identical to the email_service values by design. */
+        $service = (string)($cfg['email_service'] ?? '');
+        require_once __DIR__ . DIRECTORY_SEPARATOR . 'smtp_presets.php';
+        $presets = ihymns_smtp_presets();
+        if (isset($presets[$service])) {
+            if ($host === '')              { $host   = (string)$presets[$service]['host']; }
+            if ($port <= 0)                { $port   = (int)$presets[$service]['port']; }
+            if ($secure === '' && $presets[$service]['secure'] !== '') {
+                $secure = (string)$presets[$service]['secure'];
+            }
+        }
+
         /* fromAddress() already prefers the delegate / send-as address
            (email_smtp_from_address → falls back to email_from_address). */
         $from   = self::fromAddress($cfg);

--- a/appWeb/public_html/includes/smtp_presets.php
+++ b/appWeb/public_html/includes/smtp_presets.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * ============================================================================
+ * smtp_presets.php — canonical SMTP provider presets (ONE source of truth)
+ * ============================================================================
+ *
+ * #1309 — promotes the #1303 SMTP "presets" to first-class email providers.
+ *
+ * ELI5: this is the single list of "known email companies and their server
+ * addresses" so the settings page and the actual mail sender never disagree.
+ *
+ * Detailed: previously the host/port/encryption for Microsoft 365 and Google
+ * Workspace lived ONLY in a `$SMTP_PRESETS` array inside manage/configuration.php
+ * and were surfaced as a secondary "Provider preset" dropdown nested under a
+ * generic "SMTP" provider choice — so an admin had to pick SMTP, THEN pick the
+ * preset, and the endpoints weren't known to the server-side sender at all.
+ * This file lifts that map to a shared include consumed by BOTH:
+ *   - manage/configuration.php — renders the provider <select> + the JSON
+ *     island the pre-fill JS reads;
+ *   - includes/EmailService.php — defaults host/port/secure server-side when a
+ *     first-class `office365` / `gmail` provider is selected without a manual
+ *     host (belt-and-braces if the UI pre-fill didn't run).
+ *
+ * IMPORTANT: every key except 'custom' DOUBLES as a first-class
+ * `email_service` provider value, so these keys MUST stay in lockstep with
+ * $EMAIL_SERVICE_OPTIONS in configuration.php and the dispatch switch in
+ * EmailService::dispatch(). Add a provider here once; both sides pick it up.
+ *
+ * Growable vocabulary lives in PHP (not an ENUM) per CLAUDE.md rule #20.
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ * @package    iHymns
+ * @subpackage Email
+ */
+
+if (!function_exists('ihymns_smtp_presets')) {
+    /**
+     * The canonical preset map.
+     *
+     * @return array<string, array{label:string, host:string, port:string, secure:string}>
+     *   Keyed by provider/preset key. `host`/`port`/`secure` are '' for
+     *   'custom' (manual entry); for a real provider they are the published
+     *   submission endpoints. `secure` is one of the $SMTP_SECURE_OPTIONS
+     *   keys ('tls' = STARTTLS:587, 'ssl' = implicit TLS:465, 'none').
+     */
+    function ihymns_smtp_presets(): array
+    {
+        return [
+            'custom'    => ['label' => 'Custom / manual',                 'host' => '',                   'port' => '',    'secure' => ''],
+            'office365' => ['label' => 'Microsoft 365 (Exchange Online)', 'host' => 'smtp.office365.com', 'port' => '587', 'secure' => 'tls'],
+            'gmail'     => ['label' => 'Google Workspace / Gmail',        'host' => 'smtp.gmail.com',     'port' => '587', 'secure' => 'tls'],
+        ];
+    }
+}

--- a/appWeb/public_html/index.php
+++ b/appWeb/public_html/index.php
@@ -864,10 +864,37 @@ if (!empty($breadcrumbItems)) {
 
 <body class="d-flex flex-column min-vh-100">
 <?php if (!empty($GLOBALS['_ihymnsMaintenanceBypass'])): /* #1233 — admin is bypassing maintenance; make that obvious. Self-contained styles (no icon/CSS deps). */ ?>
-    <div role="status" style="position:sticky;top:0;z-index:1080;background:#ffc107;color:#000;text-align:center;padding:0.5rem 1rem;font-size:0.85rem;line-height:1.3;">
+    <?php /* #1308 — was position:sticky;z-index:1080, which painted OVER the
+       position:fixed .app-header (z-1030) and hid the nav brand / profile
+       controls. Now position:fixed at the very top, and the nonce'd script
+       below pushes BOTH the fixed header (.app-header top) and the scrollable
+       content (.main-content padding-top) down by the banner's MEASURED height
+       so nothing is occluded. Height is measured (not hard-coded) because the
+       message wraps to 2–3 lines on narrow viewports; re-measured on resize.
+       The PWA install banner is suppressed during maintenance (pwa.js #1301),
+       so the single-banner layout is the only case to handle here. */ ?>
+    <div id="ihymns-maint-bypass" role="status" style="position:fixed;top:0;left:0;right:0;z-index:1040;background:#ffc107;color:#000;text-align:center;padding:0.5rem 1rem;font-size:0.85rem;line-height:1.3;">
         🔧 <strong>Maintenance mode is ON</strong> for this environment — visitors see a maintenance page; you have admin access.
         <a href="/manage/configuration" style="color:#000;text-decoration:underline;font-weight:600;">Turn it off</a>.
     </div>
+    <script nonce="<?= $cspNonce ?>">
+    (function () {
+        function applyMaintBypassOffset() {
+            var bar = document.getElementById('ihymns-maint-bypass');
+            if (!bar) return;
+            var h = bar.offsetHeight;                 /* live height incl. wrapped lines */
+            var hdr = document.querySelector('.app-header');
+            if (hdr) { hdr.style.top = h + 'px'; }    /* push fixed header below the banner */
+            var main = document.querySelector('.main-content');
+            if (main) { main.style.paddingTop = 'calc(var(--header-height) + 8px + ' + h + 'px)'; }
+        }
+        /* .app-header / .main-content are emitted AFTER this script, so wait for
+           the DOM before measuring; also re-run on resize (width → wrap → height). */
+        if (document.readyState !== 'loading') { applyMaintBypassOffset(); }
+        else { document.addEventListener('DOMContentLoaded', applyMaintBypassOffset); }
+        window.addEventListener('resize', applyMaintBypassOffset);
+    })();
+    </script>
 <?php endif; ?>
     <!-- ================================================================
          SKIP NAVIGATION LINK — Accessibility: allows keyboard users

--- a/appWeb/public_html/manage/configuration.php
+++ b/appWeb/public_html/manage/configuration.php
@@ -60,22 +60,25 @@ $csrf = csrfToken();
 $EMAIL_SETTINGS = [
     /* key                     => [label, type, secret, providers] */
     'email_service'             => ['Email service',             'select', false, null],
-    'email_from_address'        => ['From address',              'email',  false, ['smtp','sendgrid','mailgun','ses']],
-    'email_from_name'           => ['From name',                 'text',   false, ['smtp','sendgrid','mailgun','ses']],
+    /* #1309 — 'office365' and 'gmail' are first-class SMTP-AUTH providers, so
+       the SMTP + common field groups are visible for them too. */
+    'email_from_address'        => ['From address',              'email',  false, ['smtp','office365','gmail','sendgrid','mailgun','ses']],
+    'email_from_name'           => ['From name',                 'text',   false, ['smtp','office365','gmail','sendgrid','mailgun','ses']],
     /* feature C — SMTP provider preset (pre-fills host/port/secure in the
-       UI; constrained server-side to the $SMTP_PRESETS keys). */
+       UI; constrained server-side to the $SMTP_PRESETS keys). Custom SMTP
+       only — for office365/gmail the preset is implied by the provider. */
     'email_smtp_preset'         => ['SMTP provider preset',      'select', false, ['smtp']],
-    'email_smtp_host'           => ['SMTP host',                 'text',   false, ['smtp']],
-    'email_smtp_port'           => ['SMTP port',                 'number', false, ['smtp']],
-    'email_smtp_user'           => ['SMTP username',             'text',   false, ['smtp']],
-    'email_smtp_pass'           => ['SMTP password',             'password', true, ['smtp']],
-    'email_smtp_secure'         => ['SMTP encryption',           'select', false, ['smtp']],
+    'email_smtp_host'           => ['SMTP host',                 'text',   false, ['smtp','office365','gmail']],
+    'email_smtp_port'           => ['SMTP port',                 'number', false, ['smtp','office365','gmail']],
+    'email_smtp_user'           => ['SMTP username',             'text',   false, ['smtp','office365','gmail']],
+    'email_smtp_pass'           => ['SMTP password',             'password', true, ['smtp','office365','gmail']],
+    'email_smtp_secure'         => ['SMTP encryption',           'select', false, ['smtp','office365','gmail']],
     /* feature C — delegate / send-as. Optional; validated as an email in
        the save handler. When set, mail is sent FROM this mailbox while
        AUTH still uses the SMTP username above (the login mailbox must be
        granted Send-As on it in the provider's admin console). */
-    'email_smtp_from_address'   => ['Send-as / From address (delegate)', 'email', false, ['smtp']],
-    'email_smtp_from_name'      => ['Send-as display name',      'text',   false, ['smtp']],
+    'email_smtp_from_address'   => ['Send-as / From address (delegate)', 'email', false, ['smtp','office365','gmail']],
+    'email_smtp_from_name'      => ['Send-as display name',      'text',   false, ['smtp','office365','gmail']],
     'email_sendgrid_api_key'    => ['SendGrid API key',          'password', true, ['sendgrid']],
     'email_mailgun_api_key'     => ['Mailgun API key',           'password', true, ['mailgun']],
     'email_mailgun_domain'      => ['Mailgun domain',            'text',   false, ['mailgun']],
@@ -84,12 +87,20 @@ $EMAIL_SETTINGS = [
     'email_ses_secret_key'      => ['AWS secret key',            'password', true, ['ses']],
 ];
 
+/* #1309 — Microsoft 365 + Google Workspace are now FIRST-CLASS providers in
+   this dropdown (they used to be a nested "preset" under a generic SMTP entry,
+   which the owner reported as undiscoverable — the guides showed but the
+   services weren't selectable). The keys match the shared smtp_presets map so
+   the pre-fill JS + EmailService dispatch recognise them; both route through
+   the SMTP-AUTH transport. 'smtp' remains for any OTHER custom server. */
 $EMAIL_SERVICE_OPTIONS = [
-    'none'     => 'None — email login disabled',
-    'smtp'     => 'SMTP (incl. Microsoft 365 / Google Workspace)',
-    'sendgrid' => 'SendGrid',
-    'mailgun'  => 'Mailgun',
-    'ses'      => 'AWS SES',
+    'none'      => 'None — email login disabled',
+    'office365' => 'Microsoft 365 (Exchange Online)',
+    'gmail'     => 'Google Workspace / Gmail',
+    'smtp'      => 'SMTP (other / custom server)',
+    'sendgrid'  => 'SendGrid',
+    'mailgun'   => 'Mailgun',
+    'ses'       => 'AWS SES',
 ];
 
 $SMTP_SECURE_OPTIONS = [
@@ -108,11 +119,11 @@ $SMTP_SECURE_OPTIONS = [
  * reads, so adding a provider is a one-line change. (Microsoft 365 is the
  * priority target; Google Workspace second.)
  * ---------------------------------------------------------------------- */
-$SMTP_PRESETS = [
-    'custom'    => ['label' => 'Custom / manual',                 'host' => '',                  'port' => '',    'secure' => ''],
-    'office365' => ['label' => 'Microsoft 365 (Exchange Online)', 'host' => 'smtp.office365.com', 'port' => '587', 'secure' => 'tls'],
-    'gmail'     => ['label' => 'Google Workspace / Gmail',        'host' => 'smtp.gmail.com',     'port' => '587', 'secure' => 'tls'],
-];
+/* #1309 — the preset map now lives in the shared includes/smtp_presets.php so
+   EmailService.php reads the SAME host/port/secure when an office365 / gmail
+   provider is sent server-side (no drift between UI and sender). */
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'smtp_presets.php';
+$SMTP_PRESETS = ihymns_smtp_presets();
 
 /* ----------------------------------------------------------------------
  * Helpers
@@ -500,7 +511,7 @@ require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head
                 </div>
 
                 <!-- Common fields (visible when provider != 'none') -->
-                <div class="email-fields" data-provider-show="smtp,sendgrid,mailgun,ses">
+                <div class="email-fields" data-provider-show="smtp,office365,gmail,sendgrid,mailgun,ses">
                     <div class="row g-3 mb-3">
                         <div class="col-md-6">
                             <label for="email_from_address" class="form-label">From address</label>
@@ -519,14 +530,18 @@ require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head
                     </div>
                 </div>
 
-                <!-- SMTP-specific -->
-                <div class="email-fields" data-provider-show="smtp">
+                <!-- SMTP-specific (custom SMTP + the first-class office365 / gmail providers, #1309) -->
+                <div class="email-fields" data-provider-show="smtp,office365,gmail">
                     <hr class="text-secondary">
                     <h3 class="h6 mb-3"><i class="bi bi-server me-1"></i>SMTP server</h3>
 
                     <!-- feature C — provider preset. Pre-fills host / port /
                          encryption client-side from $SMTP_PRESETS (see the
-                         data-smtp-presets script JSON below). -->
+                         data-smtp-presets script JSON below). #1309: shown ONLY
+                         for the generic "SMTP (custom server)" choice — for the
+                         Microsoft 365 / Google Workspace providers the endpoint
+                         is implied and auto-filled by the provider-change JS. -->
+                    <div class="email-fields" data-provider-show="smtp">
                     <div class="row g-3 mb-3">
                         <div class="col-md-6">
                             <label for="email_smtp_preset" class="form-label">Provider preset</label>
@@ -547,6 +562,7 @@ require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head
                             </div>
                         </div>
                     </div>
+                    </div><!-- /preset row (custom-SMTP only, #1309) -->
 
                     <div class="row g-3 mb-3">
                         <div class="col-md-6">
@@ -748,7 +764,7 @@ require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head
                     </h3>
                     <div id="instr-m365" class="accordion-collapse collapse" data-bs-parent="#email-instructions">
                         <div class="accordion-body small">
-                            <p>Pick provider <strong>SMTP</strong>, then preset <strong>Microsoft 365</strong> — that fills
+                            <p>Pick provider <strong>Microsoft 365 (Exchange Online)</strong> — that fills
                                host <code>smtp.office365.com</code>, port <code>587</code>, encryption <code>STARTTLS</code>.</p>
                             <ol class="mb-2">
                                 <li><strong>Enable SMTP AUTH on the sending mailbox.</strong> In the
@@ -785,7 +801,7 @@ require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head
                     </h3>
                     <div id="instr-gws" class="accordion-collapse collapse" data-bs-parent="#email-instructions">
                         <div class="accordion-body small">
-                            <p>Pick provider <strong>SMTP</strong>, then preset <strong>Google Workspace / Gmail</strong> — that fills
+                            <p>Pick provider <strong>Google Workspace / Gmail</strong> — that fills
                                host <code>smtp.gmail.com</code>, port <code>587</code>, encryption <code>STARTTLS</code>.</p>
                             <ol class="mb-2">
                                 <li><strong>Turn on 2-Step Verification</strong> on the sending account (required before
@@ -981,15 +997,25 @@ require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head
     const portEl   = document.getElementById('email_smtp_port');
     const secureEl = document.getElementById('email_smtp_secure');
 
-    presetSel.addEventListener('change', () => {
-        const cfg = presets[presetSel.value];
+    const fill = (cfg) => {
         /* 'custom' (and any unknown key) has empty host/port/secure — skip
            so we never wipe what the admin already typed. */
         if (!cfg || !cfg.host) return;
         if (hostEl)   hostEl.value = cfg.host;
         if (portEl)   portEl.value = cfg.port;
         if (secureEl && cfg.secure) secureEl.value = cfg.secure;
-    });
+    };
+    presetSel.addEventListener('change', () => fill(presets[presetSel.value]));
+
+    /* #1309 — Microsoft 365 / Google Workspace are now first-class PROVIDERS.
+       Their email_service value matches a preset key, so when the admin picks
+       one we apply the same host/port/encryption pre-fill. Only on an explicit
+       change (never on initial load) so a previously-saved host isn't clobbered
+       when the page renders with the provider already selected. */
+    const providerSel = document.querySelector('[data-email-provider]');
+    if (providerSel) {
+        providerSel.addEventListener('change', () => fill(presets[providerSel.value]));
+    }
 })();
 </script>
 </body>

--- a/appWeb/public_html/manage/editor/api2.php
+++ b/appWeb/public_html/manage/editor/api2.php
@@ -15,8 +15,11 @@ declare(strict_types=1);
  * API + OpenAPI docs to be redone next (tracked follow-up).
  *
  * Wire format: `action` via query string (GET reads) or JSON body (POST writes).
- * Every POST requires the `X-CSRF-Token` header (the legacy editor API had NO
- * CSRF — this closes that gap). All values are bound (`bind_param`), every
+ * Every POST requires the `X-Requested-With: XMLHttpRequest` header — the same
+ * same-origin AJAX CSRF defence as the public api.php (#293), chosen over a
+ * per-form session token because the embedded token went stale / absent under
+ * the cross-subdomain token-adopted admin session and 403'd every POST (#1307).
+ * All values are bound (`bind_param`), every
  * mutation writes a `logActivity` row + a coalesced `tblSongRevisions` snapshot,
  * and every response is `{ ok, ... }` with the TRUE result (never a false
  * success — the lesson from the client-only `deleteSong()` that lied).
@@ -115,9 +118,28 @@ if ($method === 'POST') {
     $raw  = file_get_contents('php://input') ?: '';
     $body = json_decode($raw, true);
     if (!is_array($body)) { $body = []; }
-    /* CSRF on every state-changing request. */
-    if (!validateCsrf((string)($_SERVER['HTTP_X_CSRF_TOKEN'] ?? ''))) {
-        ed2_respond(['ok' => false, 'error' => 'Invalid or missing CSRF token.'], 403);
+    /* CSRF defence — aligned with the public api.php policy (#293), NOT a
+       per-form session token (#1307).
+       WHY THE CHANGE: the previous gate validated $_SESSION['csrf_token']
+       against the X-CSRF-Token header. That session token is baked into the
+       editor page HTML (window.IHYMNS_EDITOR_CSRF) at load time, so it goes
+       stale the moment the PHP session's token rotates (re-login / session
+       regeneration / GC) under a long-lived editor tab — or is simply absent
+       when the admin is authed via the adopted cross-subdomain `ihymns_auth`
+       token rather than a persistent /manage/ PHP session. Either case made
+       hash_equals() fail and 403'd EVERY api2 POST (delete_song, the line
+       enrichment upserts, …), e.g. "Here to Stay" #1289.
+       THE DEFENCE STACK (identical to api.php, which is why save_song over
+       there always worked): (1) this endpoint already requires isAuthenticated()
+       + the editor role above; the auth cookies are SameSite (manage session =
+       Strict, ihymns_auth = Lax) so a cross-site POST carries no identity → 401.
+       (2) X-Requested-With: XMLHttpRequest is a forbidden header name a cross-
+       origin <form>/navigation cannot set without a CORS preflight we never
+       honour — so only same-origin `fetch()` (editor.js ed2EnrichApi, which
+       already sends it) reaches here. That eliminates the classic CSRF surface
+       without depending on a fragile embedded token. */
+    if (($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '') !== 'XMLHttpRequest') {
+        ed2_respond(['ok' => false, 'error' => 'Cross-site POST blocked: missing or invalid X-Requested-With header.'], 403);
     }
 }
 


### PR DESCRIPTION
Targets **alpha**. Three follow-ups from testing the #1305 bundle — two regressions surfaced by exercising it, one feature gap. Atomic per-fix commits.

### #1307 — Editor `delete_song` 403 (and all api2 POSTs) — `manage/editor/api2.php`
api2 validated a per-form **session** CSRF token, which is stale/absent under this codebase's cross-subdomain token-adopted admin session (and rotates out from under a long-lived editor tab). Replaced with the **`X-Requested-With: XMLHttpRequest`** same-origin guard the public `api.php` already uses (#293) — which is exactly why `save_song` (→api.php) worked while `delete_song` (→api2) didn't. The client already sends the header. **Fixes "Here to Stay" #1289.**

### #1308 — Maintenance admin-bypass banner overlapped the fixed navbar — `index.php`
The #1233 banner was `position:sticky;z-1080`, painting over the `position:fixed` `.app-header` (z-1030) and hiding the nav/profile controls. Now `position:fixed` + a nonce'd script that offsets the header and `.main-content` by the banner's **measured** height (wraps on mobile; re-measured on resize).

### #1309 — Microsoft 365 + Google Workspace as first-class Provider options — `includes/smtp_presets.php` (new), `manage/configuration.php`, `includes/EmailService.php`
They were a hidden SMTP "preset"; now they're direct Provider choices that auto-fill host/port/encryption and route through SMTP-AUTH. New shared `smtp_presets.php` is the single source of truth for the UI **and** the sender.

## Security review (pre-PR)
- **#1307 CSRF change** — *not* a weakening: auth is still enforced (`isAuthenticated()` + editor role) before any side-effect; the SameSite auth cookies (manage=Strict, `ihymns_auth`=Lax) block cross-site POST identity → 401; `X-Requested-With` is a forbidden header cross-origin callers can't set without a preflight we don't honour. This is the codebase's own established, reviewed policy (#293). The previous session-token gate was *broken* in this auth model (provided no real protection — it just 403'd legitimate admins).
- **#1309 email** — `email_service` still validated against the allow-list on save; M365/Google host/port come from a hard-coded preset (no user input into the default); the free-text host override is unchanged in scope (SSRF hardening already parked as #1304); no secret rendered or logged.
- **#1308 banner** — nonce'd inline script, no user input, reads `offsetHeight` + sets `style` only (no `innerHTML`).

PHP `php -l` + inline-JS `node --check` clean across all five touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)