### PR TITLE
docs: refresh in-app help + Privacy/Terms to current feature set

### DIFF
--- a/appWeb/public_html/includes/pages/help.php
+++ b/appWeb/public_html/includes/pages/help.php
@@ -5,14 +5,16 @@
  *
  * PURPOSE:
  * In-app help and user guide. Provides instructions for using the
- * application, including searching, reading a song (transpose/chords,
+ * application, including accounts &amp; signing in (email, password,
+ * Sign in with Apple), searching, reading a song (transpose/chords,
  * sheet music, audio, compare versions, Presentation mode), favourites,
  * setlists, collections/series, Song of the Day, personal stats, themes,
- * PWA install, offline songs, keyboard shortcuts, and accessibility.
+ * PWA install, offline songs, Service Mode (congregation live-follow),
+ * keyboard shortcuts, and accessibility.
  *
  * Loaded via AJAX: api.php?page=help
  *
- * Last updated: 2026-06-21 (v0.990.0)
+ * Last updated: 2026-07-10 (v0.2501.0)
  */
 
 declare(strict_types=1);
@@ -55,6 +57,61 @@ declare(strict_types=1);
                         <li>Save songs to <strong>Favourites</strong> for quick access later</li>
                         <li>Use <strong>Shuffle</strong> to discover a random song</li>
                     </ul>
+                </div>
+            </div>
+        </div>
+
+        <!-- Account & Signing In (#1402/#1470/#1477/#1479) -->
+        <div class="accordion-item">
+            <h2 class="accordion-header">
+                <button class="accordion-button collapsed"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#help-account"
+                        aria-expanded="false"
+                        aria-controls="help-account">
+                    <i class="fa-solid fa-right-to-bracket me-2" aria-hidden="true"></i>
+                    Account &amp; Signing In
+                </button>
+            </h2>
+            <div id="help-account" class="accordion-collapse collapse" data-bs-parent="#help-accordion">
+                <div class="accordion-body">
+                    <p>
+                        Creating an account is <strong>optional</strong> — you can browse, search, and use
+                        offline features anonymously. Signing in lets your favourites, tags, set lists,
+                        language and theme preferences, and personal stats follow you to every device.
+                    </p>
+
+                    <h3 class="h6">Ways to sign in</h3>
+                    <ul>
+                        <li><strong>Email sign-in (no password):</strong> enter your email address and we'll send a one-tap sign-in link and a 6-digit code to your inbox — use whichever arrives first, no password to remember.</li>
+                        <li><strong>Username &amp; password:</strong> if you've set a password, sign in with your username and password instead. Use <em>Forgot password?</em> on the sign-in screen to reset it.</li>
+                        <li><strong>Sign in with Apple:</strong> always available in the iHymns app for iPhone, iPad, and Apple TV, and on the web when the site operator has switched it on. Tap <strong>Sign in with Apple</strong> and authenticate with Face&nbsp;ID, Touch&nbsp;ID, or your device passcode — Apple lets you choose whether to share your real email address or a private, forwarding &ldquo;Hide My Email&rdquo; address.</li>
+                    </ul>
+
+                    <h3 class="h6 mt-3">Linking &amp; unlinking Apple</h3>
+                    <p>
+                        On the web, open <strong>Settings &rarr; Account &amp; Profile</strong>. If Sign in
+                        with Apple is available on this site, a <strong>Connected accounts</strong> card lets
+                        you <strong>link</strong> your Apple ID to your existing account or <strong>unlink</strong>
+                        it later. You can't unlink your only way of signing back in — set a password or add a
+                        verified email address first if Apple is currently your sole sign-in method.
+                    </p>
+
+                    <h3 class="h6 mt-3">Deleting your account</h3>
+                    <p>
+                        In the iHymns app for iPhone, iPad, or Apple TV, open <strong>Account &rarr; Danger
+                        Zone &rarr; Delete Account</strong>. You'll be asked to confirm it's really you (your
+                        password, or a one-time code emailed to you) before anything is removed. Deleting your
+                        account permanently removes your account, favourites, and set lists from our servers,
+                        revokes any linked Sign in with Apple grant, and cannot be undone.
+                    </p>
+                    <p class="small text-muted mb-0">
+                        A self-service delete option in the web app is planned; until then, contact us via
+                        <a href="<?= htmlspecialchars($app["Application"]["Repo"]["Issues"]["URL"]) ?>"
+                           target="_blank" rel="noopener noreferrer">our GitHub repository</a>
+                        to request deletion of a web-only account.
+                    </p>
                 </div>
             </div>
         </div>
@@ -229,6 +286,36 @@ declare(strict_types=1);
                         Setlists you create are saved to your account if you're signed in, or to your device
                         otherwise. Signing in later associates any device-only setlists with your account.
                     </p>
+                </div>
+            </div>
+        </div>
+
+        <!-- Service Mode — congregation live-follow (#1323/#1335) -->
+        <div class="accordion-item">
+            <h2 class="accordion-header">
+                <button class="accordion-button collapsed"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#help-service-mode"
+                        aria-expanded="false"
+                        aria-controls="help-service-mode">
+                    <i class="fa-solid fa-tower-broadcast me-2" aria-hidden="true"></i>
+                    Following a Live Service
+                </button>
+            </h2>
+            <div id="help-service-mode" class="accordion-collapse collapse" data-bs-parent="#help-accordion">
+                <div class="accordion-body">
+                    <p>
+                        If your church has switched on <strong>Service Mode</strong>, a rotating code is
+                        shown on the venue's screen. Tap <strong>Join a live service</strong> on the home
+                        page, enter the code, and your device follows along — as the leader moves through
+                        the songs, your screen automatically switches to the same song they're on.
+                    </p>
+                    <ul class="mb-0">
+                        <li>No account is required to join — a green <strong>Following the service live</strong> bar appears at the bottom of the screen while you're connected.</li>
+                        <li>Tap <strong>Leave</strong> on that bar to stop following at any time.</li>
+                        <li>Following ends automatically once the service is over, or if the code's session expires.</li>
+                    </ul>
                 </div>
             </div>
         </div>

--- a/appWeb/public_html/includes/pages/privacy.php
+++ b/appWeb/public_html/includes/pages/privacy.php
@@ -30,7 +30,7 @@ $appUrl = $app["Application"]["Website"]["URL"];
     </h1>
 
     <p class="text-muted small mb-4">
-        Last updated: <?= date('j F Y') ?>
+        Last updated: 10 July 2026
     </p>
 
     <!-- Overview -->
@@ -62,14 +62,25 @@ $appUrl = $app["Application"]["Website"]["URL"];
             <h3 class="small fw-bold mt-3">2.1 Account Data (only if you create an account)</h3>
             <p>
                 Accounts are <strong>optional</strong> — you can browse, search, and use offline
-                features without one. If you choose to sign in (via a magic email link, or a
-                password where one has been set), we store the following on our servers:
+                features without one. If you choose to sign in (via a magic email link, a
+                password where one has been set, or Sign in with Apple), we store the following
+                on our servers:
             </p>
             <ul>
                 <li><strong>Email address</strong> — used to sign you in (we email you a one-time code/link) and for essential service messages. It is never sold, and not used for marketing without your consent.</li>
                 <li><strong>Profile</strong> — an optional display name, your chosen avatar source, and your preferred-languages filter.</li>
                 <li><strong>Role &amp; access tier</strong> — your permission level and content-access tier; for organisation members, your organisation membership and any licence (e.g. CCLI) held by that organisation.</li>
                 <li><strong>Synced content</strong> — favourites and set lists you save are synchronised to your account so they follow you across devices. Set lists may be shared via a link or collaborated on if you choose to.</li>
+                <li>
+                    <strong>Sign in with Apple</strong> (if you use it) — a stable, app-specific
+                    Apple identifier for your account; the email Apple gives us, which may be
+                    your real address or a private, forwarding &ldquo;Hide My Email&rdquo; alias
+                    (ending <code>@privaterelay.appleid.com</code>); and the name Apple shares on
+                    your <em>first</em> sign-in only (Apple does not send it again after that). We
+                    also store a refresh token for your Apple sign-in, used solely to revoke the
+                    Apple grant on Apple's side if you later delete your account or unlink Apple —
+                    it is never used for anything else.
+                </li>
             </ul>
             <p>You can export or delete your account data — see <em>Your Rights</em> below.</p>
 
@@ -253,7 +264,14 @@ $appUrl = $app["Application"]["Website"]["URL"];
                 each governed by their own privacy policies:
             </p>
             <ul>
-                <li><strong>CDN providers</strong> (jsDelivr, cdnjs) — for loading libraries including Bootstrap, jQuery, Font Awesome, Animate.css, Fuse.js, Tone.js, and PDF.js. These providers may log access in their server logs.</li>
+                <li><strong>CDN providers</strong> (jsDelivr, cdnjs) — for loading libraries including Bootstrap, jQuery, Font Awesome, Animate.css, Tone.js, and PDF.js. These providers may log access in their server logs.</li>
+                <li>
+                    <strong>Apple — Sign in with Apple</strong> (if you use it) — authentication only.
+                    Signing in with Apple on the web loads Apple's own JavaScript SDK from
+                    <code>appleid.cdn-apple.com</code>; Apple issues the sign-in credential directly
+                    to your browser, which we then verify. See Apple's own privacy policy for how
+                    Apple itself handles this. <a href="https://www.apple.com/legal/privacy/" target="_blank" rel="noopener noreferrer">Privacy policy</a>
+                </li>
                 <li><strong>Google Analytics 4</strong> (if enabled and consented) — anonymous usage statistics. <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">Privacy policy</a></li>
                 <li><strong>Microsoft Clarity</strong> (if enabled and consented) — anonymous usage heatmaps. <a href="https://privacy.microsoft.com/privacystatement" target="_blank" rel="noopener noreferrer">Privacy policy</a></li>
                 <li><strong>Plausible Analytics</strong> (if enabled) — privacy-focused, cookieless analytics. <a href="https://plausible.io/data-policy" target="_blank" rel="noopener noreferrer">Data policy</a></li>
@@ -312,7 +330,12 @@ $appUrl = $app["Application"]["Website"]["URL"];
                 <li><strong>Enable DNT:</strong> Activate Do Not Track in your browser to anonymise any analytics</li>
                 <li><strong>Block analytics:</strong> Use browser extensions (e.g., uBlock Origin) to block analytics entirely</li>
                 <li><strong>Access &amp; export your data:</strong> Export your locally stored data — and, if you have an account, your profile, favourites, and set lists — via Settings</li>
-                <li><strong>Delete your account:</strong> Delete your account and its synced data at any time from Settings; this removes your account record from our live database</li>
+                <li><strong>Delete your account:</strong> Permanently delete your account in the
+                    iHymns app for iPhone, iPad, or Apple TV (Account &gt; Danger Zone), after
+                    confirming it's you. This removes your account record and synced data from
+                    our live database and revokes any linked Sign in with Apple grant. A
+                    self-service option in the web app is planned; until then, web-only accounts
+                    can request deletion via the contact link below</li>
                 <li><strong>Uninstall:</strong> Remove the PWA from your device at any time</li>
             </ul>
         </div>

--- a/appWeb/public_html/includes/pages/terms.php
+++ b/appWeb/public_html/includes/pages/terms.php
@@ -30,7 +30,7 @@ $appUrl = $app["Application"]["Website"]["URL"];
     </h1>
 
     <p class="text-muted small mb-4">
-        Last updated: <?= date('j F Y') ?>
+        Last updated: 10 July 2026
     </p>
 
     <!-- Introduction -->
@@ -193,6 +193,12 @@ $appUrl = $app["Application"]["Website"]["URL"];
                 Optional analytics are disabled by default and require your consent. For full details —
                 including what we collect, cookies, retention, API-access logging, and your rights — see our
                 <a href="/privacy" data-navigate="privacy">Privacy Policy</a>.
+            </p>
+            <p>
+                You may sign in with a magic email link, a password (where one has been set), or
+                Sign in with Apple. You may permanently delete your account at any time from within
+                the iHymns app for iPhone, iPad, or Apple TV; see the Privacy Policy for what
+                deleting your account removes.
             </p>
         </div>
     </div>

--- a/appWeb/public_html/manage/help.php
+++ b/appWeb/public_html/manage/help.php
@@ -246,7 +246,7 @@ $sections = [
     [
         'id'    => 'configuration',
         'icon'  => 'bi-phone',
-        'title' => 'Native app stores',
+        'title' => 'Native app stores & Apple Sign-In',
         'group' => 'Operations',
     ],
     [
@@ -1082,6 +1082,12 @@ foreach ($sections as $s) {
                     <div class="gotcha small">
                         <strong>Gotcha:</strong> Username is set on creation and is immutable. Display name can be changed any time.
                     </div>
+                    <div class="gotcha small">
+                        <strong>Gotcha:</strong> Users can also delete <em>their own</em> account
+                        self-service from the native Apple app (#1477, re-auth required), separately
+                        from the admin-initiated Delete above. A self-service delete also revokes
+                        any linked Sign in with Apple grant and clears their API tokens.
+                    </div>
                 </section>
 
                 <section id="groups" class="help-section card-admin mb-4">
@@ -1439,7 +1445,7 @@ foreach ($sections as $s) {
                          in-progress and unpublished, so this card is
                          commonly left blank. */ ?>
                 <section id="configuration" class="help-section card-admin mb-4">
-                    <h2><i class="bi bi-phone me-2"></i>Native app stores</h2>
+                    <h2><i class="bi bi-phone me-2"></i>Native app stores &amp; Apple Sign-In</h2>
                     <p class="role-badges">
                         <span class="badge bg-danger">global_admin</span>
                     </p>
@@ -1465,6 +1471,19 @@ foreach ($sections as $s) {
                     <div class="gotcha small">
                         <strong>Gotcha:</strong> it's safe &mdash; and normal &mdash; to leave every field blank until an app is actually live on that store. Blank falls back to the ordinary PWA install prompt; nothing breaks and no banner claims an app exists before it does.
                     </div>
+                    <h3 class="h6">Apple native app &amp; Sign in with Apple credentials (#1401/#1402/#1470)</h3>
+                    <p>
+                        The same <a href="/manage/configuration">Configuration</a> page has an
+                        &ldquo;Apple native app&rdquo; card, below the Feature Gating card, holding the
+                        Apple Developer <strong>Team ID</strong> (for Universal Links), the
+                        <strong>Sign in with Apple</strong> key (Key ID + <code>.p8</code> private key
+                        &mdash; only needed for the refresh-token exchange and Apple-side revoke on
+                        account deletion; the native app's sign-in itself works before these are set),
+                        and the separate <strong>Services ID</strong> + channel allow-list that turns on
+                        Sign in with Apple for the <em>web</em> app. Every field on this card is optional
+                        and dormant until filled in &mdash; each has its own inline guidance and a
+                        set/not-set badge.
+                    </p>
                 </section>
 
                 <section id="native-api" class="help-section card-admin mb-4">


### PR DESCRIPTION
Accuracy pass on the user-facing help + legal pages reflecting this session's shipped features. Docs-only.

- **help.php:** new Account & Signing In (incl. Sign in with Apple + link/unlink), Deleting your account (native-only — grounded, no web UI exists), Following a Live Service.
- **privacy.php:** **fixed effective date** (was `date()` = always today); disclosed Sign in with Apple (§2.1/§8 + the `appleid.cdn-apple.com` SDK); updated account-deletion (§10); **removed a stale Fuse.js claim** (search is MySQL FULLTEXT since #1020).
- **terms.php:** fixed date; §8 notes SIWA + in-app deletion.
- **manage/help.php:** config section broadened to the Apple/SIWA card + a deletion gotcha.

Legal-drafting items (governing law · termination · age) are drafted for **owner/legal review**, deliberately NOT inserted. Analytics processors all verified as actually wired. Built with Sonnet, Opus-reviewed; php -l clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)