### PR TITLE
fix(web): X-Requested-With on same-origin POSTs blocked by the CSRF gate (#1517)

### DIFF
--- a/appWeb/public_html/js/modules/card-layout.js
+++ b/appWeb/public_html/js/modules/card-layout.js
@@ -68,7 +68,7 @@ async function postLayout(action, surface, payload) {
     const body = JSON.stringify({ surface, ...payload });
     const res = await fetch(`/api?action=${action}`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body,
         credentials: 'same-origin',
     });

--- a/appWeb/public_html/js/modules/setlist.js
+++ b/appWeb/public_html/js/modules/setlist.js
@@ -1885,7 +1885,7 @@ export class SetList {
             }
             fetch('/api?action=setlist_schedule_set', {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+                headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
                 credentials: 'same-origin',
                 body: JSON.stringify({
                     setlistId: listId,
@@ -1914,7 +1914,7 @@ export class SetList {
             clearBtn.addEventListener('click', () => {
                 fetch('/api?action=setlist_schedule_clear', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+                    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
                     credentials: 'same-origin',
                     body: JSON.stringify({ setlistId: listId }),
                 })
@@ -1988,7 +1988,7 @@ export class SetList {
                         btn.addEventListener('click', () => {
                             fetch('/api?action=setlist_collab_remove', {
                                 method: 'POST',
-                                headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+                                headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
                                 credentials: 'same-origin',
                                 body: JSON.stringify({
                                     setlistId: listId,
@@ -2015,7 +2015,7 @@ export class SetList {
             const permission = (prompt('Permission: "view" or "edit"?', 'edit') || 'edit').trim().toLowerCase();
             fetch('/api?action=setlist_collab_invite', {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+                headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
                 credentials: 'same-origin',
                 body: JSON.stringify({
                     setlistId: listId,


### PR DESCRIPTION
Fixes #1517. The Set List **Schedule** POST (and Clear, Invite/Remove collaborator, plus **card-layout reorder-save** — same class) 403'd with *"Cross-site POST blocked: missing X-Requested-With"* because they sent only Content-Type/Accept. Added `'X-Requested-With': 'XMLHttpRequest'` to all 5. Swept every main-app module — these were the only POST fetches missing it. `node --check` clean.