### PR TITLE
feat(email): OAuth2 drivers — Microsoft Graph (M365) + Gmail API (Google) (#1311)

### DIFF
--- a/appWeb/public_html/includes/EmailService.php
+++ b/appWeb/public_html/includes/EmailService.php
@@ -34,9 +34,18 @@ declare(strict_types=1);
  *                sending where the From / Sender address differs from the
  *                SMTP AUTH login (the login mailbox must be granted
  *                Send-As on the delegate mailbox in the provider's admin
- *                console — see the configuration.php setup guides). OAuth2
- *                (and the eventual MailerMatt service) is the future path;
- *                today it is SMTP-AUTH + an app password + delegate. (feature C)
+ *                console — see the configuration.php setup guides). (feature C)
+ *   - graph    : Microsoft 365 via Microsoft Graph (OAuth2 app-only) — #1311.
+ *                client-credentials token → POST /users/{sender}/sendMail with
+ *                the Mail.Send application permission. No SMTP, no app password;
+ *                the modern path immune to Basic-Auth / SMTP-AUTH deprecation.
+ *                Selected when email_service=office365 + email_auth_method=oauth2.
+ *   - gmail-api : Google Workspace via the Gmail API (OAuth2 service-account +
+ *                domain-wide delegation) — #1311. Signed JWT → access token
+ *                impersonating the sender → users/{sender}/messages/send (raw
+ *                base64url RFC822). Selected when email_service=gmail +
+ *                email_auth_method=oauth2. (MailerMatt remains the eventual
+ *                consolidated mechanism; these are the native OAuth2 drivers.)
  *   - log      : developer-only "send to PHP error_log" mode. Sanitises
  *                the log line — never writes the magic-link token, the
  *                6-digit code, or the verification token. The raw
@@ -199,11 +208,22 @@ final class EmailService
             case 'ses':
                 return self::sendViaSes($to, $subject, $bodyHtml, $bodyText, $cfg);
             case 'office365':
-            case 'gmail':
                 /* #1309 — Microsoft 365 / Google Workspace are first-class
-                   providers that ride the same SMTP-AUTH transport; sendViaSmtp
-                   defaults host/port/secure from the shared preset keyed by the
-                   service when the admin left them blank. */
+                   providers. #1311 — each can authenticate via SMTP-AUTH (app
+                   password) OR an OAuth2 REST API. email_auth_method picks;
+                   default 'smtp' preserves the #1309 behaviour for existing
+                   configs. M365's OAuth2 path is Microsoft Graph (app-only). */
+                if (($cfg['email_auth_method'] ?? 'smtp') === 'oauth2') {
+                    return self::sendViaGraph($to, $subject, $bodyHtml, $bodyText, $cfg);
+                }
+                return self::sendViaSmtp($to, $subject, $bodyHtml, $bodyText, $cfg);
+            case 'gmail':
+                /* #1311 — Google Workspace OAuth2 path is the Gmail API
+                   (service-account + domain-wide delegation). */
+                if (($cfg['email_auth_method'] ?? 'smtp') === 'oauth2') {
+                    return self::sendViaGmailApi($to, $subject, $bodyHtml, $bodyText, $cfg);
+                }
+                return self::sendViaSmtp($to, $subject, $bodyHtml, $bodyText, $cfg);
             case 'smtp':
                 /* feature C — real SMTP-AUTH client with STARTTLS / implicit
                    SSL, AUTH LOGIN, and delegate ("send-as") From support.
@@ -723,6 +743,219 @@ final class EmailService
     }
 
     /* -------------------------------------------------------------------
+     * Driver: Microsoft Graph (OAuth2 app-only) — #1311
+     *
+     * The modern alternative to SMTP-AUTH for Microsoft 365, immune to the
+     * Basic-Auth / SMTP-AUTH deprecation. OAuth2 client-credentials grant
+     * (app-only) against the tenant token endpoint → POST /users/{sender}/
+     * sendMail with the Mail.Send APPLICATION permission. Requires (Azure):
+     * an app registration with Mail.Send application permission + admin
+     * consent, a client secret, and the sender mailbox UPN. The client
+     * secret + bearer token are NEVER logged (only short error codes are).
+     * ----------------------------------------------------------------- */
+    private static function sendViaGraph(string $to, string $subject, string $bodyHtml, string $bodyText, array $cfg): EmailSendResult
+    {
+        $tenant = trim((string)($cfg['email_graph_tenant_id'] ?? ''));
+        $client = trim((string)($cfg['email_graph_client_id'] ?? ''));
+        $secret = (string)($cfg['email_graph_client_secret'] ?? '');
+        $sender = trim((string)($cfg['email_graph_sender'] ?? ''));
+        if ($tenant === '' || $client === '' || $secret === '' || $sender === '') {
+            return EmailSendResult::failure('graph', 'missing_tenant_client_secret_or_sender', 'NotConfigured');
+        }
+
+        $from      = self::oauthFrom($cfg, $sender);   /* default From = sender; explicit delegate = Send-As */
+        $fromEmail = $from['email'];
+
+        /* 1) OAuth2 client-credentials token. scope=.default grants the app's
+              consented application permissions (Mail.Send). */
+        $tok = self::httpPostForm(
+            'https://login.microsoftonline.com/' . rawurlencode($tenant) . '/oauth2/v2.0/token',
+            [
+                'client_id'     => $client,
+                'client_secret' => $secret,
+                'scope'         => 'https://graph.microsoft.com/.default',
+                'grant_type'    => 'client_credentials',
+            ],
+            []
+        );
+        if ($tok['err'] !== '') {
+            return EmailSendResult::failure('graph', 'token_' . $tok['err'], 'TransportError');
+        }
+        if ($tok['code'] < 200 || $tok['code'] >= 300) {
+            return EmailSendResult::failure('graph', 'token_http_' . $tok['code'] . ':' . self::oauthErr($tok['body']), 'AuthError', $tok['code']);
+        }
+        $accessToken = (string)(json_decode($tok['body'], true)['access_token'] ?? '');
+        if ($accessToken === '') {
+            return EmailSendResult::failure('graph', 'token_no_access_token', 'AuthError');
+        }
+
+        /* 2) sendMail. From defaults to the sender mailbox; an explicit
+              different From requires Send-As granted on it (the SMTP delegate
+              model). Setting From = the sender's own address is always valid. */
+        $fromAddr = ['address' => $fromEmail];
+        if (($from['name'] ?? '') !== '') { $fromAddr['name'] = (string)$from['name']; }
+        $message = [
+            'subject'      => $subject,
+            'body'         => ['contentType' => 'HTML', 'content' => $bodyHtml],
+            'toRecipients' => [['emailAddress' => ['address' => $to]]],
+            'from'         => ['emailAddress' => $fromAddr],
+        ];
+
+        $resp = self::httpPostJson(
+            'https://graph.microsoft.com/v1.0/users/' . rawurlencode($sender) . '/sendMail',
+            ['message' => $message, 'saveToSentItems' => false],
+            [
+                'Authorization: Bearer ' . $accessToken,
+                'Content-Type: application/json',
+            ]
+        );
+        if ($resp['err'] !== '') {
+            return EmailSendResult::failure('graph', $resp['err'], 'TransportError');
+        }
+        if ($resp['code'] >= 200 && $resp['code'] < 300) {
+            return EmailSendResult::success('graph', null);   /* 202 Accepted, no Message-Id */
+        }
+        return EmailSendResult::failure('graph', 'http_' . $resp['code'] . ':' . self::oauthErr($resp['body']), 'ProviderError', $resp['code']);
+    }
+
+    /* -------------------------------------------------------------------
+     * Driver: Gmail API (OAuth2 service-account + domain-wide delegation) — #1311
+     *
+     * The Google Workspace equivalent of the Graph path. A service account
+     * with domain-wide delegation for the gmail.send scope signs a JWT,
+     * exchanges it for an access token impersonating the configured sender,
+     * then POSTs a base64url RFC822 message to users/{sender}/messages/send.
+     * Requires (Google Cloud): a project with the Gmail API enabled, a
+     * service-account JSON key, and domain-wide delegation authorised for the
+     * gmail.send scope in the Workspace Admin console. The private key +
+     * bearer token are NEVER logged.
+     * ----------------------------------------------------------------- */
+    private static function sendViaGmailApi(string $to, string $subject, string $bodyHtml, string $bodyText, array $cfg): EmailSendResult
+    {
+        $saJson = (string)($cfg['email_gmail_sa_json'] ?? '');
+        $sender = trim((string)($cfg['email_gmail_sender'] ?? ''));
+        if ($saJson === '' || $sender === '') {
+            return EmailSendResult::failure('gmail-api', 'missing_service_account_or_sender', 'NotConfigured');
+        }
+        if (!function_exists('openssl_sign')) {
+            return EmailSendResult::failure('gmail-api', 'openssl_extension_missing', 'TransportError');
+        }
+        $sa = json_decode($saJson, true);
+        if (!is_array($sa) || empty($sa['client_email']) || empty($sa['private_key'])) {
+            return EmailSendResult::failure('gmail-api', 'invalid_service_account_json', 'NotConfigured');
+        }
+        /* token_uri comes from the pasted SA JSON; constrain it to a Google
+           host (defence-in-depth) so a tampered key can't aim the signed
+           assertion elsewhere. Falls back to the canonical endpoint. */
+        $tokenUri = (string)($sa['token_uri'] ?? 'https://oauth2.googleapis.com/token');
+        $tuHost   = (string)parse_url($tokenUri, PHP_URL_HOST);
+        if (stripos($tokenUri, 'https://') !== 0 || substr($tuHost, -15) !== '.googleapis.com') {
+            $tokenUri = 'https://oauth2.googleapis.com/token';
+        }
+
+        $from = self::oauthFrom($cfg, $sender);   /* default From = impersonated sender; explicit delegate = verified send-as */
+
+        /* 1) Build + sign the JWT assertion (RS256), impersonating $sender via
+              domain-wide delegation (the `sub` claim). iat is backdated 60s to
+              absorb server clock-skew vs Google (a fast clock → invalid_grant). */
+        $now    = time();
+        $header = ['alg' => 'RS256', 'typ' => 'JWT'];
+        $claims = [
+            'iss'   => (string)$sa['client_email'],
+            'sub'   => $sender,
+            'scope' => 'https://www.googleapis.com/auth/gmail.send',
+            'aud'   => $tokenUri,
+            'iat'   => $now - 60,
+            'exp'   => $now + 3600,
+        ];
+        $signingInput = self::b64url((string)json_encode($header)) . '.' . self::b64url((string)json_encode($claims));
+        $signature    = '';
+        if (!@openssl_sign($signingInput, $signature, (string)$sa['private_key'], OPENSSL_ALGO_SHA256)) {
+            return EmailSendResult::failure('gmail-api', 'jwt_signing_failed', 'AuthError');
+        }
+        $assertion = $signingInput . '.' . self::b64url($signature);
+
+        /* 2) Exchange the JWT for an access token. */
+        $tok = self::httpPostForm($tokenUri, [
+            'grant_type' => 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+            'assertion'  => $assertion,
+        ], []);
+        if ($tok['err'] !== '') {
+            return EmailSendResult::failure('gmail-api', 'token_' . $tok['err'], 'TransportError');
+        }
+        if ($tok['code'] < 200 || $tok['code'] >= 300) {
+            return EmailSendResult::failure('gmail-api', 'token_http_' . $tok['code'] . ':' . self::oauthErr($tok['body']), 'AuthError', $tok['code']);
+        }
+        $accessToken = (string)(json_decode($tok['body'], true)['access_token'] ?? '');
+        if ($accessToken === '') {
+            return EmailSendResult::failure('gmail-api', 'token_no_access_token', 'AuthError');
+        }
+
+        /* 3) Build the RFC822 message (reuse the SMTP MIME builder) and send it
+              base64url-encoded via the Gmail API. */
+        $raw  = self::smtpBuildMessage($from, $to, $subject, $bodyHtml, $bodyText);
+        $resp = self::httpPostJson(
+            'https://gmail.googleapis.com/gmail/v1/users/' . rawurlencode($sender) . '/messages/send',
+            ['raw' => self::b64url($raw)],
+            [
+                'Authorization: Bearer ' . $accessToken,
+                'Content-Type: application/json',
+            ]
+        );
+        if ($resp['err'] !== '') {
+            return EmailSendResult::failure('gmail-api', $resp['err'], 'TransportError');
+        }
+        if ($resp['code'] >= 200 && $resp['code'] < 300) {
+            $msgId = (string)(json_decode($resp['body'], true)['id'] ?? '');
+            return EmailSendResult::success('gmail-api', $msgId !== '' ? $msgId : null);
+        }
+        return EmailSendResult::failure('gmail-api', 'http_' . $resp['code'] . ':' . self::oauthErr($resp['body']), 'ProviderError', $resp['code']);
+    }
+
+    /** base64url (RFC 4648 §5, unpadded) — JWT segments + Gmail raw message. */
+    private static function b64url(string $data): string
+    {
+        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+    }
+
+    /**
+     * Extract a SHORT, secret-free error summary from an OAuth/REST error body.
+     * Never receives or returns a token/secret — the success bodies (which carry
+     * access_token) are parsed separately and never reach here.
+     */
+    private static function oauthErr(string $body): string
+    {
+        $j = json_decode($body, true);
+        if (is_array($j)) {
+            if (isset($j['error']) && is_array($j['error'])) {        /* Graph: {error:{code,message}} */
+                return self::sanitiseForLog(trim((string)($j['error']['code'] ?? '') . ' ' . (string)($j['error']['message'] ?? '')), 180);
+            }
+            if (isset($j['error_description'])) {                     /* Google/AAD: {error,error_description} */
+                return self::sanitiseForLog((string)$j['error_description'], 180);
+            }
+            if (isset($j['error']) && is_string($j['error'])) {
+                return self::sanitiseForLog($j['error'], 180);
+            }
+        }
+        return self::sanitiseForLog($body, 120);
+    }
+
+    /**
+     * #1311 — From for the OAuth2 drivers. Prefers an EXPLICIT delegate /
+     * send-as address (email_smtp_from_address) only; otherwise defaults to the
+     * OAuth sender mailbox (always authorised), NOT the generic cross-provider
+     * email_from_address — so a leftover From from another provider's setup
+     * can't silently 400/rewrite a Graph/Gmail send. A delegate From still
+     * needs Send-As (Graph) / a verified "Send mail as" alias (Gmail).
+     */
+    private static function oauthFrom(array $cfg, string $sender): array
+    {
+        $delegate = trim((string)($cfg['email_smtp_from_address'] ?? ''));
+        $email = ($delegate !== '' && filter_var($delegate, FILTER_VALIDATE_EMAIL)) ? $delegate : $sender;
+        return ['email' => $email, 'name' => self::fromAddress($cfg)['name']];
+    }
+
+    /* -------------------------------------------------------------------
      * Internal helpers
      * ----------------------------------------------------------------- */
 
@@ -783,6 +1016,15 @@ final class EmailService
             'email_sendgrid_api_key',
             'email_mailgun_api_key', 'email_mailgun_domain',
             'email_ses_region', 'email_ses_access_key', 'email_ses_secret_key',
+            /* #1311 — OAuth2 API transport. email_auth_method ('smtp'|'oauth2')
+               selects, for the office365/gmail providers, between the SMTP-AUTH
+               driver and the OAuth2 REST driver (Microsoft Graph / Gmail API).
+               office365 → Graph (tenant/client/secret + sender mailbox);
+               gmail → Gmail API (service-account JSON + impersonated sender). */
+            'email_auth_method',
+            'email_graph_tenant_id', 'email_graph_client_id',
+            'email_graph_client_secret', 'email_graph_sender',
+            'email_gmail_sa_json', 'email_gmail_sender',
         ];
         try {
             $db = getDbMysqli();

--- a/appWeb/public_html/manage/configuration.php
+++ b/appWeb/public_html/manage/configuration.php
@@ -85,6 +85,24 @@ $EMAIL_SETTINGS = [
     'email_ses_region'          => ['AWS region (e.g. eu-west-1)', 'text', false, ['ses']],
     'email_ses_access_key'      => ['AWS access key',            'password', true, ['ses']],
     'email_ses_secret_key'      => ['AWS secret key',            'password', true, ['ses']],
+    /* #1311 — OAuth2 API transport. The auth-method selector applies to the
+       office365/gmail providers; the Graph + Gmail-API credential fields show
+       only when method=oauth2 (client-side data-auth-show). The secrets (client
+       secret, service-account JSON) keep secret=true → blank-skip on save +
+       redaction from the activity-log key list. */
+    'email_auth_method'         => ['Authentication method',          'select',   false, ['office365','gmail']],
+    'email_graph_tenant_id'     => ['Azure tenant ID',                'text',     false, ['office365']],
+    'email_graph_client_id'     => ['Azure app (client) ID',          'text',     false, ['office365']],
+    'email_graph_client_secret' => ['Azure client secret',            'password', true,  ['office365']],
+    'email_graph_sender'        => ['Sender mailbox (UPN)',           'text',     false, ['office365']],
+    'email_gmail_sa_json'       => ['Service-account JSON key',       'textarea', true,  ['gmail']],
+    'email_gmail_sender'        => ['Sender mailbox (impersonated)',  'text',     false, ['gmail']],
+];
+
+/* #1311 — OAuth2 transport options for the office365/gmail providers. */
+$EMAIL_AUTH_METHOD_OPTIONS = [
+    'smtp'   => 'SMTP-AUTH (host + app password)',
+    'oauth2' => 'OAuth2 API (Microsoft Graph / Gmail API — no SMTP)',
 ];
 
 /* #1309 — Microsoft 365 + Google Workspace are now FIRST-CLASS providers in
@@ -218,6 +236,20 @@ if (($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'POST') {
                        anything else (incl. a tampered POST) → 'custom'. */
                     if ($key === 'email_smtp_preset' && !isset($SMTP_PRESETS[$value])) {
                         $value = 'custom';
+                    }
+                    /* #1311 — auth method constrained to the option list. */
+                    if ($key === 'email_auth_method' && !isset($EMAIL_AUTH_METHOD_OPTIONS[$value])) {
+                        $value = 'smtp';
+                    }
+                    /* #1311 — service-account JSON must be valid + carry the
+                       fields the Gmail-API driver needs (client_email +
+                       private_key) before it can reach EmailService. Empty is
+                       allowed (secret blank-skip below keeps the existing key). */
+                    if ($key === 'email_gmail_sa_json' && $value !== '') {
+                        $sa = json_decode($value, true);
+                        if (!is_array($sa) || empty($sa['client_email']) || empty($sa['private_key'])) {
+                            throw new \RuntimeException('Service-account JSON is not valid — it must be the downloaded key file containing "client_email" and "private_key".');
+                        }
                     }
                     /* feature C — delegate / send-as address. Empty is
                        allowed (means "no delegate, use the generic From");
@@ -585,8 +617,33 @@ require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head
                     </div>
                 </div>
 
-                <!-- SMTP-specific (custom SMTP + the first-class office365 / gmail providers, #1309) -->
-                <div class="email-fields" data-provider-show="smtp,office365,gmail">
+                <!-- #1311 — transport selector for the office365 / gmail providers:
+                     SMTP-AUTH (host + app password) vs OAuth2 API (Graph / Gmail API). -->
+                <div class="email-fields" data-provider-show="office365,gmail">
+                    <hr class="text-secondary">
+                    <div class="row g-3 mb-3">
+                        <div class="col-md-6">
+                            <label for="email_auth_method" class="form-label">Authentication method</label>
+                            <select name="email_auth_method" id="email_auth_method" class="form-select" data-email-auth-method>
+                                <?php
+                                    $authMethod = $currentSettings['email_auth_method'] ?? 'smtp';
+                                    foreach ($EMAIL_AUTH_METHOD_OPTIONS as $amVal => $amLabel):
+                                ?>
+                                    <option value="<?= htmlspecialchars($amVal, ENT_QUOTES, 'UTF-8') ?>" <?= $authMethod === $amVal ? 'selected' : '' ?>>
+                                        <?= htmlspecialchars($amLabel, ENT_QUOTES, 'UTF-8') ?>
+                                    </option>
+                                <?php endforeach; ?>
+                            </select>
+                            <div class="form-text">
+                                <strong>SMTP-AUTH</strong> = host + app password (simplest).
+                                <strong>OAuth2 API</strong> = Microsoft Graph (M365) / Gmail API (Google) — recommended where Basic-Auth / SMTP-AUTH is disabled on the tenant.
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- SMTP-specific: custom SMTP, OR the office365/gmail providers when method=SMTP-AUTH (#1309/#1311) -->
+                <div class="email-fields" data-provider-show="smtp,office365,gmail" data-auth-show="smtp">
                     <hr class="text-secondary">
                     <h3 class="h6 mb-3"><i class="bi bi-server me-1"></i>SMTP server</h3>
 
@@ -696,6 +753,72 @@ require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head
                                    placeholder="iHymns">
                         </div>
                     </div>
+                </div>
+
+                <!-- #1311 — Microsoft Graph (OAuth2 app-only); M365 + method=OAuth2 API -->
+                <div class="email-fields" data-provider-show="office365" data-auth-show="oauth2">
+                    <hr class="text-secondary">
+                    <h3 class="h6 mb-3"><i class="bi bi-microsoft me-1"></i>Microsoft Graph (OAuth2)</h3>
+                    <div class="row g-3 mb-3">
+                        <div class="col-md-6">
+                            <label for="email_graph_tenant_id" class="form-label">Azure tenant ID</label>
+                            <input type="text" name="email_graph_tenant_id" id="email_graph_tenant_id" class="form-control" autocomplete="off"
+                                   value="<?= htmlspecialchars($currentSettings['email_graph_tenant_id'] ?? '', ENT_QUOTES, 'UTF-8') ?>"
+                                   placeholder="00000000-0000-0000-0000-000000000000">
+                        </div>
+                        <div class="col-md-6">
+                            <label for="email_graph_client_id" class="form-label">App (client) ID</label>
+                            <input type="text" name="email_graph_client_id" id="email_graph_client_id" class="form-control" autocomplete="off"
+                                   value="<?= htmlspecialchars($currentSettings['email_graph_client_id'] ?? '', ENT_QUOTES, 'UTF-8') ?>"
+                                   placeholder="00000000-0000-0000-0000-000000000000">
+                        </div>
+                    </div>
+                    <div class="row g-3 mb-3">
+                        <div class="col-md-6">
+                            <label for="email_graph_client_secret" class="form-label">
+                                Client secret
+                                <?php if (!empty($currentSettings['email_graph_client_secret'])): ?>
+                                    <span class="badge bg-secondary ms-1" style="font-size: 0.65rem;">saved — leave blank to keep</span>
+                                <?php endif; ?>
+                            </label>
+                            <input type="password" name="email_graph_client_secret" id="email_graph_client_secret" class="form-control" autocomplete="new-password"
+                                   placeholder="<?= !empty($currentSettings['email_graph_client_secret']) ? '••••••••' : 'client secret VALUE (not the secret ID)' ?>">
+                        </div>
+                        <div class="col-md-6">
+                            <label for="email_graph_sender" class="form-label">Sender mailbox (UPN)</label>
+                            <input type="email" name="email_graph_sender" id="email_graph_sender" class="form-control" autocomplete="off"
+                                   value="<?= htmlspecialchars($currentSettings['email_graph_sender'] ?? '', ENT_QUOTES, 'UTF-8') ?>"
+                                   placeholder="noreply@yourtenant.com">
+                        </div>
+                    </div>
+                    <div class="form-text">Sends via the <strong>Mail.Send</strong> application permission (admin-consented). No SMTP, no app password — survives Basic-Auth deprecation. See the setup guide below.</div>
+                </div>
+
+                <!-- #1311 — Gmail API (OAuth2 service-account + domain-wide delegation); Google + method=OAuth2 API -->
+                <div class="email-fields" data-provider-show="gmail" data-auth-show="oauth2">
+                    <hr class="text-secondary">
+                    <h3 class="h6 mb-3"><i class="bi bi-google me-1"></i>Gmail API (OAuth2 service account)</h3>
+                    <div class="row g-3 mb-3">
+                        <div class="col-md-6">
+                            <label for="email_gmail_sender" class="form-label">Sender mailbox (impersonated)</label>
+                            <input type="email" name="email_gmail_sender" id="email_gmail_sender" class="form-control" autocomplete="off"
+                                   value="<?= htmlspecialchars($currentSettings['email_gmail_sender'] ?? '', ENT_QUOTES, 'UTF-8') ?>"
+                                   placeholder="noreply@yourdomain.com">
+                            <div class="form-text">The Workspace user the service account impersonates (domain-wide delegation).</div>
+                        </div>
+                        <div class="col-md-6">
+                            <label for="email_gmail_sa_json" class="form-label">
+                                Service-account JSON key
+                                <?php if (!empty($currentSettings['email_gmail_sa_json'])): ?>
+                                    <span class="badge bg-secondary ms-1" style="font-size: 0.65rem;">saved — leave blank to keep</span>
+                                <?php endif; ?>
+                            </label>
+                            <textarea name="email_gmail_sa_json" id="email_gmail_sa_json" class="form-control font-monospace" rows="4" autocomplete="off" spellcheck="false"
+                                      placeholder="<?= !empty($currentSettings['email_gmail_sa_json']) ? '•••••••• (saved — paste a new key to replace)' : 'Paste the downloaded service-account .json key file' ?>"></textarea>
+                            <div class="form-text">The downloaded key file (contains <code>client_email</code> + <code>private_key</code>). Stored in <code>tblAppSettings</code>; never echoed back to this form.</div>
+                        </div>
+                    </div>
+                    <div class="form-text">Requires the Gmail API enabled + domain-wide delegation for the <code>gmail.send</code> scope. See the setup guide below.</div>
                 </div>
 
                 <!-- SendGrid -->
@@ -809,6 +932,52 @@ require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head
         </div>
         <div class="card-body">
             <div class="accordion" id="email-instructions">
+                <!-- #1311 — Microsoft Graph (OAuth2, recommended for M365) -->
+                <div class="accordion-item bg-dark">
+                    <h3 class="accordion-header">
+                        <button class="accordion-button collapsed bg-dark text-light" type="button"
+                                data-bs-toggle="collapse" data-bs-target="#instr-graph">
+                            <i class="bi bi-microsoft me-2"></i>OAuth2 — Microsoft 365 via Graph (recommended; no SMTP)
+                        </button>
+                    </h3>
+                    <div id="instr-graph" class="accordion-collapse collapse" data-bs-parent="#email-instructions">
+                        <div class="accordion-body small">
+                            <p>Pick provider <strong>Microsoft 365</strong>, then <strong>Authentication method → OAuth2 API</strong>. No SMTP host or app password — works even when SMTP AUTH is disabled on the tenant.</p>
+                            <ol class="mb-2">
+                                <li><strong>Register an app.</strong> <a href="https://entra.microsoft.com" target="_blank" rel="noopener">Microsoft Entra admin centre</a> → <em>Applications → App registrations → New registration</em>. Copy the <strong>Application (client) ID</strong> and <strong>Directory (tenant) ID</strong> into the fields above.</li>
+                                <li><strong>Grant the application permission.</strong> <em>API permissions → Add a permission → Microsoft Graph → Application permissions → Mail.Send</em>, then <strong>Grant admin consent</strong>. (Application — <em>not</em> Delegated.)</li>
+                                <li><strong>Create a client secret.</strong> <em>Certificates &amp; secrets → New client secret</em>. Copy the secret <strong>Value</strong> (not the Secret ID) into <strong>Client secret</strong> — it's shown only once.</li>
+                                <li><strong>Sender mailbox (UPN)</strong> = the mailbox the app sends as (e.g. <code>noreply@yourtenant.com</code>). App-only Mail.Send can reach any mailbox; restrict it with an <a href="https://learn.microsoft.com/graph/auth-limit-mailbox-access" target="_blank" rel="noopener">application access policy</a> if desired.</li>
+                                <li><strong>Save</strong>, then <strong>Send test email</strong>.</li>
+                            </ol>
+                            <p class="text-secondary mb-0"><strong>If it fails:</strong> <em>token_http_401</em> → wrong tenant / client / secret; <em>http_403</em> → admin consent missing or an access policy blocks the sender; <em>http_400</em> → the From differs from the sender mailbox without Send-As.</p>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- #1311 — Gmail API (OAuth2, recommended for Google Workspace) -->
+                <div class="accordion-item bg-dark">
+                    <h3 class="accordion-header">
+                        <button class="accordion-button collapsed bg-dark text-light" type="button"
+                                data-bs-toggle="collapse" data-bs-target="#instr-gmail-api">
+                            <i class="bi bi-google me-2"></i>OAuth2 — Google Workspace via Gmail API (recommended; no SMTP)
+                        </button>
+                    </h3>
+                    <div id="instr-gmail-api" class="accordion-collapse collapse" data-bs-parent="#email-instructions">
+                        <div class="accordion-body small">
+                            <p>Pick provider <strong>Google Workspace / Gmail</strong>, then <strong>Authentication method → OAuth2 API</strong>. Uses a service account with domain-wide delegation — no app password, no per-user OAuth dance.</p>
+                            <ol class="mb-2">
+                                <li><strong>Create a service account + JSON key.</strong> <a href="https://console.cloud.google.com" target="_blank" rel="noopener">Google Cloud console</a> → a project → <em>IAM &amp; Admin → Service accounts → Create</em>, then <em>Keys → Add key → JSON</em> and download the key file.</li>
+                                <li><strong>Enable the Gmail API</strong> on the project (<em>APIs &amp; Services → Enable APIs → Gmail API</em>).</li>
+                                <li><strong>Authorise domain-wide delegation.</strong> Copy the service account's <em>Client ID</em>, then in the <a href="https://admin.google.com" target="_blank" rel="noopener">Workspace Admin console</a> → <em>Security → Access and data control → API controls → Domain-wide delegation → Add new</em>, paste the Client ID and the scope <code>https://www.googleapis.com/auth/gmail.send</code>.</li>
+                                <li><strong>Paste the JSON key</strong> into <strong>Service-account JSON key</strong> above, and set <strong>Sender mailbox</strong> to the Workspace user to impersonate.</li>
+                                <li><strong>Save</strong>, then <strong>Send test email</strong>.</li>
+                            </ol>
+                            <p class="text-secondary mb-0"><strong>If it fails:</strong> <em>invalid_service_account_json</em> → the pasted key is malformed; <em>token_http_400 / unauthorized_client</em> → domain-wide delegation not authorised for the scope (or wrong Client ID); <em>http_403</em> → Gmail API not enabled, or the sender isn't a real mailbox.</p>
+                        </div>
+                    </div>
+                </div>
+
                 <!-- Microsoft 365 (priority) -->
                 <div class="accordion-item bg-dark">
                     <h3 class="accordion-header">
@@ -1007,16 +1176,28 @@ require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head
     const providerSel = document.querySelector('[data-email-provider]');
     const groups = document.querySelectorAll('[data-provider-show]');
     if (!providerSel || groups.length === 0) return;
+    /* #1311 — second visibility axis: the auth-method selector (SMTP-AUTH vs
+       OAuth2 API), which only exists for the office365/gmail providers. A group
+       tagged data-auth-show is shown only when its method matches; groups with
+       no data-auth-show ignore the axis. For any provider WITHOUT an auth-method
+       selector (smtp/sendgrid/…), the method is implicitly 'smtp'. */
+    const authSel = document.querySelector('[data-email-auth-method]');
 
     const apply = () => {
         const current = providerSel.value;
+        const hasAuthAxis = (current === 'office365' || current === 'gmail');
+        const method = (hasAuthAxis && authSel) ? authSel.value : 'smtp';
         groups.forEach((g) => {
             const allowed = (g.dataset.providerShow || '').split(',').map(s => s.trim());
-            const visible = allowed.includes(current);
+            let visible = allowed.includes(current);
+            if (visible && g.dataset.authShow !== undefined) {
+                const authAllowed = (g.dataset.authShow || '').split(',').map(s => s.trim());
+                visible = authAllowed.includes(method);
+            }
             g.style.display = visible ? '' : 'none';
             /* Disable inputs in hidden groups so the form doesn't
-               submit stale values when the admin switches provider
-               and saves. */
+               submit stale values when the admin switches provider /
+               method and saves. */
             g.querySelectorAll('input, select, textarea').forEach((inp) => {
                 if (visible) {
                     inp.removeAttribute('disabled');
@@ -1027,6 +1208,7 @@ require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head
         });
     };
     providerSel.addEventListener('change', apply);
+    if (authSel) { authSel.addEventListener('change', apply); }
     apply();
 })();
 


### PR DESCRIPTION
Targets **alpha**. Owner-confirmed #1311 — the OAuth2 REST transport beside the SMTP-AUTH shipped in #1309, so M365 / Google survive the Basic-Auth / SMTP-AUTH deprecation. Two atomic commits (driver, config UI).

### What
- **EmailService**: `sendViaGraph()` (client-credentials → `/users/{sender}/sendMail`, Mail.Send app permission) + `sendViaGmailApi()` (RS256 service-account JWT + domain-wide delegation → `messages/send`, base64url RFC822). `dispatch()` routes office365/gmail to OAuth2 **only** when `email_auth_method=oauth2`; default `smtp` preserves all existing configs. Reuses the existing cURL/MIME/sanitise helpers; adds `b64url()` + `oauthErr()`.
- **configuration.php**: an "Authentication method" selector (SMTP-AUTH ↔ OAuth2 API) for office365/gmail; the visibility JS gains a `data-auth-show` axis; Graph + Gmail credential fields (secrets never echoed); save validation (auth-method allow-list, SA-JSON structural check); two OAuth2 setup-guide accordions (Azure + Google Cloud).

### Review (3 lenses — all PASS)
A read-only adversarial review (security · OAuth correctness · integration) returned **PASS** on all three with no blockers/majors. Three minor fixes folded in:
- OAuth **From defaults to the impersonated sender** (`oauthFrom()`), not a leftover cross-provider `email_from_address` (which Gmail would 400/rewrite); an explicit delegate = Send-As.
- JWT **`iat` backdated 60s** (clock-skew → avoids `invalid_grant`).
- SA-JSON **`token_uri` constrained to `*.googleapis.com`** (defence-in-depth).

### Security
No client secret, service-account private key, or access token is ever logged, echoed to the form, or placed in an `EmailSendResult.error` (only secret-free error codes via `oauthErr`). Existing CSRF + `manage_configuration` gate untouched.

### ⚠️ Verification note
OAuth flows **cannot be exercised from the dev box** (no Azure/Google creds; web-only operator). `php -l` + inline-JS `node --check` are clean and the flows are built to the documented Graph/Gmail contracts, but **live verification is via "Send test email"** once real credentials are configured. MailerMatt remains the eventual consolidated mechanism; these are the native drivers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)