### PR TITLE
feat(schema): Service Mode session foundation — Phase 2a (#1335)

### DIFF
--- a/.claude/live-congregant-strategy.md
+++ b/.claude/live-congregant-strategy.md
@@ -113,3 +113,29 @@ free**. Geolocation/SSID/BLE can only ever *reduce friction*, never unlock.
 Worship team = **Live Follow** (shipped). Congregation = suggest **"Service Mode"** (or "Congregation
 Follow" / "Pew Mode") — clearly distinct, and it reads as *the church running the service*, which also
 aligns better with the CCLI "church operates it" framing.
+
+## External-system integration hook (#1327) — WebMS-Intra & beyond
+Owner asked (2026-06-21) that orgs / venues / etc be able to integrate with **WebMS-Intra** in
+future. Per rule #20 (design the family up front; don't ALTER later) this shipped **dormant** in the
+Phase-1 batch (PR #1326). A design workflow (`w0ktly3yn`) surveyed the codebase idioms and **rejected
+a generic polymorphic `EntityType+EntityId` table** — rule #15 forbids it, and a numeric `EntityId`
+can't address the `SongId VARCHAR(20)` / `Abbreviation` keys the codebase already FKs on, and a no-FK
+polymorphism orphan-rots on delete. The idiomatic shape, validated adversarially, is:
+- **`tblExternalSystems`** — a registry (sibling of `tblExternalLinkTypes`); system keys live in
+  **data, not PHP** (rule #15). Seeded with a **paused `webms-intra`** row so the per-entity FKs
+  (RESTRICT) have a target (the migration seeds it — else the first insert throws under STRICT).
+- **`tblOrganisationExternalRefs` / `tblOrgVenueExternalRefs` / `tblOrgServiceScheduleExternalRefs`** —
+  per-entity dedicated ref tables (rule #15). Each carries `(Source, SourceRef)` UNIQUE (idempotent
+  re-import), `(SystemId, ExternalId)` UNIQUE (one external record ↔ one iHymns row per system, and
+  `SystemId` in the key = a **second system never needs an ALTER**), plus reserved-dormant operator
+  columns: `SyncStatus` / `SyncDirection` (VARCHAR, not ENUM), `LocalHash` + `ExternalEtag`
+  (optimistic-concurrency conflict detection), `LastError` + `LastErrorAt`, `DeletedAt` (soft-unlink
+  vs FK-cascade hard delete), `MetaJson` (loss-free), `CreatedBy`. All three entities ship in **one
+  pass** so a schedule sync never forces a third migration.
+
+**Nothing reads/writes these yet** — the actual sync engine is future, **gated** work (#1327) that
+requires, before it goes live: a **DPA** + lawful basis (org/venue address + service times are
+GDPR Art. 9-adjacent — a faith community's presence pattern); **`inbound`-first** until an outbound
+DPA exists; **production-only** runs (the 3 docroots share one MySQL — alpha/beta must not exfiltrate
+real data; gate on a sandbox `BaseUrl`); credentials **never in the DB** (`AuthScope` = a secret
+*name* hint only); sync history → `tblActivityLog` **without raw PII payloads**.

--- a/.claude/live-congregant-strategy.md
+++ b/.claude/live-congregant-strategy.md
@@ -21,6 +21,18 @@ the licence's **non-transferable / no-sublicense** clause: if CCLI reads "lyrics
 installed app" as the church *authorising a third party* to display, the church's licence would
 **not** cover it. **Silence is not permission.** → **Do not ship the auto-unlock on assumption.**
 
+> **Owner decision (2026-06-21) — risk accepted; Phase 3 UNBLOCKED.** The owner assesses this as
+> low-risk on two grounds: (1) the CCL already covers **printed** song sheets the church gives
+> congregants — which *persist and go home* — so a **temporary, presence-gated, vanishes-on-leave**
+> per-device display is *more* restrictive, not less; (2) the unlock is bound to presence and revoked
+> on leaving (no take-home copy). This is sound and materially de-risks the premise. The **one** point
+> the printed-sheet analogy doesn't settle is the non-transferable/no-sublicense angle — whether the
+> text routed through the iHymns app is "the church's own electronic display" (fine — cf.
+> ProPresenter / Proclaim / SongSelect apps operating under a church licence) or "authorising a third
+> party". A one-line written confirmation from CCLI would make it airtight but is **optional**, not a
+> gate. **Build requirement that still stands:** each device MUST render the CCL copyright notice
+> (title · author · copyright owner · the church's CCLI licence number) per song, same as print/projection.
+
 ### Reframe 2 — geolocation can't prove "in this room for this service"; a venue code can
 Browser geolocation is the **wrong primary gate**: trivially spoofable (DevTools Sensors / one-click
 extensions, no native defence), **35–100 m indoors** (can't tell the car park or the back-to-back

--- a/appWeb/.sql/migrate-external-systems.php
+++ b/appWeb/.sql/migrate-external-systems.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — External-system integration hook (Service Mode follow-on, #1325 / #1327)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * A forward-looking, DORMANT schema hook so iHymns entities (organisations,
+ * venues, service schedules — and later others) can be linked to / synced with
+ * an EXTERNAL system in future. The first target is "WebMS-Intra"; the design
+ * is system-agnostic so a second system never needs an ALTER (rule #20). Built
+ * now because the Service-Mode venue/schedule schema is landing in the same
+ * batch — adding the integration hook up front avoids a second migration.
+ *
+ * DESIGN (validated by an adversarial design workflow — see
+ * .claude/live-congregant-strategy.md §"External-system integration"):
+ *   - tblExternalSystems — a controlled-vocabulary REGISTRY of systems we hold
+ *     an identity in (sibling of tblExternalLinkTypes which classifies public
+ *     LINKS). System keys live in DATA, never hard-coded in PHP (rule #15).
+ *   - tblOrganisationExternalRefs / tblOrgVenueExternalRefs /
+ *     tblOrgServiceScheduleExternalRefs — per-entity DEDICATED mapping tables
+ *     (rule #15 forbids a generic polymorphic EntityType+EntityId FK table;
+ *     the generic "candidate A" was rejected because its numeric EntityId can't
+ *     address SongId VARCHAR keys and a no-FK polymorphism orphan-rots on
+ *     delete). Each FKs the registry + CASCADEs from its entity.
+ *
+ * Forward-looking columns reserved now (dormant) so the sync engine never
+ * forces a second migration: SyncStatus / SyncDirection (VARCHAR, app-validated,
+ * NOT ENUM); (Source, SourceRef) UNIQUE for idempotent external re-import;
+ * (SystemId, ExternalId) UNIQUE = one external record ↔ one iHymns row per
+ * system; LocalHash + ExternalEtag for optimistic-concurrency conflict
+ * detection; LastError + LastErrorAt for operator triage; DeletedAt for
+ * soft-unlink (distinct from FK-CASCADE hard delete); MetaJson for loss-free
+ * round-trip. LastSyncedAt / LastErrorAt / DeletedAt are DATETIME not TIMESTAMP.
+ *
+ * SECURITY / PRIVACY (do NOT skip when the sync engine is built — dormant now):
+ *   - tblExternalSystems.AuthScope is a secret-NAME hint only, NEVER a secret.
+ *   - Org/venue address + service times = identifiable presence patterns for a
+ *     faith community (GDPR Art. 9-adjacent). Outbound sync needs a lawful
+ *     basis + DPA; default SyncDirection is 'inbound' until one exists.
+ *   - The 3 docroots SHARE ONE MySQL — the future sync engine MUST gate live
+ *     runs to production (or a sandbox BaseUrl) so alpha/beta can't exfiltrate
+ *     real congregation data. Route sync history to tblActivityLog WITHOUT raw
+ *     PII payloads.
+ *
+ * Additive + DORMANT + IDEMPOTENT (table-existence guarded; the seed uses
+ * INSERT … ON DUPLICATE KEY UPDATE). Runs AFTER migrate-org-venues.php (FKs).
+ *
+ * @migration-adds tblExternalSystems
+ * @migration-adds tblOrganisationExternalRefs
+ * @migration-adds tblOrgVenueExternalRefs
+ * @migration-adds tblOrgServiceScheduleExternalRefs
+ *
+ * USAGE:
+ *   CLI:  php appWeb/.sql/migrate-external-systems.php
+ *   Web:  /manage/setup-database → "External-system integration hook" button
+ *
+ * @requires PHP 8.1+ with mysqli
+ */
+
+$isCli = (php_sapi_name() === 'cli');
+if (!$isCli && !defined('IHYMNS_SETUP_DASHBOARD')) {
+    header('Content-Type: text/plain; charset=UTF-8');
+    header('X-Content-Type-Options: nosniff');
+    header('Cache-Control: no-store');
+}
+function _migXS_output(string $m): void { global $isCli; echo $m . ($isCli ? "\n" : "<br>\n"); if (!$isCli) flush(); }
+function _migXS_tableExists(\mysqli $db, string $t): bool { $r = $db->query("SHOW TABLES LIKE '{$t}'"); return (bool)($r && $r->num_rows > 0); }
+
+$credFile = dirname(__DIR__) . DIRECTORY_SEPARATOR . '.auth' . DIRECTORY_SEPARATOR . 'db_credentials.php';
+if (!file_exists($credFile)) { _migXS_output("ERROR: MySQL credentials not found. Run install.php first."); return; }
+require_once $credFile;
+
+_migXS_output("");
+_migXS_output("=== iHymns — External-system integration hook (#1327) ===");
+
+try {
+    $mysql = new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME);
+    $mysql->set_charset('utf8mb4');
+} catch (\mysqli_sql_exception $e) { _migXS_output("ERROR: MySQL connection failed: " . $e->getMessage()); return; }
+_migXS_output("Connected to MySQL: " . DB_NAME);
+
+try {
+    /* 1) Registry of external systems. */
+    if (_migXS_tableExists($mysql, 'tblExternalSystems')) {
+        _migXS_output("  [SKIP] tblExternalSystems already present.");
+    } else {
+        $mysql->query(
+            "CREATE TABLE tblExternalSystems (
+                Id            INT UNSIGNED  AUTO_INCREMENT PRIMARY KEY,
+                SystemKey     VARCHAR(60)   NOT NULL COMMENT 'Stable machine key (e.g. webms-intra). App resolves systems by this — NEVER hard-code the key list in PHP (rule #15)',
+                Name          VARCHAR(120)  NOT NULL COMMENT 'Curator-facing display name (e.g. WebMS Intranet)',
+                Description   VARCHAR(255)  NULL DEFAULT NULL COMMENT 'What this system is / what the mapping means',
+                BaseUrl       VARCHAR(255)  NULL DEFAULT NULL COMMENT 'Base URL to build a deep link from a stored ExternalId; {id} placeholder substituted app-side',
+                Kind          VARCHAR(30)   NOT NULL DEFAULT 'sync' COMMENT 'sync | directory | finance | rota | identity | other — app-validated, VARCHAR not ENUM (rule #20)',
+                AuthScope     VARCHAR(40)   NULL DEFAULT NULL COMMENT 'Credential/realm hint the sync layer maps to a secret NAME — never the secret itself',
+                IsActive      TINYINT(1)    NOT NULL DEFAULT 1 COMMENT '0 = registered but paused; mappings persist, sync skips',
+                DisplayOrder  INT UNSIGNED  NOT NULL DEFAULT 0,
+                CreatedAt     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UpdatedAt     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                UNIQUE KEY uq_SystemKey (SystemKey),
+                INDEX      idx_Active   (IsActive),
+                INDEX      idx_Kind     (Kind, DisplayOrder)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+              COMMENT='Registry of external SYSTEMS an iHymns entity can be mapped/synced into (WebMS-Intra, …). SystemKey UNIQUE so keys are never hard-coded (rule #15); sibling of tblExternalLinkTypes (#833).'"
+        );
+        _migXS_output("  [OK] Created tblExternalSystems.");
+    }
+
+    /* Seed the first system row so the per-entity ref FKs (RESTRICT) have a
+       target — without this the first INSERT throws under STRICT. Idempotent. */
+    $mysql->query(
+        "INSERT INTO tblExternalSystems (SystemKey, Name, Description, Kind, IsActive, DisplayOrder)
+         VALUES ('webms-intra', 'WebMS Intranet',
+                 'Reserved integration target (#1327) — dormant until a sync engine + DPA exist.',
+                 'sync', 0, 0)
+         ON DUPLICATE KEY UPDATE SystemKey = SystemKey"
+    );
+    _migXS_output("  [OK] Seeded the 'webms-intra' system row (paused/dormant).");
+
+    /* 2) Per-organisation external refs. */
+    if (_migXS_tableExists($mysql, 'tblOrganisationExternalRefs')) {
+        _migXS_output("  [SKIP] tblOrganisationExternalRefs already present.");
+    } else {
+        $mysql->query(
+            "CREATE TABLE tblOrganisationExternalRefs (
+                Id            INT UNSIGNED  AUTO_INCREMENT PRIMARY KEY,
+                OrgId         INT UNSIGNED  NOT NULL COMMENT 'FK to tblOrganisations.Id — the iHymns org',
+                SystemId      INT UNSIGNED  NOT NULL COMMENT 'FK to tblExternalSystems.Id — which external system this id lives in',
+                ExternalId    VARCHAR(190)  NOT NULL COMMENT 'Primary identifier of the org WITHIN the external system. 190 = utf8mb4 index-safe',
+                ExternalSlug  VARCHAR(190)  NULL DEFAULT NULL COMMENT 'Optional human/slug handle in the external system',
+                SyncStatus    VARCHAR(20)   NOT NULL DEFAULT 'linked' COMMENT 'linked | pending | synced | conflict | error | deprecated — app-validated, VARCHAR not ENUM (rule #20)',
+                SyncDirection VARCHAR(20)   NOT NULL DEFAULT 'inbound' COMMENT 'none | inbound | outbound | bidirectional — VARCHAR not ENUM; inbound-first until a DPA exists',
+                Source        VARCHAR(100)  NOT NULL DEFAULT 'webms-intra' COMMENT 'Provenance of the mapping row; part of the idempotency key',
+                SourceRef     VARCHAR(190)  NULL DEFAULT NULL COMMENT 'External primary id from the Source push for idempotent re-import; NULL for a manual link (multiple NULLs coexist, rule #20)',
+                LocalHash     VARCHAR(64)   NULL DEFAULT NULL COMMENT 'Fingerprint of the iHymns row at last sync — optimistic-concurrency conflict detection',
+                ExternalEtag  VARCHAR(190)  NULL DEFAULT NULL COMMENT 'External side version/etag at last sync — conflict detection',
+                LastSyncedAt  DATETIME      NULL DEFAULT NULL COMMENT 'Last successful sync (DATETIME not TIMESTAMP — rule #20)',
+                LastError     VARCHAR(500)  NULL DEFAULT NULL COMMENT 'Last sync failure detail for operator triage (no secrets/PII)',
+                LastErrorAt   DATETIME      NULL DEFAULT NULL,
+                DeletedAt     DATETIME      NULL DEFAULT NULL COMMENT 'Soft-unlink (operator removed the link) — distinct from FK-CASCADE hard delete',
+                MetaJson      JSON          NULL DEFAULT NULL COMMENT 'Lossless extra attrs from the external system for round-trip re-export',
+                CreatedBy     INT UNSIGNED  NULL DEFAULT NULL COMMENT 'FK to tblUsers.Id — who created the link (NULL for system import)',
+                CreatedAt     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UpdatedAt     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                UNIQUE KEY uq_Org_System_Ext (OrgId, SystemId, ExternalId),
+                UNIQUE KEY uq_System_Ext     (SystemId, ExternalId),
+                UNIQUE KEY uq_SourceRef      (Source, SourceRef),
+                INDEX      idx_Org           (OrgId),
+                INDEX      idx_System        (SystemId),
+                INDEX      idx_Status        (SyncStatus),
+                CONSTRAINT fk_OrgExtRef_Org       FOREIGN KEY (OrgId)     REFERENCES tblOrganisations(Id)  ON DELETE CASCADE  ON UPDATE CASCADE,
+                CONSTRAINT fk_OrgExtRef_System    FOREIGN KEY (SystemId)  REFERENCES tblExternalSystems(Id) ON DELETE RESTRICT ON UPDATE CASCADE,
+                CONSTRAINT fk_OrgExtRef_CreatedBy FOREIGN KEY (CreatedBy) REFERENCES tblUsers(Id)          ON DELETE SET NULL ON UPDATE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+              COMMENT='Per-org external-system identity map (rule #15 dedicated ref table). (Source,SourceRef) UNIQUE = idempotent re-import (rule #20); SystemId in the keys = multi-system without an ALTER.'"
+        );
+        _migXS_output("  [OK] Created tblOrganisationExternalRefs.");
+    }
+
+    /* 3) Per-venue external refs (OrgId denorm mirrors tblOrgServiceSchedules). */
+    if (_migXS_tableExists($mysql, 'tblOrgVenueExternalRefs')) {
+        _migXS_output("  [SKIP] tblOrgVenueExternalRefs already present.");
+    } else {
+        $mysql->query(
+            "CREATE TABLE tblOrgVenueExternalRefs (
+                Id            INT UNSIGNED  AUTO_INCREMENT PRIMARY KEY,
+                VenueId       INT UNSIGNED  NOT NULL COMMENT 'FK to tblOrgVenues.Id — the iHymns venue',
+                OrgId         INT UNSIGNED  NOT NULL COMMENT 'Denorm of the venue org (app-derived, never client-trusted) for cheap org-scoped queries',
+                SystemId      INT UNSIGNED  NOT NULL COMMENT 'FK to tblExternalSystems.Id',
+                ExternalId    VARCHAR(190)  NOT NULL COMMENT 'Primary identifier of the venue WITHIN the external system',
+                ExternalSlug  VARCHAR(190)  NULL DEFAULT NULL COMMENT 'Optional human/slug handle in the external system',
+                SyncStatus    VARCHAR(20)   NOT NULL DEFAULT 'linked' COMMENT 'linked | pending | synced | conflict | error | deprecated — app-validated, VARCHAR not ENUM (rule #20)',
+                SyncDirection VARCHAR(20)   NOT NULL DEFAULT 'inbound' COMMENT 'none | inbound | outbound | bidirectional — VARCHAR not ENUM',
+                Source        VARCHAR(100)  NOT NULL DEFAULT 'webms-intra' COMMENT 'Provenance of the mapping row; part of the idempotency key',
+                SourceRef     VARCHAR(190)  NULL DEFAULT NULL COMMENT 'External primary id from the Source push for idempotent re-import; NULL for a manual link',
+                LocalHash     VARCHAR(64)   NULL DEFAULT NULL COMMENT 'Fingerprint of the iHymns row at last sync — conflict detection',
+                ExternalEtag  VARCHAR(190)  NULL DEFAULT NULL COMMENT 'External side version/etag at last sync — conflict detection',
+                LastSyncedAt  DATETIME      NULL DEFAULT NULL COMMENT 'Last successful sync (DATETIME not TIMESTAMP — rule #20)',
+                LastError     VARCHAR(500)  NULL DEFAULT NULL COMMENT 'Last sync failure detail for operator triage (no secrets/PII)',
+                LastErrorAt   DATETIME      NULL DEFAULT NULL,
+                DeletedAt     DATETIME      NULL DEFAULT NULL COMMENT 'Soft-unlink — distinct from FK-CASCADE hard delete',
+                MetaJson      JSON          NULL DEFAULT NULL COMMENT 'Lossless extra attrs for round-trip re-export',
+                CreatedBy     INT UNSIGNED  NULL DEFAULT NULL COMMENT 'FK to tblUsers.Id — who created the link (NULL for system import)',
+                CreatedAt     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UpdatedAt     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                UNIQUE KEY uq_Venue_System_Ext (VenueId, SystemId, ExternalId),
+                UNIQUE KEY uq_System_Ext       (SystemId, ExternalId),
+                UNIQUE KEY uq_SourceRef        (Source, SourceRef),
+                INDEX      idx_Venue           (VenueId),
+                INDEX      idx_Org             (OrgId),
+                INDEX      idx_System          (SystemId),
+                INDEX      idx_Status          (SyncStatus),
+                CONSTRAINT fk_VenueExtRef_Venue     FOREIGN KEY (VenueId)   REFERENCES tblOrgVenues(Id)      ON DELETE CASCADE  ON UPDATE CASCADE,
+                CONSTRAINT fk_VenueExtRef_Org       FOREIGN KEY (OrgId)     REFERENCES tblOrganisations(Id)  ON DELETE CASCADE  ON UPDATE CASCADE,
+                CONSTRAINT fk_VenueExtRef_System    FOREIGN KEY (SystemId)  REFERENCES tblExternalSystems(Id) ON DELETE RESTRICT ON UPDATE CASCADE,
+                CONSTRAINT fk_VenueExtRef_CreatedBy FOREIGN KEY (CreatedBy) REFERENCES tblUsers(Id)          ON DELETE SET NULL ON UPDATE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+              COMMENT='Per-venue external-system identity map (rule #15 dedicated ref table). (Source,SourceRef) UNIQUE = idempotent re-import (rule #20); OrgId denorm mirrors tblOrgServiceSchedules.'"
+        );
+        _migXS_output("  [OK] Created tblOrgVenueExternalRefs.");
+    }
+
+    /* 4) Per-service-schedule external refs (full org/venue/schedule scope in
+          one pass so a schedule sync never forces a third migration). */
+    if (_migXS_tableExists($mysql, 'tblOrgServiceScheduleExternalRefs')) {
+        _migXS_output("  [SKIP] tblOrgServiceScheduleExternalRefs already present.");
+    } else {
+        $mysql->query(
+            "CREATE TABLE tblOrgServiceScheduleExternalRefs (
+                Id            INT UNSIGNED  AUTO_INCREMENT PRIMARY KEY,
+                ScheduleId    INT UNSIGNED  NOT NULL COMMENT 'FK to tblOrgServiceSchedules.Id — the iHymns service time',
+                OrgId         INT UNSIGNED  NOT NULL COMMENT 'Denorm of the schedule org (app-derived, never client-trusted) for cheap org-scoped queries',
+                SystemId      INT UNSIGNED  NOT NULL COMMENT 'FK to tblExternalSystems.Id',
+                ExternalId    VARCHAR(190)  NOT NULL COMMENT 'Primary identifier of the service/event WITHIN the external system',
+                ExternalSlug  VARCHAR(190)  NULL DEFAULT NULL COMMENT 'Optional human/slug handle in the external system',
+                SyncStatus    VARCHAR(20)   NOT NULL DEFAULT 'linked' COMMENT 'linked | pending | synced | conflict | error | deprecated — app-validated, VARCHAR not ENUM (rule #20)',
+                SyncDirection VARCHAR(20)   NOT NULL DEFAULT 'inbound' COMMENT 'none | inbound | outbound | bidirectional — VARCHAR not ENUM',
+                Source        VARCHAR(100)  NOT NULL DEFAULT 'webms-intra' COMMENT 'Provenance of the mapping row; part of the idempotency key',
+                SourceRef     VARCHAR(190)  NULL DEFAULT NULL COMMENT 'External primary id from the Source push for idempotent re-import; NULL for a manual link',
+                LocalHash     VARCHAR(64)   NULL DEFAULT NULL COMMENT 'Fingerprint of the iHymns row at last sync — conflict detection',
+                ExternalEtag  VARCHAR(190)  NULL DEFAULT NULL COMMENT 'External side version/etag at last sync — conflict detection',
+                LastSyncedAt  DATETIME      NULL DEFAULT NULL COMMENT 'Last successful sync (DATETIME not TIMESTAMP — rule #20)',
+                LastError     VARCHAR(500)  NULL DEFAULT NULL COMMENT 'Last sync failure detail for operator triage (no secrets/PII)',
+                LastErrorAt   DATETIME      NULL DEFAULT NULL,
+                DeletedAt     DATETIME      NULL DEFAULT NULL COMMENT 'Soft-unlink — distinct from FK-CASCADE hard delete',
+                MetaJson      JSON          NULL DEFAULT NULL COMMENT 'Lossless extra attrs for round-trip re-export',
+                CreatedBy     INT UNSIGNED  NULL DEFAULT NULL COMMENT 'FK to tblUsers.Id — who created the link (NULL for system import)',
+                CreatedAt     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UpdatedAt     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                UNIQUE KEY uq_Sched_System_Ext (ScheduleId, SystemId, ExternalId),
+                UNIQUE KEY uq_System_Ext       (SystemId, ExternalId),
+                UNIQUE KEY uq_SourceRef        (Source, SourceRef),
+                INDEX      idx_Sched           (ScheduleId),
+                INDEX      idx_Org             (OrgId),
+                INDEX      idx_System          (SystemId),
+                INDEX      idx_Status          (SyncStatus),
+                CONSTRAINT fk_SchedExtRef_Sched     FOREIGN KEY (ScheduleId) REFERENCES tblOrgServiceSchedules(Id) ON DELETE CASCADE  ON UPDATE CASCADE,
+                CONSTRAINT fk_SchedExtRef_Org       FOREIGN KEY (OrgId)      REFERENCES tblOrganisations(Id)     ON DELETE CASCADE  ON UPDATE CASCADE,
+                CONSTRAINT fk_SchedExtRef_System    FOREIGN KEY (SystemId)   REFERENCES tblExternalSystems(Id)   ON DELETE RESTRICT ON UPDATE CASCADE,
+                CONSTRAINT fk_SchedExtRef_CreatedBy FOREIGN KEY (CreatedBy)  REFERENCES tblUsers(Id)             ON DELETE SET NULL ON UPDATE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+              COMMENT='Per-service-schedule external-system identity map (rule #15 dedicated ref table). (Source,SourceRef) UNIQUE = idempotent re-import (rule #20); OrgId denorm mirrors tblOrgServiceSchedules.'"
+        );
+        _migXS_output("  [OK] Created tblOrgServiceScheduleExternalRefs.");
+    }
+
+    _migXS_output("  Tables ship empty + dormant; no read/write code consumes them yet. The WebMS-Intra sync engine is future, gated work (#1327) requiring a DPA + production-only run.");
+    _migXS_output("Migration complete.");
+} catch (\mysqli_sql_exception $e) {
+    _migXS_output("ERROR: " . $e->getMessage());
+}

--- a/appWeb/.sql/migrate-service-mode-sessions.php
+++ b/appWeb/.sql/migrate-service-mode-sessions.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Service Mode sessions (Phase 2a schema, #1335 / epic #1323)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * The forward-looking schema for "Service Mode" — congregants join a live
+ * service via a venue-displayed ROTATING CODE and follow the songs in sync,
+ * reusing the #1268 Live-Follow spine (tblLiveFollowSessions + the StateRevision
+ * short-poll). Phase 3 (the temporary presence-scoped CCLI unlock) binds on top.
+ *
+ * DESIGN (locked via an adversarial design workflow — see
+ * .claude/live-congregant-strategy.md). This ships the WHOLE Phase 2+3 schema in
+ * ONE batch (rule #20), additive + dormant — no behaviour yet; the projection
+ * page (2b), congregant client (2c) and gated unlock (3) consume it later.
+ *
+ *   (1) EXTEND tblLiveFollowSessions (reuse the spine, don't fork it):
+ *       - RELAX HostUserId to NULL — a service session is anchored to a
+ *         VENUE+SCHEDULE and may be host-less. The existing one-active-per-host
+ *         supersede (`WHERE HostUserId = ?`, api.php:11618) is already NULL-safe
+ *         (`NULL = <id>` never matches), so a host creating a session never
+ *         touches a host-less service session — no api.php change needed here.
+ *       - light up VenueId / ScheduleId / OccurrenceDate (the service-occurrence
+ *         identity), SessionKind ('host' = #1268 leader follow, 'service' = this),
+ *         and Channel — the 3-DOCROOT discriminator (HTTP_HOST-derived at create)
+ *         so a session started on alpha/beta is NEVER joinable/gating on prod
+ *         (same class as the prod-stale-SongbookName bug; must be in EVERY WHERE).
+ *   (2) tblLiveFollowJoinCodes — DB-stored rotating nonce window (current +
+ *       previous + grace) per session; SESSION-SCOPED uniqueness so two venues'
+ *       identical codes never collide. The mint/rotate is transactional (2b).
+ *   (3) tblServicePresence — an ANONYMOUS congregant's presence: client-minted
+ *       PresenceDeviceId + an opaque PresenceToken (the gate key, hard-revocable),
+ *       ExpiresAt = resolved-UTC min(service-occurrence end, hard ceiling). The
+ *       Phase-3 gate reads this by token; revoked on leave/expiry/session-end.
+ *   (4) tblServicePollCounters — a PER-SESSION poll budget so a NAT-shared
+ *       congregation (many devices, one church-wifi IP) isn't throttled by the
+ *       #1268 per-IP cap (the flagged NAT fix).
+ *
+ * VARCHAR-not-ENUM for SessionKind / Status (rule #20). DATETIME (not TIMESTAMP)
+ * for the sync/expiry clocks. Additive + IDEMPOTENT (column/table guarded).
+ * Runs AFTER migrate-org-venues.php (FKs to tblOrgVenues / tblOrgServiceSchedules).
+ *
+ * @migration-adds tblLiveFollowSessions.VenueId
+ * @migration-adds tblLiveFollowSessions.ScheduleId
+ * @migration-adds tblLiveFollowSessions.OccurrenceDate
+ * @migration-adds tblLiveFollowSessions.SessionKind
+ * @migration-adds tblLiveFollowSessions.Channel
+ * @migration-adds tblLiveFollowJoinCodes
+ * @migration-adds tblServicePresence
+ * @migration-adds tblServicePollCounters
+ *
+ * USAGE:
+ *   CLI:  php appWeb/.sql/migrate-service-mode-sessions.php
+ *   Web:  /manage/setup-database → "Service Mode sessions" button
+ *
+ * @requires PHP 8.1+ with mysqli
+ */
+
+$isCli = (php_sapi_name() === 'cli');
+if (!$isCli && !defined('IHYMNS_SETUP_DASHBOARD')) {
+    header('Content-Type: text/plain; charset=UTF-8');
+    header('X-Content-Type-Options: nosniff');
+    header('Cache-Control: no-store');
+}
+function _migSMS_output(string $m): void { global $isCli; echo $m . ($isCli ? "\n" : "<br>\n"); if (!$isCli) flush(); }
+function _migSMS_tableExists(\mysqli $db, string $t): bool { $r = $db->query("SHOW TABLES LIKE '{$t}'"); return (bool)($r && $r->num_rows > 0); }
+function _migSMS_columnExists(\mysqli $db, string $t, string $c): bool
+{
+    $stmt = $db->prepare(
+        "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ? LIMIT 1"
+    );
+    $stmt->bind_param('ss', $t, $c);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+$credFile = dirname(__DIR__) . DIRECTORY_SEPARATOR . '.auth' . DIRECTORY_SEPARATOR . 'db_credentials.php';
+if (!file_exists($credFile)) { _migSMS_output("ERROR: MySQL credentials not found. Run install.php first."); return; }
+require_once $credFile;
+
+_migSMS_output("");
+_migSMS_output("=== iHymns — Service Mode sessions (#1335) ===");
+
+try {
+    $mysql = new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME);
+    $mysql->set_charset('utf8mb4');
+} catch (\mysqli_sql_exception $e) { _migSMS_output("ERROR: MySQL connection failed: " . $e->getMessage()); return; }
+_migSMS_output("Connected to MySQL: " . DB_NAME);
+
+try {
+    /* (1) Extend the #1268 spine. Gated on VenueId-absent so the whole ALTER
+          (incl. the HostUserId relax) runs once + is idempotent. */
+    if (_migSMS_columnExists($mysql, 'tblLiveFollowSessions', 'VenueId')) {
+        _migSMS_output("  [SKIP] tblLiveFollowSessions already extended.");
+    } else {
+        $mysql->query(
+            "ALTER TABLE tblLiveFollowSessions
+                MODIFY HostUserId INT UNSIGNED NULL DEFAULT NULL
+                    COMMENT 'FK to tblUsers — leader hosting; NULL for an org/venue-anchored service session (#1335)',
+                ADD COLUMN VenueId        INT UNSIGNED NULL DEFAULT NULL COMMENT 'FK tblOrgVenues — venue of this service session' AFTER OrgId,
+                ADD COLUMN ScheduleId     INT UNSIGNED NULL DEFAULT NULL COMMENT 'FK tblOrgServiceSchedules — the recurring schedule' AFTER VenueId,
+                ADD COLUMN OccurrenceDate DATE         NULL DEFAULT NULL COMMENT 'Date of this occurrence (scheduleId + date = occurrence identity)' AFTER ScheduleId,
+                ADD COLUMN SessionKind    VARCHAR(20)  NOT NULL DEFAULT 'host' COMMENT 'host = #1268 leader follow | service = #1335 venue/org session — app-validated, VARCHAR not ENUM',
+                ADD COLUMN Channel        VARCHAR(16)  NULL DEFAULT NULL COMMENT '3-docroot env discriminator (HTTP_HOST-derived at create); MUST be filtered in every join/poll/gate/prune query so a non-prod session is never joinable on prod',
+                ADD INDEX idx_Service (VenueId, ScheduleId, OccurrenceDate, IsActive),
+                ADD INDEX idx_OrgActive (OrgId, IsActive),
+                ADD CONSTRAINT fk_LiveFollow_Venue    FOREIGN KEY (VenueId)    REFERENCES tblOrgVenues(Id)          ON DELETE SET NULL ON UPDATE CASCADE,
+                ADD CONSTRAINT fk_LiveFollow_Schedule FOREIGN KEY (ScheduleId) REFERENCES tblOrgServiceSchedules(Id) ON DELETE SET NULL ON UPDATE CASCADE"
+        );
+        _migSMS_output("  [OK] Extended tblLiveFollowSessions (host NULLable + VenueId/ScheduleId/OccurrenceDate/SessionKind/Channel + indexes + FKs).");
+    }
+
+    /* (2) Rotating join codes. */
+    if (_migSMS_tableExists($mysql, 'tblLiveFollowJoinCodes')) {
+        _migSMS_output("  [SKIP] tblLiveFollowJoinCodes already present.");
+    } else {
+        $mysql->query(
+            "CREATE TABLE tblLiveFollowJoinCodes (
+                Id          BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                SessionId   INT UNSIGNED  NOT NULL COMMENT 'FK tblLiveFollowSessions',
+                Code        VARCHAR(12)   NOT NULL COMMENT 'Crockford base32 rotating join code (current/previous live)',
+                Generation  INT UNSIGNED  NOT NULL DEFAULT 0 COMMENT 'Monotonic per-session rotation counter',
+                Status      VARCHAR(20)   NOT NULL DEFAULT 'current' COMMENT 'current | previous | superseded — app-validated, VARCHAR not ENUM (rule #20)',
+                IssuedAt    DATETIME      NOT NULL,
+                ExpiresAt   DATETIME      NOT NULL COMMENT 'Rotation horizon + grace (UTC); join rejects past this',
+                CreatedAt   TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE KEY uq_Session_Code (SessionId, Code),
+                INDEX idx_Session_Status (SessionId, Status),
+                INDEX idx_Expiry (ExpiresAt),
+                CONSTRAINT fk_JoinCode_Session FOREIGN KEY (SessionId) REFERENCES tblLiveFollowSessions(Id) ON DELETE CASCADE ON UPDATE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+              COMMENT='Rotating venue join codes for Service Mode (#1335). Session-scoped uniqueness; current+previous window so a just-before-rotation scan still validates.'"
+        );
+        _migSMS_output("  [OK] Created tblLiveFollowJoinCodes.");
+    }
+
+    /* (3) Anonymous congregant presence (Phase 2 join + Phase 3 gate read). */
+    if (_migSMS_tableExists($mysql, 'tblServicePresence')) {
+        _migSMS_output("  [SKIP] tblServicePresence already present.");
+    } else {
+        $mysql->query(
+            "CREATE TABLE tblServicePresence (
+                Id               BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                SessionId        INT UNSIGNED  NOT NULL COMMENT 'FK tblLiveFollowSessions',
+                OrgId            INT UNSIGNED  NULL DEFAULT NULL COMMENT 'Denorm of the session org for the Phase-3 gate read',
+                VenueId          INT UNSIGNED  NULL DEFAULT NULL,
+                ScheduleId       INT UNSIGNED  NULL DEFAULT NULL,
+                OccurrenceDate   DATE          NULL DEFAULT NULL,
+                Channel          VARCHAR(16)   NULL DEFAULT NULL COMMENT '3-docroot env discriminator (copied from the session); filter in every query',
+                PresenceDeviceId VARCHAR(64)   NOT NULL COMMENT 'Client-minted anonymous device id (localStorage UUID) — advisory cooldown key, NOT a security control',
+                PresenceToken    CHAR(43)      NOT NULL COMMENT 'Opaque base64url 32-byte nonce — the gate key; hard-revocable (not a signed token)',
+                JoinedAt         DATETIME      NOT NULL,
+                LastSeenAt       DATETIME      NOT NULL,
+                ExpiresAt        DATETIME      NOT NULL COMMENT 'Resolved UTC = min(service-occurrence end via venue IANA tz, hard ceiling); gate + prune compare against this',
+                IsActive         TINYINT(1)    NOT NULL DEFAULT 1 COMMENT '0 = left/revoked → immediate gate revocation',
+                CreatedAt        TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UpdatedAt        TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                UNIQUE KEY uq_Token (PresenceToken),
+                UNIQUE KEY uq_DeviceSession (SessionId, PresenceDeviceId),
+                INDEX idx_Session (SessionId, IsActive),
+                INDEX idx_Gate (PresenceToken, IsActive, ExpiresAt),
+                CONSTRAINT fk_Presence_Session FOREIGN KEY (SessionId) REFERENCES tblLiveFollowSessions(Id) ON DELETE CASCADE ON UPDATE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+              COMMENT='Anonymous congregant presence for Service Mode (#1335). PresenceToken = the Phase-3 gate key; ExpiresAt = resolved-UTC service end; one row per device per session (re-join reactivates).'"
+        );
+        _migSMS_output("  [OK] Created tblServicePresence.");
+    }
+
+    /* (4) Per-session NAT-safe poll budget. */
+    if (_migSMS_tableExists($mysql, 'tblServicePollCounters')) {
+        _migSMS_output("  [SKIP] tblServicePollCounters already present.");
+    } else {
+        $mysql->query(
+            "CREATE TABLE tblServicePollCounters (
+                Id          BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                SessionId   INT UNSIGNED NOT NULL COMMENT 'FK tblLiveFollowSessions',
+                WindowStart DATETIME     NOT NULL COMMENT 'Start of the fixed counting window (UTC)',
+                PollCount   INT UNSIGNED NOT NULL DEFAULT 0 COMMENT 'Polls served to the WHOLE session in this window — NAT-safe per-session budget (not per-IP, which would throttle a congregation behind one church-wifi IP)',
+                CreatedAt   TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE KEY uq_Session_Window (SessionId, WindowStart),
+                INDEX idx_Window (WindowStart),
+                CONSTRAINT fk_PollCtr_Session FOREIGN KEY (SessionId) REFERENCES tblLiveFollowSessions(Id) ON DELETE CASCADE ON UPDATE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+              COMMENT='Per-session poll budget for Service Mode (#1335) — the NAT-safe replacement for the #1268 per-IP poll cap.'"
+        );
+        _migSMS_output("  [OK] Created tblServicePollCounters.");
+    }
+
+    _migSMS_output("  Tables ship empty + dormant; the projection page (2b), congregant client (2c) + gated unlock (3) consume them. NOTHING joins/gates yet.");
+    _migSMS_output("Migration complete.");
+} catch (\mysqli_sql_exception $e) {
+    _migSMS_output("ERROR: " . $e->getMessage());
+}

--- a/appWeb/.sql/schema.sql
+++ b/appWeb/.sql/schema.sql
@@ -2998,8 +2998,13 @@ CREATE TABLE IF NOT EXISTS tblSongEmbeddings (
 CREATE TABLE IF NOT EXISTS tblLiveFollowSessions (
     Id                   INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     SessionCode          VARCHAR(12)  NOT NULL COMMENT 'Short human code / QR payload congregants enter to join',
-    HostUserId           INT UNSIGNED NOT NULL COMMENT 'FK to tblUsers — the worship leader hosting',
+    HostUserId           INT UNSIGNED NULL DEFAULT NULL COMMENT 'FK to tblUsers — leader hosting; NULL for an org/venue-anchored service session (#1335)',
     OrgId                INT UNSIGNED NULL DEFAULT NULL COMMENT 'FK to tblOrganisations',
+    VenueId              INT UNSIGNED NULL DEFAULT NULL COMMENT 'FK tblOrgVenues — venue of this service session (#1335)',
+    ScheduleId           INT UNSIGNED NULL DEFAULT NULL COMMENT 'FK tblOrgServiceSchedules — the recurring schedule (#1335)',
+    OccurrenceDate       DATE         NULL DEFAULT NULL COMMENT 'Date of this occurrence (scheduleId + date = occurrence identity) (#1335)',
+    SessionKind          VARCHAR(20)  NOT NULL DEFAULT 'host' COMMENT 'host = #1268 leader follow | service = #1335 venue/org session — app-validated, VARCHAR not ENUM',
+    Channel              VARCHAR(16)  NULL DEFAULT NULL COMMENT '3-docroot env discriminator (HTTP_HOST-derived at create); filter in every join/poll/gate/prune query (#1335)',
     SetlistId            VARCHAR(100) NULL DEFAULT NULL COMMENT 'Soft link to the setlist being followed',
     CurrentSongId        VARCHAR(20)  NULL DEFAULT NULL COMMENT 'FK to tblSongs — the song currently displayed',
     CurrentComponentIndex INT        NULL DEFAULT NULL COMMENT 'Index into the arrangement/component order being shown',
@@ -3015,15 +3020,78 @@ CREATE TABLE IF NOT EXISTS tblLiveFollowSessions (
     UNIQUE KEY uq_Code   (SessionCode),
     INDEX      idx_Host  (HostUserId),
     INDEX      idx_Active (IsActive, LastHeartbeatAt),
+    INDEX      idx_Service (VenueId, ScheduleId, OccurrenceDate, IsActive),
+    INDEX      idx_OrgActive (OrgId, IsActive),
 
     CONSTRAINT fk_LiveFollow_Host
         FOREIGN KEY (HostUserId) REFERENCES tblUsers(Id) ON DELETE CASCADE ON UPDATE CASCADE,
     CONSTRAINT fk_LiveFollow_Org
         FOREIGN KEY (OrgId) REFERENCES tblOrganisations(Id) ON DELETE SET NULL ON UPDATE CASCADE,
     CONSTRAINT fk_LiveFollow_Song
-        FOREIGN KEY (CurrentSongId) REFERENCES tblSongs(SongId) ON DELETE SET NULL ON UPDATE CASCADE
+        FOREIGN KEY (CurrentSongId) REFERENCES tblSongs(SongId) ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT fk_LiveFollow_Venue
+        FOREIGN KEY (VenueId) REFERENCES tblOrgVenues(Id) ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT fk_LiveFollow_Schedule
+        FOREIGN KEY (ScheduleId) REFERENCES tblOrgServiceSchedules(Id) ON DELETE SET NULL ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
-  COMMENT='Live-follow broadcast sessions for native present+follow (#1090 P7).';
+  COMMENT='Live-follow broadcast sessions for native present+follow (#1090 P7); extended for Service Mode org/venue/service sessions (#1335).';
+
+-- ----------------------------------------------------------------------------
+-- Service Mode (#1335) — rotating venue join codes + anonymous congregant
+-- presence + per-session poll budget. Dormant until Phase 2b/2c/3. Mirror of
+-- migrate-service-mode-sessions.php.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS tblLiveFollowJoinCodes (
+    Id          BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    SessionId   INT UNSIGNED  NOT NULL COMMENT 'FK tblLiveFollowSessions',
+    Code        VARCHAR(12)   NOT NULL COMMENT 'Crockford base32 rotating join code (current/previous live)',
+    Generation  INT UNSIGNED  NOT NULL DEFAULT 0 COMMENT 'Monotonic per-session rotation counter',
+    Status      VARCHAR(20)   NOT NULL DEFAULT 'current' COMMENT 'current | previous | superseded — app-validated, VARCHAR not ENUM (rule #20)',
+    IssuedAt    DATETIME      NOT NULL,
+    ExpiresAt   DATETIME      NOT NULL COMMENT 'Rotation horizon + grace (UTC); join rejects past this',
+    CreatedAt   TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_Session_Code (SessionId, Code),
+    INDEX idx_Session_Status (SessionId, Status),
+    INDEX idx_Expiry (ExpiresAt),
+    CONSTRAINT fk_JoinCode_Session FOREIGN KEY (SessionId) REFERENCES tblLiveFollowSessions(Id) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='Rotating venue join codes for Service Mode (#1335). Session-scoped uniqueness; current+previous window so a just-before-rotation scan still validates.';
+
+CREATE TABLE IF NOT EXISTS tblServicePresence (
+    Id               BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    SessionId        INT UNSIGNED  NOT NULL COMMENT 'FK tblLiveFollowSessions',
+    OrgId            INT UNSIGNED  NULL DEFAULT NULL COMMENT 'Denorm of the session org for the Phase-3 gate read',
+    VenueId          INT UNSIGNED  NULL DEFAULT NULL,
+    ScheduleId       INT UNSIGNED  NULL DEFAULT NULL,
+    OccurrenceDate   DATE          NULL DEFAULT NULL,
+    Channel          VARCHAR(16)   NULL DEFAULT NULL COMMENT '3-docroot env discriminator (copied from the session); filter in every query',
+    PresenceDeviceId VARCHAR(64)   NOT NULL COMMENT 'Client-minted anonymous device id (localStorage UUID) — advisory cooldown key, NOT a security control',
+    PresenceToken    CHAR(43)      NOT NULL COMMENT 'Opaque base64url 32-byte nonce — the gate key; hard-revocable (not a signed token)',
+    JoinedAt         DATETIME      NOT NULL,
+    LastSeenAt       DATETIME      NOT NULL,
+    ExpiresAt        DATETIME      NOT NULL COMMENT 'Resolved UTC = min(service-occurrence end via venue IANA tz, hard ceiling); gate + prune compare against this',
+    IsActive         TINYINT(1)    NOT NULL DEFAULT 1 COMMENT '0 = left/revoked → immediate gate revocation',
+    CreatedAt        TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UpdatedAt        TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_Token (PresenceToken),
+    UNIQUE KEY uq_DeviceSession (SessionId, PresenceDeviceId),
+    INDEX idx_Session (SessionId, IsActive),
+    INDEX idx_Gate (PresenceToken, IsActive, ExpiresAt),
+    CONSTRAINT fk_Presence_Session FOREIGN KEY (SessionId) REFERENCES tblLiveFollowSessions(Id) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='Anonymous congregant presence for Service Mode (#1335). PresenceToken = the Phase-3 gate key; ExpiresAt = resolved-UTC service end; one row per device per session (re-join reactivates).';
+
+CREATE TABLE IF NOT EXISTS tblServicePollCounters (
+    Id          BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    SessionId   INT UNSIGNED NOT NULL COMMENT 'FK tblLiveFollowSessions',
+    WindowStart DATETIME     NOT NULL COMMENT 'Start of the fixed counting window (UTC)',
+    PollCount   INT UNSIGNED NOT NULL DEFAULT 0 COMMENT 'Polls served to the WHOLE session in this window — NAT-safe per-session budget (not per-IP, which would throttle a congregation behind one church-wifi IP)',
+    CreatedAt   TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_Session_Window (SessionId, WindowStart),
+    INDEX idx_Window (WindowStart),
+    CONSTRAINT fk_PollCtr_Session FOREIGN KEY (SessionId) REFERENCES tblLiveFollowSessions(Id) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='Per-session poll budget for Service Mode (#1335) — the NAT-safe replacement for the #1268 per-IP poll cap.';
 
 
 -- ============================================================================

--- a/appWeb/.sql/schema.sql
+++ b/appWeb/.sql/schema.sql
@@ -3461,3 +3461,130 @@ CREATE TABLE IF NOT EXISTS tblOrgServiceSchedules (
     CONSTRAINT fk_OrgSchedules_Org   FOREIGN KEY (OrgId)   REFERENCES tblOrganisations(Id) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
   COMMENT='Recurring service times per venue — Service Mode Phase 1 (#1325). The service-occurrence (scheduleId,date) is computed at read time; Phase-2 sessions + Phase-3 unlock bind to it.';
+
+-- ----------------------------------------------------------------------------
+-- External-system integration hook (#1327) — DORMANT. Lets iHymns entities be
+-- linked to / synced with an external system (first: WebMS-Intra), system-
+-- agnostic so a 2nd system needs no ALTER (rule #20). Per-entity dedicated ref
+-- tables (rule #15, NOT a generic polymorphic FK) + a registry. Mirror of
+-- migrate-external-systems.php. See .claude/live-congregant-strategy.md.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS tblExternalSystems (
+    Id            INT UNSIGNED  AUTO_INCREMENT PRIMARY KEY,
+    SystemKey     VARCHAR(60)   NOT NULL COMMENT 'Stable machine key (e.g. webms-intra). App resolves systems by this — NEVER hard-code the key list in PHP (rule #15)',
+    Name          VARCHAR(120)  NOT NULL COMMENT 'Curator-facing display name (e.g. WebMS Intranet)',
+    Description   VARCHAR(255)  NULL DEFAULT NULL COMMENT 'What this system is / what the mapping means',
+    BaseUrl       VARCHAR(255)  NULL DEFAULT NULL COMMENT 'Base URL to build a deep link from a stored ExternalId; {id} placeholder substituted app-side',
+    Kind          VARCHAR(30)   NOT NULL DEFAULT 'sync' COMMENT 'sync | directory | finance | rota | identity | other — app-validated, VARCHAR not ENUM (rule #20)',
+    AuthScope     VARCHAR(40)   NULL DEFAULT NULL COMMENT 'Credential/realm hint the sync layer maps to a secret NAME — never the secret itself',
+    IsActive      TINYINT(1)    NOT NULL DEFAULT 1 COMMENT '0 = registered but paused; mappings persist, sync skips',
+    DisplayOrder  INT UNSIGNED  NOT NULL DEFAULT 0,
+    CreatedAt     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UpdatedAt     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_SystemKey (SystemKey),
+    INDEX      idx_Active   (IsActive),
+    INDEX      idx_Kind     (Kind, DisplayOrder)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='Registry of external SYSTEMS an iHymns entity can be mapped/synced into (WebMS-Intra, …). SystemKey UNIQUE so keys are never hard-coded (rule #15); sibling of tblExternalLinkTypes (#833).';
+
+CREATE TABLE IF NOT EXISTS tblOrganisationExternalRefs (
+    Id            INT UNSIGNED  AUTO_INCREMENT PRIMARY KEY,
+    OrgId         INT UNSIGNED  NOT NULL COMMENT 'FK to tblOrganisations.Id — the iHymns org',
+    SystemId      INT UNSIGNED  NOT NULL COMMENT 'FK to tblExternalSystems.Id — which external system this id lives in',
+    ExternalId    VARCHAR(190)  NOT NULL COMMENT 'Primary identifier of the org WITHIN the external system. 190 = utf8mb4 index-safe',
+    ExternalSlug  VARCHAR(190)  NULL DEFAULT NULL COMMENT 'Optional human/slug handle in the external system',
+    SyncStatus    VARCHAR(20)   NOT NULL DEFAULT 'linked' COMMENT 'linked | pending | synced | conflict | error | deprecated — app-validated, VARCHAR not ENUM (rule #20)',
+    SyncDirection VARCHAR(20)   NOT NULL DEFAULT 'inbound' COMMENT 'none | inbound | outbound | bidirectional — VARCHAR not ENUM; inbound-first until a DPA exists',
+    Source        VARCHAR(100)  NOT NULL DEFAULT 'webms-intra' COMMENT 'Provenance of the mapping row; part of the idempotency key',
+    SourceRef     VARCHAR(190)  NULL DEFAULT NULL COMMENT 'External primary id from the Source push for idempotent re-import; NULL for a manual link (multiple NULLs coexist, rule #20)',
+    LocalHash     VARCHAR(64)   NULL DEFAULT NULL COMMENT 'Fingerprint of the iHymns row at last sync — optimistic-concurrency conflict detection',
+    ExternalEtag  VARCHAR(190)  NULL DEFAULT NULL COMMENT 'External side version/etag at last sync — conflict detection',
+    LastSyncedAt  DATETIME      NULL DEFAULT NULL COMMENT 'Last successful sync (DATETIME not TIMESTAMP — rule #20)',
+    LastError     VARCHAR(500)  NULL DEFAULT NULL COMMENT 'Last sync failure detail for operator triage (no secrets/PII)',
+    LastErrorAt   DATETIME      NULL DEFAULT NULL,
+    DeletedAt     DATETIME      NULL DEFAULT NULL COMMENT 'Soft-unlink (operator removed the link) — distinct from FK-CASCADE hard delete',
+    MetaJson      JSON          NULL DEFAULT NULL COMMENT 'Lossless extra attrs from the external system for round-trip re-export',
+    CreatedBy     INT UNSIGNED  NULL DEFAULT NULL COMMENT 'FK to tblUsers.Id — who created the link (NULL for system import)',
+    CreatedAt     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UpdatedAt     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_Org_System_Ext (OrgId, SystemId, ExternalId),
+    UNIQUE KEY uq_System_Ext     (SystemId, ExternalId),
+    UNIQUE KEY uq_SourceRef      (Source, SourceRef),
+    INDEX      idx_Org           (OrgId),
+    INDEX      idx_System        (SystemId),
+    INDEX      idx_Status        (SyncStatus),
+    CONSTRAINT fk_OrgExtRef_Org       FOREIGN KEY (OrgId)     REFERENCES tblOrganisations(Id)  ON DELETE CASCADE  ON UPDATE CASCADE,
+    CONSTRAINT fk_OrgExtRef_System    FOREIGN KEY (SystemId)  REFERENCES tblExternalSystems(Id) ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT fk_OrgExtRef_CreatedBy FOREIGN KEY (CreatedBy) REFERENCES tblUsers(Id)          ON DELETE SET NULL ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='Per-org external-system identity map (rule #15 dedicated ref table). (Source,SourceRef) UNIQUE = idempotent re-import (rule #20); SystemId in the keys = multi-system without an ALTER.';
+
+CREATE TABLE IF NOT EXISTS tblOrgVenueExternalRefs (
+    Id            INT UNSIGNED  AUTO_INCREMENT PRIMARY KEY,
+    VenueId       INT UNSIGNED  NOT NULL COMMENT 'FK to tblOrgVenues.Id — the iHymns venue',
+    OrgId         INT UNSIGNED  NOT NULL COMMENT 'Denorm of the venue org (app-derived, never client-trusted) for cheap org-scoped queries',
+    SystemId      INT UNSIGNED  NOT NULL COMMENT 'FK to tblExternalSystems.Id',
+    ExternalId    VARCHAR(190)  NOT NULL COMMENT 'Primary identifier of the venue WITHIN the external system',
+    ExternalSlug  VARCHAR(190)  NULL DEFAULT NULL COMMENT 'Optional human/slug handle in the external system',
+    SyncStatus    VARCHAR(20)   NOT NULL DEFAULT 'linked' COMMENT 'linked | pending | synced | conflict | error | deprecated — app-validated, VARCHAR not ENUM (rule #20)',
+    SyncDirection VARCHAR(20)   NOT NULL DEFAULT 'inbound' COMMENT 'none | inbound | outbound | bidirectional — VARCHAR not ENUM',
+    Source        VARCHAR(100)  NOT NULL DEFAULT 'webms-intra' COMMENT 'Provenance of the mapping row; part of the idempotency key',
+    SourceRef     VARCHAR(190)  NULL DEFAULT NULL COMMENT 'External primary id from the Source push for idempotent re-import; NULL for a manual link',
+    LocalHash     VARCHAR(64)   NULL DEFAULT NULL COMMENT 'Fingerprint of the iHymns row at last sync — conflict detection',
+    ExternalEtag  VARCHAR(190)  NULL DEFAULT NULL COMMENT 'External side version/etag at last sync — conflict detection',
+    LastSyncedAt  DATETIME      NULL DEFAULT NULL COMMENT 'Last successful sync (DATETIME not TIMESTAMP — rule #20)',
+    LastError     VARCHAR(500)  NULL DEFAULT NULL COMMENT 'Last sync failure detail for operator triage (no secrets/PII)',
+    LastErrorAt   DATETIME      NULL DEFAULT NULL,
+    DeletedAt     DATETIME      NULL DEFAULT NULL COMMENT 'Soft-unlink — distinct from FK-CASCADE hard delete',
+    MetaJson      JSON          NULL DEFAULT NULL COMMENT 'Lossless extra attrs for round-trip re-export',
+    CreatedBy     INT UNSIGNED  NULL DEFAULT NULL COMMENT 'FK to tblUsers.Id — who created the link (NULL for system import)',
+    CreatedAt     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UpdatedAt     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_Venue_System_Ext (VenueId, SystemId, ExternalId),
+    UNIQUE KEY uq_System_Ext       (SystemId, ExternalId),
+    UNIQUE KEY uq_SourceRef        (Source, SourceRef),
+    INDEX      idx_Venue           (VenueId),
+    INDEX      idx_Org             (OrgId),
+    INDEX      idx_System          (SystemId),
+    INDEX      idx_Status          (SyncStatus),
+    CONSTRAINT fk_VenueExtRef_Venue     FOREIGN KEY (VenueId)   REFERENCES tblOrgVenues(Id)      ON DELETE CASCADE  ON UPDATE CASCADE,
+    CONSTRAINT fk_VenueExtRef_Org       FOREIGN KEY (OrgId)     REFERENCES tblOrganisations(Id)  ON DELETE CASCADE  ON UPDATE CASCADE,
+    CONSTRAINT fk_VenueExtRef_System    FOREIGN KEY (SystemId)  REFERENCES tblExternalSystems(Id) ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT fk_VenueExtRef_CreatedBy FOREIGN KEY (CreatedBy) REFERENCES tblUsers(Id)          ON DELETE SET NULL ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='Per-venue external-system identity map (rule #15 dedicated ref table). (Source,SourceRef) UNIQUE = idempotent re-import (rule #20); OrgId denorm mirrors tblOrgServiceSchedules.';
+
+CREATE TABLE IF NOT EXISTS tblOrgServiceScheduleExternalRefs (
+    Id            INT UNSIGNED  AUTO_INCREMENT PRIMARY KEY,
+    ScheduleId    INT UNSIGNED  NOT NULL COMMENT 'FK to tblOrgServiceSchedules.Id — the iHymns service time',
+    OrgId         INT UNSIGNED  NOT NULL COMMENT 'Denorm of the schedule org (app-derived, never client-trusted) for cheap org-scoped queries',
+    SystemId      INT UNSIGNED  NOT NULL COMMENT 'FK to tblExternalSystems.Id',
+    ExternalId    VARCHAR(190)  NOT NULL COMMENT 'Primary identifier of the service/event WITHIN the external system',
+    ExternalSlug  VARCHAR(190)  NULL DEFAULT NULL COMMENT 'Optional human/slug handle in the external system',
+    SyncStatus    VARCHAR(20)   NOT NULL DEFAULT 'linked' COMMENT 'linked | pending | synced | conflict | error | deprecated — app-validated, VARCHAR not ENUM (rule #20)',
+    SyncDirection VARCHAR(20)   NOT NULL DEFAULT 'inbound' COMMENT 'none | inbound | outbound | bidirectional — VARCHAR not ENUM',
+    Source        VARCHAR(100)  NOT NULL DEFAULT 'webms-intra' COMMENT 'Provenance of the mapping row; part of the idempotency key',
+    SourceRef     VARCHAR(190)  NULL DEFAULT NULL COMMENT 'External primary id from the Source push for idempotent re-import; NULL for a manual link',
+    LocalHash     VARCHAR(64)   NULL DEFAULT NULL COMMENT 'Fingerprint of the iHymns row at last sync — conflict detection',
+    ExternalEtag  VARCHAR(190)  NULL DEFAULT NULL COMMENT 'External side version/etag at last sync — conflict detection',
+    LastSyncedAt  DATETIME      NULL DEFAULT NULL COMMENT 'Last successful sync (DATETIME not TIMESTAMP — rule #20)',
+    LastError     VARCHAR(500)  NULL DEFAULT NULL COMMENT 'Last sync failure detail for operator triage (no secrets/PII)',
+    LastErrorAt   DATETIME      NULL DEFAULT NULL,
+    DeletedAt     DATETIME      NULL DEFAULT NULL COMMENT 'Soft-unlink — distinct from FK-CASCADE hard delete',
+    MetaJson      JSON          NULL DEFAULT NULL COMMENT 'Lossless extra attrs for round-trip re-export',
+    CreatedBy     INT UNSIGNED  NULL DEFAULT NULL COMMENT 'FK to tblUsers.Id — who created the link (NULL for system import)',
+    CreatedAt     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UpdatedAt     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_Sched_System_Ext (ScheduleId, SystemId, ExternalId),
+    UNIQUE KEY uq_System_Ext       (SystemId, ExternalId),
+    UNIQUE KEY uq_SourceRef        (Source, SourceRef),
+    INDEX      idx_Sched           (ScheduleId),
+    INDEX      idx_Org             (OrgId),
+    INDEX      idx_System          (SystemId),
+    INDEX      idx_Status          (SyncStatus),
+    CONSTRAINT fk_SchedExtRef_Sched     FOREIGN KEY (ScheduleId) REFERENCES tblOrgServiceSchedules(Id) ON DELETE CASCADE  ON UPDATE CASCADE,
+    CONSTRAINT fk_SchedExtRef_Org       FOREIGN KEY (OrgId)      REFERENCES tblOrganisations(Id)     ON DELETE CASCADE  ON UPDATE CASCADE,
+    CONSTRAINT fk_SchedExtRef_System    FOREIGN KEY (SystemId)   REFERENCES tblExternalSystems(Id)   ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT fk_SchedExtRef_CreatedBy FOREIGN KEY (CreatedBy)  REFERENCES tblUsers(Id)             ON DELETE SET NULL ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='Per-service-schedule external-system identity map (rule #15 dedicated ref table). (Source,SourceRef) UNIQUE = idempotent re-import (rule #20); OrgId denorm mirrors tblOrgServiceSchedules.';

--- a/appWeb/public_html/manage/includes/admin-links.php
+++ b/appWeb/public_html/manage/includes/admin-links.php
@@ -71,6 +71,9 @@ $_adminLinks = [
     ['users',                '/manage/users',                  'bi-people',          'Users',                 'view_users',                  'People'     ],
     ['groups',               '/manage/groups',                 'bi-people-fill',     'User Groups',           'manage_user_groups',          'People'     ],
     ['organisations',        '/manage/organisations',          'bi-building',        'Organisations',         'manage_organisations',        'People'     ],
+    /* Venues & service times (#1325) — the where/when of an org; foundation for
+       Service Mode (#1323). Same entitlement as Organisations. */
+    ['venues',               '/manage/venues',                 'bi-geo-alt',         'Venues',                'manage_organisations',        'People'     ],
     /* My Organisations (#707) — the entitlement is open to every signed-in
        role; admin-nav.php applies a data-driven hide via
        userHasOwnOrganisation() so non-admins only see this link when they

--- a/appWeb/public_html/manage/includes/migration-registry.php
+++ b/appWeb/public_html/manage/includes/migration-registry.php
@@ -2194,4 +2194,23 @@ return [
             return !$seeded;
         },
     ],
+    'service-mode-sessions' => [
+        'script' => 'migrate-service-mode-sessions.php',
+        'card' => [
+            'title'  => 'Service Mode sessions (#1335)',
+            'body'   => 'Extends <code>tblLiveFollowSessions</code> (NULL-able host + venue/schedule/'
+                      . 'occurrence/kind + the 3-docroot <code>Channel</code> discriminator) and creates'
+                      . ' <code>tblLiveFollowJoinCodes</code>, <code>tblServicePresence</code> and'
+                      . ' <code>tblServicePollCounters</code> — the dormant foundation for congregation'
+                      . ' &ldquo;Service Mode&rdquo; (#1323). Runs after Org Venues. Idempotent — safe to re-run.',
+            'button' => 'Run Service Mode Sessions Migration',
+        ],
+        /* Multi-object OR-probe (rule #19): pending until the spine column AND all
+           three new tables exist. */
+        'probe' => static fn(\mysqli $db) =>
+            !_migProbe_columnExists($db, 'tblLiveFollowSessions', 'VenueId')
+            || !_migProbe_tableExists($db, 'tblLiveFollowJoinCodes')
+            || !_migProbe_tableExists($db, 'tblServicePresence')
+            || !_migProbe_tableExists($db, 'tblServicePollCounters'),
+    ],
 ];

--- a/appWeb/public_html/manage/includes/migration-registry.php
+++ b/appWeb/public_html/manage/includes/migration-registry.php
@@ -2165,4 +2165,33 @@ return [
             !_migProbe_tableExists($db, 'tblOrgVenues')
             || !_migProbe_tableExists($db, 'tblOrgServiceSchedules'),
     ],
+    'external-systems' => [
+        'script' => 'migrate-external-systems.php',
+        'card' => [
+            'title'  => 'External-system integration hook (#1327)',
+            'body'   => 'Creates the DORMANT integration scaffold: <code>tblExternalSystems</code>'
+                      . ' (system registry, seeded with a paused <code>webms-intra</code> row) plus'
+                      . ' per-entity ref tables <code>tblOrganisationExternalRefs</code>,'
+                      . ' <code>tblOrgVenueExternalRefs</code> and'
+                      . ' <code>tblOrgServiceScheduleExternalRefs</code> — so orgs / venues / service'
+                      . ' times can be linked to WebMS-Intra (or another system) in future without a'
+                      . ' second migration. No read/write code consumes them yet. Runs after Org Venues.'
+                      . ' Idempotent — safe to re-run.',
+            'button' => 'Run External-Systems Migration',
+        ],
+        /* Multi-object OR-probe (rule #19): pending until all four tables exist
+           AND the seeded webms-intra registry row is present (the tableExists
+           guards short-circuit before the SELECT, so it never runs against a
+           missing table under STRICT). */
+        'probe' => static function (\mysqli $db): bool {
+            if (!_migProbe_tableExists($db, 'tblExternalSystems')) { return true; }
+            if (!_migProbe_tableExists($db, 'tblOrganisationExternalRefs')) { return true; }
+            if (!_migProbe_tableExists($db, 'tblOrgVenueExternalRefs')) { return true; }
+            if (!_migProbe_tableExists($db, 'tblOrgServiceScheduleExternalRefs')) { return true; }
+            $r = $db->query("SELECT 1 FROM tblExternalSystems WHERE SystemKey = 'webms-intra' LIMIT 1");
+            $seeded = $r && $r->num_rows > 0;
+            if ($r) { $r->close(); }
+            return !$seeded;
+        },
+    ],
 ];

--- a/appWeb/public_html/manage/venues.php
+++ b/appWeb/public_html/manage/venues.php
@@ -1,0 +1,949 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Admin: Venues & Service Times (Service Mode Phase 1, #1325)
+ *
+ * Lets an organisation define its physical VENUES (name, address, map-pin
+ * location + radius, timezone) and the RECURRING SERVICE TIMES at each venue —
+ * the foundation for "Service Mode" (#1323, congregation-wide Live Follow), and
+ * useful org metadata in its own right.
+ *
+ * WHY THIS PAGE EXISTS (ELI5): before this, an org could say *who* it is and
+ * *what city* it is in, but there was nowhere to say "we meet at the Main
+ * Sanctuary, 10am every Sunday." This page is that "where + when" editor.
+ *
+ * Data model: tblOrgVenues + tblOrgServiceSchedules (migrate-org-venues.php).
+ * lat/lng + radius are a CONVENIENCE geofence + map pin — NOT the presence gate
+ * (Service Mode Phase 2 gates on a venue-displayed rotating code; geolocation is
+ * spoofable/inaccurate indoors — see .claude/live-congregant-strategy.md).
+ *
+ * Shared infra reused (CLAUDE.md modularity rule): auth.php (isAuthenticated /
+ * userHasEntitlement), db_mysql.php (getDbMysqli + bind_param), places.php
+ * (placesLoadById for the geocoder pick), place-search.js (the Photon/Nominatim
+ * autocomplete, same module organisations.php uses), admin-nav / head-libs /
+ * admin-footer partials, .admin-table-responsive, the session-token CSRF helpers
+ * (csrfToken / validateCsrf). Gated by `manage_organisations` (same as
+ * organisations.php).
+ */
+
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'places.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'activity_log.php';
+
+if (!isAuthenticated()) {
+    header('Location: /manage/login');
+    exit;
+}
+$currentUser = getCurrentUser();
+if (!$currentUser || !userHasEntitlement('manage_organisations', $currentUser['role'] ?? null)) {
+    http_response_code(403);
+    echo '<!DOCTYPE html><html><body><h1>403 — manage_organisations required</h1></body></html>';
+    exit;
+}
+$activePage = 'venues';
+
+$error   = '';
+$success = '';
+$db      = getDbMysqli();
+
+/* ------------------------------------------------------------------
+ * Central vocabularies (CLAUDE.md: never hard-code these inline twice).
+ * RecurrenceKind is VARCHAR (app-validated) not ENUM — adding a cadence
+ * is an entry here, never an ALTER (rule #20).
+ * ------------------------------------------------------------------ */
+$DOW = [1 => 'Monday', 2 => 'Tuesday', 3 => 'Wednesday', 4 => 'Thursday', 5 => 'Friday', 6 => 'Saturday', 7 => 'Sunday'];
+$RECURRENCE_KINDS = [
+    'weekly'      => 'Every week',
+    'fortnightly' => 'Every 2 weeks',
+    'monthly_nth' => 'Monthly (nth weekday)',
+    'one_off'     => 'One-off date',
+];
+$NTH_LABELS = [1 => 'first', 2 => 'second', 3 => 'third', 4 => 'fourth', 5 => 'fifth', -1 => 'last'];
+/* Cache the IANA tz list once (DateTimeZone::listIdentifiers is the canonical
+   source — https://www.php.net/manual/en/datetimezone.listidentifiers.php). */
+$TZ_LIST = \DateTimeZone::listIdentifiers();
+
+/**
+ * Schema-presence guard. Migrations are NOT auto-applied on deploy, so the
+ * tables may not exist on this env yet ("it's in schema.sql" ≠ "it exists" —
+ * CLAUDE.md red flag). Probe INFORMATION_SCHEMA so a missing table renders a
+ * themed "run the migration" card instead of white-screening under STRICT.
+ */
+function _venuesTableExists(\mysqli $db, string $t): bool
+{
+    try {
+        $stmt = $db->prepare(
+            "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+              WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? LIMIT 1"
+        );
+        $stmt->bind_param('s', $t);
+        $stmt->execute();
+        $exists = $stmt->get_result()->fetch_row() !== null;
+        $stmt->close();
+        return $exists;
+    } catch (\Throwable $e) {
+        error_log('[manage/venues.php] table probe failed: ' . $e->getMessage());
+        return false;
+    }
+}
+$schemaReady = _venuesTableExists($db, 'tblOrgVenues') && _venuesTableExists($db, 'tblOrgServiceSchedules');
+
+/**
+ * Build a human "Every Sunday at 10:00 (90 min) · Europe/London" summary.
+ * Pure — takes the row + its effective tz, returns a string for display.
+ */
+function venueScheduleSummary(array $s, array $DOW, array $NTH_LABELS): string
+{
+    $rd   = is_array($s['_rd'] ?? null) ? $s['_rd'] : [];
+    $day  = $DOW[(int)($s['DayOfWeek'] ?? 0)] ?? '';
+    $time = substr((string)($s['StartTime'] ?? '00:00:00'), 0, 5);
+    $dur  = (int)($s['DurationMins'] ?? 0);
+    $tz   = (string)($s['_EffTz'] ?? 'UTC');
+    switch ((string)$s['RecurrenceKind']) {
+        case 'weekly':      $base = "Every {$day} at {$time}"; break;
+        case 'fortnightly': $base = "Every other {$day} at {$time}"; break;
+        case 'monthly_nth':
+            $nth  = (int)($rd['nth'] ?? 1);
+            $word = $NTH_LABELS[$nth] ?? 'first';
+            $base = "The {$word} {$day} of each month at {$time}";
+            break;
+        case 'one_off':
+            $date = (string)($rd['date'] ?? '?');
+            $base = "On {$date} at {$time}";
+            break;
+        default: $base = trim("{$day} at {$time}");
+    }
+    return "{$base} ({$dur} min) · {$tz}";
+}
+
+/**
+ * Compute the next $n occurrence datetimes (Y-m-d H:i) for a schedule, in its
+ * effective timezone. Iterates day-by-day applying a recurrence predicate —
+ * simple + correct for a short preview (caps at ~14 months of look-ahead).
+ */
+function venueNextOccurrences(array $s, int $n = 3): array
+{
+    try {
+        $tz = new \DateTimeZone((string)($s['_EffTz'] ?? 'UTC'));
+    } catch (\Throwable $e) {
+        $tz = new \DateTimeZone('UTC');
+    }
+    $rd   = is_array($s['_rd'] ?? null) ? $s['_rd'] : [];
+    $kind = (string)$s['RecurrenceKind'];
+    $dow  = (int)($s['DayOfWeek'] ?? 0);
+    $hhmm = substr((string)($s['StartTime'] ?? '00:00:00'), 0, 5);
+    $exceptions = array_flip(array_map('strval', $rd['exceptions'] ?? []));
+    $until = isset($rd['until']) && $rd['until'] !== '' ? (string)$rd['until'] : null;
+
+    if ($kind === 'one_off') {
+        $d = (string)($rd['date'] ?? '');
+        return $d !== '' ? ["{$d} {$hhmm}"] : [];
+    }
+    if ($dow < 1 || $dow > 7) {
+        return [];
+    }
+
+    // Anchor for the fortnightly week-parity test (default: today).
+    try {
+        $anchor = isset($rd['anchor']) && $rd['anchor'] !== ''
+            ? new \DateTime((string)$rd['anchor'], $tz)
+            : new \DateTime('today', $tz);
+    } catch (\Throwable $e) {
+        $anchor = new \DateTime('today', $tz);
+    }
+    $cursor = new \DateTime('today', $tz);
+    $out = [];
+    for ($i = 0; $i < 420 && count($out) < $n; $i++, $cursor->modify('+1 day')) {
+        if ((int)$cursor->format('N') !== $dow) {
+            continue;
+        }
+        $ymd = $cursor->format('Y-m-d');
+        if (isset($exceptions[$ymd]) || ($until !== null && $ymd > $until)) {
+            continue;
+        }
+        $match = false;
+        if ($kind === 'weekly') {
+            $match = true;
+        } elseif ($kind === 'fortnightly') {
+            $weeks = (int)floor((int)$anchor->diff($cursor)->days / 7);
+            $match = ($weeks % 2 === 0);
+        } elseif ($kind === 'monthly_nth') {
+            $nth = (int)($rd['nth'] ?? 1);
+            $dayOfMonth = (int)$cursor->format('j');
+            if ($nth === -1) {
+                // last weekday-of-month: no same weekday within the next 7 days
+                $probe = (clone $cursor)->modify('+7 days');
+                $match = ((int)$probe->format('n') !== (int)$cursor->format('n'));
+            } else {
+                $match = ((int)ceil($dayOfMonth / 7) === $nth);
+            }
+        }
+        if ($match) {
+            $out[] = "{$ymd} {$hhmm}";
+        }
+    }
+    return $out;
+}
+
+/* ===================================================================
+ * POST actions — every one CSRF-checked + bind_param. OrgId for a
+ * schedule is DERIVED from its venue (never trusted from the client).
+ * =================================================================== */
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && $schemaReady) {
+    if (!validateCsrf((string)($_POST['csrf_token'] ?? ''))) {
+        http_response_code(403);
+        echo 'Invalid CSRF token';
+        exit;
+    }
+    $action = (string)($_POST['action'] ?? '');
+    try {
+        switch ($action) {
+
+            /* ---- Venue create / update ---- */
+            case 'venue_save': {
+                $venueId = (int)($_POST['venue_id'] ?? 0);
+                $orgId   = (int)($_POST['org_id'] ?? 0);
+                $name    = trim((string)($_POST['name'] ?? ''));
+                $addr    = trim((string)($_POST['address_line'] ?? ''));
+                $city    = trim((string)($_POST['city'] ?? ''));
+                $post    = trim((string)($_POST['postcode'] ?? ''));
+                $cc      = strtoupper(trim((string)($_POST['country_code'] ?? '')));
+                $tz      = trim((string)($_POST['timezone'] ?? 'UTC'));
+                $placeId = (int)($_POST['place_id'] ?? 0);
+                $isActive = isset($_POST['is_active']) ? 1 : 0;
+
+                if ($name === '') { throw new \RuntimeException('Venue name is required.'); }
+                if ($orgId <= 0)  { throw new \RuntimeException('Choose an organisation first.'); }
+                if (!in_array($tz, $GLOBALS['TZ_LIST'], true)) { $tz = 'UTC'; }
+                if ($cc !== '' && !preg_match('/^[A-Z]{2}$/', $cc)) { $cc = ''; }
+
+                // Confirm the org exists (FK would throw, but this gives a friendly error).
+                $chk = $db->prepare('SELECT 1 FROM tblOrganisations WHERE Id = ? LIMIT 1');
+                $chk->bind_param('i', $orgId);
+                $chk->execute();
+                if ($chk->get_result()->fetch_row() === null) { $chk->close(); throw new \RuntimeException('Unknown organisation.'); }
+                $chk->close();
+
+                // Resolve coordinates: a geocoder pick (PlaceId) wins; else the
+                // optional manual lat/lng. placesLoadById() returns {lat,lon}.
+                $lat = ($_POST['latitude']  ?? '') !== '' ? (float)$_POST['latitude']  : null;
+                $lng = ($_POST['longitude'] ?? '') !== '' ? (float)$_POST['longitude'] : null;
+                $placeIdOrNull = $placeId > 0 ? $placeId : null;
+                if ($placeIdOrNull !== null && function_exists('placesLoadById')) {
+                    $place = placesLoadById($db, $placeIdOrNull);
+                    if ($place) {
+                        if ($lat === null && isset($place['lat'])) { $lat = (float)$place['lat']; }
+                        if ($lng === null && isset($place['lon'])) { $lng = (float)$place['lon']; }
+                    }
+                }
+                // Clamp coordinates to valid WGS84 ranges.
+                if ($lat !== null && ($lat < -90 || $lat > 90))   { $lat = null; }
+                if ($lng !== null && ($lng < -180 || $lng > 180)) { $lng = null; }
+                $radius = ($_POST['radius_metres'] ?? '') !== '' ? max(0, min(50000, (int)$_POST['radius_metres'])) : null;
+
+                $addrN = $addr !== '' ? $addr : null;
+                $cityN = $city !== '' ? $city : null;
+                $postN = $post !== '' ? $post : null;
+                $ccN   = $cc !== '' ? $cc : null;
+
+                if ($venueId > 0) {
+                    $stmt = $db->prepare(
+                        'UPDATE tblOrgVenues
+                            SET OrgId = ?, Name = ?, AddressLine = ?, City = ?, Postcode = ?,
+                                CountryCode = ?, PlaceId = ?, Latitude = ?, Longitude = ?,
+                                RadiusMetres = ?, TimeZone = ?, IsActive = ?
+                          WHERE Id = ?'
+                    );
+                    // i s s s s  s i d d  i s i  i
+                    $stmt->bind_param(
+                        'isssssiddisii',
+                        $orgId, $name, $addrN, $cityN, $postN,
+                        $ccN, $placeIdOrNull, $lat, $lng,
+                        $radius, $tz, $isActive, $venueId
+                    );
+                    $stmt->execute();
+                    $stmt->close();
+                    logActivity('venue.edit', 'organisation', (string)$orgId, ['venue_id' => $venueId, 'name' => $name]);
+                    $success = 'Venue updated.';
+                } else {
+                    $stmt = $db->prepare(
+                        'INSERT INTO tblOrgVenues
+                            (OrgId, Name, AddressLine, City, Postcode, CountryCode,
+                             PlaceId, Latitude, Longitude, RadiusMetres, TimeZone, IsActive)
+                         VALUES (?,?,?,?,?,?,?,?,?,?,?,?)'
+                    );
+                    $stmt->bind_param(
+                        'isssssiddisi',
+                        $orgId, $name, $addrN, $cityN, $postN, $ccN,
+                        $placeIdOrNull, $lat, $lng, $radius, $tz, $isActive
+                    );
+                    $stmt->execute();
+                    $venueId = (int)$db->insert_id;
+                    $stmt->close();
+                    logActivity('venue.create', 'organisation', (string)$orgId, ['venue_id' => $venueId, 'name' => $name]);
+                    $success = 'Venue added.';
+                }
+                break;
+            }
+
+            /* ---- Venue delete (CASCADE removes its schedules) ---- */
+            case 'venue_delete': {
+                $venueId = (int)($_POST['venue_id'] ?? 0);
+                if ($venueId <= 0) { throw new \RuntimeException('Missing venue.'); }
+                $stmt = $db->prepare('SELECT OrgId, Name FROM tblOrgVenues WHERE Id = ?');
+                $stmt->bind_param('i', $venueId);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_assoc();
+                $stmt->close();
+                if ($row) {
+                    $del = $db->prepare('DELETE FROM tblOrgVenues WHERE Id = ?');
+                    $del->bind_param('i', $venueId);
+                    $del->execute();
+                    $del->close();
+                    logActivity('venue.delete', 'organisation', (string)$row['OrgId'], ['venue_id' => $venueId, 'name' => $row['Name']]);
+                    $success = 'Venue deleted.';
+                }
+                break;
+            }
+
+            /* ---- Service schedule create / update ---- */
+            case 'schedule_save': {
+                $schedId = (int)($_POST['schedule_id'] ?? 0);
+                $venueId = (int)($_POST['venue_id'] ?? 0);
+                if ($venueId <= 0) { throw new \RuntimeException('Missing venue.'); }
+
+                // Derive OrgId + default tz from the venue — never trust posted OrgId.
+                $vs = $db->prepare('SELECT OrgId, TimeZone FROM tblOrgVenues WHERE Id = ?');
+                $vs->bind_param('i', $venueId);
+                $vs->execute();
+                $venue = $vs->get_result()->fetch_assoc();
+                $vs->close();
+                if (!$venue) { throw new \RuntimeException('Unknown venue.'); }
+                $orgId = (int)$venue['OrgId'];
+
+                $title = trim((string)($_POST['title'] ?? 'Service'));
+                if ($title === '') { $title = 'Service'; }
+                $kind  = (string)($_POST['recurrence_kind'] ?? 'weekly');
+                if (!array_key_exists($kind, $GLOBALS['RECURRENCE_KINDS'])) { $kind = 'weekly'; }
+                $startTime = (string)($_POST['start_time'] ?? '');
+                if (!preg_match('/^([01]\d|2[0-3]):[0-5]\d$/', $startTime)) {
+                    throw new \RuntimeException('Enter a valid start time (HH:MM).');
+                }
+                $startTime .= ':00';
+                $duration = max(1, min(1440, (int)($_POST['duration_mins'] ?? 90)));
+                $tzOverride = trim((string)($_POST['timezone'] ?? ''));
+                $tzN = ($tzOverride !== '' && in_array($tzOverride, $GLOBALS['TZ_LIST'], true)) ? $tzOverride : null;
+                $isActive = isset($_POST['is_active']) ? 1 : 0;
+
+                // DayOfWeek required for recurring kinds; NULL for one_off.
+                $dow = (int)($_POST['day_of_week'] ?? 0);
+                if ($kind !== 'one_off') {
+                    if ($dow < 1 || $dow > 7) { throw new \RuntimeException('Choose a day of the week.'); }
+                    $dowN = $dow;
+                } else {
+                    $dowN = null;
+                }
+
+                // Assemble RecurrenceData JSON from the kind-specific inputs.
+                $rd = [];
+                if ($kind === 'monthly_nth') {
+                    $nth = (int)($_POST['nth'] ?? 1);
+                    if (!in_array($nth, [1, 2, 3, 4, 5, -1], true)) { $nth = 1; }
+                    $rd['nth'] = $nth;
+                } elseif ($kind === 'one_off') {
+                    $oneOff = (string)($_POST['one_off_date'] ?? '');
+                    if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $oneOff)) { throw new \RuntimeException('Enter the one-off date (YYYY-MM-DD).'); }
+                    $rd['date'] = $oneOff;
+                } elseif ($kind === 'fortnightly') {
+                    $anchor = (string)($_POST['anchor_date'] ?? '');
+                    if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $anchor)) { $rd['anchor'] = $anchor; }
+                }
+                $until = (string)($_POST['until_date'] ?? '');
+                if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $until)) { $rd['until'] = $until; }
+                // Exceptions: comma/space/newline-separated YYYY-MM-DD dates.
+                $excRaw = (string)($_POST['exceptions'] ?? '');
+                if (trim($excRaw) !== '') {
+                    $exc = preg_split('/[\s,]+/', trim($excRaw)) ?: [];
+                    $exc = array_values(array_filter($exc, static fn($d) => preg_match('/^\d{4}-\d{2}-\d{2}$/', $d)));
+                    if ($exc) { $rd['exceptions'] = $exc; }
+                }
+                $rdJson = $rd ? json_encode($rd, JSON_UNESCAPED_SLASHES) : null;
+
+                if ($schedId > 0) {
+                    $stmt = $db->prepare(
+                        'UPDATE tblOrgServiceSchedules
+                            SET VenueId = ?, OrgId = ?, Title = ?, DayOfWeek = ?, StartTime = ?,
+                                DurationMins = ?, RecurrenceKind = ?, RecurrenceData = ?,
+                                TimeZone = ?, IsActive = ?
+                          WHERE Id = ?'
+                    );
+                    $stmt->bind_param(
+                        'iisisisssii',
+                        $venueId, $orgId, $title, $dowN, $startTime,
+                        $duration, $kind, $rdJson, $tzN, $isActive, $schedId
+                    );
+                    $stmt->execute();
+                    $stmt->close();
+                    logActivity('venue.schedule.edit', 'organisation', (string)$orgId, ['schedule_id' => $schedId, 'venue_id' => $venueId]);
+                    $success = 'Service time updated.';
+                } else {
+                    $stmt = $db->prepare(
+                        'INSERT INTO tblOrgServiceSchedules
+                            (VenueId, OrgId, Title, DayOfWeek, StartTime, DurationMins,
+                             RecurrenceKind, RecurrenceData, TimeZone, IsActive)
+                         VALUES (?,?,?,?,?,?,?,?,?,?)'
+                    );
+                    $stmt->bind_param(
+                        'iisisisssi',
+                        $venueId, $orgId, $title, $dowN, $startTime,
+                        $duration, $kind, $rdJson, $tzN, $isActive
+                    );
+                    $stmt->execute();
+                    $newId = (int)$db->insert_id;
+                    $stmt->close();
+                    logActivity('venue.schedule.create', 'organisation', (string)$orgId, ['schedule_id' => $newId, 'venue_id' => $venueId]);
+                    $success = 'Service time added.';
+                }
+                break;
+            }
+
+            /* ---- Schedule delete ---- */
+            case 'schedule_delete': {
+                $schedId = (int)($_POST['schedule_id'] ?? 0);
+                if ($schedId <= 0) { throw new \RuntimeException('Missing service time.'); }
+                $stmt = $db->prepare('SELECT OrgId FROM tblOrgServiceSchedules WHERE Id = ?');
+                $stmt->bind_param('i', $schedId);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_assoc();
+                $stmt->close();
+                if ($row) {
+                    $del = $db->prepare('DELETE FROM tblOrgServiceSchedules WHERE Id = ?');
+                    $del->bind_param('i', $schedId);
+                    $del->execute();
+                    $del->close();
+                    logActivity('venue.schedule.delete', 'organisation', (string)$row['OrgId'], ['schedule_id' => $schedId]);
+                    $success = 'Service time deleted.';
+                }
+                break;
+            }
+        }
+    } catch (\Throwable $e) {
+        $error = $e->getMessage() !== '' ? $e->getMessage() : 'Could not save your changes.';
+        error_log('[manage/venues.php] ' . $e->getMessage());
+    }
+}
+
+/* ===================================================================
+ * Load for render — org list, selected org's venues, selected venue's
+ * schedules. All reads guarded; everything echoed via htmlspecialchars.
+ * =================================================================== */
+$orgs          = [];
+$venues        = [];
+$schedules     = [];
+$selectedOrgId = (int)($_GET['org'] ?? ($_POST['org_id'] ?? 0));
+$selectedVenueId = (int)($_GET['venue'] ?? 0);
+
+if ($schemaReady) {
+    try {
+        $res = $db->query('SELECT Id, Name FROM tblOrganisations ORDER BY Name ASC');
+        $orgs = $res ? $res->fetch_all(MYSQLI_ASSOC) : [];
+        if ($selectedOrgId <= 0 && $orgs) { $selectedOrgId = (int)$orgs[0]['Id']; }
+
+        if ($selectedOrgId > 0) {
+            $stmt = $db->prepare(
+                'SELECT Id, OrgId, Name, AddressLine, City, Postcode, CountryCode,
+                        Latitude, Longitude, RadiusMetres, TimeZone, IsActive
+                   FROM tblOrgVenues WHERE OrgId = ? ORDER BY SortOrder ASC, Name ASC'
+            );
+            $stmt->bind_param('i', $selectedOrgId);
+            $stmt->execute();
+            $venues = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+            $stmt->close();
+        }
+
+        // Confirm the selected venue belongs to the selected org, then load its schedules.
+        $selectedVenue = null;
+        foreach ($venues as $v) {
+            if ((int)$v['Id'] === $selectedVenueId) { $selectedVenue = $v; break; }
+        }
+        if ($selectedVenue) {
+            $stmt = $db->prepare(
+                'SELECT Id, VenueId, Title, DayOfWeek, StartTime, DurationMins,
+                        RecurrenceKind, RecurrenceData, TimeZone, IsActive
+                   FROM tblOrgServiceSchedules WHERE VenueId = ?
+                  ORDER BY DayOfWeek ASC, StartTime ASC'
+            );
+            $stmt->bind_param('i', $selectedVenueId);
+            $stmt->execute();
+            $schedules = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+            $stmt->close();
+            // Decode RecurrenceData + resolve effective tz once per row.
+            foreach ($schedules as &$s) {
+                $s['_rd']     = json_decode((string)($s['RecurrenceData'] ?? ''), true) ?: [];
+                $s['_EffTz']  = ($s['TimeZone'] ?? null) ?: ($selectedVenue['TimeZone'] ?? 'UTC');
+            }
+            unset($s);
+        } else {
+            $selectedVenueId = 0;
+        }
+    } catch (\Throwable $e) {
+        $error = $error ?: 'Could not load venues. The schema may need migrating (/manage/setup-database).';
+        error_log('[manage/venues.php] load: ' . $e->getMessage());
+    }
+}
+
+// Find the row being edited (?edit_venue / ?edit_schedule), if any.
+$editVenue = null;
+$editVenueId = (int)($_GET['edit_venue'] ?? 0);
+foreach ($venues as $v) { if ((int)$v['Id'] === $editVenueId) { $editVenue = $v; break; } }
+$editSchedule = null;
+$editScheduleId = (int)($_GET['edit_schedule'] ?? 0);
+foreach ($schedules as $s) { if ((int)$s['Id'] === $editScheduleId) { $editSchedule = $s; break; } }
+$editSchedRd = $editSchedule ? ($editSchedule['_rd'] ?? []) : [];
+
+$selectedVenueRow = null;
+foreach ($venues as $v) { if ((int)$v['Id'] === $selectedVenueId) { $selectedVenueRow = $v; break; } }
+
+$csrf = csrfToken();
+
+/** Tiny helper: build a same-page URL preserving org/venue context. */
+function venuesUrl(array $overrides = []): string
+{
+    $base = ['org' => (int)($GLOBALS['selectedOrgId'] ?? 0)];
+    if (($GLOBALS['selectedVenueId'] ?? 0) > 0) { $base['venue'] = (int)$GLOBALS['selectedVenueId']; }
+    $q = array_filter(array_merge($base, $overrides), static fn($v) => $v !== null && $v !== '' && $v !== 0);
+    return '/manage/venues' . ($q ? '?' . http_build_query($q) : '');
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Venues &amp; Service Times — iHymns Admin</title>
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-libs.php'; ?>
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head-favicon.php'; ?>
+</head>
+<body>
+
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-nav.php'; ?>
+
+    <div class="container-admin py-4">
+
+        <h1 class="h4 mb-2"><i class="bi bi-geo-alt me-2"></i>Venues &amp; Service Times</h1>
+        <p class="text-secondary small mb-4" style="max-width: 60ch;">
+            Tell iHymns <strong>where</strong> your organisation meets and <strong>when</strong>.
+            This is the foundation for <em>Service Mode</em> (letting a congregation follow the
+            service on their own device). The map location &amp; radius are a convenience —
+            attendance is confirmed by an on-screen code, not your location.
+        </p>
+
+        <?php if ($success): ?>
+            <div class="alert alert-success py-2"><i class="bi bi-check-circle me-1"></i><?= htmlspecialchars($success) ?></div>
+        <?php endif; ?>
+        <?php if ($error): ?>
+            <div class="alert alert-danger py-2"><i class="bi bi-exclamation-triangle me-1"></i><?= htmlspecialchars($error) ?></div>
+        <?php endif; ?>
+
+        <?php if (!$schemaReady): ?>
+            <div class="card border-warning">
+                <div class="card-body">
+                    <h2 class="h6 text-warning-emphasis"><i class="bi bi-database-exclamation me-1"></i>Schema not yet migrated</h2>
+                    <p class="small mb-2">
+                        The <code>tblOrgVenues</code> / <code>tblOrgServiceSchedules</code> tables don't
+                        exist on this environment yet. Migrations aren't applied automatically on deploy.
+                    </p>
+                    <a class="btn btn-sm btn-amber-solid" href="/manage/setup-database">
+                        <i class="bi bi-database-gear me-1"></i>Open Database Setup → run “Org Venues &amp; Service Schedules”
+                    </a>
+                </div>
+            </div>
+        <?php else: ?>
+
+        <!-- Organisation selector -->
+        <form method="get" action="/manage/venues" class="row g-2 align-items-end mb-4" style="max-width: 480px;">
+            <div class="col">
+                <label for="org-select" class="form-label small fw-semibold mb-1">Organisation</label>
+                <select id="org-select" name="org" class="form-select" onchange="this.form.submit()">
+                    <?php foreach ($orgs as $o): ?>
+                        <option value="<?= (int)$o['Id'] ?>" <?= (int)$o['Id'] === $selectedOrgId ? 'selected' : '' ?>>
+                            <?= htmlspecialchars($o['Name']) ?>
+                        </option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <?php if (!$orgs): ?>
+                <div class="col-auto"><span class="text-secondary small">No organisations yet.</span></div>
+            <?php endif; ?>
+        </form>
+
+        <?php if ($selectedOrgId > 0): ?>
+        <!-- ============================ VENUES ============================ -->
+        <div class="card mb-4">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <span class="fw-semibold"><i class="bi bi-building me-1"></i>Venues</span>
+                <a class="btn btn-sm btn-amber-solid" href="<?= htmlspecialchars(venuesUrl(['edit_venue' => 'new', 'venue' => null])) ?>#venue-form">
+                    <i class="bi bi-plus-lg me-1"></i>Add venue
+                </a>
+            </div>
+            <div class="card-body p-0">
+                <?php if (!$venues): ?>
+                    <p class="text-secondary small m-3 mb-3">No venues yet. Add the place(s) your organisation meets.</p>
+                <?php else: ?>
+                <div class="table-responsive">
+                    <table class="table admin-table-responsive align-middle mb-0">
+                        <thead>
+                            <tr>
+                                <th data-col-priority="primary">Venue</th>
+                                <th data-col-priority="secondary">Location</th>
+                                <th data-col-priority="tertiary">Timezone</th>
+                                <th data-col-priority="tertiary">Status</th>
+                                <th data-col-priority="primary" class="text-end">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                        <?php foreach ($venues as $v): ?>
+                            <?php
+                                $loc = array_filter([$v['AddressLine'] ?? '', $v['City'] ?? '', $v['Postcode'] ?? '', $v['CountryCode'] ?? '']);
+                                $hasCoords = $v['Latitude'] !== null && $v['Longitude'] !== null;
+                                $isSel = (int)$v['Id'] === $selectedVenueId;
+                            ?>
+                            <tr<?= $isSel ? ' class="table-active"' : '' ?>>
+                                <td data-col-priority="primary">
+                                    <span class="fw-semibold"><?= htmlspecialchars($v['Name']) ?></span>
+                                </td>
+                                <td data-col-priority="secondary">
+                                    <span class="small"><?= $loc ? htmlspecialchars(implode(', ', $loc)) : '<span class="text-secondary">—</span>' ?></span>
+                                    <?php if ($hasCoords): ?>
+                                        <span class="badge text-bg-light ms-1" title="Map pin set (convenience geofence<?= $v['RadiusMetres'] !== null ? ', radius ' . (int)$v['RadiusMetres'] . ' m' : '' ?>)">
+                                            <i class="bi bi-pin-map"></i>
+                                        </span>
+                                    <?php endif; ?>
+                                </td>
+                                <td data-col-priority="tertiary"><span class="small"><?= htmlspecialchars($v['TimeZone']) ?></span></td>
+                                <td data-col-priority="tertiary">
+                                    <?php if ((int)$v['IsActive'] === 1): ?>
+                                        <span class="badge text-bg-success-subtle text-success-emphasis">Active</span>
+                                    <?php else: ?>
+                                        <span class="badge text-bg-secondary-subtle text-secondary-emphasis">Hidden</span>
+                                    <?php endif; ?>
+                                </td>
+                                <td data-col-priority="primary" class="text-end text-nowrap">
+                                    <a class="btn btn-sm btn-outline-primary" href="<?= htmlspecialchars(venuesUrl(['venue' => (int)$v['Id'], 'edit_venue' => null, 'edit_schedule' => null])) ?>#schedules" title="Manage service times">
+                                        <i class="bi bi-clock-history"></i><span class="d-none d-md-inline ms-1">Service times</span>
+                                    </a>
+                                    <a class="btn btn-sm btn-outline-secondary" href="<?= htmlspecialchars(venuesUrl(['edit_venue' => (int)$v['Id'], 'venue' => null])) ?>#venue-form" title="Edit venue">
+                                        <i class="bi bi-pencil"></i>
+                                    </a>
+                                    <form method="post" action="/manage/venues" class="d-inline"
+                                          onsubmit="return confirm('Delete venue “<?= htmlspecialchars(addslashes($v['Name'])) ?>” and all its service times?');">
+                                        <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                                        <input type="hidden" name="action" value="venue_delete">
+                                        <input type="hidden" name="org_id" value="<?= $selectedOrgId ?>">
+                                        <input type="hidden" name="venue_id" value="<?= (int)$v['Id'] ?>">
+                                        <button type="submit" class="btn btn-sm btn-outline-danger" title="Delete venue"><i class="bi bi-trash"></i></button>
+                                    </form>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                </div>
+                <?php endif; ?>
+            </div>
+        </div>
+
+        <!-- ===================== VENUE ADD / EDIT FORM ===================== -->
+        <?php if ($editVenue !== null || $editVenueId === 0 && ($_GET['edit_venue'] ?? '') === 'new'): ?>
+            <?php $ev = $editVenue ?? []; $isEditV = !empty($ev); ?>
+            <div class="card mb-4" id="venue-form">
+                <div class="card-header fw-semibold">
+                    <i class="bi bi-<?= $isEditV ? 'pencil' : 'plus-lg' ?> me-1"></i><?= $isEditV ? 'Edit venue' : 'Add a venue' ?>
+                </div>
+                <div class="card-body">
+                    <form method="post" action="/manage/venues" class="row g-3">
+                        <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                        <input type="hidden" name="action" value="venue_save">
+                        <input type="hidden" name="org_id" value="<?= $selectedOrgId ?>">
+                        <input type="hidden" name="venue_id" value="<?= $isEditV ? (int)$ev['Id'] : 0 ?>">
+
+                        <div class="col-md-6">
+                            <label class="form-label small fw-semibold" for="v-name">Venue name <span class="text-danger">*</span></label>
+                            <input type="text" id="v-name" name="name" class="form-control" required maxlength="150"
+                                   value="<?= htmlspecialchars($ev['Name'] ?? '') ?>" placeholder="e.g. Main Sanctuary">
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label small fw-semibold" for="v-place">Find location (optional)</label>
+                            <input type="text" id="v-place" class="form-control" autocomplete="off"
+                                   placeholder="Type an address or town to drop a map pin…"
+                                   value="<?= htmlspecialchars(trim((($ev['City'] ?? '') . ' ' . ($ev['CountryCode'] ?? '')))) ?>">
+                            <input type="hidden" id="v-place-id" name="place_id" value="">
+                            <div class="form-text">Sets the map pin (lat/lng). A convenience only — not the attendance check.</div>
+                        </div>
+
+                        <div class="col-md-6">
+                            <label class="form-label small fw-semibold" for="v-address">Address line</label>
+                            <input type="text" id="v-address" name="address_line" class="form-control" maxlength="255"
+                                   value="<?= htmlspecialchars($ev['AddressLine'] ?? '') ?>">
+                        </div>
+                        <div class="col-md-3">
+                            <label class="form-label small fw-semibold" for="v-city">City / town</label>
+                            <input type="text" id="v-city" name="city" class="form-control" maxlength="120"
+                                   value="<?= htmlspecialchars($ev['City'] ?? '') ?>">
+                        </div>
+                        <div class="col-md-3">
+                            <label class="form-label small fw-semibold" for="v-postcode">Postcode</label>
+                            <input type="text" id="v-postcode" name="postcode" class="form-control" maxlength="20"
+                                   value="<?= htmlspecialchars($ev['Postcode'] ?? '') ?>">
+                        </div>
+
+                        <div class="col-md-3">
+                            <label class="form-label small fw-semibold" for="v-cc">Country (ISO-2)</label>
+                            <input type="text" id="v-cc" name="country_code" class="form-control text-uppercase" maxlength="2"
+                                   value="<?= htmlspecialchars($ev['CountryCode'] ?? '') ?>" placeholder="GB">
+                        </div>
+                        <div class="col-md-3">
+                            <label class="form-label small fw-semibold" for="v-lat">Latitude</label>
+                            <input type="number" step="0.0000001" min="-90" max="90" id="v-lat" name="latitude" class="form-control"
+                                   value="<?= isset($ev['Latitude']) && $ev['Latitude'] !== null ? htmlspecialchars((string)$ev['Latitude']) : '' ?>">
+                        </div>
+                        <div class="col-md-3">
+                            <label class="form-label small fw-semibold" for="v-lng">Longitude</label>
+                            <input type="number" step="0.0000001" min="-180" max="180" id="v-lng" name="longitude" class="form-control"
+                                   value="<?= isset($ev['Longitude']) && $ev['Longitude'] !== null ? htmlspecialchars((string)$ev['Longitude']) : '' ?>">
+                        </div>
+                        <div class="col-md-3">
+                            <label class="form-label small fw-semibold" for="v-radius">Radius (metres)</label>
+                            <input type="number" min="0" max="50000" step="10" id="v-radius" name="radius_metres" class="form-control"
+                                   value="<?= isset($ev['RadiusMetres']) && $ev['RadiusMetres'] !== null ? (int)$ev['RadiusMetres'] : '' ?>" placeholder="e.g. 150">
+                        </div>
+
+                        <div class="col-md-6">
+                            <label class="form-label small fw-semibold" for="v-tz">Timezone</label>
+                            <select id="v-tz" name="timezone" class="form-select">
+                                <?php $vtz = $ev['TimeZone'] ?? 'Europe/London'; foreach ($TZ_LIST as $tzId): ?>
+                                    <option value="<?= htmlspecialchars($tzId) ?>" <?= $tzId === $vtz ? 'selected' : '' ?>><?= htmlspecialchars($tzId) ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                        </div>
+                        <div class="col-md-6 d-flex align-items-end">
+                            <div class="form-check">
+                                <input type="checkbox" class="form-check-input" id="v-active" name="is_active" <?= !$isEditV || (int)($ev['IsActive'] ?? 1) === 1 ? 'checked' : '' ?>>
+                                <label class="form-check-label small" for="v-active">Active (available for Service Mode)</label>
+                            </div>
+                        </div>
+
+                        <div class="col-12 d-flex gap-2">
+                            <button type="submit" class="btn btn-amber-solid"><i class="bi bi-check-lg me-1"></i><?= $isEditV ? 'Save venue' : 'Add venue' ?></button>
+                            <a class="btn btn-outline-secondary" href="<?= htmlspecialchars(venuesUrl(['edit_venue' => null])) ?>">Cancel</a>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        <?php endif; ?>
+
+        <!-- ===================== SCHEDULES (selected venue) ===================== -->
+        <?php if ($selectedVenueRow !== null): ?>
+            <div class="card mb-4" id="schedules">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <span class="fw-semibold"><i class="bi bi-calendar-week me-1"></i>Service times — <?= htmlspecialchars($selectedVenueRow['Name']) ?></span>
+                    <a class="btn btn-sm btn-amber-solid" href="<?= htmlspecialchars(venuesUrl(['edit_schedule' => 'new'])) ?>#schedule-form">
+                        <i class="bi bi-plus-lg me-1"></i>Add service time
+                    </a>
+                </div>
+                <div class="card-body p-0">
+                    <?php if (!$schedules): ?>
+                        <p class="text-secondary small m-3 mb-3">No service times yet for this venue.</p>
+                    <?php else: ?>
+                    <div class="table-responsive">
+                        <table class="table admin-table-responsive align-middle mb-0">
+                            <thead>
+                                <tr>
+                                    <th data-col-priority="primary">Service</th>
+                                    <th data-col-priority="primary">When</th>
+                                    <th data-col-priority="secondary">Next dates</th>
+                                    <th data-col-priority="tertiary">Status</th>
+                                    <th data-col-priority="primary" class="text-end">Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                            <?php foreach ($schedules as $s): ?>
+                                <?php $next = venueNextOccurrences($s, 3); ?>
+                                <tr>
+                                    <td data-col-priority="primary"><span class="fw-semibold"><?= htmlspecialchars($s['Title']) ?></span></td>
+                                    <td data-col-priority="primary"><span class="small"><?= htmlspecialchars(venueScheduleSummary($s, $DOW, $NTH_LABELS)) ?></span></td>
+                                    <td data-col-priority="secondary">
+                                        <?php if ($next): ?>
+                                            <span class="small text-secondary"><?= htmlspecialchars(implode(' · ', array_map(static fn($d) => substr($d, 0, 16), $next))) ?></span>
+                                        <?php else: ?>
+                                            <span class="small text-secondary">—</span>
+                                        <?php endif; ?>
+                                    </td>
+                                    <td data-col-priority="tertiary">
+                                        <?= (int)$s['IsActive'] === 1
+                                            ? '<span class="badge text-bg-success-subtle text-success-emphasis">Active</span>'
+                                            : '<span class="badge text-bg-secondary-subtle text-secondary-emphasis">Hidden</span>' ?>
+                                    </td>
+                                    <td data-col-priority="primary" class="text-end text-nowrap">
+                                        <a class="btn btn-sm btn-outline-secondary" href="<?= htmlspecialchars(venuesUrl(['edit_schedule' => (int)$s['Id']])) ?>#schedule-form" title="Edit"><i class="bi bi-pencil"></i></a>
+                                        <form method="post" action="/manage/venues" class="d-inline"
+                                              onsubmit="return confirm('Delete this service time?');">
+                                            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                                            <input type="hidden" name="action" value="schedule_delete">
+                                            <input type="hidden" name="schedule_id" value="<?= (int)$s['Id'] ?>">
+                                            <button type="submit" class="btn btn-sm btn-outline-danger" title="Delete"><i class="bi bi-trash"></i></button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                            </tbody>
+                        </table>
+                    </div>
+                    <?php endif; ?>
+                </div>
+            </div>
+
+            <!-- SCHEDULE ADD / EDIT FORM -->
+            <?php if ($editSchedule !== null || ($_GET['edit_schedule'] ?? '') === 'new'): ?>
+                <?php $es = $editSchedule ?? []; $isEditS = !empty($es); $esKind = $es['RecurrenceKind'] ?? 'weekly'; ?>
+                <div class="card mb-4" id="schedule-form">
+                    <div class="card-header fw-semibold">
+                        <i class="bi bi-<?= $isEditS ? 'pencil' : 'plus-lg' ?> me-1"></i><?= $isEditS ? 'Edit service time' : 'Add a service time' ?>
+                    </div>
+                    <div class="card-body">
+                        <form method="post" action="/manage/venues" class="row g-3" id="sched-form-el">
+                            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
+                            <input type="hidden" name="action" value="schedule_save">
+                            <input type="hidden" name="venue_id" value="<?= $selectedVenueId ?>">
+                            <input type="hidden" name="schedule_id" value="<?= $isEditS ? (int)$es['Id'] : 0 ?>">
+
+                            <div class="col-md-5">
+                                <label class="form-label small fw-semibold" for="s-title">Service name</label>
+                                <input type="text" id="s-title" name="title" class="form-control" maxlength="150"
+                                       value="<?= htmlspecialchars($es['Title'] ?? 'Sunday Service') ?>">
+                            </div>
+                            <div class="col-md-4">
+                                <label class="form-label small fw-semibold" for="s-kind">Repeats</label>
+                                <select id="s-kind" name="recurrence_kind" class="form-select" onchange="venuesToggleRecurrence()">
+                                    <?php foreach ($RECURRENCE_KINDS as $k => $label): ?>
+                                        <option value="<?= htmlspecialchars($k) ?>" <?= $k === $esKind ? 'selected' : '' ?>><?= htmlspecialchars($label) ?></option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </div>
+                            <div class="col-md-3" data-rec-field="day">
+                                <label class="form-label small fw-semibold" for="s-dow">Day</label>
+                                <select id="s-dow" name="day_of_week" class="form-select">
+                                    <?php foreach ($DOW as $n => $dn): ?>
+                                        <option value="<?= $n ?>" <?= (int)($es['DayOfWeek'] ?? 7) === $n ? 'selected' : '' ?>><?= htmlspecialchars($dn) ?></option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </div>
+
+                            <div class="col-md-3">
+                                <label class="form-label small fw-semibold" for="s-time">Start time</label>
+                                <input type="time" id="s-time" name="start_time" class="form-control" required
+                                       value="<?= htmlspecialchars(substr((string)($es['StartTime'] ?? '10:00:00'), 0, 5)) ?>">
+                            </div>
+                            <div class="col-md-3">
+                                <label class="form-label small fw-semibold" for="s-dur">Duration (min)</label>
+                                <input type="number" id="s-dur" name="duration_mins" class="form-control" min="1" max="1440"
+                                       value="<?= (int)($es['DurationMins'] ?? 90) ?>">
+                            </div>
+                            <div class="col-md-3" data-rec-field="nth">
+                                <label class="form-label small fw-semibold" for="s-nth">Which week</label>
+                                <select id="s-nth" name="nth" class="form-select">
+                                    <?php foreach ([1 => 'First', 2 => 'Second', 3 => 'Third', 4 => 'Fourth', 5 => 'Fifth', -1 => 'Last'] as $nv => $nl): ?>
+                                        <option value="<?= $nv ?>" <?= (int)($esKind === 'monthly_nth' ? ($editSchedRd['nth'] ?? 1) : 1) === $nv ? 'selected' : '' ?>><?= htmlspecialchars($nl) ?></option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </div>
+                            <div class="col-md-3" data-rec-field="oneoff">
+                                <label class="form-label small fw-semibold" for="s-oneoff">Date</label>
+                                <input type="date" id="s-oneoff" name="one_off_date" class="form-control"
+                                       value="<?= htmlspecialchars((string)($editSchedRd['date'] ?? '')) ?>">
+                            </div>
+
+                            <div class="col-md-3" data-rec-field="anchor">
+                                <label class="form-label small fw-semibold" for="s-anchor">Starting from</label>
+                                <input type="date" id="s-anchor" name="anchor_date" class="form-control"
+                                       value="<?= htmlspecialchars((string)($editSchedRd['anchor'] ?? '')) ?>">
+                                <div class="form-text">Sets which fortnight is “week 1”.</div>
+                            </div>
+                            <div class="col-md-3">
+                                <label class="form-label small fw-semibold" for="s-until">Until (optional)</label>
+                                <input type="date" id="s-until" name="until_date" class="form-control"
+                                       value="<?= htmlspecialchars((string)($editSchedRd['until'] ?? '')) ?>">
+                            </div>
+                            <div class="col-md-6">
+                                <label class="form-label small fw-semibold" for="s-exc">Skip dates (optional)</label>
+                                <input type="text" id="s-exc" name="exceptions" class="form-control"
+                                       value="<?= htmlspecialchars(implode(', ', $editSchedRd['exceptions'] ?? [])) ?>"
+                                       placeholder="2026-12-25, 2027-01-01">
+                                <div class="form-text">Comma-separated YYYY-MM-DD dates with no service.</div>
+                            </div>
+
+                            <div class="col-md-6">
+                                <label class="form-label small fw-semibold" for="s-tz">Timezone (override)</label>
+                                <select id="s-tz" name="timezone" class="form-select">
+                                    <option value="">Inherit venue (<?= htmlspecialchars($selectedVenueRow['TimeZone']) ?>)</option>
+                                    <?php foreach ($TZ_LIST as $tzId): ?>
+                                        <option value="<?= htmlspecialchars($tzId) ?>" <?= ($es['TimeZone'] ?? '') === $tzId ? 'selected' : '' ?>><?= htmlspecialchars($tzId) ?></option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </div>
+                            <div class="col-md-6 d-flex align-items-end">
+                                <div class="form-check">
+                                    <input type="checkbox" class="form-check-input" id="s-active" name="is_active" <?= !$isEditS || (int)($es['IsActive'] ?? 1) === 1 ? 'checked' : '' ?>>
+                                    <label class="form-check-label small" for="s-active">Active</label>
+                                </div>
+                            </div>
+
+                            <div class="col-12 d-flex gap-2">
+                                <button type="submit" class="btn btn-amber-solid"><i class="bi bi-check-lg me-1"></i><?= $isEditS ? 'Save service time' : 'Add service time' ?></button>
+                                <a class="btn btn-outline-secondary" href="<?= htmlspecialchars(venuesUrl(['edit_schedule' => null])) ?>">Cancel</a>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            <?php endif; ?>
+        <?php endif; /* selectedVenueRow */ ?>
+        <?php endif; /* selectedOrgId */ ?>
+        <?php endif; /* schemaReady */ ?>
+
+    </div>
+
+    <?php if ($schemaReady): ?>
+    <!-- Reuse the shared location autocomplete (#681) — same module organisations.php
+         uses; resolves to a tblPlaces row and writes its Id into #v-place-id. -->
+    <script src="/js/modules/place-search.js?v=<?= filemtime(dirname(__DIR__) . '/js/modules/place-search.js') ?>"></script>
+    <script>
+        (function () {
+            if (window.iHymnsPlaceSearch) {
+                var v = document.getElementById('v-place');
+                var h = document.getElementById('v-place-id');
+                if (v && h) { window.iHymnsPlaceSearch.attach(v, { hiddenIdInput: h }); }
+            }
+        })();
+        // Show only the recurrence fields relevant to the chosen cadence.
+        function venuesToggleRecurrence() {
+            var kind = (document.getElementById('s-kind') || {}).value || 'weekly';
+            var show = {
+                weekly:      ['day'],
+                fortnightly: ['day', 'anchor'],
+                monthly_nth: ['day', 'nth'],
+                one_off:     ['oneoff']
+            }[kind] || ['day'];
+            document.querySelectorAll('[data-rec-field]').forEach(function (el) {
+                el.style.display = show.indexOf(el.getAttribute('data-rec-field')) === -1 ? 'none' : '';
+            });
+        }
+        venuesToggleRecurrence();
+    </script>
+    <?php endif; ?>
+
+    <?php require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'admin-footer.php'; ?>
+</body>
+</html>


### PR DESCRIPTION
Targets **alpha**, but **stacked on #1333** (it branched from it). **⚠ Merge order: #1333 → #1334 → this.** Until #1333 merges, this PR's diff also shows #1333's two commits (venues admin UI + external-systems); once #1333 lands, this shrinks to just the Phase-2a schema commit. All three append a migration-registry entry → the last to merge needs a trivial keep-all resolve.

The forward-looking, **dormant** schema for congregation **Service Mode** (#1323) — congregants join a live service via a venue rotating code + follow the songs, reusing the #1268 Live-Follow spine. Locked via an adversarial design workflow (**GO with must-fixes**, all folded in). Whole Phase 2+3 schema in ONE batch (rule #20).

### What (commit `feat(schema): Service Mode session foundation`)
- **Extend `tblLiveFollowSessions`**: `HostUserId` → NULL (host-less service sessions; existing `WHERE HostUserId = ?` supersede is already NULL-safe) · `VenueId`/`ScheduleId`/`OccurrenceDate` · `SessionKind` (`host`|`service`) · **`Channel`** (3-docroot discriminator — prevents a non-prod session being joinable on prod) · FKs + indexes.
- **`tblLiveFollowJoinCodes`** — rotating code window, session-scoped uniqueness.
- **`tblServicePresence`** — anonymous presence: device id + opaque `PresenceToken` (Phase-3 gate key, hard-revocable) + resolved-UTC `ExpiresAt`.
- **`tblServicePollCounters`** — per-session NAT-safe poll budget.

### CI
`php -l` clean; `test-migration-registry` + `test-schema-coverage` **pass** (129 tables).

### Next (this epic, separate PRs)
**2b** projection page + operator endpoints · **2c** congregant client + anon endpoints · **3** presence-scoped CCLI unlock (per-song CCL notice). Dormant until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)