### PR TITLE
fix(scraper): SDA 403 fails loud + fast with a WAF/IP-block diagnostic (#1306)

### DIFF
--- a/.importers/scrapers/SDAHymnals_SDAHymnal.org.py
+++ b/.importers/scrapers/SDAHymnals_SDAHymnal.org.py
@@ -1056,8 +1056,18 @@ def fetch_hymn(number, base_url, home_url):
                     # All 3 attempts failed — skip this hymn
                     print(f"  server error (500) after 3 attempts.")
                     return "SKIP"
+            elif e.code in (401, 403):
+                # #1306 — a hard auth/forbidden wall (bot / WAF / datacenter-IP
+                # block), NOT a missing hymn. Return a DISTINCT sentinel so the
+                # caller aborts the whole run with an actionable diagnostic
+                # instead of the MAX_CONSEC net silently mis-reading it as
+                # "end of hymnal" (which is what hid this for a month: HASD/IA
+                # 403 every hymn from #1, the run stopped after 10, and
+                # skipped.log only said "fetch failed or no title found").
+                print(f"  HTTP {e.code} (blocked).")
+                return "FORBIDDEN"
             else:
-                # Other HTTP errors (404, 403, etc.) — don't retry, just skip
+                # Other HTTP errors (404, etc.) — don't retry, just skip
                 print(f"  HTTP {e.code}.")
                 return "SKIP"
 
@@ -1664,6 +1674,25 @@ def scrape_site(site_key, start, end, output_dir, delay, force=False, prefer_sou
             # the hymnal. This is the normal termination condition.
             print()
             break
+
+        if hymn == "FORBIDDEN":
+            # #1306 — the site refused us at the HTTP layer (403/401). This is a
+            # WAF / bot / datacenter-IP block, NOT a code or parser fault: the
+            # SAME request (browser UA, www host) from a RESIDENTIAL IP returns
+            # 200, but a cloud/datacenter IP is blocked. Abort the run loudly and
+            # immediately with an actionable message rather than burning the
+            # whole range and leaving a generic skipped.log (the #1306 failure
+            # mode — silent for a month behind "assuming end of hymnal").
+            msg = (f"BLOCKED at hymn {number}: HTTP 403/401 from {home_url}. "
+                   f"This is a WAF / datacenter-IP block, not a scraper bug — the "
+                   f"same request from a residential IP + browser UA returns 200. "
+                   f"FIX: run this scraper from a residential IP (locally / a "
+                   f"residential proxy), or disable the scheduled cloud routine. "
+                   f"See iHymns issue #1306.")
+            print(f"\n✗  {msg}")
+            log_skip(number, label, msg, book_dir)
+            skipped += 1
+            break   # stop the run — every subsequent hymn would 403 too
 
         if hymn == "SKIP":
             # This hymn couldn't be scraped — log it and continue


### PR DESCRIPTION
Targets **alpha**. Triage + observability fix for the month-long silent HASD/IA scrape failure.

**Triage (curl-first):** the scraper is already correct (browser-UA rotation, `www.` hosts, `Sec-Fetch-*`, `?no=` query). From a **residential IP** both sites return **HTTP 200 with full hymn content** (verified hymn #1 on HASD + IA, ~34 KB each). The 403s are the **scheduled cloud agent's datacenter IP** hitting the sites' WAF — operational, not a code bug. (The issue's "needs a non-datacenter IP" hypothesis is confirmed; the "maybe UA" one is ruled out — UA is already handled.)

**Fix:** `fetch_hymn()` returns a distinct `FORBIDDEN` sentinel on 401/403; the loop aborts on the first one with an actionable message in `skipped.log` instead of the `MAX_CONSEC` net silently mislabelling it *"assuming end of hymnal"*. No more month-long silent no-ops.

`python3 -m py_compile` clean. **Issue stays open** — the data still needs a scrape from a residential IP (now unblocked); I can run that here on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)