### PR TITLE
docs(handoff): self-contained RESUME POINT for cold pickup

### DIFF
--- a/.claude/sessions/2026-07-11-HANDOFF.md
+++ b/.claude/sessions/2026-07-11-HANDOFF.md
@@ -1,61 +1,54 @@
-# iHymns — Session Handoff (2026-07-10 → 2026-07-11)
+# iHymns — Session Handoff / RESUME POINT (2026-07-10 → 2026-07-11)
 
-> Consolidated handoff for a very large multi-day session. Supersedes the 2026-07-10 handoff for the resume point. Process locked by owner: **Fable 5 = deep planning (sequential, one at a time); Sonnet/Haiku = implementation; Opus = review + DDL/security**. Owner is web-only on shared DreamHost (3 docroots, one MySQL, web-run migrations). **Token/credit efficiency is a hard goal — a monthly spend limit was hit once mid-session**, which is why later work shifted to sequential single-agent (no fan-out) + a single consolidation branch.
+> **Self-contained resume doc — readable cold (even from a cleared chat).** Everything below is on `alpha` unless marked in-progress. Version is **v0.4000.0**. Companion docs to read on resume: `.claude/apple-phase2-implementation-plan.md` (the 17-PR Phase-2 plan), `.claude/live-observability-strategy.md`, `.claude/production-readiness-sequence.md`, `.claude/CLAUDE.md` (house rules), and the memory at `~/.claude/projects/<hash>/memory/MEMORY.md`.
 
-## Version
-Bumped **0.2501.0 → 0.2750.0 → 0.4000.0** across the session (`infoAppVer.php` + README badge/table + OpenAPI `info.version` + `help.php`; PWA SW cache auto-syncs, #81).
+## ⚙️ Working agreement (locked by owner — keep to it)
+- **Fable 5 = deep planning** (sequential, one Fable agent at a time; retry Fable each round, fall back to Opus if unavailable). **Sonnet/Haiku = implementation.** **Opus = review + DDL/security.**
+- **Single branch → single PR per bundle; NO PR stacking** (owner directive — avoids merge races). PRs target **`alpha`**.
+- **Token/credit efficiency is a hard goal** — the monthly spend limit was hit once this session. Prefer **sequential single agents** (no parallel fan-out); bundle related work so a big file is read once.
+- Per work item: **GitHub issue + individual commit + issue update + handoff + memory.**
+- **Proceed autonomously; only stop for a REAL owner decision** (not check-ins). The one hard stop = **production-promotion** (outward/destructive).
+- ⚠️ **GOTCHA:** PRs merge to `alpha`, which is NOT the default branch (`main`), so **"Closes #N" does NOT auto-close issues** — close them **manually** with a PR-ref comment after merge.
+- ⚠️ Sub-agents often **don't create git commits** (they treat the task instruction as non-consent) — expect to **review + commit their uncommitted work yourself**.
+- Owner is **web-only on shared DreamHost** (3 docroots — dev/beta/prod — share ONE MySQL; migrations are **web-run** via `/manage/setup-database`, never auto-applied on deploy).
 
-## MERGED to `alpha` earlier this session (individual PRs, all green)
-- **#1488/#1489/#1490** — SIWA-web Website-URLs docs (Domains vs Return URLs, the `www.ihymns.app` gap, `.p8`-optional). Adversarial verify workflow found the `www` gap.
-- **#1491** — Provisioning-Runbook expanded to click-by-click §2 (TestFlight/App Store) + **CarPlay entitlement GRANTED**.
-- **#1493** (issue #1492) — 🔒 **live Activity-Log secret leak fixed** (CWE-532): `activityLogScrubQuery()` redacts `presenceToken`/live-follow `code`+`token` from `tblActivityLog`; hashed the `live_follow_poll` rate bucket. 29-assertion CI test.
-- **#1495** (issue #1494) — Apple Deploy CI: **kill-switch `vars.APPLE_DEPLOY_ENABLED` (default OFF)** so a backend promotion can't auto-upload to the App Store; `appApple/dev-docs/**` + `*.md` path-excludes (kills the red-X on doc pushes); iOS/tvOS/watchOS/visionOS 26.0 SDK install; `ITSAppUsesNonExemptEncryption`; runbook AASA correction (beta/prod serve a **200 with the WRONG appID** — stale static file — so assert the BODY, not the status).
-- **#1496** — Runbook §2.4 Xcode emulation/simulator + device testing walkthrough (honest: tvOS/watchOS shells are still `PhaseZeroSkeletonView`; LiveFollow is a Phase-0 skeleton; env-override is DEBUG-only).
-- **#1497** — version 0.2750.0.
-- **#1499** (issue #1498) — fix: a literal `</script>` in inline-script comments broke Credit People (stray `_cplIdentifierConfig` text + dead external-link auto-detect) AND the Service-Mode `service-projection.php`/`service-lead.php` pages.
+## ★★ RESUME HERE — do these next, in order
+1. **PR-4 (LAN remote) is IN PROGRESS, UNCOMMITTED, on branch `feat/apple-p2-lanremote`** (a background agent was building it when the session ended). On that branch you'll find uncommitted: `appApple/Packages/iHymnsKit/Package.swift` (modified), and new `Sources/IHLive/LANRemote/` + `Tests/IHLiveTests/LANRemote/`. **Action:** `cd appApple && xcodegen generate`, then in `Packages/iHymnsKit` run `swift build && swift test`; Opus-review the IHRP/1 enum + TVListenerActor/RemoteSessionActor design + the TLS-loopback test approach; then **commit + push + PR to alpha** (`feat(apple): IHLive/LANRemote — IHRP/1 protocol + framer + TVListener/RemoteSession actors (#1420)`), close #1420. **If the work looks incomplete/broken, re-run the PR-4 agent** per `.claude/apple-phase2-implementation-plan.md` §2 PR-4 (spec is fully written there).
+2. **OPERATOR (owner, web-only) must run the additive/dormant migration cards** on `/manage/setup-database` before the new dormant features do anything: `maiden-surname`, `creditperson-members`, `apple-phase2-live-schema` (the big one — creates tblAuthDeviceCodes/tblSessionControlTokens/tblApnsTokens + tblServicePresence.Role + tblApiTokens device cols), and `user-auth-providers` if not already green. All idempotent + safe.
+3. **Continue the Phase-2 build** (bundles below) → the pre-wrap-up item (#1519 OG thumbnail) → wrap-up. Then STOP for owner on production-promotion.
 
-## Draft strategy docs delivered (now committed on the batch branch)
-- `.claude/live-observability-strategy.md` — client `IHLog` + backend §3.2 breadcrumbs + on-device overlay. **P0 (backend secret redaction) shipped as #1493.**
-- `.claude/production-readiness-sequence.md` — P0→P7 path to App Store (backend promotion, secret-encryption activation, web SIWA widening, CarPlay, submission). Flags: beta/prod Universal Links silently broken (stale AASA/wrong appID); promotion would auto-upload without the now-merged kill-switch.
-- `.claude/apple-phase2-implementation-plan.md` — 17-PR sequenced Phase-2 plan; PR-1 (backend batch) identified as the foundational first slice.
+## ✅ MERGED to alpha this session (v0.2501.0 → v0.4000.0)
+Earlier run: #1488-90 (SIWA-web docs), #1491 (runbook §2 + CarPlay GRANTED), **#1493 live Activity-Log secret-leak fix (CWE-532, #1492)**, **#1495 Apple-Deploy kill-switch `vars.APPLE_DEPLOY_ENABLED` + AASA-body correction (#1494)**, #1496 (Xcode-emulation §2.4), #1497 (v0.2750.0), #1499 (`</script>`-in-comment fix, #1498).
+This continuation (→ v0.4000.0):
+- **#1511** — Credit-People/admin bundle (#1500 merge-search, #1501 maiden-surname, #1502 group-members, #1503 bulk-promote, #1507 place-search UX, #1508 whitespace-trim, #1509 backup-delete) + **Apple Phase-2 PR-1** (payload v2 + `blank↔displayState` bridge #1405, projector poll-budget #1406, one-pass schema batch #1407-1410; **Opus DDL review fixed a critical `SessionId INT→BIGINT UNSIGNED` FK bug**) + v0.4000.0.
+- **#1512** — Observability §3.2 breadcrumbs + `IHLog` Swift facility (#1505, 522 swift tests) + macOS **DMG packaging** (#1510, dormant/gated `apple-dmg.yml`, kill-switch `vars.APPLE_DMG_ENABLED`).
+- **#1513 / #1515** — handoff docs. **#1514** — Phase-2 **PR-3** RFC 8628 device-code pairing (#1407-endpoints).
+- **#1516** — Phase-2 **Bundle A backend endpoints**: session-control-token #1408, manage-devices #1409, APNs bridge #1410 (all additive/DORMANT; tables live-dormant; APNs `.p8` custodied encrypted in `tblAppSettings` like the SIWA `.p8`, NOT `.auth/`).
+- **#1518** — Set-List **CSRF fix** (#1517): 5 same-origin POSTs (setlist schedule/clear/collab-invite/collab-remove + card-layout reorder-save) were missing `X-Requested-With` → 403; added it.
+Hygiene done: **Wiki refreshed + pushed** to `iHymns.wiki` master; **~13 issues closed** with PR evidence; new Apple issues milestoned (Apple v1.0); Claude memory refreshed.
 
-## Issue reconciliation done this session
-- Open-issue audit (workflow, 180 plausibly-done): closed **10** completed-but-open with evidence, status-commented **67**, 71 future/parked confirmed open. Closed-issue audit (70 recent): all correctly closed, 0 reopens.
+## 🔵 Remaining Phase-2 build (bundles — `.claude/apple-phase2-implementation-plan.md`)
+Keep ONE branch → ONE PR per bundle. **PR-1, PR-2 (IHLog), PR-3 (device-code), Bundle-A backend are DONE.**
+- **Bundle B (IN PROGRESS)** — **PR-4** IHRP/1 protocol + TVListener/RemoteSession actors (#1420, uncommitted — see RESUME #1) + **PR-5** tvOS `ProjectionCanvasView` + tvOS browse (#1504, unfiled-prereq; add a tvOS Simulator build to `apple.yml`).
+- **Bundle C** — PR-6 tvOS listener + pairing ceremony (code+QR, cert-pin, trusted-remotes, Keychain `synchronizable:false`) (#1421) + PR-7 remote control UI (#1422) + PR-8 manual-connect + VPN troubleshooter + venue doc (#1424). Needs `NSLocalNetworkUsageDescription` + `NSBonjourServices` in `project.yml` (deliberately NOT the approval-gated multicast entitlement).
+- **Bundle D** — PR-10 native Live-Follow + Service-Mode congregant clients (#1426/#1427; IHAPI endpoints + engines + fixtures) + PR-11 Watch relay (#1423).
+- **Bundle E** — PR-14 optional service mirror (#1425) + PR-15 tvOS server-following projector (#1428) + PR-16 Live Activities / Dynamic Island (#1429) + PR-17 diagnostics overlay (#1506).
+- **GATE after C/D/E:** dev-team-security Audit B (LAN pairing brute/MITM, IHRP/1 fuzz, VPN) + multi-device live-verify — before any external-TestFlight promotion.
 
-## Batch 1 — ✅ MERGED as PR #1511 (v0.4000.0) — branch `feat/admin-batch-2026-07-11`, 13 commits
-Per owner's **no-stacking** directive, all of the following landed as ONE PR. **13 commits**:
-- **Credit People / admin bundle** (verified: lint + schema CI guards + SQL-safe + CSRF/authz + live-DB tested by the agents):
-  - #1500 merge-target live-search typeahead (new `?action=merge_target_search` GET, bind_param) — replaces the unusable `<select>`.
-  - #1501 optional maiden-surname field + `migrate-add-creditperson-maiden-surname.php` + schema.sql + registry.
-  - #1502 group-members (`tblCreditPersonMembers` + migration; admin UI reuses the typeahead; public render on `/people/<slug>`; self/dupe guards; **members picker filters to registered ids only** since MemberPersonId is NOT NULL FK).
-  - #1503 bulk-promote cited-but-unregistered names ("Promote all remaining (N)" button, idempotent).
-  - #1507 place-search UX (spinner + green-check confirmation + full-hierarchy display; APCu 5-min cache tier; fixed `_placesPhotonDisplayName` dropping the district level).
-  - #1508 whitespace-trim on identifiers/URLs (shared `cpTrimmed()` server-side + delegated blur/paste client-side).
-  - #1509 manual delete of a selected DB backup (setup-database.php; realpath path-confinement reused, `validateCsrfRequest()`, global-admin re-check, type-to-confirm, PRG, activity-log, can't-delete-last-backup guard).
-- **Apple Phase 2 PR-1** (additive, DORMANT):
-  - #1405 broadcast payload v2 — `serviceMode_cleanState()` extracted (ONE allow-list, rule #26) + `displayState`/`lineIndex` + the **bidirectional `blank`↔`displayState` bridge** + `Channel` filter on `live_follow_join/_poll`. 19-assertion `test-service-state-clean.php`.
-  - #1406 projector poll budget + `pollIntervalMs` (`tblServicePresence.Role`; 40/min congregant, 90/min projector).
-  - #1407/#1408/#1409/#1410 **one-pass schema batch** `migrate-apple-phase2-live-schema.php` (tblAuthDeviceCodes/tblSessionControlTokens/tblApnsTokens + tblServicePresence.Role + tblApiTokens device cols). **Opus DDL review FIXED a critical FK bug**: `SessionId` was `INT UNSIGNED` but `tblLiveFollowSessions.Id` is `BIGINT UNSIGNED` → the hard FKs would have failed on migration-run; also added the plan's omitted `Channel` (rule #26). schema.sql + registry in sync; both CI guards pass.
-- **Version 0.4000.0** + CHANGELOG.
-- **All three strategy docs** committed.
+## 🟡 Before wrap-up (bounded)
+- **#1519 — shared-setlist OG thumbnail redesign** (two-column: header = Setlist icon + "Setlist"; left col = title; right col = "xx songs" + song list; footer = iHymns logo). Find the shared-setlist OG image generator.
 
-**✅ MERGED as PR #1511.** Remaining **OPERATOR action**: run the 3 additive/dormant/idempotent migration cards on `/manage/setup-database` — maiden-surname, creditperson-members, apple-phase2-live-schema.
+## 🟠 WRAP-UP (do last)
+- **Exhaustive "repeat-until-clean" full-codebase security fan-out** (owner B2 at full scope — only *targeted* per-batch reviews done so far, all clean).
+- **Full in-app help/guide audit** refresh (owner B3).
+- Deep Milestone/Project-board pass (light touch done). Refresh this handoff + memory.
 
-## Batch 2 — ✅ MERGED as PR #1512 — branch `feat/observability-dmg-2026-07-11`, 3 commits
-- **§3.2 Activity-Log lifecycle breadcrumbs** (`6ae8fcb4`) — completes Phase-2 PR-1's deferred half; live/service endpoints, **IDs-only**, polls never logged, verified secret-free.
-- **Observability P1 `IHLog` Swift facility + retrofit (#1505)** (`a126aa3e`) — new zero-dep `IHLog` target (subsystem `app.ihymns`; categories api/live-follow/remote/discovery/auth; `IHLogSanitize.tokenFingerprint` never-for-codes) + `APIClient`/`SessionController` retrofit (action-only, never URL/token) + `IHLogTests`; hardened `APIError`. **`swift test`: 522 pass.**
-- **macOS DMG packaging (#1510)** (`4e9cfcf0`) — dormant/gated `.github/workflows/apple-dmg.yml` (kill-switch `vars.APPLE_DMG_ENABLED` default-OFF; Developer-ID sign + `notarytool` + `stapler` + Release asset) + runbook `§1.5` owner steps. New secrets to provision: `APPLE_DEVELOPER_ID_CERT` (+ password).
+## 🔴 HELD — needs explicit owner go-ahead (do NOT do autonomously)
+- **Production-promotion execution** — `.claude/production-readiness-sequence.md` P0→P7 (backend alpha→beta→main; secret-encryption #1466 activation; web-SIWA widening + `.p8`; AASA fix — beta/prod serve a **200 with the WRONG appID** today). Every step outward/destructive.
+- **Owner provisioning** to un-dorm features: `SECRETS_MASTER_KEY` migration (#1466); web-SIWA `apple_siwa_services_id`+channel + the `.p8`; `APPLE_DEPLOY_ENABLED` (TestFlight); `APPLE_DEVELOPER_ID_CERT` + `APPLE_DMG_ENABLED` (DMG); APNs `.p8` (#1410).
 
-## Batch 3 — ✅ MERGED as PR #1514 — Apple Phase-2 PR-3 (device-code pairing, #1407)
-RFC 8628 device-code pairing: `auth_device_code_request/poll/link_lookup/approve/deny` in `api.php` + `includes/device_code.php` + `includes/pages/link.php` + `js/modules/device-link.js` + `tests/php/test-device-code.php` (31 assertions incl. dormancy/CSRF/no-secret-in-breadcrumbs structural guards). Dormant-safe (`tableExists('tblAuthDeviceCodes')`-gated). Rate-limit per-code-hash (not per-IP); breadcrumbs IDs-only. **Minor follow-up:** `tblAuthDeviceCodes` has no `ClientKind` column (omitted from the #1511 schema), so `/link` shows code+time not device-kind — cleanly addable to the still-un-run migration. Hygiene done: wiki refreshed + pushed; 11 issues closed with PR evidence; `#1504`/`#1506` milestoned; memory refreshed.
-
-## ★ STILL DEFERRED (the resume point)
-- **Observability P2 diagnostics overlay (#1506)** — Swift; **premature** (nothing live to diagnose until the Phase-2 engines exist). `live-observability-strategy.md` §2.6.
-- **Apple Phase 2 PRs 4–17** — the rest of the plan (`.claude/apple-phase2-implementation-plan.md`): session-control-token (#1408) + manage-devices (#1409) + APNs bridge (#1410) [bounded backend, tables live-dormant]; LAN-direct TV remote (IHRP/1 + actors + pairing, #1420-1424); native congregant clients (#1426/#1427); shared tvOS projection canvas (#1504); Live Activities (#1429). **PR-1 (backend foundation) + PR-2 (IHLog) + PR-3 (device-code) are DONE.**
-- **Full exhaustive codebase security fan-out** ("repeat until clean") + **deep Wiki/Project/Milestone update** + **full in-app help/guide audit** — the owner's B2/B3/B4 at full scope. Done so far: a *targeted* clean security review of both batches; CHANGELOG/README refresh; a **Wiki refresh for both batches** (pushed to `iHymns.wiki` master).
-- **HELD for owner go-ahead:** production-promotion execution (every step outward/destructive — see `.claude/production-readiness-sequence.md`).
-
-## Notes
-- The stray `_cplIdentifierConfig` text the owner still saw on dev is fixed in #1499 — clears on the next alpha→dev deploy.
-- Three background agents died on the **monthly spend limit** mid-session (Credit People, Phase 2, Fable-round-2); nothing was committed by them (no work lost). Re-done frugally afterward.
-- One Phase-2 agent died on a transient **server error** after committing commits 1–3's work; Opus finished/reviewed/committed commit 3 (schema) + wrote commit 4's test.
+## 🔑 Key files / anchors
+- Plans: `.claude/apple-phase2-implementation-plan.md` (§2 per-PR specs, §3 shipped schema, §4 security/pairing, §5 CI-verifiable) · `.claude/live-observability-strategy.md` · `.claude/production-readiness-sequence.md` · `.claude/apple-native-strategy.md` §2.4 (LAN remote design).
+- Swift: `appApple/Packages/iHymnsKit/` (`IHLog` shipped; `IHLive/LANRemote/` in progress; `IHAPI/APIClient.swift`; `IHAuth/SessionController`).
+- Backend: `appWeb/public_html/api.php`; `includes/{service_mode,device_code,session_control_token,api_tokens,apns}.php`; `.sql/migrate-apple-phase2-live-schema.php` + `schema.sql`.
+- CI: `.github/workflows/{test.yml, apple.yml, apple-deploy.yml, apple-dmg.yml}`.


### PR DESCRIPTION
Rewrites the session handoff as a **self-contained resume doc** (readable even from a cleared chat): working agreement, a numbered ★RESUME-HERE (PR-4 LAN-remote is in-progress/uncommitted on `feat/apple-p2-lanremote`; operator migration cards; continue the bundle plan), everything merged this session, the remaining Phase-2 bundles, #1519 before wrap-up, wrap-up, and the HELD production-promotion + owner-provisioning items. Docs-only.