### PR TITLE
docs(legal): disclose MWBM Partners Ltd as operator + Web SIWA runbook in Apple prep doc

### DIFF
--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -60,7 +60,7 @@ Every step below is doable by a **web-only operator** (no shell/SSH on the share
 
 #### 🍎 Operator runbook — turning on Sign in with Apple for the WEB (#1470 W0)
 
-Web SIWA is built + merged but **DORMANT**. Activating it is a **MIX** of Apple-portal clicks, ONE database migration, and TWO settings — **NOT all migrations**. Do them in order. (The *native* app's SIWA is separate — see `appApple/dev-docs/Provisioning-Runbook.md`.)
+Web SIWA is built + merged but **DORMANT**. Activating it is a **MIX** of Apple-portal clicks, ONE database migration, and TWO settings — **NOT all migrations**. Do them in order. (The *native* app's SIWA is separate — see `appApple/dev-docs/Provisioning-Runbook.md` §1.2; this same web runbook is also mirrored there as §1.4.)
 
 1. **[Apple Developer portal — NOT a migration] Create a Services ID (this is decision D1).** developer.apple.com → Certificates, Identifiers & Profiles → **Identifiers → ➕ → Services IDs** → identifier e.g. `app.ihymns.web`; tick **Sign in with Apple** → **Configure** → **Primary App ID** = `app.ihymns`. ⚠️ **It MUST be under the SAME Apple Developer Team as `app.ihymns`** (that's what "D1" means) — a different team gives a different Apple `sub`, breaking account reconciliation across native/web (and later SIGNula). There is **no migration or DB step** that creates this; only Apple's portal can.
 2. **[Apple portal] Register the return URL(s).** Same Services ID → Configure → **Website URLs** → add each docroot's domain + the return URL `https://<host>/` (the origin root) for every docroot offering web SIWA (`ihymns.app`, `dev.ihymns.app`, `beta.ihymns.app`). The web flow is popup mode but the return URL must still be registered and equal `APPLE_SIWA_WEB_RETURN_PATH` (`'/'`).

--- a/appApple/dev-docs/Provisioning-Runbook.md
+++ b/appApple/dev-docs/Provisioning-Runbook.md
@@ -137,6 +137,20 @@
 
 ---
 
+### §1.4 — Web Sign in with Apple — activation
+
+> **Web SIWA** (browser-based sign-in on `ihymns.app` / `dev.ihymns.app` / `beta.ihymns.app`) is **built + merged but DORMANT**. Activating it is a **MIX** of Apple-portal clicks, **ONE** database migration, and **TWO** settings — **NOT all migrations**. This is separate from the *native* app's SIWA key above (§1.2 Step 2) — the web flow authenticates via its own **Services ID**, not the App ID's key. (Full detail + copy-paste steps: `DEV_NOTES.md` → "🍎 Operator runbook — turning on Sign in with Apple for the WEB".)
+
+1. **[Apple Developer portal — NOT a migration] Create a Services ID (decision D1).** developer.apple.com → Certificates, Identifiers & Profiles → **Identifiers → ➕ → Services IDs** → identifier `app.ihymns.web`; tick **Sign in with Apple** → **Configure** → **Primary App ID** = `app.ihymns`. ⚠️ Must be registered under the **SAME Apple Developer Team** as `app.ihymns` (decision D1) — a different team issues a different Apple `sub`, breaking account reconciliation between native and web. Register the **return URL** `https://<host>/` (the origin root) for **every** docroot offering web SIWA (`ihymns.app`, `dev.ihymns.app`, `beta.ihymns.app`).
+2. **[/manage/setup-database migration — ONCE, shared DB]** Run **`migrate-user-auth-providers`** (→ `tblUserAuthProviders` + `tblAuthNonces`) if it isn't already green — usually already applied via §1.2 Step 5 above, since it ships with the native SIWA backend.
+3. **[/manage/configuration settings — NOT a migration]** `/manage/configuration` → **Apple native app** card → **Sign in with Apple — Web** section: paste the Services ID from Step 1 into **`apple_siwa_services_id`** (must **NOT** equal `app.ihymns`), and set **`apple_web_login_enabled`** to the channel(s) being rolled out — start `alpha`, widen to `alpha,beta`, then `all`. Web SIWA stays dormant until BOTH settings are set for the current channel.
+4. **[Code — already done]** `appleid.cdn-apple.com` is already listed in the CSP `script-src` (#1484) so Apple's JS SDK loads once enabled — no action needed.
+5. **[Verify]** On a docroot in the enabled channel, the auth modal shows a **Sign in with Apple** button; sign-in creates/links an account; Link/Unlink live in Settings → Account & Profile → **Connected accounts**.
+
+> **Why it's not all migrations:** the Services ID (Step 1) is an Apple-portal identity artifact PHP cannot create; the enable/config (Step 3) is a `tblAppSettings` write, not a schema change. Only Step 2 is an actual migration — and it's usually already done.
+
+---
+
 ## Verification walkthrough — where to look & what "good" looks like
 
 Three buckets: what you can verify **now** (Apple portals), what's **blocked on §1.1 deploy**, and what needs a **signed device build**.

--- a/appWeb/public_html/includes/infoAppVer.php
+++ b/appWeb/public_html/includes/infoAppVer.php
@@ -140,7 +140,7 @@ $app["Application"]["Vendor"]["Name"] = "iHymns";
 $app["Application"]["Vendor"]["Website"]["URL"] = "https://ihymns.app";
 
 /* Parent company name */
-$app["Application"]["Vendor"]["Parent"]["Name"] = NULL;
+$app["Application"]["Vendor"]["Parent"]["Name"] = "MWBM Partners Ltd";
 
 /* Parent company website URL */
 $app["Application"]["Vendor"]["Parent"]["Website"]["URL"] = NULL;

--- a/appWeb/public_html/includes/pages/privacy.php
+++ b/appWeb/public_html/includes/pages/privacy.php
@@ -15,9 +15,12 @@ declare(strict_types=1);
 
 $appName = $app["Application"]["Name"];
 $vendorName = $app["Application"]["Vendor"]["Name"];
+$legalEntity = $app["Application"]["Vendor"]["Parent"]["Name"] ?? $vendorName;
 $appUrl = $app["Application"]["Website"]["URL"];
 
 ?>
+
+<!-- Owner/legal review: confirm company number + registered address disclosures (UK e-commerce regs) -->
 
 <!-- ================================================================
      PRIVACY POLICY PAGE
@@ -42,6 +45,12 @@ $appUrl = $app["Application"]["Website"]["URL"];
                 your privacy. This policy explains what information we collect, how we use it,
                 and your rights when using the <?= htmlspecialchars($appName) ?> web application,
                 progressive web app (PWA), and the <?= htmlspecialchars($appName) ?> API.
+            </p>
+            <p>
+                <?= htmlspecialchars($appName) ?> is operated by
+                <strong><?= htmlspecialchars($legalEntity) ?></strong>, which is the
+                <strong>data controller</strong> responsible for your personal data under
+                applicable data protection law.
             </p>
             <p>
                 <strong>In summary:</strong> you can browse and search <strong>anonymously</strong>,

--- a/appWeb/public_html/includes/pages/terms.php
+++ b/appWeb/public_html/includes/pages/terms.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 $appName = $app["Application"]["Name"];
 $vendorName = $app["Application"]["Vendor"]["Name"];
+$legalEntity = $app["Application"]["Vendor"]["Parent"]["Name"] ?? $vendorName;
 $appUrl = $app["Application"]["Website"]["URL"];
 
 ?>
@@ -38,8 +39,9 @@ $appUrl = $app["Application"]["Website"]["URL"];
         <div class="card-body">
             <h2 class="h6 mb-3">1. Introduction</h2>
             <p>
-                Welcome to <strong><?= htmlspecialchars($appName) ?></strong>, a service provided by
-                <strong><?= htmlspecialchars($vendorName) ?></strong>.
+                <strong><?= htmlspecialchars($appName) ?></strong> is a service operated by
+                <strong><?= htmlspecialchars($legalEntity) ?></strong> ("we", "us", "our"), a
+                company registered in England and Wales.
                 <?= htmlspecialchars($appName) ?> is a digital hymn and worship song lyrics
                 application designed to assist Christians and congregations with worship,
                 wherever they may be.
@@ -97,13 +99,13 @@ $appUrl = $app["Application"]["Website"]["URL"];
                 respective copyright holders, publishers, and licensing bodies.
             </p>
             <p>
-                <?= htmlspecialchars($vendorName) ?> does not claim ownership of any song
+                <?= htmlspecialchars($legalEntity) ?> does not claim ownership of any song
                 content. All rights remain with the original rights holders.
             </p>
             <p>
                 The <?= htmlspecialchars($appName) ?> application itself — including its
                 design, code, user interface, and branding — is the proprietary property
-                of <?= htmlspecialchars($vendorName) ?> and is protected by applicable
+                of <?= htmlspecialchars($legalEntity) ?> and is protected by applicable
                 copyright and intellectual property laws.
             </p>
         </div>
@@ -225,7 +227,7 @@ $appUrl = $app["Application"]["Website"]["URL"];
         <div class="card-body">
             <h2 class="h6 mb-3">10. Limitation of Liability</h2>
             <p>
-                To the fullest extent permitted by law, <?= htmlspecialchars($vendorName) ?>
+                To the fullest extent permitted by law, <?= htmlspecialchars($legalEntity) ?>
                 shall not be liable for any direct, indirect, incidental, consequential, or
                 punitive damages arising from your use of <?= htmlspecialchars($appName) ?>.
             </p>


### PR DESCRIPTION
Owner-directed (Q1 + Q4):
- **Legal entity:** discloses **MWBM Partners Ltd** as the operating entity / data controller in the Terms (§1 operator, §3 IP ownership, §10 liability) + Privacy (§1 data controller), via a new `$legalEntity` (= `Vendor.Parent.Name`). **iHymns** stays the product/brand name everywhere else. Inline flag: a solicitor should confirm company number + registered-address disclosures (UK e-commerce regs).
- **Web SIWA runbook** added to `appApple/dev-docs/Provisioning-Runbook.md` **§1.4** (findable alongside the native Apple provisioning) — action-typed: Apple-portal Services ID = **D1, not a migration**; one migration; two `/manage/configuration` settings; the done CSP. DEV_NOTES cross-links to it.

php -l clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)