### PR TITLE
fix(api): app_status reports per-env maintenance state (#1313)

### DIFF
--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -3489,7 +3489,12 @@ if ($action !== null) {
             $db = getDbMysqli();
             /* Only fetch public-safe settings — never expose internal config.
                Dynamic IN-list with str_repeat for the bind type string. */
-            $publicKeys = ['maintenance_mode', 'maintenance_message', 'song_requests_enabled', 'motd', 'registration_mode', 'email_service', 'captcha_provider', 'ads_enabled', 'content_gating_enabled'];
+            /* #1313 — maintenance is PER-ENV and is sourced below via the canonical
+               env-aware helpers (isMaintenanceMode()/maintenanceMessage()), NOT from
+               here: the non-env-suffixed maintenance_mode/_message keys are never set,
+               so reading them made the PWA flag permanently false. The rest of these
+               public settings ARE global keys. */
+            $publicKeys = ['song_requests_enabled', 'motd', 'registration_mode', 'email_service', 'captcha_provider', 'ads_enabled', 'content_gating_enabled'];
             $placeholders = implode(',', array_fill(0, count($publicKeys), '?'));
             $stmt = $db->prepare(
                 "SELECT SettingKey, SettingValue FROM tblAppSettings WHERE SettingKey IN ({$placeholders})"
@@ -3504,9 +3509,14 @@ if ($action !== null) {
                 $settings[$row['SettingKey']] = $row['SettingValue'];
             }
 
+            /* #1313 — env-aware maintenance state via the SAME helpers the 503 gate
+               uses (includes/maintenance.php, already required by this entry point).
+               Message only when actually in maintenance, so app_status stays empty-
+               when-off as before (maintenanceMessage() otherwise returns a default). */
+            $inMaintenance = function_exists('isMaintenanceMode') ? isMaintenanceMode() : false;
             sendJson([
-                'maintenance'         => ($settings['maintenance_mode'] ?? '0') === '1',
-                'maintenanceMessage'  => $settings['maintenance_message'] ?? '',
+                'maintenance'         => $inMaintenance,
+                'maintenanceMessage'  => ($inMaintenance && function_exists('maintenanceMessage')) ? maintenanceMessage() : '',
                 'songRequestsEnabled' => ($settings['song_requests_enabled'] ?? '1') === '1',
                 'registrationMode'    => $settings['registration_mode'] ?? 'open',
                 'motd'                => $settings['motd'] ?? '',


### PR DESCRIPTION
Targets **alpha**. Fixes the env-specific caution surfaced by the #1310 readiness audit.

`/api?action=app_status` read the non-env-suffixed `maintenance_mode` / `maintenance_message` keys, but maintenance is stored/read per-env (`maintenance_mode_<env>`). So `app_status.maintenance` was always false — the 503 gate worked but the **client** signal was dead (the app.js PWA maintenance banner never showed; the #1301 install-banner suppression never fired). Now sourced from the canonical env-aware `isMaintenanceMode()` + `maintenanceMessage()` (the same helpers the gate uses), message only when actually in maintenance.

One file, `php -l` clean. Lands on alpha so it's carried into beta/main by the promotion (#1312) — no separate prod fix needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)