### PR TITLE
feat(auth): Sign in with Apple for Web — W2 sign-in + W3 linked accounts (dormant) (#1479)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -380,6 +380,20 @@ jobs:
           php tests/php/test-auth-apple-platform.php
 
       # -----------------------------------------------------------------------
+      # Step 5j-4: Linked-account UNLINK — lockout-guard truth table +
+      # masked-list shape (#1479 W3)
+      # PURE-core tests: _authProviderUnlinkSurvives()'s full survivor truth
+      # table (incl. the private-relay-email stranding case), the email-mask
+      # shape, and structural guards on both new case bodies (POST-only,
+      # validateCsrfRequest(), FOR UPDATE row locking, allow-listed provider,
+      # never selecting Subject/RefreshToken). No DB, no network.
+      # -----------------------------------------------------------------------
+      - name: Linked-account unlink — lockout guard + list masking (#1479)
+        run: |
+          echo "Running auth_provider_unlink lockout-guard + list-shape test..."
+          php tests/php/test-auth-provider-unlink.php
+
+      # -----------------------------------------------------------------------
       # Step 5k: account_delete cascade completeness guard (#1403)
       # Asserts every FK referencing tblUsers(Id) is CASCADE or SET NULL
       # (never RESTRICT/NO ACTION, which would throw mid-delete), and that
@@ -591,6 +605,9 @@ jobs:
 
       - name: auth_apple platform + single-audience guard (#1470)
         run: php tests/php/test-auth-apple-platform.php
+
+      - name: Linked-account unlink — lockout guard + list masking (#1479)
+        run: php tests/php/test-auth-provider-unlink.php
 
       - name: account_delete FK cascade coverage (#1403)
         run: php tests/php/test-account-delete-fk-coverage.php

--- a/appWeb/public_html/api-docs.yaml
+++ b/appWeb/public_html/api-docs.yaml
@@ -2786,7 +2786,26 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AuthResponse"
+                allOf:
+                  - $ref: "#/components/schemas/AuthResponse"
+                  - type: object
+                    properties:
+                      flow:
+                        type: string
+                        enum: [matched, linked, created]
+                        description: |
+                          How this sign-in resolved to an account
+                          (#1479 W2): `matched` — an already-linked
+                          Apple identity; `linked` — attached to the
+                          CURRENT bearer's account (`link: true`) or
+                          auto-linked to an existing account by verified
+                          email; `created` — a brand-new account.
+                          Appended to the OUTER response only —
+                          `AuthResponse`'s own `{token, user}` shape stays
+                          pinned (native's Swift `Codable` decode ignores
+                          unknown top-level keys). Never sensitive: the
+                          caller already holds the Apple identity token
+                          that produced this outcome.
         "400":
           description: Missing/malformed identityToken or nonce, or an invalid platform value
           content:
@@ -2821,6 +2840,169 @@ paths:
                 $ref: "#/components/schemas/Error"
         "503":
           description: Sign in with Apple not yet migrated on this environment, or Apple's key set is temporarily unreachable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api.php?action=auth_provider_unlink:
+    post:
+      operationId: authProviderUnlink
+      tags: [Authentication]
+      summary: Unlink an external-identity provider (#1479 W3)
+      description: |
+        Provider-generic unlink for the CALLER'S OWN account. Today's
+        allow-list is `['apple']` — `tblUserAuthProviders` is already
+        provider-generic (#1402), so a future provider grows the
+        allow-list, never the schema.
+
+        Requires a bearer/cookie session PLUS the same-origin CSRF check
+        (`validateCsrfRequest()`, rule #29): either the custom
+        `X-Requested-With: XMLHttpRequest` header (a cross-origin caller
+        cannot set it without a CORS preflight this server never grants),
+        or a still-valid session `csrf_token` in the body.
+
+        **Lockout guard** — refused with `409` unless a SURVIVING sign-in
+        method remains once this provider's row is removed: the
+        account's password hash is set; OR its email is verified AND
+        email-login is operational AND that email is NOT an Apple
+        private-relay alias (`@privaterelay.appleid.com` — unlinking
+        Apple deactivates that relay, so mail sent to it would bounce
+        forever); OR another, different provider is still linked.
+        Evaluated under `SELECT ... FOR UPDATE` on the account's own
+        provider rows so two concurrent unlinks (e.g. two open tabs) can
+        never each treat the OTHER as the surviving method.
+
+        On success, best-effort revokes the grant with Apple (never
+        blocks the already-committed unlink — see `apple_revoke` in the
+        audit log) and returns the SAME `providers` shape
+        `auth_providers_list` emits, so the Settings "Connected
+        accounts" card can redraw itself from this response alone. Does
+        NOT invalidate bearer tokens (unlink ≠ logout).
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema:
+            type: string
+            enum: [auth_provider_unlink]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [provider]
+              properties:
+                provider:
+                  type: string
+                  enum: [apple]
+                  description: The linked provider to remove.
+                csrf_token:
+                  type: string
+                  description: >-
+                    Optional same-origin CSRF token. Not required when
+                    the request already carries the same-origin
+                    `X-Requested-With` header (see description).
+      responses:
+        "200":
+          description: Unlinked — returns the caller's remaining linked providers
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  providers:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/LinkedProvider"
+        "400":
+          description: provider missing, or not one of the allow-listed values
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Not authenticated, or the account row vanished mid-request (a concurrent account_delete won the race)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Cross-origin request rejected (CSRF gate)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: That provider is not linked to the caller's account
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: >-
+            Lockout guard — unlinking this provider would leave the
+            account with no way to sign in (no password, no operational
+            verified non-private-relay email, no other linked provider).
+            Set a password or add a verified email address first.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: Unlinking this provider would leave your account with no way to sign in. Set a password or add a verified email address first.
+        "503":
+          description: Linked accounts are not yet available on this environment (tblUserAuthProviders not migrated)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api.php?action=auth_providers_list:
+    get:
+      operationId: authProvidersList
+      tags: [Authentication]
+      summary: List the caller's linked external-identity providers (#1479 W3)
+      description: |
+        Feeds the Settings "Connected accounts" card. Returns ONLY
+        `provider` / a masked `email_masked` / `is_private_relay` /
+        `linked_at` for each linked row — NEVER the Apple `sub`
+        (Subject) or `RefreshToken` (see `_authProviderListForUser()`'s
+        docblock). On an environment where the #1402
+        `tblUserAuthProviders` migration hasn't run yet, returns an
+        empty list rather than an error — a read-only lookup shouldn't
+        surface an alarming failure state.
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+      parameters:
+        - name: action
+          in: query
+          required: true
+          schema:
+            type: string
+            enum: [auth_providers_list]
+      responses:
+        "200":
+          description: The caller's linked providers (empty array if none, or if not yet migrated)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  providers:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/LinkedProvider"
+        "401":
+          description: Not authenticated
           content:
             application/json:
               schema:
@@ -3444,6 +3626,20 @@ paths:
                       always uses `auth_apple` with `platform: native`
                       (or the omitted default).
                     example: false
+                  appleSiwaServicesId:
+                    type: string
+                    nullable: true
+                    description: >-
+                      The Apple Services ID for the web
+                      `AppleID.auth.init({clientId: ...})` call (#1479
+                      W2). Only emitted (non-null) when
+                      `appleWebLoginEnabled` is true — null otherwise, so
+                      the front end never tries a dangling client id
+                      against a disabled/misconfigured deploy. Not a
+                      secret: a Services ID is public in the same way the
+                      native app's bundle id (used as the SIWA client id)
+                      is.
+                    example: app.ihymns.web
 
   /api.php?action=ccli_validate:
     post:
@@ -10887,6 +11083,35 @@ components:
           example: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
         user:
           $ref: "#/components/schemas/User"
+
+    LinkedProvider:
+      type: object
+      description: >-
+        One external-identity provider linked to the caller's account
+        (#1479 W3) — returned by `auth_providers_list` and
+        `auth_provider_unlink`. NEVER exposes the Apple `sub` (Subject)
+        or `RefreshToken` (see `_authProviderListForUser()`'s docblock).
+      properties:
+        provider:
+          type: string
+          example: apple
+        email_masked:
+          type: string
+          description: >-
+            Masked form of the email captured at link time (e.g.
+            `a****@e****.com`); empty string when no email was
+            captured.
+          example: a****@e****.com
+        is_private_relay:
+          type: boolean
+          description: >-
+            True when `email_masked` is derived from an Apple
+            private-relay alias (`@privaterelay.appleid.com`).
+        linked_at:
+          type: string
+          format: date-time
+          nullable: true
+          example: "2026-07-09T12:34:56+00:00"
 
     # -------------------------------------------------------------------------
     # Access & group models

--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -3323,14 +3323,240 @@ if ($action !== null) {
                 $userId
             );
 
-            sendJson(apiAuthSuccessPayload(
+            /* apiAuthSuccessPayload()'s OWN shape stays PINNED to {token,user}
+               (test-auth-response-shape.php asserts this exactly — it is the
+               native AuthSession DTO's decode contract, shared with
+               auth_login). `flow` is appended to the OUTER response here
+               instead — a Swift Codable struct silently ignores unknown
+               top-level keys, so native decodes exactly as before, while the
+               web client (#1479 W2) reads it to show the one-time "already
+               had an account? sign in and link from Settings" guidance on
+               flow==='created' without needing a second round-trip. Never
+               sensitive: 'matched'|'linked'|'created' reveals nothing the
+               caller doesn't already know (they hold the Apple identity
+               token that produced this outcome). */
+            $authResponsePayload = apiAuthSuccessPayload(
                 $token,
                 $userId,
                 $userRow['Username'],
                 $userRow['DisplayName'],
                 $userRow['Role'],
                 $userRow['AvatarService'] ?? null
-            ));
+            );
+            $authResponsePayload['flow'] = $flow;
+            sendJson($authResponsePayload);
+            break;
+
+        /* -----------------------------------------------------------------
+         * Linked-account UNLINK (#1479 W3) — provider-generic (allow-list
+         * ['apple'] today; tblUserAuthProviders/tblAuthNonces are already
+         * provider-generic per #1402, so a future provider just grows the
+         * allow-list below, never the schema).
+         *
+         * POST body (JSON): { "provider": "apple", "csrf_token": "<optional>" }
+         * Returns (200): { "ok": true, "providers": [...] } — the SAME shape
+         * `auth_providers_list` emits, so the Settings "Connected accounts"
+         * card can redraw itself from this response alone.
+         *
+         * LOCKOUT GUARD — refuses (409) unless a SURVIVING sign-in method
+         * remains after $provider is removed: see
+         * _authProviderUnlinkSurvives()'s docblock for the exact rule
+         * (password, OR a verified non-private-relay email with email-login
+         * operational, OR another linked provider). Evaluated under
+         * `SELECT ... FOR UPDATE` on the account's own provider rows so two
+         * concurrent unlinks (e.g. two open tabs) can never each treat the
+         * OTHER as the surviving method and both proceed to zero.
+         * ----------------------------------------------------------------- */
+        case 'auth_provider_unlink':
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'manage' . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'apple_siwa.php';
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'EmailService.php';
+
+            $rawBody = file_get_contents('php://input');
+            $body = json_decode($rawBody, true);
+            if (!is_array($body)) { $body = []; }
+
+            /* CSRF (rule #29) — belt-and-braces same as account_delete: the
+               global X-Requested-With gate (api.php top-of-file) already
+               blocks a cross-site POST; this is a second, independent check
+               on THIS state-changing endpoint. */
+            $csrfToken = is_string($body['csrf_token'] ?? null) ? $body['csrf_token'] : null;
+            if (!validateCsrfRequest($csrfToken)) {
+                sendJson(['error' => 'Cross-origin request rejected.'], 403);
+                break;
+            }
+
+            $authUser = getAuthenticatedUser();
+            if (!$authUser) {
+                sendJson(['error' => 'Not authenticated.'], 401);
+                break;
+            }
+            $authUserId = (int)$authUser['Id'];
+
+            /* Provider-generic table, APP-VALIDATED allow-list (rule #20 —
+               never an ENUM). Apple only today; a future provider grows this
+               array, never the schema. */
+            $providerAllowList = ['apple'];
+            $provider = is_string($body['provider'] ?? null) ? $body['provider'] : '';
+            if (!in_array($provider, $providerAllowList, true)) {
+                sendJson(['error' => 'provider must be one of: ' . implode(', ', $providerAllowList) . '.'], 400);
+                break;
+            }
+
+            $db = getDbMysqli();
+
+            /* Existence-probe first (rule #19/#1228 lesson) — this
+               docroot may not have run the #1402 migration. */
+            $probe = $db->query(
+                "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+                  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tblUserAuthProviders' LIMIT 1"
+            );
+            $ready = ($probe && $probe->fetch_row() !== null);
+            if ($probe) { $probe->close(); }
+            if (!$ready) {
+                sendJson(['error' => 'Linked accounts are not yet available.'], 503);
+                break;
+            }
+
+            /* $errorResponse stays null on success; set to [status, message,
+               reason] inside the transaction on any rejection. Using a flag
+               variable (rather than `break` from inside the try/catch) keeps
+               the transaction's commit/rollback decision the ONE place that
+               makes that call. */
+            $errorResponse = null;
+            $revokeCandidateRow = null;
+
+            $db->begin_transaction();
+            try {
+                $stmt = $db->prepare(
+                    'SELECT Id, Provider, Subject, RefreshToken FROM tblUserAuthProviders WHERE UserId = ? FOR UPDATE'
+                );
+                $stmt->bind_param('i', $authUserId);
+                $stmt->execute();
+                $providerRows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+                $stmt->close();
+
+                $targetRow = null;
+                $otherProviders = [];
+                foreach ($providerRows as $row) {
+                    if ($row['Provider'] === $provider) {
+                        $targetRow = $row;
+                    } else {
+                        $otherProviders[] = (string)$row['Provider'];
+                    }
+                }
+
+                if ($targetRow === null) {
+                    $errorResponse = [404, 'That provider is not linked to your account.', 'not_linked'];
+                } else {
+                    $userStmt = $db->prepare('SELECT PasswordHash, Email, EmailVerified FROM tblUsers WHERE Id = ? FOR UPDATE');
+                    $userStmt->bind_param('i', $authUserId);
+                    $userStmt->execute();
+                    $userDetail = $userStmt->get_result()->fetch_assoc();
+                    $userStmt->close();
+
+                    if (!$userDetail) {
+                        /* Bearer was valid a moment ago but the row is already
+                           gone (a concurrent account_delete won the race). */
+                        $errorResponse = [401, 'Not authenticated.', 'user_vanished'];
+                    } elseif (!_authProviderUnlinkSurvives(
+                        (string)($userDetail['PasswordHash'] ?? ''),
+                        ((int)($userDetail['EmailVerified'] ?? 0)) === 1,
+                        (string)($userDetail['Email'] ?? ''),
+                        EmailService::isConfigured(),
+                        $otherProviders
+                    )) {
+                        $errorResponse = [409, 'Unlinking this provider would leave your account with no way to sign in. Set a password or add a verified email address first.', 'lockout_guard'];
+                    } else {
+                        $targetRowId = (int)$targetRow['Id'];
+                        $delStmt = $db->prepare('DELETE FROM tblUserAuthProviders WHERE Id = ?');
+                        $delStmt->bind_param('i', $targetRowId);
+                        $delStmt->execute();
+                        $delStmt->close();
+                        /* Captured in PHP memory BEFORE the row is gone — the
+                           best-effort Apple revoke below runs AFTER commit
+                           (so a slow/hanging third-party call never holds the
+                           FOR UPDATE lock open), reading from this snapshot
+                           rather than the now-deleted DB row. */
+                        $revokeCandidateRow = $targetRow;
+                    }
+                }
+
+                if ($errorResponse !== null) {
+                    $db->rollback();
+                } else {
+                    $db->commit();
+                }
+            } catch (\Throwable $e) {
+                try { $db->rollback(); } catch (\Throwable $_ignore) { /* best-effort */ }
+                throw $e;
+            }
+
+            if ($errorResponse !== null) {
+                [$status, $message, $reason] = $errorResponse;
+                logActivity('auth.provider_unlink', 'user', (string)$authUserId, ['provider' => $provider, 'reason' => $reason], 'failure', $authUserId);
+                sendJson(['error' => $message], $status);
+                break;
+            }
+
+            /* Best-effort Apple revoke — NEVER blocks the (already-committed)
+               unlink on failure; see _authProviderUnlinkRevokeApple()'s
+               docblock for why it tries more than one client id. */
+            $revokeOutcome = 'skipped_no_link';
+            if ($provider === 'apple' && $revokeCandidateRow !== null) {
+                $revokeOutcome = _authProviderUnlinkRevokeApple($revokeCandidateRow);
+            }
+
+            /* Audit — provider + outcome ONLY, never the Subject/RefreshToken
+               (§5(d) / rule #6 of the strategy doc). */
+            logActivity(
+                'auth.provider_unlink',
+                'user',
+                (string)$authUserId,
+                ['provider' => $provider, 'apple_revoke' => $revokeOutcome],
+                'success',
+                $authUserId
+            );
+
+            sendJson(['ok' => true, 'providers' => _authProviderListForUser($db, $authUserId)]);
+            break;
+
+        /* -----------------------------------------------------------------
+         * List the caller's linked external-identity providers (#1479 W3) —
+         * feeds the Settings "Connected accounts" card. Returns ONLY
+         * provider / masked-email / relay-flag / linked-date — NEVER the
+         * Subject (Apple `sub`) or RefreshToken (see
+         * _authProviderListForUser()'s docblock).
+         * ----------------------------------------------------------------- */
+        case 'auth_providers_list':
+            $authUser = getAuthenticatedUser();
+            if (!$authUser) {
+                sendJson(['error' => 'Not authenticated.'], 401);
+                break;
+            }
+
+            $db = getDbMysqli();
+            $probe = $db->query(
+                "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+                  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tblUserAuthProviders' LIMIT 1"
+            );
+            $ready = ($probe && $probe->fetch_row() !== null);
+            if ($probe) { $probe->close(); }
+            if (!$ready) {
+                /* Graceful empty list rather than an error — the settings
+                   card should just show "nothing linked yet" on a docroot
+                   where the #1402 migration hasn't run, not an alarming
+                   failure state for a read-only lookup. */
+                sendJson(['providers' => []]);
+                break;
+            }
+
+            sendJson(['providers' => _authProviderListForUser($db, (int)$authUser['Id'])]);
             break;
 
         /* =================================================================
@@ -4371,6 +4597,11 @@ if ($action !== null) {
                Message only when actually in maintenance, so app_status stays empty-
                when-off as before (maintenanceMessage() otherwise returns a default). */
             $inMaintenance = function_exists('isMaintenanceMode') ? isMaintenanceMode() : false;
+            /* #1479 W2 — resolved once so the two related fields below never
+               disagree with each other (a mid-request settings change is not
+               a concern getAppSetting()'s per-request memoization already
+               closes off, but computing it twice would be needless work). */
+            $appleWebEnabledForStatus = appleWebLoginEnabledForChannel();
             sendJson([
                 'maintenance'         => $inMaintenance,
                 'maintenanceMessage'  => ($inMaintenance && function_exists('maintenanceMessage')) ? maintenanceMessage() : '',
@@ -4388,9 +4619,20 @@ if ($action !== null) {
                 /* #1470 W1 — whether Sign in with Apple for WEB is enabled on
                    THIS channel (Services ID configured AND channel allow-
                    listed). Dormant/false until manage/configuration.php's
-                   Apple card has both saved — the future web sign-in button
-                   gates its own visibility on this flag. */
-                'appleWebLoginEnabled' => appleWebLoginEnabledForChannel(),
+                   Apple card has both saved — the web sign-in button
+                   (#1479 W2) gates its own visibility on this flag. */
+                'appleWebLoginEnabled' => $appleWebEnabledForStatus,
+                /* #1479 W2 — the Apple Services ID the web popup flow passes
+                   as `AppleID.auth.init({clientId: ...})`. Only emitted when
+                   web login is actually enabled for this channel (never a
+                   dangling client id the front end could try to use against
+                   a disabled/misconfigured deploy) — null otherwise. Not a
+                   secret: a Services ID is public by the same logic as the
+                   native app's bundle id (IHYMNS_SIWA_CLIENT_ID), embedded in
+                   every browser's outbound request to Apple regardless. */
+                'appleSiwaServicesId' => $appleWebEnabledForStatus
+                    ? (string)(getAppSetting('apple_siwa_services_id', '') ?? '')
+                    : null,
             ]);
             break;
 
@@ -14429,6 +14671,194 @@ function _accountDeleteRevokeApple(array $linkRow, string $reauthMethod, array $
         error_log('[api/account_delete revoke] ' . $e->getMessage());
         return 'failed';
     }
+}
+
+/* =============================================================================
+ * LINKED-ACCOUNT UNLINK — helpers for `case 'auth_provider_unlink'` (#1479 W3)
+ *
+ * Mirrors the account_delete helpers immediately above: the case block stays
+ * a readable top-to-bottom sequence, the LOCKOUT-GUARD decision is a PURE
+ * function (no DB, no superglobals) so its full truth table — including the
+ * private-relay-email stranding case round-2 review of the SIWA-web strategy
+ * caught — is unit-testable without a database (tests/php/
+ * test-auth-provider-unlink.php), and the Apple-revoke I/O shell is kept
+ * separate from that decision.
+ * ========================================================================= */
+
+/**
+ * PURE core of the auth_provider_unlink lockout guard (strategy doc §5(d)).
+ * Decides whether the account keeps at least one WORKING sign-in method
+ * after $provider's row is removed. Every input is an explicit parameter —
+ * no DB, no superglobals — so the full truth table is assertable directly.
+ *
+ * A survivor is ANY of:
+ *   (a) $passwordHash is non-empty (tblUsers.PasswordHash <> '') — the
+ *       account can always sign in with its password.
+ *   (b) $emailVerified AND $emailLoginOperational AND the account's OWN
+ *       email is NOT an Apple private-relay alias — magic-link email
+ *       sign-in still works. The private-relay exclusion is load-bearing:
+ *       unlinking Apple deactivates that relay alias server-side, so mail
+ *       sent to it bounces forever — "the account has a verified email"
+ *       would otherwise stay true right up to the moment it becomes
+ *       permanently unusable (the exact stranding hole round-2 review of
+ *       the SIWA-web strategy caught).
+ *   (c) $otherProviders is non-empty — another, DIFFERENT linked provider
+ *       (e.g. a future Google/SIGNula link) still works.
+ *
+ * @param string   $passwordHash          tblUsers.PasswordHash.
+ * @param bool     $emailVerified         tblUsers.EmailVerified === 1.
+ * @param string   $email                 tblUsers.Email (may be '').
+ * @param bool     $emailLoginOperational EmailService::isConfigured() — the
+ *                                          SAME config app_status's
+ *                                          emailLoginEnabled flag reads.
+ * @param string[] $otherProviders        Provider names of the account's
+ *                                          OTHER tblUserAuthProviders rows
+ *                                          (excludes the one being removed).
+ * @return bool True = a surviving method remains; the unlink may proceed.
+ */
+function _authProviderUnlinkSurvives(
+    string $passwordHash,
+    bool $emailVerified,
+    string $email,
+    bool $emailLoginOperational,
+    array $otherProviders
+): bool {
+    if ($passwordHash !== '') {
+        return true;
+    }
+
+    if ($emailVerified && $emailLoginOperational) {
+        $email = trim($email);
+        if ($email !== '') {
+            $atPos = strrpos($email, '@');
+            $isPrivateRelay = ($atPos !== false)
+                && (strtolower(substr($email, $atPos + 1)) === 'privaterelay.appleid.com');
+            if (!$isPrivateRelay) {
+                return true;
+            }
+        }
+    }
+
+    return count($otherProviders) > 0;
+}
+
+/**
+ * Best-effort Apple `/auth/revoke` for auth_provider_unlink (#1479 W3).
+ * Mirrors _accountDeleteRevokeApple() immediately above, but tries BOTH of
+ * our own client ids — native's IHYMNS_SIWA_CLIENT_ID and, if configured,
+ * the web Services ID — because tblUserAuthProviders.RefreshToken holds
+ * whichever platform most recently captured one (#1470 W1 lets EITHER
+ * platform write this single column via the SAME best-effort code-exchange
+ * step in `case 'auth_apple'`) and Apple's `/auth/revoke` requires the SAME
+ * client_id that originally requested the token. Trying native first
+ * (today's only populated case) then falling back to the web Services ID is
+ * a strict improvement over guessing a single hardcoded aud, while staying
+ * non-blocking/never-fatal like every other Apple I/O call in this file —
+ * every failure is caught and mapped to 'failed', never thrown.
+ *
+ * @param array $linkRow The (already-deleted-from-DB, still in PHP memory)
+ *                         tblUserAuthProviders row snapshot — needs RefreshToken.
+ * @return string 'ok'|'failed'|'skipped_no_key'|'skipped_no_token'
+ */
+function _authProviderUnlinkRevokeApple(array $linkRow): string
+{
+    $revokeToken = isset($linkRow['RefreshToken']) && $linkRow['RefreshToken'] !== null
+        ? (string)$linkRow['RefreshToken']
+        : null;
+    if ($revokeToken === null || $revokeToken === '') {
+        return 'skipped_no_token';
+    }
+
+    $teamId = (string)(getAppSetting('apple_team_id', '') ?? '');
+    $keyId  = (string)(getAppSetting('apple_siwa_key_id', '') ?? '');
+    $p8Pem  = (string)(getAppSetting('apple_siwa_private_key', '') ?? '');
+    if ($teamId === '' || $keyId === '' || $p8Pem === '') {
+        return 'skipped_no_key';
+    }
+
+    $servicesId = trim((string)(getAppSetting('apple_siwa_services_id', '') ?? ''));
+    $candidateClientIds = array_values(array_unique(array_filter(
+        [IHYMNS_SIWA_CLIENT_ID, $servicesId],
+        static fn(string $c): bool => $c !== ''
+    )));
+
+    foreach ($candidateClientIds as $clientId) {
+        try {
+            $clientSecret = appleSiwaBuildClientSecret($teamId, $keyId, $clientId, $p8Pem, time());
+            if ($clientSecret === null) {
+                continue; /* .p8 present but doesn't parse as an EC key for this sub — try the next candidate. */
+            }
+            if (appleSiwaRevokeToken($revokeToken, 'refresh_token', $clientSecret, $clientId)) {
+                return 'ok';
+            }
+        } catch (\Throwable $e) {
+            error_log('[api/auth_provider_unlink revoke] ' . $e->getMessage());
+        }
+    }
+    return 'failed';
+}
+
+/**
+ * Mask an email address for the linked-accounts UI (#1479 W3) —
+ * `auth_providers_list` must NEVER return the raw Subject/RefreshToken, and
+ * the informational Email column is masked too (defence in depth — it's
+ * link-time metadata, not a secret, but there's no reason to echo it back in
+ * full). `alice@example.com` -> `a****@e****.com`; '' or no '@' -> ''.
+ *
+ * @param string $email Raw tblUserAuthProviders.Email (may be '').
+ * @return string Masked form, or '' when $email is empty / has no '@'.
+ */
+function _authProviderMaskEmail(string $email): string
+{
+    $atPos = strrpos($email, '@');
+    if ($email === '' || $atPos === false) {
+        return '';
+    }
+    $local  = substr($email, 0, $atPos);
+    $domain = substr($email, $atPos + 1);
+
+    $maskPart = static function (string $s): string {
+        if ($s === '') {
+            return '';
+        }
+        return $s[0] . str_repeat('*', max(1, mb_strlen($s) - 1));
+    };
+
+    $domainParts = explode('.', $domain);
+    $domainParts[0] = $maskPart($domainParts[0]);
+
+    return $maskPart($local) . '@' . implode('.', $domainParts);
+}
+
+/**
+ * Shared row-builder for the caller's linked providers (#1479 W3) — used by
+ * BOTH `auth_providers_list` and `auth_provider_unlink`'s response (so the
+ * Settings "Connected accounts" card can redraw itself from either call
+ * without a second round-trip). NEVER selects Subject or RefreshToken.
+ *
+ * @param \mysqli $db
+ * @param int     $userId
+ * @return array<int,array{provider:string,email_masked:string,is_private_relay:bool,linked_at:?string}>
+ */
+function _authProviderListForUser(\mysqli $db, int $userId): array
+{
+    $stmt = $db->prepare(
+        'SELECT Provider, Email, EmailIsPrivateRelay, CreatedAt
+           FROM tblUserAuthProviders WHERE UserId = ? ORDER BY CreatedAt ASC'
+    );
+    $stmt->bind_param('i', $userId);
+    $stmt->execute();
+    $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+    $stmt->close();
+
+    return array_map(static function (array $row): array {
+        return [
+            'provider'         => (string)$row['Provider'],
+            'email_masked'     => _authProviderMaskEmail((string)($row['Email'] ?? '')),
+            'is_private_relay' => ((int)($row['EmailIsPrivateRelay'] ?? 0)) === 1,
+            'linked_at'        => $row['CreatedAt'] !== null ? (string)$row['CreatedAt'] : null,
+        ];
+    }, $rows);
 }
 
 /**

--- a/appWeb/public_html/includes/pages/settings.php
+++ b/appWeb/public_html/includes/pages/settings.php
@@ -262,6 +262,26 @@ declare(strict_types=1);
                     </button>
                 </form>
 
+                <!-- Connected accounts (#1479 W3) — linked external identity
+                     providers (Sign in with Apple today). DORMANT by default:
+                     hidden until settings.js confirms
+                     app_status.appleWebLoginEnabled === true, matching the
+                     auth modal's Apple button gating. The list itself is
+                     populated from ?action=auth_providers_list, which
+                     already returns a MASKED email — never render anything
+                     here except escaped, server-supplied strings. -->
+                <div id="auth-connected-accounts" class="mb-3 pt-3 border-top d-none">
+                    <h3 class="h6 mb-2">Connected accounts</h3>
+                    <div id="auth-connected-accounts-msg" class="alert d-none py-2 small" role="alert"></div>
+                    <div id="auth-connected-accounts-list" class="mb-2">
+                        <p class="text-muted small mb-0">No connected accounts yet.</p>
+                    </div>
+                    <button type="button" class="btn btn-dark btn-sm" id="btn-auth-apple-link">
+                        <i class="fa-brands fa-apple me-1" aria-hidden="true"></i>
+                        Link Apple ID
+                    </button>
+                </div>
+
                 <div class="d-flex gap-2">
                     <button type="button" class="btn btn-outline-primary btn-sm" id="btn-auth-sync">
                         <i class="fa-solid fa-arrows-rotate me-1" aria-hidden="true"></i>

--- a/appWeb/public_html/js/modules/apple-signin.js
+++ b/appWeb/public_html/js/modules/apple-signin.js
@@ -1,0 +1,277 @@
+/**
+ * iHymns — Sign in with Apple (Web) — front-end orchestration (#1470 W2 / #1479)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * Drives Apple's JS SDK (`AppleID.auth`) in POPUP mode and hands the
+ * resulting credential to the existing `?action=auth_apple` backend
+ * (already live, dormant, on `platform=native` — #1402/#1470 W1). This
+ * module owns ONLY the Apple-JS + network round-trip; it never touches
+ * localStorage or app state — the caller (js/modules/user-auth.js)
+ * persists the returned token/user via the SAME saveCredentials() path
+ * password/email login already use, so every downstream sync/header/toast
+ * behaviour is identical regardless of which sign-in method produced the
+ * token.
+ *
+ * WHY POPUP, NOT REDIRECT: `ihymns_auth` is a SameSite=Lax cookie
+ * (includes/auth_cookie.php) — a cross-site `form_post` redirect (Apple's
+ * other supported mode, required whenever `scope` includes `name`/`email`)
+ * would arrive WITHOUT that cookie attached, so a "link Apple to my
+ * signed-in account" flow could never see the session. Popup mode instead
+ * hands `id_token` + `code` directly to THIS window's JS via
+ * `AppleID.auth.signIn()`, which then does a same-origin fetch() carrying
+ * the current bearer/cookie normally. See `.claude/siwa-web-signula-strategy.md`
+ * §4 for the full design.
+ *
+ * NONCE CONTRACT (must match `?action=auth_apple`'s server-side gate,
+ * api.php ~3087): the RAW nonce sent in the POST body must be
+ * `^[A-Za-z0-9._~-]{16,255}$`; the value handed to `AppleID.auth.init()` is
+ * the LOWERCASE HEX SHA-256 of that raw value (the JWT's own `nonce` claim
+ * is what Apple signs, and the server recomputes `hash('sha256', $rawNonce)`
+ * to compare against it — see appleSiwaVerifyIdentityToken()'s docblock).
+ *
+ * @link https://developer.apple.com/documentation/sign_in_with_apple/configuring_your_webpage_for_sign_in_with_apple  Apple's JS SDK reference
+ * @link https://developer.apple.com/documentation/sign_in_with_apple/errorhandling  AppleID.auth.signIn() rejection shapes
+ */
+
+/** Apple's hosted JS SDK — same CDN URL for every consumer worldwide. */
+const APPLE_JS_SDK_URL = 'https://appleid.cdn-apple.com/appleauth/static/jsapi/appleid/1/en_US/appleid.auth.js';
+
+/** Module-level singleton so a second sign-in attempt (or the Settings
+ *  "Link" button) never injects the <script> tag twice. */
+let _sdkPromise = null;
+
+/**
+ * Lazy-load Apple's JS SDK exactly once. Resolves once `window.AppleID` is
+ * usable; rejects (never throws synchronously) on a network/script failure
+ * so callers can show a friendly "couldn't load" message instead of an
+ * unhandled exception.
+ *
+ * @returns {Promise<void>}
+ */
+function _loadAppleJsSdk() {
+    if (typeof window !== 'undefined' && window.AppleID) return Promise.resolve();
+    if (_sdkPromise) return _sdkPromise;
+
+    _sdkPromise = new Promise((resolve, reject) => {
+        const script = document.createElement('script');
+        script.src = APPLE_JS_SDK_URL;
+        script.async = true;
+        script.onload = () => {
+            if (window.AppleID) {
+                resolve();
+            } else {
+                reject(new Error('Apple JS SDK loaded but window.AppleID is unavailable.'));
+            }
+        };
+        script.onerror = () => reject(new Error('Could not load the Sign in with Apple script.'));
+        document.head.appendChild(script);
+    });
+    return _sdkPromise;
+}
+
+/**
+ * 32 cryptographically-random bytes, base64url-encoded with no padding
+ * (43 chars — `A-Za-z0-9-_` only, a strict subset of the server's allowed
+ * `[A-Za-z0-9._~-]{16,255}` nonce charset). This is the RAW nonce sent in
+ * the POST body; the server re-hashes it and compares against the JWT's
+ * `nonce` claim (see this file's header docblock).
+ *
+ * @returns {string}
+ */
+function _randomNonce() {
+    const bytes = new Uint8Array(32);
+    crypto.getRandomValues(bytes);
+    let binary = '';
+    bytes.forEach((b) => { binary += String.fromCharCode(b); });
+    return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/**
+ * 16 random bytes as lowercase hex — an opaque `state` value for
+ * `AppleID.auth.init()`. Apple's own popup flow already binds `state`
+ * internally; this is defence-in-depth so a future redirect-mode fallback
+ * (W4) reusing this same function inherits the check for free.
+ *
+ * @returns {string}
+ */
+function _randomState() {
+    const bytes = new Uint8Array(16);
+    crypto.getRandomValues(bytes);
+    return Array.from(bytes).map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * Lowercase hex SHA-256 of a UTF-8 string, via SubtleCrypto — the exact
+ * transform the server applies to the raw nonce (`hash('sha256', $rawNonce)`
+ * in PHP) so the two sides agree on what the JWT's `nonce` claim should be.
+ *
+ * @param {string} input
+ * @returns {Promise<string>}
+ */
+async function _sha256HexLower(input) {
+    const data = new TextEncoder().encode(input);
+    const digest = await crypto.subtle.digest('SHA-256', data);
+    return Array.from(new Uint8Array(digest)).map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * Map an `AppleID.auth.signIn()` rejection to a short, non-technical
+ * message. Apple's documented error codes are sparse/loosely specified, so
+ * this is intentionally a small, generic switch rather than an exhaustive
+ * list — every unrecognised shape falls through to one safe default.
+ *
+ * @param {*} err
+ * @returns {string}
+ */
+function _friendlyAppleJsError(err) {
+    const code = (err && (err.error || err.code)) || '';
+    switch (code) {
+        case 'popup_closed_by_user':
+        case 'user_trigger_new_signin_flow':
+        case 'user_cancelled_authorize':
+            return 'Sign-in was cancelled.';
+        default:
+            return 'Sign in with Apple is temporarily unavailable. Please try again.';
+    }
+}
+
+/**
+ * Map an `?action=auth_apple` non-2xx HTTP status to a friendly fallback
+ * message (used only when the server didn't send its own `error` string).
+ *
+ * @param {number} status
+ * @returns {string}
+ */
+function _friendlyAppleHttpError(status) {
+    switch (status) {
+        case 401: return 'Invalid Apple sign-in response. Please try again.';
+        case 409: return 'This Apple ID is already linked to a different account.';
+        case 429: return 'Too many attempts. Please try again later.';
+        case 503: return 'Sign in with Apple is temporarily unavailable.';
+        default:  return 'Sign in with Apple failed. Please try again.';
+    }
+}
+
+/**
+ * Run the full web Sign in with Apple popup flow, then POST the resulting
+ * credential to `?action=auth_apple`.
+ *
+ * Does NOT touch localStorage or broadcast any app event — the caller is
+ * responsible for persisting `token`/`user` (via UserAuth.saveCredentials())
+ * on success, exactly as the password/email login paths already do.
+ *
+ * @param {object} opts
+ * @param {string} opts.apiUrl        Base API URL, e.g. `this.app.config.apiUrl` ('/api').
+ * @param {string} opts.clientId      Apple Services ID (`app_status.appleSiwaServicesId`).
+ * @param {boolean} [opts.link=false] true = attach Apple to the CURRENT bearer
+ *                                      instead of signing in as whichever
+ *                                      account the Apple identity resolves to.
+ * @param {object} [opts.authHeaders] Extra headers to send — pass the current
+ *                                      `Authorization: Bearer ...` header for
+ *                                      link mode (auth_apple's link=1 path
+ *                                      requires an already-authenticated bearer).
+ * @returns {Promise<
+ *   { ok: true, token: string, user: object, flow: string } |
+ *   { ok: false, error: string }
+ * >}
+ */
+export async function performAppleSignIn({ apiUrl, clientId, link = false, authHeaders = {} } = {}) {
+    if (!clientId) {
+        return { ok: false, error: 'Sign in with Apple is not configured.' };
+    }
+    if (typeof window === 'undefined' || typeof crypto === 'undefined' || !crypto.subtle
+        || typeof crypto.getRandomValues !== 'function') {
+        return { ok: false, error: 'This browser does not support Sign in with Apple.' };
+    }
+
+    try {
+        await _loadAppleJsSdk();
+    } catch {
+        return { ok: false, error: 'Could not load Sign in with Apple. Check your connection and try again.' };
+    }
+
+    const rawNonce = _randomNonce();
+    const state = _randomState();
+    let hashedNonce;
+    try {
+        hashedNonce = await _sha256HexLower(rawNonce);
+    } catch {
+        return { ok: false, error: 'This browser does not support Sign in with Apple.' };
+    }
+
+    try {
+        window.AppleID.auth.init({
+            clientId,
+            scope: 'name email',
+            redirectURI: window.location.origin + '/',
+            state,
+            nonce: hashedNonce,
+            usePopup: true,
+        });
+    } catch {
+        return { ok: false, error: 'Could not initialise Sign in with Apple.' };
+    }
+
+    let credential;
+    try {
+        credential = await window.AppleID.auth.signIn();
+    } catch (err) {
+        return { ok: false, error: _friendlyAppleJsError(err) };
+    }
+
+    const authorization = credential && credential.authorization;
+    if (!authorization || !authorization.id_token) {
+        return { ok: false, error: 'Sign in with Apple did not return a valid credential.' };
+    }
+    /* Defence in depth — see this function's docblock. Apple's popup
+       response may omit `state` entirely (undocumented either way), so only
+       reject on an EXPLICIT mismatch, never on absence. */
+    if (authorization.state !== undefined && authorization.state !== state) {
+        return { ok: false, error: 'Sign in with Apple response could not be verified. Please try again.' };
+    }
+
+    const body = {
+        identityToken: authorization.id_token,
+        nonce: rawNonce,
+        platform: 'web',
+        link: link ? 1 : 0,
+    };
+    if (authorization.code) body.authorizationCode = authorization.code;
+
+    /* `user` (name) is present ONLY on Apple's first authorization for this
+       account — snapshot it now, the server never sees it again. */
+    const userName = credential.user && credential.user.name;
+    if (userName && (userName.firstName || userName.lastName)) {
+        body.fullName = { givenName: userName.firstName || '', familyName: userName.lastName || '' };
+    }
+
+    let res;
+    try {
+        res = await fetch(`${apiUrl}?action=auth_apple`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-Requested-With': 'XMLHttpRequest',
+                ...authHeaders,
+            },
+            body: JSON.stringify(body),
+        });
+    } catch {
+        return { ok: false, error: 'Network error. Please check your connection and try again.' };
+    }
+
+    let data = null;
+    try {
+        data = await res.json();
+    } catch {
+        return { ok: false, error: `Server returned an unreadable response (HTTP ${res.status}).` };
+    }
+
+    if (!res.ok) {
+        return { ok: false, error: (data && data.error) || _friendlyAppleHttpError(res.status) };
+    }
+
+    return { ok: true, token: data.token, user: data.user, flow: data.flow || (link ? 'linked' : 'matched') };
+}

--- a/appWeb/public_html/js/modules/settings.js
+++ b/appWeb/public_html/js/modules/settings.js
@@ -22,6 +22,7 @@ import {
     STORAGE_SEARCH_HISTORY,
     STORAGE_CVD_MODE,
 } from '../constants.js';
+import { escapeHtml } from '../utils/html.js';
 
 /**
  * Strict whitelist of localStorage keys that sync to the user's
@@ -272,6 +273,127 @@ export class Settings {
             const svc = (user?.avatar_service ?? '').toString();
             const radio = document.querySelector(`#avatar-form input[name="avatar_service"][value="${CSS.escape(svc)}"]`);
             if (radio) radio.checked = true;
+
+            /* Connected accounts (#1479 W3) — fire-and-forget; the card
+               self-manages its own visibility/content once app_status +
+               auth_providers_list land, so a slow network never blocks the
+               rest of this (synchronous) refresh. */
+            this._renderConnectedAccounts();
+        } else {
+            document.getElementById('auth-connected-accounts')?.classList.add('d-none');
+        }
+    }
+
+    /* =====================================================================
+     * CONNECTED ACCOUNTS (#1479 W3) — linked external identity providers
+     * ===================================================================== */
+
+    /**
+     * Populate (or hide) the "Connected accounts" card. DORMANT by default:
+     * hides the whole card unless app_status.appleWebLoginEnabled is true
+     * AND a Services ID is configured — the SAME gate the auth modal's
+     * Apple button uses (js/modules/user-auth.js showAuthModal()).
+     */
+    async _renderConnectedAccounts() {
+        const section = document.getElementById('auth-connected-accounts');
+        if (!section) return;
+
+        const auth = this.app.userAuth;
+        if (!auth?.isLoggedIn()) {
+            section.classList.add('d-none');
+            return;
+        }
+
+        const status = await auth._ensureAppStatus?.();
+        const appleEnabled = status?.appleWebLoginEnabled === true && !!status?.appleSiwaServicesId;
+        section.classList.toggle('d-none', !appleEnabled);
+        if (!appleEnabled) return;
+
+        const providers = await auth.listLinkedProviders();
+        this._paintConnectedAccountsList(providers);
+    }
+
+    /**
+     * Render the linked-provider list from `auth_providers_list`'s response.
+     * Every server-supplied string (masked email, linked date) is passed
+     * through escapeHtml() before reaching innerHTML — never trust the
+     * network response shape, even though this endpoint is same-origin and
+     * already masks the value server-side.
+     *
+     * @param {Array<{provider:string, email_masked:string, is_private_relay:boolean, linked_at:?string}>} providers
+     */
+    _paintConnectedAccountsList(providers) {
+        const list = document.getElementById('auth-connected-accounts-list');
+        const linkBtn = document.getElementById('btn-auth-apple-link');
+        if (!list) return;
+
+        const apple = (providers || []).find((p) => p?.provider === 'apple');
+
+        if (!apple) {
+            list.innerHTML = '<p class="text-muted small mb-0">No connected accounts yet.</p>';
+            linkBtn?.classList.remove('d-none');
+            return;
+        }
+
+        linkBtn?.classList.add('d-none');
+
+        let linkedDateText = '';
+        if (apple.linked_at) {
+            const d = new Date(apple.linked_at);
+            if (!Number.isNaN(d.getTime())) linkedDateText = d.toLocaleDateString();
+        }
+        const relayBadge = apple.is_private_relay
+            ? ' <span class="badge bg-secondary-subtle text-secondary-emphasis">Private Relay</span>'
+            : '';
+        const detailText = escapeHtml(apple.email_masked || '')
+            + (linkedDateText ? ' &middot; linked ' + escapeHtml(linkedDateText) : '');
+
+        list.innerHTML = `
+            <div class="d-flex align-items-center justify-content-between border rounded p-2 mb-2">
+                <div>
+                    <i class="fa-brands fa-apple me-1" aria-hidden="true"></i>
+                    <strong>Apple</strong>${relayBadge}
+                    <small class="text-muted d-block">${detailText}</small>
+                </div>
+                <button type="button" class="btn btn-outline-danger btn-sm" id="btn-auth-apple-unlink">
+                    Unlink
+                </button>
+            </div>`;
+
+        list.querySelector('#btn-auth-apple-unlink')?.addEventListener('click', () => this._handleUnlinkProvider('apple'));
+    }
+
+    /**
+     * Confirm-then-unlink a provider. The server holds the authoritative,
+     * race-safe lockout decision (`SELECT ... FOR UPDATE`,
+     * api.php `case 'auth_provider_unlink'`) — this method only surfaces
+     * whatever it returns (incl. a 409 "would leave you with no way to sign
+     * in" refusal).
+     *
+     * @param {string} provider
+     */
+    async _handleUnlinkProvider(provider) {
+        const label = provider === 'apple' ? 'Apple' : provider;
+        if (!window.confirm(
+            `Unlink ${label} from your account? If this is your only sign-in method, the server will refuse.`
+        )) {
+            return;
+        }
+
+        const msg = document.getElementById('auth-connected-accounts-msg');
+        const show = (text, kind) => {
+            if (!msg) return;
+            msg.className = 'alert py-2 small alert-' + kind;
+            msg.textContent = text;
+            msg.classList.remove('d-none');
+        };
+
+        const result = await this.app.userAuth.unlinkProvider(provider);
+        if (result.success) {
+            show(`${label} unlinked.`, 'success');
+            this._paintConnectedAccountsList(result.providers || []);
+        } else {
+            show(result.error || 'Could not unlink account.', 'danger');
         }
     }
 
@@ -1599,6 +1721,52 @@ export class Settings {
                     passwordForm.reset();
                 } else {
                     show(result.error || 'Could not change password.', 'danger');
+                }
+            });
+        }
+
+        /* Link Apple ID (#1479 W3) — attaches Apple to the CURRENTLY
+           signed-in account via the SAME popup flow the auth modal uses,
+           with link:true so auth_apple's server-side link mode fires
+           instead of a fresh sign-in. dataset.bound guard (like the forms
+           above, unlike the plain buttons above) because a double-bound
+           handler here would pop TWO Apple popups on one click. */
+        const appleLinkBtn = document.getElementById('btn-auth-apple-link');
+        if (appleLinkBtn && !appleLinkBtn.dataset.bound) {
+            appleLinkBtn.dataset.bound = '1';
+            appleLinkBtn.addEventListener('click', async () => {
+                const msg = document.getElementById('auth-connected-accounts-msg');
+                const show = (text, kind) => {
+                    if (!msg) return;
+                    msg.className = 'alert py-2 small alert-' + kind;
+                    msg.textContent = text;
+                    msg.classList.remove('d-none');
+                };
+                appleLinkBtn.disabled = true;
+                const result = await auth.signInWithApple({ link: true });
+                appleLinkBtn.disabled = false;
+                if (result.success) {
+                    /* `flow` distinguishes a genuine new link ('linked') from
+                       the case where this Apple ID was ALREADY linked to a
+                       DIFFERENT iHymns account ('matched') — Apple `sub` is
+                       always the authoritative identity (api.php
+                       _authAppleMapAccountTxn's (a) branch runs before the
+                       link=1 path even when a bearer is present), so that
+                       scenario silently switches the local session to the
+                       OTHER account rather than attaching Apple to this one.
+                       Tell the user what actually happened rather than
+                       claiming a link that didn't occur. */
+                    if (result.flow === 'matched') {
+                        show(
+                            'This Apple ID was already linked to a different iHymns account — you are now signed in as that account.',
+                            'info'
+                        );
+                    } else {
+                        show('Apple account linked.', 'success');
+                    }
+                    this._renderConnectedAccounts();
+                } else {
+                    show(result.error || 'Could not link Apple account.', 'danger');
                 }
             });
         }

--- a/appWeb/public_html/js/modules/user-auth.js
+++ b/appWeb/public_html/js/modules/user-auth.js
@@ -17,6 +17,7 @@ import { escapeHtml } from '../utils/html.js';
 import { userHasEntitlement } from './entitlements.js';
 import { offlineQueue } from './offline-queue.js';
 import { STORAGE_AUTH_TOKEN, STORAGE_AUTH_USER } from '../constants.js';
+import { performAppleSignIn } from './apple-signin.js';
 
 export class UserAuth {
     /**
@@ -55,9 +56,14 @@ export class UserAuth {
                 if (!r.ok) throw new Error('HTTP ' + r.status);
                 this._appStatus = await r.json();
             } catch (_e) {
-                /* Permissive default — keep current behaviour. The
-                   server-side 503 is still the safety net. */
-                this._appStatus = { emailLoginEnabled: true };
+                /* Permissive default for email — keep current behaviour (the
+                   server-side 503 is still the safety net). Sign in with
+                   Apple (#1479) is the OPPOSITE default: appleWebLoginEnabled
+                   stays falsy on a failed fetch, so a transient app_status
+                   outage never shows a button that would just 503 anyway —
+                   dormancy-by-default matches the server's own fail-closed
+                   posture for this brand-new, admin-opt-in feature. */
+                this._appStatus = { emailLoginEnabled: true, appleWebLoginEnabled: false, appleSiwaServicesId: null };
             }
             return this._appStatus;
         })();
@@ -360,6 +366,117 @@ export class UserAuth {
             /* Offline / DNS / TLS failure — keep the token. */
             return false;
         }
+    }
+
+    /* =====================================================================
+     * SIGN IN WITH APPLE (Web) — #1470 W1 backend / #1479 W2-W3 front end
+     * ===================================================================== */
+
+    /**
+     * Run the web Sign in with Apple popup flow (js/modules/apple-signin.js)
+     * and, on success, persist the returned session via the SAME
+     * saveCredentials() path password/email login use — so header state,
+     * the setlist sync bar, and every downstream `ihymns:auth-changed`
+     * listener behave identically regardless of which method signed the
+     * user in.
+     *
+     * @param {object} [opts]
+     * @param {boolean} [opts.link=false] true = attach Apple to the CURRENT
+     *        bearer (Settings "Link" button) instead of signing in fresh.
+     * @returns {Promise<{ success: boolean, error?: string, flow?: string }>}
+     *          `flow` is 'matched' | 'linked' | 'created' — see
+     *          apple-signin.js's docblock. Callers show a one-time
+     *          "already had an account? sign in and link from Settings"
+     *          hint only on 'created'.
+     */
+    async signInWithApple({ link = false } = {}) {
+        const status = await this._ensureAppStatus();
+        if (status?.appleWebLoginEnabled !== true || !status?.appleSiwaServicesId) {
+            return { success: false, error: 'Sign in with Apple is not available.' };
+        }
+
+        const result = await performAppleSignIn({
+            apiUrl: this.app.config.apiUrl,
+            clientId: status.appleSiwaServicesId,
+            link,
+            /* link mode attaches Apple to the CALLER's account — auth_apple's
+               server-side link=1 path requires an already-authenticated
+               bearer (api.php ~3204) precisely so a stolen identityToken
+               can never hijack an arbitrary victim account. */
+            authHeaders: link ? this.authHeaders() : {},
+        });
+
+        if (!result.ok) {
+            return { success: false, error: result.error };
+        }
+
+        this.saveCredentials(result.token, result.user);
+        return { success: true, flow: result.flow };
+    }
+
+    /**
+     * Fetch the caller's linked external-identity providers (Settings
+     * "Connected accounts" card). Never includes the Apple `sub` or a
+     * refresh token — see `?action=auth_providers_list`'s server-side
+     * masking (api.php `_authProviderListForUser()`).
+     *
+     * @returns {Promise<Array<{provider:string, email_masked:string, is_private_relay:boolean, linked_at:?string}>>}
+     */
+    async listLinkedProviders() {
+        if (!this.isLoggedIn()) return [];
+        try {
+            const res = await fetch(`${this.app.config.apiUrl}?action=auth_providers_list`, {
+                headers: {
+                    'X-Requested-With': 'XMLHttpRequest',
+                    ...this.authHeaders(),
+                },
+            });
+            if (!res.ok) return [];
+            const data = await res.json();
+            return Array.isArray(data.providers) ? data.providers : [];
+        } catch {
+            return [];
+        }
+    }
+
+    /**
+     * Unlink a provider from the current account (Settings "Unlink"
+     * button). The server enforces a lockout guard (409) that this method
+     * simply surfaces — it never attempts to pre-validate that guard
+     * client-side (the server holds the authoritative, race-safe view via
+     * `SELECT ... FOR UPDATE`, see api.php `case 'auth_provider_unlink'`).
+     *
+     * @param {string} provider e.g. 'apple'
+     * @returns {Promise<{ success: boolean, error?: string, providers?: Array }>}
+     */
+    async unlinkProvider(provider) {
+        let res;
+        try {
+            res = await fetch(`${this.app.config.apiUrl}?action=auth_provider_unlink`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest',
+                    ...this.authHeaders(),
+                },
+                body: JSON.stringify({ provider }),
+            });
+        } catch {
+            return { success: false, error: 'Network error. Please check your connection and try again.' };
+        }
+
+        let data = null;
+        try {
+            data = await res.json();
+        } catch {
+            return { success: false, error: `Server returned an unreadable response (HTTP ${res.status}).` };
+        }
+
+        if (!res.ok) {
+            return { success: false, error: data?.error || 'Could not unlink account.' };
+        }
+
+        return { success: true, providers: Array.isArray(data.providers) ? data.providers : [] };
     }
 
     /* =====================================================================
@@ -1182,6 +1299,22 @@ export class UserAuth {
                     <div class="modal-body">
                         <div id="auth-error" class="alert alert-danger d-none" role="alert"></div>
 
+                        <!-- Sign in with Apple (#1470 W1 backend / #1479 W2 front end).
+                             DORMANT by default: hidden until _ensureAppStatus()
+                             confirms app_status.appleWebLoginEnabled === true AND a
+                             Services ID is configured (see the .then() below). Uses
+                             the bundled FontAwesome Apple glyph in lieu of Apple's
+                             official logo asset (not vendored in this repo) — an
+                             HIG-adjacent, not pixel-exact, treatment. -->
+                        <div id="auth-apple-section" class="d-none mb-3">
+                            <button type="button" class="btn btn-dark w-100" id="auth-apple-signin-btn">
+                                <i class="fa-brands fa-apple me-2" aria-hidden="true"></i>
+                                <span id="auth-apple-signin-text">Sign in with Apple</span>
+                                <span id="auth-apple-signin-spinner" class="spinner-border spinner-border-sm ms-2 d-none" role="status"></span>
+                            </button>
+                            <div class="text-center text-muted small mt-2">or</div>
+                        </div>
+
                         <form id="auth-form" novalidate>
                             <div class="mb-3" id="auth-display-name-group" style="display:${mode === 'register' ? '' : 'none'}">
                                 <label for="auth-display-name" class="form-label">Display Name</label>
@@ -1359,6 +1492,55 @@ export class UserAuth {
                 }
             });
         }
+
+        /* Sign in with Apple (#1479 W2) — reveal the button in BOTH login
+           and register modes (auth_apple resolves to a sign-in OR a fresh
+           account with no separate "register with Apple" flow needed).
+           _ensureAppStatus() is memoized so this never triggers a second
+           network fetch alongside the email-login check above. */
+        this._ensureAppStatus().then((status) => {
+            const appleEnabled = status?.appleWebLoginEnabled === true && !!status?.appleSiwaServicesId;
+            modal.querySelector('#auth-apple-section')?.classList.toggle('d-none', !appleEnabled);
+        });
+
+        modal.querySelector('#auth-apple-signin-btn')?.addEventListener('click', async () => {
+            const btn = modal.querySelector('#auth-apple-signin-btn');
+            const spinner = modal.querySelector('#auth-apple-signin-spinner');
+            const errorEl = modal.querySelector('#auth-error');
+
+            errorEl?.classList.add('d-none');
+            btn.disabled = true;
+            spinner?.classList.remove('d-none');
+
+            const result = await this.signInWithApple({ link: false });
+
+            spinner?.classList.add('d-none');
+            btn.disabled = false;
+
+            if (result.success) {
+                bsModal.hide();
+                this._updateHeaderState();
+                this.app.setList?.renderSyncBar();
+                /* One-time guidance on a brand-new account (§5 of the SIWA-web
+                   strategy) — never an interactive "an account with this email
+                   already exists" prompt (that would be an enumeration
+                   oracle). The user can link a pre-existing password/email
+                   account to Apple afterwards from Settings. */
+                if (result.flow === 'created') {
+                    this.app.showToast(
+                        'Account created with Apple! Already had an iHymns account? Sign in and link Apple from Settings.',
+                        'info',
+                        6000
+                    );
+                } else {
+                    this.app.showToast('Signed in with Apple! Syncing your data...', 'success', 3000);
+                }
+                this.triggerUserDataSync();
+            } else {
+                errorEl.textContent = result.error || 'Sign in with Apple failed.';
+                errorEl.classList.remove('d-none');
+            }
+        });
 
         /* Toggle between login and register */
         modal.querySelector('#auth-toggle')?.addEventListener('click', () => {

--- a/tests/php/test-auth-provider-unlink.php
+++ b/tests/php/test-auth-provider-unlink.php
@@ -1,0 +1,270 @@
+<?php
+/**
+ * iHymns — Linked-account UNLINK: lockout-guard truth table + list-shape
+ * masking (#1479 W3)
+ *
+ * api.php is a 13k+-line dispatcher that executes real request-handling code
+ * at file-scope on require (the test-auth-response-shape.php precedent
+ * explains why) — so this test:
+ *
+ *   1. Extracts JUST the PURE _authProviderUnlinkSurvives() function body via
+ *      a balanced-brace scan and eval()s that single definition — no
+ *      dispatcher code runs, no DB, no network — then asserts the FULL
+ *      lockout-guard truth table, including the private-relay-email
+ *      stranding case round-2 review of the SIWA-web strategy caught (a
+ *      verified, non-relay email with email-login operational is a survivor;
+ *      the SAME email at @privaterelay.appleid.com is NOT, unless another
+ *      provider is also linked).
+ *   2. Extracts JUST the PURE _authProviderMaskEmail() function body and
+ *      asserts its masking shape (never the raw address; '' on absent/
+ *      malformed input).
+ *   3. Extracts _authProviderListForUser() and source-greps its SQL SELECT
+ *      list to prove it NEVER selects Subject or RefreshToken — the
+ *      structural guard behind "auth_providers_list must never return the
+ *      Apple sub or refresh token".
+ *   4. Source-greps `case 'auth_provider_unlink':`'s body for the load-bearing
+ *      shape: POST-only, validateCsrfRequest() called, the row lock is a real
+ *      `FOR UPDATE`, and the lockout decision is delegated to
+ *      _authProviderUnlinkSurvives() rather than re-inlined ad hoc.
+ *
+ *   php tests/php/test-auth-provider-unlink.php
+ *
+ * Exit status 0 = all assertions pass, 1 = at least one failure.
+ */
+
+declare(strict_types=1);
+
+$apiFile = dirname(__DIR__, 2) . '/appWeb/public_html/api.php';
+if (!is_readable($apiFile)) {
+    fwrite(STDERR, "FATAL: could not read $apiFile\n");
+    exit(1);
+}
+$apiSrc = (string)file_get_contents($apiFile);
+
+$failures = 0;
+$passed = 0;
+
+function _tapuAssert(bool $cond, string $label): void
+{
+    global $failures, $passed;
+    if ($cond) {
+        $passed++;
+        echo "PASS: $label\n";
+    } else {
+        $failures++;
+        fwrite(STDERR, "FAIL: $label\n");
+    }
+}
+
+/**
+ * Extract one top-level `function $name(...) { ... }` definition from
+ * $source via a balanced-brace scan (mirrors test-auth-response-shape.php's
+ * _tarsExtractFunction() — the codebase's array literals use `[...]`, never
+ * `{...}`, so simple brace counting is safe here).
+ */
+function _tapuExtractFunction(string $source, string $name): ?string
+{
+    if (!preg_match('/function\s+' . preg_quote($name, '/') . '\s*\(/', $source, $m, PREG_OFFSET_CAPTURE)) {
+        return null;
+    }
+    $start = $m[0][1];
+    $bracePos = strpos($source, '{', $start);
+    if ($bracePos === false) {
+        return null;
+    }
+    $depth = 0;
+    $len = strlen($source);
+    for ($i = $bracePos; $i < $len; $i++) {
+        if ($source[$i] === '{') {
+            $depth++;
+        } elseif ($source[$i] === '}') {
+            $depth--;
+            if ($depth === 0) {
+                return substr($source, $start, $i - $start + 1);
+            }
+        }
+    }
+    return null;
+}
+
+function _tapuCaseBody(string $source, string $caseLabel): ?string
+{
+    $needle = "case '{$caseLabel}':";
+    $start = strpos($source, $needle);
+    if ($start === false) {
+        return null;
+    }
+    $bodyStart = $start + strlen($needle);
+    $nextCase = strpos($source, "\n        case '", $bodyStart);
+    return substr($source, $bodyStart, ($nextCase !== false ? $nextCase : strlen($source)) - $bodyStart);
+}
+
+foreach (['_authProviderUnlinkSurvives', '_authProviderMaskEmail', '_authProviderListForUser'] as $fnName) {
+    $fnSrc = _tapuExtractFunction($apiSrc, $fnName);
+    if ($fnSrc === null) {
+        fwrite(STDERR, "FATAL: could not extract {$fnName}() from api.php — has it been renamed or removed?\n");
+        exit(1);
+    }
+    /* eval() a single, isolated function DEFINITION — no dispatcher code, no
+       superglobals, no I/O. Safe: this is source we just extracted and are
+       about to assert the shape/behaviour of, not arbitrary/untrusted input. */
+    eval($fnSrc);
+    if (!function_exists($fnName)) {
+        fwrite(STDERR, "FATAL: eval() of the extracted function did not define {$fnName}().\n");
+        exit(1);
+    }
+}
+
+/* ---------------------------------------------------------------------- *
+ * 1. _authProviderUnlinkSurvives() — the full lockout-guard truth table.
+ * ---------------------------------------------------------------------- */
+
+/* (a) A password always survives, regardless of every other input. */
+_tapuAssert(
+    _authProviderUnlinkSurvives('somehash', false, '', false, []) === true,
+    '(a) non-empty PasswordHash survives unlink even with no email/other provider'
+);
+_tapuAssert(
+    _authProviderUnlinkSurvives('somehash', true, 'a@privaterelay.appleid.com', false, []) === true,
+    '(a) password ALSO survives when the (irrelevant) email happens to be a private-relay alias'
+);
+
+/* (b) Verified, non-relay email + operational email login = a survivor. */
+_tapuAssert(
+    _authProviderUnlinkSurvives('', true, 'alice@example.com', true, []) === true,
+    '(b) verified non-relay email + email-login operational + no other provider → survives'
+);
+
+/* THE STRANDING CASE (round-2 review finding #3) — a verified email that IS
+   the Apple private-relay alias must NOT count as a survivor: unlinking
+   Apple deactivates the relay, so mail to it bounces forever. */
+_tapuAssert(
+    _authProviderUnlinkSurvives('', true, 'abc123@privaterelay.appleid.com', true, []) === false,
+    'STRANDING CASE: verified @privaterelay.appleid.com email is NOT a survivor (would strand the account) → refused (409)'
+);
+_tapuAssert(
+    _authProviderUnlinkSurvives('', true, 'ABC123@PRIVATERELAY.APPLEID.COM', true, []) === false,
+    'STRANDING CASE is detected case-INSENSITIVELY (uppercase relay host)'
+);
+
+/* Un-verified email never counts, even if it "looks" fine. */
+_tapuAssert(
+    _authProviderUnlinkSurvives('', false, 'alice@example.com', true, []) === false,
+    'un-verified email (EmailVerified=0) is NOT a survivor, even with email-login operational and no relay'
+);
+
+/* Verified + non-relay, but email-login is NOT operational (no provider configured). */
+_tapuAssert(
+    _authProviderUnlinkSurvives('', true, 'alice@example.com', false, []) === false,
+    'verified non-relay email is NOT a survivor when email-login is NOT operational (EmailService::isConfigured() false)'
+);
+
+/* Empty email string never counts, even if EmailVerified/operational are both true (shouldn't happen in practice, but the pure function must not misbehave on it). */
+_tapuAssert(
+    _authProviderUnlinkSurvives('', true, '', true, []) === false,
+    'empty account email is NOT a survivor even when EmailVerified/operational are both true'
+);
+
+/* (c) Another linked provider is a survivor on its own, independent of (a)/(b). */
+_tapuAssert(
+    _authProviderUnlinkSurvives('', false, '', false, ['google']) === true,
+    '(c) another linked provider survives with no password and no usable email at all'
+);
+_tapuAssert(
+    _authProviderUnlinkSurvives('', true, 'abc123@privaterelay.appleid.com', true, ['google']) === true,
+    '(c) another linked provider rescues the STRANDING CASE — the private-relay email alone would refuse, but the extra provider allows it'
+);
+
+/* The true "nothing survives" refusal: no password, no usable email, no other provider. */
+_tapuAssert(
+    _authProviderUnlinkSurvives('', false, '', false, []) === false,
+    'the fully degenerate case (no password, no email, no other provider) is refused'
+);
+
+/* ---------------------------------------------------------------------- *
+ * 2. _authProviderMaskEmail() — masking shape.
+ * ---------------------------------------------------------------------- */
+_tapuAssert(_authProviderMaskEmail('') === '', 'empty string masks to empty string');
+_tapuAssert(_authProviderMaskEmail('not-an-email') === '', 'a string with no @ masks to empty string');
+_tapuAssert(_authProviderMaskEmail('alice@example.com') === 'a****@e******.com', 'alice@example.com masks to a****@e******.com');
+_tapuAssert(_authProviderMaskEmail('a@b.co') === 'a*@b*.co', 'single-char local/domain-label masks with exactly one star (never zero)');
+_tapuAssert(
+    _authProviderMaskEmail('user@mail.sub.example.com') === 'u***@m***.sub.example.com',
+    'multi-label domain masks ONLY the first label, keeping the rest of the domain readable'
+);
+/* The masked output must never contain the raw local-part or first domain
+   label verbatim (the whole point of masking). */
+_tapuAssert(!str_contains(_authProviderMaskEmail('alice@example.com'), 'alice'), 'masked output never contains the raw local-part');
+_tapuAssert(!str_contains(_authProviderMaskEmail('alice@example.com'), 'example'), 'masked output never contains the raw first domain label');
+
+/* ---------------------------------------------------------------------- *
+ * 3. _authProviderListForUser() never selects Subject/RefreshToken.
+ * ---------------------------------------------------------------------- */
+$listFnSrc = _tapuExtractFunction($apiSrc, '_authProviderListForUser');
+_tapuAssert($listFnSrc !== null, '_authProviderListForUser() found in api.php');
+if ($listFnSrc !== null) {
+    _tapuAssert(!str_contains($listFnSrc, 'Subject'), '_authProviderListForUser() SQL never references Subject (the Apple sub)');
+    _tapuAssert(!str_contains($listFnSrc, 'RefreshToken'), '_authProviderListForUser() SQL never references RefreshToken');
+    _tapuAssert(str_contains($listFnSrc, 'EmailIsPrivateRelay'), '_authProviderListForUser() selects EmailIsPrivateRelay (feeds is_private_relay)');
+    _tapuAssert(str_contains($listFnSrc, '_authProviderMaskEmail('), '_authProviderListForUser() masks Email via _authProviderMaskEmail() rather than returning it raw');
+}
+
+/* ---------------------------------------------------------------------- *
+ * 4. Structural guards on `case 'auth_provider_unlink'`'s body.
+ * ---------------------------------------------------------------------- */
+$unlinkBody = _tapuCaseBody($apiSrc, 'auth_provider_unlink');
+_tapuAssert($unlinkBody !== null, "case 'auth_provider_unlink' found in api.php");
+
+if ($unlinkBody !== null) {
+    _tapuAssert(
+        (bool)preg_match('/REQUEST_METHOD\'\]\s*!==\s*\'POST\'/', $unlinkBody),
+        "case 'auth_provider_unlink' rejects non-POST requests"
+    );
+    _tapuAssert(
+        (bool)preg_match('/validateCsrfRequest\s*\(/', $unlinkBody),
+        "case 'auth_provider_unlink' calls validateCsrfRequest() (rule #29 same-origin CSRF check)"
+    );
+    _tapuAssert(
+        (bool)preg_match('/getAuthenticatedUser\s*\(/', $unlinkBody),
+        "case 'auth_provider_unlink' requires a bearer via getAuthenticatedUser()"
+    );
+    _tapuAssert(
+        (bool)preg_match('/FOR UPDATE/', $unlinkBody),
+        "case 'auth_provider_unlink' locks rows with FOR UPDATE before deciding (race-safe lockout guard)"
+    );
+    _tapuAssert(
+        (bool)preg_match('/_authProviderUnlinkSurvives\s*\(/', $unlinkBody),
+        "case 'auth_provider_unlink' delegates the lockout decision to the shared, tested _authProviderUnlinkSurvives() rather than re-inlining it"
+    );
+    _tapuAssert(
+        (bool)preg_match('/\bin_array\s*\(\s*\$provider\s*,\s*\$providerAllowList\s*,\s*true\s*\)/', $unlinkBody),
+        "case 'auth_provider_unlink' validates \$provider against an explicit allow-list (never an unchecked value reaching SQL)"
+    );
+    _tapuAssert(
+        (bool)preg_match('/_authProviderUnlinkRevokeApple\s*\(/', $unlinkBody),
+        "case 'auth_provider_unlink' attempts a best-effort Apple revoke via the shared helper"
+    );
+    _tapuAssert(
+        (bool)preg_match('/logActivity\s*\(\s*\'auth\.provider_unlink\'/', $unlinkBody),
+        "case 'auth_provider_unlink' audits via logActivity('auth.provider_unlink', ...)"
+    );
+    /* Never logs the Apple sub / refresh token — same discipline as the SIWA
+       sources guard (test-apple-siwa-sources.php), scoped to this new case. */
+    _tapuAssert(!str_contains($unlinkBody, "'Subject'"), "case 'auth_provider_unlink' never logs or echoes the raw Subject column name in a sensitive context");
+}
+
+$listBody = _tapuCaseBody($apiSrc, 'auth_providers_list');
+_tapuAssert($listBody !== null, "case 'auth_providers_list' found in api.php");
+if ($listBody !== null) {
+    _tapuAssert(
+        (bool)preg_match('/getAuthenticatedUser\s*\(/', $listBody),
+        "case 'auth_providers_list' requires a bearer via getAuthenticatedUser()"
+    );
+    _tapuAssert(
+        (bool)preg_match('/_authProviderListForUser\s*\(/', $listBody),
+        "case 'auth_providers_list' delegates to the shared _authProviderListForUser() row-builder"
+    );
+}
+
+echo "\n$passed passed, $failures failed.\n";
+exit($failures > 0 ? 1 : 0);


### PR DESCRIPTION
Closes #1479 (W2+W3 of #1470). Surfaces web SIWA — **dormant** until an owner provisions Apple + enables a channel.

**W2** — `apple-signin.js` (Apple JS popup, nonce/state, POST auth_apple platform=web) + a gated button in `user-auth.js` + `app_status.appleSiwaServicesId` + `auth_apple` `flow` field.
**W3** — new **`auth_provider_unlink`** (bearer + CSRF + provider allow-list + `FOR UPDATE` + the pure `_authProviderUnlinkSurvives()` **lockout guard** refusing to strand a relay-only account, 409; best-effort Apple revoke *after* commit) + **`auth_providers_list`** (masked, never the sub) + a gated "Connected accounts" card in Settings.

No schema change. CI: `test-auth-provider-unlink.php` (36, incl. the private-relay stranding case). `php -l`/`node --check` clean; all Apple/auth tests green. OpenAPI updated for the 2 new endpoints. Built with Sonnet, Opus-reviewed (lockout guard · CSRF/bearer/allow-list · FOR UPDATE · revoke-after-commit · dormancy no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)