### PR TITLE
fix(credits): de-duplicate people-credit lists — same person shown twice (#1355)

### DIFF
--- a/appWeb/public_html/includes/SongData.php
+++ b/appWeb/public_html/includes/SongData.php
@@ -3271,6 +3271,25 @@ class SongData
         $row['adaptors']     = $this->_getAdaptors($songId);
         $row['translators']  = $this->_getTranslators($songId);
         $row['artists']      = $this->_getArtists($songId);    /* #587 */
+        /* #1355 — de-duplicate each people-credit list case-insensitively (order
+           preserved, first occurrence wins). A person credited twice in the same
+           role (a duplicate tblSong<Role> row) must surface ONCE — both in each row
+           and in the song-view "Words & Music" combine (#603). Fixed at the source so
+           the public song page, print (song_data) and export all dedupe alike. */
+        foreach (['writers', 'composers', 'arrangers', 'adaptors', 'translators', 'artists'] as $_creditKey) {
+            if (empty($row[$_creditKey]) || !is_array($row[$_creditKey])) { continue; }
+            $_seenCredit = [];
+            $row[$_creditKey] = array_values(array_filter(
+                array_map(static fn($n) => trim((string)$n), $row[$_creditKey]),
+                static function (string $n) use (&$_seenCredit): bool {
+                    if ($n === '') { return false; }
+                    $k = mb_strtolower($n);
+                    if (isset($_seenCredit[$k])) { return false; }
+                    $_seenCredit[$k] = true;
+                    return true;
+                }
+            ));
+        }
         $row['components']   = $this->_getComponents($songId);
         /* Tags attached here too so the single-song read path matches
            the bulk getSongs() shape (#496 follow-up). Uses the same


### PR DESCRIPTION
Fixes the owner-reported bug: a person credited twice in the same role rendered twice on the song view — "Words & Music: Deborah Melle Kerner Rettino; Deborah Melle Kerner Rettino" and a repeated Artist.

**Root cause:** `SongData::_fetchSongRow()` builds each credit list (`_getWriters`/`_getComposers`/`_getArtists`/…) with `SELECT Name … ORDER BY Id` and no de-dupe, so duplicate `tblSong<Role>` rows surface verbatim. The song-view #603 "Words & Music" combine only de-duped for the equality *comparison*, not the rendered names.

**Fix:** de-dupe each of writers/composers/arrangers/adaptors/translators/artists case-insensitively + order-preserving at the source — so the public song page, print (`song_data`) and export all show each person once. Pure display de-dupe; no data mutation.

**Note:** the underlying duplicate rows (this song has Deborah as a writer twice + Psalty as an artist twice) are a separate data-quality matter — an editor guard against adding the same person twice could follow.

Closes #1355. `php -l` clean. No schema/migration change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)