### PR TITLE
chore(claude): enable codex@openai-codex plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -49,6 +49,7 @@
     ]
   },
   "enabledPlugins": {
-    "dev-team@dev-team": true
+    "dev-team@dev-team": true,
+    "codex@openai-codex": true
   }
 }


### PR DESCRIPTION
Auto-generated `.claude/settings.json` change — adds `codex@openai-codex` to `enabledPlugins`. No app code, no secrets, not deployed (`.claude/` is repo tooling).