### PR TITLE
feat: observability (IHLog + §3.2 breadcrumbs) + macOS DMG packaging (deferred bundle)

### DIFF
--- a/.github/workflows/apple-dmg.yml
+++ b/.github/workflows/apple-dmg.yml
@@ -1,0 +1,389 @@
+# Apple macOS DMG — signed + notarized direct distribution (#1510)
+#
+# ELI5: The App Store is the PRIMARY way people get iHymns on a Mac (via
+# "Designed for iPad" compatibility, no separate Mac target — see
+# `appApple/project.yml`'s `iHymns` target header). This workflow builds a
+# SECOND, independent artifact from the SAME source: a signed + notarized
+# `.dmg` (containing the `.app` + an `/Applications` shortcut) that the owner
+# can hand out directly — download, drag to Applications, done — without
+# going through the App Store at all. It is published as a **GitHub Release
+# asset**, never uploaded anywhere else.
+#
+# DETAILED: Mirrors `.github/workflows/apple-deploy.yml`'s (#1400) structure
+# and kill-switch idiom closely, but is a DIFFERENT distribution channel with
+# a DIFFERENT signing identity, so it is intentionally its own workflow file
+# rather than a fourth Fastlane lane bolted onto `appApple/fastlane/Fastfile`:
+#   - `apple-deploy.yml` signs with the org's **Apple Distribution**
+#     certificate (`APPLE_CERTIFICATE`) for TestFlight/App Store upload.
+#   - THIS workflow signs with a **Developer ID Application** certificate —
+#     Apple's SEPARATE identity type for software distributed OUTSIDE the
+#     Mac App Store (Developer ID apps need no App-Store-style provisioning
+#     profile at all; they're authorized for Gatekeeper via notarization
+#     instead). Reusing the distribution cert would not work here even if it
+#     were technically importable — Xcode's `developer-id` export method
+#     specifically re-signs with a Developer ID Application identity.
+# This file NEVER touches `apple-deploy.yml`'s own signing/upload logic.
+#
+# VARIABLES:
+#   vars.APPLE_DMG_ENABLED — kill-switch, the SAME idiom as
+#   `apple-deploy.yml`'s `vars.APPLE_DEPLOY_ENABLED` (which itself mirrors
+#   `deploy.yml`'s `vars.SFTP_ENABLED`). Must be the literal string 'true' to
+#   let the "Build + notarize + release (.dmg)" job run at all. Unset (the
+#   default — nothing in this repo sets it) means the job is SKIPPED
+#   entirely on every manual dispatch or tag push: no archive, no
+#   notarization, no Release asset. The owner sets this via the GitHub web
+#   UI — Settings → Secrets and variables → Actions → Variables tab → New
+#   repository variable — only once the two new secrets below are
+#   provisioned and this pipeline has been reviewed; this file never sets it
+#   itself. The always-on `guard` job below posts a `::notice::` stating
+#   whether DMG packaging is enabled/disabled on every single run, so a
+#   skipped build is never mistaken for a completed one just because the
+#   workflow's overall run still shows green (the `guard` job succeeding is
+#   enough to make the run conclusion "success" even while `build` is
+#   skipped) — same reasoning as `apple-deploy.yml`'s own header comment.
+#
+# NEW SECRETS (this workflow only — distinct from `apple-deploy.yml`'s nine):
+#   APPLE_DEVELOPER_ID_CERT          — base64-encoded `.p12` export of a
+#                                      **Developer ID Application** certificate
+#                                      (NOT the Apple Distribution certificate
+#                                      apple-deploy.yml uses — a different
+#                                      Apple identity type entirely).
+#   APPLE_DEVELOPER_ID_CERT_PASSWORD — the `.p12` export password.
+#   See `appApple/dev-docs/Provisioning-Runbook.md` §1.5 for the exact owner
+#   steps (create the cert, export it, base64 it, paste it in).
+#
+# REUSED SECRETS (already exist for `apple-deploy.yml` — read-only reuse,
+# never redefined here):
+#   APPLE_TEAM_ID  — signs `DEVELOPMENT_TEAM` at archive/export time.
+#   ASC_KEY_ID / ASC_ISSUER_ID / ASC_API_KEY — the SAME App Store Connect API
+#   key already used for TestFlight/App Store uploads. `notarytool` accepts
+#   an API key for authentication too (Apple's own documented notarization
+#   auth method — no separate Apple ID/app-specific-password flow needed).
+#   `ASC_API_KEY` is RAW `.p8` file contents (Fastfile's own documented
+#   convention) and is written to a temp key file for `notarytool`, which
+#   only accepts a file path, not inline content.
+#
+# STATUS: DORMANT until the owner (a) provisions the two new secrets above,
+# (b) reviews this pipeline, and (c) flips `APPLE_DMG_ENABLED` to `true`.
+# Nothing in this file runs on a normal push to any branch — only manual
+# `workflow_dispatch` or a `v*` tag push, and only once the kill-switch is on.
+#
+# ⚠️ FLAGGED UNCERTAINTY — read before enabling (untested on a real Mac with
+# real signing assets; this pipeline cannot be exercised end-to-end in this
+# session):
+#   1. **Archive destination string.** `iHymns`'s `supportedDestinations:
+#      [iOS, macOS, visionOS]` (`project.yml`) has NO Mac Catalyst entry, so
+#      the `macOS` destination is Apple's "Designed for iPad" mode (running
+#      the multiplatform target natively on Apple Silicon — see
+#      `Provisioning-Runbook.md` §2.4.3, which confirms Xcode shows this as
+#      **"My Mac (Designed for iPad)"**, a genuinely resizable native window,
+#      not a fixed-aspect-ratio iPad-in-a-box). This workflow archives with
+#      `-destination 'generic/platform=macOS'` (no `variant=` qualifier) —
+#      chosen because `.github/workflows/apple.yml`'s ALREADY-GREEN, already
+#      -running CI build step for this exact scheme uses the concrete form
+#      `platform=macOS,arch=arm64` with no variant and builds successfully,
+#      which is real evidence (not a guess) that plain `platform=macOS` is
+#      unambiguous for this target (there is no Catalyst destination to
+#      disambiguate from). The archive step here uses the *generic* form
+#      (`generic/platform=macOS`, Apple's documented archiving idiom — an
+#      archive isn't bound to one running instance) rather than the
+#      concrete `arch=arm64` form apple.yml's plain build uses, on the
+#      reasoning that they resolve to the same, only, macOS destination this
+#      target supports. **This has not been proven with a real archive run.**
+#   2. **Signing style.** This workflow uses MANUAL code signing
+#      (`CODE_SIGN_STYLE=Manual` + `CODE_SIGN_IDENTITY="Developer ID
+#      Application"`, no provisioning profile, no `-allowProvisioningUpdates`,
+#      no ASC key involvement) rather than automatic signing — deliberately,
+#      because Developer ID / notarized distribution is documented to need
+#      NO App-Store-style provisioning profile at all, and manual signing
+#      with an explicit identity is the well-established pattern for Mac
+#      Developer-ID CI pipelines. Whether the `iHymns` target's
+#      Associated-Domains entitlement (`project.yml`) causes any complication
+#      signing manually outside the App Store has NOT been verified on a
+#      real Mac — if `xcodebuild archive`/`-exportArchive` complains about
+#      the entitlement needing a matching provisioning profile, this may
+#      need to switch to automatic signing (mirroring
+#      `prepare_signed_archives` in the Fastfile) instead.
+#   3. **DMG tool.** Uses plain `hdiutil create` (no extra Homebrew
+#      dependency, deterministic) rather than the `create-dmg` formula the
+#      task brief also allowed — a reviewer wanting the cosmetic
+#      icon-layout/background-image polish `create-dmg` provides can swap
+#      this step later without touching anything else in the pipeline.
+#   Owner/reviewer: please validate 1–2 with a real signed archive attempt
+#   before relying on this pipeline for actual distribution.
+name: Apple macOS DMG
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to attach the DMG to (e.g. v0.2500.0-macos). Ignored for tag-triggered runs (uses the pushed tag); if left blank on a manual run, a timestamped tag is generated.'
+        required: false
+        type: string
+  push:
+    tags:
+      - 'v*'
+    # Deliberately NO path filter on the tag trigger (unlike apple-deploy.yml's
+    # push-to-branch filter) — a tag is a deliberate "cut a release" act
+    # regardless of which files the tagged commit touches, and the
+    # `APPLE_DMG_ENABLED` kill-switch below is the real safety gate.
+
+permissions:
+  contents: write   # required to create/update the GitHub Release + upload the asset
+
+# Only one DMG build per ref at a time.
+concurrency:
+  group: apple-dmg-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # ===========================================================================
+  # GUARD — always runs, never fails the workflow. Posts a loud ::notice::
+  # stating whether DMG packaging is enabled so a SKIPPED build (because
+  # APPLE_DMG_ENABLED isn't 'true') can never be mistaken for a completed one
+  # — same reasoning as apple-deploy.yml's own guard job.
+  # ===========================================================================
+  guard:
+    name: DMG status guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Report Apple DMG kill-switch status
+        run: |
+          if [ "${{ vars.APPLE_DMG_ENABLED }}" = "true" ]; then
+            echo "::notice::Apple macOS DMG packaging is ENABLED (repo Variable APPLE_DMG_ENABLED=true) — the Build + notarize + release job WILL run for this dispatch/tag push and may publish a GitHub Release asset."
+          else
+            echo "::notice::Apple macOS DMG packaging is DISABLED — set repo Variable APPLE_DMG_ENABLED=true (Settings -> Secrets and variables -> Actions -> Variables) once APPLE_DEVELOPER_ID_CERT + APPLE_DEVELOPER_ID_CERT_PASSWORD are provisioned. The Build + notarize + release job will be SKIPPED for this run — no archive, no notarization, no Release asset."
+          fi
+
+  build:
+    name: Build + notarize + release (.dmg)
+    runs-on: macos-26
+    timeout-minutes: 60
+    # Kill-switch (load-bearing — see the header comment's VARIABLES
+    # section). Unset/anything other than the literal string 'true' means
+    # this job is SKIPPED entirely.
+    if: vars.APPLE_DMG_ENABLED == 'true'
+    env:
+      DMG_KEYCHAIN_NAME: ihymns-dmg-ci.keychain-db
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Select Xcode 26
+        run: |
+          # Same pinned OS-26 toolchain as apple.yml/apple-deploy.yml.
+          sudo xcode-select -s "$(ls -d /Applications/Xcode_26*.app | head -1)"
+          xcodebuild -version
+
+      # -- Install the platform runtimes this archive needs --
+      # A macOS "Designed for iPad" archive of a multiplatform target still
+      # needs the iOS/tvOS/watchOS/visionOS SDKs installed on the runner —
+      # the same "iOS 26.0 is not installed"-class failure apple-deploy.yml's
+      # own comment documents applies here too, even though this job only
+      # ever archives the macOS destination. The macOS SDK itself ships
+      # inside Xcode already, so it needs no separate download step.
+      - name: Install required platform SDKs
+        run: |
+          sudo xcodebuild -downloadPlatform iOS
+          sudo xcodebuild -downloadPlatform tvOS
+          sudo xcodebuild -downloadPlatform watchOS
+          sudo xcodebuild -downloadPlatform visionOS
+
+      - name: Install tooling
+        run: brew install xcodegen
+
+      - name: Generate Xcode project
+        working-directory: appApple
+        run: xcodegen generate
+
+      # ---------------------------------------------------------------------
+      # Import the Developer ID Application certificate into a throwaway
+      # keychain scoped to this job — the SAME "ephemeral keychain, never the
+      # runner's login keychain" pattern as Fastfile's
+      # `import_distribution_certificate` private lane, translated to plain
+      # shell since this workflow does not invoke fastlane at all (a
+      # DIFFERENT identity type than every existing Fastlane lane uses).
+      # ---------------------------------------------------------------------
+      - name: Import Developer ID Application certificate
+        env:
+          APPLE_DEVELOPER_ID_CERT: ${{ secrets.APPLE_DEVELOPER_ID_CERT }}
+          APPLE_DEVELOPER_ID_CERT_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERT_PASSWORD }}
+        run: |
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          echo "::add-mask::$KEYCHAIN_PASSWORD"
+          echo "DMG_KEYCHAIN_PASSWORD=$KEYCHAIN_PASSWORD" >> "$GITHUB_ENV"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$DMG_KEYCHAIN_NAME"
+          security set-keychain-settings -lut 3600 "$DMG_KEYCHAIN_NAME"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$DMG_KEYCHAIN_NAME"
+
+          EXISTING_KEYCHAINS="$(security list-keychains -d user | sed 's/[[:space:]]*"\(.*\)"/\1/')"
+          # shellcheck disable=SC2086
+          security list-keychains -d user -s "$DMG_KEYCHAIN_NAME" $EXISTING_KEYCHAINS
+
+          CERT_PATH="$RUNNER_TEMP/developer-id.p12"
+          printf '%s' "$APPLE_DEVELOPER_ID_CERT" | base64 --decode > "$CERT_PATH"
+          security import "$CERT_PATH" \
+            -k "$DMG_KEYCHAIN_NAME" \
+            -P "$APPLE_DEVELOPER_ID_CERT_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s \
+            -k "$KEYCHAIN_PASSWORD" "$DMG_KEYCHAIN_NAME"
+          rm -f "$CERT_PATH"
+
+      # ---------------------------------------------------------------------
+      # Archive — manual signing with the imported Developer ID Application
+      # identity. See the header comment's "FLAGGED UNCERTAINTY" §1/§2 for
+      # the destination-string and signing-style reasoning.
+      # `ENABLE_HARDENED_RUNTIME=YES` + `OTHER_CODE_SIGN_FLAGS="--timestamp"`
+      # are both REQUIRED for notarization to succeed later (Apple rejects
+      # notarization submissions that lack Hardened Runtime or a secure
+      # signing timestamp) — set here as command-line overrides since
+      # `project.yml` doesn't declare Hardened Runtime today (it's a
+      # Developer-ID/notarization-only concern, not part of the app's own
+      # shape).
+      # ---------------------------------------------------------------------
+      - name: Archive (macOS — Designed for iPad destination)
+        working-directory: appApple
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          xcodebuild archive \
+            -project iHymns.xcodeproj \
+            -scheme iHymns \
+            -configuration Release \
+            -destination 'generic/platform=macOS' \
+            -archivePath "$RUNNER_TEMP/iHymns-macos.xcarchive" \
+            CODE_SIGN_STYLE=Manual \
+            CODE_SIGN_IDENTITY="Developer ID Application" \
+            DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
+            CODE_SIGNING_REQUIRED=YES \
+            CODE_SIGNING_ALLOWED=YES \
+            ENABLE_HARDENED_RUNTIME=YES \
+            OTHER_CODE_SIGN_FLAGS="--timestamp"
+
+      - name: Write Developer-ID exportOptions.plist
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          cat > "$RUNNER_TEMP/ExportOptions.plist" <<PLIST
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>method</key>
+            <string>developer-id</string>
+            <key>teamID</key>
+            <string>${APPLE_TEAM_ID}</string>
+            <key>signingStyle</key>
+            <string>manual</string>
+            <key>signingCertificate</key>
+            <string>Developer ID Application</string>
+            <key>destination</key>
+            <string>export</string>
+          </dict>
+          </plist>
+          PLIST
+
+      - name: Export the .app
+        working-directory: appApple
+        run: |
+          xcodebuild -exportArchive \
+            -archivePath "$RUNNER_TEMP/iHymns-macos.xcarchive" \
+            -exportOptionsPlist "$RUNNER_TEMP/ExportOptions.plist" \
+            -exportPath "$RUNNER_TEMP/export"
+
+      # ---------------------------------------------------------------------
+      # Package: .app + /Applications symlink -> a compressed, read-only DMG.
+      # Plain `hdiutil` (no extra Homebrew formula) — see header §3.
+      # ---------------------------------------------------------------------
+      - name: Create the DMG
+        run: |
+          STAGING_DIR="$RUNNER_TEMP/dmg-staging"
+          mkdir -p "$STAGING_DIR"
+          cp -R "$RUNNER_TEMP/export/iHymns.app" "$STAGING_DIR/"
+          ln -s /Applications "$STAGING_DIR/Applications"
+
+          hdiutil create \
+            -volname "iHymns" \
+            -srcfolder "$STAGING_DIR" \
+            -ov -format UDZO \
+            "$RUNNER_TEMP/iHymns.dmg"
+
+      - name: Sign the DMG
+        run: |
+          IDENTITY="$(security find-identity -v -p codesigning "$DMG_KEYCHAIN_NAME" \
+            | grep "Developer ID Application" | head -1 \
+            | sed -E 's/^[[:space:]]*[0-9]+\)[[:space:]]+[A-F0-9]+[[:space:]]+"(.*)"$/\1/')"
+          codesign --sign "$IDENTITY" --timestamp "$RUNNER_TEMP/iHymns.dmg"
+          codesign --verify --verbose "$RUNNER_TEMP/iHymns.dmg"
+
+      # ---------------------------------------------------------------------
+      # Notarize with the SAME App Store Connect API key apple-deploy.yml
+      # already uses for TestFlight/App Store uploads — notarytool only
+      # accepts a KEY FILE path (not inline content), so ASC_API_KEY's raw
+      # .p8 contents are written to a temp file first and removed
+      # immediately after (mirrors Fastfile's own "sensitive file removed as
+      # soon as its one use is done" pattern for the distribution .p12).
+      # ---------------------------------------------------------------------
+      - name: Notarize the DMG
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_API_KEY: ${{ secrets.ASC_API_KEY }}
+        run: |
+          KEY_DIR="$RUNNER_TEMP/asc-key"
+          mkdir -p "$KEY_DIR"
+          KEY_PATH="$KEY_DIR/AuthKey_${ASC_KEY_ID}.p8"
+          printf '%s' "$ASC_API_KEY" > "$KEY_PATH"
+          chmod 600 "$KEY_PATH"
+
+          xcrun notarytool submit "$RUNNER_TEMP/iHymns.dmg" \
+            --key "$KEY_PATH" \
+            --key-id "$ASC_KEY_ID" \
+            --issuer "$ASC_ISSUER_ID" \
+            --wait \
+            --output-format json
+
+          rm -f "$KEY_PATH"
+
+      - name: Staple + verify the notarization ticket
+        run: |
+          xcrun stapler staple "$RUNNER_TEMP/iHymns.dmg"
+          xcrun stapler validate "$RUNNER_TEMP/iHymns.dmg"
+          spctl --assess --type open --context context:primary-signature -v "$RUNNER_TEMP/iHymns.dmg"
+
+      - name: Clean up ephemeral keychain
+        if: always()
+        run: |
+          security delete-keychain "$DMG_KEYCHAIN_NAME" 2>/dev/null || true
+
+      - name: Upload DMG as a workflow artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: iHymns-macos-dmg-${{ github.sha }}
+          path: ${{ runner.temp }}/iHymns.dmg
+          retention-days: 30
+          if-no-files-found: ignore
+
+      - name: Determine release tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          elif [ -n "${{ github.event.inputs.tag }}" ]; then
+            echo "tag=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=macos-dmg-$(date -u +%Y%m%d%H%M)-${GITHUB_SHA::8}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish GitHub Release asset
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: iHymns macOS ${{ steps.tag.outputs.tag }}
+          files: ${{ runner.temp }}/iHymns.dmg
+          fail_on_unmatched_files: true

--- a/appApple/Packages/iHymnsKit/Package.swift
+++ b/appApple/Packages/iHymnsKit/Package.swift
@@ -19,14 +19,16 @@
 // and spot-checked by the LOC/quality gates in Scripts/):
 //
 //   IHFeatures  (screens + view models)
-//      ├── IHModels, IHAPI, IHAuth, IHPersistence, IHLive, IHDesign, IHAppSupport
-//   IHAuth        → IHAPI, IHModels
-//   IHAPI         → IHModels
+//      ├── IHModels, IHAPI, IHAuth, IHPersistence, IHLive, IHDesign, IHAppSupport, IHLog
+//   IHAuth        → IHAPI, IHModels, IHLog
+//   IHAPI         → IHModels, IHLog
 //   IHPersistence → IHModels                (+ GRDB.swift, external dep)
-//   IHLive        → IHAPI                   (which pulls in IHModels transitively)
+//   IHLive        → IHAPI, IHLog            (which pulls in IHModels transitively)
 //   IHAppSupport  → IHModels
 //   IHDesign      → (SwiftUI only, no iHymnsKit deps)
 //   IHModels      → (no deps — the foundation: Sendable Codable DTOs)
+//   IHLog         → (no deps — the foundation: os.Logger/OSSignposter facade;
+//                     see #1505 / .claude/live-observability-strategy.md §2.1)
 //
 // Reference: .claude/apple-native-strategy.md §1.2 (module responsibilities),
 // §1.3 (Swift 6 strict concurrency posture), §1.8 (versioning/build).
@@ -52,6 +54,7 @@ let package = Package(
         // working from both the app shells (via XcodeGen's package
         // reference) and from other targets inside this same package.
         .library(name: "IHModels", targets: ["IHModels"]),
+        .library(name: "IHLog", targets: ["IHLog"]),
         .library(name: "IHAPI", targets: ["IHAPI"]),
         .library(name: "IHAuth", targets: ["IHAuth"]),
         .library(name: "IHPersistence", targets: ["IHPersistence"]),
@@ -134,10 +137,33 @@ let package = Package(
             swiftSettings: sharedSwiftSettings
         ),
 
-        // MARK: - IHAPI (→ IHModels)
+        // MARK: - IHLog (foundation layer, beside IHModels — zero
+        // iHymnsKit-internal deps; only system frameworks: `os` (Logger +
+        // OSSignposter) and CryptoKit (SHA-256 for `IHLogSanitize`), never
+        // an external SwiftPM package)
+        //
+        // #1505 (`.claude/live-observability-strategy.md` §2.1). Its own
+        // leaf target rather than folded into `IHModels` (wrong layer —
+        // `IHModels` is pure Sendable DTOs with no side effects) or
+        // `IHAppSupport` (the strategy doc is explicit: that would drag the
+        // analytics-adjacent module into every target that just wants to
+        // log). `IHAPI`/`IHAuth`/`IHLive` import it directly below;
+        // `IHFeatures` gets it both transitively through those and directly
+        // (its own view models log too).
+        .target(
+            name: "IHLog",
+            swiftSettings: sharedSwiftSettings
+        ),
+        .testTarget(
+            name: "IHLogTests",
+            dependencies: ["IHLog"],
+            swiftSettings: sharedSwiftSettings
+        ),
+
+        // MARK: - IHAPI (→ IHModels, IHLog)
         .target(
             name: "IHAPI",
-            dependencies: ["IHModels"],
+            dependencies: ["IHModels", "IHLog"],
             swiftSettings: sharedSwiftSettings
         ),
         .testTarget(
@@ -146,10 +172,10 @@ let package = Package(
             swiftSettings: sharedSwiftSettings
         ),
 
-        // MARK: - IHAuth (→ IHAPI, IHModels)
+        // MARK: - IHAuth (→ IHAPI, IHModels, IHLog)
         .target(
             name: "IHAuth",
-            dependencies: ["IHAPI", "IHModels"],
+            dependencies: ["IHAPI", "IHModels", "IHLog"],
             swiftSettings: sharedSwiftSettings
         ),
         .testTarget(
@@ -176,10 +202,10 @@ let package = Package(
             swiftSettings: sharedSwiftSettings
         ),
 
-        // MARK: - IHLive (→ IHAPI)
+        // MARK: - IHLive (→ IHAPI, IHLog)
         .target(
             name: "IHLive",
-            dependencies: ["IHAPI"],
+            dependencies: ["IHAPI", "IHLog"],
             swiftSettings: sharedSwiftSettings
         ),
         .testTarget(
@@ -231,7 +257,8 @@ let package = Package(
                 "IHPersistence",
                 "IHLive",
                 "IHDesign",
-                "IHAppSupport"
+                "IHAppSupport",
+                "IHLog"
             ],
             swiftSettings: sharedSwiftSettings
         ),

--- a/appApple/Packages/iHymnsKit/Sources/IHAPI/APIClient+Networking.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHAPI/APIClient+Networking.swift
@@ -1,0 +1,262 @@
+// APIClient+Networking.swift
+// IHAPI
+//
+// ELI5: The actual "dial the phone and listen" part of talking to the
+// server, PLUS a running commentary of what happened — split into its own
+// file so `APIClient.swift` doesn't have to hold both the "what can I ask
+// for" list AND the low-level plumbing.
+//
+// DETAILED: Split out of `APIClient.swift` (see that file's own "MARK: -
+// Networking core" pointer comment) — a same-target file split, the exact
+// pattern `APIClient+Auth.swift`/`APIClient+Discovery.swift` already
+// established, enabled here by widening `session`/`bearerToken`/
+// `retryBaseDelaySeconds`/`maxAttempts` from `private` to `internal` in the
+// primary file.
+//
+// #1505 UPDATE (`.claude/live-observability-strategy.md` §2.2) — this file
+// is ALSO where the client-side observability retrofit for the request/
+// retry pipeline lives:
+//   - `performOnce(_:)` wraps every single-attempt send in an
+//     `OSSignposter` `"api.request"` interval (Instruments time-profiling),
+//     and logs exactly one `IHLog.api` line per attempt: `.debug` on
+//     success, `.error` on failure — endpoint `action`, `APIError` case
+//     name, HTTP status, and duration in milliseconds, ALL `.public`
+//     (strategy §4: none of those four things is ever secret). It NEVER
+//     logs `request.url` — the query string is the one place a future
+//     `presenceToken`/follow-token could appear once the congregant client
+//     exists (strategy §0.2's own backend leak finding is exactly this
+//     mistake, made server-side).
+//   - `performIdempotentGET(_:)` additionally logs a `.notice` each time it
+//     DECIDES to retry (before the `Task.sleep`), and a `.notice` "giving
+//     up" line the one time it exhausts `maxAttempts` — a different,
+//     coarser-grained signal than `performOnce`'s per-attempt `.error`
+//     (that logs "this one attempt failed"; this logs "the retry policy
+//     itself gave up/kept going").
+// `classify(httpStatus:retryAfterSeconds:)` and `makeURLRequest` (both in
+// `APIClient.swift`) stay pure/unlogged, exactly as strategy §2.2
+// specifies.
+import Foundation
+import IHLog
+import IHModels
+import os
+
+extension APIClient {
+    /// Sends `endpoint` as a GET, retrying transient failures with
+    /// exponential backoff + jitter (honouring a server `Retry-After` when
+    /// present), up to `maxAttempts` attempts total.
+    ///
+    /// ELI5: Try it; if the server hiccupped in a way that trying again
+    /// might fix, wait a little (a little longer each time) and try again —
+    /// up to twice more — otherwise give up and hand back the error. Each
+    /// time it decides to wait-and-retry (or finally gives up), it writes
+    /// one line saying so.
+    ///
+    /// DETAILED: Only ever called for GETs (every catalogue read is one) —
+    /// strategy §1.5 is explicit that non-idempotent POSTs must NEVER be
+    /// auto-retried this way (they go through `IHPersistence`'s
+    /// pending-sync queue with server-side dedupe instead, a Phase-1
+    /// concern). Deliberately `internal` (module-visible), not `private` —
+    /// `APIClient+Discovery.swift` (#180) calls this directly for its two
+    /// idempotent GETs. `isRetryable(_:)` decides WHICH `APIError` cases
+    /// are worth another attempt; `.unauthorized` and `.decoding` never are
+    /// (retrying either can't possibly succeed — the token is bad, or the
+    /// payload is wrong shape).
+    func performIdempotentGET(_ endpoint: Endpoint) async throws -> Data {
+        var attempt = 1
+        while true {
+            do {
+                return try await performOnce(endpoint)
+            } catch let error as APIError {
+                guard attempt < maxAttempts, Self.isRetryable(error) else {
+                    // Only log "giving up" when the retry BUDGET (not just
+                    // this one attempt) is exhausted — a non-retryable
+                    // error on the very first attempt already got its own
+                    // `.error` line from `performOnce` below, and calling
+                    // THAT a "give up after N" would misreport N.
+                    if attempt >= maxAttempts {
+                        IHLog.api.notice(
+                            "api.retry giving up action=\(endpoint.action, privacy: .public) attempts=\(attempt, privacy: .public)"
+                        )
+                    }
+                    throw error
+                }
+                let delay = Self.delaySeconds(
+                    forAttempt: attempt,
+                    retryAfterSeconds: Self.retryAfterSeconds(from: error),
+                    base: retryBaseDelaySeconds
+                )
+                IHLog.api.notice(
+                    "api.retry action=\(endpoint.action, privacy: .public) attempt=\(attempt, privacy: .public) error=\(error.caseName, privacy: .public) delayMs=\(Int((delay * 1_000).rounded()), privacy: .public)"
+                )
+                try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                attempt += 1
+            }
+        }
+    }
+
+    /// Sends `endpoint` exactly once — no retry — and maps every possible
+    /// failure (transport-level `URLError`, non-2xx HTTP status, or any
+    /// other thrown error) into the `APIError` taxonomy, so nothing but
+    /// `APIError` ever escapes this actor's networking boundary. Wraps the
+    /// attempt in an `OSSignposter` interval and writes exactly one
+    /// `IHLog.api` line (`.debug` on success, `.error` on failure).
+    ///
+    /// DETAILED: Deliberately `internal` (module-visible), not `private` —
+    /// `APIClient+Auth.swift` (#1398) calls this directly for the
+    /// non-idempotent `auth_login`/`auth_logout` POSTs, which must NEVER go
+    /// through the retrying `performIdempotentGET` above (strategy §1.5:
+    /// "never auto-retry non-idempotent POSTs").
+    ///
+    /// **Privacy (strategy §4, binding):** the signpost/log messages below
+    /// carry only `endpoint.action` (a fixed, developer-authored string
+    /// like `"songs_index"` — never a query value), the `APIError` case
+    /// NAME (not its associated values — see `APIError.caseName`'s own doc
+    /// comment for why), the HTTP status, and the duration. `request.url`
+    /// (which DOES include the query string) is never logged.
+    func performOnce(_ endpoint: Endpoint) async throws -> Data {
+        let signpostID = IHLog.signposter.makeSignpostID()
+        let interval = IHLog.signposter.beginInterval(
+            "api.request",
+            id: signpostID,
+            "\(endpoint.action, privacy: .public)"
+        )
+        let clock = ContinuousClock()
+        let start = clock.now
+        defer { IHLog.signposter.endInterval("api.request", interval) }
+
+        do {
+            let request = Self.makeURLRequest(
+                for: endpoint,
+                in: environment,
+                bearerToken: endpoint.requiresAuth ? bearerToken : nil
+            )
+
+            let data: Data
+            let response: URLResponse
+            do {
+                (data, response) = try await session.data(for: request)
+            } catch is URLError {
+                // Every transport-level failure (no connectivity, DNS failure,
+                // timed out, connection lost mid-flight, ...) is surfaced as
+                // `.offline` — from the app's perspective these all mean "the
+                // request never reached/returned from the server," which is
+                // exactly `.offline`'s documented meaning. Treating them all
+                // alike (rather than trying to finely distinguish "definitely
+                // no network" from "probably a blip") also keeps this mapping
+                // simple and `isRetryable(.offline) == true` below still gives
+                // a genuine blip its couple of quick retries — a hard-offline
+                // device just fails those retries near-instantly too, so the
+                // added latency is negligible.
+                throw APIError.offline
+            } catch {
+                // Anything else (extremely unlikely for `URLSession.data(for:)`,
+                // which documents `URLError` as its throw type) still gets
+                // folded into the taxonomy rather than escaping as a raw
+                // foreign error type. The underlying error's own description
+                // is deliberately NOT carried into `APIError.server`'s
+                // `message` here for logging purposes — `caseName`/
+                // `httpStatusForLogging` (what actually reaches `IHLog`
+                // below) never read `message` at all, so this is unchanged
+                // behaviour for every EXISTING caller that inspects the
+                // thrown error directly; only the NEW log line is affected.
+                throw APIError.server(status: -1, message: String(describing: error))
+            }
+
+            guard let http = response as? HTTPURLResponse else {
+                throw APIError.server(status: -1, message: "Non-HTTP response")
+            }
+
+            if let apiError = Self.classify(httpStatus: http.statusCode, retryAfterSeconds: Self.retryAfterSeconds(from: http)) {
+                throw apiError
+            }
+
+            let elapsedMs = Self.milliseconds(from: start, to: clock.now)
+            IHLog.api.debug(
+                "api.request ok action=\(endpoint.action, privacy: .public) ms=\(elapsedMs, privacy: .public)"
+            )
+            return data
+        } catch let error as APIError {
+            let elapsedMs = Self.milliseconds(from: start, to: clock.now)
+            IHLog.api.error(
+                "api.request failed action=\(endpoint.action, privacy: .public) error=\(error.caseName, privacy: .public) status=\(error.httpStatusForLogging ?? -1, privacy: .public) ms=\(elapsedMs, privacy: .public)"
+            )
+            throw error
+        }
+    }
+
+    /// Converts a `ContinuousClock` interval into whole milliseconds, for
+    /// `.public` duration logging (strategy §4) — a plain `Int` is simpler
+    /// to read in Console.app than a `Duration`'s own `description`, and
+    /// keeps every duration this file logs in the same unit.
+    nonisolated private static func milliseconds(from start: ContinuousClock.Instant, to end: ContinuousClock.Instant) -> Int {
+        let components = start.duration(to: end).components
+        let milliseconds = Double(components.seconds) * 1_000 + Double(components.attoseconds) / 1_000_000_000_000_000
+        return Int(milliseconds.rounded())
+    }
+
+    /// Parses the server's `Retry-After` response header (seconds form —
+    /// the only form iHymns' backend sends) into an `Int`, if present.
+    nonisolated private static func retryAfterSeconds(from response: HTTPURLResponse) -> Int? {
+        guard let header = response.value(forHTTPHeaderField: "Retry-After") else { return nil }
+        return Int(header)
+    }
+
+    /// Extracts the `Retry-After` hint already carried on a classified
+    /// `.maintenance`/`.rateLimited` error, if any.
+    nonisolated private static func retryAfterSeconds(from error: APIError) -> Int? {
+        switch error {
+        case .maintenance(let seconds): return seconds
+        case .rateLimited(let seconds): return seconds
+        default: return nil
+        }
+    }
+
+    /// Whether a given failure is worth retrying at all.
+    ///
+    /// ELI5: "Was this the kind of problem that trying again might fix?"
+    ///
+    /// DETAILED: `nonisolated` + pure + `static` so it's independently unit
+    /// -testable (`IHAPITests`) without spinning up the actor or any
+    /// networking. `.maintenance`/`.rateLimited`/a 5xx `.server` and
+    /// `.offline` (see `performOnce`'s reasoning above) are transient —
+    /// worth another attempt. `.unauthorized` (the token itself is bad),
+    /// `.accountLocked` (retrying inside a ~3-attempt window can't outlast a
+    /// real lockout), and `.decoding` (the payload shape is wrong) are NOT —
+    /// no amount of retrying changes any of those outcomes, so failing fast
+    /// serves the caller better than three attempts' worth of wasted
+    /// latency.
+    nonisolated private static func isRetryable(_ error: APIError) -> Bool {
+        switch error {
+        case .offline, .maintenance, .rateLimited:
+            return true
+        case .server(let status, _):
+            return (500...599).contains(status)
+        case .unauthorized, .accountLocked, .decoding:
+            return false
+        }
+    }
+
+    /// Computes how long to wait before the next attempt.
+    ///
+    /// ELI5: "Wait this long" — usually a bit longer each time, with a
+    /// small random wobble so a fleet of clients retrying together don't
+    /// all hammer the server on the exact same beat (the classic
+    /// "thundering herd" problem) — but if the server told us exactly how
+    /// long to wait (`Retry-After`), that instruction wins outright.
+    ///
+    /// - Parameters:
+    ///   - attempt: The attempt number that just failed (1-based).
+    ///   - retryAfterSeconds: The server's own hint, if it sent one.
+    ///   - base: `retryBaseDelaySeconds` — exposed as a parameter (rather
+    ///     than reading the actor's stored property directly) purely so
+    ///     this stays a `nonisolated static` pure function, independently
+    ///     unit-testable with zero actor hops.
+    nonisolated private static func delaySeconds(forAttempt attempt: Int, retryAfterSeconds: Int?, base: Double) -> Double {
+        if let retryAfterSeconds, retryAfterSeconds > 0 {
+            return Double(retryAfterSeconds)
+        }
+        let exponential = base * pow(2.0, Double(attempt - 1))
+        let jitter = Double.random(in: 0...(exponential * 0.25))
+        return exponential + jitter
+    }
+}

--- a/appApple/Packages/iHymnsKit/Sources/IHAPI/APIClient.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHAPI/APIClient.swift
@@ -47,24 +47,35 @@ public actor APIClient {
     /// `URLSession` (via `URLProtocol` stubbing, see `IHAPITests`) without
     /// touching real network — see Apple's guidance on testing networking
     /// code: https://developer.apple.com/documentation/foundation/urlprotocol.
-    private let session: URLSession
+    ///
+    /// `internal` (not `private`) for the same same-target-file-split
+    /// reason `performOnce`/`performIdempotentGET`'s own doc comments give
+    /// below: the networking core (those two methods + the retry-policy
+    /// helpers) now lives in `APIClient+Networking.swift`, split out once
+    /// the #1505 `IHLog` instrumentation retrofit pushed this file back
+    /// over the repo's 400-line LOC-budget tripwire
+    /// (`Scripts/loc-budget.sh`) — `private` is file-scoped in Swift, so a
+    /// same-MODULE extension in a different file needs at least `internal`
+    /// visibility on every stored property it touches.
+    let session: URLSession
 
     /// The current session token, if any. `nil` for a signed-out client —
     /// every read this file implements is public and works fine with no
     /// token; `IHAuth.SessionController` is what actually populates this
     /// once a user signs in, via `updateBearerToken(_:)` below.
-    private var bearerToken: String?
+    private(set) var bearerToken: String?
 
-    /// Base delay (seconds) for the exponential-backoff retry policy below.
-    /// A real Double, not a fixed constant, purely so the test suite can
-    /// shrink it to a few milliseconds — nobody wants a unit test that
-    /// takes several real seconds to prove a retry loop works.
-    private let retryBaseDelaySeconds: Double
+    /// Base delay (seconds) for the exponential-backoff retry policy in
+    /// `APIClient+Networking.swift`. A real Double, not a fixed constant,
+    /// purely so the test suite can shrink it to a few milliseconds —
+    /// nobody wants a unit test that takes several real seconds to prove a
+    /// retry loop works.
+    let retryBaseDelaySeconds: Double
 
     /// Maximum number of ATTEMPTS (the first try plus retries) an
     /// idempotent GET makes before surfacing its last error — strategy
     /// §1.5's "max 3".
-    private let maxAttempts = 3
+    let maxAttempts = 3
 
     /// Creates a client bound to one environment.
     ///
@@ -237,164 +248,16 @@ public actor APIClient {
     }
 
     // MARK: - Networking core
-
-    /// Sends `endpoint` as a GET, retrying transient failures with
-    /// exponential backoff + jitter (honouring a server `Retry-After` when
-    /// present), up to `maxAttempts` attempts total.
-    ///
-    /// ELI5: Try it; if the server hiccupped in a way that trying again
-    /// might fix, wait a little (a little longer each time) and try again —
-    /// up to twice more — otherwise give up and hand back the error.
-    ///
-    /// DETAILED: Only ever called for GETs (every catalogue read above is
-    /// one) — strategy §1.5 is explicit that non-idempotent POSTs must
-    /// NEVER be auto-retried this way (they go through
-    /// `IHPersistence`'s pending-sync queue with server-side dedupe
-    /// instead, a Phase-1 concern). Deliberately `internal` (module-visible),
-    /// not `private` — `APIClient+Discovery.swift` (#180) calls this
-    /// directly for its two idempotent GETs, the same same-target-file-split
-    /// reason `performOnce` below was already relaxed to `internal` for
-    /// `APIClient+Auth.swift` (#1398). `isRetryable(_:)` decides WHICH
-    /// `APIError` cases are worth another attempt; `.unauthorized` and
-    /// `.decoding` never are (retrying either can't possibly succeed —
-    /// the token is bad, or the payload is wrong shape).
-    func performIdempotentGET(_ endpoint: Endpoint) async throws -> Data {
-        var attempt = 1
-        while true {
-            do {
-                return try await performOnce(endpoint)
-            } catch let error as APIError {
-                guard attempt < maxAttempts, Self.isRetryable(error) else { throw error }
-                let delay = Self.delaySeconds(
-                    forAttempt: attempt,
-                    retryAfterSeconds: Self.retryAfterSeconds(from: error),
-                    base: retryBaseDelaySeconds
-                )
-                try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
-                attempt += 1
-            }
-        }
-    }
-
-    /// Sends `endpoint` exactly once — no retry — and maps every possible
-    /// failure (transport-level `URLError`, non-2xx HTTP status, or any
-    /// other thrown error) into the `APIError` taxonomy, so nothing but
-    /// `APIError` ever escapes this actor's networking boundary.
-    ///
-    /// DETAILED: Deliberately `internal` (module-visible), not `private` —
-    /// `APIClient+Auth.swift` (#1398) calls this directly for the
-    /// non-idempotent `auth_login`/`auth_logout` POSTs, which must NEVER
-    /// go through the retrying `performIdempotentGET` above (strategy §1.5:
-    /// "never auto-retry non-idempotent POSTs"). Splitting auth into its
-    /// own file (rather than growing this one further) keeps this file
-    /// under the repo's LOC-budget tripwire (`Scripts/loc-budget.sh`) — this
-    /// access-level relaxation is what makes that same-target file split
-    /// possible (`private` is file-scoped in Swift; `internal` is not).
-    func performOnce(_ endpoint: Endpoint) async throws -> Data {
-        let request = Self.makeURLRequest(
-            for: endpoint,
-            in: environment,
-            bearerToken: endpoint.requiresAuth ? bearerToken : nil
-        )
-
-        let data: Data
-        let response: URLResponse
-        do {
-            (data, response) = try await session.data(for: request)
-        } catch is URLError {
-            // Every transport-level failure (no connectivity, DNS failure,
-            // timed out, connection lost mid-flight, ...) is surfaced as
-            // `.offline` — from the app's perspective these all mean "the
-            // request never reached/returned from the server," which is
-            // exactly `.offline`'s documented meaning. Treating them all
-            // alike (rather than trying to finely distinguish "definitely
-            // no network" from "probably a blip") also keeps this mapping
-            // simple and `isRetryable(.offline) == true` below still gives
-            // a genuine blip its couple of quick retries — a hard-offline
-            // device just fails those retries near-instantly too, so the
-            // added latency is negligible.
-            throw APIError.offline
-        } catch {
-            // Anything else (extremely unlikely for `URLSession.data(for:)`,
-            // which documents `URLError` as its throw type) still gets
-            // folded into the taxonomy rather than escaping as a raw
-            // foreign error type.
-            throw APIError.server(status: -1, message: String(describing: error))
-        }
-
-        guard let http = response as? HTTPURLResponse else {
-            throw APIError.server(status: -1, message: "Non-HTTP response")
-        }
-
-        if let apiError = Self.classify(httpStatus: http.statusCode, retryAfterSeconds: Self.retryAfterSeconds(from: http)) {
-            throw apiError
-        }
-        return data
-    }
-
-    /// Parses the server's `Retry-After` response header (seconds form —
-    /// the only form iHymns' backend sends) into an `Int`, if present.
-    nonisolated private static func retryAfterSeconds(from response: HTTPURLResponse) -> Int? {
-        guard let header = response.value(forHTTPHeaderField: "Retry-After") else { return nil }
-        return Int(header)
-    }
-
-    /// Extracts the `Retry-After` hint already carried on a classified
-    /// `.maintenance`/`.rateLimited` error, if any.
-    nonisolated private static func retryAfterSeconds(from error: APIError) -> Int? {
-        switch error {
-        case .maintenance(let seconds): return seconds
-        case .rateLimited(let seconds): return seconds
-        default: return nil
-        }
-    }
-
-    /// Whether a given failure is worth retrying at all.
-    ///
-    /// ELI5: "Was this the kind of problem that trying again might fix?"
-    ///
-    /// DETAILED: `nonisolated` + pure + `static` so it's independently unit
-    /// -testable (`IHAPITests`) without spinning up the actor or any
-    /// networking. `.maintenance`/`.rateLimited`/a 5xx `.server` and
-    /// `.offline` (see `performOnce`'s reasoning above) are transient —
-    /// worth another attempt. `.unauthorized` (the token itself is bad),
-    /// `.accountLocked` (retrying inside a ~3-attempt window can't outlast a
-    /// real lockout), and `.decoding` (the payload shape is wrong) are NOT —
-    /// no amount of retrying changes any of those outcomes, so failing fast
-    /// serves the caller better than three attempts' worth of wasted
-    /// latency.
-    nonisolated private static func isRetryable(_ error: APIError) -> Bool {
-        switch error {
-        case .offline, .maintenance, .rateLimited:
-            return true
-        case .server(let status, _):
-            return (500...599).contains(status)
-        case .unauthorized, .accountLocked, .decoding:
-            return false
-        }
-    }
-
-    /// Computes how long to wait before the next attempt.
-    ///
-    /// ELI5: "Wait this long" — usually a bit longer each time, with a
-    /// small random wobble so a fleet of clients retrying together don't
-    /// all hammer the server on the exact same beat (the classic
-    /// "thundering herd" problem) — but if the server told us exactly how
-    /// long to wait (`Retry-After`), that instruction wins outright.
-    ///
-    /// - Parameters:
-    ///   - attempt: The attempt number that just failed (1-based).
-    ///   - retryAfterSeconds: The server's own hint, if it sent one.
-    ///   - base: `retryBaseDelaySeconds` — exposed as a parameter (rather
-    ///     than reading the actor's stored property directly) purely so
-    ///     this stays a `nonisolated static` pure function, independently
-    ///     unit-testable with zero actor hops.
-    nonisolated private static func delaySeconds(forAttempt attempt: Int, retryAfterSeconds: Int?, base: Double) -> Double {
-        if let retryAfterSeconds, retryAfterSeconds > 0 {
-            return Double(retryAfterSeconds)
-        }
-        let exponential = base * pow(2.0, Double(attempt - 1))
-        let jitter = Double.random(in: 0...(exponential * 0.25))
-        return exponential + jitter
-    }
+    //
+    // `performIdempotentGET`/`performOnce` (the retry loop + the single-
+    // attempt send/classify), the `retryAfterSeconds`/`isRetryable`/
+    // `delaySeconds` retry-policy helpers, AND their #1505 `IHLog`
+    // instrumentation (signposts + `.debug`/`.notice`/`.error` breadcrumbs,
+    // strategy §2.2) all live in `APIClient+Networking.swift` — split out
+    // of this file the same way `APIClient+Auth.swift`/
+    // `APIClient+Discovery.swift` already were, once the instrumentation
+    // pushed this file back over the repo's 400-line LOC-budget tripwire
+    // (`Scripts/loc-budget.sh`). `session`/`bearerToken`/
+    // `retryBaseDelaySeconds`/`maxAttempts` above are `internal`, not
+    // `private`, for exactly this same-target-file-split reason.
 }

--- a/appApple/Packages/iHymnsKit/Sources/IHAPI/APIError.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHAPI/APIError.swift
@@ -74,3 +74,54 @@ public enum APIError: Error, Sendable, Equatable {
     /// drift, and worth logging loudly per strategy §1.5.
     case decoding
 }
+
+// MARK: - #1505 logging-safe descriptors
+//
+// `APIClient+Networking.swift`'s `IHLog.api.error(...)` retrofit (strategy
+// §2.2/§4) needs to name WHICH case failed and WHAT HTTP status it maps to,
+// without ever interpolating the raw `Error` value itself — `Equatable`'s
+// synthesized `String(describing:)` output for `.server`/`.maintenance`/
+// etc. would print their associated values too, and `.server`'s `message`
+// in particular can carry an arbitrary underlying transport error's
+// description (`performOnce`'s generic `catch` branch), which is exactly
+// the kind of "we didn't anticipate what's in there" payload strategy §4
+// says must never reach a log line, at any privacy level.
+extension APIError {
+    /// Just the case name (`"offline"`, `"maintenance"`, ...) — safe to log
+    /// at `.public` privacy. Associated values are deliberately excluded;
+    /// see this section's header comment.
+    var caseName: String {
+        switch self {
+        case .offline: return "offline"
+        case .maintenance: return "maintenance"
+        case .unauthorized: return "unauthorized"
+        case .accountLocked: return "accountLocked"
+        case .rateLimited: return "rateLimited"
+        case .server: return "server"
+        case .decoding: return "decoding"
+        }
+    }
+
+    /// The HTTP status this case corresponds to, mirroring
+    /// `APIClient.classify(httpStatus:retryAfterSeconds:)`'s mapping in
+    /// reverse — `nil` for `.offline` (the request never reached/returned
+    /// from the server at all) and `.decoding` (the HTTP layer succeeded;
+    /// only the body's shape was wrong). Safe to log at `.public` privacy:
+    /// a bare integer, never the response body it came with.
+    var httpStatusForLogging: Int? {
+        switch self {
+        case .offline, .decoding:
+            return nil
+        case .maintenance:
+            return 503
+        case .unauthorized:
+            return 401
+        case .accountLocked:
+            return 423
+        case .rateLimited:
+            return 429
+        case .server(let status, _):
+            return status
+        }
+    }
+}

--- a/appApple/Packages/iHymnsKit/Sources/IHAuth/SessionController.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHAuth/SessionController.swift
@@ -27,8 +27,17 @@
 // could still authenticate with the very token this call meant to kill —
 // revoking server-side FIRST closes that window regardless of what happens
 // to the local copy afterwards.
+//
+// #1505 UPDATE (`.claude/live-observability-strategy.md` §2.2) — every
+// signed-out↔signed-in TRANSITION (never a same-state re-publish — "log
+// transitions, not states") writes one `IHLog.auth` `.notice`, via the
+// single `setState(_:userId:)` chokepoint every public entry point below
+// funnels through. `userId` is `.private`; the token/username are NEVER
+// logged, at any level (strategy §4). `restoreFromStorage()`'s 401
+// self-heal (an INVOLUNTARY sign-out) additionally logs an `.error`.
 import Foundation
 import IHAPI
+import IHLog
 
 /// The current authentication state of the app.
 ///
@@ -145,11 +154,20 @@ public actor SessionController {
 
         await apiClient.updateBearerToken(token)
         do {
-            _ = try await apiClient.authMe()
-            setState(.signedIn(token: token))
+            // Captured (rather than the original `_ = try await ...`
+            // discard) so the `.notice` transition log below can carry the
+            // signed-in user's numeric id — #1505, strategy §2.2.
+            let user = try await apiClient.authMe()
+            setState(.signedIn(token: token), userId: user.id)
         } catch APIError.unauthorized {
             try? await tokenStore.delete()
             await apiClient.updateBearerToken(nil)
+            // Unlike `signOut()`'s benign `.unauthorized` handling (a
+            // deliberate sign-out that finds nothing left to revoke), THIS
+            // is involuntary — the app is about to silently drop a user who
+            // believed they were still signed in: "a 401 forces sign-out"
+            // (strategy §2.2), logged `.error` not `.notice`.
+            IHLog.auth.error("session: stored token rejected (401) on restore — forcing sign-out")
             setState(.signedOut)
         } catch {
             setState(.signedIn(token: token))
@@ -172,7 +190,9 @@ public actor SessionController {
     ///   catalogue-read failures (#1399).
     public func signIn(username: String, password: String) async throws {
         let session = try await apiClient.authLogin(username: username, password: password)
-        try await signIn(token: session.token)
+        // Private `userId:` overload (#1505) — this call site already
+        // knows who just signed in, for the `.notice` transition log.
+        try await signIn(token: session.token, userId: session.user.id)
     }
 
     /// Signs in with an email + 6-digit code pair (the code emailed by a
@@ -192,7 +212,8 @@ public actor SessionController {
     ///   or reinterpret" contract as `signIn(username:password:)`.
     public func signIn(email: String, code: String) async throws {
         let session = try await apiClient.authEmailLoginVerify(email: email, code: code)
-        try await signIn(token: session.token)
+        // See `signIn(username:password:)`'s matching comment above.
+        try await signIn(token: session.token, userId: session.user.id)
     }
 
     /// Persists `token` and transitions to `.signedIn`.
@@ -208,9 +229,22 @@ public actor SessionController {
     /// call straight into this once it already holds a token, without
     /// re-deriving one from a username/password round trip it never had.
     public func signIn(token: String) async throws {
+        // No caller-known userId here (a bare token, no `AuthUser` — e.g. a
+        // future SIWA flow, or today's tests). The `.notice` transition log
+        // (#1505) still fires; it just omits the userId field.
+        try await signIn(token: token, userId: nil)
+    }
+
+    /// The actual sign-in implementation `signIn(token:)` above, and the
+    /// username/password + email/code flows earlier in this file, all
+    /// funnel through — the ONE place a bearer token is persisted and
+    /// `state` transitions to `.signedIn`. `userId`: passed through to
+    /// `setState(_:userId:)`'s `.notice` log (`.private`, #1505); `nil`
+    /// when unknown, never a reason to skip the log entirely.
+    private func signIn(token: String, userId: Int?) async throws {
         try await tokenStore.save(token)
         await apiClient.updateBearerToken(token)
-        setState(.signedIn(token: token))
+        setState(.signedIn(token: token), userId: userId)
     }
 
     /// Clears the stored token and transitions to `.signedOut` — but ONLY
@@ -304,9 +338,38 @@ public actor SessionController {
         setState(.signedOut)
     }
 
-    /// Updates `state` and publishes it to every `stateUpdates` subscriber.
-    private func setState(_ newState: SessionState) {
+    /// Updates `state`, publishes it to every `stateUpdates` subscriber, and
+    /// — ONLY when signed-in-ness actually flips — writes one `IHLog.auth`
+    /// `.notice` (#1505, "log transitions, not states").
+    ///
+    /// ELI5: "We're now in this new state — tell everyone watching, and (if
+    /// this is actually a change) write it down."
+    ///
+    /// DETAILED: Every public entry point in this actor funnels through
+    /// here, so this is the ONE place the transition log lives. Comparing
+    /// `state.isSignedIn` (the OLD value, captured before it's overwritten)
+    /// against `newState.isSignedIn` suppresses a same-state republish
+    /// (e.g. `restoreFromStorage()`'s "no stored token" path, already
+    /// `.signedOut`) from producing a `.notice` — that would log a STATE,
+    /// not a transition. `userId`: `.private`, logged only on a
+    /// signed-out→signed-in transition, when known (`nil` otherwise, per
+    /// `signIn(token:userId:)`'s doc comment); ignored on the way out
+    /// (`.signedIn` never stored one to look back up here).
+    private func setState(_ newState: SessionState, userId: Int? = nil) {
+        let wasSignedIn = state.isSignedIn
         state = newState
         continuation.yield(newState)
+
+        guard wasSignedIn != newState.isSignedIn else { return }
+
+        if newState.isSignedIn {
+            if let userId {
+                IHLog.auth.notice("session: signed out -> signed in (userId: \(userId, privacy: .private))")
+            } else {
+                IHLog.auth.notice("session: signed out -> signed in")
+            }
+        } else {
+            IHLog.auth.notice("session: signed in -> signed out")
+        }
     }
 }

--- a/appApple/Packages/iHymnsKit/Sources/IHLog/IHLog.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLog/IHLog.swift
@@ -1,0 +1,131 @@
+// IHLog.swift
+// IHLog
+//
+// ELI5: The one place every other part of the app goes to write down "what
+// just happened" so that later — on a Mac's Console app, or in a
+// TestFlight tester's exported diagnostics — someone can figure out WHY a
+// live-follow session, a remote connection, or a network call failed,
+// without that someone needing physical access to the failing device while
+// it's failing.
+//
+// DETAILED: #1505 (P1 of the observability programme,
+// `.claude/live-observability-strategy.md` §2.1). Wraps Apple's unified
+// logging system (`os.Logger`, https://developer.apple.com/documentation/os/logger)
+// behind ONE small enum of pre-built `Logger`/`OSSignposter` instances so
+// every call site writes `IHLog.api.debug(...)` instead of constructing its
+// own `Logger(subsystem:category:)` — the same "extract first, use second"
+// modularity rule this repo applies everywhere else (`.claude/CLAUDE.md`),
+// applied here to keep the SUBSYSTEM string (which is what a saved
+// Console.app search / `sysdiagnose` grep keys off, strategy §2.6) from
+// drifting into two different literals across the codebase.
+//
+// `subsystem = "app.ihymns"` intentionally matches the existing literal in
+// `IHAppSupport/IHAnalyticsSink.swift:29` (which this file does NOT modify,
+// per the task brief — that file predates IHLog and has its own narrow
+// DEBUG-only `#if DEBUG` logger for analytics-event tracing). Keeping both
+// on the same subsystem string means a single Console.app filter
+// (`subsystem == "app.ihymns"`) surfaces every iHymns log line on the
+// device, regardless of which internal facility wrote it.
+//
+// WHY a `Logger` per CATEGORY rather than one shared `Logger` for
+// everything: Console.app/`sysdiagnose` predicates can filter on
+// `category` too (e.g. "show me only `remote` — the LAN TV-connection
+// noise, not the API traffic"), and Apple's own guidance recommends one
+// category per functional area for exactly this reason. `signposter` is a
+// separate `OSSignposter` (not a `Logger`) because Instruments' time-profile
+// tooling reads signpost intervals through that distinct API surface — see
+// https://developer.apple.com/documentation/os/ossignposter.
+//
+// Deliberately NOT configurable at runtime (strategy §2.3): `os.Logger` is
+// always-on by OS design, `.debug` calls are free when nobody is streaming/
+// viewing them, and a custom verbosity gate would only add a "logging was
+// off during the one test run that mattered" failure mode. The on-device
+// diagnostic overlay (a LATER phase, §2.6) is the only user-facing toggle;
+// this file has none.
+import Foundation
+import os
+
+/// The shared logging facility every iHymnsKit target writes through.
+///
+/// ELI5: "Where do I write down what just happened?" — pick the `Logger`
+/// that matches what you're doing (`api` for a network call, `auth` for a
+/// sign-in/out event, ...) and call `.debug`/`.notice`/`.error`/`.fault` on
+/// it, exactly like Apple's own `Logger` API.
+///
+/// DETAILED: A stateless `enum` (never instantiated) holding only `static
+/// let` constants — `Logger`/`OSSignposter` are both documented as
+/// thread-safe/`Sendable` value-ish wrappers around the unified logging
+/// system, so these constants are safe to read from any actor or
+/// `@Sendable` closure with no synchronization of our own (verified by
+/// `IHLogTests`'s "usable from an actor" case). No call site should ever
+/// construct its own `Logger(subsystem:category:)` — that would fork the
+/// subsystem string this whole facility exists to keep singular.
+public enum IHLog {
+
+    /// The ONE subsystem every iHymns log line (from this facility or from
+    /// `IHAnalyticsSink`'s pre-existing DEBUG logger) is tagged with — the
+    /// exact string a Console.app/`sysdiagnose` search predicate matches
+    /// on. Changing this is a breaking change to every saved filter/
+    /// documented debugging recipe (strategy §2.6/§6), so it is asserted
+    /// stable by `IHLogTests`.
+    public static let subsystem = "app.ihymns"
+
+    /// The exact `category` string each `Logger` below is built with, kept
+    /// as named constants (rather than only as literals inline in the
+    /// `Logger(...)` calls) purely so `IHLogTests` can assert they're
+    /// stable WITHOUT needing to introspect a constructed `Logger` — Apple's
+    /// `Logger` type does not expose its own subsystem/category back out
+    /// once built, so the only way to guard "these strings never silently
+    /// change" is to test the strings themselves, at the point they're
+    /// defined. `internal` (not `public`) — this is a Console-predicate
+    /// implementation detail, not part of the facility's public contract
+    /// (`IHLog.api` etc. are the contract).
+    enum Category {
+        static let api = "api"
+        static let liveFollow = "live-follow"
+        static let remote = "remote"
+        static let discovery = "discovery"
+        static let auth = "auth"
+        static let signposts = "spans"
+    }
+
+    /// Network-layer events — `IHAPI.APIClient` request/response/retry
+    /// lifecycle (§2.2). NEVER carries a URL, query string, request body,
+    /// or `Authorization` header value (§4) — only the endpoint `action`
+    /// name, the `APIError` case, HTTP status, and duration.
+    public static let api = Logger(subsystem: subsystem, category: Category.api)
+
+    /// Live-Follow / Service-Mode session lifecycle — join/poll-health/
+    /// freshness/broadcast/session-end transitions (strategy §2.4, a
+    /// binding contract for the not-yet-built engine; nothing calls this
+    /// yet as of #1505/P1). Category is `"live-follow"` (hyphenated, not
+    /// `liveFollow`) to match the exact Console predicate strategy §2.4
+    /// names.
+    public static let liveFollow = Logger(subsystem: subsystem, category: Category.liveFollow)
+
+    /// LAN remote-control session lifecycle — connect/pair/apply spans for
+    /// the not-yet-built `IHLive/LANRemote` engine (strategy §2.5). NEVER
+    /// carries a pairing code.
+    public static let remote = Logger(subsystem: subsystem, category: Category.remote)
+
+    /// LAN discovery (Bonjour browse results, local-network permission
+    /// state) — again for the not-yet-built `LANRemote` engine (strategy
+    /// §2.5). Local-network-permission-denied is called out there as "the
+    /// single most valuable TestFlight line" this category will ever carry.
+    public static let discovery = Logger(subsystem: subsystem, category: Category.discovery)
+
+    /// Sign-in/out session-state transitions — `IHAuth.SessionController`
+    /// (§2.2). `.private` for any user/device identifier; NEVER the bearer
+    /// token or username at any privacy level (§4).
+    public static let auth = Logger(subsystem: subsystem, category: Category.auth)
+
+    /// Signpost intervals (`"api.request"`, and later `"live.join"`/
+    /// `"live.poll.gap"`/`"lan.connect"`/`"remote.apply"` per strategy
+    /// §2.4/§2.5) — read by Instruments' time-profile tooling, a distinct
+    /// API surface from `Logger` (see
+    /// https://developer.apple.com/documentation/os/ossignposter). Category
+    /// `"spans"` groups every signpost interval this app emits under one
+    /// Console/Instruments filter, separate from the plain log-line
+    /// categories above.
+    public static let signposter = OSSignposter(subsystem: subsystem, category: Category.signposts)
+}

--- a/appApple/Packages/iHymnsKit/Sources/IHLog/IHLogSanitize.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLog/IHLogSanitize.swift
@@ -1,0 +1,70 @@
+// IHLogSanitize.swift
+// IHLog
+//
+// ELI5: Turns a secret login pass into a short, safe "fingerprint" — like a
+// partial fingerprint at a crime scene, it's enough to say "yep, same
+// person as before" without ever revealing enough to steal their identity.
+//
+// DETAILED: #1505 (`.claude/live-observability-strategy.md` §4). The
+// strategy's binding privacy rule is that a bearer/presence/follow token is
+// NEVER interpolated into a log line, at ANY privacy level — but a
+// developer diagnosing "why did this specific session fail three times"
+// still benefits from being able to correlate a client-side `.error` line
+// with the matching server-side `tblActivityLog`/`tblApiKeyUsage` row
+// WITHOUT the raw secret ever appearing in either place. `tokenFingerprint`
+// is that correlation key: a short, one-way, deterministic digest safe to
+// log at `.public` (strategy §4: "Token fingerprints ... are `.public`").
+import CryptoKit
+import Foundation
+
+/// Sanitization helpers for anything that must NEVER appear verbatim in a
+/// log line.
+///
+/// ELI5: "I need to write SOMETHING down about this secret, without writing
+/// down the secret itself."
+public enum IHLogSanitize {
+
+    /// An 8-character lowercase-hex prefix of the SHA-256 digest of `token`
+    /// — safe to log at `.public` privacy as a correlation key.
+    ///
+    /// ELI5: Turns a 64-character login pass into an 8-character stand-in
+    /// that's the same every time for the SAME pass, but tells you nothing
+    /// about what the real pass is.
+    ///
+    /// DETAILED — **NEVER use this for a join/session/pairing CODE.** This
+    /// function is only safe for a HIGH-ENTROPY credential (≥128 bits, e.g.
+    /// iHymns' 64-hex-character `tblApiTokens`/presence/follow tokens,
+    /// which are ~256 bits of randomness): even truncated to a 32-bit
+    /// (8 hex char) prefix, brute-forcing which of 2^256 possible SHA-256
+    /// preimages produced a given 8-char prefix is still computationally
+    /// infeasible — the prefix narrows an attacker's search space by only
+    /// 32 bits, leaving the other ~224+ bits of the real token exactly as
+    /// hard to guess as before. A join/session/rotating CODE (strategy §0.2/
+    /// §4: iHymns' Service-Mode/Live-Follow codes are Crockford-base32,
+    /// ~29–39 bits) has NO such margin: a 29-bit code space is entirely
+    /// brute-forceable OFFLINE against a leaked digest in seconds on
+    /// ordinary hardware, so even a "safe-looking" fingerprint of a code is
+    /// really just the code, one extra (trivial) step removed. Codes must
+    /// be correlated some other way (e.g. the session's numeric id +
+    /// rotation `Generation`, per strategy §3.1/§4) — never through this
+    /// function.
+    ///
+    /// Deterministic (same input → same output, always) and pure — no
+    /// device/session state is mixed in, so two client processes (or a
+    /// client and the server, if the server ever adopts the identical
+    /// algorithm) computing this over the same token agree without needing
+    /// to exchange anything else. Uses SHA-256 via CryptoKit
+    /// (https://developer.apple.com/documentation/cryptokit/sha256), a
+    /// first-party Apple system framework — not an external SwiftPM
+    /// dependency — keeping this target's `Package.swift` `dependencies:`
+    /// list empty, matching its "zero-dependency leaf" design (§2.1).
+    ///
+    /// - Parameter token: The full, high-entropy secret value. Never logged
+    ///   itself — only this function's return value may be.
+    /// - Returns: 8 lowercase hex characters, e.g. `"2cf24dba"`.
+    public static func tokenFingerprint(_ token: String) -> String {
+        let digest = SHA256.hash(data: Data(token.utf8))
+        let hex = digest.map { String(format: "%02x", $0) }.joined()
+        return String(hex.prefix(8))
+    }
+}

--- a/appApple/Packages/iHymnsKit/Tests/IHLogTests/IHLogTests.swift
+++ b/appApple/Packages/iHymnsKit/Tests/IHLogTests/IHLogTests.swift
@@ -1,0 +1,113 @@
+// IHLogTests.swift
+// IHLogTests
+//
+// ELI5: Checks that the labels we use to find our own log lines later
+// (`subsystem`/`category`) never quietly change, and that the "safe
+// fingerprint" helper always gives the same short answer for the same
+// secret.
+//
+// DETAILED: #1505 (`.claude/live-observability-strategy.md` §6: "Swift:
+// `IHLogTests` (subsystem/category constants stable = Console-predicate
+// contract; `tokenFingerprint` vector; usable-from-actor)"). `os.Logger`
+// does not expose its own `subsystem`/`category` back out once constructed
+// (there is no `Logger.subsystem`/`Logger.category` getter in the public
+// API), so these tests assert the underlying STRING constants
+// (`IHLog.subsystem`, `IHLog.Category.*`) directly, at their source of
+// definition, rather than trying to introspect a built `Logger` instance.
+// `@testable import IHLog` is required for `Category` (module-internal by
+// design — see its doc comment in `IHLog.swift`).
+import Foundation
+import Testing
+@testable import IHLog
+
+@Suite("IHLog")
+struct IHLogTests {
+
+    // MARK: - Subsystem/category stability (Console-predicate contract)
+
+    @Test("Subsystem is the one stable Console-predicate value")
+    func subsystemIsStable() {
+        // Must match IHAppSupport/IHAnalyticsSink.swift:29's literal too —
+        // this file cannot import IHAppSupport (wrong layering direction,
+        // see Package.swift's layering comment), so that agreement is
+        // enforced by code review + this doc comment, not a cross-target
+        // test.
+        #expect(IHLog.subsystem == "app.ihymns")
+    }
+
+    @Test("Category names are stable Console-predicate values")
+    func categoryNamesAreStable() {
+        #expect(IHLog.Category.api == "api")
+        #expect(IHLog.Category.liveFollow == "live-follow")
+        #expect(IHLog.Category.remote == "remote")
+        #expect(IHLog.Category.discovery == "discovery")
+        #expect(IHLog.Category.auth == "auth")
+        #expect(IHLog.Category.signposts == "spans")
+    }
+
+    // MARK: - Usable from an actor (Sendable)
+
+    /// Not a runtime assertion so much as a COMPILE-time one: if
+    /// `Logger`/`OSSignposter` (or `IHLog` itself) ever stopped being safe
+    /// to reference from inside an `actor` under Swift 6 strict
+    /// concurrency, this test file would fail to BUILD, not just fail to
+    /// pass — exactly the guard strategy §6 asks for.
+    @Test("IHLog's loggers are usable from inside an actor")
+    func usableFromActor() async {
+        actor LoggerProbe {
+            func touchEveryLogger() {
+                IHLog.api.debug("probe")
+                IHLog.liveFollow.debug("probe")
+                IHLog.remote.debug("probe")
+                IHLog.discovery.debug("probe")
+                IHLog.auth.debug("probe")
+                _ = IHLog.signposter.makeSignpostID()
+            }
+        }
+        let probe = LoggerProbe()
+        await probe.touchEveryLogger()
+    }
+}
+
+@Suite("IHLogSanitize")
+struct IHLogSanitizeTests {
+
+    @Test("Known vector: SHA-256('hello') → its 8-char hex prefix")
+    func knownVector() {
+        // Full SHA-256("hello") is
+        // 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+        // (independently verified via `shasum -a 256`); the function's
+        // contract is the first 8 hex characters of that digest.
+        #expect(IHLogSanitize.tokenFingerprint("hello") == "2cf24dba")
+    }
+
+    @Test("Deterministic — same input always produces the same fingerprint")
+    func deterministic() {
+        let token = "a-64-hex-character-style-high-entropy-example-token-value-000"
+        #expect(IHLogSanitize.tokenFingerprint(token) == IHLogSanitize.tokenFingerprint(token))
+    }
+
+    @Test("Different inputs produce different fingerprints")
+    func differsForDifferentInput() {
+        #expect(IHLogSanitize.tokenFingerprint("token-a") != IHLogSanitize.tokenFingerprint("token-b"))
+    }
+
+    @Test("Always exactly 8 lowercase hex characters")
+    func fixedLowercaseHexLength() {
+        let fingerprint = IHLogSanitize.tokenFingerprint("some-arbitrary-token-value")
+        #expect(fingerprint.count == 8)
+        #expect(fingerprint.allSatisfy { "0123456789abcdef".contains($0) })
+    }
+
+    @Test("Usable from inside an actor")
+    func usableFromActor() async {
+        actor FingerprintProbe {
+            func fingerprint(of token: String) -> String {
+                IHLogSanitize.tokenFingerprint(token)
+            }
+        }
+        let probe = FingerprintProbe()
+        let fingerprint = await probe.fingerprint(of: "actor-context-token")
+        #expect(fingerprint.count == 8)
+    }
+}

--- a/appApple/dev-docs/Provisioning-Runbook.md
+++ b/appApple/dev-docs/Provisioning-Runbook.md
@@ -3,7 +3,7 @@
 > **Click-level, owner-only** Apple provisioning steps for the native Universal app.
 > Companion to `.claude/apple-native-owner-runbook.md` (long-lead overview) and epic **#895**.
 > Nothing here is executable by the build agent — these are your Apple-account + iHymns-admin actions.
-> Last updated **2026-07-10** (in-app account deletion shipped — #1478; web Sign in with Apple W1–W3 + the §1.4 activation steps + its CSP allowance — #1471/#1480/#1484; version now **0.2750.0**; incorporates the owner Q&A corrections: Family Sharing N/A, APNs deferred, private-relay email optional; **CarPlay entitlement GRANTED** — §1.3 Step 4 rewritten for the enable steps; **§2 distribution-readiness walkthrough expanded to full click-by-click steps**; **CI/CD pipeline hardening** — `project.yml` now declares `INFOPLIST_KEY_ITSAppUsesNonExemptEncryption: NO` on `iHymns`+`iHymnsTV` (§2.2.B.1/§2.3.A.4 now DONE), and every "AASA returns 200" verification step below is **corrected**: a bare `200` is NOT proof the real responder is live — `beta.ihymns.app`/`ihymns.app`/`www.ihymns.app` all return `200` today but still serve a **stale legacy AASA with the WRONG appID**; only `dev.ihymns.app` serves the real one — see §1.2 Step 6, §2.1, §2.3.A.2, and the Verification-walkthrough Bucket B; **§2.4 expanded into a full click-by-click Simulator + real-device testing walkthrough** — project generation, per-platform Simulator runs (incl. the honest finding that `iHymnsTV`/`iHymnsWatch` still render only the Phase-0 `PhaseZeroSkeletonView` placeholder today, not real screens), the native macOS "Designed for iPad" run, the `APIEnvironment` runtime override (verified `DEBUG`-only, so it does NOT exist in a real TestFlight/App Store build), an honest multi-device Live-Follow/Service-Mode section (the LAN-direct remote is Phase-2 design-only per `IHLive/LiveFollowEngine.swift`'s own header — zero `NWBrowser`/Bonjour code exists yet — and the server-mediated engine is itself only a Phase-0 freshness-check skeleton with no UI wired to it), Accessibility Inspector + Environment Overrides for VoiceOver/Dynamic Type/contrast, real-device run steps, and a limitations table).
+> Last updated **2026-07-11** (added **§1.5 — Direct macOS DMG distribution**, #1510: a new signed + notarized `.dmg` GitHub Release pipeline, `.github/workflows/apple-dmg.yml`, gated behind its own `APPLE_DMG_ENABLED` kill-switch and two new secrets — entirely DORMANT/additive, does not change anything below). Previously (2026-07-10): in-app account deletion shipped — #1478; web Sign in with Apple W1–W3 + the §1.4 activation steps + its CSP allowance — #1471/#1480/#1484; version now **0.2750.0**; incorporates the owner Q&A corrections: Family Sharing N/A, APNs deferred, private-relay email optional; **CarPlay entitlement GRANTED** — §1.3 Step 4 rewritten for the enable steps; **§2 distribution-readiness walkthrough expanded to full click-by-click steps**; **CI/CD pipeline hardening** — `project.yml` now declares `INFOPLIST_KEY_ITSAppUsesNonExemptEncryption: NO` on `iHymns`+`iHymnsTV` (§2.2.B.1/§2.3.A.4 now DONE), and every "AASA returns 200" verification step below is **corrected**: a bare `200` is NOT proof the real responder is live — `beta.ihymns.app`/`ihymns.app`/`www.ihymns.app` all return `200` today but still serve a **stale legacy AASA with the WRONG appID**; only `dev.ihymns.app` serves the real one — see §1.2 Step 6, §2.1, §2.3.A.2, and the Verification-walkthrough Bucket B; **§2.4 expanded into a full click-by-click Simulator + real-device testing walkthrough** — project generation, per-platform Simulator runs (incl. the honest finding that `iHymnsTV`/`iHymnsWatch` still render only the Phase-0 `PhaseZeroSkeletonView` placeholder today, not real screens), the native macOS "Designed for iPad" run, the `APIEnvironment` runtime override (verified `DEBUG`-only, so it does NOT exist in a real TestFlight/App Store build), an honest multi-device Live-Follow/Service-Mode section (the LAN-direct remote is Phase-2 design-only per `IHLive/LiveFollowEngine.swift`'s own header — zero `NWBrowser`/Bonjour code exists yet — and the server-mediated engine is itself only a Phase-0 freshness-check skeleton with no UI wired to it), Accessibility Inspector + Environment Overrides for VoiceOver/Dynamic Type/contrast, real-device run steps, and a limitations table).
 
 ---
 
@@ -170,6 +170,50 @@
 > **Why it's not all migrations:** the Services ID + Website URLs (Steps 1–2) are Apple-portal identity artifacts PHP cannot create; the enable/config (Step 4) is a `tblAppSettings` write, not a schema change. Only Step 3 is an actual migration — and it's usually already done.
 
 > **Web sign-in does NOT need the `.p8` / Team ID / Key ID** (unlike the *native* revoke path in §1.2). The web flow authenticates by verifying Apple's `id_token` against Apple's **public** JWKS (`appleSiwaVerifyIdentityToken()`) — no secret required — so Steps 1–4 are sufficient for sign-in. The `authorizationCode`→token exchange that *does* use the `.p8` is best-effort and only captures a **refresh token**; without it, sign-in still succeeds and only the **account-deletion Apple-revoke** for web users degrades to `skipped_no_token`. Provision the `.p8`/Team ID/Key ID (same creds as native) before **production** for a complete revoke path — not a blocker for alpha.
+
+---
+
+## §1.5 — Direct macOS DMG distribution (#1510)
+
+> **Owner-only, DORMANT until you complete these steps.** The App Store ("Designed for iPad" compatibility, §2.3.D) is the **primary** way people get iHymns on a Mac. This section adds a **second, independent** channel: a signed + notarized `.dmg` published as a **GitHub Release asset**, for anyone you want to hand the app to directly (no App Store account, no review wait). Pipeline: `.github/workflows/apple-dmg.yml`. It runs **nothing** until you complete every step below — it is gated behind its own kill-switch variable, separate from `apple-deploy.yml`'s.
+
+### Step 1 — Create a Developer ID Application certificate *(a DIFFERENT identity from the one §2.2.A.3 already created)*
+
+> ⚠️ **Do not reuse the "Apple Distribution" certificate from §2.2.A.3.** TestFlight/App Store uploads and direct (outside-the-App-Store) distribution use two genuinely different Apple certificate *types* — Xcode's Developer-ID export step specifically looks for a **Developer ID Application** identity.
+
+1. **developer.apple.com/account** → **Certificates, Identifiers & Profiles** → **Certificates** → **➕**.
+2. Choose **Developer ID Application** (listed under "Software" — NOT "Apple Distribution" or "Apple Development").
+3. Follow Apple's CSR prompt — on a Mac: **Keychain Access → Certificate Assistant → Request a Certificate from a Certificate Authority…** → save the `.certSigningRequest` → upload it on Apple's page.
+4. **Download** the resulting `.cer` → double-click to install it into **Keychain Access** (login keychain) → right-click the new certificate → **Export "Developer ID Application: …"…** → save as a **`.p12`**, choosing an export password when prompted.
+5. **Good** = you're holding a `.p12` file and its password. Store both in your password manager — the `.p12` itself only needs to live in the GitHub secret afterward, not on disk.
+
+### Step 2 — Base64-encode the `.p12` and paste it into GitHub
+
+1. On the Mac holding the `.p12`: `base64 -i "Developer ID Application.p12" | pbcopy`.
+2. **GitHub web UI** (this project's standing preference — visual confirmation per secret, nothing passes through a CLI): repo → **Settings → Secrets and variables → Actions → Secrets tab → New repository secret**.
+
+   | Secret name | Value / where it comes from |
+   |---|---|
+   | `APPLE_DEVELOPER_ID_CERT` | the base64 text just copied (the WHOLE output, not the raw `.p12` binary) |
+   | `APPLE_DEVELOPER_ID_CERT_PASSWORD` | the export password from Step 1.5 |
+
+3. **Good** = both secret names show under **Settings → Secrets and variables → Actions** (values stay hidden after saving — expected). These are **new** secrets, distinct from the nine `apple-deploy.yml` already reads (§2.2.A.4) — the workflow never touches those.
+
+### Step 3 — Flip the kill-switch variable
+
+1. Same screen, **Variables** tab instead of **Secrets** → **New repository variable**.
+2. **Name**: `APPLE_DMG_ENABLED`. **Value**: `true`.
+3. **Good** = the very next manual run (or `v*` tag push) of "Apple macOS DMG" actually archives/notarizes/publishes instead of the `build` job showing **Skipped**. Leave this **unset** (or anything other than `true`) until Steps 1–2 are both done — the workflow's own `guard` job posts a `::notice::` on every run stating whether it's enabled or disabled, so you always know which state you're in without opening the skipped job.
+
+### Step 4 — Run it
+
+- **Manual**: repo → **Actions** tab → **Apple macOS DMG** (left sidebar) → **Run workflow** → optionally fill in a **tag** (e.g. `v0.2500.0-macos`) to name the Release; leave blank and it generates a timestamped tag automatically.
+- **Automatic**: push a `v*`-shaped git tag (e.g. `git tag v0.2500.0 && git push origin v0.2500.0`) — no path filter, so any tag push triggers it once the kill-switch is on.
+- **Good** = a new entry appears under repo → **Releases**, with `iHymns.dmg` attached as a downloadable asset. Anyone downloading it, double-clicking, and dragging the app to `/Applications` should see Gatekeeper open it without a warning (notarization + stapling verified) — try this yourself once on a **different** Mac (or one that's never trusted your Developer ID before) before handing it out widely.
+
+### Not yet verified — read before relying on this for a real release
+
+The build agent could not exercise this pipeline end-to-end (no real Mac / real Apple Developer assets available in that session) — `.github/workflows/apple-dmg.yml`'s own header comment flags the specific open questions (exact archive destination string, whether manual signing needs a Developer-ID provisioning profile because of the Associated-Domains entitlement, DMG tool choice). **Run it once yourself and watch the log carefully** before treating a future tag push as a routine, unattended release step.
 
 ---
 

--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -13276,6 +13276,7 @@ if ($action !== null) {
             $deact = $db->prepare('UPDATE tblLiveFollowSessions SET IsActive = 0 WHERE HostUserId = ? AND IsActive = 1');
             $deact->bind_param('i', $userId);
             $deact->execute();
+            $superseded = $deact->affected_rows > 0;
             $deact->close();
 
             /* Crockford-ish base32, no ambiguous glyphs (no I/L/O/U/0/1). */
@@ -13305,6 +13306,14 @@ if ($action !== null) {
                 }
             }
             if (!$inserted) { sendJson(['error' => 'Could not allocate a session code, please retry.'], 503); break; }
+
+            /* §3.2 breadcrumb — numeric Id only, never the SessionCode. */
+            $newSessionId = (int)$db->insert_id;
+            logActivity('live.session.create', 'live_session', (string)$newSessionId, [
+                'superseded'  => $superseded,
+                'has_setlist' => $setlistId !== null,
+                'has_song'    => $songId !== null,
+            ]);
 
             sendJson(['ok' => true, 'code' => $code, 'revision' => 0]);
             break;
@@ -13345,6 +13354,15 @@ if ($action !== null) {
             $chkSong->close();
             if (!$songOk) { sendJson(['error' => 'Unknown song.'], 400); break; }
 
+            /* §3.2 breadcrumb prep — resolve the numeric Id + the PRE-update
+               CurrentSongId so a genuine song change (vs a component-index-only
+               nudge) can be detected after the write; IDs only, never the code. */
+            $preSel = $db->prepare('SELECT Id, CurrentSongId FROM tblLiveFollowSessions WHERE SessionCode = ? AND HostUserId = ? AND IsActive = 1');
+            $preSel->bind_param('si', $code, $userId);
+            $preSel->execute();
+            $preRow = $preSel->get_result()->fetch_assoc();
+            $preSel->close();
+
             $upd = $db->prepare(
                 'UPDATE tblLiveFollowSessions
                     SET CurrentSongId = ?, CurrentComponentIndex = ?, StateJson = ?,
@@ -13358,6 +13376,10 @@ if ($action !== null) {
             $changed = $upd->affected_rows;
             $upd->close();
             if ($changed === 0) { sendJson(['ok' => false, 'error' => 'Session not found, not yours, or ended.'], 409); break; }
+
+            if ($preRow && (string)($preRow['CurrentSongId'] ?? '') !== (string)$songId) {
+                logActivity('live.broadcast.song', 'live_session', (string)$preRow['Id'], ['song_id' => $songId]);
+            }
 
             $sel = $db->prepare('SELECT StateRevision FROM tblLiveFollowSessions WHERE SessionCode = ? AND HostUserId = ?');
             $sel->bind_param('si', $code, $userId);
@@ -13421,10 +13443,23 @@ if ($action !== null) {
             if (!preg_match('/^[A-Z0-9]{4,12}$/', $code)) { sendJson(['error' => 'Invalid session code.'], 400); break; }
 
             $db = getDbMysqli();
+
+            /* §3.2 breadcrumb prep — resolve the numeric Id before ending so the
+               log carries an id, never the SessionCode. */
+            $endSel = $db->prepare('SELECT Id FROM tblLiveFollowSessions WHERE SessionCode = ? AND HostUserId = ?');
+            $endSel->bind_param('si', $code, $userId);
+            $endSel->execute();
+            $endRow = $endSel->get_result()->fetch_assoc();
+            $endSel->close();
+
             $end = $db->prepare('UPDATE tblLiveFollowSessions SET IsActive = 0 WHERE SessionCode = ? AND HostUserId = ?');
             $end->bind_param('si', $code, $userId);
             $end->execute();
             $end->close();
+
+            if ($endRow) {
+                logActivity('live.session.end', 'live_session', (string)$endRow['Id'], []);
+            }
 
             sendJson(['ok' => true]);
             break;
@@ -13455,7 +13490,7 @@ if ($action !== null) {
                with Service Mode; keep this literal in sync. #1386 */
             $channel = serviceMode_channel();
             $stmt = $db->prepare(
-                'SELECT s.CurrentSongId, s.CurrentComponentIndex, s.StateJson, s.StateRevision,
+                'SELECT s.Id, s.CurrentSongId, s.CurrentComponentIndex, s.StateJson, s.StateRevision,
                         u.DisplayName AS HostName
                    FROM tblLiveFollowSessions s
                    JOIN tblUsers u ON u.Id = s.HostUserId
@@ -13469,13 +13504,21 @@ if ($action !== null) {
 
             /* Identical message for missing / expired / wrong code so liveness
                can't be probed cheaply (combined with the rate limit). */
-            if (!$row) { sendJson(['ok' => false, 'error' => 'Session not found or ended.'], 404); break; }
+            if (!$row) {
+                /* §3.2 breadcrumb — no numeric id to log (nothing matched); the
+                   reason is generic on purpose (never the code, never "wrong
+                   code" vs "expired" — that would re-open the anti-probe leak). */
+                logActivity('live.session.join', 'live_session', '', ['reason' => 'not_found_or_stale'], 'failure');
+                sendJson(['ok' => false, 'error' => 'Session not found or ended.'], 404); break;
+            }
 
             /* Mint a per-follower token (16 random bytes → 32 hex chars). It is
                STATELESS — nothing is persisted server-side; it exists purely so
                the poll endpoint can bucket the rate limiter per follower instead
                of per shared NAT IP. The session CODE stays the access control. */
             $followToken = bin2hex(random_bytes(16));
+
+            logActivity('live.session.join', 'live_session', (string)$row['Id'], []);
 
             sendJson([
                 'ok'              => true,
@@ -13590,7 +13633,10 @@ if ($action !== null) {
 
             $canOperate = ($role === 'global_admin' || $role === 'admin')
                 || in_array($orgId, userIsOrgAdminOf($userId), true);
-            if (!$canOperate) { sendJson(['error' => 'Not authorised for this organisation.'], 403); break; }
+            if (!$canOperate) {
+                logActivity('service.session.start', 'organisation', (string)$orgId, ['reason' => 'not_authorised', 'venue_id' => $venueId], 'failure');
+                sendJson(['error' => 'Not authorised for this organisation.'], 403); break;
+            }
 
             /* Schedule (if given) must belong to the venue → start/duration/tz. */
             $startTime = '10:00:00'; $duration = 90; $schedTz = $venueTz; $scheduleIdN = null;
@@ -13616,6 +13662,7 @@ if ($action !== null) {
             );
             $deact->bind_param('sisi', $channel, $venueId, $occDate, $scheduleIdN);
             $deact->execute();
+            $superseded = $deact->affected_rows > 0;
             $deact->close();
 
             /* Insert the session (SessionKind=service; SessionCode is the spine's
@@ -13643,7 +13690,14 @@ if ($action !== null) {
             if ($newSessionId === 0) { sendJson(['error' => 'Could not start the session, please retry.'], 503); break; }
 
             $code = serviceMode_mintCode($db, $newSessionId);
-            logActivity('service.session.start', 'organisation', (string)$orgId, ['session_id' => $newSessionId, 'venue_id' => $venueId, 'channel' => $channel]);
+            logActivity('service.session.start', 'organisation', (string)$orgId, [
+                'session_id'       => $newSessionId,
+                'venue_id'         => $venueId,
+                'channel'          => $channel,
+                'schedule_id'      => $scheduleIdN,
+                'occurrence_date'  => $occDate,
+                'superseded'       => $superseded,
+            ]);
             sendJson(['ok' => true, 'sessionId' => $newSessionId, 'code' => $code, 'occurrenceEnd' => $endUtc]);
             break;
         }
@@ -13651,8 +13705,9 @@ if ($action !== null) {
         case 'service_code_rotate':
         case 'service_code_current':
         case 'service_session_end': {
-            $isRotate = ($action === 'service_code_rotate');
-            $isEnd    = ($action === 'service_session_end');
+            $isRotate  = ($action === 'service_code_rotate');
+            $isEnd     = ($action === 'service_session_end');
+            $isCurrent = ($action === 'service_code_current');
             if (($isRotate || $isEnd) && $_SERVER['REQUEST_METHOD'] !== 'POST') { sendJson(['error' => 'POST method required.'], 405); break; }
             $authUser = getAuthenticatedUser();
             if (!$authUser) { sendJson(['error' => 'Not authenticated.'], 401); break; }
@@ -13676,12 +13731,32 @@ if ($action !== null) {
             $sstmt->execute();
             $sess = $sstmt->get_result()->fetch_assoc();
             $sstmt->close();
-            if (!$sess) { sendJson(['error' => 'Unknown session.'], 404); break; }
+            if (!$sess) {
+                /* §3.2 breadcrumb — failures only for rotate/current (the
+                   service_session_end 404 is unchanged, no entry requested).
+                   OrgId is unresolved (no matching session), so entityId is
+                   empty — the reason + session_id are the useful signal. */
+                if ($isRotate || $isCurrent) {
+                    logActivity(
+                        $isRotate ? 'service.code.rotate' : 'service.code.current',
+                        'organisation', '', ['session_id' => $sessionId, 'reason' => 'unknown_session'], 'failure'
+                    );
+                }
+                sendJson(['error' => 'Unknown session.'], 404); break;
+            }
             $orgId = (int)$sess['OrgId'];
             $canOperate = ($role === 'global_admin' || $role === 'admin')
                 || (int)$sess['HostUserId'] === $userId
                 || in_array($orgId, userIsOrgAdminOf($userId), true);
-            if (!$canOperate) { sendJson(['error' => 'Not authorised.'], 403); break; }
+            if (!$canOperate) {
+                if ($isRotate || $isCurrent) {
+                    logActivity(
+                        $isRotate ? 'service.code.rotate' : 'service.code.current',
+                        'organisation', (string)$orgId, ['session_id' => $sessionId, 'reason' => 'not_authorised'], 'failure'
+                    );
+                }
+                sendJson(['error' => 'Not authorised.'], 403); break;
+            }
 
             if ($isEnd) {
                 $db->begin_transaction();
@@ -13699,7 +13774,10 @@ if ($action !== null) {
             }
 
             if ($isRotate) {
-                if ((int)$sess['IsActive'] !== 1) { sendJson(['error' => 'Session is not active.'], 409); break; }
+                if ((int)$sess['IsActive'] !== 1) {
+                    logActivity('service.code.rotate', 'organisation', (string)$orgId, ['session_id' => $sessionId, 'reason' => 'session_not_active'], 'failure');
+                    sendJson(['error' => 'Session is not active.'], 409); break;
+                }
                 /* The rotate doubles as a heartbeat keeping the session fresh. */
                 $hb = $db->prepare('UPDATE tblLiveFollowSessions SET LastHeartbeatAt = UTC_TIMESTAMP() WHERE Id = ?');
                 $hb->bind_param('i', $sessionId); $hb->execute(); $hb->close();
@@ -13732,6 +13810,7 @@ if ($action !== null) {
                     $code = serviceMode_mintCode($db, $sessionId);
                     sendJson(['ok' => true, 'code' => $code]);
                 } else {
+                    logActivity('service.code.current', 'organisation', (string)$orgId, ['session_id' => $sessionId, 'reason' => 'session_not_active'], 'failure');
                     sendJson(['ok' => false, 'error' => 'Session not active.'], 409);
                 }
                 break;
@@ -13770,17 +13849,26 @@ if ($action !== null) {
 
             $db = getDbMysqli();
             $channel = serviceMode_channel();
-            $sstmt = $db->prepare("SELECT OrgId, HostUserId FROM tblLiveFollowSessions WHERE Id = ? AND SessionKind = 'service' AND Channel = ? AND IsActive = 1");
+            /* CurrentSongId added to the SELECT (§3.2) so a genuine song change
+               can be detected below without a second round-trip. */
+            $sstmt = $db->prepare("SELECT OrgId, HostUserId, CurrentSongId FROM tblLiveFollowSessions WHERE Id = ? AND SessionKind = 'service' AND Channel = ? AND IsActive = 1");
             $sstmt->bind_param('is', $sessionId, $channel);
             $sstmt->execute();
             $sess = $sstmt->get_result()->fetch_assoc();
             $sstmt->close();
-            if (!$sess) { sendJson(['error' => 'Unknown or ended session.'], 404); break; }
+            if (!$sess) {
+                /* OrgId is unresolved (no matching session) — entityId empty. */
+                logActivity('service.broadcast.song', 'organisation', '', ['session_id' => $sessionId, 'reason' => 'unknown_or_ended'], 'failure');
+                sendJson(['error' => 'Unknown or ended session.'], 404); break;
+            }
             $orgId = (int)$sess['OrgId'];
             $canOperate = ($role === 'global_admin' || $role === 'admin')
                 || (int)$sess['HostUserId'] === $userId
                 || in_array($orgId, userIsOrgAdminOf($userId), true);
-            if (!$canOperate) { sendJson(['error' => 'Not authorised.'], 403); break; }
+            if (!$canOperate) {
+                logActivity('service.broadcast.song', 'organisation', (string)$orgId, ['session_id' => $sessionId, 'reason' => 'not_authorised'], 'failure');
+                sendJson(['error' => 'Not authorised.'], 403); break;
+            }
 
             if ($songId !== null) {
                 $chk = $db->prepare('SELECT 1 FROM tblSongs WHERE SongId = ? LIMIT 1');
@@ -13788,7 +13876,10 @@ if ($action !== null) {
                 $chk->execute();
                 $ok = $chk->get_result()->fetch_row() !== null;
                 $chk->close();
-                if (!$ok) { sendJson(['error' => 'Unknown song.'], 400); break; }
+                if (!$ok) {
+                    logActivity('service.broadcast.song', 'organisation', (string)$orgId, ['session_id' => $sessionId, 'reason' => 'unknown_song'], 'failure');
+                    sendJson(['error' => 'Unknown song.'], 400); break;
+                }
             }
 
             $upd = $db->prepare(
@@ -13805,6 +13896,12 @@ if ($action !== null) {
             $rev->execute();
             $revision = (int)($rev->get_result()->fetch_assoc()['StateRevision'] ?? 0);
             $rev->close();
+
+            /* §3.2 — song-change only, never on a component-index-only nudge. */
+            if ($songId !== null && (string)($sess['CurrentSongId'] ?? '') !== (string)$songId) {
+                logActivity('service.broadcast.song', 'organisation', (string)$orgId, ['session_id' => $sessionId, 'song_id' => $songId, 'channel' => $channel]);
+            }
+
             sendJson(['ok' => true, 'revision' => $revision]);
             break;
         }
@@ -13833,7 +13930,9 @@ if ($action !== null) {
             $channel = serviceMode_channel();
             $sess = serviceMode_resolveJoin($db, $code, $venueId, $channel);
             if (!$sess) {
-                /* Opaque — don't distinguish wrong/expired/unknown (anti-probe). */
+                /* Opaque — don't distinguish wrong/expired/unknown (anti-probe).
+                   §3.2 breadcrumb: OrgId is unresolved, never the code. */
+                logActivity('service.presence.join', 'organisation', '', ['reason' => 'code_not_active', 'channel' => $channel], 'failure');
                 sendJson(['ok' => false, 'error' => 'That code isn’t active. Check the screen and try again.'], 404);
                 break;
             }
@@ -13886,6 +13985,9 @@ if ($action !== null) {
             }
             $ins->execute();
             $ins->close();
+
+            /* §3.2 breadcrumb — never the presence device id, only ids/channel. */
+            logActivity('service.presence.join', 'organisation', $orgId !== null ? (string)$orgId : '', ['session_id' => $sessionId, 'channel' => $channel]);
 
             sendJson([
                 'ok' => true,
@@ -13962,11 +14064,29 @@ if ($action !== null) {
             $token = (string)(($body = json_decode(file_get_contents('php://input'), true)) && is_array($body) ? ($body['presenceToken'] ?? '') : '');
             if (!preg_match('/^[A-Za-z0-9_\-]{43}$/', $token)) { sendJson(['ok' => true]); break; }
             $db = getDbMysqli();
+
+            /* §3.2 breadcrumb prep — resolve session/org/channel from the
+               presence row BEFORE revoking; IDs only, never the token. */
+            $leaveSel = $db->prepare('SELECT SessionId, OrgId, Channel FROM tblServicePresence WHERE PresenceToken = ?');
+            $leaveSel->bind_param('s', $token);
+            $leaveSel->execute();
+            $leaveRow = $leaveSel->get_result()->fetch_assoc();
+            $leaveSel->close();
+
             /* Immediate gate revocation. */
             $upd = $db->prepare('UPDATE tblServicePresence SET IsActive = 0 WHERE PresenceToken = ?');
             $upd->bind_param('s', $token);
             $upd->execute();
             $upd->close();
+
+            if ($leaveRow) {
+                $leaveOrgId = $leaveRow['OrgId'] !== null ? (string)(int)$leaveRow['OrgId'] : '';
+                logActivity('service.presence.leave', 'organisation', $leaveOrgId, [
+                    'session_id' => $leaveRow['SessionId'] !== null ? (int)$leaveRow['SessionId'] : null,
+                    'channel'    => (string)($leaveRow['Channel'] ?? ''),
+                ]);
+            }
+
             sendJson(['ok' => true]);
             break;
         }


### PR DESCRIPTION
Second consolidated PR (no stacking) — the observability + DMG deferred bundle. **3 commits.** All verified: `php -l` clean, `swift build`/`swift test` green (522 tests), actionlint + YAML clean, security spot-checks clean.

Closes #1505, #1510.

## Observability (per `.claude/live-observability-strategy.md`)
- **§3.2 backend breadcrumbs** (`6ae8fcb4`) — completes the deferred half of Apple Phase-2 PR-1: `logActivity` lifecycle breadcrumbs on the live/service endpoints (`live.session.create/join/end`, `live.broadcast.song` song-change-only, `service.broadcast.song` + failures, `service.presence.join/leave`, `service_code_rotate/current` failures, `service.session.start` extended). **IDs only — never a code/token/digest** (verified); polls never logged.
- **P1 `IHLog` Swift facility + retrofit (#1505)** (`a126aa3e`) — new zero-dep `IHLog` SwiftPM target (subsystem `app.ihymns`; categories api/live-follow/remote/discovery/auth; `OSSignposter`; `IHLogSanitize.tokenFingerprint` never-for-codes) + `IHLogTests`; retrofitted `APIClient.performOnce`/retry-loop (action-only, never the URL) + `SessionController` sign-in/out transitions (userId `.private`). Hardened `APIError` so associated values can't leak into logs. **swift test: 522 pass.**

## Distribution
- **macOS DMG packaging (#1510)** (`4e9cfcf0`) — new `.github/workflows/apple-dmg.yml`: archive the Designed-for-iPad macOS build, export a Developer-ID `.app`, `hdiutil` DMG, `notarytool` + `stapler`, publish as a GitHub Release asset. **Dormant/gated** behind a new `vars.APPLE_DMG_ENABLED` kill-switch (default OFF, mirrors #1494) with an always-on guard `::notice::`. New secrets documented: `APPLE_DEVELOPER_ID_CERT` (+ password). Runbook `§1.5` added with the owner provisioning steps. Honestly flags 3 items unverifiable without a provisioned Developer-ID cert + real Mac (archive destination, manual-signing choice, DMG tool).

## Deferred (still open, tracked)
Diagnostics overlay #1506 (premature — diagnoses live-session state the Phase-2 engines don't produce yet); Apple Phase-2 PRs 2-17; exhaustive security fan-out + deep Wiki/Milestone/in-app-help refresh.
