### PR TITLE
feat(auth): RFC 8628 device-code pairing endpoints + /link approval (#1407)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -438,6 +438,22 @@ jobs:
           php tests/php/test-analytics-ingest.php
 
       # -----------------------------------------------------------------------
+      # Step 5m: RFC 8628 device-code pairing (#1407)
+      # Exercises the pure user_code minter/normaliser (Crockford alphabet
+      # round-trip, invalid-length/-glyph/-type rejection), then structurally
+      # guards api.php's five auth_device_code_* case bodies: every one is
+      # authDeviceCodesTableExists()-gated (dormancy), approve/deny call
+      # validateCsrfRequest() + require an authenticated user, and — the
+      # load-bearing privacy contract — NO logActivity() breadcrumb anywhere
+      # in the family ever references the device_code/user_code or a
+      # hash/substr of either.
+      # -----------------------------------------------------------------------
+      - name: RFC 8628 device-code pairing (#1407)
+        run: |
+          echo "Running device-code pairing helper + breadcrumb-hygiene test..."
+          php tests/php/test-device-code.php
+
+      # -----------------------------------------------------------------------
       # Step 6: Validate JSON files
       # Checks that critical JSON files are valid using Node.js
       # Validates: data/songs.json, manifest.json (in both beta and production)
@@ -640,3 +656,6 @@ jobs:
 
       - name: Analytics-ingestion validation (#1448)
         run: php tests/php/test-analytics-ingest.php
+
+      - name: RFC 8628 device-code pairing (#1407)
+        run: php tests/php/test-device-code.php

--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -424,6 +424,16 @@ if ($page !== null) {
             require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'pages' . DIRECTORY_SEPARATOR . 'settings.php';
             break;
 
+        case 'link':
+            /* RFC 8628 device-code pairing (#1407) — the page a human visits
+               (from a TV screen's on-screen URL, or a QR/`verification_uri_
+               complete` deep link) to approve a limited-input client's
+               sign-in request. Auth-required + user-specific (like
+               settings/favorites/setlist), so deliberately NOT added to
+               $_cacheablePages below. */
+            require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'pages' . DIRECTORY_SEPARATOR . 'link.php';
+            break;
+
         case 'stats':
             require __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'pages' . DIRECTORY_SEPARATOR . 'stats.php';
             break;
@@ -5245,6 +5255,312 @@ if ($action !== null) {
 
             sendJson(['ok' => true, 'deleted' => true]);
             break;
+
+        /* =================================================================
+         * RFC 8628 DEVICE-CODE PAIRING (#1407)
+         *
+         * A limited-input client (tvOS today) can't type a username/
+         * password. It POSTs `auth_device_code_request` to get a
+         * device_code (kept secret, polled with) + a short user_code
+         * (shown on-screen); a human enters that user_code at /link on a
+         * device they're already signed into and approves/denies; the
+         * limited-input client keeps POSTing `auth_device_code_poll` until
+         * it gets back a normal iHymns bearer token. Full RFC + threat
+         * model: includes/device_code.php's header doc-block.
+         *
+         * `tblAuthDeviceCodes` shipped live-dormant in #1511 — every case
+         * below is authDeviceCodesTableExists()-gated so an un-migrated
+         * docroot degrades to a clean 503 (rule #19/#28 dormancy) instead
+         * of a STRICT-mode mysqli exception on a missing table.
+         * ================================================================= */
+
+        case 'auth_device_code_request': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') { sendJson(['error' => 'invalid_request'], 405); break; }
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'device_code.php';
+            $db = getDbMysqli();
+            if (!authDeviceCodesTableExists($db)) {
+                sendJson(['error' => 'Device pairing is not available yet.'], 503); break;
+            }
+
+            /* Mint-abuse guard. No identity exists yet (that's the whole
+               point of the flow) so this is necessarily per-IP — a
+               legitimate limited-input client mints exactly once per
+               pairing attempt, so a generous cap never trips real usage. */
+            checkRateLimit('auth_device_code_request', $_SERVER['REMOTE_ADDR'] ?? '', 20, 3600, true, null);
+
+            $channel = serviceMode_channel();
+            [$deviceCode, $userCode] = deviceCode_mint($db, $channel);
+            if ($deviceCode === null) {
+                sendJson(['error' => 'Could not start pairing, please retry.'], 503); break;
+            }
+
+            /* §3.2 breadcrumb — no entity resolved yet (anonymous mint);
+               channel only, NEVER the device_code/user_code (see
+               includes/device_code.php's header doc-block). */
+            logActivity('auth.device_code.request', '', '', ['channel' => $channel]);
+
+            $verificationUri = getCanonicalUrl('/link');
+            sendJson([
+                'device_code'               => $deviceCode,
+                'user_code'                 => $userCode,
+                'verification_uri'          => $verificationUri,
+                'verification_uri_complete' => $verificationUri . '?user_code=' . rawurlencode($userCode),
+                'expires_in'                => AUTH_DEVICE_CODE_TTL_SECONDS,
+                'interval'                  => AUTH_DEVICE_CODE_POLL_INTERVAL_SECONDS,
+            ]);
+            break;
+        }
+
+        case 'auth_device_code_poll': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') { sendJson(['error' => 'invalid_request'], 405); break; }
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'device_code.php';
+            $db = getDbMysqli();
+            if (!authDeviceCodesTableExists($db)) {
+                sendJson(['error' => 'temporarily_unavailable'], 503); break;
+            }
+
+            $body = json_decode(file_get_contents('php://input'), true);
+            if (!is_array($body)) { $body = []; }
+            $deviceCode = (string)($body['device_code'] ?? '');
+            if (!preg_match('/^[a-f0-9]{64}$/', $deviceCode)) {
+                sendJson(['error' => 'invalid_request'], 400); break;
+            }
+            $hash = hash('sha256', $deviceCode);
+
+            /* Rate-limit PER DEVICE-CODE (hashed), NEVER per-IP (rule #26)
+               — several limited-input devices can legitimately share one
+               IP (e.g. a church media room), and this must not throttle
+               device B because device A is polling. */
+            checkRateLimit('auth_device_code_poll', 'devcode:' . substr($hash, 0, 24), 120, 60, true, null);
+
+            $channel  = serviceMode_channel();
+            $interval = AUTH_DEVICE_CODE_POLL_INTERVAL_SECONDS;
+            /* Expiry + slow_down are both computed SQL-side (UTC_TIMESTAMP()/
+               TIMESTAMPDIFF) rather than pulled into PHP and compared with
+               strtotime() — avoids any PHP-vs-SQL clock-drift class of bug
+               (the same discipline read_rate_limit.php's header documents). */
+            $stmt = $db->prepare(
+                'SELECT Id, Status, UserId,
+                        (ExpiresAt <= UTC_TIMESTAMP()) AS IsExpired,
+                        (LastPolledAt IS NOT NULL AND TIMESTAMPDIFF(SECOND, LastPolledAt, UTC_TIMESTAMP()) < ?) AS TooFast
+                   FROM tblAuthDeviceCodes WHERE DeviceCodeHash = ? AND Channel = ? LIMIT 1'
+            );
+            $stmt->bind_param('iss', $interval, $hash, $channel);
+            $stmt->execute();
+            $row = $stmt->get_result()->fetch_assoc();
+            $stmt->close();
+
+            if (!$row) {
+                /* Opaque — unknown device_code (never seen / already pruned)
+                   reads identically to "expired" (anti-probe, RFC 8628 §3.5). */
+                sendJson(['error' => 'expired_token'], 400); break;
+            }
+
+            $id      = (int)$row['Id'];
+            $status  = (string)$row['Status'];
+            $expired = (bool)$row['IsExpired'];
+            $tooFast = (bool)$row['TooFast'];
+
+            /* Every poll (incl. a slow_down/expired one) bumps the
+               counters — PollCount is an observability signal, and
+               LastPolledAt is what the NEXT poll's TooFast calc reads. */
+            $bump = $db->prepare('UPDATE tblAuthDeviceCodes SET PollCount = PollCount + 1, LastPolledAt = UTC_TIMESTAMP() WHERE Id = ?');
+            $bump->bind_param('i', $id);
+            $bump->execute();
+            $bump->close();
+
+            if ($tooFast) {
+                sendJson(['error' => 'slow_down'], 400); break;
+            }
+
+            /* Expiry is authoritative over Status (RFC 8628 §3.4/§3.5) — an
+               approved-but-now-expired grant must never still be
+               exchangeable. Lazily flip a still-pending row to 'expired'
+               for observability; best-effort, not required for correctness
+               (the IsExpired check above is what actually gates the reply). */
+            if ($expired) {
+                if ($status === 'pending') {
+                    $exp = $db->prepare("UPDATE tblAuthDeviceCodes SET Status = 'expired' WHERE Id = ? AND Status = 'pending'");
+                    $exp->bind_param('i', $id); $exp->execute(); $exp->close();
+                }
+                sendJson(['error' => 'expired_token'], 400); break;
+            }
+
+            if ($status === 'pending')  { sendJson(['error' => 'authorization_pending'], 400); break; }
+            if ($status === 'denied')   { sendJson(['error' => 'access_denied'], 400); break; }
+            if ($status !== 'approved') { sendJson(['error' => 'expired_token'], 400); break; } /* consumed | unknown */
+
+            /* Atomic single-use consume. The UPDATE's WHERE clause — not the
+               SELECT above — is the actual race guard: InnoDB serialises
+               concurrent UPDATEs against the same row, so of two
+               near-simultaneous polls at most one ever sees affected_rows
+               > 0. The loser falls through to the SAME expired_token reply
+               a genuine replay gets (opaque — never distinguishes "already
+               consumed" from "never was approved"). */
+            $consume = $db->prepare("UPDATE tblAuthDeviceCodes SET Status = 'consumed' WHERE Id = ? AND Status = 'approved'");
+            $consume->bind_param('i', $id);
+            $consume->execute();
+            $won = $consume->affected_rows > 0;
+            $consume->close();
+            if (!$won) {
+                sendJson(['error' => 'expired_token'], 400); break;
+            }
+
+            $userId  = (int)($row['UserId'] ?? 0);
+            $userRow = $userId > 0 ? _authAppleFetchActiveUser($db, $userId) : null;
+            if ($userRow === null) {
+                /* Integrity guard — an approved row must always carry a
+                   UserId, and that user must still be active. Extremely
+                   unlikely (the account would have to be disabled/deleted
+                   in the seconds between /link approval and this poll) but
+                   never silently mints a token for a stale/absent account. */
+                logActivity('auth.device_code.consume', 'user', (string)$userId, ['channel' => $channel, 'reason' => 'account_unavailable'], 'failure');
+                sendJson(['error' => 'access_denied'], 400); break;
+            }
+
+            /* Mint the standard bearer token — byte-identical machinery to
+               auth_login (api.php ~2216) / auth_apple (api.php ~3286). */
+            $token       = bin2hex(random_bytes(32));
+            $expiresAtTs = time() + 30 * 86400;
+            $expiresAt   = gmdate('c', $expiresAtTs);
+            $tokenHash   = hash('sha256', $token);
+            $tstmt = $db->prepare('INSERT INTO tblApiTokens (Token, UserId, ExpiresAt) VALUES (?, ?, ?)');
+            $tstmt->bind_param('sis', $tokenHash, $userId, $expiresAt);
+            $tstmt->execute();
+            $tstmt->close();
+            setAuthTokenCookie($token, $expiresAtTs);
+            $updLogin = $db->prepare('UPDATE tblUsers SET LastLoginAt = NOW(), LoginCount = LoginCount + 1 WHERE Id = ?');
+            $updLogin->bind_param('i', $userId);
+            $updLogin->execute();
+            $updLogin->close();
+
+            /* §3.2 breadcrumb — IDs only. NEVER the device_code/user_code
+               or a digest of either (includes/device_code.php header). */
+            logActivity('auth.device_code.consume', 'user', (string)$userId, ['channel' => $channel]);
+
+            sendJson(apiAuthSuccessPayload(
+                $token,
+                $userId,
+                $userRow['Username'],
+                $userRow['DisplayName'],
+                $userRow['Role'],
+                $userRow['AvatarService'] ?? null
+            ));
+            break;
+        }
+
+        case 'auth_device_code_link_lookup': {
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'device_code.php';
+            $authUser = getAuthenticatedUser();
+            if (!$authUser) { sendJson(['error' => 'Not authenticated.'], 401); break; }
+
+            $db = getDbMysqli();
+            if (!authDeviceCodesTableExists($db)) {
+                sendJson(['error' => 'Device pairing is not available yet.'], 503); break;
+            }
+
+            $userId = (int)$authUser['Id'];
+            /* Brute-force guard (shared budget with approve/deny below) —
+               keyed per authenticated user, never per-IP (rule #26). */
+            checkRateLimit('auth_device_code_link', $_SERVER['REMOTE_ADDR'] ?? '', AUTH_DEVICE_CODE_LINK_ATTEMPT_MAX, AUTH_DEVICE_CODE_LINK_ATTEMPT_WINDOW_SECONDS, true, $userId);
+
+            $userCode = deviceCode_normaliseUserCode($_GET['user_code'] ?? '');
+            if ($userCode === '') { sendJson(['ok' => false, 'error' => 'invalid_code'], 400); break; }
+
+            $channel = serviceMode_channel();
+            /* No device "kind"/client-label column exists on the shipped
+               tblAuthDeviceCodes shape (#1511) — the RFC 8628 request never
+               requires a client to identify itself, and adding one now
+               would re-open a shipped one-pass schema batch for a single
+               cosmetic field (CLAUDE.md rule #20). What IS shown: the code
+               is genuinely pending + how long it has left. */
+            $stmt = $db->prepare(
+                "SELECT TIMESTAMPDIFF(SECOND, UTC_TIMESTAMP(), ExpiresAt) AS ExpiresIn
+                   FROM tblAuthDeviceCodes
+                  WHERE UserCode = ? AND Channel = ? AND Status = 'pending' AND ExpiresAt > UTC_TIMESTAMP()
+                  LIMIT 1"
+            );
+            $stmt->bind_param('ss', $userCode, $channel);
+            $stmt->execute();
+            $row = $stmt->get_result()->fetch_assoc();
+            $stmt->close();
+
+            if (!$row) {
+                /* Opaque — no such code / already resolved / expired all
+                   read the same (anti-probe). */
+                sendJson(['ok' => false, 'error' => 'not_found']); break;
+            }
+
+            sendJson(['ok' => true, 'userCode' => $userCode, 'expiresIn' => max(0, (int)$row['ExpiresIn'])]);
+            break;
+        }
+
+        case 'auth_device_code_approve':
+        case 'auth_device_code_deny': {
+            $isApprove = ($action === 'auth_device_code_approve');
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') { sendJson(['error' => 'POST method required.'], 405); break; }
+
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'manage' . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'device_code.php';
+
+            $body = json_decode(file_get_contents('php://input'), true);
+            if (!is_array($body)) { $body = []; }
+
+            /* CSRF (rule #29) — belt-and-braces same as account_delete /
+               auth_provider_unlink: the global X-Requested-With gate
+               (api.php top-of-file) already blocks a cross-site POST; this
+               is a second, independent check on THIS state-changing
+               endpoint. */
+            $csrfToken = is_string($body['csrf_token'] ?? null) ? $body['csrf_token'] : null;
+            if (!validateCsrfRequest($csrfToken)) {
+                sendJson(['error' => 'Cross-origin request rejected.'], 403); break;
+            }
+
+            $authUser = getAuthenticatedUser();
+            if (!$authUser) { sendJson(['error' => 'Not authenticated.'], 401); break; }
+            $userId = (int)$authUser['Id'];
+
+            $db = getDbMysqli();
+            if (!authDeviceCodesTableExists($db)) {
+                sendJson(['error' => 'Device pairing is not available yet.'], 503); break;
+            }
+
+            /* Brute-force guard on the user_code — a wrong guess still
+               consumes budget, keyed per authenticated user (rule #26). */
+            checkRateLimit('auth_device_code_link', $_SERVER['REMOTE_ADDR'] ?? '', AUTH_DEVICE_CODE_LINK_ATTEMPT_MAX, AUTH_DEVICE_CODE_LINK_ATTEMPT_WINDOW_SECONDS, true, $userId);
+
+            $userCode = deviceCode_normaliseUserCode($body['user_code'] ?? '');
+            if ($userCode === '') { sendJson(['ok' => false, 'error' => 'invalid_code'], 400); break; }
+
+            $channel = serviceMode_channel();
+            if ($isApprove) {
+                $upd = $db->prepare(
+                    "UPDATE tblAuthDeviceCodes SET Status = 'approved', UserId = ?
+                      WHERE UserCode = ? AND Channel = ? AND Status = 'pending' AND ExpiresAt > UTC_TIMESTAMP()"
+                );
+                $upd->bind_param('iss', $userId, $userCode, $channel);
+            } else {
+                $upd = $db->prepare(
+                    "UPDATE tblAuthDeviceCodes SET Status = 'denied'
+                      WHERE UserCode = ? AND Channel = ? AND Status = 'pending' AND ExpiresAt > UTC_TIMESTAMP()"
+                );
+                $upd->bind_param('ss', $userCode, $channel);
+            }
+            $upd->execute();
+            $ok = $upd->affected_rows > 0;
+            $upd->close();
+
+            $breadcrumb = $isApprove ? 'auth.device_code.approve' : 'auth.device_code.deny';
+            if (!$ok) {
+                /* §3.2 breadcrumb — IDs only, NEVER the user_code. */
+                logActivity($breadcrumb, 'user', (string)$userId, ['channel' => $channel, 'reason' => 'not_found_or_resolved'], 'failure');
+                sendJson(['ok' => false, 'error' => 'That code isn’t active. Check the device and try again.'], 404); break;
+            }
+
+            logActivity($breadcrumb, 'user', (string)$userId, ['channel' => $channel]);
+            sendJson(['ok' => true]);
+            break;
+        }
 
         /* =================================================================
          * ADMIN USER MANAGEMENT — API endpoints for /manage/ panel

--- a/appWeb/public_html/includes/device_code.php
+++ b/appWeb/public_html/includes/device_code.php
@@ -1,0 +1,260 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — RFC 8628 OAuth Device Authorization Grant helpers (#1407)
+ *
+ * PURPOSE:
+ * ELI5: this is the "type this code shown on your TV into your phone's
+ * browser" sign-in flow. A limited-input client (tvOS today; any future
+ * limited-input device tomorrow) can't type a username/password. Instead it
+ * asks the server for a random secret ("device_code", never shown) plus a
+ * short human-friendly code ("user_code", e.g. "ABCD-EFGH") that IS shown
+ * on-screen. The user opens iHymns on a phone/laptop they're already signed
+ * into, types the short code at /link, and approves. Meanwhile the TV keeps
+ * asking "am I approved yet?" (polling) until the answer is yes — at which
+ * point it gets a normal iHymns bearer token, exactly as if it had typed a
+ * password itself.
+ *
+ * DETAILED — RFC 8628 (OAuth 2.0 Device Authorization Grant):
+ * @link https://www.rfc-editor.org/rfc/rfc8628
+ *   §3.1 the user_code the human enters; §3.2 the device_code + the full
+ *   `device_authorization_response` shape (device_code, user_code,
+ *   verification_uri, verification_uri_complete, expires_in, interval);
+ *   §3.4 the token exchange on approval; §3.5 the `slow_down` /
+ *   `authorization_pending` / `access_denied` / `expired_token` polling error
+ *   vocabulary this module's callers in api.php reproduce.
+ *
+ * SCHEMA: this module talks to `tblAuthDeviceCodes`, which shipped
+ * live-dormant in #1511 (`appWeb/.sql/schema.sql` +
+ * `migrate-apple-phase2-live-schema.php`) — this PR (#1407) is the FIRST
+ * consumer. Every read/write in here (and in the api.php case blocks that
+ * call it) is `authDeviceCodesTableExists()`-gated so a docroot where the
+ * migration card hasn't been run yet degrades to a clean 503 instead of a
+ * white-screening STRICT-mode mysqli exception (CLAUDE.md rule #19 dormancy
+ * + the #1228 "false-check is dead code, a missing table THROWS" lesson).
+ *
+ * SECURITY (mirrors Service Mode's #1335/#1406 conventions, rule #26):
+ *   - CHANNEL-SCOPED: every query filters `Channel = serviceMode_channel()`
+ *     so an alpha-minted device_code/user_code can never be approved (or
+ *     exchanged) against beta/production — the 3-docroot shared-DB class of
+ *     bug this rule exists to prevent.
+ *   - The raw `device_code` is NEVER stored — only its SHA-256 hex
+ *     (`DeviceCodeHash`). Same discipline as `tblPasswordResetTokens` /
+ *     `tblApiTokens.Token`.
+ *   - `user_code` reuses `serviceMode_generateCode()` (Service Mode's
+ *     Crockford base32 join-code minter, #1335) rather than forking a SECOND
+ *     base32 alphabet — CLAUDE.md's modularity rule: one alphabet, one
+ *     minter, reused.
+ *   - Rate limiting is deliberately asymmetric by endpoint (rule #26 — never
+ *     a blanket per-IP cap where a shared identity exists to key on
+ *     instead): the mint endpoint (no identity yet) is per-IP; the poll
+ *     endpoint is keyed on the device_code's OWN hash (never per-IP — many
+ *     limited-input devices can legitimately share one IP, e.g. a church's
+ *     media room); the /link approve/deny/lookup calls are keyed on the
+ *     AUTHENTICATED user id (never per-IP, for the same reason).
+ *
+ * BREADCRUMBS (observability §3.2 convention, #1512): `auth.device_code.
+ * request` / `.approve` / `.deny` / `.consume` are logged by the api.php
+ * case blocks that call into this module — IDs ONLY, never the device_code,
+ * the user_code, or a digest of either (unlike, say, `auth.login`'s
+ * `token_prefix`, a device_code/user_code is a short-lived SHARED SECRET a
+ * human is meant to read off a screen and type elsewhere; logging even a
+ * hash narrows the guess space for an attacker who can see the audit log).
+ * Polls are NEVER logged (mirrors `service_poll` — logging every ~5s poll
+ * from a waiting TV would flood the table for zero audit value).
+ *
+ * @link https://www.php.net/manual/en/function.hash.php            hash('sha256', …)
+ * @link https://www.php.net/manual/en/function.random-bytes.php    random_bytes()
+ * @link https://www.php.net/manual/en/mysqli-stmt.bind-param.php   bind_param()
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ */
+
+/* Reuses serviceMode_channel() (the 3-docroot env discriminator) and
+   serviceMode_generateCode() (the Crockford base32 minter) — see the
+   file-header note above on why a second alphabet/minter is never forked. */
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'service_mode.php';
+
+/**
+ * RFC 8628 §3.2 `expires_in` — how long a freshly-minted device_code/
+ * user_code pair stays exchangeable. Short-lived by design: a code sitting
+ * unclaimed on a TV screen for hours would be an unnecessarily long window
+ * for someone else in the room to type it in.
+ */
+const AUTH_DEVICE_CODE_TTL_SECONDS = 300;
+
+/**
+ * RFC 8628 §3.2/§3.5 `interval` — the minimum seconds a client MUST wait
+ * between polls. A poll faster than this gets `slow_down` (§3.5) instead of
+ * the real answer. 5s matches every major device-flow implementation's
+ * default (Google, GitHub, Microsoft) and keeps the poll endpoint cheap.
+ */
+const AUTH_DEVICE_CODE_POLL_INTERVAL_SECONDS = 5;
+
+/**
+ * Closed vocabulary for `tblAuthDeviceCodes.Status` — VARCHAR, app-validated
+ * here, never an ENUM (CLAUDE.md rule #20: an ENUM value-add is itself a
+ * migration). The shipped migration's column COMMENT documents four values
+ * (`pending | approved | denied | expired`, written before this PR existed);
+ * `consumed` is this PR's addition — the single-use post-exchange terminal
+ * state (RFC 8628 device_codes are one-shot: once successfully exchanged for
+ * a bearer token, a replay of the SAME device_code must never mint a second
+ * token). It fits the column's existing `VARCHAR(20)` unchanged, so no
+ * schema touch was needed to add it — exactly the point of VARCHAR-not-ENUM.
+ */
+const AUTH_DEVICE_CODE_STATUSES = ['pending', 'approved', 'denied', 'expired', 'consumed'];
+
+/** Brute-force guard (rule: "guard against brute-forcing the user_code") —
+ *  shared budget across the /link lookup + approve + deny calls, keyed per
+ *  AUTHENTICATED user (never per-IP — a shared church office IP must not
+ *  throttle every signed-in curator at once). */
+const AUTH_DEVICE_CODE_LINK_ATTEMPT_MAX            = 10;
+const AUTH_DEVICE_CODE_LINK_ATTEMPT_WINDOW_SECONDS = 600;
+
+/**
+ * Memoised INFORMATION_SCHEMA existence probe for `tblAuthDeviceCodes`.
+ *
+ * ELI5: "does the pairing table exist yet? remember the answer so we only
+ * ask once per request."
+ *
+ * DETAILED: mirrors the established per-module probe pattern
+ * (`_readRateLimitTableExists()`, `serviceMode_presenceRoleColumnExists()`,
+ * `creditPersonMembersTableExists()`, …) rather than a shared generic
+ * `tableExists()` — this codebase deliberately keeps each probe local +
+ * memoised per module (CLAUDE.md #19/#28 dormancy convention) so every
+ * caller degrades independently. mysqli runs under
+ * `MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT` (`db_mysql.php`), so a bare
+ * query against a missing table THROWS (the #1228 lesson) — this returns
+ * `false` on ANY error, never lets that exception escape.
+ */
+function authDeviceCodesTableExists(\mysqli $db): bool
+{
+    static $exists = null;
+    if ($exists !== null) {
+        return $exists;
+    }
+    try {
+        $st = $db->prepare(
+            "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+              WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tblAuthDeviceCodes' LIMIT 1"
+        );
+        $st->execute();
+        $exists = $st->get_result()->fetch_row() !== null;
+        $st->close();
+    } catch (\Throwable $_e) {
+        $exists = false; /* un-migrated install → treat as absent → caller 503s */
+    }
+    return $exists;
+}
+
+/**
+ * Generate a fresh RFC 8628 §3.1 `user_code` — 8 Crockford base32 characters
+ * (reusing `serviceMode_generateCode()`, #1335 — no ambiguous glyphs, so a
+ * human reading it off a TV never confuses 0/O or 1/I/L), formatted with a
+ * separator (`ABCD-EFGH`) purely for on-screen/typing readability. The
+ * separator is stripped again by `deviceCode_normaliseUserCode()` before any
+ * DB lookup, so storage stays a single flat 9-char string
+ * (`tblAuthDeviceCodes.UserCode VARCHAR(12)` comfortably fits it).
+ *
+ * PURE apart from its call into `random_int()` (via serviceMode_generateCode)
+ * — no DB, no superglobals.
+ */
+function deviceCode_generateUserCode(): string
+{
+    $raw = serviceMode_generateCode(8);
+    return substr($raw, 0, 4) . '-' . substr($raw, 4, 4);
+}
+
+/**
+ * Normalise a user-submitted `user_code` (from the /link form, or a
+ * `?user_code=` deep-link query param) into the canonical stored shape, or
+ * `''` when the input can't possibly be a valid code.
+ *
+ * ELI5: "however the human typed/pasted it — lowercase, no dash, extra
+ * spaces — turn it into the exact shape we saved in the database, or say
+ * 'nope' if it's not even the right length/alphabet."
+ *
+ * DETAILED: strips everything except letters/digits (mirrors
+ * `service_join`'s own code-cleaning: `strtoupper(preg_replace('/[^A-Za-z0-
+ * 9]/', '', …))`), then rejects anything that isn't EXACTLY 8 characters
+ * drawn from `SERVICE_MODE_CODE_ALPHABET` (Service Mode's own Crockford
+ * base32 set, service_mode.php) — a length/alphabet mismatch can never match
+ * a row we minted, so failing fast here saves a wasted DB round-trip and
+ * gives a consistent opaque-shaped rejection alongside the "not found" case
+ * the caller returns on a genuine miss.
+ *
+ * PURE — no DB, no superglobals.
+ *
+ * @param mixed $raw Untrusted input (`$_GET['user_code']` / decoded JSON body field).
+ * @return string The canonical `XXXX-XXXX` form, or `''` if invalid.
+ */
+function deviceCode_normaliseUserCode(mixed $raw): string
+{
+    /* Reject non-string input up front — a `?user_code[]=` query-string
+       trick or a JSON body sending a number/array/bool must degrade to the
+       same "invalid" result as any other malformed code, WITHOUT emitting a
+       PHP "Array to string conversion" warning by (string)-casting an
+       array. */
+    if (!is_string($raw)) {
+        return '';
+    }
+    $stripped = preg_replace('/[^A-Za-z0-9]/', '', $raw) ?? '';
+    $upper    = strtoupper($stripped);
+    if (strlen($upper) !== 8) {
+        return '';
+    }
+    if (preg_match('/[^' . preg_quote(SERVICE_MODE_CODE_ALPHABET, '/') . ']/', $upper)) {
+        return '';
+    }
+    return substr($upper, 0, 4) . '-' . substr($upper, 4, 4);
+}
+
+/**
+ * Mint + persist a fresh device_code/user_code pair scoped to `$channel`
+ * (rule #26). Returns the RAW device_code (the caller hands this to the
+ * requesting client — it is NEVER stored) alongside the human user_code.
+ *
+ * DETAILED: `DeviceCodeHash` and `UserCode` both carry a UNIQUE constraint
+ * (the shipped DDL, migrate-apple-phase2-live-schema.php). At this
+ * entropy/alphabet size a collision is astronomically unlikely, but this
+ * mirrors the established retry-on-1062 shape (`serviceMode_mintCode()`,
+ * `service_session_start`'s SessionCode insert) rather than assuming success
+ * — six attempts, bind-once-mutate-in-loop (the bound PHP variables are
+ * re-read by reference on each `execute()`, so `bind_param()` is called
+ * exactly once outside the loop).
+ *
+ * @return array{0:?string,1:?string} [deviceCode, userCode], or [null, null]
+ *                                     if every retry collided (caller 503s).
+ */
+function deviceCode_mint(\mysqli $db, string $channel): array
+{
+    $ttl        = AUTH_DEVICE_CODE_TTL_SECONDS;
+    $hash       = '';
+    $userCode   = '';
+    $ins = $db->prepare(
+        "INSERT INTO tblAuthDeviceCodes (DeviceCodeHash, UserCode, Status, Channel, ExpiresAt)
+         VALUES (?, ?, 'pending', ?, DATE_ADD(UTC_TIMESTAMP(), INTERVAL ? SECOND))"
+    );
+    $ins->bind_param('sssi', $hash, $userCode, $channel, $ttl);
+
+    for ($attempt = 0; $attempt < 6; $attempt++) {
+        $deviceCode = bin2hex(random_bytes(32)); /* 64 hex chars — matches tblApiTokens' own raw-token shape */
+        $hash       = hash('sha256', $deviceCode);
+        $userCode   = deviceCode_generateUserCode();
+        try {
+            $ins->execute();
+            $ins->close();
+            return [$deviceCode, $userCode];
+        } catch (\mysqli_sql_exception $e) {
+            if ($e->getCode() !== 1062) {
+                $ins->close();
+                throw $e;
+            }
+            /* UNIQUE collision on DeviceCodeHash or UserCode — retry with fresh values. */
+        }
+    }
+    $ins->close();
+    return [null, null];
+}

--- a/appWeb/public_html/includes/pages/link.php
+++ b/appWeb/public_html/includes/pages/link.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * iHymns — Device-Code Pairing "Link a device" page (#1407)
+ *
+ * PURPOSE:
+ * ELI5: this is the page a human lands on to approve a TV (or any other
+ * limited-input device) signing in to their iHymns account. The TV shows a
+ * short code on-screen; the human comes here (by typing the URL, scanning a
+ * QR code, or following the `verification_uri_complete` deep link the TV's
+ * own on-screen instructions give), enters that code, and taps Approve.
+ *
+ * DETAILED:
+ * Server-rendered shell only — the "look up this code" / "approve" / "deny"
+ * work happens client-side via js/modules/device-link.js (SPA fragment
+ * pattern, mirrors settings.js/setlist.js: this template renders static
+ * markup + an optional prefill, the JS module does the fetch()es against
+ * `?action=auth_device_code_link_lookup` / `_approve` / `_deny`). Loaded via
+ * AJAX: `/api?page=link`.
+ *
+ * Auth-required + per-user (which device is pending, whether Approve/Deny
+ * succeeded) — like settings.php/favorites.php/setlist.php this page is
+ * deliberately NOT in api.php's `$_cacheablePages` allow-list, so it is
+ * never served from the shared-fragment ETag cache.
+ *
+ * The `?user_code=` query param is the `verification_uri_complete` deep-link
+ * shape RFC 8628 §3.3 describes (optional convenience — a plain
+ * `verification_uri` + manually-typed code always works too). We prefill the
+ * input with it, normalised through the SAME parser the server-side lookup/
+ * approve/deny endpoints use, so a garbled or bogus query string just yields
+ * an empty (not broken) prefill rather than echoing raw attacker-controlled
+ * text into the page.
+ *
+ * @link https://www.rfc-editor.org/rfc/rfc8628#section-3.3  verification_uri_complete
+ */
+
+declare(strict_types=1);
+
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'device_code.php';
+
+/**
+ * Variables provided by the calling context (api.php) before this template
+ * is included. Declared here so intelephense can resolve the references in
+ * the body of the file (#634); the runtime injection itself is unchanged.
+ *
+ * @var array $app Parsed iHymns application metadata — unused by this
+ *                  template today, kept for parity with sibling page
+ *                  partials that DO read $app.
+ */
+
+/* deviceCode_normaliseUserCode() both validates AND reformats (uppercase,
+   dash-inserted) — an invalid/garbled/absent query param safely collapses
+   to '' (empty prefill), never a raw echo of untrusted input. */
+$_prefillUserCode = deviceCode_normaliseUserCode($_GET['user_code'] ?? '');
+
+?>
+<section class="page-link" aria-label="Link a device">
+
+    <h1 class="h4 mb-3">
+        <i class="fa-solid fa-tv me-2" aria-hidden="true"></i>
+        Link a Device
+    </h1>
+
+    <p class="text-muted small mb-4">
+        Enter the code shown on your TV (or other device) to sign it in to
+        your iHymns account.
+    </p>
+
+    <!-- Shown when the visitor isn't signed in; device-link.js toggles
+         visibility based on window.iHymnsApp.userAuth.isLoggedIn(). -->
+    <div id="link-signed-out" class="alert alert-info d-none" role="alert">
+        <p class="mb-2">Sign in to approve a device.</p>
+        <button type="button" class="btn btn-sm btn-outline-primary" id="link-login-btn">
+            Sign In
+        </button>
+    </div>
+
+    <!-- Shown once signed in; device-link.js toggles visibility. -->
+    <div id="link-signed-in-wrap" class="d-none">
+        <form id="link-code-form" class="mb-3" autocomplete="off" novalidate>
+            <label for="link-user-code" class="form-label">Device code</label>
+            <input type="text" class="form-control text-uppercase" id="link-user-code" name="user_code"
+                   placeholder="ABCD-EFGH" maxlength="9"
+                   value="<?= htmlspecialchars($_prefillUserCode, ENT_QUOTES, 'UTF-8') ?>"
+                   inputmode="text" autocapitalize="characters" autocorrect="off" spellcheck="false" required>
+            <button type="submit" class="btn btn-primary mt-2" id="link-lookup-btn">
+                <i class="fa-solid fa-magnifying-glass me-1" aria-hidden="true"></i>
+                Look Up
+            </button>
+        </form>
+
+        <!-- device-link.js renders the "found — Approve/Deny" confirmation,
+             or an opaque not-found/expired message, into this region. -->
+        <div id="link-result" aria-live="polite"></div>
+    </div>
+
+</section>

--- a/appWeb/public_html/js/modules/device-link.js
+++ b/appWeb/public_html/js/modules/device-link.js
@@ -1,0 +1,154 @@
+/**
+ * iHymns — Device-Code Pairing "Link a device" page controller (#1407)
+ *
+ * PURPOSE:
+ * ELI5: this is the code that runs the /link page — checking a code the
+ * user typed in against the server, showing "yes, a device is waiting" (or
+ * an opaque "that code isn't active"), and wiring up the Approve / Deny
+ * buttons.
+ *
+ * DETAILED:
+ * Mirrors settings-language-filter.js's self-contained module shape (no
+ * dependency on the Router's `this.app` — reads the bearer token straight
+ * from localStorage like that module does) rather than the class-based
+ * modules (favorites.js, setlist.js) since this page has no per-navigation
+ * state to retain between visits.
+ *
+ * Endpoints consumed (api.php, includes/device_code.php):
+ *   GET  ?action=auth_device_code_link_lookup&user_code=XXXX-XXXX
+ *   POST ?action=auth_device_code_approve  { user_code }
+ *   POST ?action=auth_device_code_deny     { user_code }
+ * All three require an Authorization: Bearer header (session-based
+ * `isAuthenticated()` doesn't apply here — this is the main-app bearer/
+ * cookie auth surface, api.php's own getAuthenticatedUser(), same as every
+ * other main-app account action e.g. auth_provider_unlink). The approve/deny
+ * POSTs additionally rely on api.php's blanket X-Requested-With CSRF gate +
+ * validateCsrfRequest()'s same-origin fallback (rule #29) — this module
+ * never bakes/sends a csrf_token field, matching unlinkProvider()'s
+ * established precedent (user-auth.js).
+ */
+
+const STORAGE_AUTH_TOKEN = 'ihymns_auth_token';
+
+function getToken() {
+    try { return localStorage.getItem(STORAGE_AUTH_TOKEN) || null; } catch { return null; }
+}
+
+function authHeaders() {
+    const token = getToken();
+    return token ? { 'Authorization': `Bearer ${token}` } : {};
+}
+
+/** Normalise a typed code the SAME way the server does, purely for the
+ *  "does this even look like a code" UX check before spending a network
+ *  round-trip — the server re-validates authoritatively regardless. */
+function looksLikeCode(raw) {
+    const stripped = String(raw || '').replace(/[^A-Za-z0-9]/g, '').toUpperCase();
+    return stripped.length === 8;
+}
+
+async function lookupCode(userCode) {
+    const url = new URL('/api', window.location.origin);
+    url.searchParams.set('action', 'auth_device_code_link_lookup');
+    url.searchParams.set('user_code', userCode);
+    const res = await fetch(url.toString(), {
+        headers: { 'X-Requested-With': 'XMLHttpRequest', ...authHeaders() },
+    });
+    if (res.status === 401) return { ok: false, error: 'not_authenticated' };
+    if (res.status === 429) return { ok: false, error: 'rate_limited' };
+    try { return await res.json(); } catch { return { ok: false, error: 'network' }; }
+}
+
+async function resolveCode(userCode, approve) {
+    const action = approve ? 'auth_device_code_approve' : 'auth_device_code_deny';
+    const res = await fetch(`/api?action=${action}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest', ...authHeaders() },
+        body: JSON.stringify({ user_code: userCode }),
+    });
+    if (res.status === 401) return { ok: false, error: 'not_authenticated' };
+    if (res.status === 429) return { ok: false, error: 'rate_limited' };
+    try { return await res.json(); } catch { return { ok: false, error: 'network' }; }
+}
+
+function renderResult(resultEl, html) {
+    if (resultEl) resultEl.innerHTML = html;
+}
+
+/**
+ * Boot the /link page. Idempotent (safe to call once per page load; the SPA
+ * router replaces the whole fragment on every navigation so there's no
+ * "already booted" state to guard here, unlike a persistent-DOM module).
+ */
+export function bootDeviceLinkPage() {
+    const signedOut = document.getElementById('link-signed-out');
+    const signedInWrap = document.getElementById('link-signed-in-wrap');
+    const form = document.getElementById('link-code-form');
+    const input = document.getElementById('link-user-code');
+    const resultEl = document.getElementById('link-result');
+    const loginBtn = document.getElementById('link-login-btn');
+    if (!form || !input || !resultEl || !signedOut || !signedInWrap) return;
+
+    const app = window.iHymnsApp;
+    const loggedIn = !!getToken();
+
+    signedOut.classList.toggle('d-none', loggedIn);
+    signedInWrap.classList.toggle('d-none', !loggedIn);
+
+    if (!loggedIn) {
+        loginBtn?.addEventListener('click', () => {
+            app?.userAuth?.showAuthModal?.('login');
+        });
+        return;
+    }
+
+    form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const raw = input.value;
+        if (!looksLikeCode(raw)) {
+            renderResult(resultEl, '<div class="alert alert-warning py-2" role="alert">Enter the 8-character code exactly as shown.</div>');
+            return;
+        }
+        renderResult(resultEl, '<p class="text-muted small mb-0"><i class="fa-solid fa-spinner fa-spin me-1" aria-hidden="true"></i>Checking…</p>');
+
+        const lookup = await lookupCode(raw);
+        if (!lookup.ok) {
+            const msg = lookup.error === 'not_authenticated'
+                ? 'Your sign-in expired — please sign in again.'
+                : lookup.error === 'rate_limited'
+                    ? 'Too many attempts — please wait a few minutes and try again.'
+                    : 'That code isn’t active. Check the device and try again.';
+            renderResult(resultEl, `<div class="alert alert-warning py-2" role="alert">${msg}</div>`);
+            return;
+        }
+
+        const userCode = lookup.userCode;
+        const minutesLeft = Math.max(1, Math.ceil((lookup.expiresIn || 0) / 60));
+        renderResult(resultEl, `
+            <div class="alert alert-info" role="alert">
+                <p class="mb-2">A device is waiting to sign in with code <strong>${userCode}</strong> (expires in about ${minutesLeft} minute${minutesLeft === 1 ? '' : 's'}).</p>
+                <button type="button" class="btn btn-success btn-sm me-2" id="link-approve-btn">
+                    <i class="fa-solid fa-check me-1" aria-hidden="true"></i>Approve
+                </button>
+                <button type="button" class="btn btn-outline-danger btn-sm" id="link-deny-btn">
+                    <i class="fa-solid fa-xmark me-1" aria-hidden="true"></i>Deny
+                </button>
+            </div>`);
+
+        const finish = async (approve) => {
+            renderResult(resultEl, '<p class="text-muted small mb-0"><i class="fa-solid fa-spinner fa-spin me-1" aria-hidden="true"></i>Working…</p>');
+            const result = await resolveCode(userCode, approve);
+            if (result.ok) {
+                renderResult(resultEl, approve
+                    ? '<div class="alert alert-success py-2" role="alert"><i class="fa-solid fa-circle-check me-1" aria-hidden="true"></i>Device approved — it should sign in within a few seconds.</div>'
+                    : '<div class="alert alert-secondary py-2" role="alert">Device sign-in denied.</div>');
+                form.reset();
+            } else {
+                renderResult(resultEl, '<div class="alert alert-warning py-2" role="alert">That code is no longer active. It may have expired or already been resolved.</div>');
+            }
+        };
+
+        document.getElementById('link-approve-btn')?.addEventListener('click', () => finish(true));
+        document.getElementById('link-deny-btn')?.addEventListener('click', () => finish(false));
+    });
+}

--- a/appWeb/public_html/js/modules/router.js
+++ b/appWeb/public_html/js/modules/router.js
@@ -275,6 +275,15 @@ export class Router {
                 return { page: 'setlist', params: {} };
             case 'settings':
                 return { page: 'settings', params: {} };
+            case 'link': {
+                /* RFC 8628 device-code pairing "Link a device" page (#1407).
+                   Forwards an optional ?user_code= from the verification_uri_
+                   complete deep link (RFC 8628 §3.3, e.g. a QR code/on-screen
+                   URL a TV shows) through to the server-rendered prefill. */
+                const sp = new URLSearchParams(window.location.search || '');
+                const userCode = (sp.get('user_code') || '').trim();
+                return { page: 'link', params: userCode ? { user_code: userCode.slice(0, 20) } : {} };
+            }
             case 'stats':
             case 'statistics':
                 return { page: 'stats', params: {} };
@@ -393,6 +402,12 @@ export class Router {
         }
         if (params.number) {
             url.searchParams.set('number', params.number);
+        }
+        /* Device-code pairing deep-link prefill (#1407) — forwarded straight
+           through so link.php can echo it (normalised) into the code input's
+           value attribute server-side, same pattern as songbook/number above. */
+        if (params.user_code) {
+            url.searchParams.set('user_code', params.user_code);
         }
 
         return url.toString();
@@ -538,6 +553,7 @@ export class Router {
             'setlist': 'Set Lists — ' + appName,
             'setlist-shared': 'Shared Set List — ' + appName,
             'settings': 'Settings — ' + appName,
+            'link': 'Link a Device — ' + appName,
             'stats': 'Usage Statistics — ' + appName,
             'writer': 'Writer — ' + appName,
             'help': 'Help — ' + appName,
@@ -749,6 +765,13 @@ export class Router {
         /* Initialise settings controls on settings page */
         if (page === 'settings') {
             this.app.settings.initSettingsPage();
+        }
+
+        /* Device-code pairing "Link a device" page (#1407). */
+        if (page === 'link') {
+            import('./device-link.js')
+                .then(m => m.bootDeviceLinkPage())
+                .catch(err => console.error('[Router] device-link init failed:', err));
         }
 
         /* After the new page HTML is in the DOM, broadcast the current auth

--- a/appWeb/public_html/manage/includes/migration-registry.php
+++ b/appWeb/public_html/manage/includes/migration-registry.php
@@ -2597,9 +2597,13 @@ return [
                       . 'and creates <code>tblAuthDeviceCodes</code> (RFC 8628 device-code pairing, #1407), '
                       . '<code>tblSessionControlTokens</code> (scoped remote-control delegation, #1408), and '
                       . '<code>tblApnsTokens</code> (device + Live Activity push tokens, #1410). '
-                      . 'Entirely dormant — no endpoint reads/writes the three new tables yet, and the two '
-                      . 'ALTERed columns are additive/nullable-or-defaulted so every existing row and read/'
-                      . 'write keeps working unchanged. Additive, idempotent — safe to re-run.',
+                      . '<code>tblAuthDeviceCodes</code> now has real consumers — the '
+                      . '<code>auth_device_code_request</code>/<code>_poll</code>/<code>_link_lookup</code>/'
+                      . '<code>_approve</code>/<code>_deny</code> API actions + the <code>/link</code> page '
+                      . '(#1407, table-existence-gated so this card must be applied first) — while '
+                      . '<code>tblSessionControlTokens</code>/<code>tblApnsTokens</code> and the two ALTERed '
+                      . 'columns stay dormant (additive/nullable-or-defaulted, no existing read/write changes) '
+                      . 'until their own PRs (#1408/#1409/#1410) ship. Additive, idempotent — safe to re-run.',
             'button' => 'Run Apple Phase-2 Live Schema Migration',
         ],
         /* Multi-object OR-probe (rule #19): pending until EVERY one of the five

--- a/tests/php/test-device-code.php
+++ b/tests/php/test-device-code.php
@@ -1,0 +1,217 @@
+<?php
+
+/**
+ * iHymns — RFC 8628 device-code pairing helpers + endpoint hygiene (#1407)
+ *
+ * Two parts:
+ *   1. Exercises the PURE functions in includes/device_code.php directly
+ *      (deviceCode_normaliseUserCode(), deviceCode_generateUserCode()) — no
+ *      DB, no superglobals, safe to require_once like service_mode.php
+ *      (mirrors test-service-state-clean.php's approach).
+ *   2. Source-greps api.php's five `auth_device_code_*` case bodies for the
+ *      load-bearing structural properties this PR's spec calls out:
+ *        - every case is authDeviceCodesTableExists()-gated (dormancy, rule
+ *          #19/#28) before touching tblAuthDeviceCodes
+ *        - the approve/deny case calls validateCsrfRequest() (rule #29)
+ *        - NO breadcrumb (logActivity() call) inside any of the five cases
+ *          — or inside includes/device_code.php — ever passes the
+ *          device_code/user_code/hash variables as a detail value (the
+ *          "IDs only, never the code or a digest of it" contract).
+ *
+ *   php tests/php/test-device-code.php
+ *
+ * Exit status 0 = clean, 1 = at least one failure.
+ */
+
+declare(strict_types=1);
+
+require_once dirname(__DIR__, 2) . '/appWeb/public_html/includes/device_code.php';
+
+$failures = 0;
+$passed = 0;
+
+function _tdcAssert(bool $cond, string $label): void
+{
+    global $failures, $passed;
+    if ($cond) { $passed++; echo "PASS: $label\n"; }
+    else { $failures++; fwrite(STDERR, "FAIL: $label\n"); }
+}
+
+/* -------------------------------------------------------------------------
+ * 1. deviceCode_normaliseUserCode()
+ * ------------------------------------------------------------------------- */
+
+_tdcAssert(deviceCode_normaliseUserCode('ABCDEFGH') === 'ABCD-EFGH', 'flat 8-char code gains the canonical dash');
+_tdcAssert(deviceCode_normaliseUserCode('ABCD-EFGH') === 'ABCD-EFGH', 'already-dashed code round-trips unchanged');
+_tdcAssert(deviceCode_normaliseUserCode('abcd-efgh') === 'ABCD-EFGH', 'lowercase is upper-cased');
+_tdcAssert(deviceCode_normaliseUserCode(' ABCD EFGH ') === 'ABCD-EFGH', 'stray whitespace is stripped');
+_tdcAssert(deviceCode_normaliseUserCode('') === '', 'empty input -> rejected');
+_tdcAssert(deviceCode_normaliseUserCode('ABCDEFG') === '', '7-char (too short) -> rejected');
+_tdcAssert(deviceCode_normaliseUserCode('ABCDEFGHJ') === '', '9-char (too long) -> rejected');
+_tdcAssert(deviceCode_normaliseUserCode('ABCDEFGI') === '', "'I' (ambiguous glyph, not in Crockford alphabet) -> rejected");
+_tdcAssert(deviceCode_normaliseUserCode('ABCDEFG0') === '', "'0' (ambiguous glyph, not in Crockford alphabet) -> rejected");
+_tdcAssert(deviceCode_normaliseUserCode(['ABCDEFGH']) === '', 'array input (type-confusion attempt) -> rejected, not a fatal');
+_tdcAssert(deviceCode_normaliseUserCode(null) === '', 'null input -> rejected, not a fatal');
+
+/* -------------------------------------------------------------------------
+ * 2. deviceCode_generateUserCode()
+ * ------------------------------------------------------------------------- */
+
+$seen = [];
+$allValid = true;
+for ($i = 0; $i < 200; $i++) {
+    $code = deviceCode_generateUserCode();
+    if (!preg_match('/^[' . preg_quote(SERVICE_MODE_CODE_ALPHABET, '/') . ']{4}-[' . preg_quote(SERVICE_MODE_CODE_ALPHABET, '/') . ']{4}$/', $code)) {
+        $allValid = false;
+    }
+    /* Round-trips through the normaliser unchanged — the minter and the
+       validator must agree on the canonical shape. */
+    if (deviceCode_normaliseUserCode($code) !== $code) {
+        $allValid = false;
+    }
+    $seen[$code] = true;
+}
+_tdcAssert($allValid, '200 generated user_codes all match XXXX-XXXX over the Crockford alphabet and round-trip through the normaliser');
+/* Not a strict uniqueness guarantee (base32^8 space, birthday-paradox odds
+   of a collision in 200 draws are negligible) — a collision here would
+   indicate a broken RNG, not bad luck. */
+_tdcAssert(count($seen) === 200, '200 generated user_codes were all distinct (RNG sanity, not a uniqueness guarantee)');
+
+/* -------------------------------------------------------------------------
+ * 3. Structural checks against api.php's case bodies.
+ * ------------------------------------------------------------------------- */
+
+$apiFile = dirname(__DIR__, 2) . '/appWeb/public_html/api.php';
+$apiSrc = (string)file_get_contents($apiFile);
+$deviceCodeSrc = (string)file_get_contents(dirname(__DIR__, 2) . '/appWeb/public_html/includes/device_code.php');
+
+/**
+ * Extract one `case '<label>':` … up to the next top-level `case`/`default`
+ * at the same 8-space indent (mirrors test-auth-apple-platform.php's
+ * _taapCaseBody()). Handles the shared `case 'a': case 'b': { ... }` shape
+ * (auth_device_code_approve/_deny) by searching from EITHER label.
+ */
+function _tdcCaseBody(string $source, string $caseLabel): ?string
+{
+    $needle = "case '{$caseLabel}':";
+    $start = strpos($source, $needle);
+    if ($start === false) {
+        return null;
+    }
+    $bodyStart = $start + strlen($needle);
+    $nextCase = strpos($source, "\n        case '", $bodyStart);
+    $nextDefault = strpos($source, "\n        default:", $bodyStart);
+    $ends = array_filter([$nextCase, $nextDefault], static fn($v) => $v !== false);
+    $end = $ends ? min($ends) : strlen($source);
+    return substr($source, $bodyStart, $end - $bodyStart);
+}
+
+$actions = [
+    'auth_device_code_request',
+    'auth_device_code_poll',
+    'auth_device_code_link_lookup',
+    'auth_device_code_approve',
+    'auth_device_code_deny',
+];
+
+$bodies = [];
+foreach ($actions as $a) {
+    _tdcAssert(str_contains($apiSrc, "case '{$a}':"), "case '{$a}' found in api.php");
+    $body = _tdcCaseBody($apiSrc, $a);
+    $bodies[$a] = $body ?? '';
+}
+/* auth_device_code_approve/_deny is ONE combined `case 'a': case 'b': { ... }`
+   block (both labels share the single executable body that follows the
+   SECOND label) — _tdcCaseBody() on the FIRST label of a fallthrough pair
+   only captures the (empty) gap up to the next `case`, not the real body.
+   Re-point it at the body actually extracted for the second label. */
+if (trim($bodies['auth_device_code_approve']) === '') {
+    $bodies['auth_device_code_approve'] = $bodies['auth_device_code_deny'];
+}
+
+foreach ($actions as $a) {
+    _tdcAssert(
+        str_contains($bodies[$a], 'authDeviceCodesTableExists('),
+        "case '{$a}' gates on authDeviceCodesTableExists() (rule #19/#28 dormancy)"
+    );
+}
+
+foreach (['auth_device_code_approve', 'auth_device_code_deny'] as $a) {
+    _tdcAssert(
+        str_contains($bodies[$a], 'validateCsrfRequest('),
+        "case '{$a}' calls validateCsrfRequest() (rule #29)"
+    );
+    _tdcAssert(
+        str_contains($bodies[$a], 'getAuthenticatedUser('),
+        "case '{$a}' requires an authenticated user"
+    );
+}
+
+/* The "IDs only, never the code/digest" contract — scan EVERY logActivity(...)
+   call's argument list (balanced-paren extraction, since a detail array can
+   itself contain nested parens/brackets) across all five case bodies AND
+   includes/device_code.php, and assert none of them mention the raw
+   device_code/user_code carriers or a hash/substr of them. */
+function _tdcExtractLogActivityCalls(string $source): array
+{
+    $calls = [];
+    $offset = 0;
+    while (($pos = strpos($source, 'logActivity(', $offset)) !== false) {
+        $parenStart = $pos + strlen('logActivity(') - 1; // points at the '('
+        $depth = 0;
+        $len = strlen($source);
+        $end = null;
+        for ($i = $parenStart; $i < $len; $i++) {
+            if ($source[$i] === '(') { $depth++; }
+            elseif ($source[$i] === ')') {
+                $depth--;
+                if ($depth === 0) { $end = $i; break; }
+            }
+        }
+        if ($end === null) { break; }
+        $calls[] = substr($source, $pos, $end - $pos + 1);
+        $offset = $end + 1;
+    }
+    return $calls;
+}
+
+/* Identifiers that would leak the shared secret or a fingerprint of it.
+   NOT the string 'device_code' itself — every one of these breadcrumbs is
+   legitimately NAMED 'auth.device_code.<verb>' (a fixed action-name string
+   literal, arg 1), so that substring alone would false-positive on every
+   single call. What must NEVER appear is a reference to the VARIABLE
+   carrying the raw code/hash, or an inline hash(...) computed for logging
+   (a fresh digest would be just as much a fingerprint leak as reusing the
+   stored one). */
+$forbiddenNeedles = ['$deviceCode', '$userCode', '$hash', 'hash('];
+$logActivityCalls = array_merge(
+    _tdcExtractLogActivityCalls(implode("\n", $bodies)),
+    _tdcExtractLogActivityCalls($deviceCodeSrc)
+);
+_tdcAssert(count($logActivityCalls) >= 4, 'found at least one logActivity() call per breadcrumb (request/approve/deny/consume) — got ' . count($logActivityCalls));
+
+$leaked = false;
+foreach ($logActivityCalls as $call) {
+    foreach ($forbiddenNeedles as $needle) {
+        if (str_contains($call, $needle)) {
+            $leaked = true;
+            fwrite(STDERR, "  -> forbidden token '$needle' found in: " . trim(preg_replace('/\s+/', ' ', $call)) . "\n");
+        }
+    }
+}
+_tdcAssert(!$leaked, 'no logActivity() call anywhere in the device-code cases (or includes/device_code.php) references the device_code, user_code, or a hash/substr of either');
+
+/* Polls are never logged for the ROUTINE outcomes (pending/slow_down/denied/
+   expired) — mirrors service_poll's "polls never logged" convention
+   (includes/device_code.php header doc-block). The ONLY logActivity() calls
+   in the whole poll body are the terminal ones on the token-mint path: the
+   success breadcrumb + the (rare) integrity-guard failure breadcrumb — both
+   named 'auth.device_code.consume', never a per-poll entry for the four
+   early-return error replies above them. */
+$pollLogCalls = _tdcExtractLogActivityCalls($bodies['auth_device_code_poll']);
+_tdcAssert(count($pollLogCalls) === 2, "case 'auth_device_code_poll' calls logActivity() exactly twice (success + integrity-guard failure), never per-poll for pending/slow_down/denied/expired — got " . count($pollLogCalls));
+$pollLogNames = array_map(static fn($c) => str_contains($c, "'auth.device_code.consume'"), $pollLogCalls);
+_tdcAssert(!in_array(false, $pollLogNames, true), "every logActivity() call in case 'auth_device_code_poll' is tagged 'auth.device_code.consume'");
+
+echo "\n$passed passed, $failures failed.\n";
+exit($failures > 0 ? 1 : 0);


### PR DESCRIPTION
Apple Phase-2 **PR-3 — RFC 8628 device-code pairing (#1407)**. Additive backend + `/link` approval; **dormant-safe** (its `tblAuthDeviceCodes` table shipped live-dormant in #1511, so every path is `tableExists`-gated → clean 503 until the migration card runs). One commit. 31-assertion test + existing suites pass; `php -l`/`node --check` clean.

Implements #1407.

## Endpoints (`api.php`)
- `auth_device_code_request` (anon, per-IP rate-limited) — mints device_code (SHA-256 stored, raw never) + a Crockford user_code (reuses `serviceMode_generateCode()`, no forked base32); RFC 8628 §3.2 response shape.
- `auth_device_code_poll` (anon, **per-code-hash** rate-limited, never per-IP) — `slow_down`/`authorization_pending`/`access_denied`/`expired_token`; expiry/slow_down computed SQL-side; atomic single-use `UPDATE ... WHERE Status='approved'` → mints the standard bearer token.
- `auth_device_code_link_lookup` (authed) + `auth_device_code_approve`/`_deny` (authed, `validateCsrfRequest()`, per-user rate-limited) — the `/link` confirmation flow.
- New `includes/pages/link.php` fragment + `js/modules/device-link.js` (SPA `?page=` convention).

## Security
- Breadcrumbs `auth.device_code.request/.approve/.deny/.consume` — **IDs + channel only, never the device_code/user_code or a digest** (asserted by the test via balanced-paren extraction of every `logActivity` in the family). Polls never log (only the terminal consume). `Channel`-filtered everywhere (rule #26). CSRF via `validateCsrfRequest()` (rule #29).

## Follow-ups (minor, noted)
- `tblAuthDeviceCodes` has no `ClientKind` column (the plan wanted one; it was omitted from the #1511 schema — my DDL review missed it), so `/link` shows the code + time-remaining, not a device kind. Since the migration is still dormant/un-run everywhere, `ClientKind` could be added to the existing migration cleanly (not a "second migration") in a small follow-up.
