### PR TITLE
docs(session): 2026-07-10 mega-session handoff

### DIFF
--- a/.claude/sessions/2026-07-10-HANDOFF.md
+++ b/.claude/sessions/2026-07-10-HANDOFF.md
@@ -1,31 +1,34 @@
-# Session handoff — 2026-07-10
+# Session handoff — 2026-07-10 (mega session)
 
-Two work streams this session. Persistent Claude memory mirrors this (auto-loaded next session).
+Nine PRs merged to `alpha` (v**0.2501.0**). Persistent Claude memory mirrors this (auto-loaded next session). Owner process this session: **Fable 5 = deep planning (sequential rounds); Sonnet/Haiku = implementation; Opus = review + genuinely-complex only.** Per work item: GitHub issue + individual commit + handoff + memory. Owner is web-only on shared DreamHost (3 docroots, one MySQL, web-run migrations).
 
-## 1. Secret encryption-at-rest (#1466) — MERGED to alpha ✅
+## Merged to `alpha`
+| PR | What | State |
+|---|---|---|
+| #1469 | Secret encryption-at-rest (#1466) + **v0.2501.0** | DORMANT (delivered via clean branch off alpha — feat/apple-universal was already squash-merged as #1464) |
+| #1471 | SIWA-web **W1** backend (`auth_apple` `platform=web`) + strategy doc | DORMANT |
+| #1473 | OpenAPI refresh (+24 actions) | — |
+| #1475 | Apple **TestFlight/App-Store readiness** → `appApple/dev-docs/Provisioning-Runbook.md` §2 (+ #1474) | — |
+| #1476 | OpenAPI drift completion (#1472) | — |
+| #1478 | **In-app account deletion** (native, App Review 5.1.1(v), #1477) — closes the App Store blocker | live (native) |
+| #1480 | SIWA-web **W2/W3** (web sign-in popup + Connected-accounts link/unlink + `auth_provider_unlink`/`auth_providers_list`) | DORMANT |
+| #1482 | **Admin-configurable feature gating** P1 registry + P2 enforcement (#1481) | DORMANT (nested 2-flag) |
+| #1483 | In-app help refresh + Privacy/Terms factual fixes | — |
 
-- Version bumped **0.2500.0 → 0.2501.0** (infoAppVer / README / OpenAPI synced).
-- Independent multi-agent adversarial security review → **SAFE_TO_PROCEED**; 3 defence-in-depth hardenings folded in (placeholder/all-same-nibble master-key rejection in `_secretCryptoNormalise()` [+4 tests → 45]; `escapeHtml()` on the Rotate undecryptable list; Global-Admin gate on the whole setup-database Secret-encryption panel).
-- Delivered via clean branch **`feat/secret-encryption-1466`** off alpha (because `feat/apple-universal` was already squash-merged into alpha as **#1464**/v0.2500.0 — a direct feat/apple-universal→alpha PR would have re-merged 56 already-landed commits). PR **#1469** squash-merged to alpha (`6448a927`), alpha deploy green.
-- **Feature remains fully DORMANT** (no master key provisioned; verified no-op). Owner activation sequence unchanged (provision `SECRETS_MASTER_KEY` → deploy seeds all 3 docroots → verify fingerprints/sentinel/beacons → run the `confirm=1` encrypt-in-place migration card → rotate provider-side keys).
-- NOTE: local `feat/apple-universal` still carries the 3 pre-cherry-pick commits (`187f0447`/`342effc0`/`71f268d3`); reconcile by merging alpha back in, or reset to origin/alpha.
+## Fable-planned (both approved + built)
+- **SIWA-web / SIGNula.id** — `.claude/siwa-web-signula-strategy.md`. Option C (build direct now, federate to SIGNula later; SIGNula.id has no partner OAuth/OIDC — filed `MWBMPartners/SIGNula.id#89`). Tracking **#1470**. Load-bearing owner decision **D1**: SIGNula's Apple Services ID in the SAME Apple team as `app.ihymns`.
+- **Admin-configurable gating** — `.claude/admin-configurable-gating-strategy.md`. Honest boundary: *admins compose, devs register primitives* (~⅓–½ of future gates pure-UI). Tracking **#1481**.
 
-## 2. Sign in with Apple for Web + SIGNula.id federation — PLANNED + W1 built (dormant)
+## Reviews delivered
+- **Apple distribution readiness** (runbook §2 / #1474): pipeline built (Fastlane, apple.yml/apple-deploy.yml); blockers = **backend only on alpha/dev.ihymns.app** (promote alpha→beta→main before device testing — Release builds hit prod which lacks auth_apple/account_delete/analytics), AASA 301→200 on prod, App Store metadata/screenshots, deployment target 26.0. Native **client has NO SIWA** (backend-only #1402; login = password + email-code) — separate feature.
+- **Privacy Policy & Terms** — factual fixes shipped in #1483; **legal drafts** (governing law England & Wales, account termination, age/eligibility) returned for **owner/legal review, NOT inserted**. Confirm the legal entity name (`$vendorName` resolves to "iHymns", not MWBM Partners Ltd) before wiring them.
 
-Strategy: **`.claude/siwa-web-signula-strategy.md`** (2 sequential Fable-5 planning rounds + Opus review). Tracking: **iHymns #1470**, **MWBMPartners/SIGNula.id#89** (federation contract).
-
-- **Recommendation Option C** (owner-approved): build iHymns-**direct** SIWA-for-web now (provider-generic, no schema change, ~3–4 dev-days), federate to SIGNula **later**. Option B (delegate to SIGNula now) is **not buildable** — SIGNula v2.6.0-beta has no partner OAuth/OIDC (only email+password login, HS256/opaque tokens, no JWKS).
-- **Load-bearing owner decision D1:** SIGNula's Apple **Services ID under the same Apple Developer Team** as `app.ihymns` → deterministic `sub` reconciliation.
-- Opus correction: the planning "login-CSRF" finding was **refuted** (api.php's global `X-Requested-With` guard already blocks cross-site POSTs) — conditional-cookie change + O7 dropped.
-
-### Branch `feat/siwa-web` (off alpha) — 2 commits, **NOT pushed**
-- `37625e5f` docs(auth): strategy doc.
-- `31a312b5` feat(auth): **W1 backend, DORMANT** — `platform` param + Services-ID audience (single aud, never try-both) + channel-gated `apple_web_login_enabled`/`apple_siwa_services_id` settings + `appleSiwaExchangeCode` redirect_uri + Host-validated web redirect + `app_status.appleWebLoginEnabled`. Tests 34+25, all existing auth tests green, php -l clean. No schema change.
-
-### RESUME
-1. **Owner decision: push `feat/siwa-web` + open PR to alpha?** (repo auto-merges green alpha PRs). W1 is a verified dormant no-op.
-2. Then **W2** (front-end `js/modules/apple-signin.js`, Apple JS popup, button gated on `appleWebLoginEnabled`, first-auth fullName) and **W3** (Settings "Connected accounts" + provider-generic `auth_provider_unlink` with the private-relay-aware lockout guard + best-effort Apple revoke).
-3. **W0 owner provisioning** (Apple Services ID same-team [D1], per-docroot return URLs, private-relay outbound mail) gates real activation; other decisions D3/D4/O1–O6 in strategy §10.
-
-## 3. Queued, NOT yet started
-- **Thorough OpenAPI/Swagger refresh** of `appWeb/public_html/api-docs.yaml` to the current feature set (Apple auth, account_delete, analytics, gating, service mode, works/external-links, …) — own issue + individual commit. Owner said: do it **after** the SIWA work.
+## RESUME — owner actions pending
+1. **Legal drafts** (Terms) — approve + provide the registered entity name → I'll wire them (Sonnet).
+2. **CSP fix #1484** — add `appleid.cdn-apple.com` to `index.php` `script-src` before enabling web SIWA (else the Apple SDK is blocked).
+3. **Activate the 3 dormant families** (each needs its owner sequence):
+   - **#1466 secret encryption:** provision `SECRETS_MASTER_KEY` on all 3 docroots → run the encrypt-in-place migration card.
+   - **Web SIWA (W0):** Apple Services ID same-team as `app.ihymns` (**D1**) + per-docroot return URLs + relay outbound mail → save Services ID + enable a channel on `/manage/configuration`. Then the CSP fix (#1484).
+   - **Admin gating:** run the `gating-registry` migration card → define caps + rules on `/manage/feature-gating` → flip `content_gating_enabled` + `feature_gating_rules_enabled`.
+4. **feat/apple-universal reconciliation:** local branch still carries the 3 pre-cherry-pick #1466 commits — merge alpha back in or reset to origin/alpha.
+5. **Tracked follow-ups:** #1474 (Apple readiness), #1484 (CSP), SIGNula#89 (federation contract), songbook_export tier-trim gap (gating strategy §5), gating P3+ (`gate_api_action`), native `features` map, promote the Apple backend to prod.


### PR DESCRIPTION
Updates the `.claude/sessions/` handoff for the full 2026-07-10 session (9 PRs, the dormant SIWA-web + admin-gating + secret-encryption families, and the owner-activation/resume actions). Dev-docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)