### PR TITLE
fix(manage): literal </script> in inline-script comments broke Credit People + Service Mode pages

### DIFF
--- a/appWeb/public_html/manage/credit-people.php
+++ b/appWeb/public_html/manage/credit-people.php
@@ -2408,10 +2408,14 @@ $totalInUseUnregistered = count(array_filter($people, static fn($p) =>
         window._iHymnsLinkTypes = <?= json_encode($linkTypesForPerson, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
         /* #1367 — the authority-control identifier registry slice the
            paste-a-URL auto-extract needs (every provider's label + raw extract
-           pattern bodies + pickable flag). JSON_HEX_TAG escapes < and > to
-           < / >, so the payload can NEVER contain a literal
-           "</script>" however the bodies are shaped; slashes are LEFT ESCAPED
-           (no JSON_UNESCAPED_SLASHES) as the belt-and-braces choice — "\/" is
+           pattern bodies + pickable flag). JSON_HEX_TAG escapes < and > in the
+           PAYLOAD so it can never contain a script-closing sequence. NOTE: this
+           comment must NOT write that sequence literally either — the HTML
+           parser closes the <script> on the raw bytes regardless of JS comment
+           syntax, which previously terminated this block early (dumping the
+           config as page text AND leaving an unterminated comment that broke
+           window._iHymnsLinkTypes and the paste-a-URL auto-detect). Slashes in
+           the payload are LEFT ESCAPED (no JSON_UNESCAPED_SLASHES) — "\/" is
            valid JSON and harmless to new RegExp(). */
         window._cpIdentifierConfig = <?= json_encode(creditIdentifierClientConfig(), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
     </script>

--- a/appWeb/public_html/manage/service-lead.php
+++ b/appWeb/public_html/manage/service-lead.php
@@ -197,9 +197,12 @@ $joinBase = ((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https
            projection laptop; this page just connects to an existing session. */
         import { ServiceBroadcaster } from '/js/modules/service-broadcast.js';
 
-        /* JSON_HEX_* so an org-admin-controlled venue/schedule name containing
-           "</script>" (or < > & ' ") in a session label can't break out of this
-           inline module script — the established convention (tiers.php). */
+        /* JSON_HEX_* so an org-admin-controlled venue/schedule name containing a
+           script-closing sequence (or < > & ' ") in a session label can't break
+           out of this inline module — the established convention (tiers.php).
+           NOTE: this comment must not write that closing sequence literally
+           either; the HTML parser terminates the <script> on the raw bytes
+           regardless of JS comment syntax. */
         const SESSIONS = <?= json_encode($sessionList, JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
         const KEEPALIVE_MS = 45000;   // idle heartbeat — comfortably inside the 90s freshness window
         let session = null, keepaliveTimer = null, broadcaster = null;

--- a/appWeb/public_html/manage/service-projection.php
+++ b/appWeb/public_html/manage/service-projection.php
@@ -205,9 +205,12 @@ $DOW = [1 => 'Mon', 2 => 'Tue', 3 => 'Wed', 4 => 'Thu', 5 => 'Fri', 6 => 'Sat', 
            projection laptop + the leader device share ONE driver core). */
         import { ServiceBroadcaster } from '/js/modules/service-broadcast.js';
 
-        /* JSON_HEX_* so an org-admin-controlled venue/schedule Name containing
-           "</script>" (or < > & ' ") can't break out of this inline module
-           script — the established convention (tiers.php, credit-people.php). */
+        /* JSON_HEX_* so an org-admin-controlled venue/schedule Name containing a
+           script-closing sequence (or < > & ' ") can't break out of this inline
+           module — the established convention (tiers.php, credit-people.php).
+           NOTE: this comment must not write that closing sequence literally
+           either; the HTML parser terminates the <script> on the raw bytes
+           regardless of JS comment syntax. */
         const VENUES = <?= json_encode($venues, JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
         const DOW = <?= json_encode($DOW, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
         const JOIN_BASE = <?= json_encode($joinBase, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;


### PR DESCRIPTION
Closes #1498.

**Reported:** Credit People edit page shows raw `window._cplIdentifierConfig = {…}` as body text; the paste-a-URL external-link auto-detect doesn't select MusicBrainz.

**Root cause (one bug, two symptoms):** a `<script>` comment in `credit-people.php` wrote a literal `</script>`. The HTML parser closes the script on those bytes → the tail rendered as text **and** the block became a JS syntax error (unterminated `/*`), so `window._iHymnsLinkTypes` never loaded → the auto-detect couldn't map the detected slug to the dropdown option.

**Also fixed:** the identical latent pattern in `service-projection.php` + `service-lead.php` module scripts.

**Fix:** reworded all three comments to avoid writing the closing sequence literally. `php -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)