### PR TITLE
fix(setlists): LIVE shares + canonical SongIds — rewrite snapshot model (#1380) — v0.1315.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **A multiplatform Christian lyrics application for worship enhancement**
 
-[![Version: 0.1302.0 Alpha](https://img.shields.io/badge/Version-0.1253.0%20Alpha-orange.svg)](#environments)
+[![Version: 0.1315.0 Alpha](https://img.shields.io/badge/Version-0.1315.0%20Alpha-orange.svg)](#environments)
 [![License: Proprietary](https://img.shields.io/badge/License-Proprietary-red.svg)](LICENSING.md)
 [![Security Policy](https://img.shields.io/badge/Security-Policy-brightgreen.svg)](SECURITY.md)
 [![Platform: Web](https://img.shields.io/badge/Platform-Web%20PWA-blue.svg)](#platforms)
@@ -23,7 +23,7 @@
 
 | Platform | Technology | Status |
 | --- | --- | --- |
-| Web PWA | HTML5, CSS3, Bootstrap 5.3, vanilla JS, PHP 8.1+, MySQL 5.7+ / MariaDB 10.3+ | **Alpha** (v0.1302.0) |
+| Web PWA | HTML5, CSS3, Bootstrap 5.3, vanilla JS, PHP 8.1+, MySQL 5.7+ / MariaDB 10.3+ | **Alpha** (v0.1315.0) |
 | iOS / iPadOS / tvOS | Swift 6.3, SwiftUI | Scaffold / in progress (~14 Swift sources) |
 | Android / Fire OS | Kotlin, Jetpack Compose | Scaffold / in progress (~12 Kotlin sources) |
 

--- a/appWeb/.sql/migrate-backfill-canonical-songids.php
+++ b/appWeb/.sql/migrate-backfill-canonical-songids.php
@@ -1,0 +1,357 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Backfill canonical SongIds for legacy draft ids (#1380)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Before #1380, the Song Editor minted a client-side DRAFT id ("song-" + base36
+ * timestamp + random) for a new song and the save UPSERTed it verbatim — so some
+ * saved songs carry a permanent, non-canonical `song-XXXX` SongId. From #1380 the
+ * server assigns a canonical `<Abbr>-NNNN` id on first save, but rows already
+ * persisted with a draft id need this one-shot data fix.
+ *
+ * WHAT IT REWRITES, per draft-id song:
+ *   1. tblSongs.SongId  (the rename) — the 41 FK children referencing
+ *      tblSongs(SongId) all declare ON UPDATE CASCADE, so the new id propagates to
+ *      every FK child AUTOMATICALLY in the same UPDATE. We do NOT touch them.
+ *   2. The NON-FK / JSON stores that hold a SongId but have no FK, so do NOT
+ *      cascade and must be rewritten by hand:
+ *        - tblContentRestrictions.EntityId  (where EntityType = 'song')
+ *        - tblUserSetlists.SongsJson        (array of {id,…} objects)
+ *        - tblSharedSetlists.Data           (snapshot songs[] + arrangements{} keys)
+ *   3. tblSongRedirects(OldSongId, NewSongId) — a redirect row so any bookmarked
+ *      /song/song-XXXX permalink keeps resolving to the new canonical id.
+ *
+ * DELIBERATELY LEFT UNTOUCHED (audit / historical record — rewriting them would
+ * falsify the past):
+ *   tblSongRevisions.PreviousData / NewData, tblActivityLog, tblBulkImportJobs.*,
+ *   tblLyricsConflicts.*Data.
+ *
+ * SAFETY GATES (defense in depth):
+ *   - Registry 'manual' => true: EXCLUDED from "Apply all" and the pending counter.
+ *   - DRY-RUN by default. A web run without ?confirm=1 (or a CLI run without
+ *     --confirm) only REPORTS — it never mutates. The mutating path REFUSES with a
+ *     clean exit 0 unless explicitly confirmed, so a stray bulk fetch is harmless.
+ *   - IDEMPOTENT: re-running after a partial/complete apply finds fewer / no draft
+ *     ids and is a no-op. INSERT IGNORE on the redirect row tolerates re-runs.
+ *   - PER-SONG TRANSACTIONAL: each song's rename + JSON rewrites + redirect commit
+ *     together or roll back together; one bad song never half-applies.
+ *   - CASCADE PRE-CHECK: REFUSES up-front if ANY FK referencing tblSongs(SongId)
+ *     lacks ON UPDATE CASCADE (an older drifted install) — pointing the operator to
+ *     run migrate-songid-prefix-fixup.php first, so the rename can never orphan a
+ *     child row.
+ *
+ * USAGE:
+ *   Web (dry-run):  /manage/setup-database → "Backfill canonical SongIds (#1380)"
+ *   Web (apply):    add &confirm=1 to the run URL (type-to-confirm card)
+ *   CLI (dry-run):  php appWeb/.sql/migrate-backfill-canonical-songids.php
+ *   CLI (apply):    php appWeb/.sql/migrate-backfill-canonical-songids.php --confirm
+ *
+ * @requires PHP 8.1+ with mysqli
+ */
+
+$isCli = (PHP_SAPI === 'cli');
+if (!$isCli && !defined('IHYMNS_SETUP_DASHBOARD')) {
+    header('Content-Type: text/plain; charset=UTF-8');
+    header('X-Content-Type-Options: nosniff');
+    header('Cache-Control: no-store');
+}
+
+function _migBCS_out(string $m): void { global $isCli; echo $m . ($isCli ? "\n" : "<br>\n"); if (!$isCli) { @flush(); } }
+
+/* CONFIRM resolution: CLI uses --confirm; web uses ?confirm=1. Anything else is a
+   DRY RUN (report only). The default-safe stance means an operator who just clicks
+   the card sees the plan first and must opt in to mutate. */
+$confirm = false;
+if ($isCli) {
+    $confirm = in_array('--confirm', $argv ?? [], true);
+} else {
+    $confirm = (($_GET['confirm'] ?? '') === '1');
+}
+$dryRun = !$confirm;
+
+/* Load standalone DB credentials (the migration cannot assume the app bootstrap ran). */
+require_once dirname(__DIR__) . '/public_html/includes/db_mysql.php';
+require_once dirname(__DIR__) . '/public_html/includes/song_importers.php';
+
+_migBCS_out("");
+_migBCS_out("=== iHymns — Backfill canonical SongIds for draft ids (#1380) ===");
+_migBCS_out($dryRun
+    ? "MODE: DRY RUN (report only). Add " . ($isCli ? '--confirm' : '&confirm=1') . " to APPLY."
+    : "MODE: APPLY (mutating). Per-song transactional.");
+
+$db = function_exists('getDbMysqli') ? getDbMysqli() : null;
+if (!($db instanceof mysqli)) {
+    _migBCS_out('ERROR: could not connect to database.');
+    if ($isCli) { exit(1); }
+    return;
+}
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+/* -------------------------------------------------------------------------
+ * Cascade pre-check — REFUSE if any FK to tblSongs(SongId) is not ON UPDATE
+ * CASCADE. Without it, UPDATE tblSongs SET SongId would either fail (RESTRICT)
+ * or orphan children (SET NULL / NO ACTION). A drifted older install must run
+ * migrate-songid-prefix-fixup.php first (which adds the missing cascades).
+ * ------------------------------------------------------------------------- */
+try {
+    $stmt = $db->prepare(
+        "SELECT rc.CONSTRAINT_NAME, rc.UPDATE_RULE, k.TABLE_NAME
+           FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS rc
+           JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE k
+             ON k.CONSTRAINT_SCHEMA = rc.CONSTRAINT_SCHEMA
+            AND k.CONSTRAINT_NAME   = rc.CONSTRAINT_NAME
+          WHERE rc.CONSTRAINT_SCHEMA = DATABASE()
+            AND rc.REFERENCED_TABLE_NAME = 'tblSongs'
+            AND k.REFERENCED_COLUMN_NAME = 'SongId'"
+    );
+    $stmt->execute();
+    $fkRows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+    $stmt->close();
+
+    $nonCascade = array_values(array_filter(
+        $fkRows,
+        static fn(array $r): bool => strtoupper((string)$r['UPDATE_RULE']) !== 'CASCADE'
+    ));
+    if (count($nonCascade) > 0) {
+        _migBCS_out('[REFUSE] ' . count($nonCascade) . ' FK(s) referencing tblSongs(SongId) are NOT ON UPDATE CASCADE:');
+        foreach (array_slice($nonCascade, 0, 20) as $r) {
+            _migBCS_out('         ' . $r['TABLE_NAME'] . '.' . $r['CONSTRAINT_NAME'] . ' = ' . $r['UPDATE_RULE']);
+        }
+        _migBCS_out('         Run migrate-songid-prefix-fixup.php first (it adds the cascades), then re-run this.');
+        if ($isCli) { exit(1); }
+        return;
+    }
+    _migBCS_out('[ok] all ' . count($fkRows) . ' FKs referencing tblSongs(SongId) are ON UPDATE CASCADE.');
+} catch (\Throwable $e) {
+    _migBCS_out('ERROR: FK cascade pre-check failed: ' . $e->getMessage());
+    if ($isCli) { exit(1); }
+    return;
+}
+
+/* -------------------------------------------------------------------------
+ * Collect every draft-id song.
+ * ------------------------------------------------------------------------- */
+$drafts = [];
+try {
+    $res = $db->query(
+        "SELECT SongId, SongbookAbbr, Number,
+                (SELECT IsOfficial FROM tblSongbooks b WHERE b.Abbreviation = s.SongbookAbbr LIMIT 1) AS IsOfficial
+           FROM tblSongs s
+          WHERE SongId LIKE 'song-%'"
+    );
+    while ($r = $res->fetch_assoc()) { $drafts[] = $r; }
+    $res->close();
+} catch (\Throwable $e) {
+    _migBCS_out('ERROR: draft scan failed: ' . $e->getMessage());
+    if ($isCli) { exit(1); }
+    return;
+}
+
+if (empty($drafts)) {
+    _migBCS_out('[ok] no draft-id songs found — nothing to backfill.');
+    return;
+}
+_migBCS_out('[scan] ' . count($drafts) . ' draft-id song' . (count($drafts) === 1 ? '' : 's') . ' to process.');
+
+/* Prepared statements reused across songs. */
+$existsStmt    = $db->prepare('SELECT 1 FROM tblSongs WHERE SongId = ? LIMIT 1');
+$renameStmt    = $db->prepare('UPDATE tblSongs SET SongId = ?, Number = COALESCE(Number, ?) WHERE SongId = ?');
+$restrictStmt  = $db->prepare("UPDATE tblContentRestrictions SET EntityId = ? WHERE EntityType = 'song' AND EntityId = ?");
+/* LIKE candidate-filter narrows the JSON rewrites to rows that actually embed the
+   old id (most rows don't), so we json_decode only the candidates. The exact `===`
+   compare inside guards against a substring false-positive. */
+$setlistScanStmt = $db->prepare("SELECT UserId, SetlistId, SongsJson FROM tblUserSetlists WHERE SongsJson LIKE CONCAT('%', ?, '%')");
+$setlistUpdStmt  = $db->prepare('UPDATE tblUserSetlists SET SongsJson = ? WHERE UserId = ? AND SetlistId = ?');
+$shareScanStmt   = $db->prepare("SELECT ShareId, Data FROM tblSharedSetlists WHERE Data LIKE CONCAT('%', ?, '%')");
+$shareUpdStmt    = $db->prepare('UPDATE tblSharedSetlists SET Data = ? WHERE ShareId = ?');
+$redirectStmt    = $db->prepare("INSERT IGNORE INTO tblSongRedirects (OldSongId, NewSongId, Reason, Note) VALUES (?, ?, 'rename', '#1380 canonical SongId backfill')");
+
+/* Reserved-id ledger so a DRY RUN report is accurate when several drafts share a
+   songbook: in dry-run the DB is never mutated, so _bulkImport_nextSongNumberFor
+   would return the SAME next slot each time — the ledger makes each subsequent mint
+   skip the one we already proposed. In APPLY mode the earlier rename has already
+   landed before the next mint, so the ledger simply confirms (no double-count). */
+$reservedIds = [];
+
+/* Mint a free canonical id for a draft, walking past ids already taken in tblSongs
+   (UNIQUE backstop) OR already reserved earlier in this run. */
+$mintCanonicalId = static function (string $abbr) use ($db, $existsStmt, &$reservedIds): array {
+    $n = _bulkImport_nextSongNumberFor($db, $abbr);
+    $candidate = sprintf('%s-%04d', $abbr, $n);
+    $takenInDb = static function (string $c) use ($existsStmt): bool {
+        $existsStmt->bind_param('s', $c);
+        $existsStmt->execute();
+        return $existsStmt->get_result()->fetch_row() !== null;
+    };
+    while (isset($reservedIds[$candidate]) || $takenInDb($candidate)) {
+        $n++;
+        $candidate = sprintf('%s-%04d', $abbr, $n);
+    }
+    $reservedIds[$candidate] = true;
+    return [$candidate, $n];
+};
+
+/* Rewrite every exact-`===` occurrence of $oldId inside a setlist SongsJson object
+   array. Returns [newJson|null, changed]. */
+$rewriteSetlistJson = static function (string $rawJson, string $oldId, string $newId): array {
+    $decoded = json_decode($rawJson, true);
+    if (!is_array($decoded)) { return [null, false]; }
+    $changed = false;
+    foreach ($decoded as &$entry) {
+        if (is_array($entry) && isset($entry['id']) && (string)$entry['id'] === $oldId) {
+            $entry['id'] = $newId;
+            $changed = true;
+        }
+    }
+    unset($entry);
+    if (!$changed) { return [null, false]; }
+    return [json_encode($decoded, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), true];
+};
+
+/* Rewrite a shared-setlist Data payload: songs[] id strings + arrangements{} keys. */
+$rewriteShareData = static function (string $rawJson, string $oldId, string $newId): array {
+    $decoded = json_decode($rawJson, true);
+    if (!is_array($decoded)) { return [null, false]; }
+    $changed = false;
+    if (isset($decoded['songs']) && is_array($decoded['songs'])) {
+        foreach ($decoded['songs'] as &$sid) {
+            if ((string)$sid === $oldId) { $sid = $newId; $changed = true; }
+        }
+        unset($sid);
+    }
+    if (isset($decoded['arrangements']) && is_array($decoded['arrangements']) && array_key_exists($oldId, $decoded['arrangements'])) {
+        $arrVal = $decoded['arrangements'][$oldId];
+        unset($decoded['arrangements'][$oldId]);
+        /* Preserve any existing value at the new key (extremely unlikely); the
+           moved arrangement wins since it belongs to the renamed song. */
+        $decoded['arrangements'][$newId] = $arrVal;
+        $changed = true;
+    }
+    if (!$changed) { return [null, false]; }
+    return [json_encode($decoded, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), true];
+};
+
+$applied = 0;
+$skipped = 0;
+$errors  = 0;
+
+foreach ($drafts as $d) {
+    $oldId      = (string)$d['SongId'];
+    $abbr       = (string)$d['SongbookAbbr'];
+    if ($abbr === '') { $abbr = 'Misc'; }
+    $isOfficial = (bool)($d['IsOfficial'] ?? false);
+    $curNumber  = $d['Number'];
+
+    [$newId, $slot] = $mintCanonicalId($abbr);
+    $adoptNumber = ($isOfficial && ($curNumber === null)) ? $slot : null;
+
+    /* --- count affected non-FK rows (report + sanity) --- */
+    $restrictCount = 0; $setlistCount = 0; $shareCount = 0;
+    try {
+        $cStmt = $db->prepare("SELECT COUNT(*) FROM tblContentRestrictions WHERE EntityType = 'song' AND EntityId = ?");
+        $cStmt->bind_param('s', $oldId); $cStmt->execute();
+        $restrictCount = (int)($cStmt->get_result()->fetch_row()[0] ?? 0); $cStmt->close();
+    } catch (\Throwable $_e) { /* table may be absent on a minimal install */ }
+
+    /* --- DRY RUN: report and continue, no mutation --- */
+    if ($dryRun) {
+        /* candidate-scan the JSON stores for the affected-count report */
+        try {
+            $setlistScanStmt->bind_param('s', $oldId); $setlistScanStmt->execute();
+            foreach ($setlistScanStmt->get_result()->fetch_all(MYSQLI_ASSOC) as $row) {
+                [, $ch] = $rewriteSetlistJson((string)$row['SongsJson'], $oldId, $newId);
+                if ($ch) { $setlistCount++; }
+            }
+        } catch (\Throwable $_e) {}
+        try {
+            $shareScanStmt->bind_param('s', $oldId); $shareScanStmt->execute();
+            foreach ($shareScanStmt->get_result()->fetch_all(MYSQLI_ASSOC) as $row) {
+                [, $ch] = $rewriteShareData((string)$row['Data'], $oldId, $newId);
+                if ($ch) { $shareCount++; }
+            }
+        } catch (\Throwable $_e) {}
+
+        $numNote = $adoptNumber !== null ? (' (+ adopt Number ' . $adoptNumber . ')') : '';
+        _migBCS_out(sprintf(
+            '  [plan] %s → %s%s  | restrictions:%d setlists:%d shares:%d',
+            $oldId, $newId, $numNote, $restrictCount, $setlistCount, $shareCount
+        ));
+        $applied++; /* count of would-apply */
+        continue;
+    }
+
+    /* --- APPLY: per-song transaction --- */
+    try {
+        $db->begin_transaction();
+
+        /* 1. rename tblSongs (FK children cascade automatically) */
+        $renameStmt->bind_param('sis', $newId, $adoptNumber, $oldId);
+        $renameStmt->execute();
+
+        /* 2a. non-FK content restrictions */
+        $restrictStmt->bind_param('ss', $newId, $oldId);
+        $restrictStmt->execute();
+
+        /* 2b. user setlists (JSON object array) */
+        $setlistScanStmt->bind_param('s', $oldId); $setlistScanStmt->execute();
+        $setlistRows = $setlistScanStmt->get_result()->fetch_all(MYSQLI_ASSOC);
+        foreach ($setlistRows as $row) {
+            [$newJson, $ch] = $rewriteSetlistJson((string)$row['SongsJson'], $oldId, $newId);
+            if ($ch) {
+                $uid = (int)$row['UserId']; $sid = (string)$row['SetlistId'];
+                $setlistUpdStmt->bind_param('sis', $newJson, $uid, $sid);
+                $setlistUpdStmt->execute();
+                $setlistCount++;
+            }
+        }
+
+        /* 2c. shared setlists (snapshot songs[] + arrangements{}) */
+        $shareScanStmt->bind_param('s', $oldId); $shareScanStmt->execute();
+        $shareRows = $shareScanStmt->get_result()->fetch_all(MYSQLI_ASSOC);
+        foreach ($shareRows as $row) {
+            [$newData, $ch] = $rewriteShareData((string)$row['Data'], $oldId, $newId);
+            if ($ch) {
+                $shid = (string)$row['ShareId'];
+                $shareUpdStmt->bind_param('ss', $newData, $shid);
+                $shareUpdStmt->execute();
+                $shareCount++;
+            }
+        }
+
+        /* 3. permalink redirect (idempotent — INSERT IGNORE on PK collision) */
+        $redirectStmt->bind_param('ss', $oldId, $newId);
+        $redirectStmt->execute();
+
+        $db->commit();
+        $numNote = $adoptNumber !== null ? (' (Number=' . $adoptNumber . ')') : '';
+        _migBCS_out(sprintf(
+            '  [done] %s → %s%s  | restrictions:%d setlists:%d shares:%d',
+            $oldId, $newId, $numNote, $restrictCount, $setlistCount, $shareCount
+        ));
+        $applied++;
+    } catch (\Throwable $e) {
+        try { $db->rollback(); } catch (\Throwable $_) {}
+        _migBCS_out('  [ERROR] ' . $oldId . ' → ' . $newId . ' rolled back: ' . $e->getMessage());
+        $errors++;
+    }
+}
+
+$existsStmt->close();   $renameStmt->close();    $restrictStmt->close();
+$setlistScanStmt->close(); $setlistUpdStmt->close();
+$shareScanStmt->close();   $shareUpdStmt->close(); $redirectStmt->close();
+
+_migBCS_out('');
+if ($dryRun) {
+    _migBCS_out("[summary] DRY RUN — {$applied} song(s) would be renamed. Re-run with "
+        . ($isCli ? '--confirm' : '&confirm=1') . ' to APPLY.');
+} else {
+    _migBCS_out("[summary] APPLIED {$applied} rename(s), {$errors} error(s).");
+    if ($errors > 0) {
+        _migBCS_out('[note] errored songs were rolled back individually and left as draft ids — re-run to retry.');
+    }
+}

--- a/appWeb/.sql/migrate-shared-setlist-live-link.php
+++ b/appWeb/.sql/migrate-shared-setlist-live-link.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Live-link a shared setlist to the owner's server-stored setlist (#1380)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Setlist sharing has always been SNAPSHOT-based: the share API froze a copy of
+ * the songs into tblSharedSetlists.Data at share time, so the owner's later edits
+ * to their LIVE setlist (tblUserSetlists) never reached link-holders. This migration
+ * adds the two columns that let a share LINK to the owner's live row instead of
+ * freezing a copy:
+ *
+ *   tblSharedSetlists.OwnerUserId     — FK -> tblUsers.Id of the authenticated owner.
+ *   tblSharedSetlists.SourceSetlistId — the owner's tblUserSetlists.SetlistId.
+ *
+ * (OwnerUserId, SourceSetlistId) resolves the CURRENT setlist at read time. When
+ * either is NULL the share stays snapshot-only (legacy / anonymous create), so the
+ * change is fully backward-compatible: existing share rows keep working unchanged.
+ *
+ * Additive + IDEMPOTENT — each ADD is column-existence-gated and the FK add is
+ * INFORMATION_SCHEMA.TABLE_CONSTRAINTS-gated (mysqli runs under
+ * MYSQLI_REPORT_ERROR|STRICT, so an unguarded duplicate-ADD would THROW). The read
+ * path (SharedSetlist.php) is column-existence-gated too, so the app works whether
+ * or not this has run — an un-migrated install simply never live-links.
+ *
+ * @migration-adds tblSharedSetlists.OwnerUserId
+ * @migration-adds tblSharedSetlists.SourceSetlistId
+ *
+ * USAGE:
+ *   Web:  /manage/setup-database → "Live-link shared setlists (#1380)" button
+ *   CLI:  php appWeb/.sql/migrate-shared-setlist-live-link.php
+ *
+ * @requires PHP 8.1+ with mysqli
+ */
+
+/* ELI5: are we on the command line, or clicked in the web dashboard?
+   WHY: a web run needs plain-text headers; the dashboard sets a sentinel constant so
+   the migration runner captures our echo output instead of leaking raw HTTP headers
+   (mirrors every other migrate-*.php). */
+$isCli = (PHP_SAPI === 'cli');
+if (!$isCli && !defined('IHYMNS_SETUP_DASHBOARD')) {
+    header('Content-Type: text/plain; charset=UTF-8');
+    header('X-Content-Type-Options: nosniff');
+    header('Cache-Control: no-store');
+}
+
+/* ELI5: print one progress line, CLI- or HTML-formatted depending on where we run.
+   WHY: a single helper keeps the migration legible in the terminal AND in the
+   dashboard's live <pre> capture. */
+function _migSSLL_out(string $m): void { global $isCli; echo $m . ($isCli ? "\n" : "<br>\n"); if (!$isCli) { @flush(); } }
+
+/* ELI5: does this column already exist on this table?
+   WHY: idempotency — re-running the migration is a safe no-op. Bound param (rule #5),
+   never string-interpolation.
+   https://dev.mysql.com/doc/refman/8.0/en/information-schema-columns-table.html */
+function _migSSLL_columnExists(\mysqli $db, string $t, string $c): bool
+{
+    $stmt = $db->prepare(
+        "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ? LIMIT 1"
+    );
+    $stmt->bind_param('ss', $t, $c);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+/* ELI5: does a named FK / constraint already exist on this table?
+   WHY: the FK ADD is not column-gated — guard it against its own constraint name so a
+   re-run never trips ER_DUP_KEYNAME under STRICT.
+   https://dev.mysql.com/doc/refman/8.0/en/information-schema-table-constraints-table.html */
+function _migSSLL_constraintExists(\mysqli $db, string $t, string $name): bool
+{
+    $stmt = $db->prepare(
+        "SELECT 1 FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+          WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = ? AND CONSTRAINT_NAME = ? LIMIT 1"
+    );
+    $stmt->bind_param('ss', $t, $name);
+    $stmt->execute();
+    $exists = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    return $exists;
+}
+
+/* ELI5: load the MySQL login details written by install.php.
+   WHY: the migration runs standalone (CLI or web) so it needs its own connection; it
+   cannot assume the app bootstrap has run. Bail clearly if the install step is missing. */
+$credFile = dirname(__DIR__) . DIRECTORY_SEPARATOR . '.auth' . DIRECTORY_SEPARATOR . 'db_credentials.php';
+if (!file_exists($credFile)) { _migSSLL_out("ERROR: MySQL credentials not found. Run install.php first."); return; }
+require_once $credFile;
+
+_migSSLL_out("");
+_migSSLL_out("=== iHymns — Live-link shared setlists (tblSharedSetlists, #1380) ===");
+
+/* ELI5: open the database connection.
+   WHY: mysqli runs under MYSQLI_REPORT_ERROR|STRICT app-wide, so a bad statement THROWS;
+   catch the connect failure to print a friendly line instead of a stack trace. */
+try {
+    $mysql = new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME);
+    $mysql->set_charset('utf8mb4');
+} catch (\mysqli_sql_exception $e) { _migSSLL_out("ERROR: MySQL connection failed: " . $e->getMessage()); return; }
+_migSSLL_out("Connected to MySQL: " . DB_NAME);
+
+try {
+    /* ELI5: add the owner-user link column only if missing.
+       WHY: idempotency — a guarded ADD COLUMN keeps re-runs a clean no-op rather than a
+       1060 error. Byte-identical to the schema.sql mirror so a fresh install equals a
+       migrated one. NULL = legacy/anonymous snapshot-only share. */
+    if (_migSSLL_columnExists($mysql, 'tblSharedSetlists', 'OwnerUserId')) {
+        _migSSLL_out("  [SKIP] tblSharedSetlists.OwnerUserId already present.");
+    } else {
+        $mysql->query(
+            "ALTER TABLE tblSharedSetlists
+                ADD COLUMN OwnerUserId INT UNSIGNED NULL DEFAULT NULL
+                COMMENT 'Live-share link: FK to tblUsers.Id of the authenticated owner. NULL = legacy/anonymous snapshot-only share (#1380).'
+                AFTER Data"
+        );
+        _migSSLL_out("  [OK] Added tblSharedSetlists.OwnerUserId.");
+    }
+
+    /* ELI5: add the source-setlist-id column only if missing.
+       WHY: (OwnerUserId, SourceSetlistId) is what resolves the owner's CURRENT setlist at
+       read time. VARCHAR(100) matches tblUserSetlists.SetlistId. NULL = snapshot-only. */
+    if (_migSSLL_columnExists($mysql, 'tblSharedSetlists', 'SourceSetlistId')) {
+        _migSSLL_out("  [SKIP] tblSharedSetlists.SourceSetlistId already present.");
+    } else {
+        $mysql->query(
+            "ALTER TABLE tblSharedSetlists
+                ADD COLUMN SourceSetlistId VARCHAR(100) NULL DEFAULT NULL
+                COMMENT 'Live-share link: the owner''s tblUserSetlists.SetlistId. (OwnerUserId, SourceSetlistId) resolves the CURRENT setlist at read time. NULL = snapshot-only (#1380).'
+                AFTER OwnerUserId"
+        );
+        _migSSLL_out("  [OK] Added tblSharedSetlists.SourceSetlistId.");
+    }
+
+    /* ELI5: add the (OwnerUserId, SourceSetlistId) lookup index only if missing.
+       WHY: setlist_get resolves the live row by this exact pair; the index keeps that
+       read cheap. Guarded by its key name so a re-run is a no-op under STRICT. */
+    if (_migSSLL_constraintExists($mysql, 'tblSharedSetlists', 'idx_LiveSource')) {
+        _migSSLL_out("  [SKIP] index idx_LiveSource already present.");
+    } else {
+        /* A KEY is not in TABLE_CONSTRAINTS — probe STATISTICS for the index name. */
+        $idxStmt = $mysql->prepare(
+            "SELECT 1 FROM INFORMATION_SCHEMA.STATISTICS
+              WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tblSharedSetlists'
+                AND INDEX_NAME = 'idx_LiveSource' LIMIT 1"
+        );
+        $idxStmt->execute();
+        $idxExists = $idxStmt->get_result()->fetch_row() !== null;
+        $idxStmt->close();
+        if ($idxExists) {
+            _migSSLL_out("  [SKIP] index idx_LiveSource already present.");
+        } else {
+            $mysql->query("ALTER TABLE tblSharedSetlists ADD KEY idx_LiveSource (OwnerUserId, SourceSetlistId)");
+            _migSSLL_out("  [OK] Added index idx_LiveSource.");
+        }
+    }
+
+    /* ELI5: add the FK to tblUsers only if the named constraint is missing.
+       WHY: ON DELETE SET NULL means deleting a user demotes their shares to snapshot-only
+       rather than vanishing them; ON UPDATE CASCADE keeps the link valid if a user id ever
+       moves. Guarded by constraint name so a re-run never trips ER_FK_DUP_NAME. */
+    if (_migSSLL_constraintExists($mysql, 'tblSharedSetlists', 'fk_SharedSetlists_OwnerUser')) {
+        _migSSLL_out("  [SKIP] FK fk_SharedSetlists_OwnerUser already present.");
+    } else {
+        $mysql->query(
+            "ALTER TABLE tblSharedSetlists
+                ADD CONSTRAINT fk_SharedSetlists_OwnerUser
+                    FOREIGN KEY (OwnerUserId) REFERENCES tblUsers(Id)
+                    ON DELETE SET NULL ON UPDATE CASCADE"
+        );
+        _migSSLL_out("  [OK] Added FK fk_SharedSetlists_OwnerUser.");
+    }
+
+    _migSSLL_out("Migration complete.");
+} catch (\mysqli_sql_exception $e) {
+    _migSSLL_out("ERROR: " . $e->getMessage());
+}

--- a/appWeb/.sql/schema.sql
+++ b/appWeb/.sql/schema.sql
@@ -1149,6 +1149,8 @@ CREATE TABLE IF NOT EXISTS tblUserSetlists (
 CREATE TABLE IF NOT EXISTS tblSharedSetlists (
     ShareId         VARCHAR(16)     NOT NULL PRIMARY KEY COMMENT '8 hex chars by default; column wider for forward-compat',
     Data            JSON            NOT NULL COMMENT 'Full setlist payload as written by the share API',
+    OwnerUserId     INT UNSIGNED    NULL DEFAULT NULL COMMENT 'Live-share link: FK to tblUsers.Id of the authenticated owner. NULL = legacy/anonymous snapshot-only share (#1380).',
+    SourceSetlistId VARCHAR(100)    NULL DEFAULT NULL COMMENT 'Live-share link: the owner''s tblUserSetlists.SetlistId. (OwnerUserId, SourceSetlistId) resolves the CURRENT setlist at read time. NULL = snapshot-only (#1380).',
     CreatedBy       INT UNSIGNED    NULL DEFAULT NULL COMMENT 'FK to tblUsers (NULL for guest creates)',
     CreatedAt       TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UpdatedAt       TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
@@ -1156,8 +1158,11 @@ CREATE TABLE IF NOT EXISTS tblSharedSetlists (
 
     INDEX idx_CreatedBy (CreatedBy),
     INDEX idx_CreatedAt (CreatedAt),
+    KEY idx_LiveSource (OwnerUserId, SourceSetlistId),
 
     CONSTRAINT fk_SharedSetlists_User FOREIGN KEY (CreatedBy) REFERENCES tblUsers(Id)
+        ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT fk_SharedSetlists_OwnerUser FOREIGN KEY (OwnerUserId) REFERENCES tblUsers(Id)
         ON DELETE SET NULL ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 

--- a/appWeb/public_html/api-docs.yaml
+++ b/appWeb/public_html/api-docs.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 
 info:
   title: iHymns API
-  version: "0.1302.0"
+  version: "0.1315.0"
   description: |
     The iHymns API provides programmatic access to the iHymns hymn and song
     database. It powers the iHymns Progressive Web App (PWA), enabling song

--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -1472,24 +1472,58 @@ if ($action !== null) {
 
             /* Sanitise inputs */
             $setlistName  = mb_substr(trim($body['name']), 0, 200);
-            /* #1343-B — resolve any PublicId in the song list to its SongId before
-               the existing allow-list regex (unchanged), so a non-web client that
-               built the setlist from opaque permalinks stores canonical SongIds.
-               LAZY (#1343-B review): getDbMysqli() is touched only for a
-               PublicId-shaped token, so SongId-only input (the web app) adds no DB
-               dependency here and a malformed request still 400s before any DB hit.
-               Gated/no-op pre-migration. */
+            /* #1343-B — resolve any PublicId in the song list to its SongId, so a
+               non-web client that built the setlist from opaque permalinks stores
+               canonical SongIds.
+               #1380 — KEEP draft ids: the legacy allow-list regex `^[A-Za-z]+-\d+$`
+               SILENTLY DROPPED any draft-id song (song-XXXX), so a shared setlist
+               that contained an unsaved draft lost it without warning. We now resolve
+               PublicIds and keep every token matching a SAFE charset; the downstream
+               live-link read path resolves the owner's CURRENT setlist anyway, so
+               freezing a filtered subset here was doubly wrong.
+               #1380 SECURITY (XSS) — but we must NOT swing to "keep everything": the
+               shared-page client renders the id verbatim into `data-song-id="…"` and
+               `href="/song/…"`, and its escapeHtml() (the textContent→innerHTML idiom)
+               does NOT escape a double-quote — so an id like `x" onmouseover="…` would
+               break out of the attribute (stored XSS). Re-introduce a SAFE charset
+               filter that STILL admits draft `song-XXXX` AND canonical `<Abbr>-NNNN`
+               but blocks quotes / brackets / spaces / any HTML metacharacter, plus a
+               length cap. A metachar-bearing token is never a real SongId, so dropping
+               it is correct — this is NOT the over-strict `\d+$` form we removed.
+               LAZY: getDbMysqli() is touched only for a PublicId-shaped token, so
+               SongId-only input (the web app) adds no DB dependency here. */
             $setlistSongs = array_values(array_filter(
                 array_map(static function ($s) {
-                    $s = trim($s);
+                    $s = trim((string)$s);
                     if (songPublicId_looksLikePublicId($s)) {
                         $s = songPublicId_resolveToSongId(getDbMysqli(), $s);
                     }
-                    return $s;
+                    /* Cap length BEFORE the charset match so a pathologically long id
+                       (a DoS / payload vector) can never reach the store. */
+                    $s = mb_substr($s, 0, 100);
+                    /* SAFE charset: letters, digits, underscore, hyphen only. Admits
+                       both draft (song-1a2b3c) and canonical (MP-988) ids; rejects
+                       every HTML metacharacter that could break an attribute. */
+                    return preg_match('/^[A-Za-z0-9_-]+$/', $s) === 1 ? $s : '';
                 }, $body['songs']),
-                fn($s) => preg_match('/^[A-Za-z]+-\d+$/', $s)
+                static fn($s) => $s !== ''
             ));
             $ownerId      = preg_replace('/[^a-f0-9\-]/', '', strtolower(trim($body['owner'])));
+
+            /* #1380 — LIVE-LINK resolution. A signed-in owner sharing one of their
+               server-stored setlists (tblUserSetlists) links the share to that LIVE
+               row so their later edits reach link-holders, instead of freezing a
+               snapshot. The anon localStorage UUID ($ownerId) is kept for back-compat
+               (it gates legacy snapshot updates) but is NOT the auth boundary — the
+               live link is gated on a real authenticated user owning the named
+               setlist (IDOR-safe; see the ownership probe below). */
+            $authUser   = getAuthenticatedUser();
+            $authUserId = $authUser ? (int)$authUser['Id'] : null;
+            $sourceSetlistId = isset($body['setlistId'])
+                ? preg_replace('/[^a-zA-Z0-9_\-]/', '', (string)$body['setlistId'])
+                : '';
+            $liveOwnerUserId  = null;   /* set only when ownership is proven */
+            $liveSourceSetlist = null;
 
             if ($setlistName === '' || $ownerId === '') {
                 sendJson(['error' => 'Invalid name or owner ID.'], 400);
@@ -1509,6 +1543,31 @@ if ($action !== null) {
 
             require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'SharedSetlist.php';
 
+            /* #1380 — IDOR-safe LIVE-LINK gate. Only attach the live link when a
+               REAL authenticated user PROVABLY owns the named setlist. The bound
+               existence probe against (UserId, SetlistId) is the authorisation
+               boundary — a forged `setlistId` for someone else's setlist simply
+               fails the probe and falls through to a harmless snapshot-only share
+               (NOT a 403, because anonymous sharing is a legitimate path). The anon
+               localStorage UUID is never trusted here. */
+            if ($authUserId !== null && $sourceSetlistId !== '') {
+                try {
+                    $ownStmt = getDbMysqli()->prepare(
+                        'SELECT 1 FROM tblUserSetlists WHERE UserId = ? AND SetlistId = ? LIMIT 1'
+                    );
+                    $ownStmt->bind_param('is', $authUserId, $sourceSetlistId);
+                    $ownStmt->execute();
+                    $ownsIt = $ownStmt->get_result()->fetch_row() !== null;
+                    $ownStmt->close();
+                    if ($ownsIt) {
+                        $liveOwnerUserId   = $authUserId;
+                        $liveSourceSetlist = $sourceSetlistId;
+                    }
+                } catch (\Throwable $_e) {
+                    /* Probe failure → fall through to snapshot-only; never elevate. */
+                }
+            }
+
             /* Determine ID: use existing if updating, generate new otherwise */
             $shareId  = null;
             $existing = null;
@@ -1520,9 +1579,27 @@ if ($action !== null) {
                         sendJson(['error' => 'Shared set list not found.'], 404);
                         break;
                     }
-                    if (($existing['owner'] ?? '') !== $ownerId) {
-                        sendJson(['error' => 'You do not own this shared set list.'], 403);
-                        break;
+                    /* #1380 — STRENGTHENED update IDOR. Two ownership models:
+                       (a) the row was created as a LIVE share (it carries an
+                           OwnerUserId) → the ONLY valid editor is that SAME
+                           authenticated user. A request that isn't signed in as the
+                           owner is rejected 403, regardless of the anon UUID it
+                           presents (the UUID is client-controlled and must not be
+                           able to seize a live, user-owned share).
+                       (b) the row is a LEGACY/anonymous snapshot (OwnerUserId NULL)
+                           → fall back to the historical anon-UUID check so existing
+                           snapshot shares keep updating from the same device. */
+                    $existingOwnerUserId = $existing['_ownerUserId'] ?? null;
+                    if ($existingOwnerUserId !== null) {
+                        if ($authUserId === null || $authUserId !== (int)$existingOwnerUserId) {
+                            sendJson(['error' => 'You do not own this shared set list.'], 403);
+                            break;
+                        }
+                    } else {
+                        if (($existing['owner'] ?? '') !== $ownerId) {
+                            sendJson(['error' => 'You do not own this shared set list.'], 403);
+                            break;
+                        }
                     }
                     $shareId = $candidateId;
                 }
@@ -1539,7 +1616,15 @@ if ($action !== null) {
                     if (songPublicId_looksLikePublicId($sid)) {
                         $sid = songPublicId_resolveToSongId(getDbMysqli(), $sid);
                     }
-                    if (!preg_match('/^[A-Za-z]+-\d+$/', $sid)) continue;
+                    /* #1380 — keep arrangements keyed on a draft id (song-XXXX) too
+                       (the old `^[A-Za-z]+-\d+$` regex silently dropped them, mirroring
+                       the song-list bug above), but apply the SAME XSS-safe charset +
+                       length guard as the song list: the arrangement KEY is also a song
+                       id and a metachar-bearing one would be a stored-XSS vector if any
+                       client ever rendered it into an attribute. */
+                    $sid = mb_substr(trim($sid), 0, 100);
+                    if ($sid === '') continue;
+                    if (preg_match('/^[A-Za-z0-9_-]+$/', $sid) !== 1) continue;
                     if (!is_array($arr)) continue;
                     $validArr = array_values(array_filter($arr, fn($v) => is_int($v) && $v >= 0));
                     if (count($validArr) > 0) {
@@ -1563,9 +1648,23 @@ if ($action !== null) {
                 $shareData['arrangements'] = $arrangements;
             }
 
+            /* #1380 — resolve the live-link columns to PERSIST on this write.
+               On UPDATE we must not silently DEMOTE an existing live share back to
+               snapshot-only just because the current request didn't (re)prove the
+               link — so we carry forward the existing OwnerUserId/SourceSetlistId
+               when the request didn't establish a (stronger, equal-owner) link. The
+               update-IDOR gate above already guaranteed that, for a live row, the
+               requester IS the owner, so carrying the link forward is safe. */
+            $persistOwnerUserId   = $liveOwnerUserId;
+            $persistSourceSetlist = $liveSourceSetlist;
+            if ($isUpdate && $persistOwnerUserId === null && ($existing['_ownerUserId'] ?? null) !== null) {
+                $persistOwnerUserId   = (int)$existing['_ownerUserId'];
+                $persistSourceSetlist = $existing['_sourceSetlistId'] ?? null;
+            }
+
             if ($isUpdate) {
                 $shareData['id'] = $shareId;
-                if (!sharedSetlistUpdate($shareId, $shareData)) {
+                if (!sharedSetlistUpdate($shareId, $shareData, $persistOwnerUserId, $persistSourceSetlist, $persistOwnerUserId)) {
                     sendJson(['error' => 'Failed to save shared set list.'], 500);
                     break;
                 }
@@ -1575,7 +1674,7 @@ if ($action !== null) {
                 for ($i = 0; $i < 10; $i++) {
                     $shareId         = bin2hex(random_bytes(4));
                     $shareData['id'] = $shareId;
-                    $result = sharedSetlistInsert($shareId, $shareData);
+                    $result = sharedSetlistInsert($shareId, $shareData, $persistOwnerUserId, $persistSourceSetlist, $persistOwnerUserId);
                     if ($result === true)  { $created = true;  break; }
                     if ($result === null)  { /* hard failure */ break; }
                     /* false = collision; try a new ID */
@@ -1619,23 +1718,51 @@ if ($action !== null) {
 
             require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'SharedSetlist.php';
 
-            $data = sharedSetlistGet($shareId);
-            if ($data === null) {
+            /* #1380 / FIX 5 — the live-vs-snapshot projection (and the XSS-safe id
+               allow-list) now lives in the ONE shared resolver so the social card
+               (og-image.php) and the page meta (index.php) stay live too and don't
+               re-fork it. The resolver does its own row read; we read the raw
+               snapshot ONCE more here ONLY for the wire metadata the resolver does
+               not project (id / created / updated) and to distinguish 404 (no such
+               share) from 410 (live link to a deleted setlist). Two PK lookups on a
+               16-char key is negligible and keeps the projection single-sourced. */
+            $db   = getDbMysqli();
+            $wire = sharedSetlistResolveWire($db, $shareId);
+            if ($wire === null) {
                 sendJson(['error' => 'Shared set list not found.'], 404);
                 break;
             }
+
+            if ($wire['unavailable']) {
+                /* The owner deleted the underlying setlist — the share is a live
+                   link to a row that no longer exists. 410 Gone is the honest
+                   answer: the resource was here, isn't now. */
+                sharedSetlistMarkViewed($shareId);
+                sendJson(['unavailable' => true, 'reason' => 'revoked', 'id' => $shareId], 410);
+                break;
+            }
+
+            /* Raw snapshot — id / created / updated only (the resolver projects
+               name/songs/arrangements/live). Private owner keys are never read here. */
+            $meta = sharedSetlistGet($shareId);
+
             sharedSetlistMarkViewed($shareId);
 
-            /* Return public-safe fields only (exclude owner UUID) */
+            /* PUBLIC-SAFE response — strict ALLOW-LIST. NEVER echo any of the
+               owner-identifying fields: owner (anon UUID), _ownerUserId,
+               _sourceSetlistId, CreatedBy, or any email. The only fields that
+               leave the server are: id, name, songs, live, created, updated, and
+               (optionally) arrangements. (#1380) */
             $response = [
-                'id'      => $data['id'] ?? $shareId,
-                'name'    => $data['name'] ?? 'Untitled',
-                'songs'   => $data['songs'] ?? [],
-                'created' => $data['created'] ?? null,
-                'updated' => $data['updated'] ?? null,
+                'id'      => $meta['id'] ?? $shareId,
+                'name'    => $wire['name'],
+                'songs'   => $wire['songs'],
+                'live'    => $wire['live'],
+                'created' => $meta['created'] ?? null,
+                'updated' => $meta['updated'] ?? null,
             ];
-            if (!empty($data['arrangements'])) {
-                $response['arrangements'] = $data['arrangements'];
+            if (!empty($wire['arrangements'])) {
+                $response['arrangements'] = $wire['arrangements'];
             }
 
             sendJson($response);

--- a/appWeb/public_html/includes/SharedSetlist.php
+++ b/appWeb/public_html/includes/SharedSetlist.php
@@ -21,13 +21,84 @@ require_once __DIR__ . DIRECTORY_SEPARATOR . 'config.php';
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'db_mysql.php';
 
 /**
+ * Column-existence probe for the #1380 live-link columns
+ * (tblSharedSetlists.OwnerUserId + SourceSetlistId).
+ *
+ * The two columns arrive via migrate-shared-setlist-live-link.php. Until that
+ * has run, every helper here MUST keep using the legacy 2-column shape — mysqli
+ * runs under MYSQLI_REPORT_ERROR|STRICT, so SELECTing / INSERTing a column that
+ * does not exist would THROW and break sharing entirely. The probe is
+ * static-cached for the request so the INFORMATION_SCHEMA round-trip happens at
+ * most once per request even when the share helpers run in a loop. Fail-open: on
+ * any probe error we report "absent" and the legacy path runs. (#1380)
+ */
+function _sharedSetlistLiveLinkColumns(): bool
+{
+    static $cached = null;
+    if ($cached !== null) return $cached;
+    try {
+        $db   = getDbMysqli();
+        /* Both columns must exist before we use either — a multi-object check,
+           never a partial one (matches the migration's OR-probe). Bound params
+           (rule #5), never string-interpolation. */
+        $stmt = $db->prepare(
+            "SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+              WHERE TABLE_SCHEMA = DATABASE()
+                AND TABLE_NAME   = 'tblSharedSetlists'
+                AND COLUMN_NAME IN ('OwnerUserId', 'SourceSetlistId')"
+        );
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_row();
+        $stmt->close();
+        $cached = ((int)($row[0] ?? 0) === 2);
+    } catch (\Throwable $_e) {
+        $cached = false; /* fail-open → legacy 2-column path */
+    }
+    return $cached;
+}
+
+/**
  * Load a shared setlist by ID. Returns the decoded payload array or
  * null if not found in either store.
+ *
+ * When the #1380 live-link columns are present, OwnerUserId / SourceSetlistId
+ * are returned under the PRIVATE keys `_ownerUserId` / `_sourceSetlistId`
+ * (leading underscore = "server-internal, never echoed to clients" — callers
+ * MUST strip these before building any response). These resolve the owner's
+ * CURRENT live setlist at read time.
  */
 function sharedSetlistGet(string $shareId): ?array
 {
     try {
-        $db   = getDbMysqli();
+        $db = getDbMysqli();
+
+        /* Live-link columns selected only when present, so a pre-migration
+           install keeps working with the legacy 2-column read. */
+        if (_sharedSetlistLiveLinkColumns()) {
+            $stmt = $db->prepare(
+                'SELECT Data, OwnerUserId, SourceSetlistId FROM tblSharedSetlists WHERE ShareId = ?'
+            );
+            $stmt->bind_param('s', $shareId);
+            $stmt->execute();
+            $row = $stmt->get_result()->fetch_assoc();
+            $stmt->close();
+            $raw = (string)($row['Data'] ?? '');
+            if ($raw !== '') {
+                $decoded = json_decode($raw, true);
+                if (is_array($decoded)) {
+                    /* PRIVATE keys (leading underscore) — owner identity is
+                       NEVER part of the public wire shape; setlist_get strips
+                       them when building its allow-listed response. */
+                    $decoded['_ownerUserId']     = isset($row['OwnerUserId']) && $row['OwnerUserId'] !== null
+                        ? (int)$row['OwnerUserId'] : null;
+                    $decoded['_sourceSetlistId'] = isset($row['SourceSetlistId']) && $row['SourceSetlistId'] !== null
+                        ? (string)$row['SourceSetlistId'] : null;
+                    return $decoded;
+                }
+            }
+            return null;
+        }
+
         $stmt = $db->prepare('SELECT Data FROM tblSharedSetlists WHERE ShareId = ?');
         $stmt->bind_param('s', $shareId);
         $stmt->execute();
@@ -48,9 +119,20 @@ function sharedSetlistGet(string $shareId): ?array
  * Atomically insert a new shared setlist. Returns true on success,
  * false on a duplicate-ID collision so the caller can retry with a
  * fresh ID, or null on a hard failure (caller should surface a 500).
+ *
+ * The optional $ownerUserId / $sourceSetlistId persist the #1380 live-link
+ * (the share resolves the owner's CURRENT setlist at read time); $createdBy
+ * fills the long-unused CreatedBy audit column. All three are written only
+ * when the live-link columns exist — a pre-migration install falls open to the
+ * legacy 2-column INSERT so sharing never breaks on a partly-migrated deploy.
  */
-function sharedSetlistInsert(string $shareId, array $data): ?bool
-{
+function sharedSetlistInsert(
+    string $shareId,
+    array $data,
+    ?int $ownerUserId = null,
+    ?string $sourceSetlistId = null,
+    ?int $createdBy = null
+): ?bool {
     $json = json_encode($data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
 
     /* MySQL atomic insert — duplicate-key collision is the signal so
@@ -58,9 +140,20 @@ function sharedSetlistInsert(string $shareId, array $data): ?bool
        23000 (string); mysqli_sql_exception::getCode() returns the
        MySQL error number 1062 (ER_DUP_ENTRY) for the same condition. */
     try {
-        $db   = getDbMysqli();
-        $stmt = $db->prepare('INSERT INTO tblSharedSetlists (ShareId, Data) VALUES (?, ?)');
-        $stmt->bind_param('ss', $shareId, $json);
+        $db = getDbMysqli();
+        if (_sharedSetlistLiveLinkColumns()) {
+            $stmt = $db->prepare(
+                'INSERT INTO tblSharedSetlists (ShareId, Data, OwnerUserId, SourceSetlistId, CreatedBy)
+                 VALUES (?, ?, ?, ?, ?)'
+            );
+            /* Types: ShareId=s, Data=s, OwnerUserId=i, SourceSetlistId=s, CreatedBy=i.
+               mysqli sends SQL NULL when a bound PHP null is paired with any type, so
+               an anonymous/legacy share (all three null) writes clean NULLs. */
+            $stmt->bind_param('ssisi', $shareId, $json, $ownerUserId, $sourceSetlistId, $createdBy);
+        } else {
+            $stmt = $db->prepare('INSERT INTO tblSharedSetlists (ShareId, Data) VALUES (?, ?)');
+            $stmt->bind_param('ss', $shareId, $json);
+        }
         $stmt->execute();
         $stmt->close();
         return true;
@@ -76,13 +169,48 @@ function sharedSetlistInsert(string $shareId, array $data): ?bool
  * Update an existing shared setlist. If no row matches (e.g. a legacy
  * file-only share that migrate-users.php hasn't imported yet) we INSERT it,
  * promoting it into MySQL. Returns true on success, false on DB failure.
+ *
+ * The optional #1380 live-link args mirror sharedSetlistInsert(): they are
+ * written only when the live-link columns exist (else the legacy 2-column path
+ * runs). On the UPDATE branch the live-link columns are refreshed too, so
+ * re-sharing a setlist that gained an owner since its first share upgrades it
+ * from snapshot-only to live without a separate code path.
  */
-function sharedSetlistUpdate(string $shareId, array $data): bool
-{
+function sharedSetlistUpdate(
+    string $shareId,
+    array $data,
+    ?int $ownerUserId = null,
+    ?string $sourceSetlistId = null,
+    ?int $createdBy = null
+): bool {
     $json = json_encode($data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
 
     try {
-        $db   = getDbMysqli();
+        $db = getDbMysqli();
+
+        if (_sharedSetlistLiveLinkColumns()) {
+            $stmt = $db->prepare(
+                'UPDATE tblSharedSetlists
+                    SET Data = ?, OwnerUserId = ?, SourceSetlistId = ?, CreatedBy = ?, UpdatedAt = NOW()
+                  WHERE ShareId = ?'
+            );
+            /* Types: Data=s, OwnerUserId=i, SourceSetlistId=s, CreatedBy=i, ShareId=s. */
+            $stmt->bind_param('sisis', $json, $ownerUserId, $sourceSetlistId, $createdBy, $shareId);
+            $stmt->execute();
+            $affected = $stmt->affected_rows;
+            $stmt->close();
+            if ($affected > 0) return true;
+            /* No row matched — promote into MySQL on first edit (with live link). */
+            $stmt = $db->prepare(
+                'INSERT INTO tblSharedSetlists (ShareId, Data, OwnerUserId, SourceSetlistId, CreatedBy)
+                 VALUES (?, ?, ?, ?, ?)'
+            );
+            $stmt->bind_param('ssisi', $shareId, $json, $ownerUserId, $sourceSetlistId, $createdBy);
+            $stmt->execute();
+            $stmt->close();
+            return true;
+        }
+
         $stmt = $db->prepare('UPDATE tblSharedSetlists SET Data = ?, UpdatedAt = NOW() WHERE ShareId = ?');
         $stmt->bind_param('ss', $json, $shareId);
         $stmt->execute();
@@ -98,6 +226,151 @@ function sharedSetlistUpdate(string $shareId, array $data): bool
     } catch (\Throwable $_e) {
         /* WS-J: no disk fallback — a DB failure is a clean false. */
         return false;
+    }
+}
+
+/**
+ * XSS-safe song-id allow-list (#1380).
+ *
+ * The shared-setlist song ids are stored with NO charset validation at the
+ * write boundary for setlists synced via user_setlists_sync (the editor /
+ * other clients write tblUserSetlists.SongsJson directly), and the public
+ * shared-page client renders each id verbatim into `data-song-id="…"` and
+ * `href="/song/…"`. Its escapeHtml() (the textContent→innerHTML idiom) does
+ * NOT escape a double-quote, so an id carrying a quote could break out of the
+ * attribute (stored XSS). This helper is the single, shared id allow-list:
+ *   - caps length (a long id is never real, and is a DoS / payload vector);
+ *   - admits draft (`song-1a2b3c`) AND canonical (`<Abbr>-NNNN`) ids;
+ *   - rejects every HTML metacharacter (quotes, brackets, spaces).
+ * Returns the trimmed id when safe, or '' when it must be dropped. A
+ * metachar-bearing token is never a real SongId, so dropping it is correct —
+ * this is NOT the over-strict `\d+$` form #1380 removed.
+ */
+function sharedSetlistSafeSongId(string $id): string
+{
+    /* Code-point-safe length cap, then the SAFE charset match. */
+    $id = function_exists('mb_substr') ? mb_substr(trim($id), 0, 100) : substr(trim($id), 0, 100);
+    return preg_match('/^[A-Za-z0-9_-]+$/', $id) === 1 ? $id : '';
+}
+
+/**
+ * Resolve a shared setlist to its PUBLIC WIRE shape — the single source of the
+ * live-vs-snapshot projection (#1380).
+ *
+ * Before this helper, three call sites each computed name/songs independently:
+ *   - api.php setlist_get   (live-aware: read the owner's CURRENT setlist);
+ *   - og-image.php          (snapshot-only: stale name/count on a live share);
+ *   - index.php OG/meta      (snapshot-only: same staleness).
+ * Extracting the projection here (modularity rule) makes the social-card image
+ * and the page meta tags LIVE too, and de-dupes the id allow-list (FIX 1).
+ *
+ * Returns:
+ *   ['name' => string, 'songs' => string[] (id strings), 'arrangements' => array,
+ *    'live' => bool, 'unavailable' => bool]
+ * or null when the share id is not found at all (caller → 404).
+ *
+ * PUBLIC-SAFE: the return NEVER carries _ownerUserId / _sourceSetlistId / owner /
+ * CreatedBy / any email — those private keys are read internally here and dropped.
+ *
+ * `unavailable` is true ONLY when the share is a LIVE link whose underlying
+ * tblUserSetlists row the owner has since deleted (the honest "no longer shared"
+ * state → 410 for the JSON API; an empty card for OG/meta). A live-read FAILURE
+ * (DB blip) is NOT unavailable — it degrades to the frozen snapshot (fail-safe).
+ */
+function sharedSetlistResolveWire(\mysqli $db, string $shareId): ?array
+{
+    $data = sharedSetlistGet($shareId);
+    if ($data === null) {
+        return null;
+    }
+
+    /* Private keys returned by sharedSetlistGet() when the live-link columns
+       exist — read internally, never echoed. */
+    $ownerUserId     = $data['_ownerUserId'] ?? null;
+    $sourceSetlistId = $data['_sourceSetlistId'] ?? null;
+
+    /* Default to the frozen SNAPSHOT, with the FIX-1 id guard applied so even a
+       legacy snapshot (written before the guard existed) can't carry an
+       attribute-breaking id into a renderer. */
+    $snapshotSongs = [];
+    foreach (($data['songs'] ?? []) as $sid) {
+        $safe = sharedSetlistSafeSongId((string)$sid);
+        if ($safe !== '') { $snapshotSongs[] = $safe; }
+    }
+    $snapshotArrangements = [];
+    foreach (($data['arrangements'] ?? []) as $sid => $arr) {
+        $safe = sharedSetlistSafeSongId((string)$sid);
+        if ($safe !== '' && is_array($arr)) { $snapshotArrangements[$safe] = $arr; }
+    }
+
+    $result = [
+        'name'         => (string)($data['name'] ?? 'Untitled'),
+        'songs'        => $snapshotSongs,
+        'arrangements' => $snapshotArrangements,
+        'live'         => false,
+        'unavailable'  => false,
+    ];
+
+    /* No live link → snapshot is the answer. */
+    if ($ownerUserId === null || $sourceSetlistId === null || $sourceSetlistId === '') {
+        return $result;
+    }
+
+    /* LIVE resolution — serve the owner's CURRENT setlist from tblUserSetlists so
+       their later edits reach link-holders. A missing row = revoked (unavailable);
+       any other failure degrades to the snapshot above (fail-safe). */
+    try {
+        $liveStmt = $db->prepare(
+            'SELECT Name, SongsJson FROM tblUserSetlists WHERE UserId = ? AND SetlistId = ? LIMIT 1'
+        );
+        $ownerUserIdInt    = (int)$ownerUserId;
+        $sourceSetlistIdSt = (string)$sourceSetlistId;
+        $liveStmt->bind_param('is', $ownerUserIdInt, $sourceSetlistIdSt);
+        $liveStmt->execute();
+        $liveRow = $liveStmt->get_result()->fetch_assoc();
+        $liveStmt->close();
+
+        if ($liveRow === null) {
+            /* Owner deleted the underlying setlist — the live link points at a
+               row that no longer exists. Honest "no longer shared". */
+            $result['unavailable'] = true;
+            return $result;
+        }
+
+        /* Project the SongsJson OBJECT array
+           ([{id,title,songbook,number,arrangement?}, …]) to the wire shape:
+           an array of SongId STRINGS plus an arrangements map. Apply the FIX-1
+           id guard to each id (user_setlists_sync stores ids with no charset
+           validation, so this is the defense-in-depth boundary). */
+        $liveDecoded = json_decode((string)$liveRow['SongsJson'], true);
+        $liveSongs        = [];
+        $liveArrangements = [];
+        if (is_array($liveDecoded)) {
+            foreach ($liveDecoded as $s) {
+                if (!is_array($s) || !isset($s['id'])) { continue; }
+                $sid = sharedSetlistSafeSongId((string)$s['id']);
+                if ($sid === '') { continue; }
+                $liveSongs[] = $sid;
+                if (isset($s['arrangement']) && is_array($s['arrangement'])) {
+                    $arr = array_values(array_filter(
+                        $s['arrangement'],
+                        static fn($v) => is_int($v) && $v >= 0
+                    ));
+                    if (count($arr) > 0) { $liveArrangements[$sid] = $arr; }
+                }
+            }
+        }
+
+        $result['name']         = (string)$liveRow['Name'];
+        $result['songs']        = $liveSongs;
+        $result['arrangements'] = $liveArrangements;
+        $result['live']         = true;
+        return $result;
+    } catch (\Throwable $_e) {
+        /* Live read failed — degrade to the frozen snapshot rather than erroring
+           (fail-safe). Logged so a systemic outage leaves a trail. */
+        error_log('[sharedSetlistResolveWire] live resolution failed: ' . $_e->getMessage());
+        return $result;
     }
 }
 

--- a/appWeb/public_html/includes/infoAppVer.php
+++ b/appWeb/public_html/includes/infoAppVer.php
@@ -79,7 +79,7 @@ $app["Application"]["Description"]["Keywords"] = "hymns, worship, lyrics, songbo
 /* Semantic version number (MAJOR.MINOR.PATCH) */
 /* Auto-bumped by the version-bump GitHub Action on push to beta */
 /* v1.x.x = Phase 1 (local JSON data), v2.x.x = Phase 2 (iLyrics dB) */
-$app["Application"]["Version"]["Number"] = "0.1302.0";
+$app["Application"]["Version"]["Number"] = "0.1315.0";
 
 /* Version name: human-readable release name (e.g., "Hymnal", NULL if unused) */
 $app["Application"]["Version"]["Name"] = NULL;

--- a/appWeb/public_html/includes/pages/setlist-shared.php
+++ b/appWeb/public_html/includes/pages/setlist-shared.php
@@ -41,6 +41,21 @@ declare(strict_types=1);
         </a>
     </div>
 
+    <!-- Unavailable state (#1380) — a LIVE-linked share whose underlying set list
+         the owner has since deleted (server returns 410). Distinct from the
+         "broken link" error above so a revoked share reads as intentional. -->
+    <div id="shared-setlist-unavailable" class="d-none">
+        <div class="alert alert-secondary" role="alert">
+            <i class="fa-solid fa-circle-info me-2" aria-hidden="true"></i>
+            <strong>No longer shared</strong> — This set list is no longer shared or available.
+            The person who shared it may have removed it.
+        </div>
+        <a href="/setlist" class="btn btn-outline-primary btn-sm" data-navigate="setlist">
+            <i class="fa-solid fa-arrow-left me-1" aria-hidden="true"></i>
+            Go to My Set Lists
+        </a>
+    </div>
+
     <!-- Shared set list content (hidden by default, populated by JS) -->
     <div id="shared-setlist-content" class="d-none">
 
@@ -50,6 +65,13 @@ declare(strict_types=1);
             <div>
                 <strong>Shared Set List</strong>
                 <small class="d-block">Someone shared this set list with you. Import it to use it.</small>
+                <!-- Live-link note (#1380) — shown by JS only when the share resolves
+                     the owner's CURRENT set list (data.live === true), so edits the
+                     owner makes flow through to this view. -->
+                <small id="shared-setlist-live-note" class="d-none d-block text-info-emphasis mt-1">
+                    <i class="fa-solid fa-rotate me-1" aria-hidden="true"></i>
+                    This set list updates live — you&rsquo;ll always see the latest version.
+                </small>
             </div>
         </div>
 

--- a/appWeb/public_html/index.php
+++ b/appWeb/public_html/index.php
@@ -570,8 +570,13 @@ try {
         $pageType = 'other';
         $shareId = $matches[1];
         require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'SharedSetlist.php';
-        $shareData = sharedSetlistGet($shareId);
-        if (is_array($shareData)) {
+        /* #1380 / FIX 5 — resolve through the SHARED live-vs-snapshot resolver so the
+           OG/meta tags reflect the owner's CURRENT setlist (name + count) on a live
+           share, not the frozen snapshot. `unavailable` (a live link the owner has
+           since deleted) and null (no such share) both leave the static defaults in
+           place — there's no live preview to advertise for a no-longer-shared link. */
+        $shareData = sharedSetlistResolveWire(getDbMysqli(), $shareId);
+        if (is_array($shareData) && empty($shareData['unavailable'])) {
             $setlistName = $shareData['name'] ?? 'Shared Set List';
             $setlistSongCount = count($shareData['songs'] ?? []);
             $ogTitle = htmlspecialchars($setlistName) . ' — Shared Set List — ' . $app["Application"]["Name"];

--- a/appWeb/public_html/js/modules/setlist.js
+++ b/appWeb/public_html/js/modules/setlist.js
@@ -1325,6 +1325,12 @@ export class SetList {
             name: list.name,
             songs: list.songs.map(s => s.id),
             owner: this.getOwnerId(),
+            /* #1380 — the LOCAL setlist id doubles as the server-side
+               tblUserSetlists.SetlistId (same id is used by the sync API). Sending
+               it lets the server LIVE-LINK the share to the owner's stored setlist
+               (gated server-side on the authenticated user owning that row), so the
+               owner's later edits reach link-holders instead of freezing a snapshot. */
+            setlistId: listId,
         };
 
         /* Include arrangements map only if any songs have custom arrangements */
@@ -1343,6 +1349,10 @@ export class SetList {
                 headers: {
                     'Content-Type': 'application/json',
                     'X-Requested-With': 'XMLHttpRequest',
+                    /* #1380 — include the bearer token when signed in so the server
+                       can identify the owner and establish the live link. Anonymous
+                       users (no token) still share fine — just snapshot-only. */
+                    ...(this.app?.userAuth?.authHeaders?.() || {}),
                 },
                 body: JSON.stringify(payload),
             });
@@ -1385,6 +1395,15 @@ export class SetList {
 
         /* Show a brief loading indicator */
         this.app.showToast('Creating share link...', 'info', 1500);
+
+        /* #1380 — when signed in, push the current setlists to the server FIRST so
+           the (UserId, SetlistId) row exists when the share API tries to live-link
+           to it. The _scheduleSync debounce (1.5 s) might not have fired yet, so a
+           freshly-created or freshly-edited setlist could otherwise be shared as a
+           snapshot. Best-effort: a sync failure just falls back to snapshot-only. */
+        if (this.app?.userAuth?.isLoggedIn?.()) {
+            try { await this.app.userAuth.syncSetlists(this.getAll(), 'replace'); } catch (_e) {}
+        }
 
         const shareUrl = await this.generateShareLink(listId);
         if (!shareUrl) {
@@ -1465,6 +1484,14 @@ export class SetList {
                 headers: { 'X-Requested-With': 'XMLHttpRequest' },
             });
 
+            /* #1380 — 410 Gone: the share was a LIVE link to a setlist the owner
+               has since deleted (revoked). Signal that distinctly so the page shows
+               a friendly "no longer shared" state instead of the generic "broken
+               link" error (which a null return triggers). */
+            if (response.status === 410) {
+                return { unavailable: true };
+            }
+
             if (!response.ok) return null;
 
             const data = await response.json();
@@ -1474,6 +1501,9 @@ export class SetList {
                 name: data.name,
                 songIds: data.songs,
                 arrangements: data.arrangements || {},
+                /* #1380 — true when the server resolved the owner's CURRENT setlist
+                   (a live link); the page can note "updates live" to the viewer. */
+                live: data.live === true,
             };
         } catch {
             return null;
@@ -1542,6 +1572,9 @@ export class SetList {
         const loadingEl = document.getElementById('shared-setlist-loading');
         const errorEl = document.getElementById('shared-setlist-error');
         const contentEl = document.getElementById('shared-setlist-content');
+        /* #1380 — distinct "no longer shared" state (a revoked LIVE link), so a
+           deleted-by-owner share reads as intentional, not as a broken link. */
+        const unavailableEl = document.getElementById('shared-setlist-unavailable');
 
         if (!loadingEl || !errorEl || !contentEl) return;
 
@@ -1559,6 +1592,22 @@ export class SetList {
             sharedData = this.parseLegacySharedSetlist(shareData);
         }
 
+        /* #1380 — three outcomes:
+           (a) unavailable → the live link's underlying setlist was deleted (410):
+               show the friendly "no longer shared" block (if the page provides it),
+               else fall back to the generic error.
+           (b) null → genuinely broken / malformed link: the existing error block.
+           (c) data → render. */
+        if (sharedData && sharedData.unavailable) {
+            loadingEl.classList.add('d-none');
+            if (unavailableEl) {
+                unavailableEl.classList.remove('d-none');
+            } else {
+                errorEl.classList.remove('d-none');
+            }
+            return;
+        }
+
         if (!sharedData) {
             loadingEl.classList.add('d-none');
             errorEl.classList.remove('d-none');
@@ -1569,6 +1618,12 @@ export class SetList {
         const titleEl = document.getElementById('shared-setlist-title');
         const countEl = document.getElementById('shared-setlist-count');
         const pluralEl = document.getElementById('shared-setlist-plural');
+        /* #1380 — optional "this set list updates live" note when the share is a
+           live link (the owner's edits flow through). */
+        const liveNoteEl = document.getElementById('shared-setlist-live-note');
+        if (liveNoteEl) {
+            liveNoteEl.classList.toggle('d-none', !sharedData.live);
+        }
 
         if (titleEl) titleEl.textContent = sharedData.name;
         if (countEl) countEl.textContent = sharedData.songIds.length;

--- a/appWeb/public_html/manage/editor/editor.js
+++ b/appWeb/public_html/manage/editor/editor.js
@@ -4903,7 +4903,47 @@ function autoSaveSongsPerSong(ids) {
             }).then(function (res) {
                 return res.json().then(function (data) {
                     if (res.ok && data.ok) {
-                        saved.push(id);
+                        /* #1380 — the server may have promoted a client draft id
+                           (song-XXXX) to a canonical <Abbr>-NNNN id on this first
+                           save. Relabel the in-memory copy so subsequent saves /
+                           navigation use the real id and the sidebar shows it,
+                           WITHOUT a full reload. assignedId/previousId are present
+                           only when a rename happened. */
+                        if (data.assignedId && data.previousId) {
+                            var renamed = (songData.songs || []).find(function (s) {
+                                return s.id === data.previousId;
+                            });
+                            if (renamed) { renamed.id = data.assignedId; }
+                            if (currentSongId === data.previousId) {
+                                currentSongId = data.assignedId;
+                            }
+                            /* #1380 FIX 2 — re-key the two OTHER module-scope refs that
+                               still point at the now-dead draft id, or they silently rot:
+                               (a) modifiedSongIds — if the draft id is still in the dirty
+                                   set, delete it and add the canonical id. Otherwise the
+                                   draft id is NEVER cleared (the save loop only deletes
+                                   ids it was asked to save), so the song shows a stuck
+                                   "modified" badge AND every later autosave that looks up
+                                   the draft id finds nothing → falls back to a full-corpus
+                                   save. */
+                            if (modifiedSongIds.has(data.previousId)) {
+                                modifiedSongIds.delete(data.previousId);
+                                modifiedSongIds.add(data.assignedId);
+                            }
+                            /* (b) _renderedSongId — the id serialiseSongForSave /
+                               syncSongExternalLinksFromDom resolve against. If the
+                               just-renamed song is the one on screen and this still
+                               holds the draft id, a subsequent external-link DOM edit
+                               would mismatch and be dropped. Re-point it at the
+                               canonical id. */
+                            if (_renderedSongId === data.previousId) {
+                                _renderedSongId = data.assignedId;
+                            }
+                            renderSongList();
+                            saved.push(data.assignedId);
+                        } else {
+                            saved.push(id);
+                        }
                     } else {
                         /* Compose a maximally-useful error string. The
                            API ships error_detail (and optionally
@@ -5257,7 +5297,10 @@ function addNewSong() {
        different draft) and producing the ugly ids the owner spotted
        (song-1780869822259-d). base36 timestamp (~8 chars) + 4 random fits with
        room; the 'song-' prefix is preserved (it's how unsaved drafts are
-       detected). [Tracked: server should assign a canonical SongId on first save.] */
+       detected). #1380 — the server NOW assigns a canonical <Abbr>-NNNN SongId on
+       the first save (save_song_core.php) and returns assignedId/previousId;
+       autoSaveSongsPerSong() relabels this in-memory draft to the canonical id
+       on success, so the ugly 'song-XXXX' id is transient (one save) not permanent. */
     var newId = ('song-' + Date.now().toString(36) + Math.random().toString(36).slice(2, 6)).slice(0, 20);
 
     /* Build the blank song object with all required fields. The

--- a/appWeb/public_html/manage/editor/save_song_core.php
+++ b/appWeb/public_html/manage/editor/save_song_core.php
@@ -271,9 +271,52 @@ function editorSaveSongCore(): array
         $componentCount = is_array($song['components'] ?? null) ? count($song['components']) : 0;
         $arrangementJson = _sanitiseArrangement($song['arrangement'] ?? null, $componentCount);
 
+        /* #1380 — canonical SongId assignment for DRAFT ids. The editor mints a
+           client-side draft id ("song-" + base36 ts + random) when a curator hits
+           "New Song" (editor.js addNewSong) and the save UPSERTs it verbatim — so a
+           saved song could keep an ugly, non-canonical `song-XXXX` id forever. Mint
+           the proper `<Abbr>-NNNN` id on the FIRST save instead, BEFORE any INSERT,
+           and tell the client to relabel its in-memory copy (assignedId/previousId
+           in the response). A non-draft id (an existing real SongId) is untouched. */
+        $previousId = $songId;                                   /* the id the client sent */
+        $assignedId = null;                                      /* set only when we rename */
+        $isDraftId  = (strncmp($songId, 'song-', 5) === 0);
+
         try {
             $db = getDbMysqli();
             $db->begin_transaction();
+
+            if ($isDraftId) {
+                /* Reuse the bulk-import next-number helper so the editor and the
+                   importer agree on how a songbook's next slot is chosen. The
+                   collision-safe loop walks past any id already taken (the UNIQUE
+                   PK on tblSongs.SongId is the final backstop). $songbookAbbr is
+                   already coerced to 'Misc' when blank, so we always have a book. */
+                require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'song_importers.php';
+                $n        = _bulkImport_nextSongNumberFor($db, $songbookAbbr);
+                $existsStmt = $db->prepare('SELECT 1 FROM tblSongs WHERE SongId = ? LIMIT 1');
+                $candidate  = sprintf('%s-%04d', $songbookAbbr, $n);
+                $existsStmt->bind_param('s', $candidate);
+                $existsStmt->execute();
+                while ($existsStmt->get_result()->fetch_row() !== null) {
+                    $n++;
+                    $candidate = sprintf('%s-%04d', $songbookAbbr, $n);
+                    $existsStmt->bind_param('s', $candidate);
+                    $existsStmt->execute();
+                }
+                $existsStmt->close();
+
+                $songId     = $candidate;        /* canonical id used by ALL inserts below */
+                $assignedId = $candidate;        /* signal the rename to the client */
+
+                /* An official songbook numbers its songs; if the curator hadn't set
+                   a Number yet, adopt the slot we just chose so the number and the id
+                   tail agree. Unofficial / Misc books leave Number NULL (the id is the
+                   cross-record link there — #392). */
+                if ($isOfficialSongbook && $number === null) {
+                    $number = $n;
+                }
+            }
 
             /* Capture previous state for the revision row (#400) */
             $previousData = null;
@@ -305,17 +348,23 @@ function editorSaveSongCore(): array
                 $arrProbe->close();
             } catch (\Throwable $_e) { /* default false */ }
 
-            /* UPSERT tblSongs — now carries TuneName + Iswc (#497) and
-               ArrangementJson (#892) when the column exists. */
-            if ($hasArrangementCol) {
-                $upsert = $db->prepare(
-                    'INSERT INTO tblSongs
-                        (SongId, Number, Title, SongbookAbbr, Language,
-                         Copyright, TuneName, Ccli, Iswc, Verified, LyricsPublicDomain,
-                         MusicPublicDomain, HasAudio, HasSheetMusic, LyricsText,
-                         ArrangementJson)
-                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                     ON DUPLICATE KEY UPDATE
+            /* #1380 FIX 3 — TOCTOU-safe write for a FRESHLY-MINTED canonical id.
+               The mint loop above checks "is this id free?" then we INSERT — a
+               read-then-write window. Two concurrent FIRST saves in one songbook can
+               BOTH pass the existence check before either writes, then both reach the
+               shared UPSERT — and `ON DUPLICATE KEY UPDATE` would SILENTLY OVERWRITE
+               the first song's row with the second's (data loss, no error). So when we
+               just minted a canonical id ($assignedId !== null — always a brand-new
+               CREATE, $prevRow is null), use a PLAIN INSERT with NO ON DUPLICATE KEY
+               UPDATE clause: a colliding PK throws ER_DUP_ENTRY (1062), which the
+               surrounding catch turns into a clean rollback → 500 the client retries
+               (the editor's per-song save loop re-mints a fresh slot on retry).
+               A GENUINE update (or a non-draft create) keeps the existing UPSERT — a
+               re-save of an existing real SongId MUST update it, not error. The
+               ON DUPLICATE KEY UPDATE tail is therefore appended only when NOT minting. */
+            $upsertDuplicateClause = $assignedId !== null
+                ? ''
+                : ' ON DUPLICATE KEY UPDATE
                         Number = VALUES(Number), Title = VALUES(Title),
                         SongbookAbbr = VALUES(SongbookAbbr),
                         Language = VALUES(Language), Copyright = VALUES(Copyright),
@@ -325,8 +374,26 @@ function editorSaveSongCore(): array
                         LyricsPublicDomain = VALUES(LyricsPublicDomain),
                         MusicPublicDomain = VALUES(MusicPublicDomain),
                         HasAudio = VALUES(HasAudio), HasSheetMusic = VALUES(HasSheetMusic),
-                        LyricsText = VALUES(LyricsText),
-                        ArrangementJson = VALUES(ArrangementJson)'
+                        LyricsText = VALUES(LyricsText)';
+
+            /* UPSERT tblSongs — now carries TuneName + Iswc (#497) and
+               ArrangementJson (#892) when the column exists. The duplicate-key tail
+               is conditional per the FIX-3 minted-create rule above. */
+            if ($hasArrangementCol) {
+                /* The ArrangementJson column adds one more VALUES()-updated field to
+                   the (non-minting) UPDATE tail. */
+                $arrUpdateTail = $upsertDuplicateClause === ''
+                    ? ''
+                    : $upsertDuplicateClause . ',
+                        ArrangementJson = VALUES(ArrangementJson)';
+                $upsert = $db->prepare(
+                    'INSERT INTO tblSongs
+                        (SongId, Number, Title, SongbookAbbr, Language,
+                         Copyright, TuneName, Ccli, Iswc, Verified, LyricsPublicDomain,
+                         MusicPublicDomain, HasAudio, HasSheetMusic, LyricsText,
+                         ArrangementJson)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+                     . $arrUpdateTail
                 );
                 /* SongbookName denorm column dropped (WS-E #1013 ph2) —
                    16 cols / 16 placeholders / 16 bind types. */
@@ -343,18 +410,8 @@ function editorSaveSongCore(): array
                         (SongId, Number, Title, SongbookAbbr, Language,
                          Copyright, TuneName, Ccli, Iswc, Verified, LyricsPublicDomain,
                          MusicPublicDomain, HasAudio, HasSheetMusic, LyricsText)
-                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                     ON DUPLICATE KEY UPDATE
-                        Number = VALUES(Number), Title = VALUES(Title),
-                        SongbookAbbr = VALUES(SongbookAbbr),
-                        Language = VALUES(Language), Copyright = VALUES(Copyright),
-                        TuneName = VALUES(TuneName),
-                        Ccli = VALUES(Ccli), Iswc = VALUES(Iswc),
-                        Verified = VALUES(Verified),
-                        LyricsPublicDomain = VALUES(LyricsPublicDomain),
-                        MusicPublicDomain = VALUES(MusicPublicDomain),
-                        HasAudio = VALUES(HasAudio), HasSheetMusic = VALUES(HasSheetMusic),
-                        LyricsText = VALUES(LyricsText)'
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+                     . $upsertDuplicateClause
                 );
                 /* SongbookName denorm column dropped (WS-E #1013 ph2) —
                    15 cols / 15 placeholders / 15 bind types. */
@@ -1124,8 +1181,18 @@ function editorSaveSongCore(): array
                file cache + its regeneration hooks were removed. */
 
             /* $action is 'create' or 'edit' here (reassigned in the txn) — preserve
-               the EXACT legacy wire response, which emitted that, not 'save_song'. */
-            return ['status' => 200, 'body' => ['ok' => true, 'songId' => $songId, 'action' => $action]];
+               the EXACT legacy wire response, which emitted that, not 'save_song'.
+               #1380 — when a draft id was promoted to a canonical id, also return
+               assignedId (the new canonical id) + previousId (the draft id the
+               client sent) so editor.js can relabel its in-memory song without a
+               reload. Both are OMITTED on a normal save (non-draft id), so the wire
+               shape is byte-identical to today for the common case. */
+            $respBody = ['ok' => true, 'songId' => $songId, 'action' => $action];
+            if ($assignedId !== null) {
+                $respBody['assignedId'] = $assignedId;
+                $respBody['previousId'] = $previousId;
+            }
+            return ['status' => 200, 'body' => $respBody];
         } catch (\Throwable $e) {
             if (isset($db) && $db instanceof mysqli) {
                 try { $db->rollback(); } catch (\Throwable $_) {}

--- a/appWeb/public_html/manage/includes/migration-registry.php
+++ b/appWeb/public_html/manage/includes/migration-registry.php
@@ -2382,4 +2382,72 @@ return [
         ],
         'probe' => static fn(\mysqli $db) => !_migProbe_columnExists($db, 'tblCreditPeople', 'BirthDatePrecision'),
     ],
+
+    'shared-setlist-live-link' => [
+        'script' => 'migrate-shared-setlist-live-link.php',
+        'card' => [
+            'title'  => 'Live-link shared setlists (#1380)',
+            'body'   => 'Adds <code>tblSharedSetlists.OwnerUserId</code> (FK to'
+                      . ' <code>tblUsers</code>) and <code>SourceSetlistId</code> so a public'
+                      . ' share LINKS to the owner&rsquo;s live <code>tblUserSetlists</code> row'
+                      . ' instead of freezing a snapshot — the owner&rsquo;s later edits then'
+                      . ' reach link-holders. Both NULL = legacy/anonymous snapshot-only share'
+                      . ' (existing shares keep working unchanged). Additive, idempotent —'
+                      . ' column-existence + constraint-name guarded, safe to re-run.',
+            'button' => 'Run Live-Link Shared Setlists Migration',
+        ],
+        /* Multi-object OR-probe (rule #19): pending until BOTH columns exist, so a
+           partial apply never shows the card green. Detects real completion. */
+        'probe' => static fn(\mysqli $db) =>
+            !_migProbe_columnExists($db, 'tblSharedSetlists', 'OwnerUserId')
+            || !_migProbe_columnExists($db, 'tblSharedSetlists', 'SourceSetlistId'),
+    ],
+
+    'backfill-canonical-songids' => [
+        'script' => 'migrate-backfill-canonical-songids.php',
+        /* #1380 — DATA REWRITE + manual-only: EXCLUDED from "Apply all" (both the JS bulk
+           runner and the no-JS apply-all loop) and the pending counter. A WEB run defaults
+           to ?dry=1 REPORT-ONLY and REFUSES to mutate without ?confirm=1, so it can NEVER
+           be triggered by an "Apply all" bulk fetch. Renames every draft SongId
+           (song-XXXX) to its canonical <Abbr>-NNNN id; FK children cascade automatically,
+           the non-FK / JSON stores are rewritten in-band, each song in its own transaction. */
+        'manual' => true,
+        /* #1380 FIX 4 — this manual migration has a real DRY-RUN: a web run WITHOUT
+           &confirm=1 only REPORTS (it refuses to mutate). setup-database.php auto-
+           appends &confirm=1 to a `manual` card's run link, so without this flag the
+           ONLY button would mutate — denying the WEB-ONLY operator the dry-run-first
+           path the script was designed around. `dryRunnable` makes the card ALSO
+           render a distinct "Dry-run (report only)" link (no &confirm=1, no type-to-
+           confirm) alongside the confirm/apply button, and tailors the manual-card
+           copy/confirm wording away from the destructive-DROP defaults. The C6
+           JSON-column DROP is `manual` but NOT dryRunnable (it has no report mode), so
+           it keeps the drop-only single button. */
+        'dryRunnable' => true,
+        'card' => [
+            'title'  => 'Backfill canonical SongIds (#1380)',
+            'body'   => 'DATA REWRITE — renames every legacy draft <code>song-XXXX</code>'
+                      . ' SongId to its canonical <code>&lt;Abbr&gt;-NNNN</code> id (the 41 FK'
+                      . ' children cascade via <code>ON UPDATE CASCADE</code>; the non-FK / JSON'
+                      . ' stores — <code>tblContentRestrictions.EntityId</code>,'
+                      . ' <code>tblUserSetlists.SongsJson</code>, <code>tblSharedSetlists.Data</code>'
+                      . ' — are rewritten in-band, and a <code>tblSongRedirects</code> row keeps'
+                      . ' old permalinks alive). Do NOT run via &ldquo;Apply all&rdquo;. Defaults'
+                      . ' to <strong>dry-run</strong> (report only); pass <code>&amp;confirm=1</code>'
+                      . ' to mutate. Per-song transactional + idempotent — safe to re-run.',
+            'button' => 'Backfill Canonical SongIds (dry-run unless confirmed)',
+        ],
+        /* "Pending" while ANY draft-id song remains; self-clears to applied once every
+           SongId is canonical. Detects real completion from live data (never always-true). */
+        'probe' => static function (\mysqli $db): bool {
+            try {
+                $r = $db->query("SELECT 1 FROM tblSongs WHERE SongId LIKE 'song-%' LIMIT 1");
+                $pending = ($r && $r->fetch_row() !== null);
+                if ($r) { $r->close(); }
+                return $pending;
+            } catch (\Throwable $_e) {
+                /* Table absent (fresh install pre-Install) → not pending. */
+                return false;
+            }
+        },
+    ],
 ];

--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -509,11 +509,16 @@ $migrationCards  = [];
 $migrationProbes = [];
 $migrationManual = [];   /* #1235 P4/C6 — slugs flagged 'manual' (destructive, gated): excluded
                             from "Apply all" + the pending counter; single-run needs confirm=1. */
+$migrationDryRunnable = []; /* #1380 FIX 4 — slugs flagged 'dryRunnable': a manual migration that
+                              ALSO supports a report-only run WITHOUT &confirm=1 (e.g. the canonical
+                              SongId backfill). The card renders a distinct "Dry-run (report only)"
+                              link so the WEB-ONLY operator can preview before mutating. */
 foreach ($MIGRATIONS as $_slug => $_entry) {
     $scriptMap[$_slug]       = $_entry['script'];
     $migrationCards[$_slug]  = $_entry['card'];
     $migrationProbes[$_slug] = $_entry['probe'];
-    if (!empty($_entry['manual'])) { $migrationManual[$_slug] = true; }
+    if (!empty($_entry['manual']))      { $migrationManual[$_slug] = true; }
+    if (!empty($_entry['dryRunnable'])) { $migrationDryRunnable[$_slug] = true; }
 }
 unset($_slug, $_entry);
 /* Captured during bulk-run so the failure can be surfaced as a visible
@@ -2012,7 +2017,11 @@ if ($hasCredentials && defined('DB_HOST')) {
                                     </span>
                                 <?php endif; ?>
                                 <?php if (!empty($migrationManual[$_pa])): ?>
-                                    <span class="badge bg-danger ms-2">manual &amp; destructive — run by hand, not by &ldquo;Apply all&rdquo;</span>
+                                    <span class="badge bg-danger ms-2"><?=
+                                        !empty($migrationDryRunnable[$_pa])
+                                            ? 'manual data rewrite — run by hand, not by &ldquo;Apply all&rdquo;'
+                                            : 'manual &amp; destructive — run by hand, not by &ldquo;Apply all&rdquo;'
+                                    ?></span>
                                 <?php endif; ?>
                             </span>
                             <?php
@@ -2020,20 +2029,34 @@ if ($hasCredentials && defined('DB_HOST')) {
                                    confirm=1 (the script refuses without it) + a confirm() dialog.
                                    #1298 — plus the type-to-confirm speed-bump (data attribute carries
                                    the exact slug the operator must type). Layered on top of the
-                                   server-side confirm=1 / sentinel gate, never instead of it. */
+                                   server-side confirm=1 / sentinel gate, never instead of it.
+                                   #1380 FIX 4 — a `dryRunnable` manual migration (the SongId backfill)
+                                   tailors the confirm() copy to "applies the data rewrite" and gets a
+                                   distinct report-only run link (below) without &confirm=1. */
                                 $_paManual  = !empty($migrationManual[$_pa]);
+                                $_paDryRun  = !empty($migrationDryRunnable[$_pa]);
                                 $_paHref    = '?action=' . htmlspecialchars($_pa) . ($_paManual ? '&amp;confirm=1' : '');
                                 $_paOnclick = $_paManual
-                                    ? ' onclick="return confirm(\'This is a DESTRUCTIVE, irreversible migration. It only proceeds behind the pre-drop verification gate. Continue?\');"'
+                                    ? ($_paDryRun
+                                        ? ' onclick="return confirm(\'This APPLIES the data rewrite immediately (it mutates the database). Use the Dry-run link first to preview. Continue?\');"'
+                                        : ' onclick="return confirm(\'This is a DESTRUCTIVE, irreversible migration. It only proceeds behind the pre-drop verification gate. Continue?\');"')
                                     : '';
                                 $_paType    = $_paManual
                                     ? ' data-type-to-confirm="' . htmlspecialchars($_pa, ENT_QUOTES) . '"'
                                     : '';
                             ?>
-                            <a href="<?= $_paHref ?>"<?= $_paOnclick ?><?= $_paType ?>
-                               class="btn btn-sm <?= $_paManual ? 'btn-danger' : 'btn-outline-info' ?> flex-shrink-0 <?= $hasCredentials ? '' : 'disabled' ?>">
-                                Run &amp; show output
-                            </a>
+                            <span class="d-flex gap-2 flex-shrink-0">
+                                <?php if ($_paManual && $_paDryRun): ?>
+                                    <a href="?action=<?= htmlspecialchars($_pa) ?>"
+                                       class="btn btn-sm btn-outline-info <?= $hasCredentials ? '' : 'disabled' ?>">
+                                        Dry-run (report only)
+                                    </a>
+                                <?php endif; ?>
+                                <a href="<?= $_paHref ?>"<?= $_paOnclick ?><?= $_paType ?>
+                                   class="btn btn-sm <?= $_paManual ? 'btn-danger' : 'btn-outline-info' ?> <?= $hasCredentials ? '' : 'disabled' ?>">
+                                    Run &amp; show output
+                                </a>
+                            </span>
                         </li>
                     <?php endforeach; ?>
                 </ul>
@@ -2168,33 +2191,57 @@ if ($hasCredentials && defined('DB_HOST')) {
             <?php
                 /* Render helper — single card markup reused for both
                    the pending grid and the inside-expander grid. */
-                $_renderCard = static function (string $migAction, array $card, bool $hasCreds, bool $isManual = false): void {
+                $_renderCard = static function (string $migAction, array $card, bool $hasCreds, bool $isManual = false, bool $isDryRunnable = false): void {
                     /* #1235 P4/C6 — a manual/destructive migration's run link carries confirm=1
                        (the script REFUSES a web run without it) + a JS confirm() dialog, mirroring
                        the drop-legacy pattern; the button is danger-styled and the card flagged.
                        ADDITIONAL client speed-bump (#1298): the anchor also carries
                        data-type-to-confirm="<slug>" so the shared inline JS forces the operator to
                        type the exact migration slug before the destructive request fires. This is
-                       layered ON TOP of the server-side confirm=1 / sentinel gate — never instead. */
+                       layered ON TOP of the server-side confirm=1 / sentinel gate — never instead.
+
+                       #1380 FIX 4 — a manual migration that is ALSO `dryRunnable` (the canonical
+                       SongId backfill) is a DATA REWRITE, not a schema drop: its mutate button
+                       still carries confirm=1 + type-to-confirm, but the operator needs a real
+                       report-first path too. So we ALSO render a distinct "Dry-run (report only)"
+                       link WITHOUT &confirm=1 (and without the type-to-confirm), and we tailor the
+                       confirm() / badge wording away from the destructive-DROP defaults (which talk
+                       about a "pre-drop verification gate" that doesn't apply here). */
                     $href    = '?action=' . htmlspecialchars($migAction) . ($isManual ? '&amp;confirm=1' : '');
                     $btnClass = $isManual ? 'btn-danger' : 'btn-info';
                     $onclick = $isManual
-                        ? ' onclick="return confirm(\'This is a DESTRUCTIVE, irreversible migration. It only proceeds if the pre-drop verification gate is green and &lt;24h old. Continue?\');"'
+                        ? ($isDryRunnable
+                            ? ' onclick="return confirm(\'This APPLIES the data rewrite immediately (it mutates the database). Run the Dry-run link first to preview. Continue?\');"'
+                            : ' onclick="return confirm(\'This is a DESTRUCTIVE, irreversible migration. It only proceeds if the pre-drop verification gate is green and &lt;24h old. Continue?\');"')
                         : '';
                     /* The required phrase IS the migration slug — shown to the operator in the
                        prompt and matched case-sensitively. htmlspecialchars guards the attribute. */
                     $typeToConfirm = $isManual
                         ? ' data-type-to-confirm="' . htmlspecialchars($migAction, ENT_QUOTES) . '"'
                         : '';
+                    /* #1380 FIX 4 — the report-only run link: same action, NO &confirm=1 → the
+                       script stays in dry-run and only reports. No type-to-confirm / native
+                       confirm() (a read-only report needs no speed-bump). */
+                    $dryRunHref = '?action=' . htmlspecialchars($migAction);
                     ?>
                     <div class="col-md-6">
                         <div class="card bg-dark <?= $isManual ? 'border-danger' : 'border-secondary' ?> h-100">
                             <div class="card-body">
                                 <h5 class="card-title"><?= $card['title'] ?></h5>
                                 <?php if ($isManual): ?>
-                                    <span class="badge bg-danger mb-2">Manual &amp; destructive — NOT run by &ldquo;Apply all&rdquo;</span>
+                                    <span class="badge bg-danger mb-2"><?=
+                                        $isDryRunnable
+                                            ? 'Manual data rewrite — NOT run by &ldquo;Apply all&rdquo;'
+                                            : 'Manual &amp; destructive — NOT run by &ldquo;Apply all&rdquo;'
+                                    ?></span>
                                 <?php endif; ?>
                                 <p class="card-text text-secondary small"><?= $card['body'] ?></p>
+                                <?php if ($isManual && $isDryRunnable): ?>
+                                    <a href="<?= $dryRunHref ?>"
+                                       class="btn btn-outline-info btn-action me-2 <?= $hasCreds ? '' : 'disabled' ?>">
+                                        Dry-run (report only)
+                                    </a>
+                                <?php endif; ?>
                                 <a href="<?= $href ?>"<?= $onclick ?><?= $typeToConfirm ?>
                                    class="btn <?= $btnClass ?> btn-action <?= $hasCreds ? '' : 'disabled' ?>">
                                     <?= htmlspecialchars($card['button']) ?>
@@ -2213,7 +2260,7 @@ if ($hasCredentials && defined('DB_HOST')) {
                 <?php
                     $_card = $migrationCards[$_migAction] ?? null;
                     if (!$_card) continue;     /* slug in $migrationOrder but no card body */
-                    $_renderCard($_migAction, $_card, $hasCredentials, !empty($migrationManual[$_migAction]));
+                    $_renderCard($_migAction, $_card, $hasCredentials, !empty($migrationManual[$_migAction]), !empty($migrationDryRunnable[$_migAction]));
                 ?>
             <?php endforeach; ?>
 
@@ -2244,7 +2291,7 @@ if ($hasCredentials && defined('DB_HOST')) {
                         <div class="card-body">
                             <div class="row g-3">
                                 <?php foreach ($_appliedRenderable as $_appliedAction): ?>
-                                    <?php $_renderCard($_appliedAction, $migrationCards[$_appliedAction], $hasCredentials, !empty($migrationManual[$_appliedAction])); ?>
+                                    <?php $_renderCard($_appliedAction, $migrationCards[$_appliedAction], $hasCredentials, !empty($migrationManual[$_appliedAction]), !empty($migrationDryRunnable[$_appliedAction])); ?>
                                 <?php endforeach; ?>
                             </div>
                         </div>

--- a/appWeb/public_html/og-image.php
+++ b/appWeb/public_html/og-image.php
@@ -107,8 +107,17 @@ try {
         $cleanId = preg_replace('/[^a-f0-9]/', '', strtolower(trim($setlistId)));
         if ($cleanId !== '' && strlen($cleanId) <= 16) {
             require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'SharedSetlist.php';
-            $setlistInfo = sharedSetlistGet($cleanId);
-            if (is_array($setlistInfo)) $mode = 'setlist';
+            /* #1380 / FIX 5 — resolve through the SHARED live-vs-snapshot resolver so
+               the social card reflects the owner's CURRENT setlist (name + count),
+               not the frozen share-time snapshot. Returns the same XSS-safe id shape
+               the API serves. `unavailable` (a live link whose underlying setlist the
+               owner deleted) and null (no such share) both fall through to the generic
+               card — there's nothing meaningful to preview. */
+            $wire = sharedSetlistResolveWire(getDbMysqli(), $cleanId);
+            if (is_array($wire) && empty($wire['unavailable'])) {
+                $setlistInfo = $wire;   /* ['name','songs','arrangements','live','unavailable'] */
+                $mode = 'setlist';
+            }
         }
     }
 } catch (\Throwable $e) {


### PR DESCRIPTION
Closes #1380. Base: `alpha`. **The setlist-sharing rewrite you asked for** — from frozen snapshots to live shares, adversarially reviewed (security + correctness, all findings fixed).

## What was broken
Sharing **froze a snapshot** at share time and **silently dropped** any song whose id wasn't `<letters>-<digits>` — so a newly-added song (kept its editor **draft id** because saves never assigned a canonical SongId) vanished from shares (your 4→3), and **owner edits never reached link-holders**. Setlists began browser-only/anonymous; server-side per-account storage came later but sharing was never rebuilt to use it.

## The fix (your locked model)
- **Live shares** — an authenticated owner links the share to their `(UserId, SetlistId)`; `setlist_get` reads the **current** setlist, so edits show for everyone instantly. Snapshot kept only as fallback for anonymous/legacy. Deleted source → clean **"no longer available"** (410). OG/social previews read live too (shared resolver).
- **No silent drops** + an XSS-safe charset guard on ids (keeps draft/canonical, blocks attribute-breakout).
- **Canonical SongIds** — new songs get `<Abbr>-NNNN` on first save (collision-safe, race-safe); the editor re-keys all in-memory refs so later saves don't double-insert or drop link edits. A **manual, dry-run-first, confirm-gated, transactional** backfill migration fixes existing draft ids (relies on the 41 `ON UPDATE CASCADE` FKs; rewrites only the JSON/non-FK stores; writes redirects; leaves audit history alone).
- **Read-only non-owners**; Import stays an optional fork.

## Security
IDOR-gated live-mint + share-update (bound ownership probe; authed-owner match; anon-UUID only for legacy rows); strict public-safe response allow-list (no owner UUID/email/CreatedBy). Adversarial review fixed: the XSS charset filter, editor rename completeness, the mint TOCTOU (plain INSERT), backfill dry-run reachability (web-only operator), and live OG. php -l + node --check clean; schema-coverage + migration-registry guards pass.

## ⚠️ Operator steps after merge
1. Run the **"Live Shared Set Lists (#1380)"** migration card on `/manage/setup-database` (additive; dormant code is column-gated so it's safe before the migration).
2. Canonical-SongId backfill is **optional + manual**: use its **Dry-run (report only)** link first to review, then the confirm/apply button (it's excluded from "Apply all").

Version → **0.1315.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)