### PR TITLE
fix(security): redact query-string secrets from the Activity Log (#1492)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -301,6 +301,11 @@ jobs:
           echo "Running secret-crypto-admin DB-free surface test..."
           php tests/php/test-secret-crypto-admin.php
 
+      - name: Activity Log query-string secret redaction (#1492)
+        run: |
+          echo "Running activity-log-scrub redaction guard test..."
+          php tests/php/test-activity-log-scrub.php
+
       - name: OpenLyrics importer enrichment (#1130)
         run: |
           echo "Running OpenLyrics importer enrichment test..."

--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -13495,7 +13495,10 @@ if ($action !== null) {
                un-throttled code-existence oracle for those legacy callers. */
             $liveTok = preg_replace('/[^a-f0-9]/', '', substr((string)($_GET['token'] ?? ''), 0, 40));
             if ($liveTok !== '') {
-                $liveBucket = 'tok:' . $liveTok;
+                /* #1492 — bucket on a HASH of the follow token, never the raw
+                   token (which would persist into tblLoginAttempts.IpAddress).
+                   Mirrors service_poll's presence-token bucket. */
+                $liveBucket = 'tok:' . substr(hash('sha256', $liveTok), 0, 24);
                 checkRateLimit('live_follow_poll', $liveBucket, 40, 60, true);
                 recordRateLimitHit('live_follow_poll', $liveBucket);
             } else {

--- a/appWeb/public_html/includes/activity_log.php
+++ b/appWeb/public_html/includes/activity_log.php
@@ -704,6 +704,60 @@ function _activityLogExternalIpLookup(string $ip): ?array
  *                       'index', 'editor_api', 'manage', 'og_image',
  *                       'sitemap', 'song_media'.
  */
+/**
+ * Redact secret-bearing values from a raw URL query string before it is
+ * written to the Activity Log.
+ *
+ * ELI5: some API URLs carry a secret in the address bar — a live-follow session
+ * code, a follow token, a presence token. We log the query string so admins can
+ * see what was called, but the SECRET part must be blanked first, or the log
+ * itself becomes a place secrets leak from.
+ *
+ * DETAILED: `installRequestActivityLogger()` records `Details.query` for every
+ * request. GET endpoints (`live_follow_poll` / `live_follow_join` /
+ * `service_poll`) pass `code` / `token` / `presenceToken` as query parameters,
+ * so without scrubbing the raw secret lands in `tblActivityLog` — a standing
+ * violation of this file's own header rule ("NEVER log … bearer tokens,
+ * magic-link tokens…"). We keep the parameter NAME (so `action=service_poll&
+ * presenceToken=[redacted]&since=41` stays forensically useful) and replace the
+ * VALUE of any parameter whose name looks credential-like. Deliberately a
+ * denylist that errs toward over-redaction — losing a little forensic detail is
+ * safe; leaking a token is not (#1492).
+ *
+ * Pure (no I/O) so it is directly unit-testable
+ * (`tests/php/test-activity-log-scrub.php`).
+ *
+ * @param string $query Raw query string with no leading '?', e.g. `a=1&token=xyz`.
+ * @return string       Same string with credential-like values → `[redacted]`.
+ * @link https://cwe.mitre.org/data/definitions/532.html  CWE-532: Insertion of Sensitive Information into Log File
+ */
+function activityLogScrubQuery(string $query): string
+{
+    if ($query === '') {
+        return '';
+    }
+    // Case-insensitive: a parameter whose NAME contains any of these substrings
+    // is treated as secret-bearing. Covers the explicit poll/join params
+    // (presenceToken, token, code, state) plus the general credential vocabulary.
+    static $secretName = '/token|code|secret|key|password|passwd|auth|signature|otp|nonce|state/i';
+    $pairs = explode('&', $query);
+    foreach ($pairs as $i => $pair) {
+        if ($pair === '') {
+            continue;
+        }
+        $eq = strpos($pair, '=');
+        if ($eq === false) {
+            continue; // a bare flag like `debug` — no value to leak
+        }
+        $name  = substr($pair, 0, $eq);
+        $value = substr($pair, $eq + 1);
+        if ($value !== '' && preg_match($secretName, $name)) {
+            $pairs[$i] = $name . '=[redacted]';
+        }
+    }
+    return implode('&', $pairs);
+}
+
 function installRequestActivityLogger(string $source): void
 {
     static $installed = false;
@@ -741,7 +795,10 @@ function installRequestActivityLogger(string $source): void
                 [
                     'status'      => $statusInt,
                     'path'        => substr($path,  0, 255),
-                    'query'       => substr($query, 0, 255),
+                    /* #1492 — scrub credential-bearing query params (session
+                       codes, follow/presence tokens) BEFORE the 255-cap so a
+                       secret truncated mid-value can never survive. */
+                    'query'       => substr(activityLogScrubQuery($query), 0, 255),
                     'duration_ms' => $duration,
                 ],
                 $result,

--- a/tests/php/test-activity-log-scrub.php
+++ b/tests/php/test-activity-log-scrub.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * iHymns — Activity Log query-string secret redaction guard (#1492)
+ *
+ * Exercises includes/activity_log.php::activityLogScrubQuery() — the pure
+ * function that blanks credential-bearing query parameters before the raw
+ * request query string is written to tblActivityLog.Details.query by
+ * installRequestActivityLogger(). Without it, GET endpoints that carry a
+ * secret in the query (live_follow_poll/join → code + token; service_poll →
+ * presenceToken) persist that secret into the Activity Log on every request
+ * (CWE-532). Asserts the load-bearing properties so a regression re-opens the
+ * leak at CI time:
+ *
+ *   - credential-like params (token/code/presenceToken/state/secret/password/
+ *     key/auth/signature/otp/nonce) have their VALUE replaced with [redacted]
+ *   - the parameter NAME is preserved (the row stays forensically useful)
+ *   - benign params (action/since/id/page/q) pass through UNCHANGED
+ *   - matching is case-insensitive
+ *   - a value containing '=' (base64 padding) is fully redacted
+ *   - a bare flag (no '=') and an empty value are left as-is (nothing to leak)
+ *   - duplicate params are each handled
+ *   - the two real-world poll query strings redact correctly
+ *
+ *   php tests/php/test-activity-log-scrub.php
+ *
+ * Exit status 0 = clean, 1 = at least one failure.
+ */
+
+declare(strict_types=1);
+
+require_once dirname(__DIR__, 2) . '/appWeb/public_html/includes/activity_log.php';
+
+$failures = 0;
+$passed = 0;
+
+function _alsAssert(bool $cond, string $label): void
+{
+    global $failures, $passed;
+    if ($cond) {
+        $passed++;
+        echo "PASS: $label\n";
+    } else {
+        $failures++;
+        fwrite(STDERR, "FAIL: $label\n");
+    }
+}
+
+function _alsEq(string $got, string $want, string $label): void
+{
+    _alsAssert($got === $want, $label . ($got === $want ? '' : "\n      got:  {$got}\n      want: {$want}"));
+}
+
+/* ---- 1. The two real-world leak vectors -------------------------------- */
+_alsEq(
+    activityLogScrubQuery('action=service_poll&presenceToken=Zx9K7realTOKENvalue43chars0000000000000000&since=41'),
+    'action=service_poll&presenceToken=[redacted]&since=41',
+    'service_poll: presenceToken redacted, action+since preserved'
+);
+_alsEq(
+    activityLogScrubQuery('action=live_follow_poll&code=ABC123&token=deadbeefcafe&since=5'),
+    'action=live_follow_poll&code=[redacted]&token=[redacted]&since=5',
+    'live_follow_poll: BOTH code and token redacted, action+since preserved'
+);
+_alsEq(
+    activityLogScrubQuery('action=live_follow_join&code=WXYZ99'),
+    'action=live_follow_join&code=[redacted]',
+    'live_follow_join: session code redacted'
+);
+
+/* ---- 2. Credential vocabulary (name-based) ----------------------------- */
+foreach (['token', 'code', 'presenceToken', 'state', 'secret', 'password', 'passwd',
+          'apiKey', 'api_key', 'csrf_token', 'signature', 'otp', 'nonce', 'authToken'] as $k) {
+    _alsEq(
+        activityLogScrubQuery("a=1&{$k}=SECRETVALUE&b=2"),
+        "a=1&{$k}=[redacted]&b=2",
+        "redacts credential param '{$k}'"
+    );
+}
+
+/* ---- 3. Case-insensitive --------------------------------------------- */
+_alsEq(activityLogScrubQuery('Token=X'),        'Token=[redacted]',        'case-insensitive: Token');
+_alsEq(activityLogScrubQuery('CODE=X'),         'CODE=[redacted]',         'case-insensitive: CODE');
+_alsEq(activityLogScrubQuery('PresenceToken=X'), 'PresenceToken=[redacted]', 'case-insensitive: PresenceToken');
+
+/* ---- 4. Benign params pass through unchanged -------------------------- */
+_alsEq(
+    activityLogScrubQuery('action=songs_index&since=41&id=1008&page=2&q=amazing'),
+    'action=songs_index&since=41&id=1008&page=2&q=amazing',
+    'benign query is byte-identical (no over-redaction of action/since/id/page/q)'
+);
+
+/* ---- 5. Structural edge cases ---------------------------------------- */
+_alsEq(activityLogScrubQuery(''), '', 'empty query → empty');
+_alsEq(activityLogScrubQuery('debug'), 'debug', 'bare flag (no "=") left as-is');
+_alsEq(activityLogScrubQuery('token='), 'token=', 'empty value not rewritten to [redacted] (nothing to leak)');
+_alsEq(
+    activityLogScrubQuery('state=eyJhbGciOiJ9.payload=='),
+    'state=[redacted]',
+    'value containing "=" (base64 padding) fully redacted'
+);
+_alsEq(
+    activityLogScrubQuery('token=aaa&x=1&token=bbb'),
+    'token=[redacted]&x=1&token=[redacted]',
+    'duplicate credential params each redacted'
+);
+_alsEq(
+    activityLogScrubQuery('&&token=x&&'),
+    '&&token=[redacted]&&',
+    'empty segments preserved, credential still redacted'
+);
+
+/* ---- 6. The secret VALUE never survives anywhere in the output -------- */
+$leaky = 'presenceToken=SUPERSECRET_DO_NOT_LEAK_0123456789&code=SESSIONCODE99';
+$scrubbed = activityLogScrubQuery($leaky);
+_alsAssert(strpos($scrubbed, 'SUPERSECRET_DO_NOT_LEAK') === false, 'the raw presence token does not appear in output');
+_alsAssert(strpos($scrubbed, 'SESSIONCODE99') === false, 'the raw session code does not appear in output');
+
+/* ----------------------------------------------------------------------- */
+echo "\n";
+echo "activity-log-scrub: {$passed} passed, {$failures} failed\n";
+exit($failures > 0 ? 1 : 0);


### PR DESCRIPTION
Closes #1492.

## The leak (live today)
`installRequestActivityLogger()` logs the **raw request query string** to `tblActivityLog.Details.query` on every request. GET endpoints carry secrets in the query, so they're persisted in the audit log (**CWE-532**):
- `live_follow_poll` / `live_follow_join` → `code` (session code) + `token` (follow token)
- `service_poll` → `presenceToken` (the rule-#26 CCLI presence gate key)

This violates `activity_log.php`'s own header rule that logs never carry bearer/magic-link tokens.

## Fix
1. **`activityLogScrubQuery()`** (pure) — replaces the VALUE of any credential-like param (name matches `/token|code|secret|key|password|passwd|auth|signature|otp|nonce|state/i`) with `[redacted]`, keeps the NAME (`action=service_poll&presenceToken=[redacted]&since=41` stays useful). Scrubs **before** the 255-cap so a truncated secret can't survive.
2. **Hash the `live_follow_poll` rate bucket** (`'tok:'.substr(hash('sha256',$liveTok),0,24)`) — was bucketing on the raw token (persisted into `tblLoginAttempts.IpAddress`); now mirrors `service_poll`.
3. **`tests/php/test-activity-log-scrub.php`** — 29 assertions (both real leak vectors, credential vocabulary, case-insensitivity, benign-param passthrough, structural edge cases, raw-value-never-survives), wired into CI.

Surfaced by the Fable observability planning pass. No schema change; additive; benign query params are byte-identical (verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)