### PR TITLE
feat(auth): Sign in with Apple for Web — W1 backend (dormant) + strategy (#1470)

### DIFF
--- a/.claude/sessions/2026-07-10-HANDOFF.md
+++ b/.claude/sessions/2026-07-10-HANDOFF.md
@@ -1,0 +1,31 @@
+# Session handoff — 2026-07-10
+
+Two work streams this session. Persistent Claude memory mirrors this (auto-loaded next session).
+
+## 1. Secret encryption-at-rest (#1466) — MERGED to alpha ✅
+
+- Version bumped **0.2500.0 → 0.2501.0** (infoAppVer / README / OpenAPI synced).
+- Independent multi-agent adversarial security review → **SAFE_TO_PROCEED**; 3 defence-in-depth hardenings folded in (placeholder/all-same-nibble master-key rejection in `_secretCryptoNormalise()` [+4 tests → 45]; `escapeHtml()` on the Rotate undecryptable list; Global-Admin gate on the whole setup-database Secret-encryption panel).
+- Delivered via clean branch **`feat/secret-encryption-1466`** off alpha (because `feat/apple-universal` was already squash-merged into alpha as **#1464**/v0.2500.0 — a direct feat/apple-universal→alpha PR would have re-merged 56 already-landed commits). PR **#1469** squash-merged to alpha (`6448a927`), alpha deploy green.
+- **Feature remains fully DORMANT** (no master key provisioned; verified no-op). Owner activation sequence unchanged (provision `SECRETS_MASTER_KEY` → deploy seeds all 3 docroots → verify fingerprints/sentinel/beacons → run the `confirm=1` encrypt-in-place migration card → rotate provider-side keys).
+- NOTE: local `feat/apple-universal` still carries the 3 pre-cherry-pick commits (`187f0447`/`342effc0`/`71f268d3`); reconcile by merging alpha back in, or reset to origin/alpha.
+
+## 2. Sign in with Apple for Web + SIGNula.id federation — PLANNED + W1 built (dormant)
+
+Strategy: **`.claude/siwa-web-signula-strategy.md`** (2 sequential Fable-5 planning rounds + Opus review). Tracking: **iHymns #1470**, **MWBMPartners/SIGNula.id#89** (federation contract).
+
+- **Recommendation Option C** (owner-approved): build iHymns-**direct** SIWA-for-web now (provider-generic, no schema change, ~3–4 dev-days), federate to SIGNula **later**. Option B (delegate to SIGNula now) is **not buildable** — SIGNula v2.6.0-beta has no partner OAuth/OIDC (only email+password login, HS256/opaque tokens, no JWKS).
+- **Load-bearing owner decision D1:** SIGNula's Apple **Services ID under the same Apple Developer Team** as `app.ihymns` → deterministic `sub` reconciliation.
+- Opus correction: the planning "login-CSRF" finding was **refuted** (api.php's global `X-Requested-With` guard already blocks cross-site POSTs) — conditional-cookie change + O7 dropped.
+
+### Branch `feat/siwa-web` (off alpha) — 2 commits, **NOT pushed**
+- `37625e5f` docs(auth): strategy doc.
+- `31a312b5` feat(auth): **W1 backend, DORMANT** — `platform` param + Services-ID audience (single aud, never try-both) + channel-gated `apple_web_login_enabled`/`apple_siwa_services_id` settings + `appleSiwaExchangeCode` redirect_uri + Host-validated web redirect + `app_status.appleWebLoginEnabled`. Tests 34+25, all existing auth tests green, php -l clean. No schema change.
+
+### RESUME
+1. **Owner decision: push `feat/siwa-web` + open PR to alpha?** (repo auto-merges green alpha PRs). W1 is a verified dormant no-op.
+2. Then **W2** (front-end `js/modules/apple-signin.js`, Apple JS popup, button gated on `appleWebLoginEnabled`, first-auth fullName) and **W3** (Settings "Connected accounts" + provider-generic `auth_provider_unlink` with the private-relay-aware lockout guard + best-effort Apple revoke).
+3. **W0 owner provisioning** (Apple Services ID same-team [D1], per-docroot return URLs, private-relay outbound mail) gates real activation; other decisions D3/D4/O1–O6 in strategy §10.
+
+## 3. Queued, NOT yet started
+- **Thorough OpenAPI/Swagger refresh** of `appWeb/public_html/api-docs.yaml` to the current feature set (Apple auth, account_delete, analytics, gating, service mode, works/external-links, …) — own issue + individual commit. Owner said: do it **after** the SIWA work.

--- a/.claude/siwa-web-signula-strategy.md
+++ b/.claude/siwa-web-signula-strategy.md
@@ -1,0 +1,154 @@
+# Sign in with Apple for Web + SIGNula.id federation — strategy (DRAFT for owner review)
+
+> **Status: DRAFT — awaiting owner approval. No implementation, issues, or branches created from this yet.**
+> Produced by two sequential deep-planning rounds on **Fable 5** (round 1 = deep draft, round 2 = adversarial verify + refine), then reviewed on Opus. Date: **2026-07-10**.
+> **Grounding:** every iHymns claim verified against code on `alpha` (the `feat/apple-universal` auth backend merged via #1464/#1469); every SIGNula claim verified against the public repo `MWBMPartners/SIGNula.id` at **v2.6.0-beta** (`VERSION` confirmed; last push 2026-04-24). File/line refs are to the verified sources.
+>
+> **Tracking:** iHymns **#1470** (this initiative); SIGNula federation contract (§6.2) filed as **MWBMPartners/SIGNula.id#89**. Owner-approved (2026-07-10): Option C, build W1 backend dormant first.
+
+The three asks (owner, verbatim intent):
+1. We set up Sign in with Apple (SIWA) for the Apple **native** app — implement it for **web/PWA** too.
+2. How does that impact the **later** plan to integrate iHymns sign-in with **SIGNula.id** (MWBM's universal SSO, which also brokers Apple ID)?
+3. Let a pre-existing "native" iHymns account (password / magic-link) **link** to Apple via SIWA, and **later** also link to SIGNula.id.
+
+---
+
+## Adversarial review notes (what was verified / corrected in round 2)
+
+> **Correction (Opus post-review, 2026-07-10):** round-2 finding **#4 (login-CSRF via the unconditional cookie set) is REFUTED.** `api.php` enforces a **global `X-Requested-With: XMLHttpRequest` guard on every POST** (lines 271-322; only `song_request_submit` is exempted, via an Origin/Referer same-origin check). A cross-site POST to `auth_apple` is therefore already blocked — `X-Requested-With` is a forbidden header a cross-origin caller can't set without a CORS preflight the server never grants, and the `text/plain`/form trick can't set it either. The cookie is thus only ever set on same-origin XHR already, so the "conditional cookie" change is redundant and is **DROPPED from W1** (one fewer change to security-critical code; no live vuln). Findings **#1 (redirect_uri), #2 (SIGNula webhook names), #3 (private-relay unlink stranding), #5 (channel rollout), #6 (RefreshToken)** all stand. **O7** (extend a conditional-cookie fix to `auth_login`) is likewise moot for the same reason — dropped.
+
+**Verified against source (not trusted from the first pass):**
+- **The decisive claim stands.** SIGNula.id v2.6.0-beta has **no partner-facing OAuth2/OIDC authorization server.** Confirmed: `web/public_html/oauth/authorize.php` is SIGNula acting as an OAuth **client** ("…for delegate email sending", providers `microsoft_graph`/`google_workspace`, purpose `email|signin`); the partner API (`web/public_html/api/v1/index.php`) exposes only `/auth/login` (email+password), `/oauth/providers|linked|link|unlink` — no partner `/authorize` or `/token` issuance; **no `.well-known/openid-configuration`, no JWKS** anywhere (recursive tree search); documented access tokens are `eyJhbGciOiJIUzI1NiIs…` (**HS256, symmetric — not partner-verifiable**), and `AuthController.php` actually mints **opaque** random session tokens. **⇒ "Delegate to SIGNula now" is not buildable today. Recommendation unchanged: Option C.**
+- `appleSiwaVerifyIdentityToken()` (`includes/apple_siwa.php:378`) — `$expectedAud` is a parameter; strict single-expected aud check (accepts the RFC 7519 array-containing shape, never "try-both"); RS256 pinned as a reject-gate. Confirmed.
+- Nonce contract (`api.php:3087` + `apple_siwa.php:452`): `hash_equals($nonceClaim, hash('sha256',$rawNonce))` — web-compatible. Confirmed.
+- Linking guards (`api.php:3170-3183`, `14059-14094`, `13863`): authenticated-bearer requirement for link mode; strict 4-condition email auto-link incl. target `EmailVerified=1`; two named-UNIQUE 409s; transactional rollback + create-race retry. Confirmed.
+- `ihymns_auth` is SameSite=Lax (`includes/auth_cookie.php:69`); `api.php` sets no CORS headers. The popup-over-redirect argument holds. Confirmed.
+- Schema is provider-generic (`schema.sql:3815`); the two web settings don't exist yet. Confirmed.
+
+**Corrected (first pass was wrong / incomplete):**
+1. **`apple_siwa.php` needs ONE change after all.** `appleSiwaExchangeCode()` omits `redirect_uri`; Apple requires it for **web** code exchanges (native ASAuthorization sends none — current code correct for native). Without it every web code exchange fails ⇒ web-first users never capture a `RefreshToken` ⇒ Apple-side revoke on delete/unlink degrades to `skipped_no_token`. Fix: one additive optional `?string $redirectUri = null` appended to the form body when non-null. Verify path unchanged.
+2. **SIGNula webhook event names are a docs/code mismatch** — code ships `user.account_deleted` and **no `oauth.*` events**. The §6.2 contract must pin exact names and require the `oauth.*` events be *implemented*, not assumed.
+3. **Unlink lockout guard had a private-relay stranding hole.** After unlink+revoke, Apple deactivates the relay alias ⇒ mail bounces forever. The guard must not count a `@privaterelay.appleid.com` email as a surviving sign-in method.
+4. **New security finding: login-CSRF via the unconditional cookie set.** `auth_apple` calls `setAuthTokenCookie()` unconditionally (`api.php:3238`) and the cookie is accepted as a bearer. Only set the cookie on **verified same-origin** requests (the rule #29 `X-Requested-With` + Origin/Referer-host machinery). Native uses the JSON bearer and never needed the cookie. (Same latent exposure exists on `auth_login` — optional parity hardening, O7.)
+5. **Global toggle → channel allow-list.** One shared DB × three docroots on different code versions means a single global `apple_web_login_enabled='1'` flips all three at once. Use a **channel allow-list** value (`'alpha'` → `'alpha,beta'` → `'all'`) checked against `ihymns_environment()` for safe staged rollout with one row. Fail-closed on un-promoted docroots verified (old code ignores `platform`, web tokens 401).
+6. **RefreshToken-at-rest = non-blocking follow-up**, not a dependency. `secretEncrypt/secretDecrypt` (#1466) are value-level, column-agnostic with plaintext fallthrough — clean for this column — but #1466 is itself dormant/awaiting activation. Do **not** sequence web SIWA behind it.
+
+**Walked back:** nothing in the central recommendation. Option C survives intact.
+
+---
+
+## 1. Goals & non-goals
+
+**Goals:** (1) SIWA on Web/PWA with the same account-mapping as native; (2) forward-compat with a later SIGNula SSO at near-zero rework; (3) link/unlink Apple from Settings on an existing account, and later SIGNula too.
+
+**Non-goals (v1):** becoming a SIGNula client today (not buildable — §3); other direct providers (schema supports them; deferred); WebAuthn in iHymns (a federation dividend from SIGNula, not a local build); DB merge; Apple server-to-server revocation notifications (W4); redirect-mode SIWA (W4 fallback).
+
+## 2. Current state (verified)
+
+- `includes/apple_siwa.php` is a complete, reusable SIWA library — audience and client-id are **parameters**; JWKS cache + single-use nonce ledger reuse verbatim. Only the `api.php` call sites hardcode `IHYMNS_SIWA_CLIENT_ID` (`app.ihymns`).
+- **One required library change:** `appleSiwaExchangeCode()` gains an optional `redirect_uri` (correction #1).
+- Nonce contract is web-compatible (lowercase hex; raw within the server's `[A-Za-z0-9._~-]{16,255}` gate).
+- `_authAppleMapAccount`: (a) existing `(apple,sub)`→login; (b) `link=1` w/ authenticated bearer; (c) strict 4-condition email auto-link; (d) create new passwordless account. Transactional + duplicate-race retry. Bearer minted identically to `auth_login`; cookie via `auth_cookie.php` (SameSite=Lax, `.ihymns.app`).
+- Schema: `tblUserAuthProviders` + `tblAuthNonces` provider-generic (`schema.sql:3815+`). **No schema change needed for web, nor for SIGNula later.**
+- **New for web:** Apple **Services ID** (web aud ≠ App ID `app.ihymns`); registered domains/return URLs; front-end flow; a `platform` discriminator in `auth_apple`; linked-accounts settings UI + unlink endpoint; two `tblAppSettings` rows.
+- **Deployment note:** the `auth_apple` backend is now on `alpha` (merged); its `migrate-user-auth-providers` card must be applied on the shared DB before web SIWA can transact (`auth_apple` already 503s cleanly when it isn't).
+
+## 3. Central architectural fork — recommend **Option C**
+
+- **Apple `sub` is stable per (user × Developer Team).** A Services ID in the **same team** as `app.ihymns` yields the **same `sub`** as native ⇒ web and native share `tblUserAuthProviders` rows with zero reconciliation; and if SIGNula's Apple client is in that team too, SIGNula's stored Apple `provider_user_id` equals iHymns' `Subject` ⇒ **deterministic join** at federation time. Different team ⇒ only weak email reconciliation (useless for hide-my-email users). **→ OWNER DECISION D1 (highest leverage): provision SIGNula's Apple Services ID in the same Apple Developer team as `app.ihymns`.**
+- **Option A** (direct now, federate later): days to ship, smallest surface, best UX, no lock-in.
+- **Option B** (delegate to SIGNula now): **BLOCKED** — no partner SSO flow exists in SIGNula v2.6.0-beta; would require building + hardening partner-SSO in the SIGNula repo first.
+- **★ Option C (recommended)** = Option A's build + codify the federation contract (§6.2) as a SIGNula-repo issue + the provider-generic model we already have + D1. Nothing in A is throwaway (verify library, mapping, linking, nonce ledger serve native forever).
+
+## 4. SIWA-for-web design
+
+**Provisioning (owner, W0):** Services ID (suggest `app.ihymns.web`) in the same team, grouped under the App ID; register **every** docroot hostname as domain + return URL; register the outbound mail domain/addresses for private-relay forwarding (this gates *account recovery* for relay users, §5/§8). No new secrets — same Team ID/Key ID/`.p8`.
+
+**Front-end: Apple JS, POPUP mode.** Redirect mode with name/email scope uses a cross-site `form_post`; SameSite=Lax means the session cookie isn't attached ⇒ a redirect *link* flow can't see the session. Popup hands `id_token`+`code` to our JS, which does a **same-origin** POST to `?action=auth_apple` (X-Requested-With) — no new server entry point. Redirect mode is a W4 fallback only.
+
+**Flow:** lazy-load `appleid.auth.js`; mint `rawNonce` + `state`; `AppleID.auth.init({clientId:<services id>, scope:'name email', redirectURI, state, nonce: sha256hex_lowercase(rawNonce), usePopup:true})`; on success POST `{identityToken, nonce: rawNonce, authorizationCode, fullName?, platform:'web', link:0|1}` with `X-Requested-With` (bearer for link mode). Verify `state` client-side before posting.
+
+**Server changes:**
+- `apple_siwa.php` — **one change:** `appleSiwaExchangeCode(…, ?string $redirectUri = null)`.
+- `api.php auth_apple` — accept `platform` (allow-list `native|web`, default `native`; else 400). Resolve **exactly one** `$expectedAud` (native→`IHYMNS_SIWA_CLIENT_ID`, web→`getAppSetting('apple_siwa_services_id')`). Web requested but unconfigured / channel not in `apple_web_login_enabled` allow-list → 503 dormant. **Never try both auds.** Use the resolved client id + this docroot's registered redirect URI in the code exchange. For `platform=web`: require same-origin markers on **all** requests and **only set the auth cookie when verified same-origin** (correction #4). Audit `platform`.
+- **Why one endpoint (not `auth_apple_web`):** resolution only *selects* which of our own two client ids to check; a web token replayed as native fails `bad_aud` and vice-versa; both ids share one team so `(apple,sub)` maps to the same row. A second endpoint would duplicate ~230 lines (rate-limit/gates/mapping/audit) = the real long-term risk. One endpoint, one resolved aud, shared `siwa_login` nonce purpose (single-use, no cross-platform interaction).
+- `app_status` — add `appleWebLoginEnabled` (resolved for this channel).
+- `configuration.php` — Apple card gains `apple_siwa_services_id` (non-secret; validate shape; reject `== app.ihymns`) + `apple_web_login_enabled` (channel allow-list, default `''` = dormant).
+- Front-end — new `js/modules/apple-signin.js` consumed by the auth UI; button gated on `appleWebLoginEnabled`.
+- Tests — aud cross-rejection matrix, platform validation, per-channel dormancy no-op, exchange-body `redirect_uri` presence, cookie-only-on-same-origin.
+
+**Private relay:** email never identity; `fullName` only on first authorization (forward it in the popup); relay-alias rotation absorbed by the sub-keyed warm path.
+
+## 5. Account-linking model
+
+(a) existing `(apple,sub)` → login. (b) new identity → strict auto-link else create; **no** interactive "email exists" prompt (enumeration oracle) — UI uses `flow:'created'` to guide "sign in with your password, then link from Settings". (c) explicit `link=1`: authenticated bearer + same-origin; guards verified present (bearer-required, two UNIQUE 409s, rollback); **D4** step-up re-auth before linking = not required v1.
+
+**(d) NEW unlink** — provider-generic `?action=auth_provider_unlink`; bearer + same-origin. **Lockout guard (revised):** refuse unless a *surviving* method remains — `PasswordHash<>''`; **or** (`EmailVerified=1` **and** email is **not** `@privaterelay.appleid.com` **and** email-login is operational); **or** another provider row (different provider). Run under `SELECT … FOR UPDATE` on the account's provider rows (two concurrent unlinks can't each count the other as survivor). Then best-effort Apple revoke (needs the captured RefreshToken — correction #1), delete row, audit. Does not invalidate bearers (unlink ≠ logout). Residual: unlink-then-forgot-password with a dead relay email = admin-recoverable only (document in runbook).
+
+**Extending to SIGNula later:** `Provider='signula'`, `Subject=usr_…`, nonce `Purpose='signula_login'` — zero schema change; same guard logic.
+
+## 6. SIGNula federation impact & migration
+
+**6.1** Identity keys forward-compatible as-is; Apple-sub reconciliation deterministic **iff D1**; one broker per provider button (never Apple-direct + Apple-via-SIGNula for the same button).
+
+**6.2 The federation contract** (file as a SIGNula-repo issue — the entire cost of ask #2 today):
+- OAuth2 authorization-code + **PKCE (S256)** for partners; **RS256/ES256 id_tokens** via JWKS + OIDC discovery; `nonce`+`state`; kid rotation.
+- **Stable `sub`** — decide **pairwise vs global** (O4).
+- Claims: `email`, `email_verified` (defined semantics), and a **linked-provider-subjects** claim/endpoint exposing `provider`+`provider_user_id` (makes the D1 Apple-sub join executable).
+- Webhooks: **pin exact event names** (code ships `user.account_deleted`; `oauth.linked`/`oauth.unlinked` must be *added* — correction #2); fixed HMAC header; signed timestamp/replay window.
+- **Token revocation** (RFC 7009). RP-initiated/back-channel logout: **optional/deferred** (iHymns mints its own bearers post-exchange — document this session model).
+- Client registration; exact-match HTTPS redirect allow-list (no wildcards); id_token ≤10 min + skew rule; rate limits.
+
+**Staged:** F0 = direct build (§4/§5). F1 = add SIGNula as an *additional* button once it ships the contract. F2 = reconciliation matcher (Apple-sub join under D1; email fallback → manual review) + webhook consumer. F3 = optionally re-point the **web** Apple button through SIGNula — **recommend never for native** (App Review + zero marginal cost keep native direct forever), so F3 buys little; park it.
+
+## 7. Schema impact
+
+**NONE.** Both tables already provider-generic; new config = two `tblAppSettings` rows (no migration card for settings). Precondition: `migrate-user-auth-providers` applied on the shared DB.
+
+## 8. Security
+
+- **aud confusion** — one resolved expectedAud from a two-value allow-list of *our own* client ids; never try-both; RS256 reject-gate.
+- **Nonce replay** — single-use `UNIQUE(Purpose,NonceHash)` ledger (shared DB, atomic, burn-after-verify); lowercase-hex discipline.
+- **CSRF / login-CSRF** — same-origin markers for all `platform=web`; **cookie set only on verified same-origin** (correction #4); link/unlink bearer-bound. **O7:** apply the same conditional-cookie fix to `auth_login`/magic-link (pre-existing exposure; recommend yes, separate commit).
+- **Open redirect** — none in v1 (popup only).
+- **Email takeover** — verified 4-condition guard.
+- **Private relay** — never identity-keyed; **outbound-domain registration gates recovery mail** (W0).
+- **RefreshToken at rest** — plaintext TEXT today, useless without the `.p8`, never logged (static-test-guarded). Fold into #1466 (encrypt-on-write + decrypt-on-revoke + a sweep in the encrypt-in-place card) **after** #1466 is owner-activated. **Not a blocker.**
+- **SIGNula trust boundary (future)** — asymmetric tokens only; HMAC webhooks; availability isolation (SIGNula down must never block Apple-direct or password login).
+- **Third-party JS** — `appleid.auth.js` from Apple CDN: lazy-load, degrades if blocked; **O3** checks CSP.
+- Standing checklist 1–9 swept over the new surface.
+
+## 9. Phasing
+
+- **W0** — preconditions (owner): D1–D3; Services ID + domains/return URLs (all 3 docroots); relay outbound-mail registration; confirm migration card applied.
+- **W1** — backend (0.5–1d): `platform` param + channel-gated settings + `appleSiwaExchangeCode` redirect_uri + conditional cookie + tests. **Dormant/no-op until configured.**
+- **W2** — front-end sign-in (1–2d): `apple-signin.js`, button gating, first-auth `fullName`.
+- **W3** — linked-accounts settings UI + unlink with the revised lockout guard (~1d).
+- **W4** — hardening: redirect fallback, Apple S2S revocation notifications, RefreshToken encryption (post-#1466), `auth_login` cookie parity (O7).
+- **S1** — SIGNula partner-SSO per §6.2 (**weeks, in the SIGNula repo**). **S2** — iHymns↔SIGNula federation (2–4d in iHymns).
+
+W1–W3 = one PR / three commits, **~3–4 dev-days**. Rollout: land on alpha → `apple_web_login_enabled='alpha'` → soak → promote code to beta/prod → widen the channel list (never past the docroots running the new code).
+
+## 10. Open questions / owner decisions
+
+| # | Decision | Recommendation |
+|---|---|---|
+| **D1** | SIGNula's Apple Services ID in the **same Apple team** as `app.ihymns`? | **Yes** — decide before SIGNula's Apple client gets real users. |
+| **D2** | Approve **Option C** + file the §6.2 contract as a SIGNula-repo issue? | Yes. |
+| **D3** | Web SIWA under iHymns branding now (not blocked on SIGNula)? | Yes. |
+| **D4** | Step-up re-auth before **linking**? | No for v1 (machinery exists to add later). |
+| **O1** | Exact 3 docroot hostnames for Apple registration + channel-rollout shape. | Register all three; roll out alpha→beta→prod. |
+| **O2** | Private-relay outbound-email domain registered? | Verify/do in W0 (gates recovery mail). |
+| **O3** | Any CSP blocking `appleid.cdn-apple.com`? | Audit in W1. |
+| **O4** | SIGNula subject pairwise vs global; SDK plans; partner-SSO roadmap. | SIGNula's call; iHymns is agnostic. |
+| **O5** | During soak: sign-in-only (suppress `created`) or full sign-up? | Optional; default = parity with native. |
+| **O6** | SIGNula `account_tier` → iHymns `TIER_CAPS` (#1352) mapping? | Park until F2. |
+| **O7** | Extend conditional-cookie login-CSRF fix to `auth_login`/magic-link? | Yes, W4, separate commit. |
+
+## 11. Effort / value
+
+W0 ≈ 0 code + owner portal · W1 0.5–1d (high — unlocks everything) · W2 1–2d (highest user-visible) · W3 ~1d (unlink lockout = the only genuinely new security logic) · W4 1–2d (low, schedulable) · S1 **weeks in the SIGNula repo** · S2 2–4d in iHymns. **Total for asks #1+#3 ≈ 3–4 dev-days + provisioning; ask #2 = one decision (D1) + one contract document today.**
+
+---
+
+*Planning provenance: 2 sequential Fable-5 deep-planning rounds (round 1 draft, round 2 adversarial verify+refine) + Opus review, 2026-07-10. This is a draft for owner review — no code, issues, or branches have been created from it.*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -355,6 +355,31 @@ jobs:
           php tests/php/test-apple-siwa-sources.php
 
       # -----------------------------------------------------------------------
+      # Step 5j-2: Sign in with Apple for WEB — dormancy gate + redirect-URI
+      # + code-exchange body (#1470 W1)
+      # PURE-core tests: _appleSiwaExchangeCodeBody() redirect_uri inclusion/
+      # omission, _appleWebLoginEnabledCore()'s full channel allow-list truth
+      # table, and _appleSiwaWebHostAllowed()'s Host-header validation. No DB,
+      # no network.
+      # -----------------------------------------------------------------------
+      - name: Sign in with Apple for web — dormancy gate + redirect URI (#1470)
+        run: |
+          echo "Running Apple SIWA web dormancy/redirect-URI test..."
+          php tests/php/test-apple-siwa-web.php
+
+      # -----------------------------------------------------------------------
+      # Step 5j-3: `auth_apple` platform discriminator + single-audience
+      # resolution (#1470 W1)
+      # Asserts the platform allow-list (native/web/absent accepted, anything
+      # else rejected) and structurally guards the "never try both auds"
+      # invariant + the web dormancy-gate-before-DB-write ordering.
+      # -----------------------------------------------------------------------
+      - name: auth_apple platform + single-audience guard (#1470)
+        run: |
+          echo "Running auth_apple platform/audience guard test..."
+          php tests/php/test-auth-apple-platform.php
+
+      # -----------------------------------------------------------------------
       # Step 5k: account_delete cascade completeness guard (#1403)
       # Asserts every FK referencing tblUsers(Id) is CASCADE or SET NULL
       # (never RESTRICT/NO ACTION, which would throw mid-delete), and that
@@ -560,6 +585,12 @@ jobs:
 
       - name: Sign in with Apple — static source guards (#1402/#1403)
         run: php tests/php/test-apple-siwa-sources.php
+
+      - name: Sign in with Apple for web — dormancy gate + redirect URI (#1470)
+        run: php tests/php/test-apple-siwa-web.php
+
+      - name: auth_apple platform + single-audience guard (#1470)
+        run: php tests/php/test-auth-apple-platform.php
 
       - name: account_delete FK cascade coverage (#1403)
         run: php tests/php/test-account-delete-fk-coverage.php

--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -3091,6 +3091,40 @@ if ($action !== null) {
                 break;
             }
 
+            /* Platform discriminator (#1470 W1) — selects which of OUR OWN
+               two client ids to check as the identity token's `aud`. PURE
+               resolver (tests/php/test-auth-apple-platform.php) so the
+               allow-list is unit-testable without a request. Absent/empty
+               defaults to 'native' — every existing caller (the shipped
+               native app) never sends this field, so its request is
+               byte-identical to before this change. */
+            $platformResolved = _authApplePlatformResolve($body['platform'] ?? null);
+            if (!$platformResolved['ok']) {
+                sendJson(['error' => "platform must be 'native' or 'web'."], 400);
+                break;
+            }
+            $platform = $platformResolved['platform'];
+
+            /* Resolve EXACTLY ONE expected audience — this app NEVER tries
+               both client ids against the same token (that would let a
+               native-app identity token be accepted as a web login, or vice
+               versa — an aud-confusion hole). 'web' is additionally gated on
+               BOTH a configured Services ID AND this channel's rollout
+               allow-list (appleWebLoginEnabledForChannel(), includes/
+               apple_siwa.php) — both settings default unset/empty, so
+               platform=web stays a byte-identical 503 dormant no-op (the
+               SAME shape as the tblUserAuthProviders gate above) until an
+               admin opts in via manage/configuration.php. */
+            if ($platform === 'web') {
+                if (!appleWebLoginEnabledForChannel()) {
+                    sendJson(['error' => 'Sign in with Apple is not yet available.'], 503);
+                    break;
+                }
+                $expectedAud = trim((string)(getAppSetting('apple_siwa_services_id', '') ?? ''));
+            } else {
+                $expectedAud = IHYMNS_SIWA_CLIENT_ID;
+            }
+
             /* authorizationCode is optional and only ever used for a
                best-effort refresh-token capture (§2.6) — malformed/absent
                both just mean "skip the exchange", never an error response. */
@@ -3144,7 +3178,7 @@ if ($action !== null) {
             }
 
             $verifyNow = time();
-            $verify = appleSiwaVerifyIdentityToken($identityToken, $jwks, IHYMNS_SIWA_CLIENT_ID, $rawNonce, $verifyNow);
+            $verify = appleSiwaVerifyIdentityToken($identityToken, $jwks, $expectedAud, $rawNonce, $verifyNow);
             if ($verify['ok'] !== true) {
                 /* ONE generic message for every verify failure — no replay/
                    enumeration oracle (§2.7). The precise reason is a fixed
@@ -3195,18 +3229,30 @@ if ($action !== null) {
 
             /* §2.6 — best-effort refresh-token capture, AFTER the mapping
                transaction commits. NEVER fatal: sign-in must succeed even if
-               Apple's token endpoint hiccups or the owner hasn't provisioned
+               Apple's token endpoint hiccups, the owner hasn't provisioned
                the .p8 key yet (account_delete's revoke then just degrades to
-               `skipped_no_token`). */
+               `skipped_no_token`), or — web only — this docroot's Host
+               header doesn't resolve to a registered redirect_uri.
+               $expectedAud IS the right client id to present to Apple here
+               too: native's is IHYMNS_SIWA_CLIENT_ID (unchanged from before
+               #1470), web's is the Services ID resolved above. */
             if ($authorizationCode !== null) {
                 try {
                     $teamId = (string)(getAppSetting('apple_team_id', '') ?? '');
                     $keyId  = (string)(getAppSetting('apple_siwa_key_id', '') ?? '');
                     $p8Pem  = (string)(getAppSetting('apple_siwa_private_key', '') ?? '');
-                    if ($teamId !== '' && $keyId !== '' && $p8Pem !== '') {
-                        $clientSecret = appleSiwaBuildClientSecret($teamId, $keyId, IHYMNS_SIWA_CLIENT_ID, $p8Pem, time());
+                    /* #1470 W1 — web needs a validated redirect_uri; a null
+                       (untrusted/foreign Host header) means "skip the
+                       exchange" rather than ever sending Apple a request
+                       built from unvalidated input. Native never had a
+                       redirect_uri concept, so this stays null for it
+                       (byte-identical to the pre-#1470 3-arg call). */
+                    $webRedirectUri = ($platform === 'web') ? appleSiwaWebRedirectUri() : null;
+                    $skipExchange   = ($platform === 'web' && $webRedirectUri === null);
+                    if (!$skipExchange && $teamId !== '' && $keyId !== '' && $p8Pem !== '') {
+                        $clientSecret = appleSiwaBuildClientSecret($teamId, $keyId, $expectedAud, $p8Pem, time());
                         if ($clientSecret !== null) {
-                            $tokenResp = appleSiwaExchangeCode($authorizationCode, $clientSecret, IHYMNS_SIWA_CLIENT_ID);
+                            $tokenResp = appleSiwaExchangeCode($authorizationCode, $clientSecret, $expectedAud, $webRedirectUri);
                             if ($tokenResp !== null && !empty($tokenResp['refresh_token']) && is_string($tokenResp['refresh_token'])) {
                                 $refreshToken = $tokenResp['refresh_token'];
                                 $updStmt = $db->prepare(
@@ -3260,7 +3306,8 @@ if ($action !== null) {
             }
 
             /* Audit (#535) — NEVER the sub, email claim, nonce, identityToken,
-               or refresh token (§2.2 step 12). */
+               or refresh token (§2.2 step 12). `platform` (#1470 W1) is a
+               fixed 'native'|'web' code, never PII, safe to log. */
             logActivity(
                 'auth.login_apple',
                 'user',
@@ -3268,6 +3315,7 @@ if ($action !== null) {
                 [
                     'username'      => $userRow['Username'],
                     'flow'          => $flow,
+                    'platform'      => $platform,
                     'private_relay' => $isPrivateRelayFlag,
                     'token_prefix'  => substr(hash('sha256', $token), 0, 12),
                 ],
@@ -4288,6 +4336,13 @@ if ($action !== null) {
          * No authentication required — used by PWA on startup
          * ----------------------------------------------------------------- */
         case 'app_status':
+            /* #1470 W1 — appleWebLoginEnabledForChannel() lives in the shared
+               Apple-SIWA module (already require_once'd by the auth_apple
+               case above); app_status needs it too so the future web
+               sign-in button can gate on ONE flag instead of re-deriving
+               the services-id + channel-allow-list logic client-side. */
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'apple_siwa.php';
+
             $db = getDbMysqli();
             /* Only fetch public-safe settings — never expose internal config.
                Dynamic IN-list with str_repeat for the bind type string. */
@@ -4330,6 +4385,12 @@ if ($action !== null) {
                    decide between a "lyrics protected" surface and a full
                    fetch (#1010 forward-looking content_gating_enabled flag). */
                 'contentGatingEnabled' => ($settings['content_gating_enabled'] ?? '0') === '1',
+                /* #1470 W1 — whether Sign in with Apple for WEB is enabled on
+                   THIS channel (Services ID configured AND channel allow-
+                   listed). Dormant/false until manage/configuration.php's
+                   Apple card has both saved — the future web sign-in button
+                   gates its own visibility on this flag. */
+                'appleWebLoginEnabled' => appleWebLoginEnabledForChannel(),
             ]);
             break;
 
@@ -13741,6 +13802,30 @@ function apiAuthSuccessPayload(
  * _authAppleMapAccountTxn(); its wrapper _authAppleMapAccount() owns the
  * transaction boundary + the one-shot race retry §2.5(d) calls for.
  * ========================================================================= */
+
+/**
+ * Resolve+validate the `platform` discriminator for ?action=auth_apple
+ * (#1470 W1) — PURE (no DB, no superglobals) so
+ * tests/php/test-auth-apple-platform.php can assert the allow-list without
+ * a request. Absent/empty → 'native' (every existing caller — the shipped
+ * native app — never sends this field, so its request resolves EXACTLY as
+ * it did before this discriminator existed). Any OTHER value is invalid; the
+ * caller (the `auth_apple` case body) responds with its standard 400 shape
+ * rather than silently guessing a platform.
+ *
+ * @param mixed $platformRaw The raw `platform` value from the decoded JSON body (or null/absent).
+ * @return array{ok:bool,platform:?string} ok=false ⇒ platform is always null.
+ */
+function _authApplePlatformResolve($platformRaw): array
+{
+    if ($platformRaw === null || $platformRaw === '') {
+        return ['ok' => true, 'platform' => 'native'];
+    }
+    if ($platformRaw === 'native' || $platformRaw === 'web') {
+        return ['ok' => true, 'platform' => $platformRaw];
+    }
+    return ['ok' => false, 'platform' => null];
+}
 
 /**
  * Record a failed auth_apple attempt: a Success=0 tblLoginAttempts row (feeds

--- a/appWeb/public_html/includes/apple_siwa.php
+++ b/appWeb/public_html/includes/apple_siwa.php
@@ -77,6 +77,30 @@ if (basename($_SERVER['SCRIPT_FILENAME'] ?? '') === basename(__FILE__)) {
  *  the ES256 client_secret's `sub` claim (§3.4). */
 const IHYMNS_SIWA_CLIENT_ID = 'app.ihymns';
 
+/**
+ * The single Apple-registered "return URL" path for the WEB (browser popup)
+ * Sign in with Apple flow (#1470 W1). MUST be byte-identical to:
+ *   (a) the Return URL registered against the `apple_siwa_services_id`
+ *       Services ID in Apple's Developer portal — for EVERY docroot
+ *       hostname (dev./beta./www./bare-apex `ihymns.app`); and
+ *   (b) the `redirectURI` the W2 front-end's `AppleID.auth.init({...})`
+ *       call supplies (`js/modules/apple-signin.js`, not built by this W1
+ *       backend slice) when it initiates the popup flow.
+ * Apple's `/auth/token` code-exchange REJECTS the request (400
+ * "invalid_grant") on ANY mismatch between the redirect_uri implied by the
+ * original `/auth/authorize` popup call and the one resent here — so a
+ * change to this constant is a breaking change that must be mirrored in
+ * BOTH Apple's portal and the front-end in the same deploy.
+ *
+ * '/' (the origin root) rather than a dedicated `/auth/apple/callback`-style
+ * path: POPUP mode (plan §4) means Apple's redirect happens INSIDE the
+ * popup/iframe, never the top-level page, so there is no server-rendered
+ * "callback page" to route to — the popup's own JS reads the result and
+ * closes itself. A future REDIRECT-mode fallback (plan §4/W4) would need a
+ * real routed path here instead of the bare root.
+ */
+const APPLE_SIWA_WEB_RETURN_PATH = '/';
+
 /** DER encoding of AlgorithmIdentifier { rsaEncryption, NULL } — the fixed prefix
  *  every RSA SubjectPublicKeyInfo carries. OID 1.2.840.113549.1.1.1. */
 const _APPLE_SIWA_RSA_ALGID_DER = "\x30\x0D\x06\x09\x2A\x86\x48\x86\xF7\x0D\x01\x01\x01\x05\x00";
@@ -522,6 +546,141 @@ function appleSiwaBuildClientSecret(string $teamId, string $keyId, string $clien
 }
 
 /* =============================================================================
+ * WEB SIWA — dormancy gate + redirect-URI helpers (#1470 W1)
+ *
+ * Everything below is settings/environment plumbing, NOT crypto — it decides
+ * (a) whether ?action=auth_apple should even ENTERTAIN `platform=web` on
+ * THIS deploy channel, and (b) what redirect_uri a web code exchange must
+ * present. Both are consumed by api.php's `auth_apple` AND `app_status`
+ * cases (the latter needs `appleWebLoginEnabledForChannel()` to decide
+ * whether to advertise a web sign-in button at all) — living here keeps
+ * every Apple-SIWA-specific decision in the ONE module (this file's
+ * top-of-file docblock), rather than forking a second copy into a generic
+ * settings/config include.
+ *
+ * DORMANCY: with `apple_siwa_services_id` unset (the shipped default), both
+ * helpers below are inert — appleWebLoginEnabledForChannel() short-circuits
+ * to false via its PURE core before ever inspecting the channel allow-list,
+ * so `platform=web` 503s exactly like today's un-migrated-table gate.
+ * ========================================================================== */
+
+/**
+ * Is Sign in with Apple for WEB enabled on the CURRENT deploy channel?
+ * Requires BOTH:
+ *   1. `apple_siwa_services_id` (manage/configuration.php) is a non-empty,
+ *      admin-configured Services ID — the web `aud` ?action=auth_apple will
+ *      check identity tokens against.
+ *   2. The current channel (ihymns_environment(): 'alpha' | 'beta' |
+ *      'production') is covered by the `apple_web_login_enabled`
+ *      comma-separated allow-list setting (or that setting is the literal
+ *      `all`).
+ * All three docroots SHARE ONE DATABASE (rule #1233/#1352 precedent), so a
+ * single global on/off flag would flip every channel at once the moment an
+ * admin saves a Services ID — the channel allow-list is what lets the
+ * owner soak web sign-in on `alpha` alone before widening it.
+ *
+ * Delegates entirely to the PURE _appleWebLoginEnabledCore() so
+ * tests/php/test-apple-siwa-web.php can exercise the full allow-list truth
+ * table without a database.
+ *
+ * @return bool
+ */
+function appleWebLoginEnabledForChannel(): bool
+{
+    $servicesId = function_exists('getAppSetting') ? (string)(getAppSetting('apple_siwa_services_id', '') ?? '') : '';
+    $allowList  = function_exists('getAppSetting') ? (string)(getAppSetting('apple_web_login_enabled', '') ?? '') : '';
+    $channel    = function_exists('ihymns_environment') ? ihymns_environment() : 'production';
+    return _appleWebLoginEnabledCore($servicesId, $allowList, $channel);
+}
+
+/**
+ * PURE core of appleWebLoginEnabledForChannel() — no DB, no superglobals, no
+ * `ihymns_environment()` call; every input is an explicit parameter so the
+ * full truth table (no services id / empty allow-list / channel not listed /
+ * channel listed / `all` / mixed-case + whitespace tokens) is assertable
+ * without any environment setup.
+ *
+ * @param string $servicesId The raw `apple_siwa_services_id` setting value.
+ * @param string $allowList  The raw `apple_web_login_enabled` setting value —
+ *                              a comma-separated list of channel tokens, or
+ *                              the single literal `all`. Empty = disabled
+ *                              everywhere (the shipped default).
+ * @param string $channel    The CURRENT deploy channel (ihymns_environment()'s
+ *                              return value: 'alpha' | 'beta' | 'production').
+ * @return bool
+ */
+function _appleWebLoginEnabledCore(string $servicesId, string $allowList, string $channel): bool
+{
+    if (trim($servicesId) === '') {
+        return false;
+    }
+    $tokens = array_filter(array_map(
+        static fn(string $t): string => strtolower(trim($t)),
+        explode(',', $allowList)
+    ), static fn(string $t): bool => $t !== '');
+    if (!$tokens) {
+        return false;
+    }
+    $channel = strtolower(trim($channel));
+    foreach ($tokens as $token) {
+        if ($token === 'all' || $token === $channel) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * The web redirect_uri for THIS request's docroot — 'https://' . $host .
+ * APPLE_SIWA_WEB_RETURN_PATH, where $host is $_SERVER['HTTP_HOST'] validated
+ * against OUR OWN domain first. Returns null (never a guess, never a
+ * fallback host) when the Host fails validation, so the caller's code
+ * exchange degrades to "skip the exchange" (best-effort — see
+ * appleSiwaExchangeCode()'s docblock) rather than ever sending Apple a
+ * redirect_uri built from untrusted input.
+ *
+ * SECURITY (CWE-640, Host-header injection): $_SERVER['HTTP_HOST'] is
+ * attacker-controlled on the wire. The validation lives in the PURE
+ * _appleSiwaWebHostAllowed() below so it is unit-testable without faking a
+ * request; this wrapper is the only place that reads the superglobal.
+ *
+ * @return string|null
+ */
+function appleSiwaWebRedirectUri(): ?string
+{
+    $host = (string)($_SERVER['HTTP_HOST'] ?? '');
+    if (!_appleSiwaWebHostAllowed($host)) {
+        return null;
+    }
+    return 'https://' . $host . APPLE_SIWA_WEB_RETURN_PATH;
+}
+
+/**
+ * PURE host validator for appleSiwaWebRedirectUri(). Accepts exactly
+ * `ihymns.app` or any subdomain of it (`*.ihymns.app`) — a SUFFIX check
+ * rather than includes/config.php's appCanonicalHost() closed 4-entry list,
+ * deliberately chosen here because iHymns owns the DNS for the whole
+ * `ihymns.app` zone, so nobody else can ever stand up a subdomain that
+ * matches this suffix; the closed list would otherwise need a code change
+ * for every new docroot subdomain the owner adds. The companion charset
+ * gate rejects anything that isn't a bare hostname (no scheme/port/path/
+ * userinfo/CR-LF) BEFORE the suffix check runs, so a crafted Host header
+ * like `evil.com` can never smuggle a `.ihymns.app`-ending suffix past a
+ * naive `str_ends_with()` call via characters the charset gate excludes.
+ *
+ * @param string $host Raw candidate host (already lower/trim-normalised inside).
+ * @return bool
+ */
+function _appleSiwaWebHostAllowed(string $host): bool
+{
+    $host = strtolower(trim($host));
+    if ($host === '' || !preg_match('/^[a-z0-9.-]+$/', $host)) {
+        return false;
+    }
+    return $host === 'ihymns.app' || str_ends_with($host, '.ihymns.app');
+}
+
+/* =============================================================================
  * I/O SHELL — curl + DB (kept thin; all crypto decisions live in the pure
  * functions above so these are easy to eyeball for "does this call the right
  * pure function with the right inputs")
@@ -746,6 +905,40 @@ function appleSiwaConsumeNonce(\mysqli $db, string $purpose, string $rawNonce): 
 }
 
 /**
+ * PURE builder for appleSiwaExchangeCode()'s `application/x-www-form-urlencoded`
+ * POST body — split out of that function (#1470 W1) so
+ * tests/php/test-apple-siwa-web.php can assert the EXACT presence/absence of
+ * `redirect_uri` WITHOUT a network call (appleSiwaExchangeCode() itself always
+ * hits `https://appleid.apple.com/auth/token`, which CI must never do).
+ *
+ * Apple's `/auth/token` endpoint REJECTS the whole request (400
+ * "invalid_request") if `redirect_uri` is PRESENT but empty — native's
+ * ASAuthorization flow never had a redirect_uri to begin with, so the key is
+ * OMITTED ENTIRELY (never sent as `redirect_uri=`) whenever $redirectUri is
+ * null or ''. That keeps every existing (native) caller's body
+ * BYTE-IDENTICAL to before this function existed.
+ *
+ * @param string      $code         The `authorizationCode` from the client's SIWA credential.
+ * @param string      $clientSecret ES256 JWT from appleSiwaBuildClientSecret().
+ * @param string      $clientId     IHYMNS_SIWA_CLIENT_ID (native) or the Services ID (web).
+ * @param string|null $redirectUri  Web only — appleSiwaWebRedirectUri()'s result. Null/'' → omitted.
+ * @return string application/x-www-form-urlencoded body.
+ */
+function _appleSiwaExchangeCodeBody(string $code, string $clientSecret, string $clientId, ?string $redirectUri): string
+{
+    $params = [
+        'grant_type'    => 'authorization_code',
+        'code'          => $code,
+        'client_id'     => $clientId,
+        'client_secret' => $clientSecret,
+    ];
+    if ($redirectUri !== null && $redirectUri !== '') {
+        $params['redirect_uri'] = $redirectUri;
+    }
+    return http_build_query($params);
+}
+
+/**
  * Exchange an authorization code for Apple tokens (incl. a `refresh_token`)
  * at `POST /auth/token`. Only useful within ~5 minutes of the original
  * authorization (Apple's window) — called right after auth_apple's mapping
@@ -753,23 +946,24 @@ function appleSiwaConsumeNonce(\mysqli $db, string $purpose, string $rawNonce): 
  * can later hand to appleSiwaRevokeToken(). Best-effort by design: every
  * failure here is non-fatal to sign-in (caller logs an outcome, never blocks).
  *
- * @param string $code         The `authorizationCode` from the client's SIWA credential.
- * @param string $clientSecret ES256 JWT from appleSiwaBuildClientSecret().
- * @param string $clientId     IHYMNS_SIWA_CLIENT_ID.
+ * @param string      $code         The `authorizationCode` from the client's SIWA credential.
+ * @param string      $clientSecret ES256 JWT from appleSiwaBuildClientSecret().
+ * @param string      $clientId     IHYMNS_SIWA_CLIENT_ID (native) or the Services ID (web).
+ * @param string|null $redirectUri  #1470 W1 — Apple REQUIRES `redirect_uri` on a web code
+ *                                    exchange (native's ASAuthorization sends none, so this
+ *                                    stays null for every native call). Only included in the
+ *                                    outbound body when non-null/non-empty — see
+ *                                    _appleSiwaExchangeCodeBody()'s docblock for why a
+ *                                    present-but-empty value is never sent either.
  * @return array|null Decoded JSON body (contains `refresh_token`) on HTTP 200 with a token present, else null.
  */
-function appleSiwaExchangeCode(string $code, string $clientSecret, string $clientId): ?array
+function appleSiwaExchangeCode(string $code, string $clientSecret, string $clientId, ?string $redirectUri = null): ?array
 {
     if ($code === '' || $clientSecret === '' || !function_exists('curl_init')) {
         return null;
     }
 
-    $body = http_build_query([
-        'grant_type'    => 'authorization_code',
-        'code'          => $code,
-        'client_id'     => $clientId,
-        'client_secret' => $clientSecret,
-    ]);
+    $body = _appleSiwaExchangeCodeBody($code, $clientSecret, $clientId, $redirectUri);
 
     $decoded = _appleSiwaPostForm('https://appleid.apple.com/auth/token', $body);
     if (!is_array($decoded) || empty($decoded['refresh_token']) || !is_string($decoded['refresh_token'])) {

--- a/appWeb/public_html/manage/configuration.php
+++ b/appWeb/public_html/manage/configuration.php
@@ -42,6 +42,12 @@ require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEP
    for the public read path; this page needs the stronger guarantee. */
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'secret_crypto.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'maintenance.php';
+/* #1470 W1 — needed for the IHYMNS_SIWA_CLIENT_ID constant (the save_apple
+   handler below rejects a pasted Services ID that matches the native App
+   ID) and for the two new appleWebLoginEnabledForChannel()-adjacent
+   settings this card now manages. No DB/network side effect at require
+   time — see that file's own top-of-file docblock. */
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'apple_siwa.php';
 
 if (!isAuthenticated()) {
     header('Location: /manage/login');
@@ -518,6 +524,48 @@ if (($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'POST') {
                     $privateKeyVal = $candidate;
                 }
 
+                /* #1470 W1 — Sign in with Apple for WEB. Two NON-secret
+                   companion settings: the Services ID is public-by-definition
+                   (same visibility class as the native bundle id above), and
+                   the channel allow-list is just a rollout dial — neither
+                   needs the secret=true / blank-means-keep convention the
+                   private key above uses; both are safe to echo back into
+                   the form and are saved every submit (never "leave blank to
+                   keep"), matching apple_team_id/apple_siwa_key_id's own
+                   always-overwrite behaviour just above. */
+                $servicesIdVal = trim((string)($_POST['apple_siwa_services_id'] ?? ''));
+                if ($servicesIdVal !== '') {
+                    if (!preg_match('/^[A-Za-z0-9][A-Za-z0-9.\-]{0,254}$/', $servicesIdVal)) {
+                        throw new \RuntimeException('Apple Services ID doesn\'t look like a valid identifier (letters/digits/dot/hyphen, starting with a letter or digit, e.g. "app.ihymns.web").');
+                    }
+                    if ($servicesIdVal === IHYMNS_SIWA_CLIENT_ID) {
+                        throw new \RuntimeException('That is the NATIVE App ID ("' . IHYMNS_SIWA_CLIENT_ID . '") — Sign in with Apple for web needs a SEPARATE Services ID (e.g. "app.ihymns.web"), not the App ID reused here.');
+                    }
+                }
+
+                /* Channel allow-list — each comma-separated token must be one
+                   of the three canonical channels (ihymns_environment()'s
+                   return values) or the single literal "all". Anything else
+                   (a typo, a stray docroot hostname pasted here by mistake)
+                   is rejected outright rather than silently ignored, since a
+                   token that never matches would look "saved" but do nothing. */
+                $webLoginEnabledVal = trim((string)($_POST['apple_web_login_enabled'] ?? ''));
+                if ($webLoginEnabledVal !== '') {
+                    $validChannelTokens = ['alpha', 'beta', 'production', 'all'];
+                    $webChannelTokens = array_values(array_filter(array_map('trim', explode(',', $webLoginEnabledVal)), static fn(string $t): bool => $t !== ''));
+                    foreach ($webChannelTokens as $tok) {
+                        if (!in_array(strtolower($tok), $validChannelTokens, true)) {
+                            throw new \RuntimeException('Web login channel allow-list must be a comma-separated list of "alpha", "beta", "production", or "all" — "' . $tok . '" is none of those.');
+                        }
+                    }
+                    /* Normalise to lowercase for storage — appleWebLoginEnabledForChannel()'s
+                       PURE core already lowercases on read, but storing it
+                       normalised keeps the admin-echoed value and the raw
+                       tblAppSettings row identical (no surprise casing on
+                       the next page load). */
+                    $webLoginEnabledVal = implode(',', array_map('strtolower', $webChannelTokens));
+                }
+
                 $changedKeys = ['apple_team_id', 'apple_siwa_key_id'];
                 $saveSetting($db, 'apple_team_id', $teamIdVal);
                 $saveSetting($db, 'apple_siwa_key_id', $keyIdVal);
@@ -525,6 +573,10 @@ if (($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'POST') {
                     $changedKeys[] = 'apple_siwa_private_key';
                     $saveSetting($db, 'apple_siwa_private_key', $privateKeyVal);
                 }
+                $changedKeys[] = 'apple_siwa_services_id';
+                $saveSetting($db, 'apple_siwa_services_id', $servicesIdVal);
+                $changedKeys[] = 'apple_web_login_enabled';
+                $saveSetting($db, 'apple_web_login_enabled', $webLoginEnabledVal);
 
                 if (function_exists('logActivity')) {
                     logActivity(
@@ -639,6 +691,15 @@ $appleTeamId = (string)(getAppSetting('apple_team_id', '') ?? '');
    email_gmail_sa_json above). */
 $appleSiwaKeyId = (string)(getAppSetting('apple_siwa_key_id', '') ?? '');
 $appleSiwaPrivateKeySet = ((string)(getAppSetting('apple_siwa_private_key', '') ?? '')) !== '';
+
+/* Sign in with Apple for WEB (#1470 W1) — both NON-secret, echoed back as-is
+   (no "leave blank to keep" convention). appleWebLoginEnabledForChannel()
+   itself is not called here — this page shows the RAW saved setting values,
+   not a resolved per-channel boolean (an admin editing this form needs to
+   see exactly what is stored, on whichever docroot they happen to be
+   viewing it from). */
+$appleSiwaServicesId = (string)(getAppSetting('apple_siwa_services_id', '') ?? '');
+$appleWebLoginEnabledSetting = (string)(getAppSetting('apple_web_login_enabled', '') ?? '');
 
 /* Native app store IDs (#1403/#1462) — the values echoed back are the
    CANONICAL, parsed IDs saved by save_native_apps above (never a raw
@@ -868,6 +929,57 @@ require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'head
                         <strong>not</strong> the App Store Connect API deploy key
                         (<code>APPLE_ASC_KEY_P8</code>) — that is a different key, used only by the
                         release pipeline.
+                    </div>
+                </div>
+
+                <div class="col-12"><hr class="text-secondary my-2"></div>
+
+                <div class="col-12">
+                    <h3 class="h6 mb-1">
+                        <i class="bi bi-globe me-1"></i>Sign in with Apple — Web (#1470)
+                        <span class="badge <?= $appleSiwaServicesId === '' ? 'bg-secondary' : 'bg-success' ?> ms-1" style="font-size: 0.65rem;">
+                            <?= $appleSiwaServicesId === '' ? 'Services ID not set' : 'Services ID set' ?>
+                        </span>
+                        <span class="badge <?= $appleWebLoginEnabledSetting === '' ? 'bg-secondary' : 'bg-success' ?> ms-1" style="font-size: 0.65rem;">
+                            <?= $appleWebLoginEnabledSetting === '' ? 'Disabled on every channel' : ('Enabled: ' . htmlspecialchars($appleWebLoginEnabledSetting, ENT_QUOTES, 'UTF-8')) ?>
+                        </span>
+                    </h3>
+                    <p class="small text-secondary mb-3">
+                        Web/PWA Sign in with Apple uses a SEPARATE <strong>Services ID</strong>
+                        (developer.apple.com &rarr; Identifiers &rarr; "+" &rarr; Services IDs — grouped
+                        under the <code>app.ihymns</code> App ID, same Apple Developer Team as the
+                        native app above), <strong>not</strong> the App ID itself. Register the return
+                        URL <code>https://&lt;each docroot host&gt;/</code> against that Services ID for
+                        EVERY docroot this app is deployed to (e.g. <code>https://ihymns.app/</code>,
+                        <code>https://beta.ihymns.app/</code>, <code>https://dev.ihymns.app/</code>) —
+                        it must match exactly what the web sign-in button sends, or Apple's code
+                        exchange fails. Both fields below are dormant: web sign-in stays entirely
+                        unavailable (a clean 503, identical to today) until BOTH a Services ID is
+                        saved here AND the current channel is included in the allow-list below.
+                    </p>
+                </div>
+                <div class="col-md-6">
+                    <label for="apple_siwa_services_id" class="form-label">Services ID</label>
+                    <input type="text" name="apple_siwa_services_id" id="apple_siwa_services_id" class="form-control"
+                           maxlength="255" placeholder="app.ihymns.web" autocomplete="off"
+                           value="<?= htmlspecialchars($appleSiwaServicesId, ENT_QUOTES, 'UTF-8') ?>">
+                    <div class="form-text">
+                        Not a secret (same visibility class as the native app's bundle id) — but must
+                        NOT be <code>app.ihymns</code> (that's the App ID, a different identifier).
+                        Leave blank to clear (disables web sign-in on every channel).
+                    </div>
+                </div>
+                <div class="col-md-6">
+                    <label for="apple_web_login_enabled" class="form-label">Enabled on channels</label>
+                    <input type="text" name="apple_web_login_enabled" id="apple_web_login_enabled" class="form-control"
+                           maxlength="60" placeholder="alpha   or   alpha,beta   or   all"
+                           value="<?= htmlspecialchars($appleWebLoginEnabledSetting, ENT_QUOTES, 'UTF-8') ?>">
+                    <div class="form-text">
+                        Comma-separated <code>alpha</code> / <code>beta</code> / <code>production</code>,
+                        or the single word <code>all</code>. All three docroots share ONE database, so
+                        this is a staged-rollout dial for the shared-DB deploy — e.g. start with
+                        <code>alpha</code>, widen to <code>alpha,beta</code> once verified, then
+                        <code>all</code>. Leave blank to disable on every channel (the safe default).
                     </div>
                 </div>
 

--- a/tests/php/test-apple-siwa-web.php
+++ b/tests/php/test-apple-siwa-web.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * iHymns — Sign in with Apple for WEB: dormancy gate + redirect-URI + code-
+ * exchange body helpers (#1470 W1)
+ *
+ * Exercises the THREE PURE cores includes/apple_siwa.php gained for the web
+ * SIWA slice — no DB, no network, no request:
+ *
+ *   1. _appleSiwaExchangeCodeBody() — proves `redirect_uri` is INCLUDED iff a
+ *      non-empty value is passed and OMITTED (byte-identical to the pre-#1470
+ *      native-only body) when null/empty. appleSiwaExchangeCode() itself
+ *      always POSTs to https://appleid.apple.com/auth/token, which CI must
+ *      never actually call — this pure body-builder is the extracted seam
+ *      the plan's test-writing guidance calls for.
+ *   2. _appleWebLoginEnabledCore() — the full channel allow-list truth table
+ *      (no services id / empty allow-list / channel not listed / channel
+ *      listed / `all` / mixed-case + whitespace tokens), plus the impure
+ *      wrapper appleWebLoginEnabledForChannel() resolves to false in THIS
+ *      CI environment (no DB credentials — mirrors test-gating-noop.php's
+ *      "no stub needed, the real fail-safe defaults do the job" approach).
+ *   3. _appleSiwaWebHostAllowed() — the Host-header validation
+ *      appleSiwaWebRedirectUri() relies on before ever building a URL from
+ *      $_SERVER['HTTP_HOST'], plus the impure wrapper exercised end-to-end
+ *      by temporarily setting $_SERVER['HTTP_HOST'].
+ *
+ *   php tests/php/test-apple-siwa-web.php
+ *
+ * Exit status 0 = all assertions pass, 1 = at least one failure.
+ */
+
+declare(strict_types=1);
+
+require_once dirname(__DIR__, 2) . '/appWeb/public_html/includes/apple_siwa.php';
+
+$failures = 0;
+$passed = 0;
+
+function _tasw_assert(bool $cond, string $label): void
+{
+    global $failures, $passed;
+    if ($cond) {
+        $passed++;
+        echo "PASS: $label\n";
+    } else {
+        $failures++;
+        fwrite(STDERR, "FAIL: $label\n");
+    }
+}
+
+/* ------------------------------------------------------------------------ *
+ * 1. _appleSiwaExchangeCodeBody() — redirect_uri inclusion/omission.
+ * ------------------------------------------------------------------------ */
+$bodyNoRedirect = _appleSiwaExchangeCodeBody('CODE1', 'SECRET1', 'app.ihymns', null);
+parse_str($bodyNoRedirect, $parsedNoRedirect);
+_tasw_assert(!array_key_exists('redirect_uri', $parsedNoRedirect), 'null redirectUri: redirect_uri key is OMITTED entirely');
+_tasw_assert(
+    $parsedNoRedirect === [
+        'grant_type'    => 'authorization_code',
+        'code'          => 'CODE1',
+        'client_id'     => 'app.ihymns',
+        'client_secret' => 'SECRET1',
+    ],
+    'null redirectUri: body is the byte-identical pre-#1470 4-key shape'
+);
+
+$bodyEmptyRedirect = _appleSiwaExchangeCodeBody('CODE1', 'SECRET1', 'app.ihymns', '');
+_tasw_assert($bodyEmptyRedirect === $bodyNoRedirect, 'empty-string redirectUri produces the SAME body as null (never sent as redirect_uri=)');
+
+$bodyWithRedirect = _appleSiwaExchangeCodeBody('CODE2', 'SECRET2', 'app.ihymns.web', 'https://ihymns.app/');
+parse_str($bodyWithRedirect, $parsedWithRedirect);
+_tasw_assert(($parsedWithRedirect['redirect_uri'] ?? null) === 'https://ihymns.app/', 'non-empty redirectUri: redirect_uri is present with the exact value');
+_tasw_assert(
+    array_keys($parsedWithRedirect) === ['grant_type', 'code', 'client_id', 'client_secret', 'redirect_uri'],
+    'non-empty redirectUri: the other four keys are unchanged and redirect_uri is appended last'
+);
+
+/* appleSiwaExchangeCode()'s own guard clauses never touch the network. */
+_tasw_assert(appleSiwaExchangeCode('', 'SECRET', 'app.ihymns') === null, 'appleSiwaExchangeCode(): empty code short-circuits to null (no network)');
+_tasw_assert(appleSiwaExchangeCode('CODE', '', 'app.ihymns') === null, 'appleSiwaExchangeCode(): empty clientSecret short-circuits to null (no network)');
+_tasw_assert(appleSiwaExchangeCode('CODE', '', 'app.ihymns', 'https://ihymns.app/') === null, 'appleSiwaExchangeCode(): guard clause still short-circuits with a redirectUri present');
+
+/* ------------------------------------------------------------------------ *
+ * 2. _appleWebLoginEnabledCore() — full truth table.
+ * ------------------------------------------------------------------------ */
+_tasw_assert(_appleWebLoginEnabledCore('', 'alpha', 'alpha') === false, 'no Services ID → false regardless of allow-list/channel');
+_tasw_assert(_appleWebLoginEnabledCore('app.ihymns.web', '', 'alpha') === false, 'Services ID set but allow-list EMPTY → false (disabled everywhere, the shipped default)');
+_tasw_assert(_appleWebLoginEnabledCore('app.ihymns.web', 'beta', 'alpha') === false, 'Services ID set, allow-list has a DIFFERENT channel → false');
+_tasw_assert(_appleWebLoginEnabledCore('app.ihymns.web', 'alpha', 'alpha') === true, 'Services ID set, allow-list contains the current channel → true');
+_tasw_assert(_appleWebLoginEnabledCore('app.ihymns.web', 'alpha,beta', 'beta') === true, 'multi-token allow-list: current channel is one of several → true');
+_tasw_assert(_appleWebLoginEnabledCore('app.ihymns.web', 'alpha,beta', 'production') === false, 'multi-token allow-list: current channel is NOT listed → false');
+_tasw_assert(_appleWebLoginEnabledCore('app.ihymns.web', 'all', 'production') === true, 'the literal "all" matches every channel');
+_tasw_assert(_appleWebLoginEnabledCore('app.ihymns.web', ' ALPHA , Beta ', 'alpha') === true, 'allow-list tokens are trimmed + case-insensitive');
+_tasw_assert(_appleWebLoginEnabledCore('  ', 'all', 'alpha') === false, 'whitespace-only Services ID counts as unset → false even with "all"');
+_tasw_assert(_appleWebLoginEnabledCore('app.ihymns.web', ',,', 'alpha') === false, 'an allow-list of only empty/comma tokens → false (never a stray-match)');
+
+/* The impure wrapper, exercised for real: no DB credentials in CI, so
+   getAppSetting() catches getDbMysqli()'s RuntimeException and returns its
+   default ('') for both settings — mirrors test-gating-noop.php's approach
+   of proving the REAL fail-safe defaults, not a stub. */
+_tasw_assert(appleWebLoginEnabledForChannel() === false, 'appleWebLoginEnabledForChannel(): byte-identical dormant no-op with no settings configured (real getAppSetting()/ihymns_environment(), no DB in CI)');
+
+/* ------------------------------------------------------------------------ *
+ * 3. _appleSiwaWebHostAllowed() — Host-header validation.
+ * ------------------------------------------------------------------------ */
+_tasw_assert(_appleSiwaWebHostAllowed('ihymns.app') === true, 'bare apex "ihymns.app" is allowed');
+_tasw_assert(_appleSiwaWebHostAllowed('www.ihymns.app') === true, '"www.ihymns.app" subdomain is allowed');
+_tasw_assert(_appleSiwaWebHostAllowed('beta.ihymns.app') === true, '"beta.ihymns.app" subdomain is allowed');
+_tasw_assert(_appleSiwaWebHostAllowed('dev.ihymns.app') === true, '"dev.ihymns.app" subdomain is allowed');
+_tasw_assert(_appleSiwaWebHostAllowed('IHYMNS.APP') === true, 'case-insensitive: "IHYMNS.APP" is allowed');
+_tasw_assert(_appleSiwaWebHostAllowed('') === false, 'empty host is rejected');
+_tasw_assert(_appleSiwaWebHostAllowed('evil.com') === false, 'a foreign domain is rejected');
+_tasw_assert(_appleSiwaWebHostAllowed('notihymns.app') === false, 'a look-alike host missing the dot boundary ("notihymns.app") is rejected');
+_tasw_assert(_appleSiwaWebHostAllowed('ihymns.app.evil.com') === false, 'a suffix-spoof attempt ("ihymns.app.evil.com") is rejected — the domain must END WITH .ihymns.app, not merely contain it');
+_tasw_assert(_appleSiwaWebHostAllowed('ihymns.app@evil.com') === false, 'a userinfo-injection attempt is rejected by the bare-hostname charset gate');
+_tasw_assert(_appleSiwaWebHostAllowed("ihymns.app\r\nX-Injected: 1") === false, 'a CR/LF header-injection attempt is rejected by the charset gate');
+_tasw_assert(_appleSiwaWebHostAllowed('ihymns.app:8443') === false, 'a host:port pair is rejected by the charset gate (no colon allowed)');
+
+/* The impure wrapper, via a temporarily-faked $_SERVER['HTTP_HOST'] — safe
+   in a CLI test process (no real request in flight). */
+$origHost = $_SERVER['HTTP_HOST'] ?? null;
+$_SERVER['HTTP_HOST'] = 'beta.ihymns.app';
+_tasw_assert(appleSiwaWebRedirectUri() === 'https://beta.ihymns.app/', 'appleSiwaWebRedirectUri(): valid docroot host → "https://<host>" . APPLE_SIWA_WEB_RETURN_PATH');
+$_SERVER['HTTP_HOST'] = 'evil.example.com';
+_tasw_assert(appleSiwaWebRedirectUri() === null, 'appleSiwaWebRedirectUri(): a foreign/spoofed Host header → null (never a guessed fallback)');
+if ($origHost === null) {
+    unset($_SERVER['HTTP_HOST']);
+} else {
+    $_SERVER['HTTP_HOST'] = $origHost;
+}
+
+_tasw_assert(APPLE_SIWA_WEB_RETURN_PATH === '/', 'APPLE_SIWA_WEB_RETURN_PATH is the documented "/" origin-root value');
+
+echo "\n$passed passed, $failures failed.\n";
+exit($failures > 0 ? 1 : 0);

--- a/tests/php/test-auth-apple-platform.php
+++ b/tests/php/test-auth-apple-platform.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * iHymns — `?action=auth_apple` platform discriminator + single-audience
+ * resolution (#1470 W1)
+ *
+ * api.php is a 13k+-line dispatcher that executes real request-handling code
+ * at file-scope on require (the test-auth-response-shape.php precedent
+ * explains why) — so this test:
+ *
+ *   1. Extracts JUST the pure _authApplePlatformResolve() function body via a
+ *      balanced-brace scan and eval()s that single definition — no
+ *      dispatcher code runs, no DB, no network — then asserts its full
+ *      allow-list behaviour (native/web/absent accepted, everything else
+ *      rejected, including type-confusion inputs a tampered JSON body could
+ *      send: 0, false, [], 'Native').
+ *   2. Source-greps `case 'auth_apple':`'s body to prove the "never try both
+ *      auds" invariant structurally: appleSiwaVerifyIdentityToken() is
+ *      called EXACTLY ONCE, and that one call site uses the single resolved
+ *      $expectedAud variable rather than a literal IHYMNS_SIWA_CLIENT_ID
+ *      (which would silently re-introduce "always check native's aud", the
+ *      exact regression W1 fixes) or two side-by-side verify attempts.
+ *   3. Source-greps that the `platform=web` branch is dormancy-gated by
+ *      appleWebLoginEnabledForChannel() BEFORE _authAppleMapAccount() ever
+ *      runs — i.e. the dormant/disabled path can't reach the DB writes.
+ *
+ *   php tests/php/test-auth-apple-platform.php
+ *
+ * Exit status 0 = all assertions pass, 1 = at least one failure.
+ */
+
+declare(strict_types=1);
+
+$apiFile = dirname(__DIR__, 2) . '/appWeb/public_html/api.php';
+if (!is_readable($apiFile)) {
+    fwrite(STDERR, "FATAL: could not read $apiFile\n");
+    exit(1);
+}
+$apiSrc = (string)file_get_contents($apiFile);
+
+$failures = 0;
+$passed = 0;
+
+function _taap_assert(bool $cond, string $label): void
+{
+    global $failures, $passed;
+    if ($cond) {
+        $passed++;
+        echo "PASS: $label\n";
+    } else {
+        $failures++;
+        fwrite(STDERR, "FAIL: $label\n");
+    }
+}
+
+/**
+ * Extract one top-level `function $name(...) { ... }` definition from
+ * $source via a balanced-brace scan (mirrors test-auth-response-shape.php's
+ * _tarsExtractFunction() — the codebase's array literals use `[...]`, never
+ * `{...}`, so simple brace counting is safe here).
+ */
+function _taapExtractFunction(string $source, string $name): ?string
+{
+    if (!preg_match('/function\s+' . preg_quote($name, '/') . '\s*\(/', $source, $m, PREG_OFFSET_CAPTURE)) {
+        return null;
+    }
+    $start = $m[0][1];
+    $bracePos = strpos($source, '{', $start);
+    if ($bracePos === false) {
+        return null;
+    }
+    $depth = 0;
+    $len = strlen($source);
+    for ($i = $bracePos; $i < $len; $i++) {
+        if ($source[$i] === '{') { $depth++; }
+        elseif ($source[$i] === '}') {
+            $depth--;
+            if ($depth === 0) {
+                return substr($source, $start, $i - $start + 1);
+            }
+        }
+    }
+    return null;
+}
+
+$fnSrc = _taapExtractFunction($apiSrc, '_authApplePlatformResolve');
+if ($fnSrc === null) {
+    fwrite(STDERR, "FATAL: could not extract _authApplePlatformResolve() from api.php — has it been renamed or removed?\n");
+    exit(1);
+}
+
+/* eval() a single, isolated function DEFINITION — no dispatcher code, no
+   superglobals, no I/O. Safe: this is source we just extracted and are
+   about to assert the shape of, not arbitrary/untrusted input. */
+eval($fnSrc);
+
+if (!function_exists('_authApplePlatformResolve')) {
+    fwrite(STDERR, "FATAL: eval() of the extracted function did not define _authApplePlatformResolve().\n");
+    exit(1);
+}
+
+/* ---------------------------------------------------------------------- *
+ * 1. Allow-list truth table.
+ * ---------------------------------------------------------------------- */
+_taap_assert(_authApplePlatformResolve(null) === ['ok' => true, 'platform' => 'native'], 'absent (null) platform → ok, defaults to "native"');
+_taap_assert(_authApplePlatformResolve('') === ['ok' => true, 'platform' => 'native'], 'empty-string platform → ok, defaults to "native"');
+_taap_assert(_authApplePlatformResolve('native') === ['ok' => true, 'platform' => 'native'], '"native" → ok, platform="native"');
+_taap_assert(_authApplePlatformResolve('web') === ['ok' => true, 'platform' => 'web'], '"web" → ok, platform="web"');
+
+foreach (['Native', 'WEB', 'ios', 'android', ' web', 'web ', 'native;web', 0, 1, false, true, [], ['web']] as $bad) {
+    $label = is_scalar($bad) ? var_export($bad, true) : gettype($bad) . '(' . json_encode($bad) . ')';
+    $result = _authApplePlatformResolve($bad);
+    _taap_assert($result === ['ok' => false, 'platform' => null], "invalid platform $label → rejected (ok=false, platform=null)");
+}
+
+/* ---------------------------------------------------------------------- *
+ * 2. "Never try both auds" — structural guard on the real case body.
+ * ---------------------------------------------------------------------- */
+function _taapCaseBody(string $source, string $caseLabel): ?string
+{
+    $needle = "case '{$caseLabel}':";
+    $start = strpos($source, $needle);
+    if ($start === false) {
+        return null;
+    }
+    $bodyStart = $start + strlen($needle);
+    $nextCase = strpos($source, "\n        case '", $bodyStart);
+    return substr($source, $bodyStart, ($nextCase !== false ? $nextCase : strlen($source)) - $bodyStart);
+}
+
+$authAppleBody = _taapCaseBody($apiSrc, 'auth_apple');
+_taap_assert($authAppleBody !== null, "case 'auth_apple' found in api.php");
+
+if ($authAppleBody !== null) {
+    /* Match the actual INVOCATION form ("$verify = appleSiwaVerifyIdentityToken(")
+       rather than the bare function name — a nearby explanatory comment
+       ("Re-decoded again inside appleSiwaVerifyIdentityToken() (cheap; ...)")
+       also contains the bare name and would otherwise double-count as a
+       second call. */
+    $verifyCallCount = preg_match_all('/\$verify\s*=\s*appleSiwaVerifyIdentityToken\s*\(/', $authAppleBody);
+    _taap_assert($verifyCallCount === 1, "case 'auth_apple' calls appleSiwaVerifyIdentityToken() EXACTLY ONCE (found {$verifyCallCount}) — never tries a second aud on failure");
+    _taap_assert(
+        (bool)preg_match('/appleSiwaVerifyIdentityToken\s*\(\s*\$identityToken\s*,\s*\$jwks\s*,\s*\$expectedAud\s*,/', $authAppleBody),
+        "the one appleSiwaVerifyIdentityToken() call uses the single resolved \$expectedAud variable (not a literal IHYMNS_SIWA_CLIENT_ID)"
+    );
+    _taap_assert(
+        !(bool)preg_match('/appleSiwaVerifyIdentityToken\s*\([^)]*IHYMNS_SIWA_CLIENT_ID/', $authAppleBody),
+        "no appleSiwaVerifyIdentityToken() call hardcodes IHYMNS_SIWA_CLIENT_ID directly (that would silently re-introduce native-only aud checking)"
+    );
+    _taap_assert(
+        (bool)preg_match('/_authApplePlatformResolve\s*\(/', $authAppleBody),
+        "case 'auth_apple' calls _authApplePlatformResolve() (the shared, tested resolver) rather than re-inlining its own allow-list check"
+    );
+
+    /* Dormancy gate ordering: appleWebLoginEnabledForChannel() must appear
+       BEFORE _authAppleMapAccount() (the first DB-write path) in source
+       order, so a disabled/unconfigured web request 503s before any account
+       mapping/creation is attempted. */
+    $gatePos = strpos($authAppleBody, 'appleWebLoginEnabledForChannel(');
+    $mapPos  = strpos($authAppleBody, '_authAppleMapAccount(');
+    _taap_assert($gatePos !== false, "case 'auth_apple' calls appleWebLoginEnabledForChannel()");
+    _taap_assert($mapPos !== false, "case 'auth_apple' calls _authAppleMapAccount()");
+    _taap_assert($gatePos !== false && $mapPos !== false && $gatePos < $mapPos, 'the web dormancy gate runs BEFORE account mapping — a disabled/unconfigured web request never reaches the DB-write path');
+}
+
+echo "\n$passed passed, $failures failed.\n";
+exit($failures > 0 ? 1 : 0);


### PR DESCRIPTION
Closes part of #1470 (W1 backend). Base: `alpha`.

## Summary

**W1 (backend only) of Sign in with Apple for the Web/PWA** — plus the owner-approved strategy doc and a session handoff. **Fully DORMANT and a verified no-op**: a `platform=web` request 503s exactly like today until an admin configures **both** an Apple Services ID **and** the channel allow-list. Native `auth_apple` is byte-identical to before.

Strategy (Option C — build iHymns-direct SIWA-for-web now, federate to SIGNula later): [`.claude/siwa-web-signula-strategy.md`](../blob/feat/siwa-web/.claude/siwa-web-signula-strategy.md). Produced by 2 sequential Fable-5 planning rounds + Opus review. Companion: SIGNula federation contract `MWBMPartners/SIGNula.id#89`.

## Commits (3)

1. **docs(auth):** the strategy doc.
2. **feat(auth): W1 backend (dormant):**
   - `api.php auth_apple`: a `platform` discriminator (`native|web`; absent → `native`; else 400) selects **exactly one** expected audience — native = `IHYMNS_SIWA_CLIENT_ID`, web = the admin-set Services ID — and verifies the token against that single `aud` (**never try-both**, no aud-confusion). Web is gated on `appleWebLoginEnabledForChannel()`. The best-effort code exchange uses the resolved client id + a **Host-validated** web `redirect_uri` (Apple requires it for web codes), skipping gracefully on an untrusted Host. `platform` added to the success audit (fixed code, not PII).
   - `api.php app_status`: exposes `appleWebLoginEnabled` (for the future web button to gate on).
   - `includes/apple_siwa.php`: `appleSiwaExchangeCode()` gains an optional `redirect_uri` (omitted when null/empty → native body byte-identical); new `appleWebLoginEnabledForChannel()` + pure core, `appleSiwaWebRedirectUri()` + pure `_appleSiwaWebHostAllowed()` (charset gate + `*.ihymns.app` suffix — Host-header-injection safe), and `APPLE_SIWA_WEB_RETURN_PATH`. `appleSiwaVerifyIdentityToken()` untouched.
   - `manage/configuration.php`: Apple card gains `apple_siwa_services_id` (validated; **rejected if it equals the App ID**) + `apple_web_login_enabled` (channel allow-list `alpha`/`beta`/`production`/`all`, staged-rollout-aware for the shared-DB docroots).
   - **No schema change** (`tblUserAuthProviders`/`tblAuthNonces` are already provider-generic).
3. **docs(session):** the 2026-07-10 handoff.

## Security notes

- **Single audience, never try-both** — resolved once from a two-value allow-list of our own client ids; RS256 reject-gate unchanged.
- **Dormancy** — the web 503 gate runs *before* JWKS/verify/nonce/DB writes; native path byte-identical (tested).
- **Host-header injection** — the web redirect_uri host passes a charset gate before a `*.ihymns.app` suffix check; a foreign/spoofed Host → `null` → the exchange is skipped (never sent to Apple).
- **"login-CSRF" concern refuted** — the planning round flagged the unconditional cookie set in `auth_apple`, but `api.php`'s global `X-Requested-With` guard (lines 271-322) already blocks cross-site POSTs, so the cookie is only ever set on same-origin XHR. No change needed; the conditional-cookie item was dropped.
- Cookie/nonce/mapping/rate-limit/link-mode logic **untouched**.

## Verification

- `php -l` clean on all changed/new files.
- New: `tests/php/test-apple-siwa-web.php` (34) + `test-auth-apple-platform.php` (25), wired into `test.yml`. All existing Apple/auth tests still green.

Built with Sonnet, reviewed on Opus (aud-confusion / dormancy / Host-validation pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
