### PR TITLE
ci(apple): install the tvOS platform so the PR-5 tvOS Simulator build passes (#1504)

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -76,6 +76,15 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             build
 
+      # The generic tvOS-Simulator destination below needs the tvOS 26.0
+      # platform, which is NOT preinstalled on the GitHub-hosted macos-26
+      # runner ("tvOS 26.0 is not installed. Please download and install the
+      # platform from Xcode > Settings > Components") — the macOS build above
+      # works because the macOS SDK is always present. Same fix apple-deploy.yml
+      # applies for the platforms IT archives; here only tvOS is needed (#1504).
+      - name: Install tvOS platform (runner ships without it, #1504)
+        run: sudo xcodebuild -downloadPlatform tvOS
+
       - name: Build (tvOS Simulator destination — proves the projection shell, #1504)
         working-directory: appApple
         run: |


### PR DESCRIPTION
Follow-up to #1523 (PR-5). PR-5 added a **tvOS Simulator build** step to `apple.yml` (the shared IHFeatures library had never been CI-compiled for tvOS). It failed on the `macos-26` runner:

```
xcodebuild: error: Unable to find a destination matching the provided destination specifier:
    { generic:1, platform:tvOS Simulator }
  error: tvOS 26.0 is not installed. Please download and install the platform...
```

**Infra gap, not a code issue** — the tvOS code compiles fine (built green on the PR-5 branch; the `macos-26` runner just ships without the tvOS 26.0 platform, whereas the macOS SDK is always present). Fix: add `sudo xcodebuild -downloadPlatform tvOS` before the tvOS build step — the **same pattern `apple-deploy.yml` already uses** for the platforms it archives (only tvOS is needed here).

#1523 auto-merged on the required checks (PHP + Lint) before this non-required Apple CI job resolved, so PR-5's code is already on `alpha`; this restores the tvOS build gate to green so future appApple PRs keep tvOS compilation covered.

Ref #1504.

🤖 Generated with [Claude Code](https://claude.com/claude-code)