### PR TITLE
feat: Service Mode (venues UI + sessions schema + external-systems hook) + songbook display label — consolidated (#1325 #1327 #1332 #1335)

### DIFF
--- a/.claude/live-congregant-strategy.md
+++ b/.claude/live-congregant-strategy.md
@@ -113,3 +113,29 @@ free**. Geolocation/SSID/BLE can only ever *reduce friction*, never unlock.
 Worship team = **Live Follow** (shipped). Congregation = suggest **"Service Mode"** (or "Congregation
 Follow" / "Pew Mode") — clearly distinct, and it reads as *the church running the service*, which also
 aligns better with the CCLI "church operates it" framing.
+
+## External-system integration hook (#1327) — WebMS-Intra & beyond
+Owner asked (2026-06-21) that orgs / venues / etc be able to integrate with **WebMS-Intra** in
+future. Per rule #20 (design the family up front; don't ALTER later) this shipped **dormant** in the
+Phase-1 batch (PR #1326). A design workflow (`w0ktly3yn`) surveyed the codebase idioms and **rejected
+a generic polymorphic `EntityType+EntityId` table** — rule #15 forbids it, and a numeric `EntityId`
+can't address the `SongId VARCHAR(20)` / `Abbreviation` keys the codebase already FKs on, and a no-FK
+polymorphism orphan-rots on delete. The idiomatic shape, validated adversarially, is:
+- **`tblExternalSystems`** — a registry (sibling of `tblExternalLinkTypes`); system keys live in
+  **data, not PHP** (rule #15). Seeded with a **paused `webms-intra`** row so the per-entity FKs
+  (RESTRICT) have a target (the migration seeds it — else the first insert throws under STRICT).
+- **`tblOrganisationExternalRefs` / `tblOrgVenueExternalRefs` / `tblOrgServiceScheduleExternalRefs`** —
+  per-entity dedicated ref tables (rule #15). Each carries `(Source, SourceRef)` UNIQUE (idempotent
+  re-import), `(SystemId, ExternalId)` UNIQUE (one external record ↔ one iHymns row per system, and
+  `SystemId` in the key = a **second system never needs an ALTER**), plus reserved-dormant operator
+  columns: `SyncStatus` / `SyncDirection` (VARCHAR, not ENUM), `LocalHash` + `ExternalEtag`
+  (optimistic-concurrency conflict detection), `LastError` + `LastErrorAt`, `DeletedAt` (soft-unlink
+  vs FK-cascade hard delete), `MetaJson` (loss-free), `CreatedBy`. All three entities ship in **one
+  pass** so a schedule sync never forces a third migration.
+
+**Nothing reads/writes these yet** — the actual sync engine is future, **gated** work (#1327) that
+requires, before it goes live: a **DPA** + lawful basis (org/venue address + service times are
+GDPR Art. 9-adjacent — a faith community's presence pattern); **`inbound`-first** until an outbound
+DPA exists; **production-only** runs (the 3 docroots share one MySQL — alpha/beta must not exfiltrate
+real data; gate on a sandbox `BaseUrl`); credentials **never in the DB** (`AuthScope` = a secret
+*name* hint only); sync history → `tblActivityLog` **without raw PII payloads**.

--- a/.claude/live-congregant-strategy.md
+++ b/.claude/live-congregant-strategy.md
@@ -21,6 +21,18 @@ the licence's **non-transferable / no-sublicense** clause: if CCLI reads "lyrics
 installed app" as the church *authorising a third party* to display, the church's licence would
 **not** cover it. **Silence is not permission.** → **Do not ship the auto-unlock on assumption.**
 
+> **Owner decision (2026-06-21) — risk accepted; Phase 3 UNBLOCKED.** The owner assesses this as
+> low-risk on two grounds: (1) the CCL already covers **printed** song sheets the church gives
+> congregants — which *persist and go home* — so a **temporary, presence-gated, vanishes-on-leave**
+> per-device display is *more* restrictive, not less; (2) the unlock is bound to presence and revoked
+> on leaving (no take-home copy). This is sound and materially de-risks the premise. The **one** point
+> the printed-sheet analogy doesn't settle is the non-transferable/no-sublicense angle — whether the
+> text routed through the iHymns app is "the church's own electronic display" (fine — cf.
+> ProPresenter / Proclaim / SongSelect apps operating under a church licence) or "authorising a third
+> party". A one-line written confirmation from CCLI would make it airtight but is **optional**, not a
+> gate. **Build requirement that still stands:** each device MUST render the CCL copyright notice
+> (title · author · copyright owner · the church's CCLI licence number) per song, same as print/projection.
+
 ### Reframe 2 — geolocation can't prove "in this room for this service"; a venue code can
 Browser geolocation is the **wrong primary gate**: trivially spoofable (DevTools Sensors / one-click
 extensions, no native defence), **35–100 m indoors** (can't tell the car park or the back-to-back

--- a/appWeb/.sql/migrate-external-systems.php
+++ b/appWeb/.sql/migrate-external-systems.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — External-system integration hook (Service Mode follow-on, #1325 / #1327)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * A forward-looking, DORMANT schema hook so iHymns entities (organisations,
+ * venues, service schedules — and later others) can be linked to / synced with
+ * an EXTERNAL system in future. The first target is "WebMS-Intra"; the design
+ * is system-agnostic so a second system never needs an ALTER (rule #20). Built
+ * now because the Service-Mode venue/schedule schema is landing in the same
+ * batch — adding the integration hook up front avoids a second migration.
+ *
+ * DESIGN (validated by an adversarial design workflow — see
+ * .claude/live-congregant-strategy.md §"External-system integration"):
+ *   - tblExternalSystems — a controlled-vocabulary REGISTRY of systems we hold
+ *     an identity in (sibling of tblExternalLinkTypes which classifies public
+ *     LINKS). System keys live in DATA, never hard-coded in PHP (rule #15).
+ *   - tblOrganisationExternalRefs / tblOrgVenueExternalRefs /
+ *     tblOrgServiceScheduleExternalRefs — per-entity DEDICATED mapping tables
+ *     (rule #15 forbids a generic polymorphic EntityType+EntityId FK table;
+ *     the generic "candidate A" was rejected because its numeric EntityId can't
+ *     address SongId VARCHAR keys and a no-FK polymorphism orphan-rots on
+ *     delete). Each FKs the registry + CASCADEs from its entity.
+ *
+ * Forward-looking columns reserved now (dormant) so the sync engine never
+ * forces a second migration: SyncStatus / SyncDirection (VARCHAR, app-validated,
+ * NOT ENUM); (Source, SourceRef) UNIQUE for idempotent external re-import;
+ * (SystemId, ExternalId) UNIQUE = one external record ↔ one iHymns row per
+ * system; LocalHash + ExternalEtag for optimistic-concurrency conflict
+ * detection; LastError + LastErrorAt for operator triage; DeletedAt for
+ * soft-unlink (distinct from FK-CASCADE hard delete); MetaJson for loss-free
+ * round-trip. LastSyncedAt / LastErrorAt / DeletedAt are DATETIME not TIMESTAMP.
+ *
+ * SECURITY / PRIVACY (do NOT skip when the sync engine is built — dormant now):
+ *   - tblExternalSystems.AuthScope is a secret-NAME hint only, NEVER a secret.
+ *   - Org/venue address + service times = identifiable presence patterns for a
+ *     faith community (GDPR Art. 9-adjacent). Outbound sync needs a lawful
+ *     basis + DPA; default SyncDirection is 'inbound' until one exists.
+ *   - The 3 docroots SHARE ONE MySQL — the future sync engine MUST gate live
+ *     runs to production (or a sandbox BaseUrl) so alpha/beta can't exfiltrate
+ *     real congregation data. Route sync history to tblActivityLog WITHOUT raw
+ *     PII payloads.
+ *
+ * Additive + DORMANT + IDEMPOTENT (table-existence guarded; the seed uses
+ * INSERT … ON DUPLICATE KEY UPDATE). Runs AFTER migrate-org-venues.php (FKs).
+ *
+ * @migration-adds tblExternalSystems
+ * @migration-adds tblOrganisationExternalRefs
+ * @migration-adds tblOrgVenueExternalRefs
+ * @migration-adds tblOrgServiceScheduleExternalRefs
+ *
+ * USAGE:
+ *   CLI:  php appWeb/.sql/migrate-external-systems.php
+ *   Web:  /manage/setup-database → "External-system integration hook" button
+ *
+ * @requires PHP 8.1+ with mysqli
+ */
+
+$isCli = (php_sapi_name() === 'cli');
+if (!$isCli && !defined('IHYMNS_SETUP_DASHBOARD')) {
+    header('Content-Type: text/plain; charset=UTF-8');
+    header('X-Content-Type-Options: nosniff');
+    header('Cache-Control: no-store');
+}
+function _migXS_output(string $m): void { global $isCli; echo $m . ($isCli ? "\n" : "<br>\n"); if (!$isCli) flush(); }
+function _migXS_tableExists(\mysqli $db, string $t): bool { $r = $db->query("SHOW TABLES LIKE '{$t}'"); return (bool)($r && $r->num_rows > 0); }
+
+$credFile = dirname(__DIR__) . DIRECTORY_SEPARATOR . '.auth' . DIRECTORY_SEPARATOR . 'db_credentials.php';
+if (!file_exists($credFile)) { _migXS_output("ERROR: MySQL credentials not found. Run install.php first."); return; }
+require_once $credFile;
+
+_migXS_output("");
+_migXS_output("=== iHymns — External-system integration hook (#1327) ===");
+
+try {
+    $mysql = new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME);
+    $mysql->set_charset('utf8mb4');
+} catch (\mysqli_sql_exception $e) { _migXS_output("ERROR: MySQL connection failed: " . $e->getMessage()); return; }
+_migXS_output("Connected to MySQL: " . DB_NAME);
+
+try {
+    /* 1) Registry of external systems. */
+    if (_migXS_tableExists($mysql, 'tblExternalSystems')) {
+        _migXS_output("  [SKIP] tblExternalSystems already present.");
+    } else {
+        $mysql->query(
+            "CREATE TABLE tblExternalSystems (
+                Id            INT UNSIGNED  AUTO_INCREMENT PRIMARY KEY,
+                SystemKey     VARCHAR(60)   NOT NULL COMMENT 'Stable machine key (e.g. webms-intra). App resolves systems by this — NEVER hard-code the key list in PHP (rule #15)',
+                Name          VARCHAR(120)  NOT NULL COMMENT 'Curator-facing display name (e.g. WebMS Intranet)',
+                Description   VARCHAR(255)  NULL DEFAULT NULL COMMENT 'What this system is / what the mapping means',
+                BaseUrl       VARCHAR(255)  NULL DEFAULT NULL COMMENT 'Base URL to build a deep link from a stored ExternalId; {id} placeholder substituted app-side',
+                Kind          VARCHAR(30)   NOT NULL DEFAULT 'sync' COMMENT 'sync | directory | finance | rota | identity | other — app-validated, VARCHAR not ENUM (rule #20)',
+                AuthScope     VARCHAR(40)   NULL DEFAULT NULL COMMENT 'Credential/realm hint the sync layer maps to a secret NAME — never the secret itself',
+                IsActive      TINYINT(1)    NOT NULL DEFAULT 1 COMMENT '0 = registered but paused; mappings persist, sync skips',
+                DisplayOrder  INT UNSIGNED  NOT NULL DEFAULT 0,
+                CreatedAt     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UpdatedAt     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                UNIQUE KEY uq_SystemKey (SystemKey),
+                INDEX      idx_Active   (IsActive),
+                INDEX      idx_Kind     (Kind, DisplayOrder)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+              COMMENT='Registry of external SYSTEMS an iHymns entity can be mapped/synced into (WebMS-Intra, …). SystemKey UNIQUE so keys are never hard-coded (rule #15); sibling of tblExternalLinkTypes (#833).'"
+        );
+        _migXS_output("  [OK] Created tblExternalSystems.");
+    }
+
+    /* Seed the first system row so the per-entity ref FKs (RESTRICT) have a
+       target — without this the first INSERT throws under STRICT. Idempotent. */
+    $mysql->query(
+        "INSERT INTO tblExternalSystems (SystemKey, Name, Description, Kind, IsActive, DisplayOrder)
+         VALUES ('webms-intra', 'WebMS Intranet',
+                 'Reserved integration target (#1327) — dormant until a sync engine + DPA exist.',
+                 'sync', 0, 0)
+         ON DUPLICATE KEY UPDATE SystemKey = SystemKey"
+    );
+    _migXS_output("  [OK] Seeded the 'webms-intra' system row (paused/dormant).");
+
+    /* 2) Per-organisation external refs. */
+    if (_migXS_tableExists($mysql, 'tblOrganisationExternalRefs')) {
+        _migXS_output("  [SKIP] tblOrganisationExternalRefs already present.");
+    } else {
+        $mysql->query(
+            "CREATE TABLE tblOrganisationExternalRefs (
+                Id            INT UNSIGNED  AUTO_INCREMENT PRIMARY KEY,
+                OrgId         INT UNSIGNED  NOT NULL COMMENT 'FK to tblOrganisations.Id — the iHymns org',
+                SystemId      INT UNSIGNED  NOT NULL COMMENT 'FK to tblExternalSystems.Id — which external system this id lives in',
+                ExternalId    VARCHAR(190)  NOT NULL COMMENT 'Primary identifier of the org WITHIN the external system. 190 = utf8mb4 index-safe',
+                ExternalSlug  VARCHAR(190)  NULL DEFAULT NULL COMMENT 'Optional human/slug handle in the external system',
+                SyncStatus    VARCHAR(20)   NOT NULL DEFAULT 'linked' COMMENT 'linked | pending | synced | conflict | error | deprecated — app-validated, VARCHAR not ENUM (rule #20)',
+                SyncDirection VARCHAR(20)   NOT NULL DEFAULT 'inbound' COMMENT 'none | inbound | outbound | bidirectional — VARCHAR not ENUM; inbound-first until a DPA exists',
+                Source        VARCHAR(100)  NOT NULL DEFAULT 'webms-intra' COMMENT 'Provenance of the mapping row; part of the idempotency key',
+                SourceRef     VARCHAR(190)  NULL DEFAULT NULL COMMENT 'External primary id from the Source push for idempotent re-import; NULL for a manual link (multiple NULLs coexist, rule #20)',
+                LocalHash     VARCHAR(64)   NULL DEFAULT NULL COMMENT 'Fingerprint of the iHymns row at last sync — optimistic-concurrency conflict detection',
+                ExternalEtag  VARCHAR(190)  NULL DEFAULT NULL COMMENT 'External side version/etag at last sync — conflict detection',
+                LastSyncedAt  DATETIME      NULL DEFAULT NULL COMMENT 'Last successful sync (DATETIME not TIMESTAMP — rule #20)',
+                LastError     VARCHAR(500)  NULL DEFAULT NULL COMMENT 'Last sync failure detail for operator triage (no secrets/PII)',
+                LastErrorAt   DATETIME      NULL DEFAULT NULL,
+                DeletedAt     DATETIME      NULL DEFAULT NULL COMMENT 'Soft-unlink (operator removed the link) — distinct from FK-CASCADE hard delete',
+                MetaJson      JSON          NULL DEFAULT NULL COMMENT 'Lossless extra attrs from the external system for round-trip re-export',
+                CreatedBy     INT UNSIGNED  NULL DEFAULT NULL COMMENT 'FK to tblUsers.Id — who created the link (NULL for system import)',
+                CreatedAt     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UpdatedAt     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                UNIQUE KEY uq_Org_System_Ext (OrgId, SystemId, ExternalId),
+                UNIQUE KEY uq_System_Ext     (SystemId, ExternalId),
+                UNIQUE KEY uq_SourceRef      (Source, SourceRef),
+                INDEX      idx_Org           (OrgId),
+                INDEX      idx_System        (SystemId),
+                INDEX      idx_Status        (SyncStatus),
+                CONSTRAINT fk_OrgExtRef_Org       FOREIGN KEY (OrgId)     REFERENCES tblOrganisations(Id)  ON DELETE CASCADE  ON UPDATE CASCADE,
+                CONSTRAINT fk_OrgExtRef_System    FOREIGN KEY (SystemId)  REFERENCES tblExternalSystems(Id) ON DELETE RESTRICT ON UPDATE CASCADE,
+                CONSTRAINT fk_OrgExtRef_CreatedBy FOREIGN KEY (CreatedBy) REFERENCES tblUsers(Id)          ON DELETE SET NULL ON UPDATE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+              COMMENT='Per-org external-system identity map (rule #15 dedicated ref table). (Source,SourceRef) UNIQUE = idempotent re-import (rule #20); SystemId in the keys = multi-system without an ALTER.'"
+        );
+        _migXS_output("  [OK] Created tblOrganisationExternalRefs.");
+    }
+
+    /* 3) Per-venue external refs (OrgId denorm mirrors tblOrgServiceSchedules). */
+    if (_migXS_tableExists($mysql, 'tblOrgVenueExternalRefs')) {
+        _migXS_output("  [SKIP] tblOrgVenueExternalRefs already present.");
+    } else {
+        $mysql->query(
+            "CREATE TABLE tblOrgVenueExternalRefs (
+                Id            INT UNSIGNED  AUTO_INCREMENT PRIMARY KEY,
+                VenueId       INT UNSIGNED  NOT NULL COMMENT 'FK to tblOrgVenues.Id — the iHymns venue',
+                OrgId         INT UNSIGNED  NOT NULL COMMENT 'Denorm of the venue org (app-derived, never client-trusted) for cheap org-scoped queries',
+                SystemId      INT UNSIGNED  NOT NULL COMMENT 'FK to tblExternalSystems.Id',
+                ExternalId    VARCHAR(190)  NOT NULL COMMENT 'Primary identifier of the venue WITHIN the external system',
+                ExternalSlug  VARCHAR(190)  NULL DEFAULT NULL COMMENT 'Optional human/slug handle in the external system',
+                SyncStatus    VARCHAR(20)   NOT NULL DEFAULT 'linked' COMMENT 'linked | pending | synced | conflict | error | deprecated — app-validated, VARCHAR not ENUM (rule #20)',
+                SyncDirection VARCHAR(20)   NOT NULL DEFAULT 'inbound' COMMENT 'none | inbound | outbound | bidirectional — VARCHAR not ENUM',
+                Source        VARCHAR(100)  NOT NULL DEFAULT 'webms-intra' COMMENT 'Provenance of the mapping row; part of the idempotency key',
+                SourceRef     VARCHAR(190)  NULL DEFAULT NULL COMMENT 'External primary id from the Source push for idempotent re-import; NULL for a manual link',
+                LocalHash     VARCHAR(64)   NULL DEFAULT NULL COMMENT 'Fingerprint of the iHymns row at last sync — conflict detection',
+                ExternalEtag  VARCHAR(190)  NULL DEFAULT NULL COMMENT 'External side version/etag at last sync — conflict detection',
+                LastSyncedAt  DATETIME      NULL DEFAULT NULL COMMENT 'Last successful sync (DATETIME not TIMESTAMP — rule #20)',
+                LastError     VARCHAR(500)  NULL DEFAULT NULL COMMENT 'Last sync failure detail for operator triage (no secrets/PII)',
+                LastErrorAt   DATETIME      NULL DEFAULT NULL,
+                DeletedAt     DATETIME      NULL DEFAULT NULL COMMENT 'Soft-unlink — distinct from FK-CASCADE hard delete',
+                MetaJson      JSON          NULL DEFAULT NULL COMMENT 'Lossless extra attrs for round-trip re-export',
+                CreatedBy     INT UNSIGNED  NULL DEFAULT NULL COMMENT 'FK to tblUsers.Id — who created the link (NULL for system import)',
+                CreatedAt     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UpdatedAt     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                UNIQUE KEY uq_Venue_System_Ext (VenueId, SystemId, ExternalId),
+                UNIQUE KEY uq_System_Ext       (SystemId, ExternalId),
+                UNIQUE KEY uq_SourceRef        (Source, SourceRef),
+                INDEX      idx_Venue           (VenueId),
+                INDEX      idx_Org             (OrgId),
+                INDEX      idx_System          (SystemId),
+                INDEX      idx_Status          (SyncStatus),
+                CONSTRAINT fk_VenueExtRef_Venue     FOREIGN KEY (VenueId)   REFERENCES tblOrgVenues(Id)      ON DELETE CASCADE  ON UPDATE CASCADE,
+                CONSTRAINT fk_VenueExtRef_Org       FOREIGN KEY (OrgId)     REFERENCES tblOrganisations(Id)  ON DELETE CASCADE  ON UPDATE CASCADE,
+                CONSTRAINT fk_VenueExtRef_System    FOREIGN KEY (SystemId)  REFERENCES tblExternalSystems(Id) ON DELETE RESTRICT ON UPDATE CASCADE,
+                CONSTRAINT fk_VenueExtRef_CreatedBy FOREIGN KEY (CreatedBy) REFERENCES tblUsers(Id)          ON DELETE SET NULL ON UPDATE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+              COMMENT='Per-venue external-system identity map (rule #15 dedicated ref table). (Source,SourceRef) UNIQUE = idempotent re-import (rule #20); OrgId denorm mirrors tblOrgServiceSchedules.'"
+        );
+        _migXS_output("  [OK] Created tblOrgVenueExternalRefs.");
+    }
+
+    /* 4) Per-service-schedule external refs (full org/venue/schedule scope in
+          one pass so a schedule sync never forces a third migration). */
+    if (_migXS_tableExists($mysql, 'tblOrgServiceScheduleExternalRefs')) {
+        _migXS_output("  [SKIP] tblOrgServiceScheduleExternalRefs already present.");
+    } else {
+        $mysql->query(
+            "CREATE TABLE tblOrgServiceScheduleExternalRefs (
+                Id            INT UNSIGNED  AUTO_INCREMENT PRIMARY KEY,
+                ScheduleId    INT UNSIGNED  NOT NULL COMMENT 'FK to tblOrgServiceSchedules.Id — the iHymns service time',
+                OrgId         INT UNSIGNED  NOT NULL COMMENT 'Denorm of the schedule org (app-derived, never client-trusted) for cheap org-scoped queries',
+                SystemId      INT UNSIGNED  NOT NULL COMMENT 'FK to tblExternalSystems.Id',
+                ExternalId    VARCHAR(190)  NOT NULL COMMENT 'Primary identifier of the service/event WITHIN the external system',
+                ExternalSlug  VARCHAR(190)  NULL DEFAULT NULL COMMENT 'Optional human/slug handle in the external system',
+                SyncStatus    VARCHAR(20)   NOT NULL DEFAULT 'linked' COMMENT 'linked | pending | synced | conflict | error | deprecated — app-validated, VARCHAR not ENUM (rule #20)',
+                SyncDirection VARCHAR(20)   NOT NULL DEFAULT 'inbound' COMMENT 'none | inbound | outbound | bidirectional — VARCHAR not ENUM',
+                Source        VARCHAR(100)  NOT NULL DEFAULT 'webms-intra' COMMENT 'Provenance of the mapping row; part of the idempotency key',
+                SourceRef     VARCHAR(190)  NULL DEFAULT NULL COMMENT 'External primary id from the Source push for idempotent re-import; NULL for a manual link',
+                LocalHash     VARCHAR(64)   NULL DEFAULT NULL COMMENT 'Fingerprint of the iHymns row at last sync — conflict detection',
+                ExternalEtag  VARCHAR(190)  NULL DEFAULT NULL COMMENT 'External side version/etag at last sync — conflict detection',
+                LastSyncedAt  DATETIME      NULL DEFAULT NULL COMMENT 'Last successful sync (DATETIME not TIMESTAMP — rule #20)',
+                LastError     VARCHAR(500)  NULL DEFAULT NULL COMMENT 'Last sync failure detail for operator triage (no secrets/PII)',
+                LastErrorAt   DATETIME      NULL DEFAULT NULL,
+                DeletedAt     DATETIME      NULL DEFAULT NULL COMMENT 'Soft-unlink — distinct from FK-CASCADE hard delete',
+                MetaJson      JSON          NULL DEFAULT NULL COMMENT 'Lossless extra attrs for round-trip re-export',
+                CreatedBy     INT UNSIGNED  NULL DEFAULT NULL COMMENT 'FK to tblUsers.Id — who created the link (NULL for system import)',
+                CreatedAt     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UpdatedAt     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                UNIQUE KEY uq_Sched_System_Ext (ScheduleId, SystemId, ExternalId),
+                UNIQUE KEY uq_System_Ext       (SystemId, ExternalId),
+                UNIQUE KEY uq_SourceRef        (Source, SourceRef),
+                INDEX      idx_Sched           (ScheduleId),
+                INDEX      idx_Org             (OrgId),
+                INDEX      idx_System          (SystemId),
+                INDEX      idx_Status          (SyncStatus),
+                CONSTRAINT fk_SchedExtRef_Sched     FOREIGN KEY (ScheduleId) REFERENCES tblOrgServiceSchedules(Id) ON DELETE CASCADE  ON UPDATE CASCADE,
+                CONSTRAINT fk_SchedExtRef_Org       FOREIGN KEY (OrgId)      REFERENCES tblOrganisations(Id)     ON DELETE CASCADE  ON UPDATE CASCADE,
+                CONSTRAINT fk_SchedExtRef_System    FOREIGN KEY (SystemId)   REFERENCES tblExternalSystems(Id)   ON DELETE RESTRICT ON UPDATE CASCADE,
+                CONSTRAINT fk_SchedExtRef_CreatedBy FOREIGN KEY (CreatedBy)  REFERENCES tblUsers(Id)             ON DELETE SET NULL ON UPDATE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+              COMMENT='Per-service-schedule external-system identity map (rule #15 dedicated ref table). (Source,SourceRef) UNIQUE = idempotent re-import (rule #20); OrgId denorm mirrors tblOrgServiceSchedules.'"
+        );
+        _migXS_output("  [OK] Created tblOrgServiceScheduleExternalRefs.");
+    }
+
+    _migXS_output("  Tables ship empty + dormant; no read/write code consumes them yet. The WebMS-Intra sync engine is future, gated work (#1327) requiring a DPA + production-only run.");
+    _migXS_output("Migration complete.");
+} catch (\mysqli_sql_exception $e) {
+    _migXS_output("ERROR: " . $e->getMessage());
+}

--- a/appWeb/.sql/migrate-service-mode-sessions.php
+++ b/appWeb/.sql/migrate-service-mode-sessions.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Service Mode sessions (Phase 2a schema, #1335 / epic #1323)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * The forward-looking schema for "Service Mode" — congregants join a live
+ * service via a venue-displayed ROTATING CODE and follow the songs in sync,
+ * reusing the #1268 Live-Follow spine (tblLiveFollowSessions + the StateRevision
+ * short-poll). Phase 3 (the temporary presence-scoped CCLI unlock) binds on top.
+ *
+ * DESIGN (locked via an adversarial design workflow — see
+ * .claude/live-congregant-strategy.md). This ships the WHOLE Phase 2+3 schema in
+ * ONE batch (rule #20), additive + dormant — no behaviour yet; the projection
+ * page (2b), congregant client (2c) and gated unlock (3) consume it later.
+ *
+ *   (1) EXTEND tblLiveFollowSessions (reuse the spine, don't fork it):
+ *       - RELAX HostUserId to NULL — a service session is anchored to a
+ *         VENUE+SCHEDULE and may be host-less. The existing one-active-per-host
+ *         supersede (`WHERE HostUserId = ?`, api.php:11618) is already NULL-safe
+ *         (`NULL = <id>` never matches), so a host creating a session never
+ *         touches a host-less service session — no api.php change needed here.
+ *       - light up VenueId / ScheduleId / OccurrenceDate (the service-occurrence
+ *         identity), SessionKind ('host' = #1268 leader follow, 'service' = this),
+ *         and Channel — the 3-DOCROOT discriminator (HTTP_HOST-derived at create)
+ *         so a session started on alpha/beta is NEVER joinable/gating on prod
+ *         (same class as the prod-stale-SongbookName bug; must be in EVERY WHERE).
+ *   (2) tblLiveFollowJoinCodes — DB-stored rotating nonce window (current +
+ *       previous + grace) per session; SESSION-SCOPED uniqueness so two venues'
+ *       identical codes never collide. The mint/rotate is transactional (2b).
+ *   (3) tblServicePresence — an ANONYMOUS congregant's presence: client-minted
+ *       PresenceDeviceId + an opaque PresenceToken (the gate key, hard-revocable),
+ *       ExpiresAt = resolved-UTC min(service-occurrence end, hard ceiling). The
+ *       Phase-3 gate reads this by token; revoked on leave/expiry/session-end.
+ *   (4) tblServicePollCounters — a PER-SESSION poll budget so a NAT-shared
+ *       congregation (many devices, one church-wifi IP) isn't throttled by the
+ *       #1268 per-IP cap (the flagged NAT fix).
+ *
+ * VARCHAR-not-ENUM for SessionKind / Status (rule #20). DATETIME (not TIMESTAMP)
+ * for the sync/expiry clocks. Additive + IDEMPOTENT (column/table guarded).
+ * Runs AFTER migrate-org-venues.php (FKs to tblOrgVenues / tblOrgServiceSchedules).
+ *
+ * @migration-adds tblLiveFollowSessions.VenueId
+ * @migration-adds tblLiveFollowSessions.ScheduleId
+ * @migration-adds tblLiveFollowSessions.OccurrenceDate
+ * @migration-adds tblLiveFollowSessions.SessionKind
+ * @migration-adds tblLiveFollowSessions.Channel
+ * @migration-adds tblLiveFollowJoinCodes
+ * @migration-adds tblServicePresence
+ * @migration-adds tblServicePollCounters
+ *
+ * USAGE:
+ *   CLI:  php appWeb/.sql/migrate-service-mode-sessions.php
+ *   Web:  /manage/setup-database → "Service Mode sessions" button
+ *
+ * @requires PHP 8.1+ with mysqli
+ */
+
+$isCli = (php_sapi_name() === 'cli');
+if (!$isCli && !defined('IHYMNS_SETUP_DASHBOARD')) {
+    header('Content-Type: text/plain; charset=UTF-8');
+    header('X-Content-Type-Options: nosniff');
+    header('Cache-Control: no-store');
+}
+function _migSMS_output(string $m): void { global $isCli; echo $m . ($isCli ? "\n" : "<br>\n"); if (!$isCli) flush(); }
+function _migSMS_tableExists(\mysqli $db, string $t): bool { $r = $db->query("SHOW TABLES LIKE '{$t}'"); return (bool)($r && $r->num_rows > 0); }
+function _migSMS_columnExists(\mysqli $db, string $t, string $c): bool
+{
+    $stmt = $db->prepare(
+        "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ? LIMIT 1"
+    );
+    $stmt->bind_param('ss', $t, $c);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+$credFile = dirname(__DIR__) . DIRECTORY_SEPARATOR . '.auth' . DIRECTORY_SEPARATOR . 'db_credentials.php';
+if (!file_exists($credFile)) { _migSMS_output("ERROR: MySQL credentials not found. Run install.php first."); return; }
+require_once $credFile;
+
+_migSMS_output("");
+_migSMS_output("=== iHymns — Service Mode sessions (#1335) ===");
+
+try {
+    $mysql = new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME);
+    $mysql->set_charset('utf8mb4');
+} catch (\mysqli_sql_exception $e) { _migSMS_output("ERROR: MySQL connection failed: " . $e->getMessage()); return; }
+_migSMS_output("Connected to MySQL: " . DB_NAME);
+
+try {
+    /* (1) Extend the #1268 spine. Gated on VenueId-absent so the whole ALTER
+          (incl. the HostUserId relax) runs once + is idempotent. */
+    if (_migSMS_columnExists($mysql, 'tblLiveFollowSessions', 'VenueId')) {
+        _migSMS_output("  [SKIP] tblLiveFollowSessions already extended.");
+    } else {
+        $mysql->query(
+            "ALTER TABLE tblLiveFollowSessions
+                MODIFY HostUserId INT UNSIGNED NULL DEFAULT NULL
+                    COMMENT 'FK to tblUsers — leader hosting; NULL for an org/venue-anchored service session (#1335)',
+                ADD COLUMN VenueId        INT UNSIGNED NULL DEFAULT NULL COMMENT 'FK tblOrgVenues — venue of this service session' AFTER OrgId,
+                ADD COLUMN ScheduleId     INT UNSIGNED NULL DEFAULT NULL COMMENT 'FK tblOrgServiceSchedules — the recurring schedule' AFTER VenueId,
+                ADD COLUMN OccurrenceDate DATE         NULL DEFAULT NULL COMMENT 'Date of this occurrence (scheduleId + date = occurrence identity)' AFTER ScheduleId,
+                ADD COLUMN SessionKind    VARCHAR(20)  NOT NULL DEFAULT 'host' COMMENT 'host = #1268 leader follow | service = #1335 venue/org session — app-validated, VARCHAR not ENUM',
+                ADD COLUMN Channel        VARCHAR(16)  NULL DEFAULT NULL COMMENT '3-docroot env discriminator (HTTP_HOST-derived at create); MUST be filtered in every join/poll/gate/prune query so a non-prod session is never joinable on prod',
+                ADD INDEX idx_Service (VenueId, ScheduleId, OccurrenceDate, IsActive),
+                ADD INDEX idx_OrgActive (OrgId, IsActive),
+                ADD CONSTRAINT fk_LiveFollow_Venue    FOREIGN KEY (VenueId)    REFERENCES tblOrgVenues(Id)          ON DELETE SET NULL ON UPDATE CASCADE,
+                ADD CONSTRAINT fk_LiveFollow_Schedule FOREIGN KEY (ScheduleId) REFERENCES tblOrgServiceSchedules(Id) ON DELETE SET NULL ON UPDATE CASCADE"
+        );
+        _migSMS_output("  [OK] Extended tblLiveFollowSessions (host NULLable + VenueId/ScheduleId/OccurrenceDate/SessionKind/Channel + indexes + FKs).");
+    }
+
+    /* (2) Rotating join codes. */
+    if (_migSMS_tableExists($mysql, 'tblLiveFollowJoinCodes')) {
+        _migSMS_output("  [SKIP] tblLiveFollowJoinCodes already present.");
+    } else {
+        $mysql->query(
+            "CREATE TABLE tblLiveFollowJoinCodes (
+                Id          BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                SessionId   INT UNSIGNED  NOT NULL COMMENT 'FK tblLiveFollowSessions',
+                Code        VARCHAR(12)   NOT NULL COMMENT 'Crockford base32 rotating join code (current/previous live)',
+                Generation  INT UNSIGNED  NOT NULL DEFAULT 0 COMMENT 'Monotonic per-session rotation counter',
+                Status      VARCHAR(20)   NOT NULL DEFAULT 'current' COMMENT 'current | previous | superseded — app-validated, VARCHAR not ENUM (rule #20)',
+                IssuedAt    DATETIME      NOT NULL,
+                ExpiresAt   DATETIME      NOT NULL COMMENT 'Rotation horizon + grace (UTC); join rejects past this',
+                CreatedAt   TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE KEY uq_Session_Code (SessionId, Code),
+                INDEX idx_Session_Status (SessionId, Status),
+                INDEX idx_Expiry (ExpiresAt),
+                CONSTRAINT fk_JoinCode_Session FOREIGN KEY (SessionId) REFERENCES tblLiveFollowSessions(Id) ON DELETE CASCADE ON UPDATE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+              COMMENT='Rotating venue join codes for Service Mode (#1335). Session-scoped uniqueness; current+previous window so a just-before-rotation scan still validates.'"
+        );
+        _migSMS_output("  [OK] Created tblLiveFollowJoinCodes.");
+    }
+
+    /* (3) Anonymous congregant presence (Phase 2 join + Phase 3 gate read). */
+    if (_migSMS_tableExists($mysql, 'tblServicePresence')) {
+        _migSMS_output("  [SKIP] tblServicePresence already present.");
+    } else {
+        $mysql->query(
+            "CREATE TABLE tblServicePresence (
+                Id               BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                SessionId        INT UNSIGNED  NOT NULL COMMENT 'FK tblLiveFollowSessions',
+                OrgId            INT UNSIGNED  NULL DEFAULT NULL COMMENT 'Denorm of the session org for the Phase-3 gate read',
+                VenueId          INT UNSIGNED  NULL DEFAULT NULL,
+                ScheduleId       INT UNSIGNED  NULL DEFAULT NULL,
+                OccurrenceDate   DATE          NULL DEFAULT NULL,
+                Channel          VARCHAR(16)   NULL DEFAULT NULL COMMENT '3-docroot env discriminator (copied from the session); filter in every query',
+                PresenceDeviceId VARCHAR(64)   NOT NULL COMMENT 'Client-minted anonymous device id (localStorage UUID) — advisory cooldown key, NOT a security control',
+                PresenceToken    CHAR(43)      NOT NULL COMMENT 'Opaque base64url 32-byte nonce — the gate key; hard-revocable (not a signed token)',
+                JoinedAt         DATETIME      NOT NULL,
+                LastSeenAt       DATETIME      NOT NULL,
+                ExpiresAt        DATETIME      NOT NULL COMMENT 'Resolved UTC = min(service-occurrence end via venue IANA tz, hard ceiling); gate + prune compare against this',
+                IsActive         TINYINT(1)    NOT NULL DEFAULT 1 COMMENT '0 = left/revoked → immediate gate revocation',
+                CreatedAt        TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UpdatedAt        TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                UNIQUE KEY uq_Token (PresenceToken),
+                UNIQUE KEY uq_DeviceSession (SessionId, PresenceDeviceId),
+                INDEX idx_Session (SessionId, IsActive),
+                INDEX idx_Gate (PresenceToken, IsActive, ExpiresAt),
+                CONSTRAINT fk_Presence_Session FOREIGN KEY (SessionId) REFERENCES tblLiveFollowSessions(Id) ON DELETE CASCADE ON UPDATE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+              COMMENT='Anonymous congregant presence for Service Mode (#1335). PresenceToken = the Phase-3 gate key; ExpiresAt = resolved-UTC service end; one row per device per session (re-join reactivates).'"
+        );
+        _migSMS_output("  [OK] Created tblServicePresence.");
+    }
+
+    /* (4) Per-session NAT-safe poll budget. */
+    if (_migSMS_tableExists($mysql, 'tblServicePollCounters')) {
+        _migSMS_output("  [SKIP] tblServicePollCounters already present.");
+    } else {
+        $mysql->query(
+            "CREATE TABLE tblServicePollCounters (
+                Id          BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                SessionId   INT UNSIGNED NOT NULL COMMENT 'FK tblLiveFollowSessions',
+                WindowStart DATETIME     NOT NULL COMMENT 'Start of the fixed counting window (UTC)',
+                PollCount   INT UNSIGNED NOT NULL DEFAULT 0 COMMENT 'Polls served to the WHOLE session in this window — NAT-safe per-session budget (not per-IP, which would throttle a congregation behind one church-wifi IP)',
+                CreatedAt   TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE KEY uq_Session_Window (SessionId, WindowStart),
+                INDEX idx_Window (WindowStart),
+                CONSTRAINT fk_PollCtr_Session FOREIGN KEY (SessionId) REFERENCES tblLiveFollowSessions(Id) ON DELETE CASCADE ON UPDATE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+              COMMENT='Per-session poll budget for Service Mode (#1335) — the NAT-safe replacement for the #1268 per-IP poll cap.'"
+        );
+        _migSMS_output("  [OK] Created tblServicePollCounters.");
+    }
+
+    _migSMS_output("  Tables ship empty + dormant; the projection page (2b), congregant client (2c) + gated unlock (3) consume them. NOTHING joins/gates yet.");
+    _migSMS_output("Migration complete.");
+} catch (\mysqli_sql_exception $e) {
+    _migSMS_output("ERROR: " . $e->getMessage());
+}

--- a/appWeb/.sql/migrate-songbook-display-abbr.php
+++ b/appWeb/.sql/migrate-songbook-display-abbr.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Songbook display label (#1332)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Adds tblSongbooks.DisplayAbbr — an OPTIONAL free-text label shown to users in
+ * place of the Abbreviation badge (so a book can display "AH-OLD", "Psalty:Kids",
+ * etc.). The Abbreviation column itself stays strictly alphanumeric because it is
+ * the SongId prefix (MP-1008, parsed <letters>-<digits> by the PWA router /
+ * OG-image / API validators); decoupling the display label from the code lets the
+ * label use - _ : with ZERO change to SongIds, URLs or any FK. NULL = fall back to
+ * the Abbreviation.
+ *
+ * Additive + IDEMPOTENT (column-existence guarded). The read path
+ * (SongData::_songbookDisplayAbbrSelect) is INFORMATION_SCHEMA-gated, so the app
+ * works whether or not this migration has run yet.
+ *
+ * @migration-adds tblSongbooks.DisplayAbbr
+ *
+ * USAGE:
+ *   CLI:  php appWeb/.sql/migrate-songbook-display-abbr.php
+ *   Web:  /manage/setup-database → "Songbook display label" button
+ *
+ * @requires PHP 8.1+ with mysqli
+ */
+
+$isCli = (php_sapi_name() === 'cli');
+if (!$isCli && !defined('IHYMNS_SETUP_DASHBOARD')) {
+    header('Content-Type: text/plain; charset=UTF-8');
+    header('X-Content-Type-Options: nosniff');
+    header('Cache-Control: no-store');
+}
+function _migSDA_output(string $m): void { global $isCli; echo $m . ($isCli ? "\n" : "<br>\n"); if (!$isCli) flush(); }
+function _migSDA_columnExists(\mysqli $db, string $t, string $c): bool
+{
+    $stmt = $db->prepare(
+        "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ? LIMIT 1"
+    );
+    $stmt->bind_param('ss', $t, $c);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+$credFile = dirname(__DIR__) . DIRECTORY_SEPARATOR . '.auth' . DIRECTORY_SEPARATOR . 'db_credentials.php';
+if (!file_exists($credFile)) { _migSDA_output("ERROR: MySQL credentials not found. Run install.php first."); return; }
+require_once $credFile;
+
+_migSDA_output("");
+_migSDA_output("=== iHymns — Songbook display label (#1332) ===");
+
+try {
+    $mysql = new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME);
+    $mysql->set_charset('utf8mb4');
+} catch (\mysqli_sql_exception $e) { _migSDA_output("ERROR: MySQL connection failed: " . $e->getMessage()); return; }
+_migSDA_output("Connected to MySQL: " . DB_NAME);
+
+try {
+    if (_migSDA_columnExists($mysql, 'tblSongbooks', 'DisplayAbbr')) {
+        _migSDA_output("  [SKIP] tblSongbooks.DisplayAbbr already present.");
+    } else {
+        $mysql->query(
+            "ALTER TABLE tblSongbooks
+                ADD COLUMN DisplayAbbr VARCHAR(30) NULL DEFAULT NULL
+                COMMENT 'Optional free-text display label shown in place of Abbreviation (any chars incl. - _ :); Abbreviation stays the alphanumeric SongId prefix. NULL = show Abbreviation (#1332).'
+                AFTER Abbreviation"
+        );
+        _migSDA_output("  [OK] Added tblSongbooks.DisplayAbbr.");
+    }
+    _migSDA_output("Migration complete.");
+} catch (\mysqli_sql_exception $e) {
+    _migSDA_output("ERROR: " . $e->getMessage());
+}

--- a/appWeb/.sql/schema.sql
+++ b/appWeb/.sql/schema.sql
@@ -2998,8 +2998,13 @@ CREATE TABLE IF NOT EXISTS tblSongEmbeddings (
 CREATE TABLE IF NOT EXISTS tblLiveFollowSessions (
     Id                   INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     SessionCode          VARCHAR(12)  NOT NULL COMMENT 'Short human code / QR payload congregants enter to join',
-    HostUserId           INT UNSIGNED NOT NULL COMMENT 'FK to tblUsers — the worship leader hosting',
+    HostUserId           INT UNSIGNED NULL DEFAULT NULL COMMENT 'FK to tblUsers — leader hosting; NULL for an org/venue-anchored service session (#1335)',
     OrgId                INT UNSIGNED NULL DEFAULT NULL COMMENT 'FK to tblOrganisations',
+    VenueId              INT UNSIGNED NULL DEFAULT NULL COMMENT 'FK tblOrgVenues — venue of this service session (#1335)',
+    ScheduleId           INT UNSIGNED NULL DEFAULT NULL COMMENT 'FK tblOrgServiceSchedules — the recurring schedule (#1335)',
+    OccurrenceDate       DATE         NULL DEFAULT NULL COMMENT 'Date of this occurrence (scheduleId + date = occurrence identity) (#1335)',
+    SessionKind          VARCHAR(20)  NOT NULL DEFAULT 'host' COMMENT 'host = #1268 leader follow | service = #1335 venue/org session — app-validated, VARCHAR not ENUM',
+    Channel              VARCHAR(16)  NULL DEFAULT NULL COMMENT '3-docroot env discriminator (HTTP_HOST-derived at create); filter in every join/poll/gate/prune query (#1335)',
     SetlistId            VARCHAR(100) NULL DEFAULT NULL COMMENT 'Soft link to the setlist being followed',
     CurrentSongId        VARCHAR(20)  NULL DEFAULT NULL COMMENT 'FK to tblSongs — the song currently displayed',
     CurrentComponentIndex INT        NULL DEFAULT NULL COMMENT 'Index into the arrangement/component order being shown',
@@ -3015,15 +3020,78 @@ CREATE TABLE IF NOT EXISTS tblLiveFollowSessions (
     UNIQUE KEY uq_Code   (SessionCode),
     INDEX      idx_Host  (HostUserId),
     INDEX      idx_Active (IsActive, LastHeartbeatAt),
+    INDEX      idx_Service (VenueId, ScheduleId, OccurrenceDate, IsActive),
+    INDEX      idx_OrgActive (OrgId, IsActive),
 
     CONSTRAINT fk_LiveFollow_Host
         FOREIGN KEY (HostUserId) REFERENCES tblUsers(Id) ON DELETE CASCADE ON UPDATE CASCADE,
     CONSTRAINT fk_LiveFollow_Org
         FOREIGN KEY (OrgId) REFERENCES tblOrganisations(Id) ON DELETE SET NULL ON UPDATE CASCADE,
     CONSTRAINT fk_LiveFollow_Song
-        FOREIGN KEY (CurrentSongId) REFERENCES tblSongs(SongId) ON DELETE SET NULL ON UPDATE CASCADE
+        FOREIGN KEY (CurrentSongId) REFERENCES tblSongs(SongId) ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT fk_LiveFollow_Venue
+        FOREIGN KEY (VenueId) REFERENCES tblOrgVenues(Id) ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT fk_LiveFollow_Schedule
+        FOREIGN KEY (ScheduleId) REFERENCES tblOrgServiceSchedules(Id) ON DELETE SET NULL ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
-  COMMENT='Live-follow broadcast sessions for native present+follow (#1090 P7).';
+  COMMENT='Live-follow broadcast sessions for native present+follow (#1090 P7); extended for Service Mode org/venue/service sessions (#1335).';
+
+-- ----------------------------------------------------------------------------
+-- Service Mode (#1335) — rotating venue join codes + anonymous congregant
+-- presence + per-session poll budget. Dormant until Phase 2b/2c/3. Mirror of
+-- migrate-service-mode-sessions.php.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS tblLiveFollowJoinCodes (
+    Id          BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    SessionId   INT UNSIGNED  NOT NULL COMMENT 'FK tblLiveFollowSessions',
+    Code        VARCHAR(12)   NOT NULL COMMENT 'Crockford base32 rotating join code (current/previous live)',
+    Generation  INT UNSIGNED  NOT NULL DEFAULT 0 COMMENT 'Monotonic per-session rotation counter',
+    Status      VARCHAR(20)   NOT NULL DEFAULT 'current' COMMENT 'current | previous | superseded — app-validated, VARCHAR not ENUM (rule #20)',
+    IssuedAt    DATETIME      NOT NULL,
+    ExpiresAt   DATETIME      NOT NULL COMMENT 'Rotation horizon + grace (UTC); join rejects past this',
+    CreatedAt   TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_Session_Code (SessionId, Code),
+    INDEX idx_Session_Status (SessionId, Status),
+    INDEX idx_Expiry (ExpiresAt),
+    CONSTRAINT fk_JoinCode_Session FOREIGN KEY (SessionId) REFERENCES tblLiveFollowSessions(Id) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='Rotating venue join codes for Service Mode (#1335). Session-scoped uniqueness; current+previous window so a just-before-rotation scan still validates.';
+
+CREATE TABLE IF NOT EXISTS tblServicePresence (
+    Id               BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    SessionId        INT UNSIGNED  NOT NULL COMMENT 'FK tblLiveFollowSessions',
+    OrgId            INT UNSIGNED  NULL DEFAULT NULL COMMENT 'Denorm of the session org for the Phase-3 gate read',
+    VenueId          INT UNSIGNED  NULL DEFAULT NULL,
+    ScheduleId       INT UNSIGNED  NULL DEFAULT NULL,
+    OccurrenceDate   DATE          NULL DEFAULT NULL,
+    Channel          VARCHAR(16)   NULL DEFAULT NULL COMMENT '3-docroot env discriminator (copied from the session); filter in every query',
+    PresenceDeviceId VARCHAR(64)   NOT NULL COMMENT 'Client-minted anonymous device id (localStorage UUID) — advisory cooldown key, NOT a security control',
+    PresenceToken    CHAR(43)      NOT NULL COMMENT 'Opaque base64url 32-byte nonce — the gate key; hard-revocable (not a signed token)',
+    JoinedAt         DATETIME      NOT NULL,
+    LastSeenAt       DATETIME      NOT NULL,
+    ExpiresAt        DATETIME      NOT NULL COMMENT 'Resolved UTC = min(service-occurrence end via venue IANA tz, hard ceiling); gate + prune compare against this',
+    IsActive         TINYINT(1)    NOT NULL DEFAULT 1 COMMENT '0 = left/revoked → immediate gate revocation',
+    CreatedAt        TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UpdatedAt        TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_Token (PresenceToken),
+    UNIQUE KEY uq_DeviceSession (SessionId, PresenceDeviceId),
+    INDEX idx_Session (SessionId, IsActive),
+    INDEX idx_Gate (PresenceToken, IsActive, ExpiresAt),
+    CONSTRAINT fk_Presence_Session FOREIGN KEY (SessionId) REFERENCES tblLiveFollowSessions(Id) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='Anonymous congregant presence for Service Mode (#1335). PresenceToken = the Phase-3 gate key; ExpiresAt = resolved-UTC service end; one row per device per session (re-join reactivates).';
+
+CREATE TABLE IF NOT EXISTS tblServicePollCounters (
+    Id          BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    SessionId   INT UNSIGNED NOT NULL COMMENT 'FK tblLiveFollowSessions',
+    WindowStart DATETIME     NOT NULL COMMENT 'Start of the fixed counting window (UTC)',
+    PollCount   INT UNSIGNED NOT NULL DEFAULT 0 COMMENT 'Polls served to the WHOLE session in this window — NAT-safe per-session budget (not per-IP, which would throttle a congregation behind one church-wifi IP)',
+    CreatedAt   TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_Session_Window (SessionId, WindowStart),
+    INDEX idx_Window (WindowStart),
+    CONSTRAINT fk_PollCtr_Session FOREIGN KEY (SessionId) REFERENCES tblLiveFollowSessions(Id) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='Per-session poll budget for Service Mode (#1335) — the NAT-safe replacement for the #1268 per-IP poll cap.';
 
 
 -- ============================================================================

--- a/appWeb/.sql/schema.sql
+++ b/appWeb/.sql/schema.sql
@@ -3461,3 +3461,130 @@ CREATE TABLE IF NOT EXISTS tblOrgServiceSchedules (
     CONSTRAINT fk_OrgSchedules_Org   FOREIGN KEY (OrgId)   REFERENCES tblOrganisations(Id) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
   COMMENT='Recurring service times per venue — Service Mode Phase 1 (#1325). The service-occurrence (scheduleId,date) is computed at read time; Phase-2 sessions + Phase-3 unlock bind to it.';
+
+-- ----------------------------------------------------------------------------
+-- External-system integration hook (#1327) — DORMANT. Lets iHymns entities be
+-- linked to / synced with an external system (first: WebMS-Intra), system-
+-- agnostic so a 2nd system needs no ALTER (rule #20). Per-entity dedicated ref
+-- tables (rule #15, NOT a generic polymorphic FK) + a registry. Mirror of
+-- migrate-external-systems.php. See .claude/live-congregant-strategy.md.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS tblExternalSystems (
+    Id            INT UNSIGNED  AUTO_INCREMENT PRIMARY KEY,
+    SystemKey     VARCHAR(60)   NOT NULL COMMENT 'Stable machine key (e.g. webms-intra). App resolves systems by this — NEVER hard-code the key list in PHP (rule #15)',
+    Name          VARCHAR(120)  NOT NULL COMMENT 'Curator-facing display name (e.g. WebMS Intranet)',
+    Description   VARCHAR(255)  NULL DEFAULT NULL COMMENT 'What this system is / what the mapping means',
+    BaseUrl       VARCHAR(255)  NULL DEFAULT NULL COMMENT 'Base URL to build a deep link from a stored ExternalId; {id} placeholder substituted app-side',
+    Kind          VARCHAR(30)   NOT NULL DEFAULT 'sync' COMMENT 'sync | directory | finance | rota | identity | other — app-validated, VARCHAR not ENUM (rule #20)',
+    AuthScope     VARCHAR(40)   NULL DEFAULT NULL COMMENT 'Credential/realm hint the sync layer maps to a secret NAME — never the secret itself',
+    IsActive      TINYINT(1)    NOT NULL DEFAULT 1 COMMENT '0 = registered but paused; mappings persist, sync skips',
+    DisplayOrder  INT UNSIGNED  NOT NULL DEFAULT 0,
+    CreatedAt     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UpdatedAt     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_SystemKey (SystemKey),
+    INDEX      idx_Active   (IsActive),
+    INDEX      idx_Kind     (Kind, DisplayOrder)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='Registry of external SYSTEMS an iHymns entity can be mapped/synced into (WebMS-Intra, …). SystemKey UNIQUE so keys are never hard-coded (rule #15); sibling of tblExternalLinkTypes (#833).';
+
+CREATE TABLE IF NOT EXISTS tblOrganisationExternalRefs (
+    Id            INT UNSIGNED  AUTO_INCREMENT PRIMARY KEY,
+    OrgId         INT UNSIGNED  NOT NULL COMMENT 'FK to tblOrganisations.Id — the iHymns org',
+    SystemId      INT UNSIGNED  NOT NULL COMMENT 'FK to tblExternalSystems.Id — which external system this id lives in',
+    ExternalId    VARCHAR(190)  NOT NULL COMMENT 'Primary identifier of the org WITHIN the external system. 190 = utf8mb4 index-safe',
+    ExternalSlug  VARCHAR(190)  NULL DEFAULT NULL COMMENT 'Optional human/slug handle in the external system',
+    SyncStatus    VARCHAR(20)   NOT NULL DEFAULT 'linked' COMMENT 'linked | pending | synced | conflict | error | deprecated — app-validated, VARCHAR not ENUM (rule #20)',
+    SyncDirection VARCHAR(20)   NOT NULL DEFAULT 'inbound' COMMENT 'none | inbound | outbound | bidirectional — VARCHAR not ENUM; inbound-first until a DPA exists',
+    Source        VARCHAR(100)  NOT NULL DEFAULT 'webms-intra' COMMENT 'Provenance of the mapping row; part of the idempotency key',
+    SourceRef     VARCHAR(190)  NULL DEFAULT NULL COMMENT 'External primary id from the Source push for idempotent re-import; NULL for a manual link (multiple NULLs coexist, rule #20)',
+    LocalHash     VARCHAR(64)   NULL DEFAULT NULL COMMENT 'Fingerprint of the iHymns row at last sync — optimistic-concurrency conflict detection',
+    ExternalEtag  VARCHAR(190)  NULL DEFAULT NULL COMMENT 'External side version/etag at last sync — conflict detection',
+    LastSyncedAt  DATETIME      NULL DEFAULT NULL COMMENT 'Last successful sync (DATETIME not TIMESTAMP — rule #20)',
+    LastError     VARCHAR(500)  NULL DEFAULT NULL COMMENT 'Last sync failure detail for operator triage (no secrets/PII)',
+    LastErrorAt   DATETIME      NULL DEFAULT NULL,
+    DeletedAt     DATETIME      NULL DEFAULT NULL COMMENT 'Soft-unlink (operator removed the link) — distinct from FK-CASCADE hard delete',
+    MetaJson      JSON          NULL DEFAULT NULL COMMENT 'Lossless extra attrs from the external system for round-trip re-export',
+    CreatedBy     INT UNSIGNED  NULL DEFAULT NULL COMMENT 'FK to tblUsers.Id — who created the link (NULL for system import)',
+    CreatedAt     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UpdatedAt     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_Org_System_Ext (OrgId, SystemId, ExternalId),
+    UNIQUE KEY uq_System_Ext     (SystemId, ExternalId),
+    UNIQUE KEY uq_SourceRef      (Source, SourceRef),
+    INDEX      idx_Org           (OrgId),
+    INDEX      idx_System        (SystemId),
+    INDEX      idx_Status        (SyncStatus),
+    CONSTRAINT fk_OrgExtRef_Org       FOREIGN KEY (OrgId)     REFERENCES tblOrganisations(Id)  ON DELETE CASCADE  ON UPDATE CASCADE,
+    CONSTRAINT fk_OrgExtRef_System    FOREIGN KEY (SystemId)  REFERENCES tblExternalSystems(Id) ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT fk_OrgExtRef_CreatedBy FOREIGN KEY (CreatedBy) REFERENCES tblUsers(Id)          ON DELETE SET NULL ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='Per-org external-system identity map (rule #15 dedicated ref table). (Source,SourceRef) UNIQUE = idempotent re-import (rule #20); SystemId in the keys = multi-system without an ALTER.';
+
+CREATE TABLE IF NOT EXISTS tblOrgVenueExternalRefs (
+    Id            INT UNSIGNED  AUTO_INCREMENT PRIMARY KEY,
+    VenueId       INT UNSIGNED  NOT NULL COMMENT 'FK to tblOrgVenues.Id — the iHymns venue',
+    OrgId         INT UNSIGNED  NOT NULL COMMENT 'Denorm of the venue org (app-derived, never client-trusted) for cheap org-scoped queries',
+    SystemId      INT UNSIGNED  NOT NULL COMMENT 'FK to tblExternalSystems.Id',
+    ExternalId    VARCHAR(190)  NOT NULL COMMENT 'Primary identifier of the venue WITHIN the external system',
+    ExternalSlug  VARCHAR(190)  NULL DEFAULT NULL COMMENT 'Optional human/slug handle in the external system',
+    SyncStatus    VARCHAR(20)   NOT NULL DEFAULT 'linked' COMMENT 'linked | pending | synced | conflict | error | deprecated — app-validated, VARCHAR not ENUM (rule #20)',
+    SyncDirection VARCHAR(20)   NOT NULL DEFAULT 'inbound' COMMENT 'none | inbound | outbound | bidirectional — VARCHAR not ENUM',
+    Source        VARCHAR(100)  NOT NULL DEFAULT 'webms-intra' COMMENT 'Provenance of the mapping row; part of the idempotency key',
+    SourceRef     VARCHAR(190)  NULL DEFAULT NULL COMMENT 'External primary id from the Source push for idempotent re-import; NULL for a manual link',
+    LocalHash     VARCHAR(64)   NULL DEFAULT NULL COMMENT 'Fingerprint of the iHymns row at last sync — conflict detection',
+    ExternalEtag  VARCHAR(190)  NULL DEFAULT NULL COMMENT 'External side version/etag at last sync — conflict detection',
+    LastSyncedAt  DATETIME      NULL DEFAULT NULL COMMENT 'Last successful sync (DATETIME not TIMESTAMP — rule #20)',
+    LastError     VARCHAR(500)  NULL DEFAULT NULL COMMENT 'Last sync failure detail for operator triage (no secrets/PII)',
+    LastErrorAt   DATETIME      NULL DEFAULT NULL,
+    DeletedAt     DATETIME      NULL DEFAULT NULL COMMENT 'Soft-unlink — distinct from FK-CASCADE hard delete',
+    MetaJson      JSON          NULL DEFAULT NULL COMMENT 'Lossless extra attrs for round-trip re-export',
+    CreatedBy     INT UNSIGNED  NULL DEFAULT NULL COMMENT 'FK to tblUsers.Id — who created the link (NULL for system import)',
+    CreatedAt     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UpdatedAt     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_Venue_System_Ext (VenueId, SystemId, ExternalId),
+    UNIQUE KEY uq_System_Ext       (SystemId, ExternalId),
+    UNIQUE KEY uq_SourceRef        (Source, SourceRef),
+    INDEX      idx_Venue           (VenueId),
+    INDEX      idx_Org             (OrgId),
+    INDEX      idx_System          (SystemId),
+    INDEX      idx_Status          (SyncStatus),
+    CONSTRAINT fk_VenueExtRef_Venue     FOREIGN KEY (VenueId)   REFERENCES tblOrgVenues(Id)      ON DELETE CASCADE  ON UPDATE CASCADE,
+    CONSTRAINT fk_VenueExtRef_Org       FOREIGN KEY (OrgId)     REFERENCES tblOrganisations(Id)  ON DELETE CASCADE  ON UPDATE CASCADE,
+    CONSTRAINT fk_VenueExtRef_System    FOREIGN KEY (SystemId)  REFERENCES tblExternalSystems(Id) ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT fk_VenueExtRef_CreatedBy FOREIGN KEY (CreatedBy) REFERENCES tblUsers(Id)          ON DELETE SET NULL ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='Per-venue external-system identity map (rule #15 dedicated ref table). (Source,SourceRef) UNIQUE = idempotent re-import (rule #20); OrgId denorm mirrors tblOrgServiceSchedules.';
+
+CREATE TABLE IF NOT EXISTS tblOrgServiceScheduleExternalRefs (
+    Id            INT UNSIGNED  AUTO_INCREMENT PRIMARY KEY,
+    ScheduleId    INT UNSIGNED  NOT NULL COMMENT 'FK to tblOrgServiceSchedules.Id — the iHymns service time',
+    OrgId         INT UNSIGNED  NOT NULL COMMENT 'Denorm of the schedule org (app-derived, never client-trusted) for cheap org-scoped queries',
+    SystemId      INT UNSIGNED  NOT NULL COMMENT 'FK to tblExternalSystems.Id',
+    ExternalId    VARCHAR(190)  NOT NULL COMMENT 'Primary identifier of the service/event WITHIN the external system',
+    ExternalSlug  VARCHAR(190)  NULL DEFAULT NULL COMMENT 'Optional human/slug handle in the external system',
+    SyncStatus    VARCHAR(20)   NOT NULL DEFAULT 'linked' COMMENT 'linked | pending | synced | conflict | error | deprecated — app-validated, VARCHAR not ENUM (rule #20)',
+    SyncDirection VARCHAR(20)   NOT NULL DEFAULT 'inbound' COMMENT 'none | inbound | outbound | bidirectional — VARCHAR not ENUM',
+    Source        VARCHAR(100)  NOT NULL DEFAULT 'webms-intra' COMMENT 'Provenance of the mapping row; part of the idempotency key',
+    SourceRef     VARCHAR(190)  NULL DEFAULT NULL COMMENT 'External primary id from the Source push for idempotent re-import; NULL for a manual link',
+    LocalHash     VARCHAR(64)   NULL DEFAULT NULL COMMENT 'Fingerprint of the iHymns row at last sync — conflict detection',
+    ExternalEtag  VARCHAR(190)  NULL DEFAULT NULL COMMENT 'External side version/etag at last sync — conflict detection',
+    LastSyncedAt  DATETIME      NULL DEFAULT NULL COMMENT 'Last successful sync (DATETIME not TIMESTAMP — rule #20)',
+    LastError     VARCHAR(500)  NULL DEFAULT NULL COMMENT 'Last sync failure detail for operator triage (no secrets/PII)',
+    LastErrorAt   DATETIME      NULL DEFAULT NULL,
+    DeletedAt     DATETIME      NULL DEFAULT NULL COMMENT 'Soft-unlink — distinct from FK-CASCADE hard delete',
+    MetaJson      JSON          NULL DEFAULT NULL COMMENT 'Lossless extra attrs for round-trip re-export',
+    CreatedBy     INT UNSIGNED  NULL DEFAULT NULL COMMENT 'FK to tblUsers.Id — who created the link (NULL for system import)',
+    CreatedAt     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UpdatedAt     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_Sched_System_Ext (ScheduleId, SystemId, ExternalId),
+    UNIQUE KEY uq_System_Ext       (SystemId, ExternalId),
+    UNIQUE KEY uq_SourceRef        (Source, SourceRef),
+    INDEX      idx_Sched           (ScheduleId),
+    INDEX      idx_Org             (OrgId),
+    INDEX      idx_System          (SystemId),
+    INDEX      idx_Status          (SyncStatus),
+    CONSTRAINT fk_SchedExtRef_Sched     FOREIGN KEY (ScheduleId) REFERENCES tblOrgServiceSchedules(Id) ON DELETE CASCADE  ON UPDATE CASCADE,
+    CONSTRAINT fk_SchedExtRef_Org       FOREIGN KEY (OrgId)      REFERENCES tblOrganisations(Id)     ON DELETE CASCADE  ON UPDATE CASCADE,
+    CONSTRAINT fk_SchedExtRef_System    FOREIGN KEY (SystemId)   REFERENCES tblExternalSystems(Id)   ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT fk_SchedExtRef_CreatedBy FOREIGN KEY (CreatedBy)  REFERENCES tblUsers(Id)             ON DELETE SET NULL ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='Per-service-schedule external-system identity map (rule #15 dedicated ref table). (Source,SourceRef) UNIQUE = idempotent re-import (rule #20); OrgId denorm mirrors tblOrgServiceSchedules.';

--- a/appWeb/.sql/schema.sql
+++ b/appWeb/.sql/schema.sql
@@ -78,6 +78,7 @@ CREATE TABLE IF NOT EXISTS tblPlaces (
 CREATE TABLE IF NOT EXISTS tblSongbooks (
     Id              INT UNSIGNED    AUTO_INCREMENT PRIMARY KEY,
     Abbreviation    VARCHAR(10)     NOT NULL UNIQUE,
+    DisplayAbbr     VARCHAR(30)     NULL DEFAULT NULL COMMENT 'Optional free-text display label shown in place of Abbreviation (any chars incl. - _ :); Abbreviation stays the alphanumeric SongId prefix. NULL = show Abbreviation (#1332).',
     Name            VARCHAR(255)    NOT NULL,
     SongCount       INT UNSIGNED    NOT NULL DEFAULT 0,
     DisplayOrder    INT UNSIGNED    NOT NULL DEFAULT 0 COMMENT 'Explicit sort order for listings / filter dropdowns',

--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -11854,6 +11854,187 @@ if ($action !== null) {
             break;
         }
 
+        /* =================================================================
+         * SERVICE MODE (#1335) — operator endpoints (Phase 2b).
+         * A venue/service session congregants join via a rotating code (2c)
+         * + (Phase 3) get a temporary presence-scoped CCLI unlock. Operator =
+         * global_admin/admin OR an org-admin/owner of the venue's org. Every
+         * row is CHANNEL-scoped (the 3-docroot guard) so an alpha/beta session
+         * is never joinable on production. State-changing POSTs inherit the
+         * X-Requested-With CSRF guard at the top of this file.
+         * ================================================================= */
+        case 'service_session_start': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') { sendJson(['error' => 'POST method required.'], 405); break; }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser) { sendJson(['error' => 'Not authenticated.'], 401); break; }
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'service_mode.php';
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'entitlements.php';
+            $userId = (int)$authUser['Id'];
+            $role   = (string)($authUser['Role'] ?? '');
+            $svcIp  = $_SERVER['REMOTE_ADDR'] ?? '';
+            checkRateLimit('service_session_start', $svcIp, 30, 3600, true, $userId);
+            recordRateLimitHit('service_session_start', 'user:' . $userId);
+
+            $body = json_decode(file_get_contents('php://input'), true);
+            if (!is_array($body)) { $body = []; }
+            $venueId    = (int)($body['venueId'] ?? 0);
+            $scheduleId = (int)($body['scheduleId'] ?? 0);
+            $occDate    = (string)($body['occurrenceDate'] ?? '');
+            if ($venueId <= 0) { sendJson(['error' => 'Missing venue.'], 400); break; }
+            if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $occDate)) { sendJson(['error' => 'Invalid occurrence date.'], 400); break; }
+
+            $db = getDbMysqli();
+            $channel = serviceMode_channel();
+
+            $vstmt = $db->prepare('SELECT OrgId, TimeZone FROM tblOrgVenues WHERE Id = ? AND IsActive = 1');
+            $vstmt->bind_param('i', $venueId);
+            $vstmt->execute();
+            $venue = $vstmt->get_result()->fetch_assoc();
+            $vstmt->close();
+            if (!$venue) { sendJson(['error' => 'Unknown venue.'], 404); break; }
+            $orgId   = (int)$venue['OrgId'];
+            $venueTz = (string)($venue['TimeZone'] ?? 'UTC');
+
+            $canOperate = ($role === 'global_admin' || $role === 'admin')
+                || in_array($orgId, userIsOrgAdminOf($userId), true);
+            if (!$canOperate) { sendJson(['error' => 'Not authorised for this organisation.'], 403); break; }
+
+            /* Schedule (if given) must belong to the venue → start/duration/tz. */
+            $startTime = '10:00:00'; $duration = 90; $schedTz = $venueTz; $scheduleIdN = null;
+            if ($scheduleId > 0) {
+                $sstmt = $db->prepare('SELECT StartTime, DurationMins, TimeZone FROM tblOrgServiceSchedules WHERE Id = ? AND VenueId = ?');
+                $sstmt->bind_param('ii', $scheduleId, $venueId);
+                $sstmt->execute();
+                $sched = $sstmt->get_result()->fetch_assoc();
+                $sstmt->close();
+                if (!$sched) { sendJson(['error' => 'Unknown schedule for this venue.'], 404); break; }
+                $startTime   = (string)$sched['StartTime'];
+                $duration    = (int)$sched['DurationMins'];
+                $schedTz     = ($sched['TimeZone'] ?? '') ?: $venueTz;
+                $scheduleIdN = $scheduleId;
+            }
+            $endUtc = serviceMode_occurrenceEndUtc($occDate, $startTime, $duration, $schedTz);
+
+            /* Supersede any prior active service session for the same occurrence + channel. */
+            $deact = $db->prepare(
+                "UPDATE tblLiveFollowSessions SET IsActive = 0
+                  WHERE SessionKind = 'service' AND IsActive = 1 AND Channel = ?
+                    AND VenueId = ? AND OccurrenceDate = ? AND (ScheduleId <=> ?)"
+            );
+            $deact->bind_param('sisi', $channel, $venueId, $occDate, $scheduleIdN);
+            $deact->execute();
+            $deact->close();
+
+            /* Insert the session (SessionKind=service; SessionCode is the spine's
+               required unique id, internal — congregants use the rotating codes).
+               ExpiresAt = the resolved-UTC occurrence end. Retry on uq_Code. */
+            $newSessionId = 0;
+            $ins = $db->prepare(
+                "INSERT INTO tblLiveFollowSessions
+                    (SessionCode, HostUserId, OrgId, VenueId, ScheduleId, OccurrenceDate,
+                     SessionKind, Channel, IsActive, StartedAt, LastHeartbeatAt, ExpiresAt, StateRevision)
+                 VALUES (?, ?, ?, ?, ?, ?, 'service', ?, 1, UTC_TIMESTAMP(), UTC_TIMESTAMP(), ?, 0)"
+            );
+            $sessionCode = '';
+            $ins->bind_param('siiiisss', $sessionCode, $userId, $orgId, $venueId, $scheduleIdN, $occDate, $channel, $endUtc);
+            for ($attempt = 0; $attempt < 6 && $newSessionId === 0; $attempt++) {
+                $sessionCode = 'SVC' . serviceMode_generateCode(8);
+                try {
+                    $ins->execute();
+                    $newSessionId = (int)$db->insert_id;
+                } catch (\mysqli_sql_exception $e) {
+                    if ($e->getCode() !== 1062) { throw $e; }
+                }
+            }
+            $ins->close();
+            if ($newSessionId === 0) { sendJson(['error' => 'Could not start the session, please retry.'], 503); break; }
+
+            $code = serviceMode_mintCode($db, $newSessionId);
+            logActivity('service.session.start', 'organisation', (string)$orgId, ['session_id' => $newSessionId, 'venue_id' => $venueId, 'channel' => $channel]);
+            sendJson(['ok' => true, 'sessionId' => $newSessionId, 'code' => $code, 'occurrenceEnd' => $endUtc]);
+            break;
+        }
+
+        case 'service_code_rotate':
+        case 'service_code_current':
+        case 'service_session_end': {
+            $isRotate = ($action === 'service_code_rotate');
+            $isEnd    = ($action === 'service_session_end');
+            if (($isRotate || $isEnd) && $_SERVER['REQUEST_METHOD'] !== 'POST') { sendJson(['error' => 'POST method required.'], 405); break; }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser) { sendJson(['error' => 'Not authenticated.'], 401); break; }
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'service_mode.php';
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'entitlements.php';
+            $userId = (int)$authUser['Id'];
+            $role   = (string)($authUser['Role'] ?? '');
+            $svcIp  = $_SERVER['REMOTE_ADDR'] ?? '';
+            checkRateLimit('service_operator', $svcIp, 600, 60, true, $userId);
+
+            $sessionId = $isRotate || $isEnd
+                ? (int)((json_decode(file_get_contents('php://input'), true) ?: [])['sessionId'] ?? 0)
+                : (int)($_GET['sessionId'] ?? 0);
+            if ($sessionId <= 0) { sendJson(['error' => 'Missing session.'], 400); break; }
+
+            $db = getDbMysqli();
+            $channel = serviceMode_channel();
+            /* Resolve the session (channel-scoped) + gate on operator. */
+            $sstmt = $db->prepare("SELECT OrgId, HostUserId, IsActive FROM tblLiveFollowSessions WHERE Id = ? AND SessionKind = 'service' AND Channel = ?");
+            $sstmt->bind_param('is', $sessionId, $channel);
+            $sstmt->execute();
+            $sess = $sstmt->get_result()->fetch_assoc();
+            $sstmt->close();
+            if (!$sess) { sendJson(['error' => 'Unknown session.'], 404); break; }
+            $orgId = (int)$sess['OrgId'];
+            $canOperate = ($role === 'global_admin' || $role === 'admin')
+                || (int)$sess['HostUserId'] === $userId
+                || in_array($orgId, userIsOrgAdminOf($userId), true);
+            if (!$canOperate) { sendJson(['error' => 'Not authorised.'], 403); break; }
+
+            if ($isEnd) {
+                $db->begin_transaction();
+                try {
+                    $e1 = $db->prepare('UPDATE tblLiveFollowSessions SET IsActive = 0 WHERE Id = ?');
+                    $e1->bind_param('i', $sessionId); $e1->execute(); $e1->close();
+                    /* Revoke all presence → immediate gate revocation. */
+                    $e2 = $db->prepare('UPDATE tblServicePresence SET IsActive = 0 WHERE SessionId = ?');
+                    $e2->bind_param('i', $sessionId); $e2->execute(); $e2->close();
+                    $db->commit();
+                } catch (\Throwable $e) { $db->rollback(); throw $e; }
+                logActivity('service.session.end', 'organisation', (string)$orgId, ['session_id' => $sessionId]);
+                sendJson(['ok' => true]);
+                break;
+            }
+
+            if ($isRotate) {
+                if ((int)$sess['IsActive'] !== 1) { sendJson(['error' => 'Session is not active.'], 409); break; }
+                /* The rotate doubles as a heartbeat keeping the session fresh. */
+                $hb = $db->prepare('UPDATE tblLiveFollowSessions SET LastHeartbeatAt = UTC_TIMESTAMP() WHERE Id = ?');
+                $hb->bind_param('i', $sessionId); $hb->execute(); $hb->close();
+                $code = serviceMode_mintCode($db, $sessionId);
+                sendJson(['ok' => true, 'code' => $code]);
+                break;
+            }
+
+            /* service_code_current — projection-page resume after a reload. */
+            $cur = $db->prepare("SELECT Code FROM tblLiveFollowJoinCodes WHERE SessionId = ? AND Status = 'current' AND ExpiresAt > UTC_TIMESTAMP() ORDER BY Generation DESC LIMIT 1");
+            $cur->bind_param('i', $sessionId);
+            $cur->execute();
+            $row = $cur->get_result()->fetch_assoc();
+            $cur->close();
+            if (!$row) {
+                /* Current expired (e.g. tab slept) — mint a fresh one if the session's still active. */
+                if ((int)$sess['IsActive'] === 1) {
+                    $code = serviceMode_mintCode($db, $sessionId);
+                    sendJson(['ok' => true, 'code' => $code]);
+                } else {
+                    sendJson(['ok' => false, 'error' => 'Session not active.'], 409);
+                }
+                break;
+            }
+            sendJson(['ok' => true, 'code' => (string)$row['Code']]);
+            break;
+        }
+
         /* -----------------------------------------------------------------
          * Unknown action
          * ----------------------------------------------------------------- */

--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -12116,10 +12116,10 @@ if ($action !== null) {
             $body = json_decode(file_get_contents('php://input'), true);
             if (!is_array($body)) { $body = []; }
             $code   = strtoupper(preg_replace('/[^A-Za-z0-9]/', '', (string)($body['code'] ?? '')));
-            $venueId = (int)($body['venueId'] ?? 0);
+            $venueId = (int)($body['venueId'] ?? 0);  /* OPTIONAL — 0 = resolve by code+channel alone (congregant typed it off the screen). */
             $deviceId = preg_replace('/[^A-Za-z0-9\-]/', '', (string)($body['presenceDeviceId'] ?? ''));
             $deviceId = mb_substr($deviceId, 0, 64);
-            if ($code === '' || $venueId <= 0 || $deviceId === '') { sendJson(['ok' => false, 'error' => 'Invalid join request.'], 400); break; }
+            if ($code === '' || $deviceId === '') { sendJson(['ok' => false, 'error' => 'Invalid join request.'], 400); break; }
 
             $db = getDbMysqli();
             $channel = serviceMode_channel();

--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -12036,6 +12036,203 @@ if ($action !== null) {
         }
 
         /* -----------------------------------------------------------------
+         * SERVICE MODE (#1335) — broadcast (operator) + congregant join/poll/
+         * leave (Phase 2c). The broadcast endpoint serves BOTH broadcaster
+         * mechanisms (the projection laptop OR a separate leader device) — it
+         * just needs the sessionId + operator auth. Congregant endpoints are
+         * anonymous, gated by the unguessable rotating code (join) / opaque
+         * presence token (poll/leave), CHANNEL-scoped, NAT-safe per-token.
+         * ----------------------------------------------------------------- */
+        case 'service_broadcast': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') { sendJson(['error' => 'POST method required.'], 405); break; }
+            $authUser = getAuthenticatedUser();
+            if (!$authUser) { sendJson(['error' => 'Not authenticated.'], 401); break; }
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'service_mode.php';
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'entitlements.php';
+            $userId = (int)$authUser['Id'];
+            $role   = (string)($authUser['Role'] ?? '');
+            checkRateLimit('service_broadcast', $_SERVER['REMOTE_ADDR'] ?? '', 600, 60, true, $userId);
+
+            $body = json_decode(file_get_contents('php://input'), true);
+            if (!is_array($body)) { $body = []; }
+            $sessionId = (int)($body['sessionId'] ?? 0);
+            if ($sessionId <= 0) { sendJson(['error' => 'Missing session.'], 400); break; }
+            $songId = isset($body['songId']) ? _liveFollowCleanSongId((string)$body['songId']) : null;
+            if ($songId === '') { $songId = null; }
+            $componentIndex = (isset($body['componentIndex']) && $body['componentIndex'] !== null)
+                ? min(9999, max(0, (int)$body['componentIndex'])) : null;
+            $stateJson = _liveFollowCleanState($body['state'] ?? null);
+
+            $db = getDbMysqli();
+            $channel = serviceMode_channel();
+            $sstmt = $db->prepare("SELECT OrgId, HostUserId FROM tblLiveFollowSessions WHERE Id = ? AND SessionKind = 'service' AND Channel = ? AND IsActive = 1");
+            $sstmt->bind_param('is', $sessionId, $channel);
+            $sstmt->execute();
+            $sess = $sstmt->get_result()->fetch_assoc();
+            $sstmt->close();
+            if (!$sess) { sendJson(['error' => 'Unknown or ended session.'], 404); break; }
+            $orgId = (int)$sess['OrgId'];
+            $canOperate = ($role === 'global_admin' || $role === 'admin')
+                || (int)$sess['HostUserId'] === $userId
+                || in_array($orgId, userIsOrgAdminOf($userId), true);
+            if (!$canOperate) { sendJson(['error' => 'Not authorised.'], 403); break; }
+
+            if ($songId !== null) {
+                $chk = $db->prepare('SELECT 1 FROM tblSongs WHERE SongId = ? LIMIT 1');
+                $chk->bind_param('s', $songId);
+                $chk->execute();
+                $ok = $chk->get_result()->fetch_row() !== null;
+                $chk->close();
+                if (!$ok) { sendJson(['error' => 'Unknown song.'], 400); break; }
+            }
+
+            $upd = $db->prepare(
+                'UPDATE tblLiveFollowSessions
+                    SET CurrentSongId = ?, CurrentComponentIndex = ?, StateJson = ?,
+                        StateRevision = StateRevision + 1, LastHeartbeatAt = UTC_TIMESTAMP()
+                  WHERE Id = ?'
+            );
+            $upd->bind_param('sisi', $songId, $componentIndex, $stateJson, $sessionId);
+            $upd->execute();
+            $upd->close();
+            $rev = $db->prepare('SELECT StateRevision FROM tblLiveFollowSessions WHERE Id = ?');
+            $rev->bind_param('i', $sessionId);
+            $rev->execute();
+            $revision = (int)($rev->get_result()->fetch_assoc()['StateRevision'] ?? 0);
+            $rev->close();
+            sendJson(['ok' => true, 'revision' => $revision]);
+            break;
+        }
+
+        case 'service_join': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') { sendJson(['error' => 'POST method required.'], 405); break; }
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'service_mode.php';
+            $svcIp = $_SERVER['REMOTE_ADDR'] ?? '';
+            /* Generous per-IP cap — a whole congregation joins at once behind one
+               church-wifi IP, so this is high; the real throttle is the per-device
+               presence row + the rotating code's air-gap. */
+            checkRateLimit('service_join', $svcIp, 300, 60, false, null);
+
+            $body = json_decode(file_get_contents('php://input'), true);
+            if (!is_array($body)) { $body = []; }
+            $code   = strtoupper(preg_replace('/[^A-Za-z0-9]/', '', (string)($body['code'] ?? '')));
+            $venueId = (int)($body['venueId'] ?? 0);
+            $deviceId = preg_replace('/[^A-Za-z0-9\-]/', '', (string)($body['presenceDeviceId'] ?? ''));
+            $deviceId = mb_substr($deviceId, 0, 64);
+            if ($code === '' || $venueId <= 0 || $deviceId === '') { sendJson(['ok' => false, 'error' => 'Invalid join request.'], 400); break; }
+
+            $db = getDbMysqli();
+            $channel = serviceMode_channel();
+            $sess = serviceMode_resolveJoin($db, $code, $venueId, $channel);
+            if (!$sess) {
+                /* Opaque — don't distinguish wrong/expired/unknown (anti-probe). */
+                sendJson(['ok' => false, 'error' => 'That code isn’t active. Check the screen and try again.'], 404);
+                break;
+            }
+            $sessionId = (int)$sess['Id'];
+
+            /* Resolve the session's ExpiresAt (the resolved-UTC occurrence end) +
+               its current broadcast state for an immediate follow. */
+            $meta = $db->prepare('SELECT ExpiresAt, CurrentSongId, CurrentComponentIndex, StateJson, StateRevision FROM tblLiveFollowSessions WHERE Id = ?');
+            $meta->bind_param('i', $sessionId);
+            $meta->execute();
+            $m = $meta->get_result()->fetch_assoc();
+            $meta->close();
+            $expiresAt = (string)($m['ExpiresAt'] ?? '');
+
+            /* Opaque presence token (base64url 32 bytes = 43 chars) — the gate key. */
+            $token = rtrim(strtr(base64_encode(random_bytes(32)), '+/', '-_'), '=');
+            $orgId = $sess['OrgId'] !== null ? (int)$sess['OrgId'] : null;
+            $sVenueId = $sess['VenueId'] !== null ? (int)$sess['VenueId'] : null;
+            $schedId = $sess['ScheduleId'] !== null ? (int)$sess['ScheduleId'] : null;
+            $occDate = $sess['OccurrenceDate'] !== null ? (string)$sess['OccurrenceDate'] : null;
+
+            /* Upsert presence: one row per (session, device); a re-join reactivates
+               + re-tokens rather than duplicating (uq_DeviceSession). */
+            $ins = $db->prepare(
+                "INSERT INTO tblServicePresence
+                    (SessionId, OrgId, VenueId, ScheduleId, OccurrenceDate, Channel,
+                     PresenceDeviceId, PresenceToken, JoinedAt, LastSeenAt, ExpiresAt, IsActive)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(), UTC_TIMESTAMP(), ?, 1)
+                 ON DUPLICATE KEY UPDATE PresenceToken = VALUES(PresenceToken),
+                     LastSeenAt = UTC_TIMESTAMP(), ExpiresAt = VALUES(ExpiresAt), IsActive = 1"
+            );
+            $ins->bind_param('iiiissssss', $sessionId, $orgId, $sVenueId, $schedId, $occDate, $channel, $deviceId, $token, $expiresAt);
+            $ins->execute();
+            $ins->close();
+
+            sendJson([
+                'ok' => true,
+                'presenceToken' => $token,
+                'currentSongId' => $m['CurrentSongId'] ?? null,
+                'componentIndex' => isset($m['CurrentComponentIndex']) ? (int)$m['CurrentComponentIndex'] : null,
+                'state' => isset($m['StateJson']) && $m['StateJson'] !== null ? json_decode((string)$m['StateJson'], true) : null,
+                'revision' => (int)($m['StateRevision'] ?? 0),
+            ]);
+            break;
+        }
+
+        case 'service_poll': {
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'service_mode.php';
+            $token = (string)($_GET['presenceToken'] ?? '');
+            if (!preg_match('/^[A-Za-z0-9_\-]{43}$/', $token)) { sendJson(['active' => false]); break; }
+            $since = max(0, (int)($_GET['since'] ?? 0));
+            /* NAT-safe: rate-limit PER TOKEN (not per IP) so many congregants
+               behind one IP each get their own budget, and one bad token can't
+               DoS the rest. 40/min comfortably covers ~2.5s polling. */
+            checkRateLimit('service_poll', 'tok:' . substr(hash('sha256', $token), 0, 24), 40, 60, false, null);
+
+            $db = getDbMysqli();
+            $channel = serviceMode_channel();
+            $stmt = $db->prepare(
+                "SELECT s.CurrentSongId, s.CurrentComponentIndex, s.StateJson, s.StateRevision
+                   FROM tblServicePresence p
+                   JOIN tblLiveFollowSessions s ON s.Id = p.SessionId
+                  WHERE p.PresenceToken = ? AND p.IsActive = 1 AND p.ExpiresAt > UTC_TIMESTAMP()
+                    AND s.IsActive = 1 AND s.Channel = ?
+                    AND s.LastHeartbeatAt > DATE_SUB(UTC_TIMESTAMP(), INTERVAL 120 SECOND)
+                  LIMIT 1"
+            );
+            $stmt->bind_param('ss', $token, $channel);
+            $stmt->execute();
+            $row = $stmt->get_result()->fetch_assoc();
+            $stmt->close();
+            if (!$row) { sendJson(['active' => false]); break; }
+
+            /* Touch liveness (best-effort; not every poll needs it but cheap). */
+            $touch = $db->prepare('UPDATE tblServicePresence SET LastSeenAt = UTC_TIMESTAMP() WHERE PresenceToken = ?');
+            $touch->bind_param('s', $token);
+            $touch->execute();
+            $touch->close();
+
+            $revision = (int)$row['StateRevision'];
+            if ($revision <= $since) { sendJson(['active' => true, 'changed' => false, 'revision' => $revision]); break; }
+            sendJson([
+                'active' => true,
+                'changed' => true,
+                'currentSongId' => $row['CurrentSongId'] ?? null,
+                'componentIndex' => isset($row['CurrentComponentIndex']) ? (int)$row['CurrentComponentIndex'] : null,
+                'state' => isset($row['StateJson']) && $row['StateJson'] !== null ? json_decode((string)$row['StateJson'], true) : null,
+                'revision' => $revision,
+            ]);
+            break;
+        }
+
+        case 'service_leave': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') { sendJson(['error' => 'POST method required.'], 405); break; }
+            $token = (string)(($body = json_decode(file_get_contents('php://input'), true)) && is_array($body) ? ($body['presenceToken'] ?? '') : '');
+            if (!preg_match('/^[A-Za-z0-9_\-]{43}$/', $token)) { sendJson(['ok' => true]); break; }
+            $db = getDbMysqli();
+            /* Immediate gate revocation. */
+            $upd = $db->prepare('UPDATE tblServicePresence SET IsActive = 0 WHERE PresenceToken = ?');
+            $upd->bind_param('s', $token);
+            $upd->execute();
+            $upd->close();
+            sendJson(['ok' => true]);
+            break;
+        }
+
+        /* -----------------------------------------------------------------
          * Unknown action
          * ----------------------------------------------------------------- */
         default:

--- a/appWeb/public_html/css/app.css
+++ b/appWeb/public_html/css/app.css
@@ -1440,12 +1440,15 @@ body[data-page-transition="blur"] ::view-transition-new(root) {
     border-left-color: rgba(255, 255, 255, 0.18);
 }
 
-/* Chorus styling — emphasised with accent gradient strip + subtle tint. */
+/* Chorus styling — emphasised with accent gradient strip + subtle tint.
+   Italic lyrics (#1337) — same treatment as Bridge/pre-chorus; keeps the
+   chorus tint + accent border, just slants the text. */
 .lyric-chorus,
 .lyric-refrain {
     background-color: var(--lyric-chorus-bg);
     border-left-color: var(--lyric-chorus-border);
     padding: 0.75rem 1rem;
+    font-style: italic;
 }
 .lyric-chorus .lyric-label,
 .lyric-refrain .lyric-label {

--- a/appWeb/public_html/includes/SongData.php
+++ b/appWeb/public_html/includes/SongData.php
@@ -339,6 +339,7 @@ class SongData
 
         $bibSelect    = $this->_songbookBibSelect();
         $langSelect   = $this->_songbookLanguageSelect();
+        $displayAbbrSelect = $this->_songbookDisplayAbbrSelect();
         $parentSelect = $this->_songbookParentSelect();
         $parentJoin   = $this->_songbookParentJoin();
         $stmt = $this->db->prepare(
@@ -349,6 +350,7 @@ class SongData
                     b.PublicationYear AS publicationYear,
                     b.Copyright       AS copyright,
                     b.Affiliation     AS affiliation
+                    {$displayAbbrSelect}
                     {$langSelect}
                     {$bibSelect}
                     {$parentSelect}
@@ -494,6 +496,36 @@ class SongData
         return $this->_bibSelectCache;
     }
     private ?string $_bibSelectCache = null;
+
+    /**
+     * Same probe-once pattern for the optional DisplayAbbr column (#1332) —
+     * a free-text label shown in place of the Abbreviation badge. The column
+     * is added by migrate-songbook-display-abbr.php; until that runs (migrations
+     * aren't auto-applied on deploy) the SELECT must not name it, or every
+     * getSongbooks() call 500s. `b.`-qualified for the parent self-join.
+     */
+    private function _songbookDisplayAbbrSelect(): string
+    {
+        if (isset($this->_displayAbbrSelectCache)) {
+            return $this->_displayAbbrSelectCache;
+        }
+        $has = false;
+        try {
+            $probe = $this->db->prepare(
+                "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+                  WHERE TABLE_SCHEMA = DATABASE()
+                    AND TABLE_NAME   = 'tblSongbooks'
+                    AND COLUMN_NAME  = 'DisplayAbbr'
+                  LIMIT 1"
+            );
+            $probe->execute();
+            $has = $probe->get_result()->fetch_row() !== null;
+            $probe->close();
+        } catch (\Throwable $_e) { /* probe failure → fall through to empty tail */ }
+        $this->_displayAbbrSelectCache = $has ? ', b.DisplayAbbr AS displayAbbr' : '';
+        return $this->_displayAbbrSelectCache;
+    }
+    private ?string $_displayAbbrSelectCache = null;
 
     /**
      * Same shape as _songbookBibSelect() but for the optional Language
@@ -1206,6 +1238,7 @@ class SongData
         }
         $bibSelect    = $this->_songbookBibSelect();
         $langSelect   = $this->_songbookLanguageSelect();
+        $displayAbbrSelect = $this->_songbookDisplayAbbrSelect();
         $parentSelect = $this->_songbookParentSelect();
         $parentJoin   = $this->_songbookParentJoin();
         $stmt = $this->db->prepare(
@@ -1216,6 +1249,7 @@ class SongData
                     b.PublicationYear AS publicationYear,
                     b.Copyright       AS copyright,
                     b.Affiliation     AS affiliation
+                    {$displayAbbrSelect}
                     {$langSelect}
                     {$bibSelect}
                     {$parentSelect}

--- a/appWeb/public_html/includes/content_access.php
+++ b/appWeb/public_html/includes/content_access.php
@@ -42,7 +42,7 @@ require_once __DIR__ . DIRECTORY_SEPARATOR . 'licences.php';
  * @param string   $platform    'PWA', 'Apple', or 'Android'
  * @return array{allowed: bool, reason: string}
  */
-function checkContentAccess(string $entityType, string $entityId, ?int $userId, string $platform = 'PWA'): array
+function checkContentAccess(string $entityType, string $entityId, ?int $userId, string $platform = 'PWA', ?string $presenceToken = null): array
 {
     $db = getDbMysqli();
 
@@ -81,6 +81,22 @@ function checkContentAccess(string $entityType, string $entityId, ?int $userId, 
            to + every ancestor org (#462). Replaces the old single-level
            query that only looked at direct memberships. */
         $userLicenceTypes = getUserEffectiveLicenceTypes($userId);
+    }
+
+    /* Service-Mode presence unlock (#1335): a congregant physically present in a
+       live service (a valid, unexpired presence token on an active session whose
+       org holds a LIVE CCLI licence) rides that org's licence for the duration —
+       so a `require_licence: ccli` rule passes. Works for ANONYMOUS congregants
+       (no userId). Revoked the instant they leave / it expires / the licence
+       lapses (serviceMode_presenceCcliNumber re-checks every call). The owner has
+       accepted the licensing basis (#1324); the per-song CCL notice is rendered
+       by song.php when this grant applies. */
+    if ($presenceToken !== null && $presenceToken !== '') {
+        require_once __DIR__ . DIRECTORY_SEPARATOR . 'service_mode.php';
+        if (function_exists('serviceMode_presenceCcliNumber')
+            && serviceMode_presenceCcliNumber($db, $presenceToken, serviceMode_channel()) !== null) {
+            $userLicenceTypes[] = 'ccli';
+        }
     }
 
     /* Evaluate rules in priority order */

--- a/appWeb/public_html/includes/pages/home.php
+++ b/appWeb/public_html/includes/pages/home.php
@@ -264,9 +264,10 @@ $homeCardEnd = '</div>';
                                 <h3 class="card-title h6 mb-1">
                                     <?= htmlspecialchars($book['name']) ?>
                                 </h3>
-                                <?php if (ihymns_songbook_show_abbr($book['name'] ?? '', $book['id'] ?? '')): ?>
+                                <?php $sbAbbr = ihymns_songbook_abbr_label($book['id'] ?? '', $book['displayAbbr'] ?? null); ?>
+                                <?php if (ihymns_songbook_show_abbr($book['name'] ?? '', $sbAbbr)): ?>
                                 <span class="badge bg-body-secondary rounded-pill">
-                                    <?= htmlspecialchars($book['id']) ?>
+                                    <?= htmlspecialchars($sbAbbr) ?>
                                 </span>
                                 <?php endif; ?>
                                 <?php if ($isUnofficial): ?>

--- a/appWeb/public_html/includes/pages/home.php
+++ b/appWeb/public_html/includes/pages/home.php
@@ -73,6 +73,17 @@ $homeCardEnd = '</div>';
         </div>
     </div>
 
+    <!-- Join a live service (#1335) — a congregant enters the rotating code shown
+         on their church's screen to follow the service in sync. Outside the
+         reorderable grid so it stays discoverable; service-follow.js wires the
+         [data-action="join-service"] click. -->
+    <div class="text-center mb-4">
+        <button type="button" class="btn btn-outline-success" data-action="join-service">
+            <i class="bi bi-broadcast-pin me-1" aria-hidden="true"></i>Join a live service
+        </button>
+        <div class="small text-muted mt-1">Enter the code shown on your church’s screen to follow along.</div>
+    </div>
+
     <!-- Customise-home toolbar (#448). Hidden until applyCardLayout()
          confirms the viewer may edit (canCustomiseOwn / canSetDefault),
          so the logged-out majority never sees a dead "Customise" button. -->

--- a/appWeb/public_html/includes/pages/song.php
+++ b/appWeb/public_html/includes/pages/song.php
@@ -135,14 +135,36 @@ $fullyPublicDomain  = $lyricsPublicDomain && $musicPublicDomain;
    actually switched on. */
 $lyricsGated = false;
 $gateReason  = '';
+$serviceCcliNumber = null;   /* #1335 — set when a present congregant rides the org's CCLI licence; drives the per-song CCL notice. */
 if (function_exists('getAppSetting') && getAppSetting('content_gating_enabled', '0') === '1'
     && function_exists('checkContentAccess')) {
     try {
         $gateViewer = function_exists('getAuthenticatedUser') ? getAuthenticatedUser() : null;
-        $gateAccess = checkContentAccess('song', (string)$songId, isset($gateViewer['Id']) ? (int)$gateViewer['Id'] : null, 'PWA');
+        /* #1335 — a congregant following a live service carries an opaque presence
+           token (set as a same-origin cookie by service-follow.js on join). It
+           lets them ride the org's live CCLI licence for gated lyrics while
+           present, and is revoked the moment they leave / it expires. */
+        $presenceTok = '';
+        if (isset($_COOKIE['ihymns_sf_presence_token'])
+            && preg_match('/^[A-Za-z0-9_\-]{43}$/', (string)$_COOKIE['ihymns_sf_presence_token'])) {
+            $presenceTok = (string)$_COOKIE['ihymns_sf_presence_token'];
+        }
+        $gateAccess = checkContentAccess(
+            'song', (string)$songId,
+            isset($gateViewer['Id']) ? (int)$gateViewer['Id'] : null,
+            'PWA',
+            $presenceTok !== '' ? $presenceTok : null
+        );
         if (empty($gateAccess['allowed'])) {
             $lyricsGated = true;
             $gateReason  = (string)($gateAccess['reason'] ?? '');
+        } elseif ($presenceTok !== '' && !$fullyPublicDomain && function_exists('serviceMode_presenceCcliNumber')) {
+            /* Allowed + a present congregant viewing a copyrighted song → the CCL
+               requires the licence-holder's copyright notice on each device. */
+            $serviceCcliNumber = serviceMode_presenceCcliNumber(
+                getDbMysqli(), $presenceTok,
+                function_exists('serviceMode_channel') ? serviceMode_channel() : 'production'
+            );
         }
     } catch (\Throwable $_e) {
         /* Gating must never break a song render — fail open (show lyrics). */
@@ -337,6 +359,12 @@ try {
                         <?php endif; ?>
                         <?= htmlspecialchars($bookName) ?>
                     </p>
+                    <?php if ($serviceCcliNumber !== null): /* #1335 — CCL copyright notice for a present congregant riding the org licence. */ ?>
+                        <p class="small text-muted fst-italic mb-0 mt-1">
+                            <i class="bi bi-shield-check me-1" aria-hidden="true"></i>
+                            Shown under your church’s CCLI Copyright Licence<?= $serviceCcliNumber !== '' ? ' #' . htmlspecialchars($serviceCcliNumber) : '' ?> while you follow the service.
+                        </p>
+                    <?php endif; ?>
                     <?php if ($songbookParent !== null && $parentSongLinkUrl !== ''):
                         /* #782 phase D — canonical-source link. Renders only
                            when the current songbook declares a parent AND we

--- a/appWeb/public_html/includes/pages/song.php
+++ b/appWeb/public_html/includes/pages/song.php
@@ -331,8 +331,9 @@ try {
                         </p>
                     <?php endif; ?>
                     <p class="text-muted mb-0">
-                        <?php if (ihymns_songbook_show_abbr($bookName, $songbook)): ?>
-                        <span class="badge bg-body-secondary"><?= htmlspecialchars($songbook) ?></span>
+                        <?php $sbAbbr = ihymns_songbook_abbr_label($songbook, (is_array($bookData ?? null) ? ($bookData['displayAbbr'] ?? null) : null)); ?>
+                        <?php if (ihymns_songbook_show_abbr($bookName, $sbAbbr)): ?>
+                        <span class="badge bg-body-secondary"><?= htmlspecialchars($sbAbbr) ?></span>
                         <?php endif; ?>
                         <?= htmlspecialchars($bookName) ?>
                     </p>

--- a/appWeb/public_html/includes/pages/songbook.php
+++ b/appWeb/public_html/includes/pages/songbook.php
@@ -71,8 +71,9 @@ if ($book === null) {
             <h1 class="h4 mb-1">
                 <i class="fa-solid fa-book me-2" aria-hidden="true"></i>
                 <?= htmlspecialchars($book['name']) ?>
-                <?php if (ihymns_songbook_show_abbr($book['name'] ?? '', $book['id'] ?? '')): ?>
-                <span class="badge bg-body-secondary ms-1"><?= htmlspecialchars($book['id']) ?></span>
+                <?php $sbAbbr = ihymns_songbook_abbr_label($book['id'] ?? '', $book['displayAbbr'] ?? null); ?>
+                <?php if (ihymns_songbook_show_abbr($book['name'] ?? '', $sbAbbr)): ?>
+                <span class="badge bg-body-secondary ms-1"><?= htmlspecialchars($sbAbbr) ?></span>
                 <?php endif; ?>
                 <?php if (empty($book['isOfficial'])): ?>
                     <!-- #1223 — "Unofficial" badge on the songbook header so the

--- a/appWeb/public_html/includes/pages/songbooks.php
+++ b/appWeb/public_html/includes/pages/songbooks.php
@@ -112,9 +112,10 @@ $stats = $songData->getStats();
                                     <h2 class="h6 card-title mb-1">
                                         <?= htmlspecialchars($book['name']) ?>
                                     </h2>
-                                    <?php if (ihymns_songbook_show_abbr($book['name'] ?? '', $book['id'] ?? '')): ?>
+                                    <?php $sbAbbr = ihymns_songbook_abbr_label($book['id'] ?? '', $book['displayAbbr'] ?? null); ?>
+                                    <?php if (ihymns_songbook_show_abbr($book['name'] ?? '', $sbAbbr)): ?>
                                     <span class="badge bg-body-secondary me-1">
-                                        <?= htmlspecialchars($book['id']) ?>
+                                        <?= htmlspecialchars($sbAbbr) ?>
                                     </span>
                                     <?php endif; ?>
                                     <?php if ($isUnofficial): ?>

--- a/appWeb/public_html/includes/service_mode.php
+++ b/appWeb/public_html/includes/service_mode.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Service Mode helpers (#1335, epic #1323)
+ *
+ * Shared server logic for congregation "Service Mode": the projection page +
+ * operator endpoints (Phase 2b), the congregant join/poll (2c) and the Phase-3
+ * presence gate all funnel through here so the rules live in ONE place.
+ *
+ * Load-bearing invariants:
+ *  - CHANNEL = the 3-docroot env discriminator (ihymns_environment()) — a
+ *    session created on alpha/beta is NEVER joinable/gating on production.
+ *    Every join/poll/gate/prune query MUST filter on it (the prod-stale class
+ *    of bug). serviceMode_channel() is the single source.
+ *  - CODES are Crockford base32 (no ambiguous glyphs), session-scoped unique,
+ *    rotated on a current+previous+grace window so a just-before-rotation scan
+ *    still validates.
+ *  - The service-occurrence END is a LOCAL time in the venue's IANA tz; it is
+ *    resolved to a UTC instant (DST-aware) and capped at a hard ceiling so a
+ *    relayed code can never unlock for an all-day window.
+ */
+
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'environment.php';
+
+/** Rotation horizon + grace for a join code (the current+previous window). */
+const SERVICE_MODE_CODE_TTL_SECONDS   = 75;
+/** Hard ceiling on any session / presence lifetime (matches the #1268 spine's 4h). */
+const SERVICE_MODE_HARD_CEILING_HOURS = 4;
+/** Crockford-ish base32 — no I/L/O/U/0/1 (matches live_follow_create). */
+const SERVICE_MODE_CODE_ALPHABET      = 'ABCDEFGHJKMNPQRSTVWXYZ23456789';
+
+/**
+ * The environment channel a Service-Mode row belongs to ('alpha'|'beta'|
+ * 'production'). The 3-docroot discriminator — stamped at create, filtered
+ * everywhere so cross-env sessions never leak (the prod-stale class of bug).
+ */
+function serviceMode_channel(): string
+{
+    return ihymns_environment();
+}
+
+/** Generate a fresh ambiguity-free join code. */
+function serviceMode_generateCode(int $len = 6): string
+{
+    $alphabet = SERVICE_MODE_CODE_ALPHABET;
+    $max = strlen($alphabet) - 1;
+    $code = '';
+    for ($i = 0; $i < $len; $i++) {
+        $code .= $alphabet[random_int(0, $max)];
+    }
+    return $code;
+}
+
+/**
+ * Resolve a service occurrence's END as a UTC 'Y-m-d H:i:s' string.
+ *
+ * StartTime is a LOCAL time of day in the venue's IANA timezone; we add
+ * DurationMins (DST-aware via DateTime) and convert to UTC — never DATE_ADD a
+ * local TIME against UTC_TIMESTAMP() (which would shift by the server tz). The
+ * result is capped at SERVICE_MODE_HARD_CEILING_HOURS from now so a relayed
+ * code can't unlock for an all-day window.
+ *
+ * @param string $occurrenceDate 'Y-m-d' of this occurrence.
+ * @param string $startTime      Local 'HH:MM' or 'HH:MM:SS'.
+ * @param int    $durationMins   Service window length.
+ * @param string $tz             Venue IANA tz (e.g. 'Europe/London'); '' → UTC.
+ */
+function serviceMode_occurrenceEndUtc(string $occurrenceDate, string $startTime, int $durationMins, string $tz): string
+{
+    $utc = new \DateTimeZone('UTC');
+    try {
+        $local = new \DateTimeZone($tz !== '' ? $tz : 'UTC');
+    } catch (\Throwable $e) {
+        $local = $utc;
+    }
+
+    $hhmmss = strlen($startTime) >= 8 ? substr($startTime, 0, 8) : substr($startTime, 0, 5);
+    $fmt    = strlen($hhmmss) >= 8 ? 'Y-m-d H:i:s' : 'Y-m-d H:i';
+    $start  = \DateTime::createFromFormat($fmt, $occurrenceDate . ' ' . $hhmmss, $local);
+
+    $ceiling = new \DateTime('now', $utc);
+    $ceiling->modify('+' . SERVICE_MODE_HARD_CEILING_HOURS . ' hours');
+
+    if ($start === false) {
+        /* Unparseable schedule → fall back to the hard ceiling from now. */
+        return $ceiling->format('Y-m-d H:i:s');
+    }
+
+    $end = clone $start;
+    $end->modify('+' . max(1, $durationMins) . ' minutes');
+    $end->setTimezone($utc);
+
+    return ($end > $ceiling ? $ceiling : $end)->format('Y-m-d H:i:s');
+}
+
+/**
+ * Transactionally mint the next rotating join code for a session:
+ * previous → superseded, current → previous, insert a fresh 'current'. Returns
+ * the new code. Locks the session's code rows (FOR UPDATE) so two near-
+ * simultaneous rotates (projection setInterval + a reload) can't race to two
+ * 'current' rows. Retries on the session-scoped (SessionId, Code) collision.
+ *
+ * @throws \mysqli_sql_exception|\RuntimeException on a real failure (caller rolls the request).
+ */
+function serviceMode_mintCode(\mysqli $db, int $sessionId): string
+{
+    $db->begin_transaction();
+    try {
+        /* Lock this session's code rows + read the high-water generation. */
+        $lock = $db->prepare('SELECT COALESCE(MAX(Generation), 0) AS g FROM tblLiveFollowJoinCodes WHERE SessionId = ? FOR UPDATE');
+        $lock->bind_param('i', $sessionId);
+        $lock->execute();
+        $gen = (int)($lock->get_result()->fetch_assoc()['g'] ?? 0) + 1;
+        $lock->close();
+
+        /* Age the window: previous → superseded, current → previous. */
+        $sup = $db->prepare("UPDATE tblLiveFollowJoinCodes SET Status = 'superseded' WHERE SessionId = ? AND Status = 'previous'");
+        $sup->bind_param('i', $sessionId);
+        $sup->execute();
+        $sup->close();
+        $prev = $db->prepare("UPDATE tblLiveFollowJoinCodes SET Status = 'previous' WHERE SessionId = ? AND Status = 'current'");
+        $prev->bind_param('i', $sessionId);
+        $prev->execute();
+        $prev->close();
+
+        /* Insert a fresh current; retry on the (SessionId, Code) UNIQUE. */
+        $ttl  = SERVICE_MODE_CODE_TTL_SECONDS;
+        $code = '';
+        $ins  = $db->prepare(
+            "INSERT INTO tblLiveFollowJoinCodes (SessionId, Code, Generation, Status, IssuedAt, ExpiresAt)
+             VALUES (?, ?, ?, 'current', UTC_TIMESTAMP(), DATE_ADD(UTC_TIMESTAMP(), INTERVAL ? SECOND))"
+        );
+        $ins->bind_param('isii', $sessionId, $code, $gen, $ttl);
+        $done = false;
+        for ($attempt = 0; $attempt < 6 && !$done; $attempt++) {
+            $code = serviceMode_generateCode(6);
+            try {
+                $ins->execute();
+                $done = true;
+            } catch (\mysqli_sql_exception $e) {
+                if ($e->getCode() !== 1062) { throw $e; }
+            }
+        }
+        $ins->close();
+        if (!$done) { throw new \RuntimeException('Could not allocate a join code.'); }
+
+        $db->commit();
+        return $code;
+    } catch (\Throwable $e) {
+        $db->rollback();
+        throw $e;
+    }
+}
+
+/**
+ * Resolve a submitted join code to its LIVE session id, scoped to the venue +
+ * channel (so two venues' identical codes never cross-validate). Accepts a
+ * 'current' or 'previous' code whose ExpiresAt is still in the future and whose
+ * session is active + fresh (LastHeartbeatAt within 90s). Returns the session
+ * row (assoc) or null. The opaque-on-failure messaging is the caller's job.
+ */
+function serviceMode_resolveJoin(\mysqli $db, string $code, int $venueId, string $channel): ?array
+{
+    $stmt = $db->prepare(
+        "SELECT s.Id, s.OrgId, s.VenueId, s.ScheduleId, s.OccurrenceDate, s.Channel
+           FROM tblLiveFollowJoinCodes c
+           JOIN tblLiveFollowSessions s ON s.Id = c.SessionId
+          WHERE c.Code = ?
+            AND c.Status IN ('current', 'previous')
+            AND c.ExpiresAt > UTC_TIMESTAMP()
+            AND s.VenueId = ?
+            AND s.Channel = ?
+            AND s.SessionKind = 'service'
+            AND s.IsActive = 1
+            AND s.LastHeartbeatAt > DATE_SUB(UTC_TIMESTAMP(), INTERVAL 90 SECOND)
+          LIMIT 1"
+    );
+    $stmt->bind_param('sis', $code, $venueId, $channel);
+    $stmt->execute();
+    $row = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+    return $row ?: null;
+}

--- a/appWeb/public_html/includes/service_mode.php
+++ b/appWeb/public_html/includes/service_mode.php
@@ -155,11 +155,16 @@ function serviceMode_mintCode(\mysqli $db, int $sessionId): string
 }
 
 /**
- * Resolve a submitted join code to its LIVE session id, scoped to the venue +
- * channel (so two venues' identical codes never cross-validate). Accepts a
- * 'current' or 'previous' code whose ExpiresAt is still in the future and whose
- * session is active + fresh (LastHeartbeatAt within 90s). Returns the session
- * row (assoc) or null. The opaque-on-failure messaging is the caller's job.
+ * Resolve a submitted join code to its LIVE service session, within a channel.
+ * A 'current' or 'previous' code whose ExpiresAt is still in the future and
+ * whose session is active + fresh (LastHeartbeatAt within 90s) resolves.
+ *
+ * $venueId is OPTIONAL: a congregant typing a code off the screen doesn't know
+ * the venue, so pass 0 to resolve by code + channel alone (codes are 6 Crockford
+ * chars ≈ 1e9 space, so a code maps to ≤1 active session in practice; the
+ * freshest wins on the rare clash). A QR deep-link can pass venueId for an exact
+ * scope. Returns the session row (assoc) or null; opaque messaging is the
+ * caller's job.
  */
 function serviceMode_resolveJoin(\mysqli $db, string $code, int $venueId, string $channel): ?array
 {
@@ -170,14 +175,15 @@ function serviceMode_resolveJoin(\mysqli $db, string $code, int $venueId, string
           WHERE c.Code = ?
             AND c.Status IN ('current', 'previous')
             AND c.ExpiresAt > UTC_TIMESTAMP()
-            AND s.VenueId = ?
+            AND (? = 0 OR s.VenueId = ?)
             AND s.Channel = ?
             AND s.SessionKind = 'service'
             AND s.IsActive = 1
             AND s.LastHeartbeatAt > DATE_SUB(UTC_TIMESTAMP(), INTERVAL 90 SECOND)
+          ORDER BY s.LastHeartbeatAt DESC
           LIMIT 1"
     );
-    $stmt->bind_param('sis', $code, $venueId, $channel);
+    $stmt->bind_param('siis', $code, $venueId, $venueId, $channel);
     $stmt->execute();
     $row = $stmt->get_result()->fetch_assoc();
     $stmt->close();

--- a/appWeb/public_html/includes/service_mode.php
+++ b/appWeb/public_html/includes/service_mode.php
@@ -189,3 +189,52 @@ function serviceMode_resolveJoin(\mysqli $db, string $code, int $venueId, string
     $stmt->close();
     return $row ?: null;
 }
+
+/**
+ * Phase 3 gate read (#1335): does this presence token entitle the holder to the
+ * org's CCLI licence right now? Returns the org's CCLI LicenceNumber (a string;
+ * may be '' if the org left it blank) when the token resolves to an ACTIVE,
+ * unexpired presence on an ACTIVE service session whose org holds a LIVE 'ccli'
+ * licence — else null. Channel-scoped (3-docroot guard). This is what lets a
+ * present congregant pass a `require_licence: ccli` rule for the duration of the
+ * service (and revoked the instant they leave / it expires / the org's licence
+ * lapses). Caller (checkContentAccess) injects 'ccli' into the effective set
+ * when this returns non-null; song.php uses the number for the CCL notice.
+ *
+ * Presence/session freshness compares UTC (those rows are UTC); the org licence
+ * expiry uses NOW() to match the existing licence layer (licences.php).
+ */
+function serviceMode_presenceCcliNumber(\mysqli $db, string $presenceToken, string $channel): ?string
+{
+    if (!preg_match('/^[A-Za-z0-9_\-]{43}$/', $presenceToken)) {
+        return null;
+    }
+    try {
+        $stmt = $db->prepare(
+            "SELECT o.LicenceNumber
+               FROM tblServicePresence p
+               JOIN tblLiveFollowSessions s ON s.Id = p.SessionId
+               JOIN tblOrganisations o      ON o.Id = s.OrgId
+              WHERE p.PresenceToken = ?
+                AND p.IsActive = 1
+                AND p.ExpiresAt > UTC_TIMESTAMP()
+                AND p.Channel = ?
+                AND s.IsActive = 1
+                AND o.LicenceType = 'ccli'
+                AND (o.LicenceExpiresAt IS NULL OR o.LicenceExpiresAt > NOW())
+              LIMIT 1"
+        );
+        $stmt->bind_param('ss', $presenceToken, $channel);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        if ($row === null) {
+            return null;
+        }
+        return (string)($row['LicenceNumber'] ?? '');
+    } catch (\Throwable $e) {
+        /* Optional tables absent / probe failure → no grant (fail closed). */
+        error_log('[service_mode/presenceCcli] ' . $e->getMessage());
+        return null;
+    }
+}

--- a/appWeb/public_html/includes/songbook_display.php
+++ b/appWeb/public_html/includes/songbook_display.php
@@ -3,12 +3,31 @@
 declare(strict_types=1);
 
 /**
- * iHymns — Songbook display helpers (#1328)
+ * iHymns — Songbook display helpers (#1328 / #1332)
  *
  * Tiny shared presentation logic for songbooks so the same rule isn't
  * re-implemented across the home tiles, the /songbooks list, the songbook
  * header, the song-meta line and the admin table.
  */
+
+if (!function_exists('ihymns_songbook_abbr_label')) {
+    /**
+     * The label to show on a songbook's abbreviation badge (#1332).
+     *
+     * ELI5: a book has a strict code (used in song URLs, letters/numbers only)
+     * and, optionally, a prettier display label that can contain any characters
+     * (e.g. "AH-OLD", "Psalty:Kids"). Show the pretty one if it's set, else the
+     * code. The code itself NEVER changes — only what the badge displays.
+     *
+     * @param string|null $abbr        The strict Abbreviation / SongId-prefix code.
+     * @param string|null $displayAbbr The optional free-text display label (NULL/'' = use the code).
+     */
+    function ihymns_songbook_abbr_label(?string $abbr, ?string $displayAbbr = null): string
+    {
+        $displayAbbr = trim((string) $displayAbbr);
+        return $displayAbbr !== '' ? $displayAbbr : trim((string) $abbr);
+    }
+}
 
 if (!function_exists('ihymns_songbook_show_abbr')) {
     /**

--- a/appWeb/public_html/js/app.js
+++ b/appWeb/public_html/js/app.js
@@ -32,6 +32,7 @@ import { SetList } from './modules/setlist.js';
 import { UserAuth } from './modules/user-auth.js';
 import { Display } from './modules/display.js';
 import { LiveFollow } from './modules/live-follow.js';
+import { ServiceFollow } from './modules/service-follow.js';
 import { Compare } from './modules/compare.js';
 import { Shortcuts } from './modules/shortcuts.js';
 import { Request } from './modules/request.js';
@@ -294,6 +295,11 @@ class iHymnsApp {
                After userAuth + display so isLoggedIn() + the song toolbar exist. */
             this.liveFollow = new LiveFollow(this);
             this.liveFollow.init();
+
+            /* Service Mode — congregant join-by-code + follow (#1335 Phase 2c).
+               Anonymous; resumes a join across reloads + wires [data-action=join-service]. */
+            this.serviceFollow = new ServiceFollow(this);
+            this.serviceFollow.init();
 
             /* Side-by-side song comparison (#102) */
             this.compare = new Compare(this);

--- a/appWeb/public_html/js/modules/service-follow.js
+++ b/appWeb/public_html/js/modules/service-follow.js
@@ -1,0 +1,216 @@
+/**
+ * iHymns — Service Mode congregant client (#1335 Phase 2c)
+ *
+ * Lets a congregant JOIN a live service by typing the rotating code shown on
+ * the venue screen, then FOLLOW the songs in sync (the worship leader /
+ * projection laptop broadcasts via service_broadcast). Mirrors the worship-team
+ * follower in live-follow.js, but over the anonymous Service-Mode endpoints with
+ * a durable per-device id (localStorage) + an opaque presence token (the gate
+ * key for the Phase-3 CCLI unlock).
+ *
+ * Anonymous by design — no login needed to follow already-entitled content; the
+ * Phase-3 unlock reads the presence token server-side. Distinct from the
+ * worship-team "Live Follow" (#1268): different endpoints, a green banner, and a
+ * "Join service" entry rather than the per-song "Join Live".
+ */
+
+const SF_POLL_MS      = 2500;                       // follower poll cadence
+const SF_PRESENCE_KEY = 'ihymns_sf_presence';       // sessionStorage: {token, rev}
+const SF_DEVICE_KEY   = 'ihymns_sf_device';         // localStorage: durable anon device id
+const SF_CODE_RE      = /^[A-Z0-9]{4,12}$/;
+
+export class ServiceFollow {
+    constructor(app) {
+        this.app = app;
+        this.token = null;
+        this.rev = 0;
+        this._pollTimer = null;
+        this._polling = false;
+        this._pendingScroll = null;
+    }
+
+    init() {
+        /* Delegated entry point — any [data-action="join-service"] triggers join. */
+        document.addEventListener('click', (e) => {
+            const trigger = e.target && e.target.closest ? e.target.closest('[data-action="join-service"]') : null;
+            if (trigger) { e.preventDefault(); this.joinService(); }
+        });
+
+        /* Resume a join across a reload (sessionStorage is per-tab). */
+        try {
+            const raw = sessionStorage.getItem(SF_PRESENCE_KEY);
+            if (raw) {
+                const saved = JSON.parse(raw);
+                if (saved && saved.token) {
+                    this.token = saved.token;
+                    this.rev = (typeof saved.rev === 'number') ? saved.rev : 0;
+                    this._showBanner();
+                    this._startPolling();
+                }
+            }
+        } catch (_e) { /* ignore */ }
+    }
+
+    /** Durable anonymous device id (NOT a login) — minted once, kept in localStorage. */
+    _deviceId() {
+        let id = null;
+        try { id = localStorage.getItem(SF_DEVICE_KEY); } catch (_e) {}
+        if (!id) {
+            id = (window.crypto && crypto.randomUUID)
+                ? crypto.randomUUID()
+                : ('dev-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 10));
+            try { localStorage.setItem(SF_DEVICE_KEY, id); } catch (_e) {}
+        }
+        return id;
+    }
+
+    async joinService() {
+        if (this.token) {
+            this.app.showToast('You’re already following a service.', 'info');
+            return;
+        }
+        const raw = await this.app.showPrompt('Enter the code shown on the screen:', '', {
+            title: 'Join the service', placeholder: 'e.g. ABC234',
+        });
+        if (raw === null) { return; }
+        const code = raw.trim().toUpperCase();
+        if (!SF_CODE_RE.test(code)) {
+            this.app.showToast('That doesn’t look like a valid service code.', 'warning');
+            return;
+        }
+        await this._doJoin(code);
+    }
+
+    async _doJoin(code) {
+        try {
+            const r = await this._api('service_join', { method: 'POST', body: { code: code, presenceDeviceId: this._deviceId() } });
+            if (!r.httpOk || !r.data || !r.data.ok) {
+                this.app.showToast((r.data && r.data.error) || 'That code isn’t active right now.', 'danger');
+                return;
+            }
+            this.token = r.data.presenceToken;
+            this.rev = (typeof r.data.revision === 'number') ? r.data.revision : 0;
+            try { sessionStorage.setItem(SF_PRESENCE_KEY, JSON.stringify({ token: this.token, rev: this.rev })); } catch (_e) {}
+            this._showBanner();
+            this._startPolling();
+            this.app.showToast('You’re following the service.', 'success');
+            this._applyState(r.data.currentSongId, r.data.componentIndex);
+        } catch (_e) {
+            this.app.showToast('Could not join the service (network error).', 'danger');
+        }
+    }
+
+    leaveService(silent = false) {
+        const token = this.token;
+        this.token = null;
+        this.rev = 0;
+        this._pendingScroll = null;
+        this._stopPolling();
+        try { sessionStorage.removeItem(SF_PRESENCE_KEY); } catch (_e) {}
+        this._removeBanner();
+        if (token) { this._api('service_leave', { method: 'POST', body: { presenceToken: token } }).catch(() => {}); }
+        if (!silent) { this.app.showToast('Left the service.', 'info'); }
+    }
+
+    _startPolling() {
+        this._stopPolling();
+        this._pollTimer = setInterval(() => this._poll(), SF_POLL_MS);
+    }
+    _stopPolling() { if (this._pollTimer) { clearInterval(this._pollTimer); this._pollTimer = null; } }
+
+    async _poll() {
+        if (!this.token || this._polling) { return; }
+        this._polling = true;
+        try {
+            const r = await this._api('service_poll', { method: 'GET', query: '&presenceToken=' + encodeURIComponent(this.token) + '&since=' + this.rev });
+            const d = r.data || {};
+            if (d.active === false) {
+                this.app.showToast('The service has ended.', 'info');
+                this.leaveService(true);
+                return;
+            }
+            if (typeof d.revision === 'number') {
+                this.rev = d.revision;
+                try { sessionStorage.setItem(SF_PRESENCE_KEY, JSON.stringify({ token: this.token, rev: this.rev })); } catch (_e) {}
+            }
+            if (d.changed === true) { this._applyState(d.currentSongId, d.componentIndex); }
+        } catch (_e) {
+            /* transient — retry next tick */
+        } finally {
+            this._polling = false;
+        }
+    }
+
+    /* Navigate to the service's current song (if different); section scroll is
+       applied after the song-page render. */
+    _applyState(songId, componentIndex) {
+        const idx = (typeof componentIndex === 'number' && componentIndex >= 0) ? componentIndex : null;
+        if (!songId) { return; }
+        const page = document.querySelector('.page-song');
+        const current = page ? (page.dataset.songId || '').trim() : '';
+        if (current && current.toUpperCase() === String(songId).toUpperCase()) {
+            if (idx !== null) { this._scrollToComponent(idx); }
+            return;
+        }
+        this._pendingScroll = idx;
+        if (this.app.router && typeof this.app.router.navigate === 'function') {
+            this.app.router.navigate('/song/' + encodeURIComponent(songId));
+            if (idx !== null) { setTimeout(() => { this._scrollToComponent(idx); this._pendingScroll = null; }, 600); }
+        } else {
+            window.location.href = '/song/' + encodeURIComponent(songId);
+        }
+    }
+
+    _scrollToComponent(index) {
+        const comps = document.querySelectorAll('.page-song .lyric-component');
+        const el = comps && comps.length > index ? comps[index] : null;
+        if (el && typeof el.scrollIntoView === 'function') {
+            el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+    }
+
+    _showBanner() {
+        if (!this.token) { return; }
+        let bar = document.getElementById('service-follow-banner');
+        if (!bar) {
+            bar = document.createElement('div');
+            bar.id = 'service-follow-banner';
+            bar.setAttribute('role', 'status');
+            /* Green — visually distinct from the worship-team (blue) Live Follow banner. */
+            bar.style.cssText = 'position:fixed;left:0;right:0;bottom:0;z-index:1080;'
+                + 'background:#198754;color:#fff;text-align:center;padding:0.4rem 1rem;'
+                + 'font-size:0.85rem;line-height:1.3;box-shadow:0 -2px 8px rgba(0,0,0,.2);'
+                + 'padding-bottom:calc(0.4rem + env(safe-area-inset-bottom, 0px));';
+            document.body.appendChild(bar);
+        }
+        bar.innerHTML = '';
+        const label = document.createElement('span');
+        label.innerHTML = '<i class="bi bi-broadcast-pin me-1"></i>Following the service live ';
+        const leave = document.createElement('button');
+        leave.type = 'button';
+        leave.className = 'btn btn-sm btn-light ms-2';
+        leave.style.cssText = 'padding:0.05rem 0.5rem;font-size:0.78rem;';
+        leave.textContent = 'Leave';
+        leave.addEventListener('click', () => this.leaveService(false));
+        bar.appendChild(label);
+        bar.appendChild(leave);
+    }
+
+    _removeBanner() {
+        const bar = document.getElementById('service-follow-banner');
+        if (bar && bar.parentNode) { bar.parentNode.removeChild(bar); }
+    }
+
+    /* Anonymous same-origin call. X-Requested-With satisfies the api.php CSRF
+       guard; no auth header (congregant isn't logged in). */
+    async _api(action, opts) {
+        opts = opts || {};
+        const url = '/api?action=' + action + (opts.query || '');
+        const init = { method: opts.method || 'GET', headers: { 'X-Requested-With': 'XMLHttpRequest' }, credentials: 'same-origin' };
+        if (opts.body) { init.headers['Content-Type'] = 'application/json'; init.body = JSON.stringify(opts.body); }
+        const res = await fetch(url, init);
+        let data = {};
+        try { data = await res.json(); } catch (_e) {}
+        return { httpOk: res.ok, status: res.status, data: data };
+    }
+}

--- a/appWeb/public_html/js/modules/service-follow.js
+++ b/appWeb/public_html/js/modules/service-follow.js
@@ -44,6 +44,7 @@ export class ServiceFollow {
                 if (saved && saved.token) {
                     this.token = saved.token;
                     this.rev = (typeof saved.rev === 'number') ? saved.rev : 0;
+                    this._setPresenceCookie(this.token);   /* re-assert for the gate after a reload */
                     this._showBanner();
                     this._startPolling();
                 }
@@ -91,6 +92,7 @@ export class ServiceFollow {
             this.token = r.data.presenceToken;
             this.rev = (typeof r.data.revision === 'number') ? r.data.revision : 0;
             try { sessionStorage.setItem(SF_PRESENCE_KEY, JSON.stringify({ token: this.token, rev: this.rev })); } catch (_e) {}
+            this._setPresenceCookie(this.token);
             this._showBanner();
             this._startPolling();
             this.app.showToast('You’re following the service.', 'success');
@@ -107,6 +109,7 @@ export class ServiceFollow {
         this._pendingScroll = null;
         this._stopPolling();
         try { sessionStorage.removeItem(SF_PRESENCE_KEY); } catch (_e) {}
+        this._clearPresenceCookie();
         this._removeBanner();
         if (token) { this._api('service_leave', { method: 'POST', body: { presenceToken: token } }).catch(() => {}); }
         if (!silent) { this.app.showToast('Left the service.', 'info'); }
@@ -199,6 +202,19 @@ export class ServiceFollow {
     _removeBanner() {
         const bar = document.getElementById('service-follow-banner');
         if (bar && bar.parentNode) { bar.parentNode.removeChild(bar); }
+    }
+
+    /* The Phase-3 content gate (song.php) reads this same-origin cookie to grant
+       a present congregant the org's CCLI unlock for gated lyrics. It's an opaque
+       presence nonce (not a credential); set on join, cleared on leave/end. */
+    _setPresenceCookie(token) {
+        try {
+            const secure = (location.protocol === 'https:') ? '; Secure' : '';
+            document.cookie = 'ihymns_sf_presence_token=' + encodeURIComponent(token) + '; path=/; SameSite=Lax' + secure;
+        } catch (_e) {}
+    }
+    _clearPresenceCookie() {
+        try { document.cookie = 'ihymns_sf_presence_token=; path=/; Max-Age=0; SameSite=Lax'; } catch (_e) {}
     }
 
     /* Anonymous same-origin call. X-Requested-With satisfies the api.php CSRF

--- a/appWeb/public_html/manage/includes/admin-links.php
+++ b/appWeb/public_html/manage/includes/admin-links.php
@@ -74,6 +74,10 @@ $_adminLinks = [
     /* Venues & service times (#1325) — the where/when of an org; foundation for
        Service Mode (#1323). Same entitlement as Organisations. */
     ['venues',               '/manage/venues',                 'bi-geo-alt',         'Venues',                'manage_organisations',        'People'     ],
+    /* Service projection (#1335) — the projector page that runs a live service +
+       shows the rotating join code. Page self-gates to org-admins; nav visible to
+       manage_organisations like Venues. */
+    ['service-projection',   '/manage/service-projection',     'bi-projector',       'Service Projection',    'manage_organisations',        'People'     ],
     /* My Organisations (#707) — the entitlement is open to every signed-in
        role; admin-nav.php applies a data-driven hide via
        userHasOwnOrganisation() so non-admins only see this link when they

--- a/appWeb/public_html/manage/includes/admin-links.php
+++ b/appWeb/public_html/manage/includes/admin-links.php
@@ -71,6 +71,9 @@ $_adminLinks = [
     ['users',                '/manage/users',                  'bi-people',          'Users',                 'view_users',                  'People'     ],
     ['groups',               '/manage/groups',                 'bi-people-fill',     'User Groups',           'manage_user_groups',          'People'     ],
     ['organisations',        '/manage/organisations',          'bi-building',        'Organisations',         'manage_organisations',        'People'     ],
+    /* Venues & service times (#1325) — the where/when of an org; foundation for
+       Service Mode (#1323). Same entitlement as Organisations. */
+    ['venues',               '/manage/venues',                 'bi-geo-alt',         'Venues',                'manage_organisations',        'People'     ],
     /* My Organisations (#707) — the entitlement is open to every signed-in
        role; admin-nav.php applies a data-driven hide via
        userHasOwnOrganisation() so non-admins only see this link when they

--- a/appWeb/public_html/manage/includes/migration-registry.php
+++ b/appWeb/public_html/manage/includes/migration-registry.php
@@ -2165,4 +2165,16 @@ return [
             !_migProbe_tableExists($db, 'tblOrgVenues')
             || !_migProbe_tableExists($db, 'tblOrgServiceSchedules'),
     ],
+    'songbook-display-abbr' => [
+        'script' => 'migrate-songbook-display-abbr.php',
+        'card' => [
+            'title'  => 'Songbook display label (#1332)',
+            'body'   => 'Adds <code>tblSongbooks.DisplayAbbr</code> — an optional free-text label'
+                      . ' shown to users in place of the Abbreviation (so a book can display'
+                      . ' &ldquo;AH-OLD&rdquo;, &ldquo;Psalty:Kids&rdquo;, …) while the Abbreviation stays'
+                      . ' the alphanumeric SongId prefix. Idempotent — safe to re-run.',
+            'button' => 'Run Songbook Display Label Migration',
+        ],
+        'probe' => static fn(\mysqli $db) => !_migProbe_columnExists($db, 'tblSongbooks', 'DisplayAbbr'),
+    ],
 ];

--- a/appWeb/public_html/manage/includes/migration-registry.php
+++ b/appWeb/public_html/manage/includes/migration-registry.php
@@ -2194,4 +2194,23 @@ return [
             return !$seeded;
         },
     ],
+    'service-mode-sessions' => [
+        'script' => 'migrate-service-mode-sessions.php',
+        'card' => [
+            'title'  => 'Service Mode sessions (#1335)',
+            'body'   => 'Extends <code>tblLiveFollowSessions</code> (NULL-able host + venue/schedule/'
+                      . 'occurrence/kind + the 3-docroot <code>Channel</code> discriminator) and creates'
+                      . ' <code>tblLiveFollowJoinCodes</code>, <code>tblServicePresence</code> and'
+                      . ' <code>tblServicePollCounters</code> — the dormant foundation for congregation'
+                      . ' &ldquo;Service Mode&rdquo; (#1323). Runs after Org Venues. Idempotent — safe to re-run.',
+            'button' => 'Run Service Mode Sessions Migration',
+        ],
+        /* Multi-object OR-probe (rule #19): pending until the spine column AND all
+           three new tables exist. */
+        'probe' => static fn(\mysqli $db) =>
+            !_migProbe_columnExists($db, 'tblLiveFollowSessions', 'VenueId')
+            || !_migProbe_tableExists($db, 'tblLiveFollowJoinCodes')
+            || !_migProbe_tableExists($db, 'tblServicePresence')
+            || !_migProbe_tableExists($db, 'tblServicePollCounters'),
+    ],
 ];

--- a/appWeb/public_html/manage/includes/migration-registry.php
+++ b/appWeb/public_html/manage/includes/migration-registry.php
@@ -2165,4 +2165,33 @@ return [
             !_migProbe_tableExists($db, 'tblOrgVenues')
             || !_migProbe_tableExists($db, 'tblOrgServiceSchedules'),
     ],
+    'external-systems' => [
+        'script' => 'migrate-external-systems.php',
+        'card' => [
+            'title'  => 'External-system integration hook (#1327)',
+            'body'   => 'Creates the DORMANT integration scaffold: <code>tblExternalSystems</code>'
+                      . ' (system registry, seeded with a paused <code>webms-intra</code> row) plus'
+                      . ' per-entity ref tables <code>tblOrganisationExternalRefs</code>,'
+                      . ' <code>tblOrgVenueExternalRefs</code> and'
+                      . ' <code>tblOrgServiceScheduleExternalRefs</code> — so orgs / venues / service'
+                      . ' times can be linked to WebMS-Intra (or another system) in future without a'
+                      . ' second migration. No read/write code consumes them yet. Runs after Org Venues.'
+                      . ' Idempotent — safe to re-run.',
+            'button' => 'Run External-Systems Migration',
+        ],
+        /* Multi-object OR-probe (rule #19): pending until all four tables exist
+           AND the seeded webms-intra registry row is present (the tableExists
+           guards short-circuit before the SELECT, so it never runs against a
+           missing table under STRICT). */
+        'probe' => static function (\mysqli $db): bool {
+            if (!_migProbe_tableExists($db, 'tblExternalSystems')) { return true; }
+            if (!_migProbe_tableExists($db, 'tblOrganisationExternalRefs')) { return true; }
+            if (!_migProbe_tableExists($db, 'tblOrgVenueExternalRefs')) { return true; }
+            if (!_migProbe_tableExists($db, 'tblOrgServiceScheduleExternalRefs')) { return true; }
+            $r = $db->query("SELECT 1 FROM tblExternalSystems WHERE SystemKey = 'webms-intra' LIMIT 1");
+            $seeded = $r && $r->num_rows > 0;
+            if ($r) { $r->close(); }
+            return !$seeded;
+        },
+    ],
 ];

--- a/appWeb/public_html/manage/service-projection.php
+++ b/appWeb/public_html/manage/service-projection.php
@@ -1,0 +1,271 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Service Projection (Service Mode Phase 2b, #1335)
+ *
+ * The web-runnable PROJECTOR page (operator is web-only on shared DreamHost —
+ * this is a browser tab the worship leader opens on the projector / foldback
+ * laptop). It starts a venue/service session and displays a large, rotating
+ * JOIN CODE that congregants enter in iHymns to follow the service (Phase 2c)
+ * — and, once CCLI-gated, get a temporary presence unlock (Phase 3).
+ *
+ * Auth: a manage operator carries the same-origin `ihymns_auth` cookie, which
+ * api.php's getAuthBearerToken() accepts — so this page's JS calls the
+ * service_* operator endpoints (api.php) with just the X-Requested-With CSRF
+ * header (the #293 pattern); the cookie authenticates. The page itself is gated
+ * to global_admin/admin or an org-admin/owner (userIsOrgAdminOf).
+ *
+ * Reuses the shared admin chrome for the SETUP view; projection mode is a
+ * full-bleed, high-contrast overlay. The rotating QR is a planned drop-in
+ * (no QR lib is bundled yet) — for now the large typeable code + join URL are
+ * shown, which is the accessible fallback we'd keep beside a QR anyway.
+ */
+
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'entitlements.php';
+
+if (!isAuthenticated()) {
+    header('Location: /manage/login');
+    exit;
+}
+$currentUser = getCurrentUser();
+$role   = (string)($currentUser['role'] ?? '');
+$userId = (int)($currentUser['id'] ?? $currentUser['Id'] ?? 0);
+$isSuper = ($role === 'global_admin' || $role === 'admin');
+$adminOrgIds = $isSuper ? [] : userIsOrgAdminOf($userId);
+if (!$isSuper && empty($adminOrgIds)) {
+    http_response_code(403);
+    echo '<!DOCTYPE html><html><body><h1>403 — you must manage an organisation to run a service projection</h1></body></html>';
+    exit;
+}
+$activePage = 'service-projection';
+$db = getDbMysqli();
+
+/* Schema-presence guard — Service Mode tables may not be migrated on this env
+   yet (migrations aren't auto-applied). Themed card instead of a white-screen. */
+function _svcProjTableExists(\mysqli $db, string $t): bool
+{
+    try {
+        $stmt = $db->prepare("SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? LIMIT 1");
+        $stmt->bind_param('s', $t);
+        $stmt->execute();
+        $ok = $stmt->get_result()->fetch_row() !== null;
+        $stmt->close();
+        return $ok;
+    } catch (\Throwable $e) { return false; }
+}
+$schemaReady = _svcProjTableExists($db, 'tblOrgVenues') && _svcProjTableExists($db, 'tblLiveFollowJoinCodes');
+
+/* Load venues (+ their schedules) the operator may run, for the picker. */
+$venues = [];
+if ($schemaReady) {
+    try {
+        if ($isSuper) {
+            $res = $db->query('SELECT Id, OrgId, Name, TimeZone FROM tblOrgVenues WHERE IsActive = 1 ORDER BY Name ASC');
+            $venues = $res ? $res->fetch_all(MYSQLI_ASSOC) : [];
+        } else {
+            /* Constant-count placeholder string from the admin-org id list (rule #5). */
+            $ph = implode(',', array_fill(0, count($adminOrgIds), '?'));
+            $types = str_repeat('i', count($adminOrgIds));
+            $stmt = $db->prepare("SELECT Id, OrgId, Name, TimeZone FROM tblOrgVenues WHERE IsActive = 1 AND OrgId IN ($ph) ORDER BY Name ASC");
+            $stmt->bind_param($types, ...$adminOrgIds);
+            $stmt->execute();
+            $venues = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+            $stmt->close();
+        }
+        /* Attach each venue's active schedules. */
+        foreach ($venues as &$v) {
+            $sstmt = $db->prepare("SELECT Id, Title, DayOfWeek, StartTime, DurationMins FROM tblOrgServiceSchedules WHERE VenueId = ? AND IsActive = 1 ORDER BY DayOfWeek, StartTime");
+            $vid = (int)$v['Id'];
+            $sstmt->bind_param('i', $vid);
+            $sstmt->execute();
+            $v['schedules'] = $sstmt->get_result()->fetch_all(MYSQLI_ASSOC);
+            $sstmt->close();
+        }
+        unset($v);
+    } catch (\Throwable $e) {
+        error_log('[manage/service-projection.php] load: ' . $e->getMessage());
+        $schemaReady = false;
+    }
+}
+
+/* Public join base — the host the congregant app lives on (same origin). */
+$joinBase = ((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https://' : 'http://')
+          . preg_replace('/[^a-zA-Z0-9.\-:]/', '', (string)($_SERVER['HTTP_HOST'] ?? 'ihymns.app'));
+$DOW = [1 => 'Mon', 2 => 'Tue', 3 => 'Wed', 4 => 'Thu', 5 => 'Fri', 6 => 'Sat', 7 => 'Sun'];
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Service Projection — iHymns Admin</title>
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-libs.php'; ?>
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-favicon.php'; ?>
+    <style>
+        /* Full-bleed projection overlay — high-contrast, theme-independent. */
+        #svc-projection { position: fixed; inset: 0; z-index: 2000; background: #0b1020; color: #fff;
+            display: none; flex-direction: column; align-items: center; justify-content: center; text-align: center; padding: 4vmin; }
+        #svc-projection.active { display: flex; }
+        .svc-proj-venue { font-size: 3.2vmin; opacity: .8; margin-bottom: 1vmin; }
+        .svc-proj-instr { font-size: 3.6vmin; opacity: .9; margin-bottom: 3vmin; }
+        .svc-proj-code { font-size: 22vmin; font-weight: 800; letter-spacing: .08em; line-height: 1;
+            font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace; }
+        .svc-proj-url { font-size: 4vmin; margin-top: 4vmin; opacity: .85; }
+        .svc-proj-foot { position: absolute; bottom: 3vmin; font-size: 2.4vmin; opacity: .6; }
+        #svc-end-btn { position: absolute; top: 3vmin; right: 3vmin; }
+    </style>
+</head>
+<body>
+
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-nav.php'; ?>
+
+    <div class="container-admin py-4">
+        <h1 class="h4 mb-2"><i class="bi bi-projector me-2"></i>Service Projection</h1>
+        <p class="text-secondary small mb-4" style="max-width: 62ch;">
+            Start a live service and project a join code your congregation enters in iHymns to follow along.
+            Open this on the screen the congregation can see. The code rotates automatically.
+        </p>
+
+        <?php if (!$schemaReady): ?>
+            <div class="card border-warning"><div class="card-body">
+                <h2 class="h6 text-warning-emphasis"><i class="bi bi-database-exclamation me-1"></i>Service Mode not migrated yet</h2>
+                <p class="small mb-2">The Service Mode tables don't exist on this environment yet (migrations aren't auto-applied).</p>
+                <a class="btn btn-sm btn-amber-solid" href="/manage/setup-database"><i class="bi bi-database-gear me-1"></i>Run “Service Mode sessions” in Database Setup</a>
+            </div></div>
+        <?php elseif (!$venues): ?>
+            <div class="alert alert-info">No venues to run yet. Add a venue + service times under <a href="/manage/venues">Venues</a> first.</div>
+        <?php else: ?>
+            <div class="card" style="max-width: 560px;">
+                <div class="card-body">
+                    <div class="mb-3">
+                        <label class="form-label small fw-semibold" for="svc-venue">Venue</label>
+                        <select id="svc-venue" class="form-select"></select>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label small fw-semibold" for="svc-schedule">Service</label>
+                        <select id="svc-schedule" class="form-select"></select>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label small fw-semibold" for="svc-date">Date</label>
+                        <input type="date" id="svc-date" class="form-control">
+                    </div>
+                    <button type="button" id="svc-start-btn" class="btn btn-amber-solid"><i class="bi bi-play-fill me-1"></i>Start &amp; project</button>
+                    <div id="svc-start-error" class="text-danger small mt-2" role="alert"></div>
+                </div>
+            </div>
+        <?php endif; ?>
+    </div>
+
+    <!-- Full-bleed projection overlay -->
+    <div id="svc-projection" role="dialog" aria-label="Service join code">
+        <button type="button" id="svc-end-btn" class="btn btn-outline-light btn-sm"><i class="bi bi-x-lg me-1"></i>End service</button>
+        <div class="svc-proj-venue" id="svc-proj-venue"></div>
+        <div class="svc-proj-instr">In iHymns, tap <strong>Join service</strong> and enter:</div>
+        <div class="svc-proj-code" id="svc-proj-code">······</div>
+        <div class="svc-proj-url" id="svc-proj-url"></div>
+        <div class="svc-proj-foot">The code changes regularly — the latest one always works.</div>
+    </div>
+
+    <?php if ($schemaReady && $venues): ?>
+    <script>
+    (function () {
+        var VENUES = <?= json_encode($venues, JSON_UNESCAPED_UNICODE) ?>;
+        var DOW = <?= json_encode($DOW) ?>;
+        var JOIN_BASE = <?= json_encode($joinBase) ?>;
+        var ROTATE_MS = 30000;
+        var api = '/api';
+        var session = null, rotateTimer = null;
+
+        var venueSel = document.getElementById('svc-venue');
+        var schedSel = document.getElementById('svc-schedule');
+        var dateInp  = document.getElementById('svc-date');
+        var startBtn = document.getElementById('svc-start-btn');
+        var startErr = document.getElementById('svc-start-error');
+        var overlay  = document.getElementById('svc-projection');
+
+        // Default date = today (local).
+        dateInp.value = new Date().toISOString().slice(0, 10);
+
+        VENUES.forEach(function (v, i) {
+            var o = document.createElement('option');
+            o.value = String(v.Id); o.textContent = v.Name;
+            venueSel.appendChild(o);
+        });
+        function fillSchedules() {
+            schedSel.innerHTML = '';
+            var v = VENUES.find(function (x) { return String(x.Id) === venueSel.value; });
+            var none = document.createElement('option'); none.value = ''; none.textContent = '— ad-hoc (no set time) —'; schedSel.appendChild(none);
+            (v && v.schedules || []).forEach(function (s) {
+                var o = document.createElement('option'); o.value = String(s.Id);
+                var d = DOW[String(s.DayOfWeek)] || '';
+                o.textContent = (s.Title || 'Service') + (d ? ' · ' + d : '') + ' ' + String(s.StartTime || '').slice(0, 5);
+                schedSel.appendChild(o);
+            });
+        }
+        venueSel.addEventListener('change', fillSchedules);
+        fillSchedules();
+
+        function apiCall(action, method, body) {
+            var opts = { method: method, headers: { 'X-Requested-With': 'XMLHttpRequest' }, credentials: 'same-origin' };
+            if (body) { opts.headers['Content-Type'] = 'application/json'; opts.body = JSON.stringify(body); }
+            return fetch(api + '?action=' + action, opts).then(function (r) { return r.json().catch(function () { return {}; }); });
+        }
+
+        function showCode(code) {
+            document.getElementById('svc-proj-code').textContent = code || '······';
+            document.getElementById('svc-proj-url').textContent = JOIN_BASE.replace(/^https?:\/\//, '') + '  ·  Join service';
+        }
+        function startRotate() {
+            if (rotateTimer) clearInterval(rotateTimer);
+            rotateTimer = setInterval(function () {
+                if (!session) return;
+                apiCall('service_code_rotate', 'POST', { sessionId: session.sessionId }).then(function (d) {
+                    if (d && d.ok && d.code) showCode(d.code);
+                });
+            }, ROTATE_MS);
+        }
+
+        startBtn.addEventListener('click', function () {
+            startErr.textContent = '';
+            startBtn.disabled = true;
+            var v = VENUES.find(function (x) { return String(x.Id) === venueSel.value; });
+            apiCall('service_session_start', 'POST', {
+                venueId: parseInt(venueSel.value, 10),
+                scheduleId: schedSel.value ? parseInt(schedSel.value, 10) : 0,
+                occurrenceDate: dateInp.value
+            }).then(function (d) {
+                startBtn.disabled = false;
+                if (!d || !d.ok) { startErr.textContent = (d && d.error) || 'Could not start the service.'; return; }
+                session = d;
+                document.getElementById('svc-proj-venue').textContent = (v ? v.Name : '');
+                showCode(d.code);
+                overlay.classList.add('active');
+                startRotate();
+            }).catch(function () { startBtn.disabled = false; startErr.textContent = 'Network error.'; });
+        });
+
+        document.getElementById('svc-end-btn').addEventListener('click', function () {
+            if (rotateTimer) clearInterval(rotateTimer);
+            if (session) apiCall('service_session_end', 'POST', { sessionId: session.sessionId });
+            session = null;
+            overlay.classList.remove('active');
+        });
+
+        // Re-fetch the current code when the tab regains focus (timers throttle when hidden).
+        document.addEventListener('visibilitychange', function () {
+            if (!document.hidden && session) {
+                fetch(api + '?action=service_code_current&sessionId=' + session.sessionId, { headers: { 'X-Requested-With': 'XMLHttpRequest' }, credentials: 'same-origin' })
+                    .then(function (r) { return r.json(); }).then(function (d) { if (d && d.ok && d.code) showCode(d.code); }).catch(function () {});
+            }
+        });
+    })();
+    </script>
+    <?php endif; ?>
+
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>
+</body>
+</html>

--- a/appWeb/public_html/manage/songbooks.php
+++ b/appWeb/public_html/manage/songbooks.php
@@ -884,6 +884,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $pubYear    = trim((string)($_POST['publication_year'] ?? '')) ?: null;
                 $copyright  = trim((string)($_POST['copyright']        ?? '')) ?: null;
                 $affiliation= trim((string)($_POST['affiliation']      ?? '')) ?: null;
+                /* #1332 — optional free-text display label (any chars, ≤30); '' → NULL. */
+                $displayAbbr = trim((string)($_POST['display_abbr']    ?? ''));
+                $displayAbbr = $displayAbbr !== '' ? mb_substr($displayAbbr, 0, 30) : null;
                 /* Places adoption sweep — display string + FK. The
                    FK is populated by the place-search JS module when
                    the curator picks a candidate; free-typing leaves
@@ -1001,6 +1004,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     $stmt->execute();
                     $stmt->close();
                 }
+                /* #1332 — display label in a schema-tolerant separate UPDATE
+                   (skipped pre-migration), same pattern as the place columns. */
+                if (placeColumnExists($db, 'tblSongbooks', 'DisplayAbbr')) {
+                    $stmt = $db->prepare('UPDATE tblSongbooks SET DisplayAbbr = ? WHERE Id = ?');
+                    $stmt->bind_param('si', $displayAbbr, $newId);
+                    $stmt->execute();
+                    $stmt->close();
+                }
                 logActivity('songbook.create', 'songbook', (string)$newId, [
                     'abbreviation'    => $abbr,
                     'name'            => $name,
@@ -1058,6 +1069,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $pubYear     = trim((string)($_POST['publication_year'] ?? '')) ?: null;
                 $copyright   = trim((string)($_POST['copyright']        ?? '')) ?: null;
                 $affiliation = trim((string)($_POST['affiliation']      ?? '')) ?: null;
+                /* #1332 — optional free-text display label (any chars, ≤30); '' → NULL. */
+                $displayAbbr = trim((string)($_POST['display_abbr']     ?? ''));
+                $displayAbbr = $displayAbbr !== '' ? mb_substr($displayAbbr, 0, 30) : null;
                 /* Places adoption sweep — display string + FK. */
                 $publicationCity   = trim((string)($_POST['publication_city']    ?? '')) ?: null;
                 $publicationCityId = (int)($_POST['publication_city_id'] ?? 0) ?: null;
@@ -1306,6 +1320,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                               WHERE Id = ?'
                         );
                         $stmt->bind_param('sii', $publicationCity, $publicationCityId, $id);
+                        $stmt->execute();
+                        $stmt->close();
+                    }
+
+                    /* #1332 — display label, schema-tolerant separate UPDATE. */
+                    if (placeColumnExists($db, 'tblSongbooks', 'DisplayAbbr')) {
+                        $stmt = $db->prepare('UPDATE tblSongbooks SET DisplayAbbr = ? WHERE Id = ?');
+                        $stmt->bind_param('si', $displayAbbr, $id);
                         $stmt->execute();
                         $stmt->close();
                     }
@@ -2352,6 +2374,12 @@ try {
         ? ', b.PublicationCity, b.PublicationCityId'
         : ', NULL AS PublicationCity, NULL AS PublicationCityId';
 
+    /* #1332 — optional free-text display label, shown in place of the
+       abbreviation. NULL AS … keeps $r['DisplayAbbr'] always set pre-migration. */
+    $displayAbbrSelect = placeColumnExists($db, 'tblSongbooks', 'DisplayAbbr')
+        ? ', b.DisplayAbbr'
+        : ', NULL AS DisplayAbbr';
+
     /* Same probe pattern for the #782 phase A parent columns. When
        the schema is live, also LEFT JOIN to the parent row so the
        list-page Parent column can render abbreviation + name in one
@@ -2381,7 +2409,7 @@ try {
     $stmt = $db->prepare(
         'SELECT b.Id, b.Abbreviation, b.Name, b.SongCount, b.DisplayOrder, b.Colour,
                 b.IsOfficial, b.Publisher, b.PublicationYear,
-                b.Copyright, b.Affiliation' . $langSelect . $placeSelect . $bibSelect . $parentSelect . ',
+                b.Copyright, b.Affiliation' . $langSelect . $placeSelect . $bibSelect . $parentSelect . $displayAbbrSelect . ',
                 COUNT(s.Id) AS ActualSongCount
            FROM tblSongbooks b
            LEFT JOIN tblSongs s ON s.SongbookAbbr = b.Abbreviation' . $parentJoin . '
@@ -2630,6 +2658,8 @@ $csrf = csrfToken();
                                         'viaf_id'             => $r['ViafId']             ?? '',
                                         'lccn'                => $r['Lccn']               ?? '',
                                         'lc_class'            => $r['LcClass']            ?? '',
+                                        /* #1332 — optional display label (free text shown in place of the abbreviation). */
+                                        'display_abbr'        => $r['DisplayAbbr']         ?? '',
                                         /* #782 phase B — parent fields. Defaults
                                            keep the modal openable on a pre-migration
                                            deployment (the LEFT JOIN above only
@@ -2943,6 +2973,17 @@ $csrf = csrfToken();
                 </div>
             </div>
 
+            <!-- #1332 — optional free-text display label (shown in place of the
+                 abbreviation; the abbreviation stays the letters/numbers song-URL code). -->
+            <div class="row g-2 mt-2">
+                <div class="col-sm-4">
+                    <label class="form-label small">Display label <span class="text-muted">(optional)</span></label>
+                    <input type="text" name="display_abbr" class="form-control form-control-sm"
+                           maxlength="30" placeholder="e.g. AH-OLD">
+                    <div class="form-text small">Shown to users instead of the abbreviation; any characters allowed.</div>
+                </div>
+            </div>
+
             <!-- #502 metadata -->
             <div class="row g-2 mt-2">
                 <div class="col-sm-3 d-flex align-items-end">
@@ -3113,6 +3154,12 @@ $csrf = csrfToken();
                         <div class="mb-3">
                             <label class="form-label">Name</label>
                             <input type="text" class="form-control" name="name" id="edit-name" maxlength="255" required>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Display label <span class="text-muted">(optional)</span></label>
+                            <input type="text" class="form-control" name="display_abbr" id="edit-display-abbr" maxlength="30"
+                                   placeholder="e.g. AH-OLD — shown instead of the abbreviation">
+                            <div class="form-text">Free text shown to users in place of the abbreviation (any characters). The abbreviation itself stays the song-URL code (letters/numbers only). Leave blank to show the abbreviation.</div>
                         </div>
                         <div class="row g-2 mb-3">
                             <div class="col-sm-6">
@@ -3673,6 +3720,10 @@ $csrf = csrfToken();
             document.getElementById('edit-id').value                = row.id;
             document.getElementById('edit-abbr-label').textContent  = row.abbreviation;
             document.getElementById('edit-name').value              = row.name;
+            /* #1332 — pre-fill the optional display label so saving the form
+               doesn't blank it. Empty string when unset. */
+            var _editDisplayAbbr = document.getElementById('edit-display-abbr');
+            if (_editDisplayAbbr) { _editDisplayAbbr.value = row.display_abbr || ''; }
             /* The colour field is now wrapped in the shared colour-picker
                partial (#715), which gives the text input the id
                edit-songbook-colour-text and adds a sibling swatch.

--- a/appWeb/public_html/manage/venues.php
+++ b/appWeb/public_html/manage/venues.php
@@ -1,0 +1,949 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Admin: Venues & Service Times (Service Mode Phase 1, #1325)
+ *
+ * Lets an organisation define its physical VENUES (name, address, map-pin
+ * location + radius, timezone) and the RECURRING SERVICE TIMES at each venue —
+ * the foundation for "Service Mode" (#1323, congregation-wide Live Follow), and
+ * useful org metadata in its own right.
+ *
+ * WHY THIS PAGE EXISTS (ELI5): before this, an org could say *who* it is and
+ * *what city* it is in, but there was nowhere to say "we meet at the Main
+ * Sanctuary, 10am every Sunday." This page is that "where + when" editor.
+ *
+ * Data model: tblOrgVenues + tblOrgServiceSchedules (migrate-org-venues.php).
+ * lat/lng + radius are a CONVENIENCE geofence + map pin — NOT the presence gate
+ * (Service Mode Phase 2 gates on a venue-displayed rotating code; geolocation is
+ * spoofable/inaccurate indoors — see .claude/live-congregant-strategy.md).
+ *
+ * Shared infra reused (CLAUDE.md modularity rule): auth.php (isAuthenticated /
+ * userHasEntitlement), db_mysql.php (getDbMysqli + bind_param), places.php
+ * (placesLoadById for the geocoder pick), place-search.js (the Photon/Nominatim
+ * autocomplete, same module organisations.php uses), admin-nav / head-libs /
+ * admin-footer partials, .admin-table-responsive, the session-token CSRF helpers
+ * (csrfToken / validateCsrf). Gated by `manage_organisations` (same as
+ * organisations.php).
+ */
+
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'places.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'activity_log.php';
+
+if (!isAuthenticated()) {
+    header('Location: /manage/login');
+    exit;
+}
+$currentUser = getCurrentUser();
+if (!$currentUser || !userHasEntitlement('manage_organisations', $currentUser['role'] ?? null)) {
+    http_response_code(403);
+    echo '<!DOCTYPE html><html><body><h1>403 — manage_organisations required</h1></body></html>';
+    exit;
+}
+$activePage = 'venues';
+
+$error   = '';
+$success = '';
+$db      = getDbMysqli();
+
+/* ------------------------------------------------------------------
+ * Central vocabularies (CLAUDE.md: never hard-code these inline twice).
+ * RecurrenceKind is VARCHAR (app-validated) not ENUM — adding a cadence
+ * is an entry here, never an ALTER (rule #20).
+ * ------------------------------------------------------------------ */
+$DOW = [1 => 'Monday', 2 => 'Tuesday', 3 => 'Wednesday', 4 => 'Thursday', 5 => 'Friday', 6 => 'Saturday', 7 => 'Sunday'];
+$RECURRENCE_KINDS = [
+    'weekly'      => 'Every week',
+    'fortnightly' => 'Every 2 weeks',
+    'monthly_nth' => 'Monthly (nth weekday)',
+    'one_off'     => 'One-off date',
+];
+$NTH_LABELS = [1 => 'first', 2 => 'second', 3 => 'third', 4 => 'fourth', 5 => 'fifth', -1 => 'last'];
+/* Cache the IANA tz list once (DateTimeZone::listIdentifiers is the canonical
+   source — https://www.php.net/manual/en/datetimezone.listidentifiers.php). */
+$TZ_LIST = \DateTimeZone::listIdentifiers();
+
+/**
+ * Schema-presence guard. Migrations are NOT auto-applied on deploy, so the
+ * tables may not exist on this env yet ("it's in schema.sql" ≠ "it exists" —
+ * CLAUDE.md red flag). Probe INFORMATION_SCHEMA so a missing table renders a
+ * themed "run the migration" card instead of white-screening under STRICT.
+ */
+function _venuesTableExists(\mysqli $db, string $t): bool
+{
+    try {
+        $stmt = $db->prepare(
+            "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+              WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? LIMIT 1"
+        );
+        $stmt->bind_param('s', $t);
+        $stmt->execute();
+        $exists = $stmt->get_result()->fetch_row() !== null;
+        $stmt->close();
+        return $exists;
+    } catch (\Throwable $e) {
+        error_log('[manage/venues.php] table probe failed: ' . $e->getMessage());
+        return false;
+    }
+}
+$schemaReady = _venuesTableExists($db, 'tblOrgVenues') && _venuesTableExists($db, 'tblOrgServiceSchedules');
+
+/**
+ * Build a human "Every Sunday at 10:00 (90 min) · Europe/London" summary.
+ * Pure — takes the row + its effective tz, returns a string for display.
+ */
+function venueScheduleSummary(array $s, array $DOW, array $NTH_LABELS): string
+{
+    $rd   = is_array($s['_rd'] ?? null) ? $s['_rd'] : [];
+    $day  = $DOW[(int)($s['DayOfWeek'] ?? 0)] ?? '';
+    $time = substr((string)($s['StartTime'] ?? '00:00:00'), 0, 5);
+    $dur  = (int)($s['DurationMins'] ?? 0);
+    $tz   = (string)($s['_EffTz'] ?? 'UTC');
+    switch ((string)$s['RecurrenceKind']) {
+        case 'weekly':      $base = "Every {$day} at {$time}"; break;
+        case 'fortnightly': $base = "Every other {$day} at {$time}"; break;
+        case 'monthly_nth':
+            $nth  = (int)($rd['nth'] ?? 1);
+            $word = $NTH_LABELS[$nth] ?? 'first';
+            $base = "The {$word} {$day} of each month at {$time}";
+            break;
+        case 'one_off':
+            $date = (string)($rd['date'] ?? '?');
+            $base = "On {$date} at {$time}";
+            break;
+        default: $base = trim("{$day} at {$time}");
+    }
+    return "{$base} ({$dur} min) · {$tz}";
+}
+
+/**
+ * Compute the next $n occurrence datetimes (Y-m-d H:i) for a schedule, in its
+ * effective timezone. Iterates day-by-day applying a recurrence predicate —
+ * simple + correct for a short preview (caps at ~14 months of look-ahead).
+ */
+function venueNextOccurrences(array $s, int $n = 3): array
+{
+    try {
+        $tz = new \DateTimeZone((string)($s['_EffTz'] ?? 'UTC'));
+    } catch (\Throwable $e) {
+        $tz = new \DateTimeZone('UTC');
+    }
+    $rd   = is_array($s['_rd'] ?? null) ? $s['_rd'] : [];
+    $kind = (string)$s['RecurrenceKind'];
+    $dow  = (int)($s['DayOfWeek'] ?? 0);
+    $hhmm = substr((string)($s['StartTime'] ?? '00:00:00'), 0, 5);
+    $exceptions = array_flip(array_map('strval', $rd['exceptions'] ?? []));
+    $until = isset($rd['until']) && $rd['until'] !== '' ? (string)$rd['until'] : null;
+
+    if ($kind === 'one_off') {
+        $d = (string)($rd['date'] ?? '');
+        return $d !== '' ? ["{$d} {$hhmm}"] : [];
+    }
+    if ($dow < 1 || $dow > 7) {
+        return [];
+    }
+
+    // Anchor for the fortnightly week-parity test (default: today).
+    try {
+        $anchor = isset($rd['anchor']) && $rd['anchor'] !== ''
+            ? new \DateTime((string)$rd['anchor'], $tz)
+            : new \DateTime('today', $tz);
+    } catch (\Throwable $e) {
+        $anchor = new \DateTime('today', $tz);
+    }
+    $cursor = new \DateTime('today', $tz);
+    $out = [];
+    for ($i = 0; $i < 420 && count($out) < $n; $i++, $cursor->modify('+1 day')) {
+        if ((int)$cursor->format('N') !== $dow) {
+            continue;
+        }
+        $ymd = $cursor->format('Y-m-d');
+        if (isset($exceptions[$ymd]) || ($until !== null && $ymd > $until)) {
+            continue;
+        }
+        $match = false;
+        if ($kind === 'weekly') {
+            $match = true;
+        } elseif ($kind === 'fortnightly') {
+            $weeks = (int)floor((int)$anchor->diff($cursor)->days / 7);
+            $match = ($weeks % 2 === 0);
+        } elseif ($kind === 'monthly_nth') {
+            $nth = (int)($rd['nth'] ?? 1);
+            $dayOfMonth = (int)$cursor->format('j');
+            if ($nth === -1) {
+                // last weekday-of-month: no same weekday within the next 7 days
+                $probe = (clone $cursor)->modify('+7 days');
+                $match = ((int)$probe->format('n') !== (int)$cursor->format('n'));
+            } else {
+                $match = ((int)ceil($dayOfMonth / 7) === $nth);
+            }
+        }
+        if ($match) {
+            $out[] = "{$ymd} {$hhmm}";
+        }
+    }
+    return $out;
+}
+
+/* ===================================================================
+ * POST actions — every one CSRF-checked + bind_param. OrgId for a
+ * schedule is DERIVED from its venue (never trusted from the client).
+ * =================================================================== */
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && $schemaReady) {
+    if (!validateCsrf((string)($_POST['csrf_token'] ?? ''))) {
+        http_response_code(403);
+        echo 'Invalid CSRF token';
+        exit;
+    }
+    $action = (string)($_POST['action'] ?? '');
+    try {
+        switch ($action) {
+
+            /* ---- Venue create / update ---- */
+            case 'venue_save': {
+                $venueId = (int)($_POST['venue_id'] ?? 0);
+                $orgId   = (int)($_POST['org_id'] ?? 0);
+                $name    = trim((string)($_POST['name'] ?? ''));
+                $addr    = trim((string)($_POST['address_line'] ?? ''));
+                $city    = trim((string)($_POST['city'] ?? ''));
+                $post    = trim((string)($_POST['postcode'] ?? ''));
+                $cc      = strtoupper(trim((string)($_POST['country_code'] ?? '')));
+                $tz      = trim((string)($_POST['timezone'] ?? 'UTC'));
+                $placeId = (int)($_POST['place_id'] ?? 0);
+                $isActive = isset($_POST['is_active']) ? 1 : 0;
+
+                if ($name === '') { throw new \RuntimeException('Venue name is required.'); }
+                if ($orgId <= 0)  { throw new \RuntimeException('Choose an organisation first.'); }
+                if (!in_array($tz, $GLOBALS['TZ_LIST'], true)) { $tz = 'UTC'; }
+                if ($cc !== '' && !preg_match('/^[A-Z]{2}$/', $cc)) { $cc = ''; }
+
+                // Confirm the org exists (FK would throw, but this gives a friendly error).
+                $chk = $db->prepare('SELECT 1 FROM tblOrganisations WHERE Id = ? LIMIT 1');
+                $chk->bind_param('i', $orgId);
+                $chk->execute();
+                if ($chk->get_result()->fetch_row() === null) { $chk->close(); throw new \RuntimeException('Unknown organisation.'); }
+                $chk->close();
+
+                // Resolve coordinates: a geocoder pick (PlaceId) wins; else the
+                // optional manual lat/lng. placesLoadById() returns {lat,lon}.
+                $lat = ($_POST['latitude']  ?? '') !== '' ? (float)$_POST['latitude']  : null;
+                $lng = ($_POST['longitude'] ?? '') !== '' ? (float)$_POST['longitude'] : null;
+                $placeIdOrNull = $placeId > 0 ? $placeId : null;
+                if ($placeIdOrNull !== null && function_exists('placesLoadById')) {
+                    $place = placesLoadById($db, $placeIdOrNull);
+                    if ($place) {
+                        if ($lat === null && isset($place['lat'])) { $lat = (float)$place['lat']; }
+                        if ($lng === null && isset($place['lon'])) { $lng = (float)$place['lon']; }
+                    }
+                }
+                // Clamp coordinates to valid WGS84 ranges.
+                if ($lat !== null && ($lat < -90 || $lat > 90))   { $lat = null; }
+                if ($lng !== null && ($lng < -180 || $lng > 180)) { $lng = null; }
+                $radius = ($_POST['radius_metres'] ?? '') !== '' ? max(0, min(50000, (int)$_POST['radius_metres'])) : null;
+
+                $addrN = $addr !== '' ? $addr : null;
+                $cityN = $city !== '' ? $city : null;
+                $postN = $post !== '' ? $post : null;
+                $ccN   = $cc !== '' ? $cc : null;
+
+                if ($venueId > 0) {
+                    $stmt = $db->prepare(
+                        'UPDATE tblOrgVenues
+                            SET OrgId = ?, Name = ?, AddressLine = ?, City = ?, Postcode = ?,
+                                CountryCode = ?, PlaceId = ?, Latitude = ?, Longitude = ?,
+                                RadiusMetres = ?, TimeZone = ?, IsActive = ?
+                          WHERE Id = ?'
+                    );
+                    // i s s s s  s i d d  i s i  i
+                    $stmt->bind_param(
+                        'isssssiddisii',
+                        $orgId, $name, $addrN, $cityN, $postN,
+                        $ccN, $placeIdOrNull, $lat, $lng,
+                        $radius, $tz, $isActive, $venueId
+                    );
+                    $stmt->execute();
+                    $stmt->close();
+                    logActivity('venue.edit', 'organisation', (string)$orgId, ['venue_id' => $venueId, 'name' => $name]);
+                    $success = 'Venue updated.';
+                } else {
+                    $stmt = $db->prepare(
+                        'INSERT INTO tblOrgVenues
+                            (OrgId, Name, AddressLine, City, Postcode, CountryCode,
+                             PlaceId, Latitude, Longitude, RadiusMetres, TimeZone, IsActive)
+                         VALUES (?,?,?,?,?,?,?,?,?,?,?,?)'
+                    );
+                    $stmt->bind_param(
+                        'isssssiddisi',
+                        $orgId, $name, $addrN, $cityN, $postN, $ccN,
+                        $placeIdOrNull, $lat, $lng, $radius, $tz, $isActive
+                    );
+                    $stmt->execute();
+                    $venueId = (int)$db->insert_id;
+                    $stmt->close();
+                    logActivity('venue.create', 'organisation', (string)$orgId, ['venue_id' => $venueId, 'name' => $name]);
+                    $success = 'Venue added.';
+                }
+                break;
+            }
+
+            /* ---- Venue delete (CASCADE removes its schedules) ---- */
+            case 'venue_delete': {
+                $venueId = (int)($_POST['venue_id'] ?? 0);
+                if ($venueId <= 0) { throw new \RuntimeException('Missing venue.'); }
+                $stmt = $db->prepare('SELECT OrgId, Name FROM tblOrgVenues WHERE Id = ?');
+                $stmt->bind_param('i', $venueId);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_assoc();
+                $stmt->close();
+                if ($row) {
+                    $del = $db->prepare('DELETE FROM tblOrgVenues WHERE Id = ?');
+                    $del->bind_param('i', $venueId);
+                    $del->execute();
+                    $del->close();
+                    logActivity('venue.delete', 'organisation', (string)$row['OrgId'], ['venue_id' => $venueId, 'name' => $row['Name']]);
+                    $success = 'Venue deleted.';
+                }
+                break;
+            }
+
+            /* ---- Service schedule create / update ---- */
+            case 'schedule_save': {
+                $schedId = (int)($_POST['schedule_id'] ?? 0);
+                $venueId = (int)($_POST['venue_id'] ?? 0);
+                if ($venueId <= 0) { throw new \RuntimeException('Missing venue.'); }
+
+                // Derive OrgId + default tz from the venue — never trust posted OrgId.
+                $vs = $db->prepare('SELECT OrgId, TimeZone FROM tblOrgVenues WHERE Id = ?');
+                $vs->bind_param('i', $venueId);
+                $vs->execute();
+                $venue = $vs->get_result()->fetch_assoc();
+                $vs->close();
+                if (!$venue) { throw new \RuntimeException('Unknown venue.'); }
+                $orgId = (int)$venue['OrgId'];
+
+                $title = trim((string)($_POST['title'] ?? 'Service'));
+                if ($title === '') { $title = 'Service'; }
+                $kind  = (string)($_POST['recurrence_kind'] ?? 'weekly');
+                if (!array_key_exists($kind, $GLOBALS['RECURRENCE_KINDS'])) { $kind = 'weekly'; }
+                $startTime = (string)($_POST['start_time'] ?? '');
+                if (!preg_match('/^([01]\d|2[0-3]):[0-5]\d$/', $startTime)) {
+                    throw new \RuntimeException('Enter a valid start time (HH:MM).');
+                }
+                $startTime .= ':00';
+                $duration = max(1, min(1440, (int)($_POST['duration_mins'] ?? 90)));
+                $tzOverride = trim((string)($_POST['timezone'] ?? ''));
+                $tzN = ($tzOverride !== '' && in_array($tzOverride, $GLOBALS['TZ_LIST'], true)) ? $tzOverride : null;
+                $isActive = isset($_POST['is_active']) ? 1 : 0;
+
+                // DayOfWeek required for recurring kinds; NULL for one_off.
+                $dow = (int)($_POST['day_of_week'] ?? 0);
+                if ($kind !== 'one_off') {
+                    if ($dow < 1 || $dow > 7) { throw new \RuntimeException('Choose a day of the week.'); }
+                    $dowN = $dow;
+                } else {
+                    $dowN = null;
+                }
+
+                // Assemble RecurrenceData JSON from the kind-specific inputs.
+                $rd = [];
+                if ($kind === 'monthly_nth') {
+                    $nth = (int)($_POST['nth'] ?? 1);
+                    if (!in_array($nth, [1, 2, 3, 4, 5, -1], true)) { $nth = 1; }
+                    $rd['nth'] = $nth;
+                } elseif ($kind === 'one_off') {
+                    $oneOff = (string)($_POST['one_off_date'] ?? '');
+                    if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $oneOff)) { throw new \RuntimeException('Enter the one-off date (YYYY-MM-DD).'); }
+                    $rd['date'] = $oneOff;
+                } elseif ($kind === 'fortnightly') {
+                    $anchor = (string)($_POST['anchor_date'] ?? '');
+                    if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $anchor)) { $rd['anchor'] = $anchor; }
+                }
+                $until = (string)($_POST['until_date'] ?? '');
+                if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $until)) { $rd['until'] = $until; }
+                // Exceptions: comma/space/newline-separated YYYY-MM-DD dates.
+                $excRaw = (string)($_POST['exceptions'] ?? '');
+                if (trim($excRaw) !== '') {
+                    $exc = preg_split('/[\s,]+/', trim($excRaw)) ?: [];
+                    $exc = array_values(array_filter($exc, static fn($d) => preg_match('/^\d{4}-\d{2}-\d{2}$/', $d)));
+                    if ($exc) { $rd['exceptions'] = $exc; }
+                }
+                $rdJson = $rd ? json_encode($rd, JSON_UNESCAPED_SLASHES) : null;
+
+                if ($schedId > 0) {
+                    $stmt = $db->prepare(
+                        'UPDATE tblOrgServiceSchedules
+                            SET VenueId = ?, OrgId = ?, Title = ?, DayOfWeek = ?, StartTime = ?,
+                                DurationMins = ?, RecurrenceKind = ?, RecurrenceData = ?,
+                                TimeZone = ?, IsActive = ?
+                          WHERE Id = ?'
+                    );
+                    $stmt->bind_param(
+                        'iisisisssii',
+                        $venueId, $orgId, $title, $dowN, $startTime,
+                        $duration, $kind, $rdJson, $tzN, $isActive, $schedId
+                    );
+                    $stmt->execute();
+                    $stmt->close();
+                    logActivity('venue.schedule.edit', 'organisation', (string)$orgId, ['schedule_id' => $schedId, 'venue_id' => $venueId]);
+                    $success = 'Service time updated.';
+                } else {
+                    $stmt = $db->prepare(
+                        'INSERT INTO tblOrgServiceSchedules
+                            (VenueId, OrgId, Title, DayOfWeek, StartTime, DurationMins,
+                             RecurrenceKind, RecurrenceData, TimeZone, IsActive)
+                         VALUES (?,?,?,?,?,?,?,?,?,?)'
+                    );
+                    $stmt->bind_param(
+                        'iisisisssi',
+                        $venueId, $orgId, $title, $dowN, $startTime,
+                        $duration, $kind, $rdJson, $tzN, $isActive
+                    );
+                    $stmt->execute();
+                    $newId = (int)$db->insert_id;
+                    $stmt->close();
+                    logActivity('venue.schedule.create', 'organisation', (string)$orgId, ['schedule_id' => $newId, 'venue_id' => $venueId]);
+                    $success = 'Service time added.';
+                }
+                break;
+            }
+
+            /* ---- Schedule delete ---- */
+            case 'schedule_delete': {
+                $schedId = (int)($_POST['schedule_id'] ?? 0);
+                if ($schedId <= 0) { throw new \RuntimeException('Missing service time.'); }
+                $stmt = $db->prepare('SELECT OrgId FROM tblOrgServiceSchedules WHERE Id = ?');
+                $stmt->bind_param('i', $schedId);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_assoc();
+                $stmt->close();
+                if ($row) {
+                    $del = $db->prepare('DELETE FROM tblOrgServiceSchedules WHERE Id = ?');
+                    $del->bind_param('i', $schedId);
+                    $del->execute();
+                    $del->close();
+                    logActivity('venue.schedule.delete', 'organisation', (string)$row['OrgId'], ['schedule_id' => $schedId]);
+                    $success = 'Service time deleted.';
+                }
+                break;
+            }
+        }
+    } catch (\Throwable $e) {
+        $error = $e->getMessage() !== '' ? $e->getMessage() : 'Could not save your changes.';
+        error_log('[manage/venues.php] ' . $e->getMessage());
+    }
+}
+
+/* ===================================================================
+ * Load for render — org list, selected org's venues, selected venue's
+ * schedules. All reads guarded; everything echoed via htmlspecialchars.
+ * =================================================================== */
+$orgs          = [];
+$venues        = [];
+$schedules     = [];
+$selectedOrgId = (int)($_GET['org'] ?? ($_POST['org_id'] ?? 0));
+$selectedVenueId = (int)($_GET['venue'] ?? 0);
+
+if ($schemaReady) {
+    try {
+        $res = $db->query('SELECT Id, Name FROM tblOrganisations ORDER BY Name ASC');
+        $orgs = $res ? $res->fetch_all(MYSQLI_ASSOC) : [];
+        if ($selectedOrgId <= 0 && $orgs) { $selectedOrgId = (int)$orgs[0]['Id']; }
+
+        if ($selectedOrgId > 0) {
+            $stmt = $db->prepare(
+                'SELECT Id, OrgId, Name, AddressLine, City, Postcode, CountryCode,
+                        Latitude, Longitude, RadiusMetres, TimeZone, IsActive
+                   FROM tblOrgVenues WHERE OrgId = ? ORDER BY SortOrder ASC, Name ASC'
+            );
+            $stmt->bind_param('i', $selectedOrgId);
+            $stmt->execute();
+            $venues = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+            $stmt->close();
+        }
+
+        // Confirm the selected venue belongs to the selected org, then load its schedules.
+        $selectedVenue = null;
+        foreach ($venues as $v) {
+            if ((int)$v['Id'] === $selectedVenueId) { $selectedVenue = $v; break; }
+        }
+        if ($selectedVenue) {
+            $stmt = $db->prepare(
+                'SELECT Id, VenueId, Title, DayOfWeek, StartTime, DurationMins,
+                        RecurrenceKind, RecurrenceData, TimeZone, IsActive
+                   FROM tblOrgServiceSchedules WHERE VenueId = ?
+                  ORDER BY DayOfWeek ASC, StartTime ASC'
+            );
+            $stmt->bind_param('i', $selectedVenueId);
+            $stmt->execute();
+            $schedules = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+            $stmt->close();
+            // Decode RecurrenceData + resolve effective tz once per row.
+            foreach ($schedules as &$s) {
+                $s['_rd']     = json_decode((string)($s['RecurrenceData'] ?? ''), true) ?: [];
+                $s['_EffTz']  = ($s['TimeZone'] ?? null) ?: ($selectedVenue['TimeZone'] ?? 'UTC');
+            }
+            unset($s);
+        } else {
+            $selectedVenueId = 0;
+        }
+    } catch (\Throwable $e) {
+        $error = $error ?: 'Could not load venues. The schema may need migrating (/manage/setup-database).';
+        error_log('[manage/venues.php] load: ' . $e->getMessage());
+    }
+}
+
+// Find the row being edited (?edit_venue / ?edit_schedule), if any.
+$editVenue = null;
+$editVenueId = (int)($_GET['edit_venue'] ?? 0);
+foreach ($venues as $v) { if ((int)$v['Id'] === $editVenueId) { $editVenue = $v; break; } }
+$editSchedule = null;
+$editScheduleId = (int)($_GET['edit_schedule'] ?? 0);
+foreach ($schedules as $s) { if ((int)$s['Id'] === $editScheduleId) { $editSchedule = $s; break; } }
+$editSchedRd = $editSchedule ? ($editSchedule['_rd'] ?? []) : [];
+
+$selectedVenueRow = null;
+foreach ($venues as $v) { if ((int)$v['Id'] === $selectedVenueId) { $selectedVenueRow = $v; break; } }
+
+$csrf = csrfToken();
+
+/** Tiny helper: build a same-page URL preserving org/venue context. */
+function venuesUrl(array $overrides = []): string
+{
+    $base = ['org' => (int)($GLOBALS['selectedOrgId'] ?? 0)];
+    if (($GLOBALS['selectedVenueId'] ?? 0) > 0) { $base['venue'] = (int)$GLOBALS['selectedVenueId']; }
+    $q = array_filter(array_merge($base, $overrides), static fn($v) => $v !== null && $v !== '' && $v !== 0);
+    return '/manage/venues' . ($q ? '?' . http_build_query($q) : '');
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Venues &amp; Service Times — iHymns Admin</title>
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-libs.php'; ?>
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-favicon.php'; ?>
+</head>
+<body>
+
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-nav.php'; ?>
+
+    <div class="container-admin py-4">
+
+        <h1 class="h4 mb-2"><i class="bi bi-geo-alt me-2"></i>Venues &amp; Service Times</h1>
+        <p class="text-secondary small mb-4" style="max-width: 60ch;">
+            Tell iHymns <strong>where</strong> your organisation meets and <strong>when</strong>.
+            This is the foundation for <em>Service Mode</em> (letting a congregation follow the
+            service on their own device). The map location &amp; radius are a convenience —
+            attendance is confirmed by an on-screen code, not your location.
+        </p>
+
+        <?php if ($success): ?>
+            <div class="alert alert-success py-2"><i class="bi bi-check-circle me-1"></i><?= htmlspecialchars($success) ?></div>
+        <?php endif; ?>
+        <?php if ($error): ?>
+            <div class="alert alert-danger py-2"><i class="bi bi-exclamation-triangle me-1"></i><?= htmlspecialchars($error) ?></div>
+        <?php endif; ?>
+
+        <?php if (!$schemaReady): ?>
+            <div class="card border-warning">
+                <div class="card-body">
+                    <h2 class="h6 text-warning-emphasis"><i class="bi bi-database-exclamation me-1"></i>Schema not yet migrated</h2>
+                    <p class="small mb-2">
+                        The <code>tblOrgVenues</code> / <code>tblOrgServiceSchedules</code> tables don't
+                        exist on this environment yet. Migrations aren't applied automatically on deploy.
+                    </p>
+                    <a class="btn btn-sm btn-amber-solid" href="/manage/setup-database">
+                        <i class="bi bi-database-gear me-1"></i>Open Database Setup → run “Org Venues &amp; Service Schedules”
+                    </a>
+                </div>
+            </div>
+        <?php else: ?>
+
+        <!-- Organisation selector -->
+        <form method="get" action="/manage/venues" class="row g-2 align-items-end mb-4" style="max-width: 480px;">
+            <div class="col">
+                <label for="org-select" class="form-label small fw-semibold mb-1">Organisation</label>
+                <select id="org-select" name="org" class="form-select" onchange="this.form.submit()">
+                    <?php foreach ($orgs as $o): ?>
+                        <option value="<?= (int)$o['Id'] ?>" <?= (int)$o['Id'] === $selectedOrgId ? 'selected' : '' ?>>
+                            <?= htmlspecialchars($o['Name']) ?>
+                        </option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <?php if (!$orgs): ?>
+                <div class="col-auto"><span class="text-secondary small">No organisations yet.</span></div>
+            <?php endif; ?>
+        </form>
+
+        <?php if ($selectedOrgId > 0): ?>
+        <!-- ============================ VENUES ============================ -->
+        <div class="card mb-4">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <span class="fw-semibold"><i class="bi bi-building me-1"></i>Venues</span>
+                <a class="btn btn-sm btn-amber-solid" href="<?= htmlspecialchars(venuesUrl(['edit_venue' => 'new', 'venue' => null])) ?>#venue-form">
+                    <i class="bi bi-plus-lg me-1"></i>Add venue
+                </a>
+            </div>
+            <div class="card-body p-0">
+                <?php if (!$venues): ?>
+                    <p class="text-secondary small m-3 mb-3">No venues yet. Add the place(s) your organisation meets.</p>
+                <?php else: ?>
+                <div class="table-responsive">
+                    <table class="table admin-table-responsive align-middle mb-0">
+                        <thead>
+                            <tr>
+                                <th data-col-priority="primary">Venue</th>
+                                <th data-col-priority="secondary">Location</th>
+                                <th data-col-priority="tertiary">Timezone</th>
+                                <th data-col-priority="tertiary">Status</th>
+                                <th data-col-priority="primary" class="text-end">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                        <?php foreach ($venues as $v): ?>
+                            <?php
+                                $loc = array_filter([$v['AddressLine'] ?? '', $v['City'] ?? '', $v['Postcode'] ?? '', $v['CountryCode'] ?? '']);
+                                $hasCoords = $v['Latitude'] !== null && $v['Longitude'] !== null;
+                                $isSel = (int)$v['Id'] === $selectedVenueId;
+                            ?>
+                            <tr<?= $isSel ? ' class="table-active"' : '' ?>>
+                                <td data-col-priority="primary">
+                                    <span class="fw-semibold"><?= htmlspecialchars($v['Name']) ?></span>
+                                </td>
+                                <td data-col-priority="secondary">
+                                    <span class="small"><?= $loc ? htmlspecialchars(implode(', ', $loc)) : '<span class="text-secondary">—</span>' ?></span>
+                                    <?php if ($hasCoords): ?>
+                                        <span class="badge text-bg-light ms-1" title="Map pin set (convenience geofence<?= $v['RadiusMetres'] !== null ? ', radius ' . (int)$v['RadiusMetres'] . ' m' : '' ?>)">
+                                            <i class="bi bi-pin-map"></i>
+                                        </span>
+                                    <?php endif; ?>
+                                </td>
+                                <td data-col-priority="tertiary"><span class="small"><?= htmlspecialchars($v['TimeZone']) ?></span></td>
+                                <td data-col-priority="tertiary">
+                                    <?php if ((int)$v['IsActive'] === 1): ?>
+                                        <span class="badge text-bg-success-subtle text-success-emphasis">Active</span>
+                                    <?php else: ?>
+                                        <span class="badge text-bg-secondary-subtle text-secondary-emphasis">Hidden</span>
+                                    <?php endif; ?>
+                                </td>
+                                <td data-col-priority="primary" class="text-end text-nowrap">
+                                    <a class="btn btn-sm btn-outline-primary" href="<?= htmlspecialchars(venuesUrl(['venue' => (int)$v['Id'], 'edit_venue' => null, 'edit_schedule' => null])) ?>#schedules" title="Manage service times">
+                                        <i class="bi bi-clock-history"></i><span class="d-none d-md-inline ms-1">Service times</span>
+                                    </a>
+                                    <a class="btn btn-sm btn-outline-secondary" href="<?= htmlspecialchars(venuesUrl(['edit_venue' => (int)$v['Id'], 'venue' => null])) ?>#venue-form" title="Edit venue">
+                                        <i class="bi bi-pencil"></i>
+                                    </a>
+                                    <form method="post" action="/manage/venues" class="d-inline"
+                                          onsubmit="return confirm('Delete venue “<?= htmlspecialchars(addslashes($v['Name'])) ?>” and all its service times?');">
+                                        <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                                        <input type="hidden" name="action" value="venue_delete">
+                                        <input type="hidden" name="org_id" value="<?= $selectedOrgId ?>">
+                                        <input type="hidden" name="venue_id" value="<?= (int)$v['Id'] ?>">
+                                        <button type="submit" class="btn btn-sm btn-outline-danger" title="Delete venue"><i class="bi bi-trash"></i></button>
+                                    </form>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                </div>
+                <?php endif; ?>
+            </div>
+        </div>
+
+        <!-- ===================== VENUE ADD / EDIT FORM ===================== -->
+        <?php if ($editVenue !== null || $editVenueId === 0 && ($_GET['edit_venue'] ?? '') === 'new'): ?>
+            <?php $ev = $editVenue ?? []; $isEditV = !empty($ev); ?>
+            <div class="card mb-4" id="venue-form">
+                <div class="card-header fw-semibold">
+                    <i class="bi bi-<?= $isEditV ? 'pencil' : 'plus-lg' ?> me-1"></i><?= $isEditV ? 'Edit venue' : 'Add a venue' ?>
+                </div>
+                <div class="card-body">
+                    <form method="post" action="/manage/venues" class="row g-3">
+                        <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                        <input type="hidden" name="action" value="venue_save">
+                        <input type="hidden" name="org_id" value="<?= $selectedOrgId ?>">
+                        <input type="hidden" name="venue_id" value="<?= $isEditV ? (int)$ev['Id'] : 0 ?>">
+
+                        <div class="col-md-6">
+                            <label class="form-label small fw-semibold" for="v-name">Venue name <span class="text-danger">*</span></label>
+                            <input type="text" id="v-name" name="name" class="form-control" required maxlength="150"
+                                   value="<?= htmlspecialchars($ev['Name'] ?? '') ?>" placeholder="e.g. Main Sanctuary">
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label small fw-semibold" for="v-place">Find location (optional)</label>
+                            <input type="text" id="v-place" class="form-control" autocomplete="off"
+                                   placeholder="Type an address or town to drop a map pin…"
+                                   value="<?= htmlspecialchars(trim((($ev['City'] ?? '') . ' ' . ($ev['CountryCode'] ?? '')))) ?>">
+                            <input type="hidden" id="v-place-id" name="place_id" value="">
+                            <div class="form-text">Sets the map pin (lat/lng). A convenience only — not the attendance check.</div>
+                        </div>
+
+                        <div class="col-md-6">
+                            <label class="form-label small fw-semibold" for="v-address">Address line</label>
+                            <input type="text" id="v-address" name="address_line" class="form-control" maxlength="255"
+                                   value="<?= htmlspecialchars($ev['AddressLine'] ?? '') ?>">
+                        </div>
+                        <div class="col-md-3">
+                            <label class="form-label small fw-semibold" for="v-city">City / town</label>
+                            <input type="text" id="v-city" name="city" class="form-control" maxlength="120"
+                                   value="<?= htmlspecialchars($ev['City'] ?? '') ?>">
+                        </div>
+                        <div class="col-md-3">
+                            <label class="form-label small fw-semibold" for="v-postcode">Postcode</label>
+                            <input type="text" id="v-postcode" name="postcode" class="form-control" maxlength="20"
+                                   value="<?= htmlspecialchars($ev['Postcode'] ?? '') ?>">
+                        </div>
+
+                        <div class="col-md-3">
+                            <label class="form-label small fw-semibold" for="v-cc">Country (ISO-2)</label>
+                            <input type="text" id="v-cc" name="country_code" class="form-control text-uppercase" maxlength="2"
+                                   value="<?= htmlspecialchars($ev['CountryCode'] ?? '') ?>" placeholder="GB">
+                        </div>
+                        <div class="col-md-3">
+                            <label class="form-label small fw-semibold" for="v-lat">Latitude</label>
+                            <input type="number" step="0.0000001" min="-90" max="90" id="v-lat" name="latitude" class="form-control"
+                                   value="<?= isset($ev['Latitude']) && $ev['Latitude'] !== null ? htmlspecialchars((string)$ev['Latitude']) : '' ?>">
+                        </div>
+                        <div class="col-md-3">
+                            <label class="form-label small fw-semibold" for="v-lng">Longitude</label>
+                            <input type="number" step="0.0000001" min="-180" max="180" id="v-lng" name="longitude" class="form-control"
+                                   value="<?= isset($ev['Longitude']) && $ev['Longitude'] !== null ? htmlspecialchars((string)$ev['Longitude']) : '' ?>">
+                        </div>
+                        <div class="col-md-3">
+                            <label class="form-label small fw-semibold" for="v-radius">Radius (metres)</label>
+                            <input type="number" min="0" max="50000" step="10" id="v-radius" name="radius_metres" class="form-control"
+                                   value="<?= isset($ev['RadiusMetres']) && $ev['RadiusMetres'] !== null ? (int)$ev['RadiusMetres'] : '' ?>" placeholder="e.g. 150">
+                        </div>
+
+                        <div class="col-md-6">
+                            <label class="form-label small fw-semibold" for="v-tz">Timezone</label>
+                            <select id="v-tz" name="timezone" class="form-select">
+                                <?php $vtz = $ev['TimeZone'] ?? 'Europe/London'; foreach ($TZ_LIST as $tzId): ?>
+                                    <option value="<?= htmlspecialchars($tzId) ?>" <?= $tzId === $vtz ? 'selected' : '' ?>><?= htmlspecialchars($tzId) ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                        </div>
+                        <div class="col-md-6 d-flex align-items-end">
+                            <div class="form-check">
+                                <input type="checkbox" class="form-check-input" id="v-active" name="is_active" <?= !$isEditV || (int)($ev['IsActive'] ?? 1) === 1 ? 'checked' : '' ?>>
+                                <label class="form-check-label small" for="v-active">Active (available for Service Mode)</label>
+                            </div>
+                        </div>
+
+                        <div class="col-12 d-flex gap-2">
+                            <button type="submit" class="btn btn-amber-solid"><i class="bi bi-check-lg me-1"></i><?= $isEditV ? 'Save venue' : 'Add venue' ?></button>
+                            <a class="btn btn-outline-secondary" href="<?= htmlspecialchars(venuesUrl(['edit_venue' => null])) ?>">Cancel</a>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        <?php endif; ?>
+
+        <!-- ===================== SCHEDULES (selected venue) ===================== -->
+        <?php if ($selectedVenueRow !== null): ?>
+            <div class="card mb-4" id="schedules">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <span class="fw-semibold"><i class="bi bi-calendar-week me-1"></i>Service times — <?= htmlspecialchars($selectedVenueRow['Name']) ?></span>
+                    <a class="btn btn-sm btn-amber-solid" href="<?= htmlspecialchars(venuesUrl(['edit_schedule' => 'new'])) ?>#schedule-form">
+                        <i class="bi bi-plus-lg me-1"></i>Add service time
+                    </a>
+                </div>
+                <div class="card-body p-0">
+                    <?php if (!$schedules): ?>
+                        <p class="text-secondary small m-3 mb-3">No service times yet for this venue.</p>
+                    <?php else: ?>
+                    <div class="table-responsive">
+                        <table class="table admin-table-responsive align-middle mb-0">
+                            <thead>
+                                <tr>
+                                    <th data-col-priority="primary">Service</th>
+                                    <th data-col-priority="primary">When</th>
+                                    <th data-col-priority="secondary">Next dates</th>
+                                    <th data-col-priority="tertiary">Status</th>
+                                    <th data-col-priority="primary" class="text-end">Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                            <?php foreach ($schedules as $s): ?>
+                                <?php $next = venueNextOccurrences($s, 3); ?>
+                                <tr>
+                                    <td data-col-priority="primary"><span class="fw-semibold"><?= htmlspecialchars($s['Title']) ?></span></td>
+                                    <td data-col-priority="primary"><span class="small"><?= htmlspecialchars(venueScheduleSummary($s, $DOW, $NTH_LABELS)) ?></span></td>
+                                    <td data-col-priority="secondary">
+                                        <?php if ($next): ?>
+                                            <span class="small text-secondary"><?= htmlspecialchars(implode(' · ', array_map(static fn($d) => substr($d, 0, 16), $next))) ?></span>
+                                        <?php else: ?>
+                                            <span class="small text-secondary">—</span>
+                                        <?php endif; ?>
+                                    </td>
+                                    <td data-col-priority="tertiary">
+                                        <?= (int)$s['IsActive'] === 1
+                                            ? '<span class="badge text-bg-success-subtle text-success-emphasis">Active</span>'
+                                            : '<span class="badge text-bg-secondary-subtle text-secondary-emphasis">Hidden</span>' ?>
+                                    </td>
+                                    <td data-col-priority="primary" class="text-end text-nowrap">
+                                        <a class="btn btn-sm btn-outline-secondary" href="<?= htmlspecialchars(venuesUrl(['edit_schedule' => (int)$s['Id']])) ?>#schedule-form" title="Edit"><i class="bi bi-pencil"></i></a>
+                                        <form method="post" action="/manage/venues" class="d-inline"
+                                              onsubmit="return confirm('Delete this service time?');">
+                                            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                                            <input type="hidden" name="action" value="schedule_delete">
+                                            <input type="hidden" name="schedule_id" value="<?= (int)$s['Id'] ?>">
+                                            <button type="submit" class="btn btn-sm btn-outline-danger" title="Delete"><i class="bi bi-trash"></i></button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                            </tbody>
+                        </table>
+                    </div>
+                    <?php endif; ?>
+                </div>
+            </div>
+
+            <!-- SCHEDULE ADD / EDIT FORM -->
+            <?php if ($editSchedule !== null || ($_GET['edit_schedule'] ?? '') === 'new'): ?>
+                <?php $es = $editSchedule ?? []; $isEditS = !empty($es); $esKind = $es['RecurrenceKind'] ?? 'weekly'; ?>
+                <div class="card mb-4" id="schedule-form">
+                    <div class="card-header fw-semibold">
+                        <i class="bi bi-<?= $isEditS ? 'pencil' : 'plus-lg' ?> me-1"></i><?= $isEditS ? 'Edit service time' : 'Add a service time' ?>
+                    </div>
+                    <div class="card-body">
+                        <form method="post" action="/manage/venues" class="row g-3" id="sched-form-el">
+                            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                            <input type="hidden" name="action" value="schedule_save">
+                            <input type="hidden" name="venue_id" value="<?= $selectedVenueId ?>">
+                            <input type="hidden" name="schedule_id" value="<?= $isEditS ? (int)$es['Id'] : 0 ?>">
+
+                            <div class="col-md-5">
+                                <label class="form-label small fw-semibold" for="s-title">Service name</label>
+                                <input type="text" id="s-title" name="title" class="form-control" maxlength="150"
+                                       value="<?= htmlspecialchars($es['Title'] ?? 'Sunday Service') ?>">
+                            </div>
+                            <div class="col-md-4">
+                                <label class="form-label small fw-semibold" for="s-kind">Repeats</label>
+                                <select id="s-kind" name="recurrence_kind" class="form-select" onchange="venuesToggleRecurrence()">
+                                    <?php foreach ($RECURRENCE_KINDS as $k => $label): ?>
+                                        <option value="<?= htmlspecialchars($k) ?>" <?= $k === $esKind ? 'selected' : '' ?>><?= htmlspecialchars($label) ?></option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </div>
+                            <div class="col-md-3" data-rec-field="day">
+                                <label class="form-label small fw-semibold" for="s-dow">Day</label>
+                                <select id="s-dow" name="day_of_week" class="form-select">
+                                    <?php foreach ($DOW as $n => $dn): ?>
+                                        <option value="<?= $n ?>" <?= (int)($es['DayOfWeek'] ?? 7) === $n ? 'selected' : '' ?>><?= htmlspecialchars($dn) ?></option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </div>
+
+                            <div class="col-md-3">
+                                <label class="form-label small fw-semibold" for="s-time">Start time</label>
+                                <input type="time" id="s-time" name="start_time" class="form-control" required
+                                       value="<?= htmlspecialchars(substr((string)($es['StartTime'] ?? '10:00:00'), 0, 5)) ?>">
+                            </div>
+                            <div class="col-md-3">
+                                <label class="form-label small fw-semibold" for="s-dur">Duration (min)</label>
+                                <input type="number" id="s-dur" name="duration_mins" class="form-control" min="1" max="1440"
+                                       value="<?= (int)($es['DurationMins'] ?? 90) ?>">
+                            </div>
+                            <div class="col-md-3" data-rec-field="nth">
+                                <label class="form-label small fw-semibold" for="s-nth">Which week</label>
+                                <select id="s-nth" name="nth" class="form-select">
+                                    <?php foreach ([1 => 'First', 2 => 'Second', 3 => 'Third', 4 => 'Fourth', 5 => 'Fifth', -1 => 'Last'] as $nv => $nl): ?>
+                                        <option value="<?= $nv ?>" <?= (int)($esKind === 'monthly_nth' ? ($editSchedRd['nth'] ?? 1) : 1) === $nv ? 'selected' : '' ?>><?= htmlspecialchars($nl) ?></option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </div>
+                            <div class="col-md-3" data-rec-field="oneoff">
+                                <label class="form-label small fw-semibold" for="s-oneoff">Date</label>
+                                <input type="date" id="s-oneoff" name="one_off_date" class="form-control"
+                                       value="<?= htmlspecialchars((string)($editSchedRd['date'] ?? '')) ?>">
+                            </div>
+
+                            <div class="col-md-3" data-rec-field="anchor">
+                                <label class="form-label small fw-semibold" for="s-anchor">Starting from</label>
+                                <input type="date" id="s-anchor" name="anchor_date" class="form-control"
+                                       value="<?= htmlspecialchars((string)($editSchedRd['anchor'] ?? '')) ?>">
+                                <div class="form-text">Sets which fortnight is “week 1”.</div>
+                            </div>
+                            <div class="col-md-3">
+                                <label class="form-label small fw-semibold" for="s-until">Until (optional)</label>
+                                <input type="date" id="s-until" name="until_date" class="form-control"
+                                       value="<?= htmlspecialchars((string)($editSchedRd['until'] ?? '')) ?>">
+                            </div>
+                            <div class="col-md-6">
+                                <label class="form-label small fw-semibold" for="s-exc">Skip dates (optional)</label>
+                                <input type="text" id="s-exc" name="exceptions" class="form-control"
+                                       value="<?= htmlspecialchars(implode(', ', $editSchedRd['exceptions'] ?? [])) ?>"
+                                       placeholder="2026-12-25, 2027-01-01">
+                                <div class="form-text">Comma-separated YYYY-MM-DD dates with no service.</div>
+                            </div>
+
+                            <div class="col-md-6">
+                                <label class="form-label small fw-semibold" for="s-tz">Timezone (override)</label>
+                                <select id="s-tz" name="timezone" class="form-select">
+                                    <option value="">Inherit venue (<?= htmlspecialchars($selectedVenueRow['TimeZone']) ?>)</option>
+                                    <?php foreach ($TZ_LIST as $tzId): ?>
+                                        <option value="<?= htmlspecialchars($tzId) ?>" <?= ($es['TimeZone'] ?? '') === $tzId ? 'selected' : '' ?>><?= htmlspecialchars($tzId) ?></option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </div>
+                            <div class="col-md-6 d-flex align-items-end">
+                                <div class="form-check">
+                                    <input type="checkbox" class="form-check-input" id="s-active" name="is_active" <?= !$isEditS || (int)($es['IsActive'] ?? 1) === 1 ? 'checked' : '' ?>>
+                                    <label class="form-check-label small" for="s-active">Active</label>
+                                </div>
+                            </div>
+
+                            <div class="col-12 d-flex gap-2">
+                                <button type="submit" class="btn btn-amber-solid"><i class="bi bi-check-lg me-1"></i><?= $isEditS ? 'Save service time' : 'Add service time' ?></button>
+                                <a class="btn btn-outline-secondary" href="<?= htmlspecialchars(venuesUrl(['edit_schedule' => null])) ?>">Cancel</a>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            <?php endif; ?>
+        <?php endif; /* selectedVenueRow */ ?>
+        <?php endif; /* selectedOrgId */ ?>
+        <?php endif; /* schemaReady */ ?>
+
+    </div>
+
+    <?php if ($schemaReady): ?>
+    <!-- Reuse the shared location autocomplete (#681) — same module organisations.php
+         uses; resolves to a tblPlaces row and writes its Id into #v-place-id. -->
+    <script src="/js/modules/place-search.js?v=<?= filemtime(dirname(__DIR__) . '/js/modules/place-search.js') ?>"></script>
+    <script>
+        (function () {
+            if (window.iHymnsPlaceSearch) {
+                var v = document.getElementById('v-place');
+                var h = document.getElementById('v-place-id');
+                if (v && h) { window.iHymnsPlaceSearch.attach(v, { hiddenIdInput: h }); }
+            }
+        })();
+        // Show only the recurrence fields relevant to the chosen cadence.
+        function venuesToggleRecurrence() {
+            var kind = (document.getElementById('s-kind') || {}).value || 'weekly';
+            var show = {
+                weekly:      ['day'],
+                fortnightly: ['day', 'anchor'],
+                monthly_nth: ['day', 'nth'],
+                one_off:     ['oneoff']
+            }[kind] || ['day'];
+            document.querySelectorAll('[data-rec-field]').forEach(function (el) {
+                el.style.display = show.indexOf(el.getAttribute('data-rec-field')) === -1 ? 'none' : '';
+            });
+        }
+        venuesToggleRecurrence();
+    </script>
+    <?php endif; ?>
+
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>
+</body>
+</html>

--- a/appWeb/public_html/service-worker.js.php
+++ b/appWeb/public_html/service-worker.js.php
@@ -155,6 +155,7 @@ const PRECACHE_ASSETS = [
     '/js/modules/share.js',
     '/js/modules/compare.js',
     '/js/modules/live-follow.js',
+    '/js/modules/service-follow.js',
     '/js/modules/shortcuts.js',
     '/js/modules/request.js',
     '/js/modules/transpose.js',


### PR DESCRIPTION
Targets **alpha**. **Single consolidated PR** (owner asked for no stacked PRs) — absorbs the recovery PR #1333 and the Phase-2a PR #1336, plus the songbook display-label feature. One branch, one review, one deploy.

### Contents (commits)
1. **`58f09b2b` — Service Mode Phase 1b**: the `/manage/venues` admin UI + "Venues" nav (the UI dropped by the #1326 squash; makes the already-migrated `tblOrgVenues`/`tblOrgServiceSchedules` usable).
2. **`6f18ca87` — Phase 1c**: dormant external-system integration hook (`tblExternalSystems` + per-entity ref tables, WebMS-Intra-ready) (#1327).
3. **`87336ab1` — Songbook display label** (#1332): optional free-text `DisplayAbbr` decoupled from the alphanumeric SongId-prefix code (migration + schema-tolerant read path + render + admin field).
4. **`cc562d1e` — Service Mode Phase 2a** (#1335): the session schema foundation — extends `tblLiveFollowSessions` (NULL-able host + venue/schedule/occurrence/kind + the 3-docroot `Channel` guard) + `tblLiveFollowJoinCodes` / `tblServicePresence` / `tblServicePollCounters`. Dormant.

### Still landing on THIS branch (no new PRs)
**2b** projection page + operator endpoints · **2c** congregant join+follow client + anonymous endpoints (NAT-safe poll) · **3** presence-scoped CCLI unlock + per-song CCL notice.

### CI
All four migration registry entries present (org-venues, external-systems, songbook-display-abbr, service-mode-sessions); `php -l` clean; `test-migration-registry` + `test-schema-coverage` **pass** (129 schema tables). After deploy, run the new `/manage/setup-database` cards: External-system hook, Songbook display label, Service Mode sessions.

> Supersedes #1333 + #1336 (folded in here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)