### PR TITLE
feat(api): Apple Phase-2 backend endpoints — control tokens + manage-devices + APNs (dormant)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -454,6 +454,23 @@ jobs:
           php tests/php/test-device-code.php
 
       # -----------------------------------------------------------------------
+      # Step 5n: APNs bridge — ES256 provider-token JWT (#1410)
+      # Locally-generated test EC P-256 keypair — never a real Apple-issued
+      # key, never a network call. Proves the DER<->JOSE raw signature
+      # conversion (shared with the SIWA client_secret builder, not
+      # re-forked) and the iss/iat-only claim shape APNs provider tokens
+      # actually use (deliberately NOT the SIWA client_secret's exp/aud/sub
+      # shape). Also asserts apnsConfigured()/apnsCredentials() stay
+      # all-empty with no settings source reachable — the "no key
+      # provisioned = guaranteed no-op" dormancy invariant, without a
+      # database.
+      # -----------------------------------------------------------------------
+      - name: APNs bridge — ES256 provider-token JWT (#1410)
+        run: |
+          echo "Running APNs provider-token JWT test..."
+          php tests/php/test-apns-jwt.php
+
+      # -----------------------------------------------------------------------
       # Step 6: Validate JSON files
       # Checks that critical JSON files are valid using Node.js
       # Validates: data/songs.json, manifest.json (in both beta and production)
@@ -659,3 +676,6 @@ jobs:
 
       - name: RFC 8628 device-code pairing (#1407)
         run: php tests/php/test-device-code.php
+
+      - name: APNs bridge — ES256 provider-token JWT (#1410)
+        run: php tests/php/test-apns-jwt.php

--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -187,6 +187,12 @@ require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 
    runs. Every read inside is gated on tblSongs.PublicId existing, so this is
    a no-op on an un-migrated install. */
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'song_public_id.php';
+/* #1409 — API token device-metadata helpers (apiTokensDeviceMetaColumnsExist()
+   etc). Loaded top-level (not per-case) because slideAuthTokenExpiry() below
+   — called on EVERY authenticated request via getAuthenticatedUser() — needs
+   apiTokensDeviceMetaColumnsExist() to decide whether to also piggyback a
+   LastSeenAt bump onto its already-throttled UPDATE. */
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'api_tokens.php';
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'card_layout.php';
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'activity_log.php';
 /* Mirror every uncaught \Throwable + PHP fatal into tblActivityLog
@@ -2232,6 +2238,15 @@ if ($action !== null) {
             $stmt->execute();
             $stmt->close();
 
+            /* #1409 — OPTIONAL device metadata (deviceName/platform/
+               appVersion). Every field is genuinely optional: a client that
+               omits them (every existing caller today) signs in
+               byte-identically to before this change. Best-effort, never
+               blocks sign-in on a write failure (see
+               apiTokenDeviceMetaStore()'s docblock). */
+            $deviceMeta = apiTokenDeviceMetaFromBody($body);
+            apiTokenDeviceMetaStore($db, $tokenHash, $deviceMeta['deviceName'], $deviceMeta['platform'], $deviceMeta['appVersion']);
+
             /* Cross-subdomain cookie (#390) */
             setAuthTokenCookie($token, $expiresAtTs);
 
@@ -2967,8 +2982,12 @@ if ($action !== null) {
                 break;
             }
 
-            /* Complete the login: find/create user, generate bearer token */
-            $loginResult = completeEmailLogin($verified['email'], $verified['userId']);
+            /* Complete the login: find/create user, generate bearer token.
+               #1409 — OPTIONAL device metadata threaded through the same
+               way as auth_login/auth_apple above (never required, best-
+               effort, never blocks sign-in). */
+            $deviceMeta = apiTokenDeviceMetaFromBody($body);
+            $loginResult = completeEmailLogin($verified['email'], $verified['userId'], $deviceMeta['deviceName'], $deviceMeta['platform'], $deviceMeta['appVersion']);
 
             /* Cross-subdomain auth cookie (#390) — completeEmailLogin()
                issues a 30-day token in tblApiTokens; mirror that lifetime
@@ -3291,6 +3310,12 @@ if ($action !== null) {
             $stmt->execute();
             $stmt->close();
 
+            /* #1409 — OPTIONAL device metadata, same discipline as
+               auth_login above (never required, best-effort, never blocks
+               sign-in). */
+            $deviceMeta = apiTokenDeviceMetaFromBody($body);
+            apiTokenDeviceMetaStore($db, $tokenHash, $deviceMeta['deviceName'], $deviceMeta['platform'], $deviceMeta['appVersion']);
+
             setAuthTokenCookie($token, $expiresAtTs);
 
             $stmt = $db->prepare('UPDATE tblUsers SET LastLoginAt = NOW(), LoginCount = LoginCount + 1 WHERE Id = ?');
@@ -3568,6 +3593,295 @@ if ($action !== null) {
 
             sendJson(['providers' => _authProviderListForUser($db, (int)$authUser['Id'])]);
             break;
+
+        /* =================================================================
+         * MANAGE-DEVICES (#1409, Apple Phase-2 PR-12) — list + remote sign-
+         * out of a user's OWN signed-in devices. `tblApiTokens.DeviceName/
+         * Platform/AppVersion/LastSeenAt` shipped live-dormant in #1511;
+         * every read/write below is apiTokensDeviceMetaColumnsExist()-gated
+         * (includes/api_tokens.php) so an un-migrated docroot degrades to a
+         * graceful empty list rather than an error. The device "id" handed
+         * to the client is a truncated hash prefix — NEVER the raw token,
+         * NEVER the full stored hash (see api_tokens.php's file header).
+         * ================================================================= */
+        case 'devices_list': {
+            $authUser = getAuthenticatedUser();
+            if (!$authUser) {
+                sendJson(['error' => 'Not authenticated.'], 401);
+                break;
+            }
+            $userId = (int)$authUser['Id'];
+
+            $db = getDbMysqli();
+            if (!apiTokensDeviceMetaColumnsExist($db)) {
+                /* Graceful empty list (mirrors auth_providers_list's own
+                   degrade-to-empty convention above) rather than an error
+                   for a read-only lookup. */
+                sendJson(['devices' => []]);
+                break;
+            }
+
+            $currentToken = getAuthBearerToken();
+            $currentHash  = $currentToken !== null ? hash('sha256', $currentToken) : '';
+
+            $now = gmdate('c');
+            $stmt = $db->prepare(
+                'SELECT Token, DeviceName, Platform, AppVersion, LastSeenAt, CreatedAt, ExpiresAt
+                   FROM tblApiTokens WHERE UserId = ? AND ExpiresAt > ?
+                  ORDER BY COALESCE(LastSeenAt, CreatedAt) DESC'
+            );
+            $stmt->bind_param('is', $userId, $now);
+            $stmt->execute();
+            $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+            $stmt->close();
+
+            $devices = array_map(static function (array $row) use ($currentHash) {
+                $tokenHash = (string)$row['Token'];
+                return [
+                    'id'         => apiTokenDeviceId($tokenHash),
+                    'deviceName' => $row['DeviceName'],
+                    'platform'   => $row['Platform'],
+                    'appVersion' => $row['AppVersion'],
+                    'lastSeenAt' => $row['LastSeenAt'],
+                    'createdAt'  => $row['CreatedAt'],
+                    'expiresAt'  => $row['ExpiresAt'],
+                    'isCurrent'  => ($currentHash !== '' && hash_equals($tokenHash, $currentHash)),
+                ];
+            }, $rows);
+
+            sendJson(['devices' => $devices]);
+            break;
+        }
+
+        case 'device_signout': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'manage' . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+
+            $body = json_decode(file_get_contents('php://input'), true);
+            if (!is_array($body)) { $body = []; }
+
+            /* CSRF (rule #29) — belt-and-braces same as auth_device_code_
+               approve / auth_provider_unlink: the global X-Requested-With
+               gate (api.php top-of-file) already blocks a cross-site POST;
+               this is a second, independent check on THIS state-changing
+               endpoint. */
+            $csrfToken = is_string($body['csrf_token'] ?? null) ? $body['csrf_token'] : null;
+            if (!validateCsrfRequest($csrfToken)) {
+                sendJson(['error' => 'Cross-origin request rejected.'], 403);
+                break;
+            }
+
+            $authUser = getAuthenticatedUser();
+            if (!$authUser) {
+                sendJson(['error' => 'Not authenticated.'], 401);
+                break;
+            }
+            $userId = (int)$authUser['Id'];
+
+            checkRateLimit('device_signout', $_SERVER['REMOTE_ADDR'] ?? '', 30, 3600, true, $userId);
+
+            $deviceId = is_string($body['id'] ?? null) ? strtolower(trim($body['id'])) : '';
+            if (!preg_match('/^[a-f0-9]{' . API_TOKEN_DEVICE_ID_LENGTH . '}$/', $deviceId)) {
+                sendJson(['error' => 'Invalid device id.'], 400);
+                break;
+            }
+
+            $db = getDbMysqli();
+            /* Own-only guard — UserId = ? is IN the DELETE's WHERE, never
+               checked afterwards, so this can only ever touch the CALLER's
+               own tokens. The LIKE prefix match against Token (the stored
+               sha256 hash) is safe: $deviceId is already regex-pinned above
+               to exactly API_TOKEN_DEVICE_ID_LENGTH lowercase hex chars, so
+               no LIKE wildcard metacharacter can reach the query from user
+               input, and a same-user prefix collision (astronomically
+               unlikely at 64 bits) would only ever let someone sign out one
+               of their OWN other devices — never cross a user boundary. */
+            $stmt = $db->prepare('DELETE FROM tblApiTokens WHERE UserId = ? AND Token LIKE CONCAT(?, "%")');
+            $stmt->bind_param('is', $userId, $deviceId);
+            $stmt->execute();
+            $revoked = $stmt->affected_rows > 0;
+            $stmt->close();
+
+            logActivity('auth.device_signout', 'user', (string)$userId, ['found' => $revoked], $revoked ? 'success' : 'failure', $userId);
+
+            if (!$revoked) {
+                sendJson(['error' => 'Unknown device.'], 404);
+                break;
+            }
+            sendJson(['ok' => true]);
+            break;
+        }
+
+        /* =================================================================
+         * APNs BRIDGE (#1410, Apple Phase-2 PR-13) — push-token registration
+         * ONLY. Entirely DORMANT: nothing in this codebase calls
+         * includes/apns.php's apnsSend() yet, and even a future caller that
+         * does gets a guaranteed `not_configured` no-op until an owner
+         * provisions a real Apple APNs Auth Key (see apns.php's file-header
+         * "NOT IN SCOPE" note — no admin-UI card ships in this change).
+         * `tblApnsTokens` shipped live-dormant in #1511; every read/write
+         * below is apnsTokensTableExists()-gated.
+         * ================================================================= */
+        case 'apns_register': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'manage' . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'apns.php';
+
+            $body = json_decode(file_get_contents('php://input'), true);
+            if (!is_array($body)) { $body = []; }
+
+            $csrfToken = is_string($body['csrf_token'] ?? null) ? $body['csrf_token'] : null;
+            if (!validateCsrfRequest($csrfToken)) {
+                sendJson(['error' => 'Cross-origin request rejected.'], 403);
+                break;
+            }
+
+            $authUser = getAuthenticatedUser();
+            if (!$authUser) {
+                sendJson(['error' => 'Not authenticated.'], 401);
+                break;
+            }
+            $userId = (int)$authUser['Id'];
+
+            $db = getDbMysqli();
+            if (!apnsTokensTableExists($db)) {
+                sendJson(['error' => 'Push notifications are not available yet.'], 503);
+                break;
+            }
+
+            checkRateLimit('apns_register', $_SERVER['REMOTE_ADDR'] ?? '', 30, 3600, true, $userId);
+
+            $pushTokenHex = is_string($body['pushToken'] ?? null) ? strtolower(trim($body['pushToken'])) : '';
+            if (!preg_match('/^[a-f0-9]{32,200}$/', $pushTokenHex) || strlen($pushTokenHex) % 2 !== 0) {
+                sendJson(['error' => 'Invalid push token.'], 400);
+                break;
+            }
+            $binToken = hex2bin($pushTokenHex);
+            if ($binToken === false) {
+                sendJson(['error' => 'Invalid push token.'], 400);
+                break;
+            }
+
+            $apnsEnv = is_string($body['apnsEnv'] ?? null) ? strtolower(trim($body['apnsEnv'])) : 'production';
+            if (!in_array($apnsEnv, APNS_ENVIRONMENTS, true)) { $apnsEnv = 'production'; }
+
+            $kind = is_string($body['kind'] ?? null) ? trim($body['kind']) : 'device';
+            if (!in_array($kind, APNS_KINDS, true)) { $kind = 'device'; }
+
+            /* Kind='liveActivity' tokens carry NO Channel column of their
+               own (the shipped #1511 DDL) — session-scoping is CARRIED
+               TRANSITIVELY through the SessionId FK, so resolve (and
+               channel-filter, rule #26) the referenced session HERE. */
+            $sessionId = null;
+            $sessionExpiresAt = null;
+            if ($kind === 'liveActivity') {
+                require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'service_mode.php';
+                $rawSessionId = (int)($body['sessionId'] ?? 0);
+                if ($rawSessionId <= 0) {
+                    sendJson(['error' => 'sessionId is required for kind=liveActivity.'], 400);
+                    break;
+                }
+                $channel = serviceMode_channel();
+                $sstmt = $db->prepare('SELECT Id, ExpiresAt FROM tblLiveFollowSessions WHERE Id = ? AND Channel = ? AND IsActive = 1');
+                $sstmt->bind_param('is', $rawSessionId, $channel);
+                $sstmt->execute();
+                $srow = $sstmt->get_result()->fetch_assoc();
+                $sstmt->close();
+                if (!$srow) {
+                    sendJson(['error' => 'Unknown or ended session.'], 404);
+                    break;
+                }
+                $sessionId = (int)$srow['Id'];
+                $sessionExpiresAt = (string)$srow['ExpiresAt'];
+            }
+
+            try {
+                $ins = $db->prepare(
+                    'INSERT INTO tblApnsTokens (Kind, UserId, SessionId, PushToken, ApnsEnv, ExpiresAt)
+                     VALUES (?, ?, ?, ?, ?, ?)
+                     ON DUPLICATE KEY UPDATE Kind = VALUES(Kind), UserId = VALUES(UserId),
+                         SessionId = VALUES(SessionId), ApnsEnv = VALUES(ApnsEnv), ExpiresAt = VALUES(ExpiresAt)'
+                );
+                $ins->bind_param('siisss', $kind, $userId, $sessionId, $binToken, $apnsEnv, $sessionExpiresAt);
+                $ins->execute();
+                $ins->close();
+            } catch (\Throwable $e) {
+                error_log('[api/apns_register] ' . $e->getMessage());
+                sendJson(['error' => 'Could not register for push notifications, please retry.'], 503);
+                break;
+            }
+
+            /* §3.2 breadcrumb — IDs + fixed vocabulary only, NEVER the push
+               token in any form (apns.php's file-header discipline). */
+            logActivity('apns.token.register', 'user', (string)$userId, ['kind' => $kind, 'apns_env' => $apnsEnv, 'session_id' => $sessionId]);
+            sendJson(['ok' => true]);
+            break;
+        }
+
+        case 'apns_unregister': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                sendJson(['error' => 'POST method required.'], 405);
+                break;
+            }
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'manage' . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'apns.php';
+
+            $body = json_decode(file_get_contents('php://input'), true);
+            if (!is_array($body)) { $body = []; }
+
+            /* CSRF (rule #29) — the #1410 task brief's own spec line for
+               this endpoint doesn't explicitly tag "CSRF" the way
+               device_signout/apns_register do, but this is still a
+               state-changing authenticated DELETE; the project-wide
+               standing rule applies uniformly regardless. */
+            $csrfToken = is_string($body['csrf_token'] ?? null) ? $body['csrf_token'] : null;
+            if (!validateCsrfRequest($csrfToken)) {
+                sendJson(['error' => 'Cross-origin request rejected.'], 403);
+                break;
+            }
+
+            $authUser = getAuthenticatedUser();
+            if (!$authUser) {
+                sendJson(['error' => 'Not authenticated.'], 401);
+                break;
+            }
+            $userId = (int)$authUser['Id'];
+
+            $db = getDbMysqli();
+            if (!apnsTokensTableExists($db)) {
+                sendJson(['ok' => true]); /* nothing to unregister on an un-migrated docroot */
+                break;
+            }
+
+            checkRateLimit('apns_unregister', $_SERVER['REMOTE_ADDR'] ?? '', 30, 3600, true, $userId);
+
+            $pushTokenHex = is_string($body['pushToken'] ?? null) ? strtolower(trim($body['pushToken'])) : '';
+            if (!preg_match('/^[a-f0-9]{32,200}$/', $pushTokenHex) || strlen($pushTokenHex) % 2 !== 0) {
+                sendJson(['error' => 'Invalid push token.'], 400);
+                break;
+            }
+            $binToken = hex2bin($pushTokenHex);
+            if ($binToken === false) {
+                sendJson(['error' => 'Invalid push token.'], 400);
+                break;
+            }
+
+            $del = $db->prepare('DELETE FROM tblApnsTokens WHERE UserId = ? AND PushToken = ?');
+            $del->bind_param('is', $userId, $binToken);
+            $del->execute();
+            $removed = $del->affected_rows > 0;
+            $del->close();
+
+            logActivity('apns.token.unregister', 'user', (string)$userId, ['removed' => $removed]);
+            sendJson(['ok' => true]);
+            break;
+        }
 
         /* =================================================================
          * USER FAVORITES — Server-side sync (#284)
@@ -14145,13 +14459,23 @@ if ($action !== null) {
          * ----------------------------------------------------------------- */
         case 'service_broadcast': {
             if ($_SERVER['REQUEST_METHOD'] !== 'POST') { sendJson(['error' => 'POST method required.'], 405); break; }
-            $authUser = getAuthenticatedUser();
-            if (!$authUser) { sendJson(['error' => 'Not authenticated.'], 401); break; }
             require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'service_mode.php';
             require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'entitlements.php';
-            $userId = (int)$authUser['Id'];
-            $role   = (string)($authUser['Role'] ?? '');
-            checkRateLimit('service_broadcast', $_SERVER['REMOTE_ADDR'] ?? '', 600, 60, true, $userId);
+            /* #1408 — session_control_token.php supplies BOTH the shared
+               serviceMode_userCanOperate() check AND the control-token
+               validator the new delegated-auth path below consults. */
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'session_control_token.php';
+
+            /* #1408 — EARLY per-IP throttle, DISTINCT bucket from the
+               per-user one below. Before this change, an unauthenticated
+               caller 401'd immediately (no DB query at all); now the
+               control-token path means auth can't be resolved until AFTER
+               the session row is read, so an anonymous/probing caller could
+               otherwise trigger unlimited session-lookup queries with zero
+               credentials at all. Generously sized (mirrors service_join's
+               own anonymous-safe per-IP cap) so it never bites a real
+               operator or delegated device. */
+            checkRateLimit('service_broadcast_probe', $_SERVER['REMOTE_ADDR'] ?? '', 300, 60, true, null);
 
             $body = json_decode(file_get_contents('php://input'), true);
             if (!is_array($body)) { $body = []; }
@@ -14178,9 +14502,34 @@ if ($action !== null) {
                 sendJson(['error' => 'Unknown or ended session.'], 404); break;
             }
             $orgId = (int)$sess['OrgId'];
-            $canOperate = ($role === 'global_admin' || $role === 'admin')
-                || (int)$sess['HostUserId'] === $userId
-                || in_array($orgId, userIsOrgAdminOf($userId), true);
+
+            /* #1408 — TWO ways to authorise a broadcast: the operator's own
+               bearer (unchanged, existing behaviour, tried FIRST and
+               authoritative when it resolves) OR a scoped, revocable
+               control token presented in the body (a delegated co-leader's
+               device that never signed in at all). The token path is only
+               even consulted when there is no authorised bearer, so an
+               operator's own request is never weakened by this addition. */
+            $authUser = getAuthenticatedUser();
+            $userId = null;
+            $canOperate = false;
+            if ($authUser) {
+                $userId = (int)$authUser['Id'];
+                $role   = (string)($authUser['Role'] ?? '');
+                $canOperate = serviceMode_userCanOperate($userId, $role, $orgId, (int)$sess['HostUserId']);
+            }
+            $viaControlToken = false;
+            if (!$canOperate) {
+                $controlToken = is_string($body['controlToken'] ?? null) ? $body['controlToken'] : '';
+                if ($controlToken !== '' && sessionControlTokensTableExists($db)
+                    && sessionControlToken_validate($db, $controlToken, $sessionId, $channel)) {
+                    $canOperate = true;
+                    $viaControlToken = true;
+                }
+            }
+
+            checkRateLimit('service_broadcast', $_SERVER['REMOTE_ADDR'] ?? '', 600, 60, true, $userId);
+
             if (!$canOperate) {
                 logActivity('service.broadcast.song', 'organisation', (string)$orgId, ['session_id' => $sessionId, 'reason' => 'not_authorised'], 'failure');
                 sendJson(['error' => 'Not authorised.'], 403); break;
@@ -14213,9 +14562,17 @@ if ($action !== null) {
             $revision = (int)($rev->get_result()->fetch_assoc()['StateRevision'] ?? 0);
             $rev->close();
 
-            /* §3.2 — song-change only, never on a component-index-only nudge. */
+            /* §3.2 — song-change only, never on a component-index-only nudge.
+               'via' (#1408) is a fixed 'bearer'|'control_token' string —
+               never sensitive, useful adoption signal for the new
+               delegated-auth path. */
             if ($songId !== null && (string)($sess['CurrentSongId'] ?? '') !== (string)$songId) {
-                logActivity('service.broadcast.song', 'organisation', (string)$orgId, ['session_id' => $sessionId, 'song_id' => $songId, 'channel' => $channel]);
+                logActivity('service.broadcast.song', 'organisation', (string)$orgId, [
+                    'session_id' => $sessionId,
+                    'song_id'    => $songId,
+                    'channel'    => $channel,
+                    'via'        => $viaControlToken ? 'control_token' : 'bearer',
+                ]);
             }
 
             sendJson(['ok' => true, 'revision' => $revision]);
@@ -14404,6 +14761,134 @@ if ($action !== null) {
             }
 
             sendJson(['ok' => true]);
+            break;
+        }
+
+        /* -----------------------------------------------------------------
+         * SESSION CONTROL TOKENS (#1408, Apple Phase-2 PR-9) — delegated
+         * remote-control of ONE live/service session without sharing the
+         * operator's login. `tblSessionControlTokens` shipped live-dormant
+         * in #1511; every read/write below is
+         * sessionControlTokensTableExists()-gated. `service_broadcast`
+         * (above) is the ONE consumer of a minted token today.
+         * ----------------------------------------------------------------- */
+        case 'service_control_token_mint': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') { sendJson(['error' => 'POST method required.'], 405); break; }
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'manage' . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'service_mode.php';
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'session_control_token.php';
+
+            $body = json_decode(file_get_contents('php://input'), true);
+            if (!is_array($body)) { $body = []; }
+
+            /* CSRF (rule #29) — belt-and-braces same as auth_device_code_
+               approve / auth_provider_unlink: the global X-Requested-With
+               gate (api.php top-of-file) already blocks a cross-site POST;
+               this is a second, independent check on THIS state-changing,
+               credential-minting endpoint. */
+            $csrfToken = is_string($body['csrf_token'] ?? null) ? $body['csrf_token'] : null;
+            if (!validateCsrfRequest($csrfToken)) {
+                sendJson(['error' => 'Cross-origin request rejected.'], 403); break;
+            }
+
+            $authUser = getAuthenticatedUser();
+            if (!$authUser) { sendJson(['error' => 'Not authenticated.'], 401); break; }
+            $userId = (int)$authUser['Id'];
+            $role   = (string)($authUser['Role'] ?? '');
+
+            $db = getDbMysqli();
+            if (!sessionControlTokensTableExists($db)) {
+                sendJson(['error' => 'Session control tokens are not available yet.'], 503); break;
+            }
+
+            checkRateLimit('service_control_token_mint', $_SERVER['REMOTE_ADDR'] ?? '', 30, 3600, true, $userId);
+
+            $sessionId = (int)($body['sessionId'] ?? 0);
+            if ($sessionId <= 0) { sendJson(['error' => 'Missing session.'], 400); break; }
+
+            $channel = serviceMode_channel();
+            $sstmt = $db->prepare("SELECT OrgId, HostUserId, ExpiresAt FROM tblLiveFollowSessions WHERE Id = ? AND SessionKind = 'service' AND Channel = ? AND IsActive = 1");
+            $sstmt->bind_param('is', $sessionId, $channel);
+            $sstmt->execute();
+            $sess = $sstmt->get_result()->fetch_assoc();
+            $sstmt->close();
+            if (!$sess) {
+                logActivity('service.control_token.mint', 'organisation', '', ['session_id' => $sessionId, 'reason' => 'unknown_or_ended'], 'failure');
+                sendJson(['error' => 'Unknown or ended session.'], 404); break;
+            }
+            $orgId = (int)$sess['OrgId'];
+            if (!serviceMode_userCanOperate($userId, $role, $orgId, (int)$sess['HostUserId'])) {
+                logActivity('service.control_token.mint', 'organisation', (string)$orgId, ['session_id' => $sessionId, 'reason' => 'not_authorised'], 'failure');
+                sendJson(['error' => 'Not authorised.'], 403); break;
+            }
+
+            $token = sessionControlToken_mint($db, $sessionId, $channel, (string)$sess['ExpiresAt']);
+            if ($token === null) {
+                sendJson(['error' => 'Could not mint a control token, please retry.'], 503); break;
+            }
+
+            /* §3.2 breadcrumb — IDs only, NEVER the raw token (this file's
+               header discipline). */
+            logActivity('service.control_token.mint', 'organisation', (string)$orgId, ['session_id' => $sessionId, 'channel' => $channel]);
+
+            sendJson([
+                'ok'        => true,
+                'token'     => $token,
+                'scope'     => 'broadcast',
+                'sessionId' => $sessionId,
+            ]);
+            break;
+        }
+
+        case 'service_control_token_revoke': {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') { sendJson(['error' => 'POST method required.'], 405); break; }
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'manage' . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'auth.php';
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'service_mode.php';
+            require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'session_control_token.php';
+
+            $body = json_decode(file_get_contents('php://input'), true);
+            if (!is_array($body)) { $body = []; }
+
+            $csrfToken = is_string($body['csrf_token'] ?? null) ? $body['csrf_token'] : null;
+            if (!validateCsrfRequest($csrfToken)) {
+                sendJson(['error' => 'Cross-origin request rejected.'], 403); break;
+            }
+
+            $authUser = getAuthenticatedUser();
+            if (!$authUser) { sendJson(['error' => 'Not authenticated.'], 401); break; }
+            $userId = (int)$authUser['Id'];
+            $role   = (string)($authUser['Role'] ?? '');
+
+            $db = getDbMysqli();
+            if (!sessionControlTokensTableExists($db)) {
+                sendJson(['error' => 'Session control tokens are not available yet.'], 503); break;
+            }
+
+            checkRateLimit('service_control_token_revoke', $_SERVER['REMOTE_ADDR'] ?? '', 60, 3600, true, $userId);
+
+            $sessionId = (int)($body['sessionId'] ?? 0);
+            if ($sessionId <= 0) { sendJson(['error' => 'Missing session.'], 400); break; }
+
+            $channel = serviceMode_channel();
+            $sstmt = $db->prepare("SELECT OrgId, HostUserId FROM tblLiveFollowSessions WHERE Id = ? AND SessionKind = 'service' AND Channel = ?");
+            $sstmt->bind_param('is', $sessionId, $channel);
+            $sstmt->execute();
+            $sess = $sstmt->get_result()->fetch_assoc();
+            $sstmt->close();
+            if (!$sess) {
+                logActivity('service.control_token.revoke', 'organisation', '', ['session_id' => $sessionId, 'reason' => 'unknown_session'], 'failure');
+                sendJson(['error' => 'Unknown session.'], 404); break;
+            }
+            $orgId = (int)$sess['OrgId'];
+            if (!serviceMode_userCanOperate($userId, $role, $orgId, (int)$sess['HostUserId'])) {
+                logActivity('service.control_token.revoke', 'organisation', (string)$orgId, ['session_id' => $sessionId, 'reason' => 'not_authorised'], 'failure');
+                sendJson(['error' => 'Not authorised.'], 403); break;
+            }
+
+            $revoked = sessionControlToken_revokeAllForSession($db, $sessionId, $channel);
+            logActivity('service.control_token.revoke', 'organisation', (string)$orgId, ['session_id' => $sessionId, 'channel' => $channel, 'revoked' => $revoked]);
+
+            sendJson(['ok' => true, 'revoked' => $revoked]);
             break;
         }
 
@@ -15411,9 +15896,26 @@ function slideAuthTokenExpiry(string $rawToken): void
         $threshold    = gmdate('c', time() + 29 * 86400);
 
         $db = getDbMysqli();
-        $stmt = $db->prepare(
-            'UPDATE tblApiTokens SET ExpiresAt = ? WHERE Token = ? AND ExpiresAt < ?'
-        );
+        /* #1409 — LastSeenAt piggybacks on this SAME already-throttled
+           UPDATE (fires at most once per ~24h of active use PER TOKEN)
+           rather than a new per-request write. A "last active" column read
+           at ~1-day granularity is still genuinely useful for a
+           manage-devices list ("today" / "3 days ago" / …), and a
+           finer-grained version would mean adding a NEW round-trip to
+           LITERALLY EVERY authenticated request across the whole app — the
+           "don't add per-request overhead carelessly" trade-off the #1409
+           plan explicitly calls out. columnExists-gated (via
+           apiTokensDeviceMetaColumnsExist(), includes/api_tokens.php) so an
+           un-migrated docroot's UPDATE stays byte-identical to before this
+           change. A future finer-grained version, if ever wanted, is a
+           one-line follow-up: a SEPARATE throttled write inside
+           getAuthenticatedUser() itself once the extra per-request query is
+           judged worth it — deliberately NOT done here. */
+        $hasDeviceMetaCols = function_exists('apiTokensDeviceMetaColumnsExist') && apiTokensDeviceMetaColumnsExist($db);
+        $sql = $hasDeviceMetaCols
+            ? 'UPDATE tblApiTokens SET ExpiresAt = ?, LastSeenAt = UTC_TIMESTAMP() WHERE Token = ? AND ExpiresAt < ?'
+            : 'UPDATE tblApiTokens SET ExpiresAt = ? WHERE Token = ? AND ExpiresAt < ?';
+        $stmt = $db->prepare($sql);
         $stmt->bind_param('sss', $newExpiresAt, $hashedToken, $threshold);
         $stmt->execute();
         $bumped = $stmt->affected_rows > 0;

--- a/appWeb/public_html/includes/api_tokens.php
+++ b/appWeb/public_html/includes/api_tokens.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — API token device metadata + manage-devices helpers (#1409, Apple
+ * Phase-2 PR-12)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * ELI5: every "device" signed into iHymns (a phone, a TV, a browser tab) is
+ * really just one row in `tblApiTokens`. This file lets that row ALSO
+ * remember a friendly name / which platform / which app version / when it
+ * was last used — so a "your devices" screen can list them and let someone
+ * sign one out remotely, without ever showing the real secret bearer token
+ * back to anyone (including the person asking).
+ *
+ * DETAILED: `tblApiTokens.DeviceName/Platform/AppVersion/LastSeenAt` shipped
+ * live-dormant in #1511 (`appWeb/.sql/schema.sql` +
+ * `migrate-apple-phase2-live-schema.php`) — this module is the FIRST
+ * consumer. Every read/write here is
+ * apiTokensDeviceMetaColumnsExist()-gated so an un-migrated docroot degrades
+ * to "skip silently" (writers) or an empty result (readers) instead of a
+ * STRICT-mode `mysqli_sql_exception` on a missing column (CLAUDE.md rule
+ * #19/#28).
+ *
+ * DEVICE IDENTIFIER — WHY A HASH PREFIX, NEVER THE RAW TOKEN:
+ * `tblApiTokens`'s PRIMARY KEY is the token's OWN sha256 hash (`Token`) —
+ * there is no separate surrogate id column, and adding one would re-open a
+ * table this codebase deliberately keeps as a one-pass shipped shape (rule
+ * #20). A "device id" handed to the CLIENT is therefore a TRUNCATED PREFIX
+ * of that hash (`API_TOKEN_DEVICE_ID_LENGTH` hex chars — 64 bits at the
+ * default 16, astronomically collision-safe within one user's own handful
+ * of tokens; even a same-user collision would only ever let them sign out
+ * one of their OWN other devices, never cross a user boundary, because
+ * every lookup this module does is ALSO scoped to `UserId = ?`). This is
+ * NOT the raw bearer token: a hash cannot be reversed to recover it (SHA-256
+ * preimage resistance), and presenting the hash back as if it WERE a bearer
+ * credential fails outright — `getAuthenticatedUser()` re-hashes whatever is
+ * presented in `Authorization: Bearer` and compares against the STORED
+ * hash, so handing back the hash itself would need to be hashed AGAIN to
+ * authenticate, which never matches. Never widen any response to the full
+ * 64-char hash NOR to the raw token.
+ *
+ * @link https://www.php.net/manual/en/function.hash.php  hash('sha256', …)
+ * @see includes/device_code.php  the sibling #1407 module this one mirrors
+ *      the memoised-probe / dormancy conventions of
+ */
+
+/** How many leading hex chars of a token's sha256 identify it to the
+ *  client — see the file header for the collision-safety reasoning. Chosen
+ *  slightly above the existing `token_prefix` AUDIT-LOG convention (12
+ *  chars, e.g. api.php's `logActivity(..., ['token_prefix' => substr(hash(...), 0, 12)])`
+ *  calls) because THIS value doubles as a lookup key (device_signout), not
+ *  just a human-readable debug label. */
+const API_TOKEN_DEVICE_ID_LENGTH = 16;
+
+/** Closed vocabulary for the OPTIONAL client-declared `platform` field —
+ *  VARCHAR, app-validated here, never an ENUM (CLAUDE.md rule #20). Mirrors
+ *  `ANALYTICS_INGEST_ALLOWED_PLATFORMS` (includes/analytics_ingest.php) so a
+ *  device's `platform` value reads consistently with the analytics
+ *  ingestion vocabulary used elsewhere in the app — not re-derived. */
+const API_TOKEN_DEVICE_PLATFORMS = ['apple', 'android', 'web'];
+
+/**
+ * Memoised INFORMATION_SCHEMA existence probe — true only when ALL FOUR
+ * #1409 columns are present. A partial apply (e.g. an interrupted migration
+ * run) must never look "ready": this checks a COUNT(*) across all four
+ * names rather than probing just one (mirrors the multi-object OR-probe
+ * convention CLAUDE.md rule #19 describes for a migration registry probe,
+ * applied here as an AND-across-columns check since every consumer in this
+ * module needs the FULL set to behave correctly).
+ */
+function apiTokensDeviceMetaColumnsExist(\mysqli $db): bool
+{
+    static $exists = null;
+    if ($exists !== null) {
+        return $exists;
+    }
+    try {
+        $st = $db->prepare(
+            "SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+              WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tblApiTokens'
+                AND COLUMN_NAME IN ('DeviceName', 'Platform', 'AppVersion', 'LastSeenAt')"
+        );
+        $st->execute();
+        $count = (int)($st->get_result()->fetch_row()[0] ?? 0);
+        $st->close();
+        $exists = ($count === 4);
+    } catch (\Throwable $_e) {
+        $exists = false; /* un-migrated install → treat as absent → callers degrade */
+    }
+    return $exists;
+}
+
+/**
+ * Clean an OPTIONAL client-declared device-metadata triple from a decoded
+ * sign-in request body. Every field is genuinely optional — an existing
+ * native client that never sends them (every caller today) must sign in
+ * byte-identically to before this addition, so malformed/absent input
+ * degrades to null, NEVER a 400 on the sign-in itself. PURE (no DB, no
+ * superglobals) — safe to unit test without a request.
+ *
+ * @param mixed $body The decoded JSON request body (or a non-array, e.g.
+ *                     when json_decode() failed).
+ * @return array{deviceName:?string,platform:?string,appVersion:?string}
+ */
+function apiTokenDeviceMetaFromBody(mixed $body): array
+{
+    if (!is_array($body)) {
+        $body = [];
+    }
+
+    $deviceName = null;
+    if (isset($body['deviceName']) && is_string($body['deviceName'])) {
+        $trimmed = trim($body['deviceName']);
+        $deviceName = $trimmed !== '' ? mb_substr($trimmed, 0, 120) : null;
+    }
+
+    $platform = null;
+    if (isset($body['platform']) && is_string($body['platform'])) {
+        $candidate = strtolower(trim($body['platform']));
+        $platform = in_array($candidate, API_TOKEN_DEVICE_PLATFORMS, true) ? $candidate : null;
+    }
+
+    $appVersion = null;
+    if (isset($body['appVersion']) && is_string($body['appVersion'])) {
+        $trimmed = trim($body['appVersion']);
+        /* Loose version-string shape (digits/dots/dashes/letters, e.g.
+           "1.4.2" or "1.4.2-beta.1") capped at the column's own VARCHAR(20)
+           width — anything wildly outside that shape is dropped rather than
+           truncated/garbled into the column. */
+        $appVersion = ($trimmed !== '' && preg_match('/^[A-Za-z0-9.\-]{1,20}$/', $trimmed)) ? $trimmed : null;
+    }
+
+    return ['deviceName' => $deviceName, 'platform' => $platform, 'appVersion' => $appVersion];
+}
+
+/**
+ * Persist an OPTIONAL device-metadata triple against the token row a
+ * sign-in flow (auth_login / auth_apple / completeEmailLogin) JUST
+ * inserted. No-ops silently — never throws, never blocks sign-in — both
+ * when the columns aren't migrated yet AND when every field was null: a
+ * sign-in must NEVER fail because of this best-effort metadata write, which
+ * is why every caller invokes this AFTER its own token INSERT has already
+ * committed (mirrors how `setAuthTokenCookie()` is called post-insert too).
+ *
+ * @param string $tokenHash sha256 hex of the just-minted raw token — the
+ *                           SAME value already written to
+ *                           `tblApiTokens.Token` by the caller.
+ */
+function apiTokenDeviceMetaStore(\mysqli $db, string $tokenHash, ?string $deviceName, ?string $platform, ?string $appVersion): void
+{
+    if ($deviceName === null && $platform === null && $appVersion === null) {
+        return;
+    }
+    if (!apiTokensDeviceMetaColumnsExist($db)) {
+        return;
+    }
+    try {
+        $stmt = $db->prepare(
+            'UPDATE tblApiTokens SET DeviceName = ?, Platform = ?, AppVersion = ? WHERE Token = ?'
+        );
+        $stmt->bind_param('ssss', $deviceName, $platform, $appVersion, $tokenHash);
+        $stmt->execute();
+        $stmt->close();
+    } catch (\Throwable $e) {
+        error_log('[api_tokens/deviceMetaStore] ' . $e->getMessage());
+    }
+}
+
+/**
+ * Truncated, display-and-lookup-safe identifier for a token row — see the
+ * file header for why this is safe to hand to the client (never the raw
+ * token, never the full hash).
+ */
+function apiTokenDeviceId(string $tokenHash): string
+{
+    return substr($tokenHash, 0, API_TOKEN_DEVICE_ID_LENGTH);
+}

--- a/appWeb/public_html/includes/apns.php
+++ b/appWeb/public_html/includes/apns.php
@@ -1,0 +1,473 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — APNs bridge: ES256 provider JWT + push-token registration (#1410,
+ * Apple Phase-2 PR-13) — DORMANT plumbing, no key provisioned yet
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * ELI5: this is the machinery a FUTURE feature (e.g. "your co-leader just
+ * requested control", "the setlist changed") would use to knock on Apple's
+ * door and say "please buzz this specific phone/watch". It does two jobs:
+ * (1) remember WHICH devices/Live Activities want to be buzzed
+ * (`apns_register`/`apns_unregister`, backed by `tblApnsTokens`), and (2)
+ * know HOW to prove to Apple's push server that the knock is really from
+ * iHymns (`apnsSend()`, a signed token + an HTTPS/2 request). Nothing in
+ * THIS change actually knocks on anyone's door — no code path here is
+ * called by any live feature yet, and even if it were, step (2) refuses to
+ * run at all until the owner pastes a real Apple-issued key.
+ *
+ * DETAILED: `tblApnsTokens` shipped live-dormant in #1511
+ * (`appWeb/.sql/schema.sql` + `migrate-apple-phase2-live-schema.php`) —
+ * this module is the FIRST consumer. Every read/write here is
+ * apnsTokensTableExists()-gated so an un-migrated docroot degrades to a
+ * clean "not available yet" response instead of a STRICT-mode
+ * `mysqli_sql_exception` on a missing table (CLAUDE.md rule #19/#28).
+ *
+ * THE TWO CRYPTO/TRANSPORT OPERATIONS:
+ *   1. SIGN (ES256) — Apple's token-based APNs provider API requires every
+ *      push request to carry a short-lived JWT ("provider authentication
+ *      token") signed with an Apple-issued EC P-256 "APNs Auth Key" (a
+ *      DIFFERENT `.p8` file from the Sign-in-with-Apple key, though both
+ *      belong to the same Apple Developer Team). `_apnsBuildJwt()` is the
+ *      PURE core (no DB, no network — testable with a locally-generated
+ *      test keypair, see tests/php/test-apns-jwt.php) and DELIBERATELY
+ *      REUSES `apple_siwa.php`'s already-battle-tested base64url +
+ *      DER→JOSE-signature helpers (`_appleSiwaB64UrlEncode()` /
+ *      `_appleSiwaDerEcdsaToRaw()`) rather than re-forking that intricate
+ *      conversion a second time (CLAUDE.md modularity rule) — see
+ *      `.claude/apple-backend-auth-plan.md` §3.4 for why the DER↔JOSE
+ *      boundary is the trap worth sharing code across, not duplicating.
+ *      The EC-P-256-key-parse-and-validate guard itself IS still a small,
+ *      separately-duplicated ~10 lines (see `_apnsBuildJwt()`'s own
+ *      docblock) — a deliberate, documented trade-off: it is the
+ *      MECHANICAL half of the job (not the crypto-subtle half, which IS
+ *      shared), and keeping it local means this dormant, never-yet-called
+ *      module carries ZERO risk of regressing the actively-used SIWA
+ *      client_secret path.
+ *   2. TRANSPORT (HTTP/2) — Apple's APNs REQUIRES HTTP/2; `apnsSend()`
+ *      explicitly probes `curl_version()`'s feature flags and refuses to
+ *      attempt a request at all (`http2_unsupported`) rather than silently
+ *      falling back to HTTP/1.1, which Apple's production gateway does not
+ *      accept. Shared-hosting curl builds vary — this has NOT been
+ *      exercised against a live Apple endpoint from this project's actual
+ *      DreamHost PHP build; flagged explicitly as an open risk rather than
+ *      assumed to work (see the PR description / handoff notes).
+ *
+ * `.p8` CUSTODY — CORRECTED FROM "outside the docroot in `.auth/`" TO
+ * "MIRROR WHAT SIWA ACTUALLY DOES":
+ * The SIWA `.p8` (includes/apple_siwa.php) is NOT filesystem-custodied — it
+ * lives in `tblAppSettings` (key `apple_siwa_private_key`), encrypted at
+ * rest by `includes/secret_crypto.php` (#1466/#1469) and read transparently
+ * via `getAppSetting()`. `appWeb/.auth/` holds only the INFRASTRUCTURE
+ * bootstrap secrets that must exist before any database read is even
+ * possible (`db_credentials.php`, the secret-encryption `secrets_master_
+ * key.php`) — never an application-level secret like a provider `.p8`. This
+ * matters operationally: the project's operator is WEB-ONLY on shared
+ * DreamHost hosting (no CLI/SFTP in the normal workflow) — a `.auth/`
+ * FILE-based key would need filesystem access the owner does not routinely
+ * have, whereas `tblAppSettings` is reachable from the SAME
+ * Global-Admin web form the SIWA key already uses. `apnsPrivateKeyPem()`
+ * below therefore checks the setting FIRST (the real, provisionable-today
+ * path once a future admin-UI card exists — out of THIS change's scope,
+ * see the file's bottom note) and falls back to an OPTIONAL
+ * `appWeb/.auth/apns_private_key.p8` file second, satisfying the literal
+ * "setting-or-file" framing while keeping the setting path primary. The new
+ * setting key (`apple_apns_private_key`) is added to `secretSettingKeys()`
+ * (includes/secret_crypto.php) in the SAME change, so whenever an admin-UI
+ * card DOES get built, the value is encrypted-at-rest from day one — this
+ * is a zero-risk, purely-additive line (an absent/never-saved setting key
+ * is a documented no-op for every consumer of that list, see
+ * `secretInventory()`'s docblock).
+ *
+ * SECURITY (mirrors device_code.php's #1407 conventions, rule #26):
+ *   - `tblApnsTokens` has NO `Channel` column of its own (the shipped #1511
+ *     DDL) — a Live-Activity token's session-scoping is CARRIED
+ *     TRANSITIVELY through its `SessionId` FK, so `apns_register` resolves
+ *     (and channel-filters) the referenced `tblLiveFollowSessions` row
+ *     itself when `Kind = 'liveActivity'` rather than needing a redundant
+ *     column on this table.
+ *   - The raw push token is stored as `VARBINARY` (matches the shipped DDL
+ *     comment "Raw APNs device/activity push token bytes") — the client
+ *     sends/receives it hex-encoded; `hex2bin()`/`bin2hex()` convert at the
+ *     boundary.
+ *   - `apnsSend()` NEVER logs a push token (raw, hex, or hashed) — only
+ *     `Kind`/`ApnsEnv`/`SessionId`/HTTP status/APNs `reason` code, all
+ *     fixed-vocabulary or numeric, never the token itself.
+ *
+ * BREADCRUMBS (observability §3.2 convention, #1512): the api.php case
+ * blocks that call into this module log `apns.token.register` /
+ * `.unregister` — IDs + fixed vocabulary ONLY (`kind`, `apns_env`,
+ * `session_id`), NEVER the push token in any form.
+ *
+ * @link https://developer.apple.com/documentation/usernotifications/establishing-a-token-based-connection-to-apns  APNs provider token
+ * @link https://developer.apple.com/documentation/usernotifications/sending-notification-requests-to-apns          APNs HTTP/2 request shape
+ * @link https://developer.apple.com/documentation/activitykit/starting-and-updating-live-activities-with-activitykit-push-notifications  Live Activity push topic suffix
+ * @link https://www.php.net/manual/en/function.curl-version.php    curl_version() feature flags (HTTP/2 probe)
+ * @link https://www.php.net/manual/en/function.openssl-sign.php
+ * @see includes/apple_siwa.php  the SIWA module this one's ES256/base64url helpers are borrowed from
+ * @see includes/device_code.php the sibling #1407 module this one mirrors the dormancy conventions of
+ *
+ * NOT IN SCOPE FOR THIS CHANGE (deliberately, per the #1410 task brief):
+ * an admin-UI card on manage/configuration.php to actually PASTE the APNs
+ * Key ID / `.p8` (mirroring the SIWA card, #1402 task F) — until that
+ * exists, `getAppSetting('apple_apns_key_id'|'apple_apns_private_key', '')`
+ * always reads empty, so `apnsConfigured()` is always false and `apnsSend()`
+ * is a guaranteed `not_configured` no-op regardless of anything else in
+ * this file.
+ */
+
+/* Reuses _appleSiwaB64UrlEncode() / _appleSiwaDerEcdsaToRaw() — see the
+   file-header note above on why the ES256 JOSE-encoding step is shared
+   rather than re-forked. apple_siwa.php has no hard DB dependency at
+   load time, so requiring it here keeps this module (and its CLI test)
+   standalone-loadable too. */
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'apple_siwa.php';
+
+/** Closed vocabulary for `tblApnsTokens.ApnsEnv` — VARCHAR, app-validated,
+ *  never an ENUM (rule #20); matches the shipped column COMMENT exactly. */
+const APNS_ENVIRONMENTS = ['sandbox', 'production'];
+
+/** Closed vocabulary for `tblApnsTokens.Kind` — VARCHAR, app-validated,
+ *  never an ENUM (rule #20); matches the shipped column COMMENT exactly. */
+const APNS_KINDS = ['device', 'liveActivity'];
+
+/** Apple's fixed Live-Activity push topic suffix (ActivityKit docs, linked
+ *  above) — appended to the bundle id ONLY for Kind='liveActivity' sends. */
+const APNS_LIVE_ACTIVITY_TOPIC_SUFFIX = '.push-type.liveactivity';
+
+/**
+ * Memoised INFORMATION_SCHEMA existence probe for `tblApnsTokens`. Mirrors
+ * `authDeviceCodesTableExists()` (device_code.php) / `sessionControlTokensTableExists()`
+ * (session_control_token.php) — one memoised probe per module, per the
+ * established per-module dormancy-gate convention (CLAUDE.md rule #19/#28).
+ */
+function apnsTokensTableExists(\mysqli $db): bool
+{
+    static $exists = null;
+    if ($exists !== null) {
+        return $exists;
+    }
+    try {
+        $st = $db->prepare(
+            "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+              WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tblApnsTokens' LIMIT 1"
+        );
+        $st->execute();
+        $exists = $st->get_result()->fetch_row() !== null;
+        $st->close();
+    } catch (\Throwable $_e) {
+        $exists = false; /* un-migrated install → treat as absent → caller 503s */
+    }
+    return $exists;
+}
+
+/**
+ * Resolve the APNs Auth Key `.p8` PEM contents — DB setting first (the
+ * real, web-provisionable-today path, mirrors SIWA), an optional
+ * filesystem file second. See the file header's "`.p8` CUSTODY" section for
+ * the full reasoning. Returns '' when neither source has a value — NEVER
+ * throws, NEVER guesses.
+ */
+function apnsPrivateKeyPem(): string
+{
+    $fromSetting = function_exists('getAppSetting')
+        ? trim((string)(getAppSetting('apple_apns_private_key', '') ?? ''))
+        : '';
+    if ($fromSetting !== '') {
+        return $fromSetting;
+    }
+
+    /* Optional file-based override for an operator who prefers filesystem
+       custody over the web Global-Admin form — mirrors the appWeb/.auth/
+       bootstrap-file location convention (db_credentials.php,
+       secrets_master_key.php) WITHOUT being wired into the installer: no
+       .example file is shipped for this path, and nothing requires it to
+       exist. Purely a secondary manual option. */
+    $keyFile = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . '.auth' . DIRECTORY_SEPARATOR . 'apns_private_key.p8';
+    if (is_file($keyFile) && is_readable($keyFile)) {
+        $contents = @file_get_contents($keyFile);
+        if (is_string($contents) && trim($contents) !== '') {
+            return trim($contents);
+        }
+    }
+
+    return '';
+}
+
+/**
+ * The three credentials `_apnsBuildJwt()` needs. `apple_team_id` is REUSED
+ * from the existing SIWA setting (includes/apple_siwa.php / api.php's
+ * auth_apple handler already read it) — the Apple Developer Team ID is the
+ * SAME value regardless of which `.p8` it signs for, so this deliberately
+ * does NOT add a second, redundant team-id setting. `apple_apns_key_id` is
+ * new (not secret — like `apple_siwa_key_id`, a Key ID is just a public
+ * identifier, meaningless without the paired private key).
+ *
+ * @return array{teamId:string,keyId:string,p8Pem:string}
+ */
+function apnsCredentials(): array
+{
+    $teamId = function_exists('getAppSetting')
+        ? trim((string)(getAppSetting('apple_team_id', '') ?? ''))
+        : '';
+    $keyId = function_exists('getAppSetting')
+        ? trim((string)(getAppSetting('apple_apns_key_id', '') ?? ''))
+        : '';
+    return ['teamId' => $teamId, 'keyId' => $keyId, 'p8Pem' => apnsPrivateKeyPem()];
+}
+
+/**
+ * Is the APNs bridge provisioned AND does the stored key actually parse as
+ * a usable EC P-256 private key? A cheap "is this feature dormant or live"
+ * check for callers that want to short-circuit before doing anything else
+ * (e.g. a future admin status panel, mirroring `$appleSiwaPrivateKeySet`'s
+ * role in manage/configuration.php).
+ */
+function apnsConfigured(): bool
+{
+    $creds = apnsCredentials();
+    if ($creds['teamId'] === '' || $creds['keyId'] === '' || $creds['p8Pem'] === '') {
+        return false;
+    }
+    return _apnsBuildJwt($creds['teamId'], $creds['keyId'], $creds['p8Pem'], time()) !== null;
+}
+
+/**
+ * Mint an APNs provider-authentication JWT (ES256) — see Apple's
+ * "Establishing a token-based connection to APNs" guide (linked in the file
+ * header). PURE apart from the `openssl_*` calls (no DB, no network, no
+ * superglobals) — every input is an explicit parameter, so
+ * tests/php/test-apns-jwt.php exercises this with a LOCALLY-GENERATED test
+ * keypair, never a real Apple-issued key.
+ *
+ * SHAPE (deliberately DIFFERENT from `appleSiwaBuildClientSecret()`'s SIWA
+ * client_secret JWT, which this is a cousin of, not a copy): the header is
+ * `{alg:'ES256', kid:<APNs Key ID>}`; the claims are JUST
+ * `{iss:<Team ID>, iat:<now>}` — APNs provider tokens carry NO `exp`/`aud`/
+ * `sub` (Apple's guide: a token is valid up to 1 hour from `iat`; Apple
+ * recommends reusing/refreshing at most once per 20 minutes and at least
+ * once per hour, not minting a fresh one per push).
+ *
+ * KEY-VALIDATION DUPLICATION (documented trade-off, see this file's header
+ * "SIGN (ES256)" section): the EC-P-256-parse-and-verify block below is
+ * mechanically identical to `appleSiwaBuildClientSecret()`'s own guard —
+ * duplicated here rather than extracted into a THIRD shared helper, so this
+ * brand-new, never-yet-called module carries zero edit risk to the
+ * actively-used SIWA sign-in path. The genuinely intricate, security-
+ * sensitive part (base64url + DER→JOSE signature conversion) IS shared —
+ * see the two `_appleSiwa*()` calls below.
+ *
+ * @param string $teamId Apple Developer Team ID (10 chars) — the JWT `iss`.
+ * @param string $keyId  The APNs Auth Key's Key ID (10 chars) — the JWS header `kid`.
+ * @param string $p8Pem  The owner-provisioned APNs `.p8` PRIVATE KEY PEM (EC P-256, PKCS#8).
+ * @param int    $now    Current unix time (injected for testability).
+ * @return string|null Compact JWS, or null when the PEM doesn't parse or isn't an EC P-256 key.
+ */
+function _apnsBuildJwt(string $teamId, string $keyId, string $p8Pem, int $now): ?string
+{
+    if ($teamId === '' || $keyId === '' || trim($p8Pem) === '') {
+        return null;
+    }
+
+    $privKey = @openssl_pkey_get_private($p8Pem);
+    if ($privKey === false) {
+        return null;
+    }
+    $details = @openssl_pkey_get_details($privKey);
+    if (!is_array($details) || ($details['type'] ?? null) !== OPENSSL_KEYTYPE_EC) {
+        return null;
+    }
+    $curveName = $details['ec']['curve_name'] ?? null;
+    /* P-256 is reported as either name depending on the OpenSSL build
+       (same two-name check as appleSiwaBuildClientSecret()). */
+    if ($curveName !== 'prime256v1' && $curveName !== 'secp256r1') {
+        return null;
+    }
+
+    $header = ['alg' => 'ES256', 'kid' => $keyId];
+    $claims = ['iss' => $teamId, 'iat' => $now];
+
+    $h64 = _appleSiwaB64UrlEncode((string)json_encode($header, JSON_UNESCAPED_SLASHES));
+    $p64 = _appleSiwaB64UrlEncode((string)json_encode($claims, JSON_UNESCAPED_SLASHES));
+    $signingInput = "{$h64}.{$p64}";
+
+    $derSig = '';
+    if (!openssl_sign($signingInput, $derSig, $privKey, OPENSSL_ALGO_SHA256)) {
+        return null;
+    }
+
+    /* P-256 → 32-byte r, 32-byte s (shared helper — see this function's
+       docblock for why this call, unlike the key-validation block above,
+       is REUSED rather than duplicated). */
+    $rawSig = _appleSiwaDerEcdsaToRaw($derSig, 32);
+    if ($rawSig === null) {
+        return null;
+    }
+
+    return $signingInput . '.' . _appleSiwaB64UrlEncode($rawSig);
+}
+
+/** Which APNs gateway host a given environment sends to. */
+function apnsEndpointHost(string $apnsEnv): string
+{
+    return $apnsEnv === 'sandbox' ? 'api.sandbox.push.apple.com' : 'api.push.apple.com';
+}
+
+/**
+ * Send ONE push notification via Apple's HTTP/2 token-based APNs API.
+ * DORMANT by construction: returns `not_configured` immediately (no
+ * network call, no DB write) unless `apnsCredentials()` resolves a usable
+ * key — which, absent an admin-UI card to provision one (see file header),
+ * is ALWAYS the case on every docroot today. Nothing in this codebase calls
+ * this function yet; it exists as plumbing for a future feature to call.
+ *
+ * ELI5: "try to buzz this one device/Live Activity, and tell me plainly
+ * what happened" — configured-but-Apple-said-no, not-configured-at-all,
+ * this-phone's-HTTP/2-can't-even-try, or genuinely sent.
+ *
+ * HTTP/2 REQUIREMENT: Apple's APNs REQUIRES HTTP/2 — this explicitly probes
+ * `curl_version()`'s feature bitmask and refuses to attempt the request at
+ * all (`http2_unsupported`) rather than silently falling back to HTTP/1.1,
+ * which Apple's gateway does not accept. THIS HAS NOT BEEN VERIFIED against
+ * a live Apple endpoint from this project's actual shared-hosting curl
+ * build — flagged as an open risk, not assumed to work.
+ *
+ * 410 / Unregistered / BadDeviceToken PRUNING: per Apple's own operational
+ * guidance, a token APNs reports as permanently dead is deleted from
+ * `tblApnsTokens` so a future caller doesn't keep re-sending to it.
+ *
+ * @param string      $pushTokenHex Lowercase hex-encoded push token (the
+ *                                  SAME shape `apns_register` stores).
+ * @param string      $apnsEnv      'sandbox' | 'production'.
+ * @param string      $kind         'device' | 'liveActivity' — selects the
+ *                                  `apns-topic` suffix + `apns-push-type`.
+ * @param array       $payload      The APNs JSON payload (an `aps` dict at
+ *                                  minimum) — caller's responsibility to
+ *                                  shape correctly; this function does not
+ *                                  validate its contents.
+ * @param string|null $collapseId   Optional `apns-collapse-id` header value.
+ * @return array{ok:bool,status:string,httpStatus?:int,reason?:?string}
+ */
+function apnsSend(\mysqli $db, string $pushTokenHex, string $apnsEnv, string $kind, array $payload, ?string $collapseId = null): array
+{
+    if (!in_array($apnsEnv, APNS_ENVIRONMENTS, true)) {
+        $apnsEnv = 'production';
+    }
+    if (!in_array($kind, APNS_KINDS, true)) {
+        $kind = 'device';
+    }
+    $pushTokenHex = strtolower($pushTokenHex);
+    if (!preg_match('/^[a-f0-9]{32,200}$/', $pushTokenHex) || strlen($pushTokenHex) % 2 !== 0) {
+        return ['ok' => false, 'status' => 'invalid_token'];
+    }
+
+    $creds = apnsCredentials();
+    if ($creds['teamId'] === '' || $creds['keyId'] === '' || $creds['p8Pem'] === '') {
+        return ['ok' => false, 'status' => 'not_configured'];
+    }
+    $jwt = _apnsBuildJwt($creds['teamId'], $creds['keyId'], $creds['p8Pem'], time());
+    if ($jwt === null) {
+        return ['ok' => false, 'status' => 'not_configured', 'reason' => 'key_unparseable'];
+    }
+
+    if (!function_exists('curl_init')) {
+        return ['ok' => false, 'status' => 'transport_unavailable', 'reason' => 'curl_missing'];
+    }
+    $curlFeatures = curl_version();
+    $http2Supported = is_array($curlFeatures)
+        && defined('CURL_VERSION_HTTP2')
+        && (((int)($curlFeatures['features'] ?? 0)) & CURL_VERSION_HTTP2) !== 0;
+    if (!$http2Supported) {
+        /* See this function's docblock — never silently attempt HTTP/1.1
+           against an HTTP/2-only endpoint. */
+        return ['ok' => false, 'status' => 'http2_unsupported'];
+    }
+
+    $topic = IHYMNS_SIWA_CLIENT_ID . ($kind === 'liveActivity' ? APNS_LIVE_ACTIVITY_TOPIC_SUFFIX : '');
+    $url = 'https://' . apnsEndpointHost($apnsEnv) . '/3/device/' . $pushTokenHex;
+
+    $headers = [
+        'authorization: bearer ' . $jwt,
+        'apns-topic: ' . $topic,
+        'apns-push-type: ' . ($kind === 'liveActivity' ? 'liveactivity' : 'alert'),
+        'apns-priority: 10',
+        'content-type: application/json',
+    ];
+    if ($collapseId !== null && $collapseId !== '') {
+        $headers[] = 'apns-collapse-id: ' . substr(preg_replace('/[^A-Za-z0-9_\-]/', '', $collapseId) ?? '', 0, 64);
+    }
+
+    $ch = curl_init($url);
+    curl_setopt_array($ch, [
+        CURLOPT_POST            => true,
+        CURLOPT_POSTFIELDS      => (string)json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+        CURLOPT_HTTPHEADER      => $headers,
+        CURLOPT_HTTP_VERSION    => CURL_HTTP_VERSION_2_0,
+        CURLOPT_RETURNTRANSFER  => true,
+        /* TLS verification is ALWAYS on for this outbound call — same
+           non-negotiable invariant apple_siwa.php documents for its own
+           outbound Apple calls. */
+        CURLOPT_SSL_VERIFYPEER  => true,
+        CURLOPT_SSL_VERIFYHOST  => 2,
+        CURLOPT_FOLLOWLOCATION  => false,
+        CURLOPT_MAXREDIRS       => 0,
+        CURLOPT_PROTOCOLS       => CURLPROTO_HTTPS,
+        CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTPS,
+        CURLOPT_CONNECTTIMEOUT  => 8,
+        CURLOPT_TIMEOUT         => 15,
+    ]);
+    $respBody   = curl_exec($ch);
+    $errno      = curl_errno($ch);
+    $httpStatus = (int)curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    if ($errno !== 0 || $respBody === false) {
+        return ['ok' => false, 'status' => 'transport_error', 'reason' => 'curl_errno_' . $errno];
+    }
+
+    if ($httpStatus === 200) {
+        return ['ok' => true, 'status' => 'sent'];
+    }
+
+    $reason = null;
+    $decoded = json_decode((string)$respBody, true);
+    if (is_array($decoded) && isset($decoded['reason']) && is_string($decoded['reason'])) {
+        $reason = $decoded['reason'];
+    }
+
+    if ($httpStatus === 410 || $reason === 'Unregistered' || $reason === 'BadDeviceToken') {
+        _apnsPruneToken($db, $pushTokenHex);
+        return ['ok' => false, 'status' => 'pruned', 'httpStatus' => $httpStatus, 'reason' => $reason];
+    }
+
+    return ['ok' => false, 'status' => 'apns_error', 'httpStatus' => $httpStatus, 'reason' => $reason];
+}
+
+/**
+ * Best-effort delete of a push token APNs has told us will never work
+ * again (410 / `Unregistered` / `BadDeviceToken`). Never throws — a prune
+ * failure must not turn an already-reported send failure into an uncaught
+ * exception.
+ */
+function _apnsPruneToken(\mysqli $db, string $pushTokenHex): void
+{
+    if (!apnsTokensTableExists($db)) {
+        return;
+    }
+    $bin = @hex2bin($pushTokenHex);
+    if ($bin === false) {
+        return;
+    }
+    try {
+        $del = $db->prepare('DELETE FROM tblApnsTokens WHERE PushToken = ?');
+        $del->bind_param('s', $bin);
+        $del->execute();
+        $del->close();
+    } catch (\Throwable $e) {
+        error_log('[apns/pruneToken] ' . $e->getMessage());
+    }
+}

--- a/appWeb/public_html/includes/secret_crypto.php
+++ b/appWeb/public_html/includes/secret_crypto.php
@@ -438,6 +438,21 @@ function secretSettingKeys(): array
         'email_graph_client_secret',
         'email_gmail_sa_json',
         'apple_siwa_private_key',
+        /* #1410 — APNs Auth Key `.p8`. NOT yet writable via any admin-UI
+           field (manage/configuration.php has no APNs card in this change —
+           see includes/apns.php's file-header "NOT IN SCOPE" note), so this
+           key currently has NO row in tblAppSettings on any docroot. Adding
+           it here now is a zero-risk, purely-additive registration: every
+           consumer of secretSettingKeys() (secretInventory(),
+           secretEncryptInPlace(), secretRotateReencrypt()) explicitly skips
+           a key with no row / an empty value (see those functions'
+           docblocks), so this has NO effect until a future PR adds the
+           admin-UI card AND an owner pastes a real key — at which point it
+           is encrypted at rest from the very first save, mirroring
+           apple_siwa_private_key's custody exactly (rule: "mirror the SIWA
+           .p8 custody pattern").
+         */
+        'apple_apns_private_key',
     ];
 }
 

--- a/appWeb/public_html/includes/session_control_token.php
+++ b/appWeb/public_html/includes/session_control_token.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * iHymns — Session control tokens (#1408, Apple Phase-2 PR-9)
+ *
+ * Copyright (c) 2026 iHymns. All rights reserved.
+ *
+ * PURPOSE:
+ * ELI5: normally only the person actually signed in as a live/service
+ * session's operator can drive the screen (pick the next song, blank it,
+ * nudge the current line). This lets that person hand a SEPARATE, throwaway
+ * key to a co-leader's device for "just THIS one session" — the co-leader
+ * never sees the operator's username/password, and the key can be switched
+ * off instantly the moment it's no longer needed (e.g. at the end of the
+ * service, or if the device is lost).
+ *
+ * DETAILED: `tblSessionControlTokens` shipped live-dormant in #1511
+ * (`appWeb/.sql/schema.sql` + `migrate-apple-phase2-live-schema.php`) — this
+ * module is the FIRST consumer. Every read/write here is
+ * sessionControlTokensTableExists()-gated so an un-migrated docroot
+ * degrades to a clean "not available yet" response instead of a
+ * STRICT-mode `mysqli_sql_exception` on a missing table (CLAUDE.md rule
+ * #19/#28 dormancy convention; the #1228 "a false-check is dead code, a
+ * missing table THROWS" lesson).
+ *
+ * SCOPE: today the ONLY consumer is `?action=service_broadcast` (api.php) —
+ * a minted token grants `Scope='broadcast'` against exactly ONE
+ * `SessionKind='service'` `tblLiveFollowSessions` row (the same row
+ * `service_broadcast` itself operates on). `Scope` is VARCHAR, app-validated
+ * against SESSION_CONTROL_TOKEN_SCOPES below (CLAUDE.md rule #20 — never an
+ * ENUM), so a future read-only `'view'` scope needs no schema change.
+ *
+ * SECURITY (mirrors `includes/device_code.php`'s #1407 conventions, rule
+ * #26 — the 3-docroot shared-DB env discriminator):
+ *   - CHANNEL-SCOPED: every mint/validate/revoke filters
+ *     `Channel = serviceMode_channel()` so an alpha-minted token can never
+ *     control a beta/production session.
+ *   - The raw token is NEVER stored — only its SHA-256 hex (`TokenHash`),
+ *     the same discipline as `tblApiTokens.Token` /
+ *     `tblAuthDeviceCodes.DeviceCodeHash`.
+ *   - Revoke is a bulk "stop delegation on this session" action (every
+ *     still-live token for that `SessionId`), not a per-token lookup — the
+ *     operator never needs to hold/store an opaque token id to switch
+ *     delegated access off, and nothing token-shaped is ever echoed back
+ *     to the operator after mint (only the raw token itself, exactly once,
+ *     in the mint response).
+ *
+ * BREADCRUMBS (observability §3.2 convention, #1512): the api.php case
+ * blocks that call into this module log `service.control_token.mint` /
+ * `.revoke` — IDs ONLY (`session_id`, `channel`), NEVER the raw token or a
+ * hash of it (mirrors `device_code.php`'s discipline for the same reason —
+ * this is a short-lived bearer-style secret, not a stable identifier; even
+ * logging a hash prefix narrows an attacker's guess space for zero audit
+ * value).
+ *
+ * @link https://www.php.net/manual/en/function.hash.php            hash('sha256', …)
+ * @link https://www.php.net/manual/en/function.random-bytes.php    random_bytes()
+ * @link https://www.php.net/manual/en/mysqli-stmt.bind-param.php   bind_param()
+ * @see includes/service_mode.php   serviceMode_channel() — the channel discriminator reused here
+ * @see includes/device_code.php    the sibling #1407 module this one's shape mirrors
+ */
+
+/* Reuses serviceMode_channel() (the 3-docroot env discriminator) — see the
+   file-header note above on why every Phase-2 auth module shares this one
+   source instead of re-deriving the channel itself. */
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'service_mode.php';
+
+/** Closed vocabulary for `tblSessionControlTokens.Scope` — VARCHAR,
+ *  app-validated here, never an ENUM (CLAUDE.md rule #20: an ENUM value-add
+ *  is itself a migration). Only `broadcast` has a consumer today; a future
+ *  read-only `view` scope (e.g. a "watch along, can't drive" delegate) fits
+ *  the existing `VARCHAR(40)` column unchanged. */
+const SESSION_CONTROL_TOKEN_SCOPES = ['broadcast'];
+
+/**
+ * Fallback short TTL (seconds) for a freshly-minted control token. The
+ * ACTUAL expiry is `LEAST(session end, now + this)` (computed SQL-side in
+ * sessionControlToken_mint()) — this constant only matters when it is
+ * SHORTER than the session's own remaining lifetime, so a delegated device
+ * is never implicitly trusted for the FULL length of a long session. 2
+ * hours comfortably covers "hand the phone to a co-leader for the second
+ * half of a service" without matching the full 4h hard ceiling
+ * (`SERVICE_MODE_HARD_CEILING_HOURS`, service_mode.php) — an operator who
+ * needs longer simply mints again (cheap, revocable, no re-auth required).
+ */
+const SESSION_CONTROL_TOKEN_TTL_SECONDS = 7200;
+
+/**
+ * Memoised INFORMATION_SCHEMA existence probe for `tblSessionControlTokens`.
+ * Mirrors `authDeviceCodesTableExists()` (device_code.php) — see that
+ * function's docblock for why this codebase keeps one memoised probe per
+ * module rather than a single shared generic `tableExists()` helper (each
+ * module degrades independently, and the probe result is cheap to compute
+ * once per request and reuse).
+ */
+function sessionControlTokensTableExists(\mysqli $db): bool
+{
+    static $exists = null;
+    if ($exists !== null) {
+        return $exists;
+    }
+    try {
+        $st = $db->prepare(
+            "SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+              WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tblSessionControlTokens' LIMIT 1"
+        );
+        $st->execute();
+        $exists = $st->get_result()->fetch_row() !== null;
+        $st->close();
+    } catch (\Throwable $_e) {
+        $exists = false; /* un-migrated install → treat as absent → caller 503s */
+    }
+    return $exists;
+}
+
+/**
+ * Resolve whether $userId (with $role) may operate the given live/service
+ * session — mint a control token for it, revoke one, or (existing,
+ * unchanged behaviour) broadcast to it directly.
+ *
+ * ELI5: "is this person allowed to drive THIS session's screen?" — yes if
+ * they're a global admin/admin, the person who started the session, or an
+ * admin/owner of the organisation the session belongs to.
+ *
+ * DETAILED: extracted here so the NEW #1408 mint/revoke endpoints reuse ONE
+ * copy instead of adding a 4th/5th inline copy of the check already
+ * duplicated across api.php's `service_session_start` /
+ * `service_code_rotate|current|end` / `service_broadcast` handlers
+ * (CLAUDE.md's non-negotiable modularity rule). Those three PRE-EXISTING
+ * inline copies are deliberately left untouched by this change — unifying
+ * them retroactively is a separate, lower-risk-when-isolated follow-up, not
+ * a behaviour change bundled into this addition.
+ *
+ * @param int    $userId            The authenticated caller.
+ * @param string $role              The caller's tblUsers.Role.
+ * @param int    $sessionOrgId      The session's OrgId (0/absent → never
+ *                                   matches an org-admin grant, only the
+ *                                   global-admin/host checks can pass).
+ * @param int    $sessionHostUserId The session's HostUserId.
+ */
+function serviceMode_userCanOperate(int $userId, string $role, int $sessionOrgId, int $sessionHostUserId): bool
+{
+    require_once __DIR__ . DIRECTORY_SEPARATOR . 'entitlements.php';
+    return ($role === 'global_admin' || $role === 'admin')
+        || $sessionHostUserId === $userId
+        || in_array($sessionOrgId, userIsOrgAdminOf($userId), true);
+}
+
+/**
+ * Mint + persist a fresh session control token scoped to $channel + one
+ * $sessionId. Returns the RAW token (the caller hands this to the operator
+ * ONCE — it is never stored, never re-derivable, never logged) or null on a
+ * genuine failure.
+ *
+ * $sessionExpiresAtUtc is the session's OWN `ExpiresAt`
+ * ('Y-m-d H:i:s'-shaped UTC string, as already read by the caller from
+ * `tblLiveFollowSessions`) — the token's `ExpiresAt` is computed SQL-side as
+ * `LEAST(that, now + SESSION_CONTROL_TOKEN_TTL_SECONDS)` so it can never
+ * drift from the session's real end via a PHP-vs-SQL clock comparison
+ * (mirrors `device_code.php`'s documented "compute expiry SQL-side"
+ * discipline).
+ *
+ * @return string|null Raw token (64 lowercase hex chars — the same shape as
+ *                      `tblApiTokens`/`tblAuthDeviceCodes` raw tokens), or
+ *                      null when the INSERT itself failed.
+ */
+function sessionControlToken_mint(\mysqli $db, int $sessionId, string $channel, string $sessionExpiresAtUtc, string $scope = 'broadcast'): ?string
+{
+    if (!in_array($scope, SESSION_CONTROL_TOKEN_SCOPES, true)) {
+        $scope = 'broadcast';
+    }
+    /* 32 random bytes = 64 hex chars — the same raw-token entropy/shape as
+       tblApiTokens.Token and tblAuthDeviceCodes' device_code (no retry loop
+       needed for a UNIQUE collision the way the 6-char human join codes
+       need one; a 256-bit random value colliding is not a practical
+       concern). */
+    $token = bin2hex(random_bytes(32));
+    $hash  = hash('sha256', $token);
+    $ttl   = SESSION_CONTROL_TOKEN_TTL_SECONDS;
+
+    try {
+        $ins = $db->prepare(
+            "INSERT INTO tblSessionControlTokens (TokenHash, SessionId, Channel, Scope, IssuedAt, ExpiresAt)
+             VALUES (?, ?, ?, ?, UTC_TIMESTAMP(), LEAST(?, DATE_ADD(UTC_TIMESTAMP(), INTERVAL ? SECOND)))"
+        );
+        $ins->bind_param('sisssi', $hash, $sessionId, $channel, $scope, $sessionExpiresAtUtc, $ttl);
+        $ins->execute();
+        $ins->close();
+    } catch (\Throwable $e) {
+        error_log('[session_control_token/mint] ' . $e->getMessage());
+        return null;
+    }
+    return $token;
+}
+
+/**
+ * Validate a presented raw control token against ONE session + channel +
+ * scope. Returns true only when the token's hash matches an UNREVOKED,
+ * UNEXPIRED row for exactly that `SessionId` + `Channel` + `Scope` — every
+ * clause lives in the SQL `WHERE` (nothing is re-checked in PHP afterwards),
+ * so this is a single indexed round trip and never a check-then-use gap.
+ */
+function sessionControlToken_validate(\mysqli $db, string $rawToken, int $sessionId, string $channel, string $scope = 'broadcast'): bool
+{
+    if ($rawToken === '' || $sessionId <= 0) {
+        return false;
+    }
+    $hash = hash('sha256', $rawToken);
+    try {
+        $stmt = $db->prepare(
+            "SELECT 1 FROM tblSessionControlTokens
+              WHERE TokenHash = ? AND SessionId = ? AND Channel = ? AND Scope = ?
+                AND RevokedAt IS NULL AND ExpiresAt > UTC_TIMESTAMP()
+              LIMIT 1"
+        );
+        $stmt->bind_param('siss', $hash, $sessionId, $channel, $scope);
+        $stmt->execute();
+        $ok = $stmt->get_result()->fetch_row() !== null;
+        $stmt->close();
+        return $ok;
+    } catch (\Throwable $e) {
+        error_log('[session_control_token/validate] ' . $e->getMessage());
+        return false;
+    }
+}
+
+/**
+ * Revoke EVERY still-live control token for one session (channel-scoped) —
+ * "stop anyone using a delegated token to control this session", not a
+ * per-token action. See the file header for why there is no per-token
+ * revoke: the operator never holds an id to target one specifically (mint
+ * hands back the raw token exactly once and nothing token-shaped is stored
+ * server-side for later reference).
+ *
+ * @return int Number of rows revoked (0 = nothing was live to begin with —
+ *             not an error, just "already clean").
+ */
+function sessionControlToken_revokeAllForSession(\mysqli $db, int $sessionId, string $channel): int
+{
+    try {
+        $upd = $db->prepare(
+            'UPDATE tblSessionControlTokens SET RevokedAt = UTC_TIMESTAMP()
+              WHERE SessionId = ? AND Channel = ? AND RevokedAt IS NULL'
+        );
+        $upd->bind_param('is', $sessionId, $channel);
+        $upd->execute();
+        $count = $upd->affected_rows;
+        $upd->close();
+        return max(0, (int)$count);
+    } catch (\Throwable $e) {
+        error_log('[session_control_token/revoke] ' . $e->getMessage());
+        return 0;
+    }
+}

--- a/appWeb/public_html/manage/includes/auth.php
+++ b/appWeb/public_html/manage/includes/auth.php
@@ -1587,11 +1587,17 @@ function verifyEmailLoginCode(string $email, string $code): ?array
  * Complete the email login flow: find or create the user, mark email as
  * verified, update login stats, and generate a bearer token.
  *
- * @param string   $email  Verified email address
- * @param int|null $userId Existing user ID (null if new user)
+ * @param string      $email       Verified email address
+ * @param int|null    $userId      Existing user ID (null if new user)
+ * @param string|null $deviceName  #1409 OPTIONAL client-declared device name
+ *                                 — never required, byte-identical login
+ *                                 for any caller that omits it (the default
+ *                                 null).
+ * @param string|null $platform    #1409 OPTIONAL 'apple'|'android'|'web'.
+ * @param string|null $appVersion  #1409 OPTIONAL client app version string.
  * @return array{token: string, user: array} Bearer token and user info
  */
-function completeEmailLogin(string $email, ?int $userId): array
+function completeEmailLogin(string $email, ?int $userId, ?string $deviceName = null, ?string $platform = null, ?string $appVersion = null): array
 {
     $db = getDbMysqli();
 
@@ -1607,11 +1613,24 @@ function completeEmailLogin(string $email, ?int $userId): array
     try {
         $result = _completeEmailLoginTxn($db, $email, $userId);
         $db->commit();
-        return $result;
     } catch (\Throwable $e) {
         try { $db->rollback(); } catch (\Throwable $_ignore) { /* best-effort */ }
         throw $e;
     }
+
+    /* #1409 — OPTIONAL device metadata, written OUTSIDE the login
+       transaction (mirrors auth_login/auth_apple's own post-insert write in
+       api.php): a metadata-store hiccup must never turn a successful login
+       into a failed one. require_once here (not assumed pre-loaded) so this
+       function stays self-sufficient regardless of which caller context
+       reaches it. */
+    if (!empty($result['token'])) {
+        require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'includes'
+                  . DIRECTORY_SEPARATOR . 'api_tokens.php';
+        apiTokenDeviceMetaStore($db, hash('sha256', (string)$result['token']), $deviceName, $platform, $appVersion);
+    }
+
+    return $result;
 }
 
 /**

--- a/tests/php/test-apns-jwt.php
+++ b/tests/php/test-apns-jwt.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * iHymns — APNs bridge: ES256 provider-token JWT (#1410)
+ *
+ * Exercises includes/apns.php's _apnsBuildJwt() with a LOCALLY-GENERATED EC
+ * P-256 test keypair — never a real Apple-issued key, never a network call.
+ * Mirrors tests/php/test-apple-client-secret.php's structure (the sibling
+ * SIWA client_secret JWT test) but asserts the DIFFERENT claim shape APNs
+ * provider tokens actually use (iss/iat only — no exp/aud/sub), and proves
+ * the DER->JOSE signature conversion round-trips correctly by re-DER-
+ * encoding the raw r‖s signature and verifying it against the public key —
+ * the same "DER->JOSE trap" apple-backend-auth-plan.md §3.4 documents.
+ *
+ *   php tests/php/test-apns-jwt.php
+ *
+ * Exit status 0 = all assertions pass, 1 = at least one failure.
+ */
+
+declare(strict_types=1);
+
+require_once dirname(__DIR__, 2) . '/appWeb/public_html/includes/apns.php';
+
+$failures = 0;
+$passed = 0;
+
+function _tajAssert(bool $cond, string $label): void
+{
+    global $failures, $passed;
+    if ($cond) {
+        $passed++;
+        echo "PASS: $label\n";
+    } else {
+        $failures++;
+        fwrite(STDERR, "FAIL: $label\n");
+    }
+}
+
+function _tajB64UrlDecode(string $s): string
+{
+    $t = strtr($s, '-_', '+/');
+    $pad = (4 - (strlen($t) % 4)) % 4;
+    $decoded = base64_decode($t . str_repeat('=', $pad));
+    return $decoded === false ? '' : $decoded;
+}
+
+/** DER helpers for the round-trip re-encode step (deliberately independent
+ *  of apple_siwa.php's own private DER helpers — this test proves the
+ *  OUTPUT is standards-conformant, not merely "internally consistent"). */
+function _tajDerLen(int $len): string
+{
+    if ($len < 0x80) { return chr($len); }
+    $b = '';
+    while ($len > 0) { $b = chr($len & 0xFF) . $b; $len >>= 8; }
+    return chr(0x80 | strlen($b)) . $b;
+}
+function _tajDerInt(string $raw): string
+{
+    $raw = ltrim($raw, "\x00");
+    if ($raw === '') { $raw = "\x00"; }
+    if ((ord($raw[0]) & 0x80) !== 0) { $raw = "\x00" . $raw; }
+    return "\x02" . _tajDerLen(strlen($raw)) . $raw;
+}
+function _tajDerEncodeEcdsa(string $r, string $s): string
+{
+    $body = _tajDerInt($r) . _tajDerInt($s);
+    return "\x30" . _tajDerLen(strlen($body)) . $body;
+}
+
+/* ---------------------------------------------------------------------- *
+ * Fixture: a fresh EC P-256 keypair (never a real Apple-issued key).
+ * ---------------------------------------------------------------------- */
+$ecKey = openssl_pkey_new(['curve_name' => 'prime256v1', 'private_key_type' => OPENSSL_KEYTYPE_EC]);
+if ($ecKey === false) {
+    fwrite(STDERR, "FATAL: could not generate a test EC P-256 keypair.\n");
+    exit(1);
+}
+openssl_pkey_export($ecKey, $ecPrivatePem);
+$ecDetails = openssl_pkey_get_details($ecKey);
+$ecPublicPem = $ecDetails['key'];
+
+$TEAM_ID = 'TEAMID1234';
+$KEY_ID  = 'APNSKEY123';
+$NOW = time();
+
+/* ---------------------------------------------------------------------- *
+ * 1. Happy path — mint + shape (iss/iat ONLY — no exp/aud/sub, unlike the
+ *    sibling SIWA client_secret JWT).
+ * ---------------------------------------------------------------------- */
+$jwt = _apnsBuildJwt($TEAM_ID, $KEY_ID, $ecPrivatePem, $NOW);
+_tajAssert($jwt !== null, 'APNs provider JWT minted');
+
+$parts = explode('.', (string)$jwt);
+_tajAssert(count($parts) === 3, 'JWT has 3 JWS segments');
+[$h64, $p64, $s64] = $parts + [null, null, null];
+
+$header = json_decode(_tajB64UrlDecode((string)$h64), true);
+_tajAssert(is_array($header) && $header['alg'] === 'ES256', 'header alg is ES256');
+_tajAssert(is_array($header) && $header['kid'] === $KEY_ID, 'header kid matches the APNs Key ID');
+_tajAssert(is_array($header) && count($header) === 2, 'header carries ONLY alg + kid (no extra claims)');
+
+$claims = json_decode(_tajB64UrlDecode((string)$p64), true);
+_tajAssert(is_array($claims) && $claims['iss'] === $TEAM_ID, 'claims iss is the Team ID');
+_tajAssert(is_array($claims) && is_int($claims['iat']) && $claims['iat'] === $NOW, 'claims iat is the injected now');
+_tajAssert(is_array($claims) && !array_key_exists('exp', $claims), 'claims carry NO exp (APNs provider tokens are exp-less, unlike SIWA client_secret)');
+_tajAssert(is_array($claims) && !array_key_exists('aud', $claims), 'claims carry NO aud');
+_tajAssert(is_array($claims) && !array_key_exists('sub', $claims), 'claims carry NO sub');
+_tajAssert(is_array($claims) && count($claims) === 2, 'claims carry ONLY iss + iat');
+
+/* ---------------------------------------------------------------------- *
+ * 2. Raw signature is exactly 64 bytes (32-byte r + 32-byte s, P-256).
+ * ---------------------------------------------------------------------- */
+$rawSig = _tajB64UrlDecode((string)$s64);
+_tajAssert(strlen($rawSig) === 64, 'raw ES256 signature is exactly 64 bytes');
+
+/* ---------------------------------------------------------------------- *
+ * 3. DER->JOSE round-trip: re-DER-encode r‖s and verify against the public
+ *    key — proves the shared _appleSiwaDerEcdsaToRaw() conversion this
+ *    function reuses (rather than re-forking) is correct here too.
+ * ---------------------------------------------------------------------- */
+$r = substr($rawSig, 0, 32);
+$s = substr($rawSig, 32, 32);
+$reDerEncoded = _tajDerEncodeEcdsa($r, $s);
+$verifyResult = openssl_verify("$h64.$p64", $reDerEncoded, (string)$ecPublicPem, OPENSSL_ALGO_SHA256);
+_tajAssert($verifyResult === 1, 'raw r‖s signature re-DER-encodes and verifies against the EC public key');
+
+/* ---------------------------------------------------------------------- *
+ * 4. Reject paths.
+ * ---------------------------------------------------------------------- */
+$rsaKey = openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
+openssl_pkey_export($rsaKey, $rsaPem);
+_tajAssert(_apnsBuildJwt($TEAM_ID, $KEY_ID, (string)$rsaPem, $NOW) === null, 'RSA key rejected (must be EC P-256)');
+_tajAssert(_apnsBuildJwt($TEAM_ID, $KEY_ID, 'not a real PEM at all', $NOW) === null, 'garbage PEM rejected');
+_tajAssert(_apnsBuildJwt('', $KEY_ID, $ecPrivatePem, $NOW) === null, 'empty teamId rejected');
+_tajAssert(_apnsBuildJwt($TEAM_ID, '', $ecPrivatePem, $NOW) === null, 'empty keyId rejected');
+_tajAssert(_apnsBuildJwt($TEAM_ID, $KEY_ID, '', $NOW) === null, 'empty PEM rejected');
+
+/* ---------------------------------------------------------------------- *
+ * 5. apnsConfigured() / apnsCredentials() stay dormant (empty) with no
+ *    tblAppSettings row reachable in this standalone CLI context — proves
+ *    the "no key provisioned = guaranteed no-op" invariant the #1410 task
+ *    brief requires, without needing a database at all.
+ * ---------------------------------------------------------------------- */
+_tajAssert(apnsConfigured() === false, 'apnsConfigured() is false with no getAppSetting()/DB context (dormant by default)');
+$creds = apnsCredentials();
+_tajAssert($creds['teamId'] === '' && $creds['keyId'] === '' && $creds['p8Pem'] === '', 'apnsCredentials() resolves all-empty with no settings source reachable');
+
+/* ---------------------------------------------------------------------- *
+ * 6. Vocabulary + endpoint-host guards (pure, no DB).
+ * ---------------------------------------------------------------------- */
+_tajAssert(apnsEndpointHost('sandbox') === 'api.sandbox.push.apple.com', 'sandbox env resolves to the sandbox APNs host');
+_tajAssert(apnsEndpointHost('production') === 'api.push.apple.com', 'production env resolves to the production APNs host');
+_tajAssert(in_array('device', APNS_KINDS, true) && in_array('liveActivity', APNS_KINDS, true), 'APNS_KINDS carries both device and liveActivity');
+_tajAssert(in_array('sandbox', APNS_ENVIRONMENTS, true) && in_array('production', APNS_ENVIRONMENTS, true), 'APNS_ENVIRONMENTS carries both sandbox and production');
+
+echo "\n$passed passed, $failures failed.\n";
+exit($failures > 0 ? 1 : 0);


### PR DESCRIPTION
Bundle A of the Phase-2 build. Implements #1408 (session control tokens), #1409 (device metadata + manage-devices), #1410 (APNs bridge). All **additive + dormant** (tables shipped live-dormant in #1511; tableExists/columnExists-gated). Security-reviewed: all SQL bound, CSRF on every state-changing write, breadcrumbs IDs-only, device-signout scoped to own tokens (LIKE arg regex-pinned), APNs key encrypted-at-rest via #1466. Closed an anonymous service_broadcast probe-amplification gap. `php -l` clean; APNs-JWT test (24) + existing suites pass. Flag: DreamHost curl HTTP/2 unverified (apnsSend refuses rather than downgrades; dormant until a key is provisioned).