### PR TITLE
feat: Service Mode Phase 1 — org Venues + Service Schedules + external-integration hook (#1325)

### DIFF
--- a/.claude/live-congregant-strategy.md
+++ b/.claude/live-congregant-strategy.md
@@ -1,0 +1,115 @@
+# Live Congregant ("Service Mode") — feasibility + phased design (DRAFT)
+
+> Draft strategy doc (2026-06-21). Owner decision pending — nothing built, no issues filed.
+> Extends the worship-team **Live Follow** (#1268) to the whole congregation, with
+> org-defined venues + recurring service times as the foundation. Research: workflow `w1a8x3nsl`.
+
+## Verdict
+
+**Feasible as a phased build — and we already own most of the spine (Live Follow #1268,
+organisations + CCLI licence, content-gating, the licence layer's time-boxed-unlock model).**
+BUT the *headline* — "auto-unlock copyrighted lyrics on a congregant's personal device because
+they're physically present" — is **BLOCKED-ON-EXTERNAL: it turns on CCLI's answer, not on code.**
+Two honest reframes fall out of the research, and they happen to point at the *same* better design:
+
+### Reframe 1 — CCLI coverage keys on WHO displays, not on who's present
+CCLI's Church Copyright License is written around the **church reproducing/displaying** lyrics
+"to assist congregational singing" (projection, print). Nothing in the public terms explicitly
+authorises **or** forbids pushing lyrics to each member's **own** device — it's a genuine grey
+zone, and **"they're in the room" is your intuition, not a CCLI category**. The central risk is
+the licence's **non-transferable / no-sublicense** clause: if CCLI reads "lyrics on a congregant's
+installed app" as the church *authorising a third party* to display, the church's licence would
+**not** cover it. **Silence is not permission.** → **Do not ship the auto-unlock on assumption.**
+
+### Reframe 2 — geolocation can't prove "in this room for this service"; a venue code can
+Browser geolocation is the **wrong primary gate**: trivially spoofable (DevTools Sensors / one-click
+extensions, no native defence), **35–100 m indoors** (can't tell the car park or the back-to-back
+congregation in the *same building* apart), permission-friction, and the heaviest privacy/GDPR
+option. The robust signal is a **venue-displayed, server-minted, short-lived rotating QR + typeable
+code** on the projection screen: *you can only read it if you're in the room*, so possession of a
+current code **is** proof-of-presence — and it disambiguates shared/back-to-back buildings **for
+free**. Geolocation/SSID/BLE can only ever *reduce friction*, never unlock.
+
+→ The org's lat/lng + service schedule become **context/convenience** (auto-surface "join your
+10:00 service?"), **not** the security boundary. The **rotating venue code** is the gate.
+
+## What exists vs. what's new (from the infra map)
+
+| Capability | Today | Gap |
+|---|---|---|
+| Org + CCLI licence | `tblOrganisations.LicenceType/Number/ExpiresAt` + `tblOrganisationLicences`; resolved per-user with org-ancestry (`licences.php`) | CCLI number is **free text, never validated**; the *time-boxed* unlock model already exists in the **licence layer** (`ExpiresAt` honoured) — reuse it, don't invent a new entitlement primitive |
+| Geographic boundary on an org | **None** — lat/lng only on `tblPlaces` (city centroid) | **greenfield**: per-org/venue lat/lng + radius |
+| Service times | per-setlist `tblSetlistSchedule` (DATE only, no time-of-day, no recurrence) | **greenfield**: recurring per-venue service windows |
+| Content gating seam | `content_access.php::checkContentAccess()` (flag-gated at `song.php:135`); `require_licence` already unlocks `ccli` when the user's effective licence set contains it | clean insert: inject a **synthetic, service-end-dated `ccli` licence** into the effective set when bound to an active service session — **zero rule-engine change** |
+| Live-Follow spine | `tblLiveFollowSessions` + `live_follow_*` (StateRevision short-poll) | leader-centric: `HostUserId NOT NULL`, `OrgId` present-but-unused, one-session-per-host. Needs org/service scoping + NULLable host + the NAT poll-anti-enumeration hardening already flagged in #1268 |
+| Geolocation (browser) | **none anywhere** | greenfield (and only ever a *secondary* signal per Reframe 2) |
+
+## Phased plan
+
+- **Phase 0 — verify with CCLI (owner, non-code, BLOCKING for the unlock).** Put the questions
+  below to CCLI *in writing*, per region iHymns targets. Until confirmed, the auto-unlock is parked;
+  everything else can proceed.
+- **Phase 1 — Org Venues + Recurring Service Schedule admin (BUILDABLE NOW; un-blocked).** ← *what you asked for.*
+  The foundation every later phase FKs to, and useful org metadata on its own.
+- **Phase 2 — "Service Mode" sessions.** Extend #1268: populate `OrgId` + a service link, NULLable
+  host, **join via the venue rotating code**; congregants follow the service's songs (entitled
+  content only — no CCLI change). Lands the #1268 NAT poll-hardening + (ideally) per-section follow.
+- **Phase 3 — service-scoped CCLI unlock (ONLY if Phase 0 confirms).** Bind a temporary `ccli`
+  licence (expires at service end) to a congregant who joined an active session at an org with a
+  live CCLI licence, via the licence layer; audited into `tblSongUsageEvents` (already dormant-ready).
+  Render the CCLI copyright-notice on each device (a CCL obligation).
+- **Phase 4 — ProPresenter / Planning Center driver (optional, later).** iHymns is already the
+  *receiver*; add a key-authed `live_follow_drive`. ProPresenter = desktop/no-cloud → needs a small
+  **on-LAN bridge** (official HTTP API in 7.9+, else the legacy WebSocket). Planning Center is cloud
+  with a real `plan.live.updated` **webhook** (the better signal). The real work is **song-identity
+  mapping** (free-text slide/plan titles → iHymns SongId; reuse `lyricsIngest_resolveSong`). Do
+  **after** per-section follow + poll-hardening.
+
+## Phase 1 detailed design (the buildable foundation)
+
+**Forward-looking schema (rule #20 — design the final DDL up front, additive, dormant, VARCHAR-not-ENUM):**
+- `tblOrgVenues` — `Id, OrgId(FK), Name, AddressLine, City, Postcode, CountryCode,
+  Latitude DECIMAL(10,7), Longitude DECIMAL(10,7), RadiusMetres SMALLINT, TimeZone VARCHAR(40),
+  IsActive, CreatedAt/UpdatedAt`. (lat/lng/radius = the *convenience* geofence + map pin.)
+- `tblOrgServiceSchedules` — `Id, VenueId(FK), Title, DayOfWeek TINYINT, StartTime TIME,
+  DurationMins SMALLINT, RecurrenceKind VARCHAR(20) [weekly|fortnightly|monthly_nth|one_off|custom],
+  RecurrenceData JSON (interval, nth-of-month, until, EXCEPTION dates), TimeZone VARCHAR(40),
+  IsActive, CreatedAt/UpdatedAt`. RecurrenceKind is VARCHAR so adding a cadence is app-level, not an ALTER.
+- Reserve a **service-occurrence** concept (a computed/instantiated `(scheduleId, date)`), which
+  Phase 2's session + Phase 3's unlock + `tblSongUsageEvents.ScheduleId` all bind to — so no re-migration.
+- schema.sql mirror + `migration-registry.php` entry + `setup-database.php` probe, per rule #19.
+
+**Friendly admin UI** (on `/manage/organisations` per-org, or a dedicated `/manage/venues`):
+- **Location**: address search → **map pin** picker (reuse the editor's live geocoder / `region_search`),
+  with a **radius slider** + a "use my current location" helper. Plain-English summary.
+- **Schedule**: a recurring-service editor — "**Every Sunday 10:00 (90 min), Europe/London**" with a
+  recurrence dropdown + exception-date list; shows the next few computed occurrences.
+- Reuses org CRUD + `manage_organisations` entitlement + `.admin-table-responsive` + sortable headers.
+- Effort: **M**. Risk: low. **Un-blocked by CCLI** — ships value immediately (org venue/service metadata).
+
+## The exact questions to put to CCLI (Phase 0)
+1. Does our Church Copyright License cover displaying a song's lyrics **live on the personal devices
+   of congregants who are physically present**, where *our church operates* the system pushing the text?
+2. Is that "projection … via an electronic device" under the CCL, or a separate per-device
+   reproduction/distribution the CCL does not grant?
+3. Does routing the text through an **app the congregant installed** cross the non-transferable /
+   no-sublicense line — and does it matter whether the church vs the app vendor "operates" it?
+4. Would the **Streaming License** (which permits distributing service audio/video to members'
+   devices) be the correct/needed frame instead — for **in-person** attendees?
+5. What **copyright-notice** must each device render, and how does the licence-number display obligation apply per-device?
+6. Confirm per **region** (CCLI terms differ US/UK/EU/…); note non-CCLI publishers/CVLI are out of scope.
+
+## Key risks
+- **Licensing (the gate)** — misclassification / sublicense; verify in writing before Phase 3. *(blocked-on-external)*
+- **Presence spoofing** — mitigated by the rotating-code air-gap + short TTL + per-device cooldown +
+  bind-to-session; geolocation never unlocks alone (config flag forbids it).
+- **Privacy** — any optional geolocation is opt-in, coarse, server-side pass/fail radius test, **not stored**.
+- **Operator is web-only / shared DB** — the rotating-code mint/display must be a **web-runnable** page;
+  nonce-consume + cooldown must be transactional on the shared MySQL (3 docroots).
+- **Accessibility** — always offer a large human-typeable code beside the QR.
+- **#1268 carry-overs** — NAT poll anti-enumeration + per-section follow should land for a real congregation.
+
+## Naming
+Worship team = **Live Follow** (shipped). Congregation = suggest **"Service Mode"** (or "Congregation
+Follow" / "Pew Mode") — clearly distinct, and it reads as *the church running the service*, which also
+aligns better with the CCLI "church operates it" framing.

--- a/appWeb/.sql/migrate-org-venues.php
+++ b/appWeb/.sql/migrate-org-venues.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Org Venues + Recurring Service Schedules (Service Mode Phase 1, #1325)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Give an organisation first-class PHYSICAL VENUES and RECURRING SERVICE TIMES —
+ * the foundation the "Service Mode" feature family (#1323: congregation-wide
+ * Live Follow) sits on, and useful org metadata in its own right. Today orgs
+ * carry only a city centroid (tblPlaces) and a per-setlist DATE-only schedule
+ * (tblSetlistSchedule) — there is no per-org geographic boundary and no
+ * recurring service-time concept. This adds:
+ *   - tblOrgVenues           — a venue (name, address, lat/lng + radius, tz).
+ *   - tblOrgServiceSchedules — recurring service windows per venue.
+ *
+ * FORWARD-LOOKING (CLAUDE.md rule #20): the schema is designed for the WHOLE
+ * Service-Mode family up front so later phases never re-migrate. lat/lng +
+ * RadiusMetres are a CONVENIENCE geofence + map pin — NOT the presence gate
+ * (Service Mode Phase 2 gates on a venue-displayed ROTATING CODE, because
+ * geolocation is spoofable/inaccurate indoors — see
+ * .claude/live-congregant-strategy.md). RecurrenceKind is VARCHAR (app-validated)
+ * not ENUM, so adding a cadence is app-level, never an ALTER. The
+ * service-OCCURRENCE (scheduleId, date) is computed at read time; Phase-2
+ * sessions + Phase-3 CCLI unlock + tblSongUsageEvents.ScheduleId bind to it.
+ *
+ * Additive + DORMANT + IDEMPOTENT (table-existence guarded). Tables ship empty.
+ *
+ * @migration-adds tblOrgVenues
+ * @migration-adds tblOrgServiceSchedules
+ *
+ * USAGE:
+ *   CLI:  php appWeb/.sql/migrate-org-venues.php
+ *   Web:  /manage/setup-database → "Org Venues & Service Schedules" button
+ *
+ * @requires PHP 8.1+ with mysqli
+ */
+
+$isCli = (php_sapi_name() === 'cli');
+if (!$isCli && !defined('IHYMNS_SETUP_DASHBOARD')) {
+    header('Content-Type: text/plain; charset=UTF-8');
+    header('X-Content-Type-Options: nosniff');
+    header('Cache-Control: no-store');
+}
+function _migOV_output(string $m): void { global $isCli; echo $m . ($isCli ? "\n" : "<br>\n"); if (!$isCli) flush(); }
+function _migOV_tableExists(\mysqli $db, string $t): bool { $r = $db->query("SHOW TABLES LIKE '{$t}'"); return (bool)($r && $r->num_rows > 0); }
+
+$credFile = dirname(__DIR__) . DIRECTORY_SEPARATOR . '.auth' . DIRECTORY_SEPARATOR . 'db_credentials.php';
+if (!file_exists($credFile)) { _migOV_output("ERROR: MySQL credentials not found. Run install.php first."); return; }
+require_once $credFile;
+
+_migOV_output("");
+_migOV_output("=== iHymns — Org Venues & Service Schedules (#1325) ===");
+
+try {
+    $mysql = new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME);
+    $mysql->set_charset('utf8mb4');
+} catch (\mysqli_sql_exception $e) { _migOV_output("ERROR: MySQL connection failed: " . $e->getMessage()); return; }
+_migOV_output("Connected to MySQL: " . DB_NAME);
+
+try {
+    if (_migOV_tableExists($mysql, 'tblOrgVenues')) {
+        _migOV_output("  [SKIP] tblOrgVenues already present.");
+    } else {
+        $mysql->query(
+            "CREATE TABLE tblOrgVenues (
+                Id           INT UNSIGNED      AUTO_INCREMENT PRIMARY KEY,
+                OrgId        INT UNSIGNED      NOT NULL COMMENT 'FK to tblOrganisations.Id — the org this venue belongs to',
+                Name         VARCHAR(150)      NOT NULL COMMENT 'Venue display name (e.g. Main Sanctuary, Church Hall)',
+                AddressLine  VARCHAR(255)      NULL DEFAULT NULL COMMENT 'Street address (free text)',
+                City         VARCHAR(120)      NULL DEFAULT NULL,
+                Postcode     VARCHAR(20)       NULL DEFAULT NULL,
+                CountryCode  CHAR(2)           NULL DEFAULT NULL COMMENT 'ISO 3166-1 alpha-2',
+                PlaceId      INT UNSIGNED      NULL DEFAULT NULL COMMENT 'FK to tblPlaces.Id — geocoder-resolved place (optional)',
+                Latitude     DECIMAL(10,7)     NULL DEFAULT NULL COMMENT 'Venue centroid latitude — convenience geofence + map pin, NOT the presence gate',
+                Longitude    DECIMAL(10,7)     NULL DEFAULT NULL COMMENT 'Venue centroid longitude',
+                RadiusMetres SMALLINT UNSIGNED NULL DEFAULT NULL COMMENT 'Convenience geofence radius; presence gate is the venue rotating code (Phase 2)',
+                TimeZone     VARCHAR(40)       NOT NULL DEFAULT 'UTC' COMMENT 'IANA tz the schedules are interpreted in (e.g. Europe/London)',
+                IsActive     TINYINT(1)        NOT NULL DEFAULT 1,
+                SortOrder    INT UNSIGNED      NOT NULL DEFAULT 0,
+                CreatedAt    TIMESTAMP         NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UpdatedAt    TIMESTAMP         NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                INDEX idx_Org   (OrgId, IsActive),
+                INDEX idx_Place (PlaceId),
+                CONSTRAINT fk_OrgVenues_Org   FOREIGN KEY (OrgId)   REFERENCES tblOrganisations(Id) ON DELETE CASCADE  ON UPDATE CASCADE,
+                CONSTRAINT fk_OrgVenues_Place FOREIGN KEY (PlaceId) REFERENCES tblPlaces(Id)        ON DELETE SET NULL ON UPDATE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+              COMMENT='Org physical venues — Service Mode Phase 1 (#1325). lat/lng/radius = convenience geofence + map pin; presence gate is the venue rotating code.'"
+        );
+        _migOV_output("  [OK] Created tblOrgVenues.");
+    }
+
+    if (_migOV_tableExists($mysql, 'tblOrgServiceSchedules')) {
+        _migOV_output("  [SKIP] tblOrgServiceSchedules already present.");
+    } else {
+        $mysql->query(
+            "CREATE TABLE tblOrgServiceSchedules (
+                Id             INT UNSIGNED      AUTO_INCREMENT PRIMARY KEY,
+                VenueId        INT UNSIGNED      NOT NULL COMMENT 'FK to tblOrgVenues.Id',
+                OrgId          INT UNSIGNED      NOT NULL COMMENT 'Denorm of the venue org (app-derived) for cheap org-scoped queries',
+                Title          VARCHAR(150)      NOT NULL DEFAULT 'Service' COMMENT 'e.g. Sunday Morning, Evening Service',
+                DayOfWeek      TINYINT UNSIGNED  NULL DEFAULT NULL COMMENT 'ISO-8601 1=Mon..7=Sun for recurring kinds; NULL for one_off (date in RecurrenceData)',
+                StartTime      TIME              NOT NULL COMMENT 'Local service start in the effective TimeZone',
+                DurationMins   SMALLINT UNSIGNED NOT NULL DEFAULT 90 COMMENT 'Service window length (drives the active-now check)',
+                RecurrenceKind VARCHAR(20)       NOT NULL DEFAULT 'weekly' COMMENT 'weekly|fortnightly|monthly_nth|one_off|custom — app-validated, VARCHAR not ENUM (rule #20)',
+                RecurrenceData JSON              NULL DEFAULT NULL COMMENT 'Kind-specific: {interval},{nth,dayOfWeek},{date} for one_off,{until},{exceptions:[dates]}',
+                TimeZone       VARCHAR(40)       NULL DEFAULT NULL COMMENT 'Override the venue tz for this schedule; NULL = inherit the venue tz',
+                IsActive       TINYINT(1)        NOT NULL DEFAULT 1,
+                SortOrder      INT UNSIGNED      NOT NULL DEFAULT 0,
+                CreatedAt      TIMESTAMP         NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UpdatedAt      TIMESTAMP         NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                INDEX idx_Venue (VenueId, IsActive),
+                INDEX idx_Org   (OrgId, IsActive),
+                INDEX idx_Day   (DayOfWeek, StartTime),
+                CONSTRAINT fk_OrgSchedules_Venue FOREIGN KEY (VenueId) REFERENCES tblOrgVenues(Id)     ON DELETE CASCADE ON UPDATE CASCADE,
+                CONSTRAINT fk_OrgSchedules_Org   FOREIGN KEY (OrgId)   REFERENCES tblOrganisations(Id) ON DELETE CASCADE ON UPDATE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+              COMMENT='Recurring service times per venue — Service Mode Phase 1 (#1325). The service-occurrence (scheduleId,date) is computed at read time; Phase-2 sessions + Phase-3 unlock bind to it.'"
+        );
+        _migOV_output("  [OK] Created tblOrgServiceSchedules.");
+    }
+
+    _migOV_output("  Tables ship empty; the admin UI (/manage/venues) populates them. lat/lng/radius are a convenience geofence — the Service-Mode presence gate is a venue rotating code (#1323).");
+    _migOV_output("Migration complete.");
+} catch (\mysqli_sql_exception $e) {
+    _migOV_output("ERROR: " . $e->getMessage());
+}

--- a/appWeb/.sql/schema.sql
+++ b/appWeb/.sql/schema.sql
@@ -3403,3 +3403,61 @@ CREATE TABLE IF NOT EXISTS tblPresentationFormatFidelity (
     CONSTRAINT fk_PresFidelity_Component FOREIGN KEY (ComponentId) REFERENCES tblSongComponents(Id) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
   COMMENT='Round-trip fidelity carrier for source styling with no first-class column; (Source,SourceRef) UNIQUE = idempotent re-import (rule #20) (#1168).';
+
+-- ----------------------------------------------------------------------------
+-- tblOrgVenues (#1325) — org physical venues for "Service Mode" (#1323). lat/lng
+-- + radius are a CONVENIENCE geofence + map pin, NOT the presence gate (Service
+-- Mode gates on a venue rotating code). Mirror of migrate-org-venues.php.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS tblOrgVenues (
+    Id           INT UNSIGNED      AUTO_INCREMENT PRIMARY KEY,
+    OrgId        INT UNSIGNED      NOT NULL COMMENT 'FK to tblOrganisations.Id — the org this venue belongs to',
+    Name         VARCHAR(150)      NOT NULL COMMENT 'Venue display name (e.g. Main Sanctuary, Church Hall)',
+    AddressLine  VARCHAR(255)      NULL DEFAULT NULL COMMENT 'Street address (free text)',
+    City         VARCHAR(120)      NULL DEFAULT NULL,
+    Postcode     VARCHAR(20)       NULL DEFAULT NULL,
+    CountryCode  CHAR(2)           NULL DEFAULT NULL COMMENT 'ISO 3166-1 alpha-2',
+    PlaceId      INT UNSIGNED      NULL DEFAULT NULL COMMENT 'FK to tblPlaces.Id — geocoder-resolved place (optional)',
+    Latitude     DECIMAL(10,7)     NULL DEFAULT NULL COMMENT 'Venue centroid latitude — convenience geofence + map pin, NOT the presence gate',
+    Longitude    DECIMAL(10,7)     NULL DEFAULT NULL COMMENT 'Venue centroid longitude',
+    RadiusMetres SMALLINT UNSIGNED NULL DEFAULT NULL COMMENT 'Convenience geofence radius; presence gate is the venue rotating code (Phase 2)',
+    TimeZone     VARCHAR(40)       NOT NULL DEFAULT 'UTC' COMMENT 'IANA tz the schedules are interpreted in (e.g. Europe/London)',
+    IsActive     TINYINT(1)        NOT NULL DEFAULT 1,
+    SortOrder    INT UNSIGNED      NOT NULL DEFAULT 0,
+    CreatedAt    TIMESTAMP         NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UpdatedAt    TIMESTAMP         NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    INDEX idx_Org   (OrgId, IsActive),
+    INDEX idx_Place (PlaceId),
+    CONSTRAINT fk_OrgVenues_Org   FOREIGN KEY (OrgId)   REFERENCES tblOrganisations(Id) ON DELETE CASCADE  ON UPDATE CASCADE,
+    CONSTRAINT fk_OrgVenues_Place FOREIGN KEY (PlaceId) REFERENCES tblPlaces(Id)        ON DELETE SET NULL ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='Org physical venues — Service Mode Phase 1 (#1325). lat/lng/radius = convenience geofence + map pin; presence gate is the venue rotating code.';
+
+-- ----------------------------------------------------------------------------
+-- tblOrgServiceSchedules (#1325) — recurring service times per venue. The
+-- service-OCCURRENCE (scheduleId,date) is computed at read time; Phase-2
+-- sessions + Phase-3 CCLI unlock bind to it. RecurrenceKind is VARCHAR
+-- (app-validated) not ENUM (rule #20). Mirror of migrate-org-venues.php.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS tblOrgServiceSchedules (
+    Id             INT UNSIGNED      AUTO_INCREMENT PRIMARY KEY,
+    VenueId        INT UNSIGNED      NOT NULL COMMENT 'FK to tblOrgVenues.Id',
+    OrgId          INT UNSIGNED      NOT NULL COMMENT 'Denorm of the venue org (app-derived) for cheap org-scoped queries',
+    Title          VARCHAR(150)      NOT NULL DEFAULT 'Service' COMMENT 'e.g. Sunday Morning, Evening Service',
+    DayOfWeek      TINYINT UNSIGNED  NULL DEFAULT NULL COMMENT 'ISO-8601 1=Mon..7=Sun for recurring kinds; NULL for one_off (date in RecurrenceData)',
+    StartTime      TIME              NOT NULL COMMENT 'Local service start in the effective TimeZone',
+    DurationMins   SMALLINT UNSIGNED NOT NULL DEFAULT 90 COMMENT 'Service window length (drives the active-now check)',
+    RecurrenceKind VARCHAR(20)       NOT NULL DEFAULT 'weekly' COMMENT 'weekly|fortnightly|monthly_nth|one_off|custom — app-validated, VARCHAR not ENUM (rule #20)',
+    RecurrenceData JSON              NULL DEFAULT NULL COMMENT 'Kind-specific: {interval},{nth,dayOfWeek},{date} for one_off,{until},{exceptions:[dates]}',
+    TimeZone       VARCHAR(40)       NULL DEFAULT NULL COMMENT 'Override the venue tz for this schedule; NULL = inherit the venue tz',
+    IsActive       TINYINT(1)        NOT NULL DEFAULT 1,
+    SortOrder      INT UNSIGNED      NOT NULL DEFAULT 0,
+    CreatedAt      TIMESTAMP         NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UpdatedAt      TIMESTAMP         NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    INDEX idx_Venue (VenueId, IsActive),
+    INDEX idx_Org   (OrgId, IsActive),
+    INDEX idx_Day   (DayOfWeek, StartTime),
+    CONSTRAINT fk_OrgSchedules_Venue FOREIGN KEY (VenueId) REFERENCES tblOrgVenues(Id)     ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT fk_OrgSchedules_Org   FOREIGN KEY (OrgId)   REFERENCES tblOrganisations(Id) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='Recurring service times per venue — Service Mode Phase 1 (#1325). The service-occurrence (scheduleId,date) is computed at read time; Phase-2 sessions + Phase-3 unlock bind to it.';

--- a/appWeb/public_html/manage/includes/migration-registry.php
+++ b/appWeb/public_html/manage/includes/migration-registry.php
@@ -2148,4 +2148,21 @@ return [
             return (int)($row['DATETIME_PRECISION'] ?? 0) < 6;
         },
     ],
+    'org-venues' => [
+        'script' => 'migrate-org-venues.php',
+        'card' => [
+            'title'  => 'Org Venues &amp; Service Schedules (#1325)',
+            'body'   => 'Creates <code>tblOrgVenues</code> (org physical venues — name, address,'
+                      . ' lat/lng + radius, timezone) and <code>tblOrgServiceSchedules</code>'
+                      . ' (recurring service times per venue). The forward-looking foundation for'
+                      . ' &ldquo;Service Mode&rdquo; (#1323); ships empty, populated by'
+                      . ' <code>/manage/venues</code>. Idempotent — safe to re-run.',
+            'button' => 'Run Org Venues Migration',
+        ],
+        /* Multi-object OR-probe (rule #19): pending until BOTH tables exist, so a
+           partial apply never shows the card green. */
+        'probe' => static fn(\mysqli $db) =>
+            !_migProbe_tableExists($db, 'tblOrgVenues')
+            || !_migProbe_tableExists($db, 'tblOrgServiceSchedules'),
+    ],
 ];


### PR DESCRIPTION
Targets **alpha**. **Phase 1** of Service Mode (#1323) — the un-blocked foundation: an org defines **where** it meets (venues), **when** (recurring service times), and (dormant) **how it can integrate** with an external system later. Three commits:

### 1a — schema foundation (`d6650db4`)
`tblOrgVenues` + `tblOrgServiceSchedules` (forward-looking, dormant, idempotent) + schema.sql mirror + registry OR-probe.

### 1b — friendly admin UI (`4d8c33b7`)
**`/manage/venues`** (gated `manage_organisations`): org selector → venue CRUD (map-pin via shared `place-search.js`, radius, timezone) → per-venue recurring service-time CRUD (weekly / fortnightly / monthly-nth / one-off + skip-dates + until + tz override) with plain-English summary + next-3-dates preview. New "Venues" nav tuple.

### 1c — dormant external-system integration hook (`81a61a46`, #1327)
Owner asked that orgs/venues/etc be able to integrate with **WebMS-Intra** in future → per rule #20 (design up front, don't ALTER later) this ships **dormant** now. **Designed via an adversarial workflow** which *rejected* a generic polymorphic table (rule #15 forbids it; numeric EntityId can't address `SongId VARCHAR` keys; no-FK polymorphism orphan-rots). Idiomatic shape instead:
- **`tblExternalSystems`** registry (keys in data not PHP), **seeded** with a paused `webms-intra` row so the RESTRICT FKs have a target.
- **`tblOrganisationExternalRefs` / `tblOrgVenueExternalRefs` / `tblOrgServiceScheduleExternalRefs`** — per-entity ref tables (rule #15), all three in one pass. Each: `(Source,SourceRef)` UNIQUE (idempotent re-import) + `(SystemId,ExternalId)` UNIQUE (multi-system without an ALTER) + reserved-dormant sync columns (status/direction VARCHAR-not-ENUM, LocalHash+ExternalEtag conflict tokens, LastError/At, DeletedAt soft-unlink, MetaJson).
- **No read/write code consumes these** — the sync engine is future, gated work (#1327): DPA + GDPR Art. 9-adjacent lawful basis, inbound-first, **production-only** (3 docroots share one MySQL), creds never in DB.

### CI
`php -l` clean on all; **`test-migration-registry`** + **`test-schema-coverage`** both **pass** (126 schema tables; 6 new tables mirrored byte-for-byte; both OR-probes are real closures incl. the seeded-row check).

### Security (self-review)
Every POST CSRF-checked + `bind_param` on every statement; output `htmlspecialchars`-escaped; schedule `OrgId` derived from its venue (never client-trusted); lat/lng clamped to WGS84, day/duration/radius range-clamped, recurrence-kind + timezone allow-list-validated; schema-presence guarded; `AuthScope` is a secret-*name* hint only (no secret in DB).

After deploy, run on `/manage/setup-database` in order: **"Org Venues & Service Schedules"** → **"External-system integration hook"**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)