### PR TITLE
chore: bump version to 0.1251.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [unreleased] — alpha
 
+- chore(version): bump app version to **0.1251.0** (`includes/infoAppVer.php`; the PWA service-worker cache version auto-syncs off it, #81). README + OpenAPI spec updated to match.
+- fix(api): **Service Mode "Go Live" fatal — `Call to undefined function checkRateLimit()`** (#1360). `includes/rate_limit.php` (which defines `checkRateLimit()`) was `require_once`'d only inside the `setlist_collab_invite` case, so every other caller (`service_session_start` / `service_broadcast` / `service_operator` / `live_follow_*`) fatal'd. Now loaded top-level in `api.php` so it is always defined. Pre-existing/latent since Service Mode #1335; surfaced on first live use.
 - chore(version): bump app version to **0.1250.0** (`includes/infoAppVer.php`; the PWA service-worker cache version auto-syncs off it, #81). README + OpenAPI spec updated to match.
 - docs(readme): remove the static **Song Library** catalogue block — song counts/songbooks now live in the backend MySQL database (`tblSongbooks` / `tblSongs`), not tied to builds, releases or deployment, so a hard-coded catalogue snapshot in the README only goes stale. Query `tblSongbooks` for the live count.
 - feat(api): **server-side content gating + extensible tier registry + read rate limiting + robust CSRF** (#1352 / #1353 / #1354) — turns the previously-advisory gating model into real server-side enforcement, makes the capability set extensible in one line, caps the heaviest public reads, and ends the sporadic "CSRF error" on admin writes. Five strands:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **A multiplatform Christian lyrics application for worship enhancement**
 
-[![Version: 0.1250.0 Alpha](https://img.shields.io/badge/Version-0.1250.0%20Alpha-orange.svg)](#environments)
+[![Version: 0.1251.0 Alpha](https://img.shields.io/badge/Version-0.1251.0%20Alpha-orange.svg)](#environments)
 [![License: Proprietary](https://img.shields.io/badge/License-Proprietary-red.svg)](LICENSING.md)
 [![Security Policy](https://img.shields.io/badge/Security-Policy-brightgreen.svg)](SECURITY.md)
 [![Platform: Web](https://img.shields.io/badge/Platform-Web%20PWA-blue.svg)](#platforms)
@@ -23,7 +23,7 @@
 
 | Platform | Technology | Status |
 | --- | --- | --- |
-| Web PWA | HTML5, CSS3, Bootstrap 5.3, vanilla JS, PHP 8.1+, MySQL 5.7+ / MariaDB 10.3+ | **Alpha** (v0.1250.0) |
+| Web PWA | HTML5, CSS3, Bootstrap 5.3, vanilla JS, PHP 8.1+, MySQL 5.7+ / MariaDB 10.3+ | **Alpha** (v0.1251.0) |
 | iOS / iPadOS / tvOS | Swift 6.3, SwiftUI | Scaffold / in progress (~14 Swift sources) |
 | Android / Fire OS | Kotlin, Jetpack Compose | Scaffold / in progress (~12 Kotlin sources) |
 

--- a/appWeb/public_html/api-docs.yaml
+++ b/appWeb/public_html/api-docs.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 
 info:
   title: iHymns API
-  version: "0.1250.0"
+  version: "0.1251.0"
   description: |
     The iHymns API provides programmatic access to the iHymns hymn and song
     database. It powers the iHymns Progressive Web App (PWA), enabling song

--- a/appWeb/public_html/includes/infoAppVer.php
+++ b/appWeb/public_html/includes/infoAppVer.php
@@ -79,7 +79,7 @@ $app["Application"]["Description"]["Keywords"] = "hymns, worship, lyrics, songbo
 /* Semantic version number (MAJOR.MINOR.PATCH) */
 /* Auto-bumped by the version-bump GitHub Action on push to beta */
 /* v1.x.x = Phase 1 (local JSON data), v2.x.x = Phase 2 (iLyrics dB) */
-$app["Application"]["Version"]["Number"] = "0.1250.0";
+$app["Application"]["Version"]["Number"] = "0.1251.0";
 
 /* Version name: human-readable release name (e.g., "Hymnal", NULL if unused) */
 $app["Application"]["Version"]["Name"] = NULL;


### PR DESCRIPTION
Minor bump 0.1250.0 → **0.1251.0** over the api-native-gating release, covering the Service Mode Go-Live `checkRateLimit()` hotfix (#1360). Updates `infoAppVer.php` (canonical — the PWA SW cache version auto-syncs off it), the README badge + platforms table, and the OpenAPI spec. Base: `alpha`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)