### PR TITLE
docs(handoff): mark batches 1+2 merged, refresh resume point

### DIFF
--- a/.claude/sessions/2026-07-11-HANDOFF.md
+++ b/.claude/sessions/2026-07-11-HANDOFF.md
@@ -22,8 +22,8 @@ Bumped **0.2501.0 → 0.2750.0 → 0.4000.0** across the session (`infoAppVer.ph
 ## Issue reconciliation done this session
 - Open-issue audit (workflow, 180 plausibly-done): closed **10** completed-but-open with evidence, status-commented **67**, 71 future/parked confirmed open. Closed-issue audit (70 recent): all correctly closed, 0 reopens.
 
-## ★ RESUME POINT — branch `feat/admin-batch-2026-07-11` (NOT pushed, needs ONE PR to alpha)
-Per owner's **no-stacking** directive, ALL of the following is on ONE branch for ONE PR. **13 commits**:
+## Batch 1 — ✅ MERGED as PR #1511 (v0.4000.0) — branch `feat/admin-batch-2026-07-11`, 13 commits
+Per owner's **no-stacking** directive, all of the following landed as ONE PR. **13 commits**:
 - **Credit People / admin bundle** (verified: lint + schema CI guards + SQL-safe + CSRF/authz + live-DB tested by the agents):
   - #1500 merge-target live-search typeahead (new `?action=merge_target_search` GET, bind_param) — replaces the unusable `<select>`.
   - #1501 optional maiden-surname field + `migrate-add-creditperson-maiden-surname.php` + schema.sql + registry.
@@ -39,15 +39,18 @@ Per owner's **no-stacking** directive, ALL of the following is on ONE branch for
 - **Version 0.4000.0** + CHANGELOG.
 - **All three strategy docs** committed.
 
-### To resume: push `feat/admin-batch-2026-07-11` → ONE PR to alpha, `Closes #1498 #1500 #1501 #1502 #1503 #1507 #1508 #1509` (+ Phase-2 #1405/#1406, and the schema batch dormant for #1407-1410). Then the **OPERATOR runs the 3 new migration cards** on `/manage/setup-database` (maiden-surname, creditperson-members, apple-phase2-live-schema) — they are additive/dormant/idempotent.
+**✅ MERGED as PR #1511.** Remaining **OPERATOR action**: run the 3 additive/dormant/idempotent migration cards on `/manage/setup-database` — maiden-surname, creditperson-members, apple-phase2-live-schema.
 
-## DEFERRED (budget-paced; tracked as open issues — pick up next session)
-- **Observability P1 `IHLog` Swift target + retrofit (#1505)** and **P2 diagnostics overlay (#1506)** — Swift, planned in `live-observability-strategy.md`.
-- **§3.2 Activity-Log lifecycle breadcrumbs** (the other half of Phase-2 PR-1 commit 4) — ~13 additive `logActivity` calls on the live/service endpoints; note filed on the observability work.
-- **macOS DMG packaging via GitHub Actions (#1510)** — Developer-ID sign + `notarytool` + `stapler` + Release asset; gate under the #1494 kill-switch.
-- **Full exhaustive codebase security fan-out** + **deep Wiki/Project/Milestone update** + **full in-app help/guide audit** — the owner's B2/B3/B4 wrap-up asks at full scope; this session did a *targeted* security review of the batch diff (clean) + CHANGELOG/README refresh only.
-- **Apple Phase 2 PRs 2–17** — the rest of the Phase-2 plan (LAN remote, congregant clients, Live Activities).
-- **HELD for owner go-ahead:** the production-promotion execution (every step outward/destructive).
+## Batch 2 — ✅ MERGED as PR #1512 — branch `feat/observability-dmg-2026-07-11`, 3 commits
+- **§3.2 Activity-Log lifecycle breadcrumbs** (`6ae8fcb4`) — completes Phase-2 PR-1's deferred half; live/service endpoints, **IDs-only**, polls never logged, verified secret-free.
+- **Observability P1 `IHLog` Swift facility + retrofit (#1505)** (`a126aa3e`) — new zero-dep `IHLog` target (subsystem `app.ihymns`; categories api/live-follow/remote/discovery/auth; `IHLogSanitize.tokenFingerprint` never-for-codes) + `APIClient`/`SessionController` retrofit (action-only, never URL/token) + `IHLogTests`; hardened `APIError`. **`swift test`: 522 pass.**
+- **macOS DMG packaging (#1510)** (`4e9cfcf0`) — dormant/gated `.github/workflows/apple-dmg.yml` (kill-switch `vars.APPLE_DMG_ENABLED` default-OFF; Developer-ID sign + `notarytool` + `stapler` + Release asset) + runbook `§1.5` owner steps. New secrets to provision: `APPLE_DEVELOPER_ID_CERT` (+ password).
+
+## ★ STILL DEFERRED (budget-paced; tracked as open issues — the resume point)
+- **Observability P2 diagnostics overlay (#1506)** — Swift; deferred as **premature** (nothing live to diagnose until the Phase-2 engines exist). Planned in `live-observability-strategy.md` §2.6.
+- **Apple Phase 2 PRs 3–17** — the rest of the plan (`.claude/apple-phase2-implementation-plan.md`): device-code pairing endpoints (#1407, the `tblAuthDeviceCodes` table is already live-dormant) + `/link` page, LAN-direct TV remote (IHRP/1 + actors + pairing, #1420-1424), native congregant clients (#1426/#1427), the shared tvOS projection canvas (#1504, unfiled-prereq for #1421/#1428), Live Activities (#1429). **PR-1 (backend foundation) + PR-2 (IHLog) are DONE.**
+- **Full exhaustive codebase security fan-out** ("repeat until clean") + **deep Wiki/Project/Milestone update** + **full in-app help/guide audit** — the owner's B2/B3/B4 at full scope. Done so far: a *targeted* clean security review of both batches; CHANGELOG/README refresh; a **Wiki refresh for both batches** (pushed to `iHymns.wiki` master).
+- **HELD for owner go-ahead:** production-promotion execution (every step outward/destructive — see `.claude/production-readiness-sequence.md`).
 
 ## Notes
 - The stray `_cplIdentifierConfig` text the owner still saw on dev is fixed in #1499 — clears on the next alpha→dev deploy.


### PR DESCRIPTION
Updates the session handoff now that both consolidated batches merged: **#1511** (Credit-People/admin + Apple Phase-2 PR-1, v0.4000.0) and **#1512** (observability §3.2 breadcrumbs + IHLog #1505 + macOS DMG #1510). Resume/deferred sections refreshed (overlay #1506 premature; Phase-2 PRs 3–17; exhaustive security/wiki/docs; HELD production-promotion). Docs-only.