### PR TITLE
fix: UI/data consistency tweaks — songbook abbr display, deleted-song pruning, maintenance banner (#1328, #1329, #1330)

### DIFF
--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -5068,6 +5068,46 @@ if ($action !== null) {
             break;
 
         /* -----------------------------------------------------------------
+         * Batch existence check for a list of SongIds (#1329).
+         * Public — only reveals whether already-public song ids still exist.
+         * The client uses it to PRUNE songs that have been deleted from the
+         * catalogue out of localStorage-backed lists (Recently Viewed etc.)
+         * so a stale cached entry never renders an unresolvable id.
+         * GET ?action=songs_exist&ids=CP-0001,MP-0042 → {exists:[ids…]}.
+         * On error returns {exists:null} so the client leaves its cache intact.
+         * ----------------------------------------------------------------- */
+        case 'songs_exist':
+            $idsRaw = (string)($_GET['ids'] ?? '');
+            /* Validate each id to the SongId charset (mirrors song_view at
+               api.php ~5097); drop anything malformed before it reaches SQL. */
+            $existIds = array_values(array_unique(array_filter(
+                array_map('trim', explode(',', $idsRaw)),
+                static fn($s) => $s !== '' && preg_match('/^[A-Za-z0-9_-]{1,32}$/', $s)
+            )));
+            if (!$existIds) { sendJson(['exists' => []]); break; }
+            if (count($existIds) > 200) { $existIds = array_slice($existIds, 0, 200); }
+            try {
+                $db = getDbMysqli();
+                /* Placeholder string built from a constant count (rule #5 —
+                   the only legitimate interpolation into SQL); values bound. */
+                $ph    = implode(',', array_fill(0, count($existIds), '?'));
+                $types = str_repeat('s', count($existIds));
+                $stmt  = $db->prepare("SELECT SongId FROM tblSongs WHERE SongId IN ($ph)");
+                $stmt->bind_param($types, ...$existIds);
+                $stmt->execute();
+                $res = $stmt->get_result();
+                $found = [];
+                while ($row = $res->fetch_row()) { $found[] = $row[0]; }
+                $stmt->close();
+                sendJson(['exists' => $found]);
+            } catch (\Throwable $e) {
+                error_log('[api/songs_exist] ' . $e->getMessage());
+                /* null (not []) so the client does NOT wrongly prune everything. */
+                sendJson(['exists' => null, 'fallback' => true]);
+            }
+            break;
+
+        /* -----------------------------------------------------------------
          * Record a song view
          *
          * POST body (JSON): { "song_id": "CP-0001" }

--- a/appWeb/public_html/includes/pages/home.php
+++ b/appWeb/public_html/includes/pages/home.php
@@ -18,6 +18,9 @@ declare(strict_types=1);
    tooltip. Static-cached per request so this require + map build
    only fires once per page load. */
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'language_names.php';
+/* Songbook display helper (#1328) — ihymns_songbook_show_abbr() hides the
+   abbreviation badge when it just repeats the title (e.g. "Psalty"/"Psalty"). */
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'songbook_display.php';
 
 /* Load song data for statistics */
 $stats = $songData->getStats();
@@ -261,9 +264,11 @@ $homeCardEnd = '</div>';
                                 <h3 class="card-title h6 mb-1">
                                     <?= htmlspecialchars($book['name']) ?>
                                 </h3>
+                                <?php if (ihymns_songbook_show_abbr($book['name'] ?? '', $book['id'] ?? '')): ?>
                                 <span class="badge bg-body-secondary rounded-pill">
                                     <?= htmlspecialchars($book['id']) ?>
                                 </span>
+                                <?php endif; ?>
                                 <?php if ($isUnofficial): ?>
                                     <!-- #1223 — "Unofficial" badge (see
                                          includes/pages/songbooks.php for the full

--- a/appWeb/public_html/includes/pages/song.php
+++ b/appWeb/public_html/includes/pages/song.php
@@ -16,6 +16,9 @@
 
 declare(strict_types=1);
 
+/* #1328 — hide the songbook abbreviation badge when it just repeats the name. */
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'songbook_display.php';
+
 /* Fetch the full song data */
 $song = $songData->getSongById($songId);
 
@@ -328,7 +331,9 @@ try {
                         </p>
                     <?php endif; ?>
                     <p class="text-muted mb-0">
+                        <?php if (ihymns_songbook_show_abbr($bookName, $songbook)): ?>
                         <span class="badge bg-body-secondary"><?= htmlspecialchars($songbook) ?></span>
+                        <?php endif; ?>
                         <?= htmlspecialchars($bookName) ?>
                     </p>
                     <?php if ($songbookParent !== null && $parentSongLinkUrl !== ''):

--- a/appWeb/public_html/includes/pages/songbook.php
+++ b/appWeb/public_html/includes/pages/songbook.php
@@ -15,6 +15,9 @@
 
 declare(strict_types=1);
 
+/* #1328 — hide the abbreviation badge when it just repeats the title. */
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'songbook_display.php';
+
 /* Fetch songbook and its songs */
 $book = $songData->getSongbook($bookId);
 $songs = $songData->getSongs($bookId);
@@ -68,7 +71,9 @@ if ($book === null) {
             <h1 class="h4 mb-1">
                 <i class="fa-solid fa-book me-2" aria-hidden="true"></i>
                 <?= htmlspecialchars($book['name']) ?>
+                <?php if (ihymns_songbook_show_abbr($book['name'] ?? '', $book['id'] ?? '')): ?>
                 <span class="badge bg-body-secondary ms-1"><?= htmlspecialchars($book['id']) ?></span>
+                <?php endif; ?>
                 <?php if (empty($book['isOfficial'])): ?>
                     <!-- #1223 — "Unofficial" badge on the songbook header so the
                          distinction persists after click-through from the list / home.

--- a/appWeb/public_html/includes/pages/songbooks.php
+++ b/appWeb/public_html/includes/pages/songbooks.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 /* #856 — language-name resolver for the tile badge tooltip. */
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'language_names.php';
+/* #1328 — hide the abbreviation badge when it just repeats the title. */
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'songbook_display.php';
 
 $songbooks = $songData->getSongbooks();
 $stats = $songData->getStats();
@@ -110,9 +112,11 @@ $stats = $songData->getStats();
                                     <h2 class="h6 card-title mb-1">
                                         <?= htmlspecialchars($book['name']) ?>
                                     </h2>
+                                    <?php if (ihymns_songbook_show_abbr($book['name'] ?? '', $book['id'] ?? '')): ?>
                                     <span class="badge bg-body-secondary me-1">
                                         <?= htmlspecialchars($book['id']) ?>
                                     </span>
+                                    <?php endif; ?>
                                     <?php if ($isUnofficial): ?>
                                         <!-- #1223 — "Unofficial" badge. Surfaces unofficial
                                              songbooks as first-class-but-badged alongside the

--- a/appWeb/public_html/includes/songbook_display.php
+++ b/appWeb/public_html/includes/songbook_display.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Songbook display helpers (#1328)
+ *
+ * Tiny shared presentation logic for songbooks so the same rule isn't
+ * re-implemented across the home tiles, the /songbooks list, the songbook
+ * header, the song-meta line and the admin table.
+ */
+
+if (!function_exists('ihymns_songbook_show_abbr')) {
+    /**
+     * Whether to render a songbook's Abbreviation badge alongside its Title.
+     *
+     * ELI5: if a book's short code is the same word as its full name, showing
+     * both just prints the word twice — so we hide the code in that case.
+     *
+     * Returns false when the abbreviation is empty or case-insensitively equal
+     * to the title (e.g. the unofficial "Psalty" book whose abbreviation is also
+     * "Psalty", #1328). The badge is only meaningful when it differs from the
+     * title it sits beside; abbreviation-only contexts (no title shown) should
+     * NOT call this — they always render the code.
+     *
+     * @param string|null $title The songbook's display name / title.
+     * @param string|null $abbr  The songbook's abbreviation (a.k.a. id).
+     */
+    function ihymns_songbook_show_abbr(?string $title, ?string $abbr): bool
+    {
+        $abbr = trim((string) $abbr);
+        if ($abbr === '') {
+            return false;
+        }
+        return strcasecmp(trim((string) $title), $abbr) !== 0;
+    }
+}

--- a/appWeb/public_html/js/app.js
+++ b/appWeb/public_html/js/app.js
@@ -340,6 +340,13 @@ class iHymnsApp {
             this.userAuth?._ensureAppStatus?.().then((status) => {
                 if (!status || !status.maintenance) return;
                 if (document.getElementById('maintenance-banner')) return;
+                /* #1330 — an admin bypassing maintenance already sees the
+                   server-rendered amber admin-bypass banner (index.php
+                   #ihymns-maint-bypass). Don't stack this second brown banner
+                   on top of it (the redundant double-banner the owner spotted);
+                   the bypass notice is authoritative + more informative. Only
+                   non-admin returning PWA users (no bypass banner) see this. */
+                if (document.getElementById('ihymns-maint-bypass')) return;
                 const bar = document.createElement('div');
                 bar.id = 'maintenance-banner';
                 bar.setAttribute('role', 'status');

--- a/appWeb/public_html/js/modules/history.js
+++ b/appWeb/public_html/js/modules/history.js
@@ -15,6 +15,7 @@
  */
 import { escapeHtml, verifiedBadge } from '../utils/html.js';
 import { toTitleCase } from '../utils/text.js';
+import { songsExist } from '../utils/song-existence.js';
 import { STORAGE_HISTORY, STORAGE_HISTORY_BACKFILLED, songbookLabel } from '../constants.js';
 
 export class History {
@@ -246,6 +247,14 @@ export class History {
     async renderHomeSection() {
         this._renderSection(this.getAll());
 
+        /* #1329 — prune entries whose song has since been DELETED from the
+           catalogue so a stale cache never renders an unresolvable id (the
+           deleted "Here to Stay" the owner spotted). Self-healing: it rewrites
+           the local cache. Runs for everyone (anon + signed-in); the signed-in
+           server pull below is already clean (song_history INNER-JOINs tblSongs)
+           and unions against this now-pruned cache. */
+        await this._pruneDeletedSongs();
+
         if (this.app?.userAuth?.isLoggedIn?.()) {
             if (this._clearedLocally) {
                 /* A clear just fired on this device; its server DELETE may not
@@ -275,6 +284,24 @@ export class History {
                 this.saveAll(merged);       /* mirror to the local cache */
                 this._renderSection(merged);
             }
+        }
+    }
+
+    /**
+     * Drop recently-viewed entries whose song no longer exists in the
+     * catalogue (#1329), rewriting the local cache + re-rendering if anything
+     * changed. No-op when the existence check can't run (offline / error) so a
+     * transient failure never wipes the cache.
+     */
+    async _pruneDeletedSongs() {
+        const items = this.getAll();
+        if (!Array.isArray(items) || items.length === 0) return;
+        const exists = await songsExist(this.app, items.map(h => h.id));
+        if (!exists) return;                 /* check failed — keep the cache */
+        const pruned = items.filter(h => h.id && exists.has(h.id));
+        if (pruned.length !== items.length) {
+            this.saveAll(pruned);
+            this._renderSection(pruned);
         }
     }
 

--- a/appWeb/public_html/js/utils/song-existence.js
+++ b/appWeb/public_html/js/utils/song-existence.js
@@ -1,0 +1,48 @@
+/**
+ * iHymns — Song existence check (#1329)
+ *
+ * Batch-checks which SongIds still exist in the catalogue, so localStorage-
+ * backed lists (Recently Viewed, and optionally Favourites / Setlists) can
+ * prune songs that have since been DELETED — a stale cached entry would
+ * otherwise render an unresolvable id (the deleted "Here to Stay" the owner
+ * spotted in Recently Viewed).
+ *
+ * Returns a Set of the ids that STILL exist, or `null` if the check couldn't
+ * run (network/parse error) so callers leave their cache UNTOUCHED rather than
+ * wrongly wiping it. Every id is checked (batched ≤150 to stay under the
+ * server's 200-id cap), so an id absent from the returned Set is genuinely
+ * gone — never just un-checked.
+ */
+
+const _CHUNK = 150;
+
+/**
+ * @param {object} app  App instance (for app.config.apiUrl).
+ * @param {string[]} ids  SongIds to check.
+ * @returns {Promise<Set<string>|null>}  Set of existing ids, or null on failure.
+ */
+export async function songsExist(app, ids) {
+    const unique = [...new Set((ids || []).filter(Boolean))];
+    if (unique.length === 0) return new Set();
+
+    const base = app?.config?.apiUrl;
+    if (!base) return null;
+
+    const found = new Set();
+    try {
+        for (let i = 0; i < unique.length; i += _CHUNK) {
+            const batch = unique.slice(i, i + _CHUNK);
+            const url = `${base}?action=songs_exist&ids=${encodeURIComponent(batch.join(','))}`;
+            const res = await fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' } });
+            if (!res.ok) return null;
+            const data = await res.json();
+            /* exists === null is the server's "couldn't check" sentinel; an
+               array (incl. empty) is authoritative. Anything else → bail safe. */
+            if (!data || !Array.isArray(data.exists)) return null;
+            data.exists.forEach((id) => found.add(id));
+        }
+        return found;
+    } catch {
+        return null;
+    }
+}

--- a/appWeb/public_html/service-worker.js.php
+++ b/appWeb/public_html/service-worker.js.php
@@ -142,6 +142,7 @@ const PRECACHE_ASSETS = [
     '/js/utils/html.js',
     '/js/utils/components.js',
     '/js/utils/text.js',
+    '/js/utils/song-existence.js',
     '/js/utils/transpose.js',
     '/js/modules/router.js',
     '/js/modules/transitions.js',


### PR DESCRIPTION
Targets **alpha**. Three small consistency fixes the owner reported after the Service-Mode merge. One PR, three atomic commits.

### `a4a3b7c1` — #1330 Maintenance banner double-stack
An admin bypassing maintenance saw TWO near-identical banners (server amber bypass notice + JS brown status banner). `app.js` now suppresses the JS banner when the authoritative server bypass banner (`#ihymns-maint-bypass`) is present. Non-admin returning-PWA users still get the brown status banner.

### `8c67b0ef` — #1328 Hide abbreviation when it equals the title
e.g. the unofficial **Psalty** book (abbr also "Psalty") printed the word twice. Shared helper `ihymns_songbook_show_abbr()` (`includes/songbook_display.php`, trimmed + case-insensitive) gates the abbr badge on the **home tiles, /songbooks list, songbook header, song-meta**. JS `songbookLabel()` already collapsed (no change). Admin table keeps the code (it's the editable field).

### `1a24fd47` — #1329 Recently Viewed showed a deleted song
The localStorage-backed list didn't check existence (server lists already JOIN `tblSongs`). New public **`GET /api?action=songs_exist&ids=…`** batch endpoint (validated ids, constant-count placeholder, `{exists:null}` on error) + shared **`utils/song-existence.js`** (chunked, null-safe) + `history.js` self-healing prune (rewrites cache + re-renders). Added to the SW precache. Favourites/Setlists are user-*curated* → left for a follow-up.

### Security (self-review)
`songs_exist` is read-only + public (only reveals public-song existence); each id validated to the SongId charset before SQL; values bound via a constant-count placeholder string (rule #5); `{exists:null}` sentinel means a server error never wrongly prunes the client cache. No new auth surface.

### Lint
`php -l` clean on all PHP (incl. `service-worker.js.php`); `node --check` clean on `app.js`, `history.js`, `song-existence.js`.

> **Not included — songbook abbreviation charset (`-`/`_`/`:`):** investigation found the abbreviation **is the SongId prefix** (`<letters>-<digits>`), parsed by the PWA router, OG-image, and 3 API validators, and a rename `CONCAT`s it into SongId — so loosening the charset would break SongId parsing/routing. Putting options to the owner separately rather than shipping a risky change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)