### PR TITLE
feat(auth): CSP for web SIWA (#1484) + Terms legal clauses + clear activation runbooks

### DIFF
--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -56,7 +56,28 @@ Every step below is doable by a **web-only operator** (no shell/SSH on the share
 7. **Later — key rotation.** Generate a new key (step 2). Add it as a **second** keyid (e.g. `k2`) alongside `k1` in `secrets_master_key.php` on **all 3** docroots, then set `'active' => 'k2'` on all 3. Confirm every docroot's panel shows the new keyid present with a matching fingerprint. **Only then** use **Rotate / re-encrypt** on the panel — re-enter your password (re-auth) and type `ROTATE` to confirm — which re-wraps every secret under the new active keyid (audit-logged by key name + actor + timestamp, never values). Finally, remove the retired `k1` entry from all 3 files.
 8. **(Independent, P4) Opcache-bust key hardening.** Optionally replace each docroot's `appWeb/.auth/opcache_bust_key.php` plaintext value with a one-way hash: `<?php return 'sha256:' . hash('sha256', '<the-plaintext-key>');`. `opcache-bust.php` now accepts both the `sha256:` hashed form and legacy plaintext. The CI deploy sender is unchanged — it still sends the raw key from the `OPCACHE_BUST_KEY` GitHub secret; only the stored comparison value on each docroot changes.
 
-> **Note:** `SECRETS_MASTER_KEY`, like every other deploy secret, is set via the GitHub **web UI** (Settings → Secrets and variables → Actions), never via `gh secret set` — the plaintext key should never pass through a local shell or clipboard longer than necessary.
+> **Note:** `SECRETS_MASTER_KEY`, like every other deploy secret, is set via the GitHub **web UI** (Settings → Secrets and variables → Actions), never via `gh secret set` — the plaintext key should never pass through a local shell or clipboard longer than necessary. Since it is already set, steps 1–3 are handled by the deploy seed on the next `appWeb/**` deploy — you are at **step 4 (verify parity) → step 5 (run the migration)**.
+
+#### 🍎 Operator runbook — turning on Sign in with Apple for the WEB (#1470 W0)
+
+Web SIWA is built + merged but **DORMANT**. Activating it is a **MIX** of Apple-portal clicks, ONE database migration, and TWO settings — **NOT all migrations**. Do them in order. (The *native* app's SIWA is separate — see `appApple/dev-docs/Provisioning-Runbook.md`.)
+
+1. **[Apple Developer portal — NOT a migration] Create a Services ID (this is decision D1).** developer.apple.com → Certificates, Identifiers & Profiles → **Identifiers → ➕ → Services IDs** → identifier e.g. `app.ihymns.web`; tick **Sign in with Apple** → **Configure** → **Primary App ID** = `app.ihymns`. ⚠️ **It MUST be under the SAME Apple Developer Team as `app.ihymns`** (that's what "D1" means) — a different team gives a different Apple `sub`, breaking account reconciliation across native/web (and later SIGNula). There is **no migration or DB step** that creates this; only Apple's portal can.
+2. **[Apple portal] Register the return URL(s).** Same Services ID → Configure → **Website URLs** → add each docroot's domain + the return URL `https://<host>/` (the origin root) for every docroot offering web SIWA (`ihymns.app`, `dev.ihymns.app`, `beta.ihymns.app`). The web flow is popup mode but the return URL must still be registered and equal `APPLE_SIWA_WEB_RETURN_PATH` (`'/'`).
+3. **[/manage/setup-database migration — ONCE, shared DB] Ensure the auth-provider tables exist.** Run the card **"Run Auth Providers Migration"** (`migrate-user-auth-providers.php` → `tblUserAuthProviders` + `tblAuthNonces`) **if it isn't already green** — it ships with the #1402 native backend, so it is likely already applied. This is the *only* migration web SIWA needs.
+4. **[/manage/configuration setting — NOT a migration] Save the Services ID + enable a channel.** `/manage/configuration` → **Apple native app** card → **Sign in with Apple — Web** section: paste the Services ID from step 1 into **`apple_siwa_services_id`** (must NOT equal `app.ihymns`), and set **`apple_web_login_enabled`** to the channel(s) you're rolling out — start `alpha`, widen `alpha,beta`, then `all`. These are `tblAppSettings` writes (shared DB), **not** schema migrations. Web SIWA stays dormant until BOTH are set for the current channel.
+5. **[Code — already done]** `appleid.cdn-apple.com` is in `index.php`'s CSP `script-src` (#1484) so Apple's JS SDK loads once enabled — no action.
+6. **[Verify]** On a docroot in the enabled channel, the auth modal shows a **Sign in with Apple** button; sign-in creates/links an account; Link/Unlink live in Settings → Account & Profile → **Connected accounts**.
+
+> **Why it's "not all migrations":** the Services ID (steps 1–2) is an Apple-portal identity artifact PHP cannot create; the enable/config (step 4) is a settings write, not a schema change. Only step 3 is an actual migration — and it's usually already done.
+
+#### 🎚 Operator runbook — turning on admin-configurable feature gating (#1481)
+
+Registry + enforcement are built + **DORMANT**. To use it:
+
+1. **[/manage/setup-database migration — ONCE, shared DB]** Run the card **"Admin-configurable feature gating (#1481 P1)"** (`migrate-add-gating-registry.php` → `tblGatingCapabilities` + `tblGatingRules`).
+2. **[/manage/feature-gating — Global Admin]** Define a capability (key `Can…`, label, default), then optionally add an enforcement **rule** mapping it to a behaviour kind (`strip_payload_keys` / `drop_media_kinds`). Assign per tier on `/manage/tiers` (the matrix auto-grows a column). Rules affect the `song_detail`/`song_data`/`random` JSON payloads (a coverage note is shown in-page).
+3. **[/manage/configuration settings]** In the **Feature gating** card, enable `content_gating_enabled` (the master content-gating switch) **and** `feature_gating_rules_enabled` (admin rules). Rules run only when BOTH are on — a byte-identical no-op until then.
 
 ### 🌐 Web/PWA — SFTP Deployment
 

--- a/appWeb/public_html/includes/pages/terms.php
+++ b/appWeb/public_html/includes/pages/terms.php
@@ -236,10 +236,64 @@ $appUrl = $app["Application"]["Website"]["URL"];
         </div>
     </div>
 
+    <!-- Governing Law & Jurisdiction -->
+    <div class="card card-settings mb-3">
+        <div class="card-body">
+            <h2 class="h6 mb-3">11. Governing Law &amp; Jurisdiction</h2>
+            <p>
+                These Terms of Use, and any dispute or claim arising out of or in connection
+                with them or their subject matter (including non-contractual disputes or claims),
+                shall be governed by and construed in accordance with the laws of
+                <strong>England and Wales</strong>. Each party irrevocably agrees that the courts
+                of England and Wales shall have exclusive jurisdiction to settle any dispute or
+                claim arising out of or in connection with these Terms.
+            </p>
+        </div>
+    </div>
+
+    <!-- Account Suspension & Termination -->
+    <div class="card card-settings mb-3">
+        <div class="card-body">
+            <h2 class="h6 mb-3">12. Account Suspension &amp; Termination</h2>
+            <p>
+                We may suspend or terminate your access to <?= htmlspecialchars($appName) ?>,
+                in whole or in part, at any time and without prior notice, if we reasonably
+                believe you have breached these Terms of Use (including the Acceptable Use
+                provisions in Section 4), engaged in fraudulent, abusive, or unlawful conduct,
+                or where suspension or termination is necessary to protect the security or
+                integrity of the service or other users. Where practicable, we will give you
+                notice of suspension or termination and the reason for it.
+            </p>
+            <p>
+                You may stop using <?= htmlspecialchars($appName) ?>, and where you hold an
+                account, delete it at any time (see our
+                <a href="/privacy" data-navigate="privacy">Privacy Policy</a>). Sections of these
+                Terms that by their nature should survive termination — including Copyright &amp;
+                Intellectual Property, Availability &amp; Updates, Limitation of Liability,
+                Governing Law, and this Section — continue to apply after your access ends.
+            </p>
+        </div>
+    </div>
+
+    <!-- Age & Eligibility -->
+    <div class="card card-settings mb-3">
+        <div class="card-body">
+            <h2 class="h6 mb-3">13. Age &amp; Eligibility</h2>
+            <p>
+                <?= htmlspecialchars($appName) ?> is intended for use by individuals capable of
+                forming a binding contract under applicable law. If you are under the age of 13
+                (or the minimum age of digital consent in your jurisdiction, if higher), you may
+                only use <?= htmlspecialchars($appName) ?> with the involvement and consent of a
+                parent or guardian. By creating an account, you confirm that you meet this age
+                requirement and that the information you provide is accurate.
+            </p>
+        </div>
+    </div>
+
     <!-- Changes to Terms -->
     <div class="card card-settings mb-3">
         <div class="card-body">
-            <h2 class="h6 mb-3">11. Changes to These Terms</h2>
+            <h2 class="h6 mb-3">14. Changes to These Terms</h2>
             <p>
                 We may update these Terms of Use from time to time. Continued use of
                 <?= htmlspecialchars($appName) ?> after changes are posted constitutes
@@ -251,7 +305,7 @@ $appUrl = $app["Application"]["Website"]["URL"];
     <!-- Contact -->
     <div class="card card-settings mb-3">
         <div class="card-body">
-            <h2 class="h6 mb-3">12. Contact</h2>
+            <h2 class="h6 mb-3">15. Contact</h2>
             <p>
                 If you have questions about these Terms of Use, please visit
                 <a href="<?= htmlspecialchars($app["Application"]["Repo"]["Issues"]["URL"]) ?>"

--- a/appWeb/public_html/index.php
+++ b/appWeb/public_html/index.php
@@ -190,7 +190,11 @@ if (!empty(APP_CONFIG['analytics']['matomo_url'])) {
 
 $cspDirectives = [
     "default-src 'self'",
-    "script-src 'self' 'nonce-{$cspNonce}' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://www.googletagmanager.com https://plausible.io https://www.clarity.ms https://cdn.usefathom.com{$cspMatomoUrl}",
+    /* appleid.cdn-apple.com serves the "Sign in with Apple JS" SDK for web SIWA (#1470 W2,
+       #1484). The popup is a window.open to appleid.apple.com (not an iframe → no frame-src),
+       and the token exchange is server-side (no connect-src needed). Harmless while web SIWA
+       is dormant; required the moment an admin enables it. */
+    "script-src 'self' 'nonce-{$cspNonce}' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://www.googletagmanager.com https://plausible.io https://www.clarity.ms https://cdn.usefathom.com https://appleid.cdn-apple.com{$cspMatomoUrl}",
     "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com",
     "img-src 'self' data: https:",
     "font-src 'self' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com",


### PR DESCRIPTION
Owner-directed follow-ups:
- **CSP (#1484):** `appleid.cdn-apple.com` added to `index.php` `script-src` (done in code, not a manual step) — the Apple SIWA JS SDK will load once web SIWA is enabled. Harmless while dormant.
- **Terms of Use:** owner-approved **Governing Law (England & Wales)**, **Account Suspension & Termination**, and **Age & Eligibility** clauses inserted (§11-13; Changes/Contact → §14-15). Vendor name = "iHymns" per owner.
- **DEV_NOTES.md:** clear action-typed **activation runbooks** — Web SIWA (D1 = an Apple-portal Services ID, **not** a migration; one migration; two settings) + admin gating — and corrected the #1466 note (`SECRETS_MASTER_KEY` is set → operator is at verify + run-migration).

php -l clean. Closes #1484.

🤖 Generated with [Claude Code](https://claude.com/claude-code)