### PR TITLE
feat(apple): tvOS listener wiring + LAN-remote pairing ceremony + trusted-remotes Settings (Apple Phase-2 PR-6, #1421)

### DIFF
--- a/.claude/apple-phase2-pr6-spec.md
+++ b/.claude/apple-phase2-pr6-spec.md
@@ -151,21 +151,28 @@ public struct LANRemotePairingCeremonyState: Sendable, Equatable {
         public var codeTTL: TimeInterval = 120          // strategy §2.4.3 "Code TTL 2min"
         public var rotateAfterFailures: Int = 5         // "5 fails→rotate" — per CODE, global
         public var maxAttemptsPerConnection: Int = 3    // per-CONNECTION cap before teardown
+        public var maxCeremonyFailures: Int = 15        // ★ POST-REVIEW FIX (see §8): CUMULATIVE
+                                                        //   ceiling across ALL rotations → disarm
         public init()
     }
     public private(set) var activeCode: String?     // nil = ceremony not running / code consumed
     public private(set) var mintedAt: Date?
-    public private(set) var wrongAttempts: Int      // per-code, reset on begin/rotate
+    public private(set) var wrongAttempts: Int      // per-code, reset on begin AND rotate
+    public private(set) var ceremonyFailures: Int   // ★ cumulative; reset ONLY on begin, NOT rotate
     public let configuration: Configuration
 
     public init(configuration: Configuration = .init())
     public func isActive(now: Date) -> Bool         // activeCode != nil && now < mintedAt+codeTTL
-    public mutating func begin(code: String, now: Date)       // (re)arm; resets wrongAttempts
+    public mutating func begin(code: String, now: Date)       // NEW ceremony; resets BOTH counters
+    public mutating func rotate(code: String, now: Date)      // ★ mid-ceremony; resets only wrongAttempts
     public mutating func end()                                 // disarm entirely
     public mutating func consume()                             // single-use: success clears activeCode
-    /// Records one wrong proof. Returns true when wrongAttempts has reached
-    /// rotateAfterFailures — the OWNER must mint+begin a fresh code (rotation).
-    public mutating func recordFailure() -> Bool
+    /// Records one wrong proof (advances BOTH counters). Returns a FailureOutcome:
+    /// .exhausted (cumulative ceiling hit → OWNER end()s the ceremony) takes
+    /// precedence over .rotate (per-code threshold → OWNER mints+rotate()s a
+    /// fresh code) over .recorded (keep going). ★ POST-REVIEW: was `-> Bool`.
+    public enum FailureOutcome: Sendable, Equatable { case recorded, rotate, exhausted }
+    public mutating func recordFailure() -> FailureOutcome
 }
 ```
 Pure (no clock reads, no RNG, no I/O) — `now` and `code` always injected, exactly the `LiveFollowEngine.isFresh(lastUpdatedAt:now:)` seam precedent. An EXPIRED code (`!isActive(now:)`) is treated by the verify path identically to "no ceremony running" — reject without counting toward rotation (an attacker must not be able to farm rotations against a dead code).
@@ -448,7 +455,7 @@ Local pre-PR verification (builder runs all): `swift test` in `appApple/Packages
 | Threat | Mitigation (mechanism, in THIS PR) | Residual |
 |---|---|---|
 | **MITM / relay during pairing** (attacker terminates TLS between remote and TV) | QR path: fingerprint pinned out-of-band → PR-4's `verify_block` rejects at handshake. Manual-code path: the proof HMACs the fingerprint the remote actually observed (§3.2) — the attacker cannot present the TV's cert, so a relayed proof binds to the WRONG fingerprint and the TV's constant-time verify rejects it. | An attacker who physically swaps the venue's displayed QR pairs the remote with the ATTACKER's device (never grants access to the real TV). Physical-space attack, out of scope; the operator sees no "Paired" banner — noted in Settings copy. |
-| **Brute-force of the 6-digit code** | Online-only (the proof exists solely inside TLS; never logged, never persisted): 3 proof attempts per connection → teardown; 4 concurrent unpaired connections (PR-4 cap); 5 wrong proofs per code → rotation; 120 s TTL; single-use; ceremony exists ONLY while the operator has the overlay open. Worst case ≤5 guesses against 10⁶ ⇒ ≤0.0005% per ceremony. | The code is knowledge-limited, not entropy-limited, by design (10-foot readability). An operator who leaves the overlay open indefinitely re-arms rotation windows — TTL auto-rotation bounds each code to 2 min regardless. |
+| **Brute-force of the 6-digit code** | Online-only (the proof exists solely inside TLS; never logged, never persisted): 3 proof attempts per connection → teardown; 4 concurrent unpaired connections (PR-4 cap); 5 wrong proofs per code → rotation; **★ POST-REVIEW FIX — a CUMULATIVE `maxCeremonyFailures` (15) ceiling across ALL rotations → the whole ceremony is disarmed (`.ceremonyExhausted`), and only a fresh operator-initiated `beginPairing()` re-opens it**; 120 s TTL; single-use; ceremony exists ONLY while the operator has the overlay open. Worst case ≤15 guesses against 10⁶ ⇒ ≤0.0015% per ceremony. | The code is knowledge-limited, not entropy-limited, by design (10-foot readability). **★ The ORIGINAL spec text here wrongly claimed "≤5 guesses / TTL auto-rotation bounds each code" — the adversarial review (2026-07-11) found rotation to a fresh RANDOM code gives a uniform-guessing attacker ZERO benefit and never STOPS the ceremony, so without the cumulative ceiling total guesses = rate × overlay-open-time (unbounded). The `maxCeremonyFailures` ceiling is the actual bound; the sticky `ceremonyFailures` counter survives TTL re-arms and intervening successful pairs, so even a "left the overlay open" operator caps an attacker at 15 total guesses per opened ceremony.** |
 | **Replay of a captured proof** | TLS 1.3 confidentiality (nothing on-path sees it) + per-connection nonce in the MAC (§3.2) + single-use code consumption. A proof is valid for exactly one (code, nonce, fingerprint) triple on one connection. | None meaningful. |
 | **Photographed / leaked ceremony QR** (contains the code) | 120 s TTL + single-use + operator-visible outcome: every success fires the `.paired(name:)` banner and lands in the trusted-remotes list; revoke is one click and also drops live connections (`disconnectPaired(tokenHash:)`). The STANDING Settings QR carries NO code. | A photo used within the TTL, on the venue LAN, while the operator isn't watching, yields a trusted pairing until noticed and revoked. Mitigated by visibility, not prevented — documented honestly (this equals the risk of the operator reading the code aloud). |
 | **Malicious remote flooding `.pairing`** | PR-4's `maxUnpairedConnections` (4) bounds slots; per-connection attempt cap (3) bounds proof traffic; nonce minting is 16 cheap random bytes; 4 KB frame cap + protocol confinement unchanged; a `.pairConfirm` before `hello` is an instant teardown. | An attacker can hold the 4 unpaired slots (pairing-availability DoS on the LAN). Accepted: LAN-local, no memory growth, visible in logs (`unpaired-cap`); PR-4 already accepted this envelope. |

--- a/appApple/Packages/iHymnsKit/Sources/IHFeatures/PairingQRCode.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHFeatures/PairingQRCode.swift
@@ -1,0 +1,58 @@
+// PairingQRCode.swift
+// IHFeatures
+//
+// ELI5: Turns a short text string (the pairing payload) into a QR-code
+// picture a phone's camera can scan — using ONLY the drawing tools already
+// built into every Apple platform, no extra library to pull in.
+//
+// DETAILED: #1421 (`.claude/apple-phase2-pr6-spec.md` §6.3/§6.4, Decision
+// D-9). `CIFilter.qrCodeGenerator()` (CoreImage's built-in QR encoder,
+// https://developer.apple.com/documentation/coreimage/ciqrcodegenerator) is
+// the ENTIRE implementation — no vendored/external QR-generation package,
+// matching this PR's "no new external package" scope tripwire (spec §8
+// D-11). `#if canImport(CoreImage)` guards the whole file's real body:
+// `IHFeatures` compiles for watchOS too (Package.swift's platform list),
+// and CoreImage is not available there — the fallback is a clean `nil`
+// (never a crash), which `TVPairingOverlayView`/`TVSettingsRemoteView`
+// handle by falling back to code/fingerprint TEXT only (spec: "views show
+// code/fingerprint text only").
+import CoreGraphics
+#if canImport(CoreImage)
+import CoreImage
+import CoreImage.CIFilterBuiltins
+#endif
+
+/// Renders a pairing payload string as a scannable QR code image.
+///
+/// ELI5: "Turn this text into a QR code picture."
+enum PairingQRCode {
+    /// - Parameters:
+    ///   - string: The exact payload to encode (`LANRemotePairingPayload
+    ///     .encodeToQRString()`'s output) — `nil` input (e.g. DER encoding
+    ///     somehow failed) is handled the same as any other failure: a
+    ///     clean `nil` result, never a crash.
+    ///   - scale: How much to enlarge CoreImage's native (very small,
+    ///     one-point-per-module) QR bitmap before rasterizing — the
+    ///     default renders crisply at the overlay's ~320pt display size
+    ///     without any blurry upscaling later.
+    static func image(from string: String?, scale: CGFloat = 10) -> CGImage? {
+        #if canImport(CoreImage)
+        guard let string, let data = string.data(using: .utf8) else { return nil }
+
+        let filter = CIFilter.qrCodeGenerator()
+        filter.message = data
+        // "M" (~15% error correction) — comfortably scannable even with a
+        // little glare/off-angle on a projector-adjacent screen, without
+        // the visual density of "H".
+        filter.correctionLevel = "M"
+
+        guard let outputImage = filter.outputImage else { return nil }
+        let scaled = outputImage.transformed(by: CGAffineTransform(scaleX: scale, y: scale))
+
+        let context = CIContext()
+        return context.createCGImage(scaled, from: scaled.extent)
+        #else
+        return nil
+        #endif
+    }
+}

--- a/appApple/Packages/iHymnsKit/Sources/IHFeatures/TVPairingOverlayView.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHFeatures/TVPairingOverlayView.swift
@@ -1,0 +1,142 @@
+// TVPairingOverlayView.swift
+// IHFeatures
+//
+// ELI5: The big full-screen "pair a remote" screen — a giant 6-digit code
+// readable from across a room, a QR code to scan instead, the TV's
+// fingerprint for a quick human cross-check, and a live "someone's trying
+// to pair" indicator, with a Cancel button to back out.
+//
+// DETAILED: #1421 (`.claude/apple-phase2-pr6-spec.md` §6.3). Shown by
+// `TVRootView` in a `ZStack` layer over the tab content while `coordinator
+// .isPairingActive` — this view itself never touches `TVListenerActor`
+// directly, only `TVRemoteControlCoordinator`'s already-`@Observable`
+// surface (the same "hold the coordinator as a plain property, not
+// `@State`" idiom `ProjectionSceneView` already establishes for
+// `ProjectionViewModel`).
+import IHDesign
+import SwiftUI
+
+/// The full-screen pairing ceremony overlay.
+public struct TVPairingOverlayView: View {
+    let coordinator: TVRemoteControlCoordinator
+
+    public init(coordinator: TVRemoteControlCoordinator) {
+        self.coordinator = coordinator
+    }
+
+    public var body: some View {
+        ZStack {
+            Color.black.opacity(0.82).ignoresSafeArea()
+            VStack(spacing: 28) {
+                Text("Pair a remote")
+                    .font(.largeTitle.bold())
+
+                codeText
+
+                qrSection
+
+                fingerprintLine
+
+                if coordinator.pairingRemoteCount > 0 {
+                    Text(pairingRemoteCountText)
+                        .font(.headline)
+                        .foregroundStyle(IHColorTokens.accent)
+                }
+
+                if let lastPairedName = coordinator.lastPairedName {
+                    Text(lastPairedName.isEmpty ? "A remote just paired." : "Paired: \(lastPairedName)")
+                        .font(.headline)
+                        .foregroundStyle(.green)
+                }
+
+                Button("Cancel") {
+                    Task { await coordinator.endPairing() }
+                }
+                .buttonStyle(.bordered)
+            }
+            .padding(48)
+            .ihGlassCard(cornerRadius: 36)
+        }
+        .task { await runCountdown() }
+    }
+
+    /// A COSMETIC-only countdown — `LANRemotePairingCeremonyState
+    /// .isActive(now:)` (`IHLive`) is what actually enforces the 2-minute
+    /// TTL regardless of whether this task ever runs; this timer exists
+    /// purely so the code shown on screen never visibly goes stale before
+    /// the TV would reject it anyway.
+    private func runCountdown() async {
+        while !Task.isCancelled {
+            try? await Task.sleep(for: .seconds(120))
+            guard !Task.isCancelled else { return }
+            await coordinator.rotateCode()
+        }
+    }
+
+    /// The giant, hall-readable code — `.kerning` widens the digit spacing
+    /// (spec: "readable across a hall"); the whole `Text` is ONE
+    /// accessibility element with a digit-by-digit spoken label rather than
+    /// VoiceOver reading the six digits as a single six-digit number.
+    private var codeText: some View {
+        let code = coordinator.pairingCode ?? "------"
+        return Text(code)
+            .font(.system(size: 120, weight: .bold, design: .monospaced))
+            .kerning(20)
+            .accessibilityLabel("Pairing code " + code.map(String.init).joined(separator: " "))
+    }
+
+    @ViewBuilder
+    private var qrSection: some View {
+        if let qrImage = PairingQRCode.image(from: coordinator.qrPayloadString(includeCode: true)) {
+            VStack(spacing: 8) {
+                Image(decorative: qrImage, scale: 1)
+                    .interpolation(.none)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 320, height: 320)
+                Text("Scan with iHymns on your phone")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    /// The short verification line — first 12 hex characters, grouped in
+    /// 4s, "enough for a human cross-check" (spec §6.3); the FULL
+    /// fingerprint lives in Settings (`TVSettingsRemoteView`, which reuses
+    /// `PairingFingerprintDisplay.grouped(_:prefixLength:)` below) for
+    /// anyone who wants to check every character.
+    private var fingerprintLine: some View {
+        let fingerprint = coordinator.listenerInfo?.fingerprint
+        let text = fingerprint.map { PairingFingerprintDisplay.grouped($0, prefixLength: 12) } ?? "unavailable"
+        return Text("Fingerprint: \(text)")
+            .font(.footnote.monospaced())
+            .foregroundStyle(.secondary)
+    }
+
+    private var pairingRemoteCountText: String {
+        coordinator.pairingRemoteCount == 1
+            ? "1 remote is trying to pair…"
+            : "\(coordinator.pairingRemoteCount) remotes are trying to pair…"
+    }
+}
+
+/// Shared "lowercase hex, grouped in 4s" display formatting — this file's
+/// own short verification line AND `TVSettingsRemoteView`'s full-fingerprint
+/// row both need EXACTLY this grouping, so it lives here once rather than
+/// two near-identical private copies (this repo's modularity rule).
+enum PairingFingerprintDisplay {
+    /// - Parameter prefixLength: `nil` groups the WHOLE string (Settings'
+    ///   full fingerprint); a value truncates first (this file's own
+    ///   12-character verification line).
+    static func grouped(_ hex: String, prefixLength: Int? = nil) -> String {
+        let source = prefixLength.map { String(hex.prefix($0)) } ?? hex
+        var groups: [String] = []
+        var remainder = Substring(source)
+        while !remainder.isEmpty {
+            groups.append(String(remainder.prefix(4)))
+            remainder = remainder.dropFirst(4)
+        }
+        return groups.joined(separator: " ")
+    }
+}

--- a/appApple/Packages/iHymnsKit/Sources/IHFeatures/TVProjectionBridge.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHFeatures/TVProjectionBridge.swift
@@ -1,0 +1,111 @@
+// TVProjectionBridge.swift
+// IHFeatures
+//
+// ELI5: The tiny translator between "what a remote just asked for" and
+// "what the projection screen should actually do about it" — one small
+// function, no networking, no listener, so it's trivial to test on its own.
+//
+// DETAILED: #1421 (`.claude/apple-phase2-pr6-spec.md` §6.2 — made real from
+// PR-5's own spec §1 sketch, `.claude/apple-phase2-pr5-spec.md`). This is
+// the PURE half of the LAN-remote ↔ projection seam; `TVRemoteControlCoordinator`
+// (this same target) is the ONLY place that touches BOTH `TVListenerActor`
+// (the LAN transport, `IHLive`) and `ProjectionViewModel` (the display
+// engine, this same file's sibling) — everything ELSE about "what does
+// `nextComponent` mean" lives here, unit-testable with a fake
+// `fetchSongDetail` closure and zero real sockets (`TVProjectionBridgeTests.swift`).
+//
+// **`default: return nil`** covers `hello`/`ping`/`endControl`/every
+// pairing-sub-protocol case (`pairChallenge`/`pairConfirm`/`pairSuccess`) —
+// all transport/pairing concerns `TVListenerActor` (`IHLive`) already
+// resolved BEFORE a frame ever reaches `controlEvents`; this bridge only
+// ever sees `ControlEvent`s built from ALREADY-PAIRED, ALREADY-legitimate
+// control intents, but the exhaustive `switch` still enumerates every
+// `IHRPMessage` case (no `@unknown default`, so the compiler forces this
+// file to be updated the day a new control intent is added).
+import IHLive
+
+/// Maps ONE remote control intent onto the `ProjectionViewModel` it should
+/// drive — the exact "make it real" of PR-5 spec §1's ~30-line bridge
+/// sketch.
+///
+/// ELI5: "The remote just said X — go make the projection screen do X, and
+/// tell me if I need to reply with an error."
+enum TVProjectionBridge {
+    /// Applies `message` to `viewModel`, returning the `IHRPMessage.error`
+    /// reply the listener should send back to the ORIGINATING connection —
+    /// `nil` means "nothing to report back" (either the intent succeeded
+    /// silently, or it wasn't a control intent this bridge owns at all).
+    ///
+    /// ELI5: "Do the thing the remote asked for; here's what to tell it, if
+    /// anything went wrong."
+    ///
+    /// `@MainActor` — `ProjectionViewModel` is itself `@MainActor` (its own
+    /// header comment), so every synchronous mutation below
+    /// (`nextComponent()`/`setDisplayState(_:)`/etc.) needs to run on that
+    /// same actor; `TVRemoteControlCoordinator` (also `@MainActor`) calls
+    /// this directly from its bridge loop with no extra hop.
+    ///
+    /// An exhaustive switch over every `IHRPMessage` case is high
+    /// CYCLOMATIC complexity by the metric's definition, but each branch is
+    /// an independent one-liner — the identical reasoning `IHRPFrame.swift`'s
+    /// own `swiftlint:disable` comment gives for its Codable switch.
+    @MainActor
+    // swiftlint:disable:next cyclomatic_complexity
+    static func apply(_ message: IHRPMessage, to viewModel: ProjectionViewModel) async -> IHRPMessage? {
+        switch message {
+        case .prepare(let songId):
+            _ = await viewModel.prepare(songId: songId)
+            return nil
+
+        case .selectSong(let songId, let componentIndex, let lineIndex):
+            switch await viewModel.selectSong(songId: songId, componentIndex: componentIndex, lineIndex: lineIndex) {
+            case .shown:
+                return nil
+            case .unavailable:
+                // The EXACT handoff strategy §2.4.3 names: a gated song's
+                // fetch failure becomes `.contentUnavailable` on the wire,
+                // never a leaked user-facing message string.
+                return .error(.contentUnavailable, message: nil)
+            case .failed:
+                // Any other failure (offline, decode, superseded) — never
+                // echo the underlying message back over the LAN link.
+                return .error(.internalError, message: nil)
+            }
+
+        case .nextComponent:
+            viewModel.nextComponent()
+            return nil
+        case .prevComponent:
+            viewModel.prevComponent()
+            return nil
+        case .nextLine:
+            viewModel.nextLine()
+            return nil
+        case .prevLine:
+            viewModel.prevLine()
+            return nil
+        case .jumpLine(let index):
+            viewModel.jumpLine(index: index)
+            return nil
+        case .setDisplayState(let displayState):
+            viewModel.setDisplayState(displayState)
+            return nil
+        case .scroll(let delta):
+            viewModel.scroll(delta: delta)
+            return nil
+        case .setAppearance(let theme, let textScale):
+            viewModel.setAppearance(theme: theme, textScale: textScale)
+            return nil
+
+        case .hello, .endControl, .ping, .state, .ack, .error, .pong, .capabilities,
+             .pairChallenge, .pairConfirm, .pairSuccess:
+            // Transport/pairing concerns `TVListenerActor` (`IHLive`)
+            // already resolved before this bridge ever sees a
+            // `ControlEvent` — this file's header comment. Named
+            // exhaustively (no `@unknown default`) so the compiler forces
+            // this file to be revisited the day a new `IHRPMessage` case
+            // is added, rather than silently falling through a catch-all.
+            return nil
+        }
+    }
+}

--- a/appApple/Packages/iHymnsKit/Sources/IHFeatures/TVRemoteControlCoordinator.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHFeatures/TVRemoteControlCoordinator.swift
@@ -1,0 +1,270 @@
+// TVRemoteControlCoordinator.swift
+// IHFeatures
+//
+// ELI5: The one object that actually "turns on" the TV's remote-control
+// receiver — builds its identity, starts listening, watches for remotes
+// trying to pair, and feeds everything the pairing overlay / Settings
+// screen need to show ("here's the code," "1 remote is trying to pair,"
+// "here's who's trusted"). It's the ONLY thing in the whole app that talks
+// to both the LAN listener AND the projection screen.
+//
+// DETAILED: #1421 (`.claude/apple-phase2-pr6-spec.md` §6.1/§6.2). The
+// composition root PR-5's own spec §1 reserved ("the listener ↔
+// `ProjectionViewModel` bridge PR-6's job"): builds `LANRemoteIdentityStore`
+// + `KeychainLANRemotePairingAuthority` + `TVListenerActor` (all `IHLive`),
+// and runs the three long-lived tasks that connect them to
+// `ProjectionViewModel` (this same target) — `TVProjectionBridge.swift`'s
+// pure mapping is what those tasks actually call.
+//
+// **No `import Network` here** (spec §8 D-11's scope tripwire): the ONE
+// port literal this file needs (`7269`, strategy §2.4.5's documented
+// default) is passed as a bare integer literal to `TVListenerActor
+// .Configuration`'s `port: NWEndpoint.Port` parameter — `NWEndpoint.Port`
+// conforms to `ExpressibleByIntegerLiteral` (confirmed against the SDK's
+// module interface), so Swift resolves the literal via the parameter's
+// already-visible type without this file ever needing to name
+// `NWEndpoint`/`Network` itself. The coordinator talks to `IHLive`'s
+// actors, never to a raw socket.
+import IHLive
+import IHLog
+import Observation
+#if os(tvOS)
+import UIKit
+#endif
+
+/// The tvOS app's ONE remote-control composition root — builds the
+/// listener, runs its bridge to `ProjectionViewModel`, and exposes
+/// everything the pairing overlay / Settings screen need to render.
+///
+/// ELI5: "Turn on the TV's remote-control receiver, and tell me everything
+/// happening with it."
+@MainActor
+@Observable
+public final class TVRemoteControlCoordinator {
+    /// The Settings "Remote Control info" panel's exact data — strategy
+    /// §2.4.5.
+    public struct ListenerInfo: Sendable, Equatable {
+        public let fingerprint: String
+        public let port: UInt16
+        public let ipAddress: String?
+    }
+
+    public private(set) var listenerInfo: ListenerInfo?
+    /// A themed, user-facing message if `start()` failed outright — the
+    /// raw error itself only ever goes to `IHLog.remote` (status codes,
+    /// never key material).
+    public private(set) var startError: String?
+    public private(set) var isPairingActive = false
+    /// The code currently on screen, if a ceremony is running — the
+    /// overlay reads this directly rather than caching its own copy.
+    public private(set) var pairingCode: String?
+    /// How many `.pairing` connections are open RIGHT NOW — the overlay's
+    /// "N remotes trying to pair" live indicator.
+    public private(set) var pairingRemoteCount = 0
+    public private(set) var pairedRemotes: [PairedRemoteRecord] = []
+    /// The most recently paired remote's name — the overlay's transient
+    /// success banner.
+    public private(set) var lastPairedName: String?
+
+    private let projectionViewModel: ProjectionViewModel
+    private var listener: TVListenerActor?
+    private var authority: KeychainLANRemotePairingAuthority?
+    private var hasStarted = false
+
+    private var bridgeInTask: Task<Void, Never>?
+    private var bridgeOutTask: Task<Void, Never>?
+    private var pairingEventsTask: Task<Void, Never>?
+
+    public init(projectionViewModel: ProjectionViewModel) {
+        self.projectionViewModel = projectionViewModel
+    }
+
+    /// Builds the identity + authority + listener, starts accepting
+    /// connections, and spawns the three long-lived bridge tasks — idempotent
+    /// (a second call while already started is a harmless no-op, matching
+    /// `RootContainerView.restoreAndSync()`'s own "guarded one-shot" `.task`
+    /// convention elsewhere in this package).
+    ///
+    /// ELI5: "Turn the TV's remote-control receiver on" — safe to ask for
+    /// twice, it only actually happens once.
+    public func start() async {
+        guard !hasStarted else { return }
+        hasStarted = true
+
+        let name = deviceName
+        do {
+            let identity = try LANRemoteIdentityStore.loadOrCreate(commonName: name)
+            let authority = KeychainLANRemotePairingAuthority()
+            self.authority = authority
+
+            let listener = try await makeListener(identity: identity, authority: authority, advertisedName: name)
+            self.listener = listener
+
+            listenerInfo = ListenerInfo(
+                fingerprint: identity.fingerprint,
+                port: await listener.boundPort?.rawValue ?? 0,
+                ipAddress: LANRemoteAddress.primaryIPv4Address()
+            )
+
+            spawnBridgeTasks(listener: listener)
+            pairedRemotes = await authority.listPairedRemotes()
+        } catch {
+            IHLog.remote.error("lanremote.coordinator start-failed error=\(String(describing: error), privacy: .public)")
+            startError = "Couldn't start the remote-control receiver. Try restarting the app."
+        }
+    }
+
+    /// Binds the documented default port, retrying ONCE with an OS-assigned
+    /// port if something else already holds it — spec §6.1/Decision D-10:
+    /// "another app squatting 7269 must not kill the feature." Deliberately
+    /// never spells `NWEndpoint.Port` as a type name anywhere in this file
+    /// (this file's header) — `usingDefaultPort` picks between two literal
+    /// `TVListenerActor.Configuration(port:)` call sites instead, so the
+    /// PORT VALUE's type is always inferred from that already-visible
+    /// parameter, never written out here.
+    private func makeListener(
+        identity: LANRemoteIdentity, authority: KeychainLANRemotePairingAuthority, advertisedName: String
+    ) async throws -> TVListenerActor {
+        do {
+            return try await startListener(usingDefaultPort: true, identity: identity, authority: authority, advertisedName: advertisedName)
+        } catch TVListenerError.listenerFailed {
+            IHLog.remote.notice("lanremote.coordinator default-port-unavailable retrying-with-any-port")
+            return try await startListener(usingDefaultPort: false, identity: identity, authority: authority, advertisedName: advertisedName)
+        }
+    }
+
+    private func startListener(
+        usingDefaultPort: Bool, identity: LANRemoteIdentity, authority: KeychainLANRemotePairingAuthority, advertisedName: String
+    ) async throws -> TVListenerActor {
+        let configuration = usingDefaultPort
+            // `7269` — strategy §2.4.5's documented default port. Written
+            // as a literal integer EXPRESSION directly here (never hoisted
+            // into a separate `UInt16` constant) because that literal form
+            // is specifically what triggers `NWEndpoint.Port`'s
+            // `ExpressibleByIntegerLiteral` conformance (this file's header
+            // comment) — an already-typed `UInt16` variable passed to this
+            // same parameter would NOT implicitly convert.
+            ? TVListenerActor.Configuration(
+                port: 7269, advertisedName: advertisedName, pairingAuthority: authority, clock: SystemLANRemoteClock()
+              )
+            : TVListenerActor.Configuration(
+                port: .any, advertisedName: advertisedName, pairingAuthority: authority, clock: SystemLANRemoteClock()
+              )
+        let listener = TVListenerActor(identity: identity, configuration: configuration)
+        try await listener.start()
+        try await listener.waitUntilReady()
+        return listener
+    }
+
+    // MARK: - Pairing control surface (the overlay/Settings "Pair" button)
+
+    public func beginPairing() async {
+        guard let listener else { return }
+        pairingCode = await listener.beginPairing()
+        isPairingActive = true
+    }
+
+    public func rotateCode() async {
+        guard let listener else { return }
+        pairingCode = await listener.rotatePairingCode()
+    }
+
+    public func endPairing() async {
+        guard let listener else { return }
+        await listener.endPairing()
+        isPairingActive = false
+        pairingCode = nil
+    }
+
+    /// Settings "Revoke" — forgets the token (so a future `hello` fails)
+    /// AND disconnects it right now if it's currently live.
+    public func revoke(_ record: PairedRemoteRecord) async {
+        guard let authority, let listener else { return }
+        await authority.revoke(tokenHash: record.tokenHashHex)
+        await listener.disconnectPaired(tokenHash: record.tokenHashHex)
+        pairedRemotes = await authority.listPairedRemotes()
+    }
+
+    /// Encodes this TV's current connect info (+ live code, if requested)
+    /// as the exact string the overlay/Settings QR renders.
+    ///
+    /// - Parameter includeCode: `true` for the ceremony QR (overlay);
+    ///   `false` for the Settings standing QR, which never carries a code.
+    public func qrPayloadString(includeCode: Bool) -> String? {
+        guard let info = listenerInfo else { return nil }
+        let payload = LANRemotePairingPayload(
+            name: Self.deviceNameStatic,
+            host: LANRemoteAddress.primaryIPv4Address(),
+            port: info.port,
+            fingerprintHex: info.fingerprint,
+            code: includeCode ? pairingCode : nil
+        )
+        return payload.encodeToQRString()
+    }
+
+    private var deviceName: String { Self.deviceNameStatic }
+
+    private static var deviceNameStatic: String {
+        #if os(tvOS)
+        UIDevice.current.name
+        #else
+        "iHymns TV"
+        #endif
+    }
+
+    // MARK: - The listener <-> ProjectionViewModel bridge (PR-5 spec §1's reserved seam)
+
+    /// Spawns the three long-lived tasks this coordinator retains for its
+    /// whole lifetime — PR-5 spec §1's "~30-line bridge," made real.
+    private func spawnBridgeTasks(listener: TVListenerActor) {
+        let projectionViewModel = projectionViewModel
+        bridgeInTask = Task { [weak self] in
+            for await event in listener.controlEvents {
+                if let reply = await TVProjectionBridge.apply(event.frame.message, to: projectionViewModel),
+                   case .error(let code, let text) = reply {
+                    await listener.sendError(code, message: text, to: event.connectionId)
+                }
+                await self?.refreshPairedRemotesIfNeeded()
+            }
+        }
+        bridgeOutTask = Task {
+            for await state in projectionViewModel.stateUpdates {
+                await listener.updateState(
+                    songId: state.songId, componentIndex: state.componentIndex,
+                    lineIndex: state.lineIndex, displayState: state.displayState
+                )
+            }
+        }
+        pairingEventsTask = Task { [weak self] in
+            for await event in listener.pairingEvents {
+                await self?.applyPairingEvent(event)
+            }
+        }
+    }
+
+    /// A no-op today — kept as the ONE place `bridgeInTask` could refresh
+    /// derived UI state after a control intent, without adding a second
+    /// polling path; reserved for a future "trusted remotes" activity
+    /// indicator, deliberately not overbuilt for this PR.
+    private func refreshPairedRemotesIfNeeded() async {}
+
+    private func applyPairingEvent(_ event: TVPairingEvent) async {
+        switch event {
+        case .remoteEnteredPairing:
+            pairingRemoteCount += 1
+        case .remoteLeftPairing:
+            pairingRemoteCount = max(0, pairingRemoteCount - 1)
+        case .codeRotated(let newCode):
+            // In-process only — NEVER logged (this module's binding
+            // instrumentation contract).
+            pairingCode = newCode
+        case .paired(let name, _):
+            lastPairedName = name
+            if let authority {
+                pairedRemotes = await authority.listPairedRemotes()
+            }
+        case .proofRejected:
+            break
+        }
+    }
+}

--- a/appApple/Packages/iHymnsKit/Sources/IHFeatures/TVRemoteControlCoordinator.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHFeatures/TVRemoteControlCoordinator.swift
@@ -65,6 +65,11 @@ public final class TVRemoteControlCoordinator {
     /// The most recently paired remote's name — the overlay's transient
     /// success banner.
     public private(set) var lastPairedName: String?
+    /// A transient operator-facing notice — set when the listener auto-
+    /// disarms the ceremony after too many wrong codes (the brute-force
+    /// ceiling, post-#1421 adversarial-review fix), shown in Settings' Pair
+    /// section; cleared the next time `beginPairing()` runs.
+    public private(set) var pairingNotice: String?
 
     private let projectionViewModel: ProjectionViewModel
     private var listener: TVListenerActor?
@@ -160,6 +165,7 @@ public final class TVRemoteControlCoordinator {
 
     public func beginPairing() async {
         guard let listener else { return }
+        pairingNotice = nil
         pairingCode = await listener.beginPairing()
         isPairingActive = true
     }
@@ -265,6 +271,14 @@ public final class TVRemoteControlCoordinator {
             }
         case .proofRejected:
             break
+        case .ceremonyExhausted:
+            // The listener disarmed the ceremony after too many wrong proofs
+            // (the cumulative brute-force ceiling) — close the overlay and
+            // tell the operator why. A fresh `beginPairing()` clears the
+            // notice and re-opens pairing.
+            isPairingActive = false
+            pairingCode = nil
+            pairingNotice = "Pairing was stopped after too many incorrect codes. Tap “Pair a remote” to try again."
         }
     }
 }

--- a/appApple/Packages/iHymnsKit/Sources/IHFeatures/TVRootView.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHFeatures/TVRootView.swift
@@ -2,29 +2,33 @@
 // IHFeatures
 //
 // ELI5: The tvOS app's actual home screen — a tab bar with "Project" (the
-// live projection screen), "Songbooks," and "Search," each reusing the
-// EXACT SAME shared screens the iOS/Mac app already has.
+// live projection screen), "Songbooks," "Search," and "Settings" (the
+// trusted-remotes/pairing screens), each reusing the EXACT SAME shared
+// screens the iOS/Mac app already has (or, for Settings, PR-6's new
+// tvOS-only content).
 //
-// DETAILED: #1504 (`.claude/apple-phase2-pr5-spec.md` §5.3). Strategy
-// §2.2's tvOS tab set is Home · Songbooks · Search · Project · Settings —
-// Home and Settings are DEFERRED here: Home needs tvOS-specific "shelf"
-// layout work nobody has designed yet, and Settings arrives together with
-// PR-6's trusted-remotes/pairing screens (no meaningful settings exist for
-// a projector shell before pairing is a real concept). Shipping the other
-// three now — reusing `SongbooksView`/`CatalogueListView` completely
+// DETAILED: #1504/#1421 (`.claude/apple-phase2-pr5-spec.md` §5.3,
+// `.claude/apple-phase2-pr6-spec.md` §6.3). Strategy §2.2's tvOS tab set is
+// Home · Songbooks · Search · Project · Settings — Home remains DEFERRED
+// here (it needs tvOS-specific "shelf" layout work nobody has designed
+// yet); Settings is NO LONGER deferred as of #1421 — PR-5's own header
+// comment named "PR-6's trusted-remotes/pairing screens" as the reason it
+// was waiting, and this is that PR. Shipping Project/Songbooks/Search/
+// Settings now — reusing `SongbooksView`/`CatalogueListView` completely
 // unmodified — proves the shared-screen composition works on tvOS well
-// before Home/Settings need to be designed for it.
+// before Home needs to be designed for it.
 //
 // Compiles on EVERY platform this package targets (it's built by the
 // macOS `swift test`/build gate too) — only the `iHymnsTV` app shell
 // (`IHymnsTVApp.swift`) actually instantiates it, mirroring the posture
 // `RootContainerView`'s own header documents for ITS `#else` (tvOS/watchOS)
-// branch, which this task does NOT touch (dead code for now — PR-6+ may
-// consolidate the two root views once tvOS gets Home/Settings).
+// branch, which this task does NOT touch (dead code for now — a future PR
+// may consolidate the two root views once tvOS gets Home).
 import IHAPI
 import SwiftUI
 
-/// The tvOS shell's root view: `TabView { Project · Songbooks · Search }`.
+/// The tvOS shell's root view: `TabView { Project · Songbooks · Search ·
+/// Settings }`, with the pairing overlay layered on top while active.
 public struct TVRootView: View {
     private let viewModel: AppRootViewModel
 
@@ -34,6 +38,13 @@ public struct TVRootView: View {
     /// screen already uses), never a second `APIClient`/`AppRootViewModel`.
     @State private var projectionViewModel: ProjectionViewModel
 
+    /// The ONE `TVRemoteControlCoordinator` this app run uses (#1421) —
+    /// built alongside `projectionViewModel` in `init` (it needs that SAME
+    /// instance, not a second one) so the listener ↔ projection bridge
+    /// drives the identical view-model the Siri-Remote driver
+    /// (`ProjectionSceneView`) does.
+    @State private var coordinator: TVRemoteControlCoordinator
+
     /// - Parameter viewModel: `AppRootViewModel` is `@MainActor`; the
     ///   `fetchSongDetail` closure below is `@Sendable async` and simply
     ///   `await`s onto it — fine under strict concurrency (the closure
@@ -42,35 +53,57 @@ public struct TVRootView: View {
     ///   `@Sendable` closure type sound here).
     public init(viewModel: AppRootViewModel) {
         self.viewModel = viewModel
-        _projectionViewModel = State(initialValue: ProjectionViewModel(fetchSongDetail: { id in
+        let projectionViewModel = ProjectionViewModel(fetchSongDetail: { id in
             try await viewModel.songDetail(id: id)
-        }))
+        })
+        _projectionViewModel = State(initialValue: projectionViewModel)
+        _coordinator = State(initialValue: TVRemoteControlCoordinator(projectionViewModel: projectionViewModel))
     }
 
     public var body: some View {
-        // `.tabItem { Label(...) }` + `TabView` (not the newer `Tab(_:
-        // systemImage:)` builder) — matches `RootContainerView.tabbedRoot`'s
-        // existing convention exactly (this repo's modularity rule: one
-        // established pattern, not two competing ones for the same thing).
-        TabView {
-            ProjectionSceneView(rootViewModel: viewModel, viewModel: projectionViewModel)
-                .tabItem { Label("Project", systemImage: "tv") }
+        ZStack {
+            // `.tabItem { Label(...) }` + `TabView` (not the newer `Tab(_:
+            // systemImage:)` builder) — matches `RootContainerView.tabbedRoot`'s
+            // existing convention exactly (this repo's modularity rule: one
+            // established pattern, not two competing ones for the same thing).
+            TabView {
+                ProjectionSceneView(rootViewModel: viewModel, viewModel: projectionViewModel)
+                    .tabItem { Label("Project", systemImage: "tv") }
 
-            NavigationStack {
-                SongbooksView(rootViewModel: viewModel)
-            }
-            .tabItem { Label("Songbooks", systemImage: "books.vertical") }
+                NavigationStack {
+                    SongbooksView(rootViewModel: viewModel)
+                }
+                .tabItem { Label("Songbooks", systemImage: "books.vertical") }
 
-            NavigationStack {
-                CatalogueListView(viewModel: viewModel)
+                NavigationStack {
+                    CatalogueListView(viewModel: viewModel)
+                }
+                .tabItem { Label("Search", systemImage: "magnifyingglass") }
+
+                NavigationStack {
+                    TVSettingsRemoteView(coordinator: coordinator)
+                }
+                .tabItem { Label("Settings", systemImage: "gear") }
             }
-            .tabItem { Label("Search", systemImage: "magnifyingglass") }
+
+            // The pairing ceremony overlay — a full-bleed layer ABOVE the
+            // tabs while a ceremony is running, never a sheet/full-screen-
+            // cover (a Settings-tab-triggered "Pair a remote…" should feel
+            // like the WHOLE TV pausing to pair, not a modal on one tab).
+            if coordinator.isPairingActive {
+                TVPairingOverlayView(coordinator: coordinator)
+            }
         }
         .task {
             // Same two one-shot-guarded calls `RootContainerView
             // .restoreAndSync()` makes — browse works signed-out either way.
             await viewModel.restoreSessionIfNeeded()
             await viewModel.loadFavoritesIfNeeded()
+        }
+        .task {
+            // Idempotent (`TVRemoteControlCoordinator.start()`'s own guard)
+            // — starts the LAN listener + spawns its bridge tasks once.
+            await coordinator.start()
         }
     }
 }

--- a/appApple/Packages/iHymnsKit/Sources/IHFeatures/TVSettingsRemoteView.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHFeatures/TVSettingsRemoteView.swift
@@ -1,0 +1,182 @@
+// TVSettingsRemoteView.swift
+// IHFeatures
+//
+// ELI5: The TV's Settings tab — "here's how a remote finds and connects to
+// this TV" (address/fingerprint/standing QR), a button to start pairing a
+// new one, and the list of remotes this TV currently trusts, each with a
+// one-tap "revoke" that immediately kicks it off.
+//
+// DETAILED: #1421 (`.claude/apple-phase2-pr6-spec.md` §6.3). Fills the
+// Settings tab slot `TVRootView`'s own header comment named as deferred
+// "until PR-6's trusted-remotes/pairing screens" exist — this is that
+// screen. The per-row destructive "Revoke" action uses the SAME
+// `.confirmationDialog` pattern `UsageStatsView.swift` already establishes
+// in this package, extended to carry WHICH row is pending (a single `Bool`
+// flag can't disambiguate rows — `pendingRevokeTarget` does).
+import IHDesign
+import IHLive
+import SwiftUI
+
+/// The tvOS Settings tab's remote-control content.
+public struct TVSettingsRemoteView: View {
+    let coordinator: TVRemoteControlCoordinator
+    @State private var pendingRevokeTarget: PairedRemoteRecord?
+
+    public init(coordinator: TVRemoteControlCoordinator) {
+        self.coordinator = coordinator
+    }
+
+    public var body: some View {
+        List {
+            remoteControlSection
+            pairSection
+            trustedRemotesSection
+        }
+        .navigationTitle("Settings")
+        .confirmationDialog(
+            "Revoke this remote?",
+            isPresented: isPresentingRevokeConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Revoke", role: .destructive) {
+                if let target = pendingRevokeTarget {
+                    Task { await coordinator.revoke(target) }
+                }
+                pendingRevokeTarget = nil
+            }
+            Button("Cancel", role: .cancel) { pendingRevokeTarget = nil }
+        } message: {
+            Text("This remote will immediately lose control of this TV.")
+        }
+    }
+
+    private var isPresentingRevokeConfirmation: Binding<Bool> {
+        Binding(get: { pendingRevokeTarget != nil }, set: { isPresented in
+            if !isPresented { pendingRevokeTarget = nil }
+        })
+    }
+
+    // MARK: - (1) Remote Control info
+
+    private var remoteControlSection: some View {
+        Section("Remote Control") {
+            statusRow
+            if let ipAddress = coordinator.listenerInfo?.ipAddress {
+                LabeledContent("IP Address", value: ipAddress)
+            }
+            if let fingerprint = coordinator.listenerInfo?.fingerprint {
+                fingerprintRow(fingerprint)
+            }
+            standingQRRow
+        }
+    }
+
+    @ViewBuilder
+    private var statusRow: some View {
+        if let startError = coordinator.startError {
+            Label(startError, systemImage: "exclamationmark.triangle")
+                .foregroundStyle(.red)
+        } else if let port = coordinator.listenerInfo?.port {
+            Label("Listening on port \(String(port))", systemImage: "antenna.radiowaves.left.and.right")
+        } else {
+            Label("Starting…", systemImage: "hourglass")
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func fingerprintRow(_ fingerprint: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Fingerprint")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            // The FULL value — this is the out-of-band value strategy
+            // §2.4.3's trust model actually pins against; the overlay's own
+            // line is a truncated 12-character convenience only.
+            Text(PairingFingerprintDisplay.grouped(fingerprint))
+                .font(.footnote.monospaced())
+        }
+    }
+
+    /// The "standing" QR — connect-info only (`includeCode: false`), safe
+    /// to leave on screen indefinitely; the pairing CODE never appears
+    /// here (spec §6.3: "never a pairing code").
+    @ViewBuilder
+    private var standingQRRow: some View {
+        if let qrImage = PairingQRCode.image(from: coordinator.qrPayloadString(includeCode: false)) {
+            VStack(alignment: .leading, spacing: 8) {
+                Image(decorative: qrImage, scale: 1)
+                    .interpolation(.none)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 180, height: 180)
+                Text("Connect info only — never shows a pairing code")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    // MARK: - (2) Pair
+
+    private var pairSection: some View {
+        Section("Pair") {
+            Button {
+                Task { await coordinator.beginPairing() }
+            } label: {
+                Label("Pair a remote…", systemImage: "qrcode.viewfinder")
+            }
+        }
+    }
+
+    // MARK: - (3) Trusted remotes
+
+    private var trustedRemotesSection: some View {
+        Section("Trusted Remotes") {
+            if coordinator.pairedRemotes.isEmpty {
+                Text("No remotes have been paired yet.")
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(coordinator.pairedRemotes) { record in
+                    pairedRemoteRow(record)
+                }
+            }
+        }
+    }
+
+    private func pairedRemoteRow(_ record: PairedRemoteRecord) -> some View {
+        HStack {
+            Image(systemName: iconName(for: record.metadata.kind))
+                .foregroundStyle(IHColorTokens.accent)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(displayName(for: record.metadata))
+                Text(record.metadata.pairedAt, style: .date)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 12)
+            Button("Revoke", role: .destructive) {
+                pendingRevokeTarget = record
+            }
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private func displayName(for metadata: LANRemotePairingMetadata) -> String {
+        guard let name = metadata.name, !name.isEmpty else { return "Unknown remote" }
+        return name
+    }
+
+    /// `IHRPRemoteKind` (`IHLive`) → SF Symbol — a UI-only mapping with
+    /// exactly one caller, so it lives here rather than on the model type
+    /// itself.
+    private func iconName(for kind: IHRPRemoteKind?) -> String {
+        switch kind {
+        case .phone: return "iphone"
+        case .pad: return "ipad"
+        case .mac: return "laptopcomputer"
+        case .vision: return "visionpro"
+        case .watchRelay: return "applewatch"
+        case nil: return "questionmark.circle"
+        }
+    }
+}

--- a/appApple/Packages/iHymnsKit/Sources/IHFeatures/TVSettingsRemoteView.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHFeatures/TVSettingsRemoteView.swift
@@ -125,6 +125,15 @@ public struct TVSettingsRemoteView: View {
             } label: {
                 Label("Pair a remote…", systemImage: "qrcode.viewfinder")
             }
+            // The brute-force ceiling's operator-facing notice (post-#1421
+            // adversarial-review fix): shown after the listener auto-disarms
+            // a ceremony that got too many wrong codes; cleared the next time
+            // "Pair a remote…" runs.
+            if let notice = coordinator.pairingNotice {
+                Label(notice, systemImage: "exclamationmark.shield")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
         }
     }
 

--- a/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/IHRPFrame.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/IHRPFrame.swift
@@ -63,6 +63,9 @@ extension IHRPFrame: Codable {
         case token, kind, songId, componentIndex, lineIndex, index, delta
         case displayState, theme, textScale, ackSeq, errorCode, message
         case state, capabilities
+        // #1421 (PR-6 spec §4) — the pairing sub-protocol's own fields.
+        // `token` (above) is REUSED for `pairSuccess`, not re-declared.
+        case proof, nonce, deviceName
     }
 
     // One `case` per `IHRPMessage` kind is the whole point of this custom
@@ -141,6 +144,22 @@ extension IHRPFrame: Codable {
             self.message = .pong
         case "capabilities":
             self.message = .capabilities(try container.decode(IHRPCapabilities.self, forKey: .capabilities))
+        case "pairChallenge":
+            guard let nonce = try container.decodeIfPresent(String.self, forKey: .nonce) else {
+                throw IHRPDecodingError.missingField("nonce", forType: type)
+            }
+            self.message = .pairChallenge(nonce: nonce)
+        case "pairConfirm":
+            guard let proof = try container.decodeIfPresent(String.self, forKey: .proof) else {
+                throw IHRPDecodingError.missingField("proof", forType: type)
+            }
+            let deviceName = try container.decodeIfPresent(String.self, forKey: .deviceName)
+            self.message = .pairConfirm(proof: proof, deviceName: deviceName)
+        case "pairSuccess":
+            guard let token = try container.decodeIfPresent(String.self, forKey: .token) else {
+                throw IHRPDecodingError.missingField("token", forType: type)
+            }
+            self.message = .pairSuccess(token: token)
         default:
             throw IHRPDecodingError.unknownMessageType(type)
         }
@@ -186,6 +205,13 @@ extension IHRPFrame: Codable {
             try container.encodeIfPresent(text, forKey: .message)
         case .capabilities(let capabilities):
             try container.encode(capabilities, forKey: .capabilities)
+        case .pairChallenge(let nonce):
+            try container.encode(nonce, forKey: .nonce)
+        case .pairConfirm(let proof, let deviceName):
+            try container.encode(proof, forKey: .proof)
+            try container.encodeIfPresent(deviceName, forKey: .deviceName)
+        case .pairSuccess(let token):
+            try container.encode(token, forKey: .token)
         }
     }
 }

--- a/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/IHRPMessage.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/IHRPMessage.swift
@@ -140,6 +140,34 @@ public enum IHRPMessage: Sendable, Equatable {
     /// Sent once, right after a `hello` is accepted (paired or freshly
     /// completes pairing) — strategy §2.4.4's `capabilities` response.
     case capabilities(IHRPCapabilities)
+
+    // MARK: Pairing sub-protocol (#1421, PR-6 spec §4)
+    //
+    // The out-of-band-code ceremony that promotes a `.pairing` connection
+    // to `.paired` — a MIX of directions (TV asks first, remote answers,
+    // TV confirms), which is why these three don't slot cleanly into
+    // either MARK section above. `LANRemotePairingProof.swift`'s header
+    // comment is the crypto design doc for `proof`; NEVER interpolate any
+    // of `nonce`/`proof`/`token` into an `IHLog` call anywhere in this
+    // module (this file's own top-of-file header note, repeated here
+    // because it's the sharpest edge in the whole sub-protocol).
+
+    /// TV → remote, sent immediately after a `hello` parks the connection
+    /// in `.pairing` — carries the per-connection nonce the proof binds to
+    /// (`LANRemotePairingProof.swift` §3.2), and doubles as the "show the
+    /// code-entry UI now" signal for the remote-side app (PR-7).
+    case pairChallenge(nonce: String)
+
+    /// Remote → TV: the pairing proof plus an optional user-facing device
+    /// name for the trusted-remotes list. **Never logged verbatim** — the
+    /// proof is code-derived (a leaked proof is nearly as sensitive as the
+    /// code itself while the ceremony is still active).
+    case pairConfirm(proof: String, deviceName: String?)
+
+    /// TV → remote, on ceremony success: the freshly-minted raw pairing
+    /// token the remote must persist (Keychain, `synchronizable: false` —
+    /// PR-7's job). **Never logged.**
+    case pairSuccess(token: String)
 }
 
 // MARK: - #1420 logging-safe case name (mirrors `IHAPI/APIError.swift`'s
@@ -171,6 +199,9 @@ extension IHRPMessage {
         case .error: return "error"
         case .pong: return "pong"
         case .capabilities: return "capabilities"
+        case .pairChallenge: return "pairChallenge"
+        case .pairConfirm: return "pairConfirm"
+        case .pairSuccess: return "pairSuccess"
         }
     }
 
@@ -190,9 +221,9 @@ extension IHRPMessage {
         switch self {
         case .hello, .prepare, .selectSong, .nextComponent, .prevComponent,
              .nextLine, .prevLine, .jumpLine, .setDisplayState, .scroll,
-             .setAppearance, .endControl, .ping:
+             .setAppearance, .endControl, .ping, .pairConfirm:
             return true
-        case .state, .ack, .error, .pong, .capabilities:
+        case .state, .ack, .error, .pong, .capabilities, .pairChallenge, .pairSuccess:
             return false
         }
     }

--- a/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/IHRPPayloads.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/IHRPPayloads.swift
@@ -161,6 +161,16 @@ public enum IHRPErrorCode: String, Sendable, Codable, Equatable, CaseIterable {
     /// `.unpaired`/`.pairing` states) and sent a control message anyway —
     /// this file's `IHRPMessage` doc comment.
     case unauthorized
+    /// The pairing PROOF was rejected — wrong/expired code, or no active
+    /// ceremony at all (`LANRemotePairingCeremony.swift`'s TTL/single-use
+    /// rules). New in #1421 (PR-6 spec §4/D-2): deliberately a DIFFERENT
+    /// code from `.unauthorized` because `RemoteSessionActor
+    /// .handleIncomingFrameData` (`RemoteSessionActor+Connection.swift`)
+    /// only disconnects on `.unauthorized` — a mistyped 6-digit code must
+    /// stay retryable ON THE SAME CONNECTION (the user just tries again)
+    /// until the per-connection attempt cap (`TVListenerActor+Pairing.swift`)
+    /// forces a teardown instead.
+    case pairingRejected
     /// The TV's own `song_detail` fetch for the requested song was denied by
     /// content gating (`.claude/CLAUDE.md` rule #28) — strategy §2.4.3.
     case contentUnavailable

--- a/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/KeychainLANRemotePairingAuthority.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/KeychainLANRemotePairingAuthority.swift
@@ -1,0 +1,226 @@
+// KeychainLANRemotePairingAuthority.swift
+// IHLive/LANRemote
+//
+// ELI5: The REAL "remember which remotes we trust" notebook — instead of
+// forgetting everything when the app quits (`InMemoryLANRemotePairingAuthority`,
+// PR-4's placeholder), this one writes each paired remote into the
+// Keychain, so the TV still remembers them after a relaunch or a reboot.
+// It never stores the remote's actual secret token — only its SHA-256
+// hash — so even someone with access to a Keychain backup can't recover a
+// working credential from it.
+//
+// DETAILED: #1421 (`.claude/apple-phase2-pr6-spec.md` §5.2 — the
+// `KeychainTokenStore` idiom, adapted for a LIST rather than a single
+// item). One `kSecClassGenericPassword` item PER paired remote:
+// `kSecAttrAccount` is the hash (never the raw token — "the account IS the
+// hash," this repo's #1421 spec quote), `kSecValueData` is the
+// JSON-encoded, NON-secret `LANRemotePairingMetadata` (device name/kind/
+// paired-at) so list+revoke stay a SINGLE Keychain query surface instead
+// of a parallel store that could desync (spec Decision D-6).
+//
+// **`kSecAttrSynchronizable = false` is EXPLICIT and HARD-CODED here — a
+// deliberate contrast with `KeychainTokenStore`'s `synchronizable`
+// property, which IS injectable** (that type's own header: `true` is the
+// iCloud-Keychain global-login TRANSPORT on phone/iPad/Mac). An
+// iCloud-synced pairing trust would silently break the proximity model
+// this whole ceremony is built on (plan §6.4's tripwire) — tvOS has no
+// iCloud Keychain anyway, but making the `false` un-overridable here means
+// that stays true even if this type is ever reused from a platform that
+// DOES have iCloud Keychain. `KeychainPairingAuthorityTests` asserts this
+// directly against `baseAttributes(account:)`.
+import Foundation
+import IHLog
+import Security
+
+/// Non-secret facts about a paired remote — a device name, its kind (for
+/// the Settings list's icon), and when it paired.
+///
+/// ELI5: "Which remote is this, what kind of device is it, and when did it
+/// pair?"
+public struct LANRemotePairingMetadata: Sendable, Codable, Equatable {
+    public var name: String?
+    public var kind: IHRPRemoteKind?
+    public var pairedAt: Date
+
+    public init(name: String? = nil, kind: IHRPRemoteKind? = nil, pairedAt: Date) {
+        self.name = name
+        self.kind = kind
+        self.pairedAt = pairedAt
+    }
+}
+
+/// One row in the trusted-remotes Settings list — `id` is the token's hash
+/// (never the raw token, which this authority never even holds in memory
+/// longer than one function call).
+///
+/// ELI5: "One entry in the 'devices that can control this TV' list."
+public struct PairedRemoteRecord: Sendable, Equatable, Identifiable {
+    public let tokenHashHex: String
+    public let metadata: LANRemotePairingMetadata
+    public var id: String { tokenHashHex }
+
+    public init(tokenHashHex: String, metadata: LANRemotePairingMetadata) {
+        self.tokenHashHex = tokenHashHex
+        self.metadata = metadata
+    }
+}
+
+/// The real, Keychain-backed `LANRemotePairingAuthority` — see this file's
+/// header for the exact `SecItem` shape.
+///
+/// ELI5: The actual, persistent "remotes we trust" notebook (as opposed to
+/// `InMemoryLANRemotePairingAuthority`, the pretend one tests use).
+///
+/// DETAILED: An `actor` — the `KeychainTokenStore` precedent (`IHAuth`):
+/// every `SecItem*` call is itself synchronous+thread-safe at the OS
+/// level, but isolating this type still gives every call site a single,
+/// uniform `await`-based API matching the `LANRemotePairingAuthority`
+/// protocol's `async` requirements.
+public actor KeychainLANRemotePairingAuthority: LANRemotePairingAuthority {
+    /// `kSecAttrService` — a private per-app namespace, the
+    /// `"app.ihymns.token"` convention (`KeychainTokenStore`) applied to
+    /// this NEW credential class.
+    private let service: String
+
+    public init(service: String = "app.ihymns.lanremote.pairedRemotes") {
+        self.service = service
+    }
+
+    public func isPairedToken(_ token: String) async -> Bool {
+        var query = baseAttributes(account: hashOf(token))
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        switch status {
+        case errSecSuccess:
+            return true
+        case errSecItemNotFound:
+            return false
+        default:
+            // Fail CLOSED for a trust decision (spec §5.2) — an
+            // unexpected Keychain error must never be silently treated as
+            // "this remote is trusted."
+            IHLog.remote.error("lanremote.authority read-failed status=\(status, privacy: .public)")
+            return false
+        }
+    }
+
+    public func registerPairedToken(_ token: String) async {
+        await registerPairedToken(token, metadata: LANRemotePairingMetadata(pairedAt: Date()))
+    }
+
+    public func registerPairedToken(_ token: String, metadata: LANRemotePairingMetadata) async {
+        let account = hashOf(token)
+        // Replace semantics — delete any existing item under this hash
+        // first (`KeychainTokenStore.save(_:)`'s identical precedent),
+        // then add the fresh one.
+        SecItemDelete(baseAttributes(account: account) as CFDictionary)
+
+        guard let payload = try? JSONEncoder().encode(metadata) else {
+            IHLog.remote.fault("lanremote.authority persist-failed reason=encode")
+            return
+        }
+        var query = baseAttributes(account: account)
+        query[kSecValueData as String] = payload
+        let status = SecItemAdd(query as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            // `.fault` (spec §5.2): the in-flight session still works
+            // (the connection's phase is already `.paired` in-memory by
+            // the time this is called), but the pairing won't survive a
+            // relaunch — an alarm-level condition worth surfacing, not a
+            // silent best-effort failure.
+            IHLog.remote.fault("lanremote.authority persist-failed status=\(status, privacy: .public)")
+            return
+        }
+    }
+
+    public func revokePairedToken(_ token: String) async {
+        await revoke(tokenHash: hashOf(token))
+    }
+
+    /// Revokes by HASH directly — what the trusted-remotes Settings list
+    /// has on hand (`PairedRemoteRecord.tokenHashHex`); it never sees the
+    /// raw token at all.
+    ///
+    /// ELI5: "Forget this remote — I already know its hash, not its secret
+    /// token."
+    public func revoke(tokenHash: String) async {
+        SecItemDelete(baseAttributes(account: tokenHash) as CFDictionary)
+    }
+
+    /// Every currently-paired remote, newest-first by `pairedAt`.
+    ///
+    /// ELI5: "List every remote this TV currently trusts."
+    ///
+    /// DETAILED: **Two queries per remote, not one** — `SecItemCopyMatching`
+    /// returns `errSecParam` when `kSecReturnData` is combined with
+    /// `kSecMatchLimitAll` for a generic-password class (empirically
+    /// verified against this exact query shape; not clearly called out in
+    /// Apple's own `SecItemCopyMatching` documentation). Step 1 lists every
+    /// matching item's ATTRIBUTES ONLY (`kSecMatchLimitAll` +
+    /// `kSecReturnAttributes`, no `kSecReturnData`) to get each account
+    /// (hash); step 2 fetches each one's `kSecValueData` individually
+    /// (`kSecMatchLimitOne` + `kSecReturnData`, the same shape
+    /// `isPairedToken(_:)` already uses successfully). A handful of paired
+    /// remotes makes N+1 Keychain round-trips a non-issue in practice.
+    public func listPairedRemotes() async -> [PairedRemoteRecord] {
+        var listQuery = baseAttributes(account: nil)
+        listQuery[kSecMatchLimit as String] = kSecMatchLimitAll
+        listQuery[kSecReturnAttributes as String] = true
+
+        var listResult: CFTypeRef?
+        let listStatus = SecItemCopyMatching(listQuery as CFDictionary, &listResult)
+        guard listStatus == errSecSuccess, let items = listResult as? [[String: Any]] else {
+            return []
+        }
+
+        let records: [PairedRemoteRecord] = items.compactMap { item in
+            guard let hash = item[kSecAttrAccount as String] as? String else { return nil }
+            return PairedRemoteRecord(tokenHashHex: hash, metadata: metadata(forAccount: hash))
+        }
+        return records.sorted { $0.metadata.pairedAt > $1.metadata.pairedAt }
+    }
+
+    /// Fetches ONE item's decoded `LANRemotePairingMetadata` by its account
+    /// (hash) — a row whose data can't be read/decoded still lists with
+    /// PLACEHOLDER metadata rather than silently vanishing (spec §5.2: "a
+    /// trust entry must never be invisible").
+    private func metadata(forAccount account: String) -> LANRemotePairingMetadata {
+        var query = baseAttributes(account: account)
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        query[kSecReturnData as String] = true
+
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess, let data = result as? Data,
+              let metadata = try? JSONDecoder().decode(LANRemotePairingMetadata.self, from: data) else {
+            return LANRemotePairingMetadata(pairedAt: .distantPast)
+        }
+        return metadata
+    }
+
+    private func hashOf(_ token: String) -> String {
+        LANRemoteFingerprint.sha256Hex(Data(token.utf8))
+    }
+
+    /// The base Keychain attribute dictionary every call above shares —
+    /// `internal` (not `private`, spec §5.2) so `KeychainPairingAuthorityTests`
+    /// can assert the `kSecAttrSynchronizable == false` / accessible /
+    /// service invariants DIRECTLY, the required unit test plan §6.4 calls
+    /// for.
+    func baseAttributes(account: String?) -> [String: Any] {
+        var query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            // EXPLICIT, hard-coded `false` — see this file's header.
+            kSecAttrSynchronizable as String: false,
+            // `KeychainTokenStore` precedent — the listener must be able
+            // to authorise reconnects right after a reboot.
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock
+        ]
+        if let account {
+            query[kSecAttrAccount as String] = account
+        }
+        return query
+    }
+}

--- a/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/LANRemoteAddress.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/LANRemoteAddress.swift
@@ -1,0 +1,63 @@
+// LANRemoteAddress.swift
+// IHLive/LANRemote
+//
+// ELI5: Figures out "what's this TV's own address on the home Wi-Fi right
+// now?" — the number an operator could type into a phone's "connect by
+// address" screen if Bonjour discovery isn't finding the TV for some
+// reason.
+//
+// DETAILED: #1421 (`.claude/apple-phase2-pr6-spec.md` §2). Feeds the
+// Settings "Remote Control info" panel (strategy §2.4.5) —
+// `TVRemoteControlCoordinator.ListenerInfo.ipAddress` (`IHFeatures`) — and
+// is reused as-is by PR-8's manual connect-by-address rung. `getifaddrs`
+// (POSIX, https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/getifaddrs.3.html)
+// enumerates every network interface on the device; this walks that list
+// ONCE, skips loopback (meaningless to show a remote user), and PREFERS
+// `en0` (the primary Wi-Fi/Ethernet interface on tvOS/iOS — Apple's own
+// convention) while still falling back to some OTHER interface's address
+// rather than `nil` if `en0` isn't up. Never throws — a Settings screen
+// showing "address unavailable" is a reasonable degraded UI, not a crash.
+import Foundation
+
+/// Best-effort local-network address lookup for this device.
+///
+/// ELI5: "What's this TV's own network address right now?"
+public enum LANRemoteAddress {
+    /// This device's primary IPv4 address, or `nil` if none can be
+    /// determined (no active interface, or a platform/sandboxing
+    /// restriction on `getifaddrs`).
+    public static func primaryIPv4Address() -> String? {
+        var ifaddrPtr: UnsafeMutablePointer<ifaddrs>?
+        guard getifaddrs(&ifaddrPtr) == 0, let firstAddr = ifaddrPtr else { return nil }
+        defer { freeifaddrs(ifaddrPtr) }
+
+        var fallback: String?
+        var pointer: UnsafeMutablePointer<ifaddrs>? = firstAddr
+        while let interface = pointer {
+            defer { pointer = interface.pointee.ifa_next }
+            guard let socketAddress = interface.pointee.ifa_addr,
+                  socketAddress.pointee.sa_family == UInt8(AF_INET),
+                  let address = ipv4String(from: socketAddress),
+                  address != "127.0.0.1" else { continue }
+
+            let name = String(cString: interface.pointee.ifa_name)
+            if name == "en0" { return address }
+            if fallback == nil { fallback = address }
+        }
+        return fallback
+    }
+
+    /// Extracts the dotted-decimal IPv4 string from a `sockaddr` already
+    /// confirmed `sa_family == AF_INET` — `inet_ntop` (POSIX,
+    /// https://man7.org/linux/man-pages/man3/inet_ntop.3.html) does the
+    /// actual byte-to-string conversion; `nil` only if that somehow fails
+    /// (malformed interface data), never expected in practice.
+    private static func ipv4String(from socketAddress: UnsafeMutablePointer<sockaddr>) -> String? {
+        var addressIn = UnsafeRawPointer(socketAddress).assumingMemoryBound(to: sockaddr_in.self).pointee
+        var buffer = [CChar](repeating: 0, count: Int(INET6_ADDRSTRLEN))
+        guard inet_ntop(AF_INET, &addressIn.sin_addr, &buffer, socklen_t(buffer.count)) != nil else { return nil }
+        // `String(cString:)` on a raw `[CChar]` array is deprecated;
+        // go through the buffer's own null-terminated pointer instead.
+        return buffer.withUnsafeBufferPointer { String(cString: $0.baseAddress!) }
+    }
+}

--- a/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/LANRemoteFingerprint.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/LANRemoteFingerprint.swift
@@ -12,13 +12,28 @@
 // `LANRemotePairingAuthority`'s in-memory reference implementation (a
 // pairing token's hash-at-rest) all need "SHA-256, then lowercase hex" —
 // this is that one function, not three near-identical private copies.
+//
+// #1421 UPDATE (PR-6 spec §3.1) — `hexString(_:)` was pulled OUT of
+// `sha256Hex(_:)`'s body so `LANRemotePairingSecrets`/`LANRemotePairingProof`
+// (`LANRemotePairingProof.swift`) can reuse the identical lowercase-hex
+// encoding for a random nonce/token and an HMAC output, which are NOT
+// SHA-256 digests themselves and so can't route through `sha256Hex(_:)`
+// directly — "add one tiny internal `hexString(_ bytes:)` helper next to
+// it rather than three private copies" (spec §3.1), applying this file's
+// own "extract first" rule to itself.
 import CryptoKit
 import Foundation
 
 enum LANRemoteFingerprint {
     /// SHA-256 of `data`, as 64 lowercase hex characters.
     static func sha256Hex(_ data: Data) -> String {
-        let digest = SHA256.hash(data: data)
-        return digest.map { String(format: "%02x", $0) }.joined()
+        hexString(Array(SHA256.hash(data: data)))
+    }
+
+    /// Lowercase hex encoding of raw `bytes` — the ONE place every
+    /// SHA-256/HMAC/random-byte hex-encoding in this module routes through
+    /// (this file's #1421 header update).
+    static func hexString(_ bytes: [UInt8]) -> String {
+        bytes.map { String(format: "%02x", $0) }.joined()
     }
 }

--- a/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/LANRemoteIdentity.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/LANRemoteIdentity.swift
@@ -33,18 +33,44 @@
 // **Why `SecItemAdd`/Keychain at all, if persistence is out of scope?**
 // Apple's `Security.framework` has no PUBLIC API to construct a `SecIdentity`
 // (the type `NWProtocolTLS.Options`' local-identity setter requires) purely
-// in-memory from a `SecCertificate` + a matching `SecKey` — the only
-// documented routes are importing a PKCS#12 blob (`SecPKCS12Import`, which
-// would mean hand-encoding ANOTHER binary format just to avoid this one) or
-// adding the certificate and key as loose Keychain items under a shared
-// label and querying `kSecClassIdentity`, which is the well-established
-// technique this file uses (and the one Apple's own Network.framework
-// sample code for custom peer-to-peer protocols uses too). Every item this
-// file adds is tagged with a UUID-unique label and is meant to be removed
-// via `removeFromKeychain()` once no longer needed (`LANRemoteTests` does
-// this in a `defer`) — this is Keychain used as unavoidable OS PLUMBING to
+// in-memory from a `SecCertificate` + a matching `SecKey` — the documented
+// route this file uses is `SecIdentityCreateWithCertificate`, which bridges
+// a certificate to its MATCHING private key already present in the
+// Keychain (found by the certificate's own embedded public-key hash).
+// Every item this file adds is tagged with a UUID-unique label (unless a
+// persistent one is supplied, #1421) and is meant to be removed via
+// `removeFromKeychain()` once no longer needed (`LANRemoteTests` does this
+// in a `defer`) — this is Keychain used as unavoidable OS PLUMBING to
 // bridge two in-memory objects into the shape TLS needs, not as the
 // "remember this across app launches" persistence PR-6 owns.
+//
+// **#1421 FIX #1 — the private key MUST be generated with
+// `kSecAttrIsPermanent: true` directly inside `SecKeyCreateRandomKey`'s OWN
+// attributes, never generated ephemeral-then-`SecItemAdd`-ed afterward.**
+// Empirically verified: an ephemeral key added via a SEPARATE
+// `SecItemAdd(kSecValueRef:)` is findable again by its own custom
+// `kSecAttrLabel`, but `SecIdentityCreateWithCertificate` silently FAILS
+// (`errSecItemNotFound`) to bridge it against ANY matching certificate —
+// that second-hand add never wires up the key's `kSecAttrApplicationLabel`
+// (its public-key hash), the ONLY thing identity-bridging matches on.
+// Apple's documented "generate a keychain-resident key" pattern
+// (https://developer.apple.com/documentation/security/certificate_key_and_trust_services/keys/generating_new_cryptographic_keys)
+// fixes this on the first try.
+//
+// **#1421 FIX #2 — never store or look up the certificate via
+// `kSecClassCertificate` + `kSecAttrLabel`.** Also empirically verified:
+// `SecItemAdd` silently OVERWRITES a certificate's requested `kSecAttrLabel`
+// with a value derived from its own Subject Common Name — a custom-label
+// lookup is unreliable the instant two self-signed identities share a
+// Common Name (every call with this factory's default `commonName`, for
+// instance). This file never stores the certificate as a
+// `kSecClassCertificate` item; its DER bytes go into a plain
+// `kSecClassGenericPassword` item instead (the same reliable pattern
+// `KeychainTokenStore`/`KeychainLANRemotePairingAuthority` already use),
+// keyed by the caller's own `label`, reconstructed via
+// `SecCertificateCreateWithData` whenever `queryIdentity(label:)` needs it —
+// `SecIdentityCreateWithCertificate` never requires the certificate itself
+// to be a stored item, only the matching PRIVATE KEY does.
 import Foundation
 import Network
 import Security
@@ -138,18 +164,45 @@ public enum LANRemoteIdentityFactory {
     ///     well-formed certificate needs SOME validity window; defaults to
     ///     5 years so a persisted (PR-6) identity doesn't need routine
     ///     rotation.
+    ///   - keychainLabel: `nil` (every PR-4 call site, UNCHANGED) keeps
+    ///     today's fresh-per-call `"app.ihymns.lanremote.\(UUID())"` label —
+    ///     this parameter is purely ADDITIVE. A non-nil value (#1421,
+    ///     `LANRemoteIdentityStore.swift`'s persistent-identity path) uses
+    ///     that EXACT label instead — the one thing that makes
+    ///     `LANRemoteIdentityStore.loadOrCreate()` able to find the SAME
+    ///     identity again on the next launch via `queryIdentity(label:)`.
     public static func generateSelfSigned(
         commonName: String = "iHymnsTV",
-        validityDays: Int = 365 * 5
+        validityDays: Int = 365 * 5,
+        keychainLabel: String? = nil
     ) throws -> LANRemoteIdentity {
+        let label = keychainLabel ?? "app.ihymns.lanremote.\(UUID().uuidString)"
+        if keychainLabel != nil {
+            // A caller-supplied (persistent) label may have stray items
+            // left over from a half-completed PRIOR generate under this
+            // same label — pre-delete so this attempt doesn't fail with
+            // `errSecDuplicateItem`. A fresh per-call UUID label (every
+            // PR-4 call site) can never collide, so this only runs for
+            // #1421's persistent-identity path.
+            removeFromKeychain(label: label)
+        }
+
+        // `kSecAttrIsPermanent: true` HERE (not a separate `SecItemAdd`
+        // afterward) — this file's #1421 header update explains why that
+        // distinction is load-bearing for `SecIdentityCreateWithCertificate`
+        // to ever succeed.
         let keyAttributes: [String: Any] = [
             kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom,
-            kSecAttrKeySizeInBits as String: 256
+            kSecAttrKeySizeInBits as String: 256,
+            kSecAttrIsPermanent as String: true,
+            kSecAttrLabel as String: label,
+            kSecAttrApplicationTag as String: Data(label.utf8),
+            // `.afterFirstUnlock` (#1421): readable right after a tvOS
+            // reboot, before a SECOND unlock — `KeychainTokenStore.save(_:)`'s
+            // identical "early-launch read must succeed" reasoning.
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock
         ]
-        var keyGenError: Unmanaged<CFError>?
-        guard let privateKey = SecKeyCreateRandomKey(keyAttributes as CFDictionary, &keyGenError) else {
-            throw LANRemoteIdentityError.keyGenerationFailed(describe(keyGenError))
-        }
+        let privateKey = try generatePermanentKey(attributes: keyAttributes)
         guard let publicKey = SecKeyCopyPublicKey(privateKey) else {
             throw LANRemoteIdentityError.keyGenerationFailed("SecKeyCopyPublicKey returned nil")
         }
@@ -165,22 +218,47 @@ public enum LANRemoteIdentityFactory {
             validityDays: validityDays
         )
 
-        guard let certificate = SecCertificateCreateWithData(nil, certificateDER as CFData) else {
-            throw LANRemoteIdentityError.certificateCreationFailed
-        }
-
-        let label = "app.ihymns.lanremote.\(UUID().uuidString)"
-        try bridgeToKeychainIdentity(privateKey: privateKey, certificate: certificate, label: label)
+        try persistCertificateDER(certificateDER, label: label)
         let secIdentityRef = try queryIdentity(label: label)
 
-        let fingerprint = LANRemoteFingerprint.sha256Hex(certificateDER)
-
         return LANRemoteIdentity(
-            fingerprint: fingerprint,
+            fingerprint: LANRemoteFingerprint.sha256Hex(certificateDER),
             certificateDER: certificateDER,
             secIdentityRef: secIdentityRef,
             keychainLabel: label
         )
+    }
+
+    /// Generates a PERMANENT (`kSecAttrIsPermanent: true`) private key,
+    /// retrying a bounded number of times on a TRANSIENT Keychain-daemon
+    /// contention failure.
+    ///
+    /// ELI5: "Ask the Keychain for a new permanent key — if it's briefly
+    /// busy and says no, wait a moment and ask again, a couple of times,
+    /// before giving up for real."
+    ///
+    /// DETAILED: #1421. Empirically observed: concurrent
+    /// `SecKeyCreateRandomKey(kSecAttrIsPermanent: true)` calls (this PR's
+    /// test suites all exercise the same factory at once) can transiently
+    /// fail (`errSecItemNotFound`/"failed to generate CDSA key") — a real
+    /// macOS/iOS Keychain-daemon contention artifact, not a defect in the
+    /// attributes passed. A bounded retry with a short linear backoff is
+    /// cheap insurance for a call that happens at most once per TV launch
+    /// in production. A genuine, non-transient failure fails identically
+    /// on every attempt and surfaces after the retries, same as before.
+    private static func generatePermanentKey(attributes: [String: Any]) throws -> SecKey {
+        var lastError: Unmanaged<CFError>?
+        for attempt in 0..<3 {
+            var keyGenError: Unmanaged<CFError>?
+            if let key = SecKeyCreateRandomKey(attributes as CFDictionary, &keyGenError) {
+                return key
+            }
+            lastError = keyGenError
+            if attempt < 2 {
+                Thread.sleep(forTimeInterval: 0.05 * Double(attempt + 1))
+            }
+        }
+        throw LANRemoteIdentityError.keyGenerationFailed(describe(lastError))
     }
 
     /// Builds and self-signs the minimal X.509 DER certificate — see
@@ -225,55 +303,91 @@ public enum LANRemoteIdentityFactory {
         return Data(certificate)
     }
 
-    /// Bridges a loose `SecKey`+`SecCertificate` pair into a queryable
-    /// `SecIdentity` by adding both to the Keychain under the same
-    /// `kSecAttrLabel` — see this file's header comment.
-    private static func bridgeToKeychainIdentity(privateKey: SecKey, certificate: SecCertificate, label: String) throws {
-        let keyQuery: [String: Any] = [
-            kSecClass as String: kSecClassKey,
-            kSecValueRef as String: privateKey,
-            kSecAttrLabel as String: label,
-            kSecAttrApplicationTag as String: Data(label.utf8)
-        ]
-        let keyStatus = SecItemAdd(keyQuery as CFDictionary, nil)
-        guard keyStatus == errSecSuccess else {
-            throw LANRemoteIdentityError.keychainBridgeFailed(status: keyStatus)
-        }
+    /// The `kSecClassGenericPassword` namespace the certificate DER bytes
+    /// are persisted under (this file's #1421 header update explains why
+    /// NOT `kSecClassCertificate`) — `kSecAttrAccount` is the caller's own
+    /// `label`, so each identity's certificate is independently addressable
+    /// the same way its private key is.
+    private static let certificateDERService = "app.ihymns.lanremote.identitycert"
 
-        let certificateQuery: [String: Any] = [
-            kSecClass as String: kSecClassCertificate,
-            kSecValueRef as String: certificate,
-            kSecAttrLabel as String: label
-        ]
-        let certificateStatus = SecItemAdd(certificateQuery as CFDictionary, nil)
-        guard certificateStatus == errSecSuccess else {
-            throw LANRemoteIdentityError.keychainBridgeFailed(status: certificateStatus)
+    /// Persists `der` (replace semantics — matches `KeychainTokenStore
+    /// .save(_:)`'s identical "delete any existing item first" convention)
+    /// so `queryIdentity(label:)` can reconstruct the certificate again in
+    /// a LATER process launch.
+    private static func persistCertificateDER(_ der: Data, label: String) throws {
+        SecItemDelete(certificateDERQuery(label: label) as CFDictionary)
+        var query = certificateDERQuery(label: label)
+        query[kSecValueData as String] = der
+        let status = SecItemAdd(query as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            throw LANRemoteIdentityError.keychainBridgeFailed(status: status)
         }
     }
 
-    private static func queryIdentity(label: String) throws -> SecIdentity {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassIdentity,
-            kSecAttrLabel as String: label,
-            kSecReturnRef as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne
+    private static func certificateDERQuery(label: String) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: certificateDERService,
+            kSecAttrAccount as String: label,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock
         ]
+    }
+
+    /// Looks up the `SecIdentity` bridged under `label` — `internal` (not
+    /// `private`, #1421 PR-6 spec §5.1) so `LANRemoteIdentityStore.swift`
+    /// (a DIFFERENT file, same `IHLive` module) can reuse this EXACT lookup
+    /// rather than duplicating it — this repo's "extract first, use
+    /// second" modularity rule applied to a same-module, cross-file helper.
+    ///
+    /// **#1421 FIX — never a direct `kSecClassIdentity`+`kSecAttrLabel`
+    /// query, and never `kSecClassCertificate`+`kSecAttrLabel` either.**
+    /// Both were empirically verified broken (this file's header). This
+    /// instead (1) reads the certificate's raw DER bytes back from the
+    /// reliable `kSecClassGenericPassword` store
+    /// `persistCertificateDER(_:label:)` wrote, (2) reconstructs a
+    /// `SecCertificate` via `SecCertificateCreateWithData`, then (3)
+    /// bridges it to a `SecIdentity` via `SecIdentityCreateWithCertificate`
+    /// — which finds the matching PERMANENT private key by the
+    /// certificate's own embedded public-key hash, never by a label.
+    ///
+    /// SECURITY-RELEVANT, not cosmetic: the ORIGINAL broken lookup meant
+    /// `TVListenerActor.start()` could silently build its TLS options from
+    /// a WRONG `SecIdentity` (some unrelated cert+key already in the login
+    /// keychain) whose ACTUAL presented fingerprint would never match the
+    /// `LANRemoteIdentity.fingerprint` shown to/pinned by a remote — every
+    /// real connection would then fail `RemoteSessionActor`'s pin check.
+    /// Existing tests never caught this because CI/most dev runs start
+    /// from a keychain with NO other identity present, where the
+    /// (unfiltered) match happened to coincide with the only identity that
+    /// existed.
+    static func queryIdentity(label: String) throws -> SecIdentity {
+        var query = certificateDERQuery(label: label)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+
         var result: CFTypeRef?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
-        guard status == errSecSuccess, let result, CFGetTypeID(result) == SecIdentityGetTypeID() else {
+        guard status == errSecSuccess, let der = result as? Data else {
             throw LANRemoteIdentityError.keychainBridgeFailed(status: status)
         }
-        // swiftlint:disable:next force_cast
-        return (result as! SecIdentity)
+        guard let certificate = SecCertificateCreateWithData(nil, der as CFData) else {
+            throw LANRemoteIdentityError.certificateCreationFailed
+        }
+
+        var identityRef: SecIdentity?
+        let identityStatus = SecIdentityCreateWithCertificate(nil, certificate, &identityRef)
+        guard identityStatus == errSecSuccess, let identityRef else {
+            throw LANRemoteIdentityError.keychainBridgeFailed(status: identityStatus)
+        }
+        return identityRef
     }
 
     /// Removes the Keychain items tagged with `label` — see
     /// `LANRemoteIdentity.removeFromKeychain()`'s doc comment.
     static func removeFromKeychain(label: String) {
         let keyQuery: [String: Any] = [kSecClass as String: kSecClassKey, kSecAttrLabel as String: label]
-        let certificateQuery: [String: Any] = [kSecClass as String: kSecClassCertificate, kSecAttrLabel as String: label]
         SecItemDelete(keyQuery as CFDictionary)
-        SecItemDelete(certificateQuery as CFDictionary)
+        SecItemDelete(certificateDERQuery(label: label) as CFDictionary)
     }
 
     private static func describe(_ error: Unmanaged<CFError>?) -> String {

--- a/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/LANRemoteIdentityStore.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/LANRemoteIdentityStore.swift
@@ -1,0 +1,108 @@
+// LANRemoteIdentityStore.swift
+// IHLive/LANRemote
+//
+// ELI5: The TV's "keep the same face forever" box — the first time the TV
+// app ever runs, it makes itself a TLS identity and locks it in the
+// Keychain under one fixed name; every time after that, it just opens the
+// box and reuses the SAME identity instead of making a new one. This is
+// what lets a paired remote's saved fingerprint keep working across every
+// future relaunch/reboot.
+//
+// DETAILED: #1421 (`.claude/apple-phase2-pr6-spec.md` §5.1). Fills the
+// persistence-policy gap `LANRemoteIdentity.swift`'s own header comment
+// explicitly deferred: "storing the identity in the Keychain is PR-6's
+// job." MUST live in `IHLive` (not `IHFeatures`) because `LANRemoteIdentity`'s
+// memberwise initializer is `internal` — only same-module code can
+// construct one directly, which is exactly what `loadOrCreate()`'s
+// "found an existing identity" branch below needs to do.
+//
+// **The load-bearing #1421 acceptance property this file exists for:**
+// `loadOrCreate()` called TWICE (i.e. two separate app launches) returns
+// the SAME `fingerprint` + the SAME `certificateDER` both times —
+// `LANRemoteIdentityStoreTests` asserts this directly. Without it, every
+// TV relaunch would silently invalidate every remote's pinned fingerprint
+// (`RemoteSessionActor`'s `expectedFingerprint`), turning "pair once" into
+// "re-pair every time the TV app restarts."
+import Foundation
+import Security
+
+/// Loads (or, on first run, generates) the TV's ONE persistent LAN-remote
+/// TLS identity.
+///
+/// ELI5: "Give me the TV's identity — the same one every time, making a
+/// new one only if there truly isn't one yet."
+public enum LANRemoteIdentityStore {
+    /// The ONE fixed Keychain label the persistent identity lives under —
+    /// deliberately NOT a per-launch UUID (unlike PR-4's own throwaway-test
+    /// label scheme, `LANRemoteIdentityFactory.generateSelfSigned`'s
+    /// default): a fixed label is what makes `queryIdentity(label:)` able
+    /// to find the SAME identity again on the next launch.
+    static let identityLabel = "app.ihymns.lanremote.identity.v1"
+
+    /// Loads the persisted identity, or generates-and-persists one on
+    /// first launch.
+    ///
+    /// ELI5: "Open the TV's identity box — if it's empty, make a new
+    /// identity and put it in the box for next time."
+    ///
+    /// DETAILED (spec §5.1's exact algorithm):
+    /// 1. `LANRemoteIdentityFactory.queryIdentity(label:)` — the SAME
+    ///    query shape PR-4's factory already uses internally, REUSED here
+    ///    rather than a second, hand-rolled `SecItemCopyMatching` call.
+    /// 2. Found → re-derive the fingerprint from the identity's OWN
+    ///    certificate (`SecIdentityCopyCertificate`/`SecCertificateCopyData`)
+    ///    rather than trusting any cached value — the certificate IS the
+    ///    fingerprint's only source of truth.
+    /// 3. `errSecItemNotFound` → generate a FRESH identity under this
+    ///    exact persistent label (`LANRemoteIdentityFactory
+    ///    .generateSelfSigned(keychainLabel:)`, #1421's new parameter).
+    /// 4. Any OTHER `OSStatus` → propagate `queryIdentity`'s own
+    ///    `.keychainBridgeFailed(status:)` unchanged (a genuine Keychain
+    ///    error, not "first launch").
+    ///
+    /// - Parameter commonName: Passed straight through to
+    ///   `generateSelfSigned` on first launch only — irrelevant once an
+    ///   identity already exists (a certificate's Common Name is cosmetic,
+    ///   never re-validated — `LANRemoteIdentity.swift`'s own header).
+    public static func loadOrCreate(commonName: String = "iHymnsTV") throws -> LANRemoteIdentity {
+        do {
+            let secIdentityRef = try LANRemoteIdentityFactory.queryIdentity(label: identityLabel)
+            return try wrapExisting(secIdentityRef)
+        } catch LANRemoteIdentityError.keychainBridgeFailed(let status) where status == errSecItemNotFound {
+            return try LANRemoteIdentityFactory.generateSelfSigned(commonName: commonName, keychainLabel: identityLabel)
+        }
+    }
+
+    /// Deletes the persisted identity — the next `loadOrCreate()` call
+    /// mints an entirely NEW one (a DIFFERENT fingerprint), which breaks
+    /// every already-paired remote's pin. Deliberately NOT surfaced in any
+    /// PR-6 UI (spec §5.1: "NOT surfaced in PR-6 UI") — this exists as a
+    /// test hook today, and a future "reset TV identity" Settings
+    /// affordance would need to warn the operator explicitly before ever
+    /// calling this.
+    ///
+    /// ELI5: "Throw away the TV's current identity — the next time it
+    /// starts, it'll make a brand new one, and every remote paired against
+    /// the OLD one will stop being trusted."
+    public static func reset() {
+        LANRemoteIdentityFactory.removeFromKeychain(label: identityLabel)
+    }
+
+    /// Re-derives a `LANRemoteIdentity` value from an already-bridged
+    /// `SecIdentity` found in the Keychain — the "identity already
+    /// existed" half of `loadOrCreate()`'s algorithm.
+    private static func wrapExisting(_ secIdentityRef: SecIdentity) throws -> LANRemoteIdentity {
+        var certificateRef: SecCertificate?
+        let status = SecIdentityCopyCertificate(secIdentityRef, &certificateRef)
+        guard status == errSecSuccess, let certificateRef else {
+            throw LANRemoteIdentityError.keychainBridgeFailed(status: status)
+        }
+        let certificateDER = SecCertificateCopyData(certificateRef) as Data
+        return LANRemoteIdentity(
+            fingerprint: LANRemoteFingerprint.sha256Hex(certificateDER),
+            certificateDER: certificateDER,
+            secIdentityRef: secIdentityRef,
+            keychainLabel: identityLabel
+        )
+    }
+}

--- a/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/LANRemotePairingAuthority.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/LANRemotePairingAuthority.swift
@@ -56,11 +56,38 @@ public protocol LANRemotePairingAuthority: Sendable {
     /// ELI5: "Remember this new remote from now on."
     func registerPairedToken(_ token: String) async
 
+    /// Records `token` as belonging to a newly-paired remote, ALONGSIDE
+    /// its `metadata` (device name/kind/paired-at, for the trusted-remotes
+    /// Settings list) — #1421 (PR-6 spec §2's protocol-extension pattern):
+    /// a NEW requirement added to this ALREADY-SHIPPED (PR-4/#1420)
+    /// protocol, with a forwarding default below so `InMemoryLANRemotePairingAuthority`
+    /// (this file) and any PR-4-era test double compile UNCHANGED.
+    ///
+    /// ELI5: "Remember this new remote from now on, plus its name and what
+    /// kind of device it is."
+    func registerPairedToken(_ token: String, metadata: LANRemotePairingMetadata) async
+
     /// Forgets `token` — the "revoke per-remote in TV Settings" action
     /// strategy §2.4.3 names (PR-6/PR-7's UI, this is its data-layer hook).
     ///
     /// ELI5: "Forget this remote — it can't control the TV anymore."
     func revokePairedToken(_ token: String) async
+}
+
+/// Default witness for the metadata-carrying registration overload above —
+/// #1421 (PR-6 spec §2): forwards to the pre-existing single-argument
+/// `registerPairedToken(_:)`, discarding the metadata, so a conformer that
+/// predates #1421 (this file's own `InMemoryLANRemotePairingAuthority`)
+/// keeps compiling with ZERO source changes. `KeychainLANRemotePairingAuthority`
+/// (`KeychainLANRemotePairingAuthority.swift`, #1421) implements the
+/// metadata-carrying overload directly instead — Swift's protocol-witness
+/// dispatch prefers a conformer's OWN matching method over this default
+/// even when called through the `any LANRemotePairingAuthority` existential
+/// `TVListenerActor.Configuration.pairingAuthority` holds.
+extension LANRemotePairingAuthority {
+    public func registerPairedToken(_ token: String, metadata: LANRemotePairingMetadata) async {
+        await registerPairedToken(token)
+    }
 }
 
 /// A simple, non-persistent `LANRemotePairingAuthority` — what

--- a/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/LANRemotePairingCeremony.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/LANRemotePairingCeremony.swift
@@ -58,11 +58,58 @@ public struct LANRemotePairingCeremonyState: Sendable, Equatable {
         /// `handlePairConfirm` enforces this one).
         public var maxAttemptsPerConnection: Int
 
-        public init(codeTTL: TimeInterval = 120, rotateAfterFailures: Int = 5, maxAttemptsPerConnection: Int = 3) {
+        /// The CUMULATIVE wrong-proof ceiling for one whole ceremony (across
+        /// EVERY rotation, from `beginPairing()` until the ceremony is
+        /// exhausted or the operator closes it) — the load-bearing
+        /// brute-force bound.
+        ///
+        /// **Why this exists (post-#1421 adversarial-review fix, spec §8
+        /// brute-force row):** `rotateAfterFailures` only swaps one RANDOM
+        /// 6-digit code for another RANDOM one — rotation gives an attacker
+        /// (who is guessing uniformly regardless) ZERO benefit and, on its
+        /// own, never STOPS the ceremony. Without a cumulative ceiling a LAN
+        /// attacker could cycle connections (4 concurrent × 3 attempts each)
+        /// indefinitely while the overlay is open and, over minutes, brute a
+        /// ~20-bit code to percent-level odds — NOT the "≤5 guesses,
+        /// 0.0005%" the §8 threat model claimed. This counter is STICKY
+        /// across rotations (only `begin(...)`, an operator-initiated fresh
+        /// ceremony, resets it — `rotate(...)` does NOT), so the TOTAL
+        /// guesses per ceremony are hard-bounded here regardless of TTL
+        /// re-arms or intervening successful pairs. Default 15 = 3 codes'
+        /// worth of rotation (`rotateAfterFailures` × 3) ⇒ ≤0.0015% per
+        /// ceremony, with generous headroom for a legitimate operator's own
+        /// mistypes.
+        public var maxCeremonyFailures: Int
+
+        public init(
+            codeTTL: TimeInterval = 120,
+            rotateAfterFailures: Int = 5,
+            maxAttemptsPerConnection: Int = 3,
+            maxCeremonyFailures: Int = 15
+        ) {
             self.codeTTL = codeTTL
             self.rotateAfterFailures = rotateAfterFailures
             self.maxAttemptsPerConnection = maxAttemptsPerConnection
+            self.maxCeremonyFailures = maxCeremonyFailures
         }
+    }
+
+    /// What one wrong proof means for the ceremony as a whole — returned by
+    /// `recordFailure()` so `TVListenerActor+Pairing.swift` can react without
+    /// re-reading the raw counters.
+    ///
+    /// ELI5: "just note it," "swap the code for a fresh one," or "that's
+    /// enough — shut the whole pairing session down."
+    public enum FailureOutcome: Sendable, Equatable {
+        /// Recorded; the current code stays live (below every threshold).
+        case recorded
+        /// `rotateAfterFailures` reached for the CURRENT code — the caller
+        /// mints a fresh code and calls `rotate(code:now:)`.
+        case rotate
+        /// `maxCeremonyFailures` reached for the WHOLE ceremony — the caller
+        /// `end()`s it; only a fresh operator-initiated `begin(code:now:)`
+        /// re-opens pairing.
+        case exhausted
     }
 
     /// The code currently displayed on the TV, or `nil` if no ceremony is
@@ -75,10 +122,16 @@ public struct LANRemotePairingCeremonyState: Sendable, Equatable {
     public private(set) var mintedAt: Date?
 
     /// Wrong `.pairConfirm` proofs recorded against the CURRENT code —
-    /// reset to `0` by `begin(code:now:)` (a fresh code starts a fresh
-    /// count; `recordFailure()`'s own rotation, when it fires, immediately
-    /// calls `begin(code:now:)` again for the new code).
+    /// reset to `0` by BOTH `begin(code:now:)` and `rotate(code:now:)` (a
+    /// fresh code, however it arrived, starts a fresh per-code count). This
+    /// is the counter that drives `rotateAfterFailures`.
     public private(set) var wrongAttempts: Int = 0
+
+    /// CUMULATIVE wrong proofs across the whole ceremony (every rotation
+    /// included) — reset ONLY by `begin(code:now:)`, deliberately NOT by
+    /// `rotate(code:now:)`, so it survives rotations and bounds the TOTAL
+    /// guesses per ceremony (see `Configuration.maxCeremonyFailures`).
+    public private(set) var ceremonyFailures: Int = 0
 
     public let configuration: Configuration
 
@@ -99,14 +152,31 @@ public struct LANRemotePairingCeremonyState: Sendable, Equatable {
         return now < mintedAt.addingTimeInterval(configuration.codeTTL)
     }
 
-    /// (Re-)arms the ceremony with a freshly-minted `code` — resets
-    /// `wrongAttempts` to `0` regardless of whatever it was before (a fresh
-    /// code deserves a fresh attempt budget, whether this is the FIRST code
-    /// of a ceremony or a rotation mid-ceremony).
+    /// Starts a BRAND-NEW ceremony (the operator opened the pairing overlay)
+    /// with a freshly-minted `code` — resets BOTH `wrongAttempts` AND the
+    /// cumulative `ceremonyFailures` to `0`. This is the ONLY thing that
+    /// clears `ceremonyFailures`; an auto-rotation mid-ceremony uses
+    /// `rotate(code:now:)` instead, which preserves it.
     ///
-    /// ELI5: "Here's the new code showing on screen now — start the clock
-    /// over."
+    /// ELI5: "Someone just opened the pairing screen — brand-new code, brand-
+    /// new attempt budget, forget everything that happened before."
     public mutating func begin(code: String, now: Date) {
+        activeCode = code
+        mintedAt = now
+        wrongAttempts = 0
+        ceremonyFailures = 0
+    }
+
+    /// Rotates to a freshly-minted `code` WITHIN the current ceremony —
+    /// resets the per-code `wrongAttempts` but deliberately PRESERVES the
+    /// cumulative `ceremonyFailures` (that's the whole point: rotation must
+    /// not hand a brute-forcer a fresh total-guess budget). Called both by
+    /// the failure-triggered rotation (`recordFailure()` → `.rotate`) and by
+    /// the overlay's cosmetic TTL refresh.
+    ///
+    /// ELI5: "Swap the on-screen code for a fresh one, but DON'T forget how
+    /// many wrong guesses this whole session has already racked up."
+    public mutating func rotate(code: String, now: Date) {
         activeCode = code
         mintedAt = now
         wrongAttempts = 0
@@ -132,16 +202,24 @@ public struct LANRemotePairingCeremonyState: Sendable, Equatable {
         activeCode = nil
     }
 
-    /// Records one wrong `.pairConfirm` proof against the CURRENT code.
+    /// Records one wrong `.pairConfirm` proof against the CURRENT code and
+    /// advances BOTH counters (per-code `wrongAttempts` and cumulative
+    /// `ceremonyFailures`).
     ///
-    /// - Returns: `true` exactly when `wrongAttempts` has just reached
-    ///   `configuration.rotateAfterFailures` — the caller (`TVListenerActor
-    ///   +Pairing.swift`) MUST respond by minting a fresh code and calling
-    ///   `begin(code:now:)` again (spec §3.4 step 4's "if
-    ///   pairingCeremony.recordFailure() { rotateActiveCode() }").
+    /// - Returns: the `FailureOutcome` the caller (`TVListenerActor
+    ///   +Pairing.swift`) must act on — `.exhausted` (the cumulative ceiling
+    ///   is reached: `end()` the ceremony) takes precedence over `.rotate`
+    ///   (the per-code threshold is reached: mint a fresh code and
+    ///   `rotate(code:now:)`), which takes precedence over `.recorded`
+    ///   (keep going). Checking `.exhausted` FIRST means the final guess
+    ///   shuts the ceremony down rather than pointlessly rotating a code
+    ///   that's about to be abandoned.
     @discardableResult
-    public mutating func recordFailure() -> Bool {
+    public mutating func recordFailure() -> FailureOutcome {
         wrongAttempts += 1
-        return wrongAttempts >= configuration.rotateAfterFailures
+        ceremonyFailures += 1
+        if ceremonyFailures >= configuration.maxCeremonyFailures { return .exhausted }
+        if wrongAttempts >= configuration.rotateAfterFailures { return .rotate }
+        return .recorded
     }
 }

--- a/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/LANRemotePairingCeremony.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/LANRemotePairingCeremony.swift
@@ -1,0 +1,147 @@
+// LANRemotePairingCeremony.swift
+// IHLive/LANRemote
+//
+// ELI5: The tiny rulebook for "is the code currently showing on the TV
+// still good to use?" — it expires after 2 minutes, it can only be used
+// ONCE, and if enough wrong guesses come in it tells the TV "mint a brand
+// new code." It doesn't talk to the network, read the clock itself, or
+// generate anything random — every input is handed to it, which is what
+// makes it trivial to test.
+//
+// DETAILED: #1421 (`.claude/apple-phase2-pr6-spec.md` §3.3 — BINDING).
+// `LANRemotePairingCeremonyState` is a plain `struct`, not an `actor`
+// (spec Decision D-7): it crosses no isolation boundary of its own — it's
+// owned as ordinary mutable state INSIDE `TVListenerActor` (the same
+// "`IHRPFrameDecoder` is a struct the actor mutates under its own
+// isolation" precedent `IHRPFramer.swift`'s header already documents for
+// this module) — and being pure `now:`-parameterised functions (no `Date()`
+// read internally, no RNG call internally) is EXACTLY what makes
+// `LANRemotePairingCeremonyTests` deterministic without a fake clock object:
+// every test just passes literal `Date(timeIntervalSince1970:)` values, the
+// same seam `LiveFollowEngine.isFresh(lastUpdatedAt:now:)` already
+// establishes in this same `IHLive` target.
+//
+// **Why an expired/absent code does NOT count toward rotation** (spec
+// Decision D-5): `rotateAfterFailures` exists to burn a code an attacker is
+// actively guessing against; if a wrong guess against an ALREADY-DEAD code
+// also counted, an attacker could spam guesses against a stale code
+// specifically to force a rotation on demand (a cheap way to churn the
+// live code while the real operator isn't looking). `TVListenerActor
+// +Pairing.swift`'s `handlePairConfirm` checks `isActive(now:)` BEFORE ever
+// calling `recordFailure()`, so a dead-code guess short-circuits to
+// rejection without touching `wrongAttempts` at all.
+import Foundation
+
+/// The pure pairing-ceremony state machine — see this file's header for why
+/// it's a `struct`, not an `actor`.
+///
+/// ELI5: "Is there a code showing right now, and has it expired, been used
+/// up, or been guessed wrong too many times?"
+public struct LANRemotePairingCeremonyState: Sendable, Equatable {
+
+    /// The three tunable numbers strategy §2.4.3 fixes — asserted literally
+    /// by `LANRemotePairingCeremonyTests` (spec §7.2: "asserted literally so
+    /// a drive-by 'tune' shows up in review").
+    public struct Configuration: Sendable, Equatable {
+        /// How long a minted code stays valid — strategy §2.4.3's "Code TTL
+        /// 2min."
+        public var codeTTL: TimeInterval
+        /// Global (per-CODE, not per-connection) wrong-proof count that
+        /// forces the TV to mint a fresh code — strategy §2.4.3's "5
+        /// fails→rotate."
+        public var rotateAfterFailures: Int
+        /// Per-CONNECTION cap on `.pairConfirm` attempts before that
+        /// connection is torn down outright — a SEPARATE, tighter guard
+        /// from `rotateAfterFailures` above (one hostile/buggy connection
+        /// can't out-guess the global rotation counter by spraying attempts
+        /// from a single socket; `TVListenerActor+Pairing.swift`'s
+        /// `handlePairConfirm` enforces this one).
+        public var maxAttemptsPerConnection: Int
+
+        public init(codeTTL: TimeInterval = 120, rotateAfterFailures: Int = 5, maxAttemptsPerConnection: Int = 3) {
+            self.codeTTL = codeTTL
+            self.rotateAfterFailures = rotateAfterFailures
+            self.maxAttemptsPerConnection = maxAttemptsPerConnection
+        }
+    }
+
+    /// The code currently displayed on the TV, or `nil` if no ceremony is
+    /// running (nobody has opened the pairing overlay) OR the last-minted
+    /// code has already been successfully consumed (`consume()`).
+    public private(set) var activeCode: String?
+
+    /// When `activeCode` was minted — `nil` exactly when `activeCode` is
+    /// `nil`. Read by `isActive(now:)`'s TTL check.
+    public private(set) var mintedAt: Date?
+
+    /// Wrong `.pairConfirm` proofs recorded against the CURRENT code —
+    /// reset to `0` by `begin(code:now:)` (a fresh code starts a fresh
+    /// count; `recordFailure()`'s own rotation, when it fires, immediately
+    /// calls `begin(code:now:)` again for the new code).
+    public private(set) var wrongAttempts: Int = 0
+
+    public let configuration: Configuration
+
+    public init(configuration: Configuration = .init()) {
+        self.configuration = configuration
+    }
+
+    /// Whether `activeCode` both EXISTS and is still within its TTL window
+    /// as of `now`. **Checks `activeCode != nil` FIRST** — `consume()`
+    /// deliberately clears only `activeCode` (not `mintedAt`), so a
+    /// `mintedAt`-only check would report a just-consumed, single-use code
+    /// as still active for the rest of its TTL window (caught by
+    /// `LANRemotePairingCeremonyTests`' single-use test).
+    ///
+    /// ELI5: "Is there still a live code right now?"
+    public func isActive(now: Date) -> Bool {
+        guard activeCode != nil, let mintedAt else { return false }
+        return now < mintedAt.addingTimeInterval(configuration.codeTTL)
+    }
+
+    /// (Re-)arms the ceremony with a freshly-minted `code` — resets
+    /// `wrongAttempts` to `0` regardless of whatever it was before (a fresh
+    /// code deserves a fresh attempt budget, whether this is the FIRST code
+    /// of a ceremony or a rotation mid-ceremony).
+    ///
+    /// ELI5: "Here's the new code showing on screen now — start the clock
+    /// over."
+    public mutating func begin(code: String, now: Date) {
+        activeCode = code
+        mintedAt = now
+        wrongAttempts = 0
+    }
+
+    /// Fully disarms the ceremony — the operator closed the pairing
+    /// overlay. A `.pairing` connection that's already parked stays parked
+    /// (`TVListenerActor`'s own state, untouched here); it simply can never
+    /// successfully confirm until `begin(code:now:)` is called again.
+    ///
+    /// ELI5: "Turn the pairing screen off."
+    public mutating func end() {
+        activeCode = nil
+        mintedAt = nil
+    }
+
+    /// Marks `activeCode` used up on a SUCCESSFUL proof — single-use, per
+    /// spec §3.1: a code that already paired one remote can never pair a
+    /// second.
+    ///
+    /// ELI5: "That code just worked — burn it so it can't be used again."
+    public mutating func consume() {
+        activeCode = nil
+    }
+
+    /// Records one wrong `.pairConfirm` proof against the CURRENT code.
+    ///
+    /// - Returns: `true` exactly when `wrongAttempts` has just reached
+    ///   `configuration.rotateAfterFailures` — the caller (`TVListenerActor
+    ///   +Pairing.swift`) MUST respond by minting a fresh code and calling
+    ///   `begin(code:now:)` again (spec §3.4 step 4's "if
+    ///   pairingCeremony.recordFailure() { rotateActiveCode() }").
+    @discardableResult
+    public mutating func recordFailure() -> Bool {
+        wrongAttempts += 1
+        return wrongAttempts >= configuration.rotateAfterFailures
+    }
+}

--- a/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/LANRemotePairingPayload.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/LANRemotePairingPayload.swift
@@ -1,0 +1,143 @@
+// LANRemotePairingPayload.swift
+// IHLive/LANRemote
+//
+// ELI5: What's actually hiding inside the QR code the TV shows — which
+// version of the format this is, the TV's name, maybe how to reach it on
+// the network, its fingerprint, and (only on the pairing-ceremony QR, never
+// the Settings "standing" one) the 6-digit code — all packed into one
+// short string a camera can scan.
+//
+// DETAILED: #1421 (`.claude/apple-phase2-pr6-spec.md` §6.3). This is a
+// SHARED wire shape, not TV-only: `TVRemoteControlCoordinator`
+// (`IHFeatures`) encodes it for the tvOS pairing overlay/Settings screen
+// this PR builds, and PR-7's phone-side QR SCANNER decodes the identical
+// string — the modularity rule applied to a data shape, not just a
+// function. `code == nil` marks the Settings "standing" QR (connect-info
+// only, safe to leave on screen indefinitely); `code != nil` marks the
+// ceremony QR (out-of-band cert pinning + the live pairing code in one
+// scan) — `TVSettingsRemoteView`/`TVPairingOverlayView` (`IHFeatures`) are
+// what choose which one to render.
+//
+// Encoded as `"ihymns-lanpair:v1:" + base64url(JSON)` — a custom
+// base64url (RFC 4648 §5, https://www.rfc-editor.org/rfc/rfc4648#section-5)
+// implementation lives in THIS file rather than reusing `Data
+// .base64EncodedString()` directly, because standard base64's `+`/`/`/`=`
+// characters are all either reserved or awkward inside a URI-like string a
+// QR-code scanner or a pasted manual-entry field might see — base64url
+// swaps `+`→`-`, `/`→`_`, and drops the `=` padding (recoverable on decode
+// from the string's own length), the same reasoning RFC 4648 gives for
+// defining it as a distinct alphabet from standard base64.
+import Foundation
+
+/// The decoded contents of an iHymns LAN-pairing QR code.
+///
+/// ELI5: "Here's the TV you'd be connecting to, and (maybe) the code to
+/// prove you're standing in front of it."
+public struct LANRemotePairingPayload: Sendable, Equatable, Codable {
+    /// The payload format version — `1` today. A future incompatible
+    /// change bumps this (and the `"ihymns-lanpair:v1:"` string prefix
+    /// alongside it), never silently changes this shape's meaning in place.
+    /// Wire key `"v"` (`CodingKeys` below) — spec §6.3's exact short field
+    /// name (a QR code's whole point is a small, dense payload); the SWIFT
+    /// property is spelled out in full because SwiftLint's `identifier_name`
+    /// rule (`appApple/.swiftlint.yml`) rejects single/two-letter Swift
+    /// identifiers — the wire shape and the Swift API are free to differ.
+    public let version: Int
+    /// The TV's advertised/device name — cosmetic, shown to the person
+    /// scanning ("Pairing with iHymns TV — Fellowship Hall").
+    public let name: String
+    /// Best-effort LAN address (`LANRemoteAddress.primaryIPv4Address()`) —
+    /// `nil` if undeterminable; PR-8's manual "connect by address" path is
+    /// the intended future reader of this field (Bonjour discovery doesn't
+    /// need it).
+    public let host: String?
+    /// The bound listener port — `nil` only in the unlikely case the TV
+    /// couldn't determine it (mirrors `host`'s optionality for the same
+    /// reason).
+    public let port: UInt16?
+    /// The TV's TLS identity fingerprint — the value a scanning remote
+    /// pins as `RemoteSessionActor.connect(to:expectedFingerprint:token:)`'s
+    /// `expectedFingerprint` (PR-4, already merged). Wire key `"fp"` — see
+    /// `version`'s doc comment above for why the Swift name is longer.
+    public let fingerprintHex: String
+    /// The live 6-digit pairing code — present ONLY on the ceremony QR
+    /// (`TVPairingOverlayView`'s `includeCode: true`); absent on the
+    /// Settings standing QR (`includeCode: false`), which carries no
+    /// secret at all and is safe to leave displayed indefinitely.
+    public let code: String?
+
+    /// `CodingKeys` maps the readable Swift property names above onto
+    /// spec §6.3's exact short wire keys (`v`/`fp`) — every other field's
+    /// wire key already matches its Swift name 1:1.
+    private enum CodingKeys: String, CodingKey {
+        case version = "v"
+        case name, host, port
+        case fingerprintHex = "fp"
+        case code
+    }
+
+    public init(
+        version: Int = 1, name: String, host: String? = nil, port: UInt16? = nil, fingerprintHex: String, code: String? = nil
+    ) {
+        self.version = version
+        self.name = name
+        self.host = host
+        self.port = port
+        self.fingerprintHex = fingerprintHex
+        self.code = code
+    }
+
+    /// The fixed string prefix every encoded payload starts with — a
+    /// custom URI-like scheme (not a REAL registered URL scheme; this is
+    /// never opened by the system, only ever scanned/pasted and decoded by
+    /// THIS type) versioned independently of `v` above so a scanner can
+    /// reject a wildly wrong format (a barcode from some OTHER app) before
+    /// even attempting base64/JSON decoding.
+    private static let qrPrefix = "ihymns-lanpair:v1:"
+
+    /// Encodes this payload as the exact string a QR code renders/a
+    /// scanner decodes — `nil` only if `JSONEncoder` itself somehow fails
+    /// (unreachable for this closed, simple-value shape in practice, but
+    /// surfaced rather than force-unwrapped per this codebase's own
+    /// `RemoteSessionError.encodingFailed` precedent).
+    public func encodeToQRString() -> String? {
+        guard let json = try? JSONEncoder().encode(self) else { return nil }
+        return Self.qrPrefix + Self.base64URLEncode(json)
+    }
+
+    /// Decodes a scanned/pasted string back into a payload — `nil` for
+    /// anything that isn't a well-formed `ihymns-lanpair:v1:`-prefixed,
+    /// base64url-encoded JSON payload of this exact shape (a garbage scan
+    /// is simply "not a valid pairing code," never a crash).
+    public init?(qrString: String) {
+        guard qrString.hasPrefix(Self.qrPrefix) else { return nil }
+        let encoded = String(qrString.dropFirst(Self.qrPrefix.count))
+        guard let data = Self.base64URLDecode(encoded),
+              let decoded = try? JSONDecoder().decode(LANRemotePairingPayload.self, from: data) else {
+            return nil
+        }
+        self = decoded
+    }
+
+    // MARK: - base64url (RFC 4648 §5) — see this file's header for why a
+    // dedicated codec lives here rather than reusing `Data
+    // .base64EncodedString()`'s standard alphabet directly.
+
+    private static func base64URLEncode(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    private static func base64URLDecode(_ string: String) -> Data? {
+        var base64 = string
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let remainder = base64.count % 4
+        if remainder > 0 {
+            base64.append(String(repeating: "=", count: 4 - remainder))
+        }
+        return Data(base64Encoded: base64)
+    }
+}

--- a/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/LANRemotePairingProof.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/LANRemotePairingProof.swift
@@ -1,0 +1,188 @@
+// LANRemotePairingProof.swift
+// IHLive/LANRemote
+//
+// ELI5: The ONE piece of math that answers "does the person standing at
+// this remote actually see the code on the TV's screen?" — turn the code
+// into a secret key, HMAC it over "which TV, which connection," and check
+// the remote's answer matches. Also mints the three kinds of random
+// secrets the pairing ceremony needs: the 6-digit code shown on the TV, the
+// per-connection nonce the proof binds to, and the 32-byte token a paired
+// remote keeps forever.
+//
+// DETAILED: #1421 (`.claude/apple-phase2-pr6-spec.md` §3.1/§3.2 — BINDING,
+// "do not improvise"). This file is the SECURITY BOUNDARY of the whole LAN
+// remote: `TVListenerActor+Pairing.swift`'s `handlePairConfirm` and PR-7's
+// (not-yet-built) remote-side pairing UI BOTH call `compute(...)`/
+// `verify(...)` below — ONE implementation, two callers, per this repo's
+// modularity rule (`.claude/CLAUDE.md`).
+//
+// **The construction (frozen by `LANRemotePairingProofTests`' golden
+// vector — changing ANY of the three pieces below breaks every
+// already-paired remote in the field; bump the pairing sub-protocol's own
+// version marker instead of touching this):**
+//   key   = HKDF<SHA256>.deriveKey(inputKeyMaterial: SymmetricKey(data:
+//           Data(code.utf8)), salt: "app.ihymns.lanremote.pair.v1", info:
+//           "proof", outputByteCount: 32)
+//   msg   = "<fingerprintHex-lowercased>.<nonceHex-lowercased>"
+//   proof = lowercase hex of HMAC<SHA256>.authenticationCode(for: msg,
+//           using: key)
+//
+// **What each ingredient buys (spec §3.2's threat-model mapping):**
+//   - `code` (via HKDF, never used raw as a MAC key) proves the person at
+//     the remote could READ the venue TV's screen — proximity, not secrecy
+//     (~20 bits of entropy; the SECURITY comes from the ONLINE caps in
+//     `LANRemotePairingCeremonyState`, never from this being uncrackable
+//     offline). HKDF's `salt`/`info` are versioned constants purely for
+//     domain separation, so this key derivation could never collide with
+//     some unrelated future use of the same 6-digit code.
+//   - `fingerprintHex` in the message IS the channel binding: the remote
+//     HMACs the cert fingerprint it actually pinned for THIS TLS connection
+//     (`RemoteSessionActor`'s `expectedFingerprint`); the TV verifies
+//     against its OWN `identity.fingerprint`. A relay/MITM attacker must
+//     terminate TLS with ITS OWN certificate (it cannot forge the TV's
+//     private key), so a relayed proof binds to the WRONG fingerprint and
+//     fails verification even before TLS pinning would have caught it.
+//   - `nonceHex` in the message is per-connection freshness — a proof
+//     captured off one connection (bug, memory dump) is worthless replayed
+//     on any other connection or after a reconnect.
+//   - Why not a real PAKE (SRP/SPAKE2)? CryptoKit ships none, a vendored
+//     one is a new pinned dependency + audit surface (forbidden by
+//     default here), and the transcript this HMAC lives inside is ALREADY
+//     inside TLS 1.3 — an HMAC channel-binding over an already-encrypted,
+//     fingerprint-pinned link + hard online caps reaches the same
+//     practical bar for a sanctuary-projector remote. Recorded as the
+//     considered-and-rejected alternative (spec §3.2, Decision D-1).
+//
+// See https://developer.apple.com/documentation/cryptokit/hkdf and
+// https://developer.apple.com/documentation/cryptokit/hmac for the
+// CryptoKit APIs this file is built on, and RFC 5869
+// (https://www.rfc-editor.org/rfc/rfc5869) for HKDF itself.
+import CryptoKit
+import Foundation
+
+/// Mints the three random secrets the pairing ceremony needs — never the
+/// proof itself (that's `LANRemotePairingProof`, this file's other half).
+///
+/// ELI5: "Give me a new 6-digit code," "give me a new per-connection
+/// secret number," "give me a new forever-token for a freshly paired
+/// remote."
+///
+/// DETAILED: A caseless `public enum` (never instantiated) holding only
+/// `public static` minting functions — the same "namespace, not a value"
+/// shape `LANRemoteFingerprint` (this module) and `IHModels/SongID`'s
+/// static factories already use. Every byte here comes from
+/// `SystemRandomNumberGenerator`, Swift's own CSPRNG
+/// (https://developer.apple.com/documentation/swift/systemrandomnumbergenerator) —
+/// never `arc4random`/`rand` called directly, and never seeded.
+public enum LANRemotePairingSecrets {
+    /// A fresh 6-digit pairing code, zero-padded (`"042317"`, never
+    /// `"42317"`) — spec §3.1: "~20 bits — its security is the ONLINE caps
+    /// (§3.4), never entropy."
+    ///
+    /// - Parameter random: Injectable for deterministic tests (spec §7.1:
+    ///   `mintCode(random: { _ in 7 })` ⇒ `"000007"`). Defaults to a real
+    ///   CSPRNG draw — production code never supplies this parameter.
+    public static func mintCode(random: () -> Int = {
+        var generator = SystemRandomNumberGenerator()
+        return Int.random(in: 0...999_999, using: &generator)
+    }) -> String {
+        String(format: "%06d", random())
+    }
+
+    /// A fresh 32-lowercase-hex-char (16-byte) per-connection nonce, minted
+    /// once when a connection enters `.pairing` — spec §3.1's connection
+    /// nonce. Not secret (it travels TV→remote in `.pairChallenge`), but
+    /// never logged regardless (this module's blanket "never log a pairing
+    /// secret" contract treats it the same as the code/token/proof).
+    public static func mintNonce() -> String {
+        LANRemoteFingerprint.hexString(randomBytes(count: 16))
+    }
+
+    /// A fresh 64-lowercase-hex-char (32-byte) pairing token — spec §3.1's
+    /// "per-remote 32-byte token" (strategy §2.4.3). The TV persists only
+    /// `sha256(token)` (`KeychainLANRemotePairingAuthority.swift`); the
+    /// remote receives this raw value exactly once, inside TLS, in
+    /// `.pairSuccess`.
+    public static func mintToken() -> String {
+        LANRemoteFingerprint.hexString(randomBytes(count: 32))
+    }
+
+    private static func randomBytes(count: Int) -> [UInt8] {
+        var generator = SystemRandomNumberGenerator()
+        return (0..<count).map { _ in UInt8.random(in: 0...255, using: &generator) }
+    }
+}
+
+/// The ONE proof function both the TV (`TVListenerActor+Pairing.swift`) and
+/// the remote (PR-7) call — see this file's header for the full crypto
+/// design.
+public enum LANRemotePairingProof {
+    /// Computes the pairing proof a remote sends in `.pairConfirm` —
+    /// deterministic (same three inputs always produce the same 64-char
+    /// lowercase-hex output), which is exactly what lets the TV recompute
+    /// and compare it in `verify(...)` below.
+    public static func compute(code: String, fingerprintHex: String, nonceHex: String) -> String {
+        let key = derivedKey(code: code)
+        let message = bindingMessage(fingerprintHex: fingerprintHex, nonceHex: nonceHex)
+        let authenticationCode = HMAC<SHA256>.authenticationCode(for: message, using: key)
+        return LANRemoteFingerprint.hexString(Array(authenticationCode))
+    }
+
+    /// Verifies a proof the TV received in `.pairConfirm` — **constant-time
+    /// by construction**: a malformed/odd-length/non-hex `proofHex` is
+    /// rejected via a plain length/format check (a NON-secret-dependent
+    /// early exit — rejecting based on the ATTACKER'S OWN malformed input
+    /// shape leaks nothing about the real proof), and every well-formed
+    /// candidate is compared via CryptoKit's own
+    /// `HMAC.isValidAuthenticationCode(_:authenticating:using:)`
+    /// (https://developer.apple.com/documentation/cryptokit/hmac/isvalidauthenticationcode(_:authenticating:using:)),
+    /// which is documented to perform the comparison in constant time.
+    /// **NEVER replace this with `==` on `String`/`Data` — that reintroduces
+    /// a timing side-channel on a security-boundary comparison** (spec
+    /// §3.2's explicit "NEVER a hand-rolled byte loop" instruction).
+    public static func verify(proofHex: String, code: String, fingerprintHex: String, nonceHex: String) -> Bool {
+        guard let proofData = hexDecodedData(proofHex) else { return false }
+        let key = derivedKey(code: code)
+        let message = bindingMessage(fingerprintHex: fingerprintHex, nonceHex: nonceHex)
+        return HMAC<SHA256>.isValidAuthenticationCode(proofData, authenticating: message, using: key)
+    }
+
+    /// HKDF-derives a 32-byte MAC key from the 6-digit code — see this
+    /// file's header for why HKDF (not the raw code bytes) is the key.
+    private static func derivedKey(code: String) -> SymmetricKey {
+        HKDF<SHA256>.deriveKey(
+            inputKeyMaterial: SymmetricKey(data: Data(code.utf8)),
+            salt: Data("app.ihymns.lanremote.pair.v1".utf8),
+            info: Data("proof".utf8),
+            outputByteCount: 32
+        )
+    }
+
+    /// The exact byte sequence the HMAC authenticates — see this file's
+    /// header for why `fingerprintHex` (channel binding) and `nonceHex`
+    /// (per-connection freshness) are both folded in. Both hex strings are
+    /// lowercased first so a caller that happens to pass uppercase hex
+    /// (from a copy-pasted fingerprint, say) still produces the identical
+    /// proof `compute`/`verify` agree on.
+    private static func bindingMessage(fingerprintHex: String, nonceHex: String) -> Data {
+        Data((fingerprintHex.lowercased() + "." + nonceHex.lowercased()).utf8)
+    }
+
+    /// Decodes a hex string into raw bytes — `nil` for an odd-length or
+    /// non-hex-digit input, which `verify(...)` maps straight to `false`.
+    /// This rejection is format-only (it never inspects the SECRET key or
+    /// message), so short-circuiting here adds no exploitable timing
+    /// signal about the real proof value.
+    private static func hexDecodedData(_ hex: String) -> Data? {
+        guard hex.count % 2 == 0 else { return nil }
+        var data = Data(capacity: hex.count / 2)
+        var index = hex.startIndex
+        while index < hex.endIndex {
+            let next = hex.index(index, offsetBy: 2)
+            guard let byte = UInt8(hex[index..<next], radix: 16) else { return nil }
+            data.append(byte)
+            index = next
+        }
+        return data
+    }
+}

--- a/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/RemoteSessionActor+Connection.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/RemoteSessionActor+Connection.swift
@@ -222,6 +222,15 @@ extension RemoteSessionActor {
             setPhase(.controlling(capabilities.currentState))
         case .state(let state):
             setPhase(.controlling(state))
+        case .pairSuccess(let token):
+            // #1421 — the ceremony's freshly-minted raw token; PR-7
+            // persists `currentPairingToken` (Keychain, `synchronizable:
+            // false`) the moment it observes this. `.capabilities` always
+            // follows on the SAME connection (`promoteToPaired`'s send
+            // order, `TVListenerActor+Pairing.swift`), so `.controlling`
+            // still gets set by that frame arriving next — this case never
+            // needs to touch `phase` itself.
+            pairingToken = token
         case .error(let code, _):
             if code == .unauthorized {
                 disconnect()

--- a/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/RemoteSessionActor.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/RemoteSessionActor.swift
@@ -101,6 +101,21 @@ public actor RemoteSessionActor {
     var expectedFingerprint: String?
     var pairingToken: String?
 
+    /// The most recently known pairing token — the value to persist
+    /// (Keychain, `synchronizable: false`, PR-7's job) so the NEXT
+    /// `connect(to:expectedFingerprint:token:)` call can take the fast
+    /// `hello(token:)` reconnect path instead of re-running the ceremony.
+    /// Set from the CONNECT-supplied token immediately (#1420) and
+    /// OVERWRITTEN the moment a fresh `.pairSuccess(token:)` arrives
+    /// (#1421, `RemoteSessionActor+Connection.swift`'s `handleIncomingFrameData`)
+    /// — a brand-new ceremony's token always supersedes whatever was
+    /// passed in at connect time.
+    ///
+    /// ELI5: "What's the current secret password this remote uses to prove
+    /// it's already trusted?" — PR-7's UI reads this after a successful
+    /// pairing so it can save it for next time.
+    public var currentPairingToken: String? { pairingToken }
+
     public private(set) var phase: RemoteSessionPhase = .idle
     let phaseContinuation: AsyncStream<RemoteSessionPhase>.Continuation
     /// A live feed of every phase transition — the UI (PR-7) drives its

--- a/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/TVListenerActor+Connections.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/TVListenerActor+Connections.swift
@@ -52,6 +52,18 @@ final class TVRemoteConnectionState {
     var decoder = IHRPFrameDecoder()
     var remoteKind: IHRPRemoteKind?
 
+    /// The per-connection nonce minted the instant this connection entered
+    /// `.pairing` (#1421, PR-6 spec §3.2) — `.pairConfirm`'s proof binds to
+    /// THIS value; `nil` before `.pairing` is entered and cleared again by
+    /// `promoteToPaired` once pairing succeeds (`TVListenerActor+Pairing.swift`).
+    var pairingNonce: String?
+
+    /// `.pairConfirm` attempts made ON THIS CONNECTION — the per-connection
+    /// cap `TVListenerActor+Pairing.swift`'s `handlePairConfirm` enforces
+    /// (distinct from `LANRemotePairingCeremonyState.wrongAttempts`, which
+    /// is GLOBAL per-code, not per-connection).
+    var pairingAttempts: Int = 0
+
     init(id: UUID, connection: NWConnection) {
         self.id = id
         self.connection = connection
@@ -177,6 +189,12 @@ extension TVListenerActor {
     /// Closes and forgets a connection.
     func teardownConnection(id: UUID, reason: String) {
         guard let state = connections.removeValue(forKey: id) else { return }
+        // #1421 (PR-6 spec §2) — a `.pairing` connection that never
+        // confirmed is disappearing; the overlay's "N remotes trying to
+        // pair" indicator needs to know, or it would over-count forever.
+        if state.pairingPhase == .pairing {
+            pairingContinuation.yield(.remoteLeftPairing(connectionId: id))
+        }
         state.connection.cancel()
         IHLog.remote.notice("lanremote.connection closed reason=\(reason, privacy: .public)")
     }

--- a/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/TVListenerActor+Messages.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/TVListenerActor+Messages.swift
@@ -65,8 +65,18 @@ extension TVListenerActor {
                 // comment).
                 IHLog.remote.notice("lanremote.pairing unpaired -> paired (reconnect)")
                 send(id: id, message: .capabilities(IHRPCapabilities(currentState: canonicalState)))
+            } else if state.pairingPhase == .pairing, let existingNonce = state.pairingNonce {
+                // A REPEAT `hello` on a connection ALREADY parked in
+                // `.pairing` (#1421 adversarial-review fix) — re-send the
+                // SAME challenge idempotently. **Never re-mint the nonce**
+                // (that would invalidate a proof the remote may already be
+                // computing over the first one) and **never re-yield
+                // `.remoteEnteredPairing`** (that would inflate the overlay's
+                // "N remotes trying to pair" count with no matching leave —
+                // one connection could otherwise drive it arbitrarily high).
+                send(id: id, message: .pairChallenge(nonce: existingNonce))
             } else {
-                // #1421 (PR-6 spec §3.4/§4) — parks the connection in
+                // #1421 (PR-6 spec §3.4/§4) — parks a FRESH connection in
                 // `.pairing`, mints the per-connection nonce the proof
                 // will bind to, and sends `.pairChallenge` — the signal
                 // that doubles as "show the code-entry UI now" for the

--- a/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/TVListenerActor+Messages.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/TVListenerActor+Messages.swift
@@ -66,9 +66,26 @@ extension TVListenerActor {
                 IHLog.remote.notice("lanremote.pairing unpaired -> paired (reconnect)")
                 send(id: id, message: .capabilities(IHRPCapabilities(currentState: canonicalState)))
             } else {
+                // #1421 (PR-6 spec §3.4/§4) — parks the connection in
+                // `.pairing`, mints the per-connection nonce the proof
+                // will bind to, and sends `.pairChallenge` — the signal
+                // that doubles as "show the code-entry UI now" for the
+                // remote (PR-7). `.notice` carries the CASE NAME only,
+                // never the nonce value itself.
                 state.pairingPhase = .pairing
+                let nonce = LANRemotePairingSecrets.mintNonce()
+                state.pairingNonce = nonce
                 IHLog.remote.notice("lanremote.pairing unpaired -> pairing")
+                send(id: id, message: .pairChallenge(nonce: nonce))
+                pairingContinuation.yield(.remoteEnteredPairing(connectionId: id, kind: kind))
             }
+
+        case .pairConfirm(let proof, let deviceName):
+            // #1421 — the ceremony's actual verification lives in
+            // `TVListenerActor+Pairing.swift`'s `handlePairConfirm`; this
+            // is purely the dispatch (mirrors `.hello`'s own dispatch
+            // shape above).
+            await handlePairConfirm(id: id, state: state, proof: proof, deviceName: deviceName)
 
         default:
             IHLog.remote.error(
@@ -85,11 +102,14 @@ extension TVListenerActor {
         case .ping:
             send(id: id, message: .pong)
 
-        case .hello, .state, .ack, .error, .pong, .capabilities:
-            // A duplicate `hello`, or a response-only case a well-behaved
-            // remote should never SEND — reject without dropping an
-            // already-trusted connection over what is most likely a bug,
-            // not an attack.
+        case .hello, .state, .ack, .error, .pong, .capabilities, .pairChallenge, .pairConfirm, .pairSuccess:
+            // A duplicate `hello`, a response-only case a well-behaved
+            // remote should never SEND, or one of the pairing-sub-protocol
+            // cases (#1421, PR-6 spec §1's explicit reject-list — a PAIRED
+            // remote injecting `.pairConfirm` must NEVER surface as a
+            // `ControlEvent`; §7.5 has a dedicated test for exactly this)
+            // — reject without dropping an already-trusted connection over
+            // what is most likely a bug, not an attack.
             send(id: id, message: .error(.malformedRequest, message: "unexpected on a paired connection"))
 
         default:
@@ -135,16 +155,29 @@ extension TVListenerActor {
     /// ELI5: "The person standing at the TV just confirmed this remote —
     /// let it in."
     ///
+    /// DETAILED: #1421 — now a thin delegate to `TVListenerActor+Pairing.swift`'s
+    /// `promoteToPaired(id:token:metadata:)`, the SAME success path
+    /// `handlePairConfirm`'s real ceremony verification uses (spec §3.4:
+    /// "`completePairing`... becomes a thin delegate to this"). Public
+    /// SIGNATURE stays byte-identical to PR-4's (`LANRemoteLoopbackTests`
+    /// calls this directly) — the only behavioural addition is that a
+    /// `.pairSuccess(token:)` frame is now ALSO sent, which is semantically
+    /// correct for every completion path and harmless to existing tests
+    /// (they `waitFor` a SPECIFIC frame on the stream; an extra frame is
+    /// simply skipped by the predicate).
+    ///
     /// - Returns: `false` if `connectionId` isn't currently `.pairing`
     ///   (already paired, already gone, or never entered pairing) — the
     ///   caller should treat that as "nothing to confirm," not an error.
     @discardableResult
     public func completePairing(connectionId: UUID, token: String) async -> Bool {
         guard let state = connections[connectionId], state.pairingPhase == .pairing else { return false }
-        await configuration.pairingAuthority.registerPairedToken(token)
-        state.pairingPhase = .paired(token: token)
+        await promoteToPaired(
+            id: connectionId,
+            token: token,
+            metadata: LANRemotePairingMetadata(name: nil, kind: state.remoteKind, pairedAt: configuration.clock.now())
+        )
         IHLog.remote.notice("lanremote.pairing pairing -> paired")
-        send(id: connectionId, message: .capabilities(IHRPCapabilities(currentState: canonicalState)))
         return true
     }
 

--- a/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/TVListenerActor+Pairing.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/TVListenerActor+Pairing.swift
@@ -1,0 +1,213 @@
+// TVListenerActor+Pairing.swift
+// IHLive/LANRemote
+//
+// ELI5: The part of the TV's brain that runs the actual pairing ceremony —
+// "here's a fresh code, go ahead and type it into your phone," checking the
+// proof a remote sends back, minting the forever-token on success, and
+// telling the UI layer what's happening every step of the way (a remote
+// showed up wanting to pair, someone typed the code wrong, the code just
+// got rotated, someone paired successfully).
+//
+// DETAILED: #1421 (`.claude/apple-phase2-pr6-spec.md` §3.4/§3.5 — BINDING).
+// Split out of `TVListenerActor.swift`/`TVListenerActor+Messages.swift` for
+// the same LOC-budget reason `+Connections.swift` documents. This file owns
+// the CEREMONY-SPECIFIC actor-isolated logic; `handlePairConfirm` is called
+// from `TVListenerActor+Messages.swift`'s `handleUnauthenticated` the
+// moment a `.pairConfirm` frame arrives on a `.pairing` connection.
+//
+// **Never logged, anywhere, at any level:** the code, the token, the proof,
+// the nonce, raw `hello` tokens — every `IHLog.remote` line in this file
+// carries only case names / transition names / statuses / attempt COUNTS.
+// This is the single easiest thing to get wrong in this whole ceremony
+// (spec §8's threat-model table, last row) — a reviewer should grep this
+// file for every `IHLog` call and confirm none of them interpolates
+// `proof`/`code`/`nonce`/`token`.
+import Foundation
+import IHLog
+
+/// Every pairing-ceremony transition the tvOS UI (`TVRemoteControlCoordinator`,
+/// `IHFeatures`) needs to react to — see `TVListenerActor.pairingEvents`.
+///
+/// ELI5: "A remote just showed up wanting to pair," "that remote gave up or
+/// got disconnected," "the code just changed," "someone paired
+/// successfully," "someone typed the code wrong."
+public enum TVPairingEvent: Sendable, Equatable {
+    /// A connection entered `.pairing` (a `hello` with no/unknown token) —
+    /// the overlay's "1 remote is trying to pair…" indicator.
+    case remoteEnteredPairing(connectionId: UUID, kind: IHRPRemoteKind?)
+    /// A `.pairing` connection was torn down before it ever confirmed.
+    case remoteLeftPairing(connectionId: UUID)
+    /// The active code just changed — either the operator's manual rotate
+    /// (`rotatePairingCode()`) or an automatic rotate after too many wrong
+    /// proofs (§3.4). **In-process only — display, NEVER log** (this
+    /// file's header contract).
+    case codeRotated(newCode: String)
+    /// A `.pairing` connection just became `.paired`.
+    case paired(name: String?, kind: IHRPRemoteKind?)
+    /// A wrong proof was rejected — `attemptsTowardRotation` is the GLOBAL
+    /// (per-code, not per-connection) wrong-attempt count at the moment of
+    /// rejection, for a "getting close to a rotation" UI hint if ever
+    /// wanted; never required to be shown.
+    case proofRejected(attemptsTowardRotation: Int)
+}
+
+extension TVListenerActor {
+
+    // MARK: - Public ceremony control surface (spec §3.4's "Ceremony public API")
+
+    /// Mints a fresh code and arms the ceremony — called when the operator
+    /// opens the pairing overlay.
+    ///
+    /// ELI5: "Show a brand-new pairing code on the TV screen."
+    public func beginPairing() -> String {
+        let code = LANRemotePairingSecrets.mintCode()
+        pairingCeremony.begin(code: code, now: configuration.clock.now())
+        return code
+    }
+
+    /// Manually mints a fresh code without waiting for a failure-triggered
+    /// rotation — the overlay's TTL countdown calls this when the
+    /// currently-displayed code is about to go stale, so the on-screen
+    /// code is never shown past its actual expiry.
+    ///
+    /// ELI5: "Show a NEW code right now" — the same thing that happens
+    /// automatically after too many wrong guesses, but triggered by the
+    /// clock instead.
+    public func rotatePairingCode() -> String {
+        rotateActiveCode()
+    }
+
+    /// Fully disarms the ceremony — the operator closed the pairing
+    /// overlay. Any connection already parked in `.pairing` stays parked;
+    /// it simply can never successfully confirm until `beginPairing()`
+    /// runs again.
+    ///
+    /// ELI5: "Turn the pairing screen off."
+    public func endPairing() {
+        pairingCeremony.end()
+    }
+
+    /// The code currently displayed, if a ceremony is running — the UI
+    /// re-reads this rather than caching its own copy.
+    public var activePairingCode: String? { pairingCeremony.activeCode }
+
+    /// Sends an `error` frame to one connection — the bridge
+    /// (`TVProjectionBridge`, `IHFeatures`) uses this to relay a
+    /// `ProjectionViewModel` failure back to the ORIGINATING remote.
+    ///
+    /// ELI5: "Tell this one remote 'that didn't work, here's why.'"
+    public func sendError(_ code: IHRPErrorCode, message: String?, to connectionId: UUID) {
+        send(id: connectionId, message: .error(code, message: message))
+    }
+
+    /// Tears down every LIVE connection whose paired token hashes to
+    /// `tokenHash` — the Settings "Revoke" action's second half (the first
+    /// half, forgetting the token so a future `hello` fails, is
+    /// `LANRemotePairingAuthority.revokePairedToken`/`revoke(tokenHash:)`).
+    /// Without this, a revoked-but-still-open connection would keep
+    /// controlling the TV until its NEXT reconnect attempt.
+    ///
+    /// ELI5: "That remote's access was just revoked — if it's currently
+    /// connected, disconnect it right now too."
+    public func disconnectPaired(tokenHash: String) {
+        // `Array(connections.keys)` snapshot first — `stop()`'s own
+        // identical precedent (`TVListenerActor.swift`'s doc comment on
+        // that method) for why iterating while `teardownConnection`
+        // mutates `connections` needs a stable snapshot.
+        for id in Array(connections.keys) {
+            guard let state = connections[id], case .paired(let token) = state.pairingPhase else { continue }
+            guard LANRemoteFingerprint.sha256Hex(Data(token.utf8)) == tokenHash else { continue }
+            teardownConnection(id: id, reason: "revoked")
+        }
+    }
+
+    // MARK: - Ceremony verification (spec §3.4's exact algorithm)
+
+    /// Dispatched from `TVListenerActor+Messages.swift`'s
+    /// `handleUnauthenticated` the moment a `.pairConfirm` frame arrives.
+    /// See spec §3.4 for the numbered algorithm this implements verbatim.
+    func handlePairConfirm(id: UUID, state: TVRemoteConnectionState, proof: String, deviceName: String?) async {
+        guard state.pairingPhase == .pairing else {
+            // A connection that skipped `hello` (still `.unpaired`) and
+            // sent `pairConfirm` directly is hostile/buggy — the SAME
+            // confinement-violation posture `handleUnauthenticated`'s
+            // `default:` branch already takes for any other out-of-order
+            // control message.
+            IHLog.remote.error("lanremote.pairing violation type=pairConfirm while unconfirmed")
+            send(id: id, message: .error(.unauthorized, message: nil))
+            teardownConnection(id: id, reason: "pairConfirm before hello")
+            return
+        }
+
+        state.pairingAttempts += 1
+        guard state.pairingAttempts <= pairingCeremony.configuration.maxAttemptsPerConnection else {
+            send(id: id, message: .error(.pairingRejected, message: nil))
+            IHLog.remote.error("lanremote.pairing attempt-cap")
+            teardownConnection(id: id, reason: "pairing attempt cap")
+            return
+        }
+
+        let now = configuration.clock.now()
+        guard pairingCeremony.isActive(now: now), let code = pairingCeremony.activeCode, let nonce = state.pairingNonce else {
+            // An expired/absent-ceremony guess does NOT count toward
+            // rotation (spec Decision D-5) — reject and return WITHOUT
+            // touching `pairingCeremony.wrongAttempts` at all.
+            send(id: id, message: .error(.pairingRejected, message: nil))
+            IHLog.remote.notice("lanremote.pairing rejected reason=inactive")
+            return
+        }
+
+        guard LANRemotePairingProof.verify(proofHex: proof, code: code, fingerprintHex: identity.fingerprint, nonceHex: nonce) else {
+            let shouldRotate = pairingCeremony.recordFailure()
+            let attemptsTowardRotation = pairingCeremony.wrongAttempts
+            if shouldRotate {
+                _ = rotateActiveCode()
+                IHLog.remote.notice("lanremote.pairing code-rotated")
+            }
+            send(id: id, message: .error(.pairingRejected, message: nil))
+            pairingContinuation.yield(.proofRejected(attemptsTowardRotation: attemptsTowardRotation))
+            IHLog.remote.notice("lanremote.pairing proof-rejected")
+            return
+        }
+
+        pairingCeremony.consume()
+        let token = LANRemotePairingSecrets.mintToken()
+        await promoteToPaired(
+            id: id,
+            token: token,
+            metadata: LANRemotePairingMetadata(name: deviceName, kind: state.remoteKind, pairedAt: now)
+        )
+        pairingContinuation.yield(.paired(name: deviceName, kind: state.remoteKind))
+        IHLog.remote.notice("lanremote.pairing pairing -> paired (ceremony)")
+    }
+
+    /// The shared success path both `handlePairConfirm` (ceremony success)
+    /// and `completePairing(connectionId:token:)` (`+Messages.swift`'s
+    /// manual/test confirmation hook, spec Decision D-3) funnel through —
+    /// registers the token with the authority, flips the connection to
+    /// `.paired`, clears its ceremony bookkeeping, and sends BOTH
+    /// `.pairSuccess` (the raw token the remote persists) and
+    /// `.capabilities` (existing PR-4 behaviour every completion path
+    /// already had).
+    func promoteToPaired(id: UUID, token: String, metadata: LANRemotePairingMetadata) async {
+        guard let state = connections[id] else { return }
+        await configuration.pairingAuthority.registerPairedToken(token, metadata: metadata)
+        state.pairingPhase = .paired(token: token)
+        state.pairingNonce = nil
+        state.pairingAttempts = 0
+        send(id: id, message: .pairSuccess(token: token))
+        send(id: id, message: .capabilities(IHRPCapabilities(currentState: canonicalState)))
+    }
+
+    /// Mints a fresh code and re-arms the ceremony, yielding `.codeRotated`
+    /// — the ONE place both `rotatePairingCode()` (manual) and
+    /// `handlePairConfirm`'s failure branch (automatic) rotate from, so the
+    /// two can never drift in what "rotate" actually does.
+    @discardableResult
+    private func rotateActiveCode() -> String {
+        let code = LANRemotePairingSecrets.mintCode()
+        pairingCeremony.begin(code: code, now: configuration.clock.now())
+        pairingContinuation.yield(.codeRotated(newCode: code))
+        return code
+    }
+}

--- a/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/TVListenerActor+Pairing.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/TVListenerActor+Pairing.swift
@@ -49,6 +49,12 @@ public enum TVPairingEvent: Sendable, Equatable {
     /// rejection, for a "getting close to a rotation" UI hint if ever
     /// wanted; never required to be shown.
     case proofRejected(attemptsTowardRotation: Int)
+    /// The whole ceremony hit its cumulative wrong-proof ceiling
+    /// (`LANRemotePairingCeremonyState.Configuration.maxCeremonyFailures`)
+    /// and was disarmed (post-#1421 adversarial-review brute-force fix). The
+    /// UI (`TVRemoteControlCoordinator`) closes the overlay and surfaces a
+    /// "too many attempts" notice; the operator must re-open pairing.
+    case ceremonyExhausted
 }
 
 extension TVListenerActor {
@@ -158,11 +164,27 @@ extension TVListenerActor {
         }
 
         guard LANRemotePairingProof.verify(proofHex: proof, code: code, fingerprintHex: identity.fingerprint, nonceHex: nonce) else {
-            let shouldRotate = pairingCeremony.recordFailure()
+            let outcome = pairingCeremony.recordFailure()
             let attemptsTowardRotation = pairingCeremony.wrongAttempts
-            if shouldRotate {
+            switch outcome {
+            case .exhausted:
+                // The CUMULATIVE per-ceremony ceiling is reached — shut the
+                // whole ceremony down (post-#1421 adversarial-review fix,
+                // spec §8 brute-force row): rotating yet another RANDOM code
+                // would hand a LAN brute-forcer an unbounded stream of
+                // guesses, which is exactly the envelope the threat model
+                // wrongly assumed rotation prevented. Disarm entirely; only
+                // a fresh operator-initiated `beginPairing()` re-opens
+                // pairing. NEVER logs the code/attempt values, only the
+                // transition.
+                pairingCeremony.end()
+                pairingContinuation.yield(.ceremonyExhausted)
+                IHLog.remote.notice("lanremote.pairing ceremony-exhausted")
+            case .rotate:
                 _ = rotateActiveCode()
                 IHLog.remote.notice("lanremote.pairing code-rotated")
+            case .recorded:
+                break
             }
             send(id: id, message: .error(.pairingRejected, message: nil))
             pairingContinuation.yield(.proofRejected(attemptsTowardRotation: attemptsTowardRotation))
@@ -191,10 +213,21 @@ extension TVListenerActor {
     /// already had).
     func promoteToPaired(id: UUID, token: String, metadata: LANRemotePairingMetadata) async {
         guard let state = connections[id] else { return }
+        let wasPairing = state.pairingPhase == .pairing
         await configuration.pairingAuthority.registerPairedToken(token, metadata: metadata)
         state.pairingPhase = .paired(token: token)
         state.pairingNonce = nil
         state.pairingAttempts = 0
+        // #1421 adversarial-review fix — a `.pairing` connection that just
+        // promoted is no longer "trying to pair"; balance the
+        // `.remoteEnteredPairing` yielded when it entered so the overlay's
+        // live count doesn't leak upward by one on every successful pair.
+        // (`teardownConnection` only yields `.remoteLeftPairing` for a still-
+        // `.pairing` connection, so a promoted one would otherwise never emit
+        // its matching leave.)
+        if wasPairing {
+            pairingContinuation.yield(.remoteLeftPairing(connectionId: id))
+        }
         send(id: id, message: .pairSuccess(token: token))
         send(id: id, message: .capabilities(IHRPCapabilities(currentState: canonicalState)))
     }
@@ -202,11 +235,14 @@ extension TVListenerActor {
     /// Mints a fresh code and re-arms the ceremony, yielding `.codeRotated`
     /// — the ONE place both `rotatePairingCode()` (manual) and
     /// `handlePairConfirm`'s failure branch (automatic) rotate from, so the
-    /// two can never drift in what "rotate" actually does.
+    /// two can never drift in what "rotate" actually does. Uses the
+    /// ceremony's `rotate(code:now:)` (NOT `begin(code:now:)`) so the
+    /// cumulative `ceremonyFailures` ceiling survives every rotation — only
+    /// `beginPairing()` (a fresh operator-opened ceremony) resets it.
     @discardableResult
     private func rotateActiveCode() -> String {
         let code = LANRemotePairingSecrets.mintCode()
-        pairingCeremony.begin(code: code, now: configuration.clock.now())
+        pairingCeremony.rotate(code: code, now: configuration.clock.now())
         pairingContinuation.yield(.codeRotated(newCode: code))
         return code
     }

--- a/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/TVListenerActor.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/TVListenerActor.swift
@@ -93,6 +93,13 @@ public actor TVListenerActor {
         /// The injected clock every outgoing frame's `timestamp` is drawn
         /// from — see `LANRemoteClock.swift`.
         public var clock: any LANRemoteClock
+        /// The pairing-ceremony tunables (TTL / rotation / attempt caps /
+        /// the cumulative brute-force ceiling) — see
+        /// `LANRemotePairingCeremonyState.Configuration`. Defaulted to the
+        /// strategy numbers; injectable so a test can drive, e.g., the
+        /// cumulative-ceiling path with a low `maxCeremonyFailures` without
+        /// staging dozens of real attempts.
+        public var pairingConfiguration: LANRemotePairingCeremonyState.Configuration
 
         public init(
             port: NWEndpoint.Port = .any,
@@ -100,7 +107,8 @@ public actor TVListenerActor {
             advertiseViaBonjour: Bool = true,
             maxUnpairedConnections: Int = 4,
             pairingAuthority: any LANRemotePairingAuthority,
-            clock: any LANRemoteClock = SystemLANRemoteClock()
+            clock: any LANRemoteClock = SystemLANRemoteClock(),
+            pairingConfiguration: LANRemotePairingCeremonyState.Configuration = .init()
         ) {
             self.port = port
             self.advertisedName = advertisedName
@@ -108,6 +116,7 @@ public actor TVListenerActor {
             self.maxUnpairedConnections = maxUnpairedConnections
             self.pairingAuthority = pairingAuthority
             self.clock = clock
+            self.pairingConfiguration = pairingConfiguration
         }
     }
 
@@ -176,7 +185,7 @@ public actor TVListenerActor {
     /// `internal` (not `private`) so `TVListenerActor+Pairing.swift` (a
     /// same-target extension file) and `+Messages.swift`'s `handlePairConfirm`
     /// dispatch can both read/mutate it.
-    var pairingCeremony = LANRemotePairingCeremonyState()
+    var pairingCeremony: LANRemotePairingCeremonyState
 
     let pairingContinuation: AsyncStream<TVPairingEvent>.Continuation
 
@@ -189,6 +198,7 @@ public actor TVListenerActor {
     public init(identity: LANRemoteIdentity, configuration: Configuration) {
         self.identity = identity
         self.configuration = configuration
+        self.pairingCeremony = LANRemotePairingCeremonyState(configuration: configuration.pairingConfiguration)
         let (stream, continuation) = AsyncStream.makeStream(of: ControlEvent.self)
         self.controlEvents = stream
         self.continuation = continuation

--- a/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/TVListenerActor.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/TVListenerActor.swift
@@ -169,12 +169,32 @@ public actor TVListenerActor {
     /// stream/continuation pair is fixed at `init` and never reassigned.
     public nonisolated let controlEvents: AsyncStream<ControlEvent>
 
+    /// The pairing-ceremony state machine (#1421, PR-6 spec §3.3/§3.4) —
+    /// pure `struct` state OWNED by this actor and mutated exclusively
+    /// under its isolation, the same "`IHRPFrameDecoder` is a struct the
+    /// actor mutates" precedent `IHRPFramer.swift`'s header documents.
+    /// `internal` (not `private`) so `TVListenerActor+Pairing.swift` (a
+    /// same-target extension file) and `+Messages.swift`'s `handlePairConfirm`
+    /// dispatch can both read/mutate it.
+    var pairingCeremony = LANRemotePairingCeremonyState()
+
+    let pairingContinuation: AsyncStream<TVPairingEvent>.Continuation
+
+    /// A live feed of pairing-ceremony transitions — `TVRemoteControlCoordinator`
+    /// (`IHFeatures`, PR-6) drives the pairing overlay's UI state off this,
+    /// the same `controlEvents` idiom above. `nonisolated` for the
+    /// identical reason.
+    public nonisolated let pairingEvents: AsyncStream<TVPairingEvent>
+
     public init(identity: LANRemoteIdentity, configuration: Configuration) {
         self.identity = identity
         self.configuration = configuration
         let (stream, continuation) = AsyncStream.makeStream(of: ControlEvent.self)
         self.controlEvents = stream
         self.continuation = continuation
+        let (pairingStream, pairingContinuation) = AsyncStream.makeStream(of: TVPairingEvent.self)
+        self.pairingEvents = pairingStream
+        self.pairingContinuation = pairingContinuation
     }
 
     /// The actual bound port once `start()` has succeeded — `nil` before

--- a/appApple/Packages/iHymnsKit/Tests/IHFeaturesTests/TVProjectionBridgeTests.swift
+++ b/appApple/Packages/iHymnsKit/Tests/IHFeaturesTests/TVProjectionBridgeTests.swift
@@ -1,0 +1,137 @@
+// TVProjectionBridgeTests.swift
+// IHFeaturesTests
+//
+// ELI5: Checks the little "remote said X, make the projection do X"
+// translator does exactly the right thing for every kind of message —
+// including making sure the two failure kinds (gated vs. everything-else)
+// never leak a real error string onto the LAN wire, and that transport/
+// pairing messages never touch the projection at all.
+//
+// DETAILED: #1421 (`.claude/apple-phase2-pr6-spec.md` §7.3). Mirrors
+// `ProjectionViewModelTests.swift`'s own "inject a fake `fetchSongDetail`
+// closure, no real network" shape (#1504) — `TVProjectionBridge` itself has
+// no networking of its own to fake, so every test here is pure, in-process,
+// and fast: no listener, no `RemoteSessionActor`, no sockets at all.
+import Foundation
+import Testing
+@testable import IHAPI
+import IHLive
+@testable import IHFeatures
+@testable import IHModels
+
+@Suite("TVProjectionBridge (#1421)")
+@MainActor
+struct TVProjectionBridgeTests {
+
+    /// Minimal, valid `SongDetail` fixture — the SAME compiler-synthesized
+    /// memberwise-init idiom `ProjectionViewModelTests`/`ProjectionResolverTests`
+    /// already establish.
+    private static func makeSongDetail(id: String, componentLineCounts: [Int]) -> SongDetail {
+        let components = componentLineCounts.enumerated().map { index, count in
+            SongComponent(
+                type: "verse", number: index + 1, lines: (0..<count).map { "Line \($0)" },
+                chords: nil, language: nil, lineIds: Array(0..<count), lineLanguages: nil
+            )
+        }
+        return SongDetail(
+            songId: SongID(rawValue: id) ?? SongID(songbookAbbreviation: "MP", number: 1),
+            number: 1, title: "Test Song \(id)", songbookAbbreviation: "MP", songbookName: "Mission Praise",
+            language: "en", copyright: "", tuneName: "", ccli: "", iswc: "",
+            verified: false, lyricsPublicDomain: false, musicPublicDomain: false,
+            hasAudio: false, hasSheetMusic: false, originCity: "", originCityId: nil, publicId: nil,
+            arrangement: nil, writers: [], composers: [], arrangers: [], adaptors: [], translators: [], artists: [],
+            components: components, tags: [], alternativeTitles: [], links: [], works: [], media: [],
+            translations: nil, annotations: nil, royaltyIds: nil
+        )
+    }
+
+    // MARK: - .selectSong
+
+    @Test(".selectSong with a succeeding fetcher returns nil and loads the song into the view model")
+    func selectSongSuccessAppliesToViewModel() async {
+        let song = Self.makeSongDetail(id: "MP-7001", componentLineCounts: [3])
+        let viewModel = ProjectionViewModel(fetchSongDetail: { _ in song })
+
+        let reply = await TVProjectionBridge.apply(.selectSong(songId: song.songId, componentIndex: nil, lineIndex: nil), to: viewModel)
+
+        #expect(reply == nil)
+        #expect(viewModel.projectionState.songId == song.songId)
+    }
+
+    @Test(".selectSong whose fetcher throws .unauthorized maps to .error(.contentUnavailable, nil) — the §2.4.3 gating handoff")
+    func selectSongUnauthorizedMapsToContentUnavailable() async {
+        let songId = SongID(songbookAbbreviation: "MP", number: 7002)
+        let viewModel = ProjectionViewModel(fetchSongDetail: { _ in throw APIError.unauthorized })
+
+        let reply = await TVProjectionBridge.apply(.selectSong(songId: songId, componentIndex: nil, lineIndex: nil), to: viewModel)
+
+        #expect(reply == .error(.contentUnavailable, message: nil))
+        #expect(viewModel.song == nil)
+    }
+
+    @Test(".selectSong whose fetcher throws .offline maps to .error(.internalError, nil) — never a leaked user-facing string")
+    func selectSongOfflineMapsToInternalErrorNoMessage() async {
+        let songId = SongID(songbookAbbreviation: "MP", number: 7003)
+        let viewModel = ProjectionViewModel(fetchSongDetail: { _ in throw APIError.offline })
+
+        let reply = await TVProjectionBridge.apply(.selectSong(songId: songId, componentIndex: nil, lineIndex: nil), to: viewModel)
+
+        guard case .error(let code, let message) = reply else {
+            Issue.record("expected .error, got \(String(describing: reply))")
+            return
+        }
+        #expect(code == .internalError)
+        #expect(message == nil)
+        #expect(viewModel.song == nil)
+    }
+
+    // MARK: - Navigation / display / appearance intents mutate the VM exactly as calling it directly would
+
+    @Test(".nextLine/.setDisplayState/.scroll/.jumpLine mutate the view model exactly as calling it directly would")
+    func navigationIntentsMutateViewModelDirectly() async {
+        let song = Self.makeSongDetail(id: "MP-7004", componentLineCounts: [4, 4])
+        let viewModel = ProjectionViewModel(fetchSongDetail: { _ in song })
+        _ = await viewModel.selectSong(songId: song.songId)
+
+        // `.nextLine` — component mode (line nil) at component 0 enters
+        // line mode at line 0 (`ProjectionResolver.nextLine`'s own rule).
+        _ = await TVProjectionBridge.apply(.nextLine, to: viewModel)
+        #expect(viewModel.position == ProjectionPosition(componentIndex: 0, lineIndex: 0))
+
+        _ = await TVProjectionBridge.apply(.setDisplayState(.blackout), to: viewModel)
+        #expect(viewModel.displayState == .blackout)
+
+        // `.scroll(delta: 2)` from (0, 0) advances two lines forward.
+        _ = await TVProjectionBridge.apply(.scroll(delta: 2), to: viewModel)
+        #expect(viewModel.position == ProjectionPosition(componentIndex: 0, lineIndex: 2))
+
+        // `.jumpLine` — within the CURRENT component only.
+        _ = await TVProjectionBridge.apply(.jumpLine(index: 3), to: viewModel)
+        #expect(viewModel.position == ProjectionPosition(componentIndex: 0, lineIndex: 3))
+
+        // Every one of these calls returned `nil` — no error to relay.
+        let lastReply = await TVProjectionBridge.apply(.prevLine, to: viewModel)
+        #expect(lastReply == nil)
+    }
+
+    // MARK: - Transport/pairing cases never reach the view model
+
+    @Test(".ping/.hello/.endControl/.pairConfirm never touch the view model")
+    func transportAndPairingCasesAreNoOps() async {
+        let song = Self.makeSongDetail(id: "MP-7005", componentLineCounts: [2])
+        let viewModel = ProjectionViewModel(fetchSongDetail: { _ in song })
+        let positionBefore = viewModel.position
+
+        let pingReply = await TVProjectionBridge.apply(.ping, to: viewModel)
+        let helloReply = await TVProjectionBridge.apply(.hello(token: nil, kind: .phone), to: viewModel)
+        let endControlReply = await TVProjectionBridge.apply(.endControl, to: viewModel)
+        let pairConfirmReply = await TVProjectionBridge.apply(.pairConfirm(proof: "irrelevant", deviceName: nil), to: viewModel)
+
+        #expect(pingReply == nil)
+        #expect(helloReply == nil)
+        #expect(endControlReply == nil)
+        #expect(pairConfirmReply == nil)
+        #expect(viewModel.song == nil)
+        #expect(viewModel.position == positionBefore)
+    }
+}

--- a/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/IHRPMessageCodecTests.swift
+++ b/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/IHRPMessageCodecTests.swift
@@ -47,8 +47,17 @@ struct IHRPMessageCodecTests {
         .ack(ackSeq: 99),
         .error(.contentUnavailable, message: "song is gated"),
         .error(.protocolVersionMismatch, message: nil),
+        .error(.pairingRejected, message: nil),
         .pong,
-        .capabilities(IHRPCapabilities(currentState: .initial))
+        .capabilities(IHRPCapabilities(currentState: .initial)),
+        // #1421 (PR-6 spec §4) — the pairing sub-protocol's own cases,
+        // including BOTH the present/absent shape of `pairConfirm`'s
+        // optional `deviceName` (the same "every optional field, both
+        // ways" discipline this array's own doc comment establishes).
+        .pairChallenge(nonce: "0123456789abcdef0123456789abcdef"),
+        .pairConfirm(proof: String(repeating: "ab", count: 32), deviceName: "Lance's iPhone"),
+        .pairConfirm(proof: String(repeating: "ab", count: 32), deviceName: nil),
+        .pairSuccess(token: String(repeating: "cd", count: 32))
     ]
 
     @Test("Every message case round-trips through JSON unchanged", arguments: sampleMessages)
@@ -76,6 +85,12 @@ struct IHRPMessageCodecTests {
         #expect(!IHRPMessage.state(.initial).isControlIntent)
         #expect(!IHRPMessage.error(.internalError, message: nil).isControlIntent)
         #expect(!IHRPMessage.capabilities(IHRPCapabilities(currentState: .initial)).isControlIntent)
+        // #1421 — `.pairConfirm` is the ONE remote→TV case in the pairing
+        // trio (a control intent); `.pairChallenge`/`.pairSuccess` are
+        // TV→remote responses, mirroring `.capabilities`'s classification.
+        #expect(IHRPMessage.pairConfirm(proof: "ab", deviceName: nil).isControlIntent)
+        #expect(!IHRPMessage.pairChallenge(nonce: "ab").isControlIntent)
+        #expect(!IHRPMessage.pairSuccess(token: "ab").isControlIntent)
     }
 
     @Test("A frame with a mismatched protocol version is rejected")

--- a/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/KeychainPairingAuthorityTests.swift
+++ b/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/KeychainPairingAuthorityTests.swift
@@ -1,0 +1,165 @@
+// KeychainPairingAuthorityTests.swift
+// IHLiveTests
+//
+// ELI5: Proves the REAL trusted-remotes notebook actually behaves like a
+// notebook — write a remote in, it's now recognized; forget it, it's not
+// anymore; ask for the whole list, get everyone back with their names/
+// kinds/paired-dates intact; and — the one that matters most — the raw
+// secret token is NEVER what's sitting in the Keychain, only its hash.
+//
+// DETAILED: #1421 (`.claude/apple-phase2-pr6-spec.md` §7.4). Gated on
+// `lanRemoteKeychainIdentityAvailable()` — reused here (rather than a
+// second identical-shaped gate function) purely as the "can this process
+// actually touch the Keychain for real" probe; it happens to be phrased
+// around `LANRemoteIdentity` generation, but the underlying limitation
+// (unsigned headless `swift test` vs. a real Keychain) is the same one
+// `KeychainLANRemotePairingAuthority`'s plain `SecItemAdd`/
+// `SecItemCopyMatching` generic-password calls would ALSO hit on a truly
+// keychain-less host — same skip message style as every other gated suite
+// in this file's folder. Every test uses a UNIQUE `service` (a random
+// suffix) so tests never see each other's leftover items, and cleans up
+// via a `defer { await authority.revokePairedToken(token) }`.
+import Foundation
+import Security
+import Testing
+@testable import IHLive
+
+@Suite(
+    "KeychainLANRemotePairingAuthority",
+    // `.serialized` — reduces (does not, on its own, fully eliminate:
+    // Swift Testing still runs DIFFERENT `@Suite` types concurrently with
+    // each other) the number of simultaneous real `Security.framework`
+    // calls in flight, which empirically lowers the odds of the SAME rare
+    // Keychain-daemon contention `LANRemoteIdentityStoreTests.swift`'s own
+    // `.serialized` comment documents. This suite's unique-per-test
+    // `service` string already makes serialization unnecessary for
+    // CORRECTNESS (no two tests here ever touch the same item) — this is
+    // purely a contention-reduction courtesy to its sibling suites.
+    .serialized,
+    .enabled(
+        if: lanRemoteKeychainIdentityAvailable(),
+        "Needs a real Keychain an unsigned headless `swift test` binary can't reliably exercise — see LANRemoteIdentityTests.swift's identical gate."
+    )
+)
+struct KeychainPairingAuthorityTests {
+
+    private func makeAuthority() -> KeychainLANRemotePairingAuthority {
+        KeychainLANRemotePairingAuthority(service: "app.ihymns.lanremote.pairedRemotes.test.\(UUID().uuidString)")
+    }
+
+    @Test("registerPairedToken(_:) then isPairedToken(_:) recognizes it; an unknown token is not paired")
+    func registerThenIsPaired() async throws {
+        // `KeychainTestSerialization` (`LANRemoteTestSupport.swift`) — see
+        // its doc comment: needed to stop THIS suite's Keychain calls from
+        // overlapping `LANRemoteIdentityTests`'/`LANRemoteIdentityStoreTests`'
+        // own, which is what actually caused #1421's observed flakiness
+        // (a per-suite `.serialized` trait alone does not prevent that).
+        try await KeychainTestSerialization.shared.run {
+            let authority = makeAuthority()
+            let token = "raw-token-\(UUID().uuidString)"
+            defer { Task { await authority.revokePairedToken(token) } }
+
+            await authority.registerPairedToken(token)
+            #expect(await authority.isPairedToken(token))
+            #expect(await !authority.isPairedToken("some-other-token"))
+        }
+    }
+
+    @Test("revokePairedToken(_:) makes isPairedToken(_:) false again")
+    func revokeByRawToken() async throws {
+        try await KeychainTestSerialization.shared.run {
+            let authority = makeAuthority()
+            let token = "raw-token-\(UUID().uuidString)"
+
+            await authority.registerPairedToken(token)
+            #expect(await authority.isPairedToken(token))
+
+            await authority.revokePairedToken(token)
+            #expect(await !authority.isPairedToken(token))
+        }
+    }
+
+    @Test("revoke(tokenHash:) — the hash-addressed path Settings actually has — also works")
+    func revokeByHash() async throws {
+        try await KeychainTestSerialization.shared.run {
+            let authority = makeAuthority()
+            let token = "raw-token-\(UUID().uuidString)"
+            let hash = LANRemoteFingerprint.sha256Hex(Data(token.utf8))
+
+            await authority.registerPairedToken(token)
+            #expect(await authority.isPairedToken(token))
+
+            await authority.revoke(tokenHash: hash)
+            #expect(await !authority.isPairedToken(token))
+        }
+    }
+
+    @Test("listPairedRemotes() round-trips metadata (name/kind/pairedAt) and sorts newest-first")
+    func listRoundTripsMetadataNewestFirst() async throws {
+        try await KeychainTestSerialization.shared.run {
+            let authority = makeAuthority()
+            let olderToken = "raw-token-older-\(UUID().uuidString)"
+            let newerToken = "raw-token-newer-\(UUID().uuidString)"
+            defer {
+                Task {
+                    await authority.revokePairedToken(olderToken)
+                    await authority.revokePairedToken(newerToken)
+                }
+            }
+
+            let olderDate = Date(timeIntervalSince1970: 1_700_000_000)
+            let newerDate = Date(timeIntervalSince1970: 1_700_001_000)
+            await authority.registerPairedToken(olderToken, metadata: LANRemotePairingMetadata(name: "Older Phone", kind: .phone, pairedAt: olderDate))
+            await authority.registerPairedToken(newerToken, metadata: LANRemotePairingMetadata(name: "Newer iPad", kind: .pad, pairedAt: newerDate))
+
+            let records = await authority.listPairedRemotes()
+            let ours = records.filter { $0.metadata.name == "Older Phone" || $0.metadata.name == "Newer iPad" }
+            #expect(ours.count == 2)
+            #expect(ours.first?.metadata.name == "Newer iPad")
+            #expect(ours.first?.metadata.kind == .pad)
+            #expect(ours.first?.metadata.pairedAt == newerDate)
+            #expect(ours.last?.metadata.name == "Older Phone")
+        }
+    }
+
+    @Test("The raw token is NEVER stored — only sha256(token) is, as the Keychain item's account")
+    func hashAtRestNeverRawToken() async throws {
+        try await KeychainTestSerialization.shared.run {
+            let authority = makeAuthority()
+            let token = "raw-token-\(UUID().uuidString)"
+            let expectedHash = LANRemoteFingerprint.sha256Hex(Data(token.utf8))
+            defer { Task { await authority.revokePairedToken(token) } }
+
+            await authority.registerPairedToken(token)
+
+            let records = await authority.listPairedRemotes()
+            #expect(records.contains { $0.tokenHashHex == expectedHash })
+            #expect(!records.contains { $0.tokenHashHex == token })
+        }
+    }
+
+    @Test("baseAttributes(account:) is synchronizable == false and accessible == afterFirstUnlock")
+    func baseAttributesInvariants() async throws {
+        try await KeychainTestSerialization.shared.run {
+            let authority = makeAuthority()
+            #expect(await authority.baseAttributesInvariantsHold(account: "some-hash"))
+        }
+    }
+}
+
+extension KeychainLANRemotePairingAuthority {
+    /// Test-only: evaluates `baseAttributes(account:)`'s three invariants
+    /// (plan §6.4's required unit test) WITHOUT ever letting the
+    /// non-`Sendable` `[String: Any]` dictionary itself cross the actor
+    /// boundary — only this `Bool` result does, which strict concurrency
+    /// is happy with.
+    fileprivate func baseAttributesInvariantsHold(account: String?) -> Bool {
+        let attributes = baseAttributes(account: account)
+        guard attributes[kSecAttrSynchronizable as String] as? Bool == false else { return false }
+        guard (attributes[kSecAttrAccessible as String] as? String) == (kSecAttrAccessibleAfterFirstUnlock as String) else {
+            return false
+        }
+        guard attributes[kSecClass as String] as? String == (kSecClassGenericPassword as String) else { return false }
+        return true
+    }
+}

--- a/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/LANRemoteIdentityStoreTests.swift
+++ b/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/LANRemoteIdentityStoreTests.swift
@@ -1,0 +1,89 @@
+// LANRemoteIdentityStoreTests.swift
+// IHLiveTests
+//
+// ELI5: Proves the TV's "keep the same face forever" box actually works —
+// asking for the identity twice in a row gives back the SAME identity both
+// times, and deliberately throwing it away then asking again gives back a
+// genuinely DIFFERENT one.
+//
+// DETAILED: #1421 (`.claude/apple-phase2-pr6-spec.md` §7.4). Gated on
+// `lanRemoteKeychainIdentityAvailable()` — the SAME headless-CI limitation
+// `LANRemoteIdentityTests.swift` (PR-4/#1420) already documents in full:
+// an unsigned `swift test` binary can `SecItemAdd` but its
+// `kSecClassIdentity` query comes back `errSecItemNotFound` with no login
+// keychain to bridge into. Every test cleans up via `LANRemoteIdentityStore
+// .reset()` in a `defer` so a full suite run never leaves this PR's
+// FIXED-label identity (`"app.ihymns.lanremote.identity.v1"`, unlike PR-4's
+// throwaway per-call UUID labels) behind in the developer/CI Keychain.
+import Foundation
+import Testing
+@testable import IHLive
+
+@Suite(
+    "LANRemoteIdentityStore persistence",
+    // `.serialized` (NOT the default parallel execution) — every test in
+    // this suite shares the ONE fixed Keychain label
+    // (`LANRemoteIdentityStore.identityLabel`, deliberately fixed so a
+    // relaunch finds the SAME identity — this file's own header comment).
+    // Running two of these tests concurrently would race two independent
+    // reset()/loadOrCreate() sequences against that single shared label,
+    // which is a TEST-ISOLATION hazard, not a real code bug — unlike
+    // `KeychainPairingAuthorityTests`, which sidesteps this entirely by
+    // giving every test its OWN randomly-suffixed `service`.
+    .serialized,
+    .enabled(
+        if: lanRemoteKeychainIdentityAvailable(),
+        "Needs login-keychain SecIdentity bridging an unsigned headless `swift test` binary can't do — see LANRemoteIdentityTests.swift's identical gate."
+    )
+)
+struct LANRemoteIdentityStoreTests {
+
+    @Test("loadOrCreate() called twice returns the SAME fingerprint and certificate DER")
+    func sameIdentityAcrossCalls() async throws {
+        // `KeychainTestSerialization` (`LANRemoteTestSupport.swift`) — see
+        // its doc comment: needed to stop THIS suite's Keychain calls from
+        // overlapping `LANRemoteIdentityTests`'/`KeychainPairingAuthorityTests`'
+        // own, which is what actually caused #1421's observed flakiness
+        // (a per-suite `.serialized` trait alone does not prevent that).
+        try await KeychainTestSerialization.shared.run {
+            LANRemoteIdentityStore.reset()
+            defer { LANRemoteIdentityStore.reset() }
+
+            let first = try LANRemoteIdentityStore.loadOrCreate()
+            let second = try LANRemoteIdentityStore.loadOrCreate()
+
+            #expect(first.fingerprint == second.fingerprint)
+            #expect(first.certificateDER == second.certificateDER)
+        }
+    }
+
+    @Test("reset() then loadOrCreate() mints a genuinely DIFFERENT identity")
+    func resetThenLoadOrCreateMintsNewIdentity() async throws {
+        try await KeychainTestSerialization.shared.run {
+            LANRemoteIdentityStore.reset()
+            defer { LANRemoteIdentityStore.reset() }
+
+            let original = try LANRemoteIdentityStore.loadOrCreate()
+            LANRemoteIdentityStore.reset()
+            let afterReset = try LANRemoteIdentityStore.loadOrCreate()
+
+            #expect(original.fingerprint != afterReset.fingerprint)
+            #expect(original.certificateDER != afterReset.certificateDER)
+        }
+    }
+
+    @Test("makeServerTLSOptions() succeeds on a LOADED (not just freshly-generated) identity")
+    func serverTLSOptionsBuildableAfterReload() async throws {
+        try await KeychainTestSerialization.shared.run {
+            LANRemoteIdentityStore.reset()
+            defer { LANRemoteIdentityStore.reset() }
+
+            _ = try LANRemoteIdentityStore.loadOrCreate()
+            // The SECOND call exercises the `wrapExisting(_:)` "found it in
+            // the Keychain" path specifically (the first call always takes
+            // the "generate fresh" branch on a clean slate).
+            let reloaded = try LANRemoteIdentityStore.loadOrCreate()
+            _ = try reloaded.makeServerTLSOptions()
+        }
+    }
+}

--- a/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/LANRemoteIdentityTests.swift
+++ b/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/LANRemoteIdentityTests.swift
@@ -16,6 +16,19 @@ import Testing
 
 @Suite(
     "LANRemoteIdentity generation",
+    // `.serialized` (#1421 addition) — `LANRemoteIdentityFactory
+    // .generateSelfSigned()`'s `kSecAttrIsPermanent: true` key generation
+    // was empirically observed (while building #1421's
+    // `LANRemoteIdentityStoreTests`/`KeychainPairingAuthorityTests`, which
+    // exercise the SAME factory and now run alongside this suite in the
+    // same `swift test` invocation) to occasionally fail transiently
+    // (`errSecItemNotFound`/"failed to generate CDSA key") under
+    // concurrent `SecKeyCreateRandomKey` calls from multiple suites at
+    // once — a shared macOS Keychain-daemon contention artifact, not a
+    // logic bug in any of the three suites. Serializing every suite that
+    // calls this factory reduces the window; see the sibling suites' own
+    // identical comment.
+    .serialized,
     .enabled(
         if: lanRemoteKeychainIdentityAvailable(),
         "Needs login-keychain SecIdentity bridging an unsigned headless `swift test` binary can't do — SecItemAdd succeeds but the kSecClassIdentity query returns errSecItemNotFound (-25300) on the CI runner. See lanRemoteKeychainIdentityAvailable(). The pure fingerprint math is covered always-on by LANRemoteFingerprintTests."
@@ -24,42 +37,55 @@ import Testing
 struct LANRemoteIdentityTests {
 
     @Test("Generates a well-formed 64-character lowercase-hex fingerprint")
-    func fingerprintShape() throws {
-        let identity = try LANRemoteIdentityFactory.generateSelfSigned()
-        defer { identity.removeFromKeychain() }
+    func fingerprintShape() async throws {
+        // `KeychainTestSerialization` (`LANRemoteTestSupport.swift`) — see
+        // its doc comment: a per-suite `.serialized` trait alone doesn't
+        // stop THIS suite's Keychain calls from overlapping a DIFFERENT
+        // suite's, which is what actually caused #1421's observed
+        // flakiness.
+        try await KeychainTestSerialization.shared.run {
+            let identity = try LANRemoteIdentityFactory.generateSelfSigned()
+            defer { identity.removeFromKeychain() }
 
-        #expect(identity.fingerprint.count == 64)
-        #expect(identity.fingerprint.allSatisfy { $0.isHexDigit && !$0.isUppercase })
-        #expect(!identity.certificateDER.isEmpty)
+            #expect(identity.fingerprint.count == 64)
+            #expect(identity.fingerprint.allSatisfy { $0.isHexDigit && !$0.isUppercase })
+            #expect(!identity.certificateDER.isEmpty)
+        }
     }
 
     @Test("The fingerprint is the SHA-256 of the certificate DER")
-    func fingerprintMatchesDER() throws {
-        let identity = try LANRemoteIdentityFactory.generateSelfSigned()
-        defer { identity.removeFromKeychain() }
+    func fingerprintMatchesDER() async throws {
+        try await KeychainTestSerialization.shared.run {
+            let identity = try LANRemoteIdentityFactory.generateSelfSigned()
+            defer { identity.removeFromKeychain() }
 
-        #expect(identity.fingerprint == LANRemoteFingerprint.sha256Hex(identity.certificateDER))
+            #expect(identity.fingerprint == LANRemoteFingerprint.sha256Hex(identity.certificateDER))
+        }
     }
 
     @Test("Two generated identities never collide")
-    func distinctEachCall() throws {
-        let first = try LANRemoteIdentityFactory.generateSelfSigned()
-        defer { first.removeFromKeychain() }
-        let second = try LANRemoteIdentityFactory.generateSelfSigned()
-        defer { second.removeFromKeychain() }
+    func distinctEachCall() async throws {
+        try await KeychainTestSerialization.shared.run {
+            let first = try LANRemoteIdentityFactory.generateSelfSigned()
+            defer { first.removeFromKeychain() }
+            let second = try LANRemoteIdentityFactory.generateSelfSigned()
+            defer { second.removeFromKeychain() }
 
-        #expect(first.fingerprint != second.fingerprint)
-        #expect(first.certificateDER != second.certificateDER)
+            #expect(first.fingerprint != second.fingerprint)
+            #expect(first.certificateDER != second.certificateDER)
+        }
     }
 
     @Test("makeServerTLSOptions() succeeds for a freshly generated identity")
-    func serverTLSOptionsBuildable() throws {
-        let identity = try LANRemoteIdentityFactory.generateSelfSigned()
-        defer { identity.removeFromKeychain() }
+    func serverTLSOptionsBuildable() async throws {
+        try await KeychainTestSerialization.shared.run {
+            let identity = try LANRemoteIdentityFactory.generateSelfSigned()
+            defer { identity.removeFromKeychain() }
 
-        // Smoke test only — the identity is actually EXERCISED end-to-end
-        // by `LANRemoteLoopbackTests`; this just confirms the TLS options
-        // object itself can be constructed without throwing.
-        _ = try identity.makeServerTLSOptions()
+            // Smoke test only — the identity is actually EXERCISED end-to-
+            // end by `LANRemoteLoopbackTests`; this just confirms the TLS
+            // options object itself can be constructed without throwing.
+            _ = try identity.makeServerTLSOptions()
+        }
     }
 }

--- a/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/LANRemotePairingCeremonyTests.swift
+++ b/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/LANRemotePairingCeremonyTests.swift
@@ -25,12 +25,15 @@ struct LANRemotePairingCeremonyTests {
 
     private let epoch = Date(timeIntervalSince1970: 1_700_000_000)
 
-    @Test("Configuration defaults are strategy's exact numbers — 120s TTL / 5 fails / 3 attempts")
+    @Test("Configuration defaults are strategy's exact numbers — 120s TTL / 5 fails / 3 attempts / 15 ceiling")
     func configurationDefaults() {
         let configuration = LANRemotePairingCeremonyState.Configuration()
         #expect(configuration.codeTTL == 120)
         #expect(configuration.rotateAfterFailures == 5)
         #expect(configuration.maxAttemptsPerConnection == 3)
+        // Post-#1421 adversarial-review brute-force ceiling — 3 codes' worth
+        // of rotation before the whole ceremony is disarmed.
+        #expect(configuration.maxCeremonyFailures == 15)
     }
 
     @Test("begin() arms the ceremony and isActive(now:) holds until exactly the TTL boundary")
@@ -67,20 +70,60 @@ struct LANRemotePairingCeremonyTests {
         state.begin(code: "042317", now: epoch)
 
         for expectedCount in 1...4 {
-            let rotated = state.recordFailure()
-            #expect(!rotated)
+            let outcome = state.recordFailure()
+            #expect(outcome == .recorded)
             #expect(state.wrongAttempts == expectedCount)
         }
         // The 5th failure hits `rotateAfterFailures` (default 5) — the
-        // rotation signal fires.
-        let fifthRotated = state.recordFailure()
-        #expect(fifthRotated)
+        // rotation signal fires (still well under the 15 cumulative ceiling).
+        let fifthOutcome = state.recordFailure()
+        #expect(fifthOutcome == .rotate)
         #expect(state.wrongAttempts == 5)
+        #expect(state.ceremonyFailures == 5)
 
-        // A fresh `begin(...)` (the caller's rotation response) resets the
-        // failure count for the NEW code.
+        // A fresh `begin(...)` (a brand-new operator-opened ceremony) resets
+        // BOTH the per-code count AND the cumulative ceremony count.
         state.begin(code: "998877", now: epoch)
         #expect(state.wrongAttempts == 0)
+        #expect(state.ceremonyFailures == 0)
+    }
+
+    @Test("rotate() resets the per-code count but PRESERVES the cumulative ceremonyFailures")
+    func rotatePreservesCumulativeCount() {
+        var state = LANRemotePairingCeremonyState()
+        state.begin(code: "042317", now: epoch)
+        state.recordFailure()
+        state.recordFailure()
+        #expect(state.wrongAttempts == 2)
+        #expect(state.ceremonyFailures == 2)
+
+        // A mid-ceremony rotation (the caller's response to `.rotate`) clears
+        // the per-code count for the fresh code but must NOT hand a brute-
+        // forcer a fresh cumulative budget.
+        state.rotate(code: "998877", now: epoch)
+        #expect(state.activeCode == "998877")
+        #expect(state.wrongAttempts == 0)
+        #expect(state.ceremonyFailures == 2)
+    }
+
+    @Test("recordFailure() returns .exhausted once the cumulative ceiling is reached, across rotations")
+    func cumulativeCeilingExhaustsCeremony() {
+        // A small ceiling so the whole path is exercised without staging 15
+        // real failures: rotate every 2, disarm the ceremony after 4 total.
+        let configuration = LANRemotePairingCeremonyState.Configuration(
+            rotateAfterFailures: 2, maxCeremonyFailures: 4
+        )
+        var state = LANRemotePairingCeremonyState(configuration: configuration)
+        state.begin(code: "111111", now: epoch)
+
+        #expect(state.recordFailure() == .recorded)          // 1 (cumulative 1)
+        #expect(state.recordFailure() == .rotate)            // 2 (cumulative 2) → rotate
+        state.rotate(code: "222222", now: epoch)             // preserves cumulative 2
+        #expect(state.recordFailure() == .recorded)          // 1 (cumulative 3)
+        // Cumulative 4 reaches maxCeremonyFailures — `.exhausted` wins over
+        // the per-code `.rotate` it would otherwise have signalled.
+        #expect(state.recordFailure() == .exhausted)         // 2 (cumulative 4)
+        #expect(state.ceremonyFailures == 4)
     }
 
     @Test("end() fully disarms — begin() afterward re-arms from a clean slate")
@@ -108,10 +151,10 @@ struct LANRemotePairingCeremonyTests {
 
         #expect(state.isActive(now: epoch.addingTimeInterval(9.9)))
         #expect(!state.isActive(now: epoch.addingTimeInterval(10.1)))
-        let firstRotated = state.recordFailure()
-        #expect(!firstRotated)
-        let secondRotated = state.recordFailure()
-        #expect(secondRotated)
+        let firstOutcome = state.recordFailure()
+        #expect(firstOutcome == .recorded)
+        let secondOutcome = state.recordFailure()
+        #expect(secondOutcome == .rotate)
     }
 }
 

--- a/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/LANRemotePairingCeremonyTests.swift
+++ b/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/LANRemotePairingCeremonyTests.swift
@@ -1,0 +1,169 @@
+// LANRemotePairingCeremonyTests.swift
+// IHLiveTests
+//
+// ELI5: Checks the pairing-ceremony rulebook does exactly what it says —
+// a code goes stale after its TTL, a used code can't be reused, enough
+// wrong guesses trigger a "please rotate" signal, and closing the pairing
+// screen fully resets things. Also checks the little QR-payload string
+// format round-trips and rejects garbage.
+//
+// DETAILED: #1421 (`.claude/apple-phase2-pr6-spec.md` §7.2 — BINDING).
+// `LANRemotePairingCeremonyState` is pure (`LANRemotePairingCeremony.swift`'s
+// header) — every test below uses literal `Date(timeIntervalSince1970:)`
+// values, never a clock object or a real sleep, the same posture
+// `IHRPFrameOrderingTests.swift` already establishes for `IHRPFrame`'s own
+// last-writer-wins ordering. `LANRemotePairingPayloadTests` (this file's
+// second `@Suite`) is folded in here rather than given its own file — spec
+// §7.5's own suggestion ("fold into `LANRemotePairingCeremonyTests`'s file
+// if LOC allows") — since both are small, always-on, no-network suites.
+import Foundation
+import Testing
+@testable import IHLive
+
+@Suite("LANRemotePairingCeremonyState")
+struct LANRemotePairingCeremonyTests {
+
+    private let epoch = Date(timeIntervalSince1970: 1_700_000_000)
+
+    @Test("Configuration defaults are strategy's exact numbers — 120s TTL / 5 fails / 3 attempts")
+    func configurationDefaults() {
+        let configuration = LANRemotePairingCeremonyState.Configuration()
+        #expect(configuration.codeTTL == 120)
+        #expect(configuration.rotateAfterFailures == 5)
+        #expect(configuration.maxAttemptsPerConnection == 3)
+    }
+
+    @Test("begin() arms the ceremony and isActive(now:) holds until exactly the TTL boundary")
+    func beginAndTTLBoundary() {
+        var state = LANRemotePairingCeremonyState()
+        state.begin(code: "042317", now: epoch)
+
+        #expect(state.activeCode == "042317")
+        #expect(state.isActive(now: epoch))
+        #expect(state.isActive(now: epoch.addingTimeInterval(119.9)))
+        #expect(!state.isActive(now: epoch.addingTimeInterval(120.1)))
+    }
+
+    @Test("A ceremony that was never begun is never active")
+    func neverBegunIsInactive() {
+        let state = LANRemotePairingCeremonyState()
+        #expect(state.activeCode == nil)
+        #expect(!state.isActive(now: epoch))
+    }
+
+    @Test("consume() is single-use — the code is inactive immediately after")
+    func consumeIsSingleUse() {
+        var state = LANRemotePairingCeremonyState()
+        state.begin(code: "042317", now: epoch)
+        state.consume()
+
+        #expect(state.activeCode == nil)
+        #expect(!state.isActive(now: epoch))
+    }
+
+    @Test("recordFailure() signals rotation only on the configured Nth failure, and begin() resets the count")
+    func recordFailureRotationThreshold() {
+        var state = LANRemotePairingCeremonyState()
+        state.begin(code: "042317", now: epoch)
+
+        for expectedCount in 1...4 {
+            let rotated = state.recordFailure()
+            #expect(!rotated)
+            #expect(state.wrongAttempts == expectedCount)
+        }
+        // The 5th failure hits `rotateAfterFailures` (default 5) — the
+        // rotation signal fires.
+        let fifthRotated = state.recordFailure()
+        #expect(fifthRotated)
+        #expect(state.wrongAttempts == 5)
+
+        // A fresh `begin(...)` (the caller's rotation response) resets the
+        // failure count for the NEW code.
+        state.begin(code: "998877", now: epoch)
+        #expect(state.wrongAttempts == 0)
+    }
+
+    @Test("end() fully disarms — begin() afterward re-arms from a clean slate")
+    func endThenReBegin() {
+        var state = LANRemotePairingCeremonyState()
+        state.begin(code: "042317", now: epoch)
+        state.recordFailure()
+        state.end()
+
+        #expect(state.activeCode == nil)
+        #expect(!state.isActive(now: epoch))
+
+        state.begin(code: "556677", now: epoch)
+        #expect(state.activeCode == "556677")
+        #expect(state.isActive(now: epoch))
+    }
+
+    @Test("A custom Configuration is honoured end to end")
+    func customConfiguration() {
+        let configuration = LANRemotePairingCeremonyState.Configuration(
+            codeTTL: 10, rotateAfterFailures: 2, maxAttemptsPerConnection: 1
+        )
+        var state = LANRemotePairingCeremonyState(configuration: configuration)
+        state.begin(code: "042317", now: epoch)
+
+        #expect(state.isActive(now: epoch.addingTimeInterval(9.9)))
+        #expect(!state.isActive(now: epoch.addingTimeInterval(10.1)))
+        let firstRotated = state.recordFailure()
+        #expect(!firstRotated)
+        let secondRotated = state.recordFailure()
+        #expect(secondRotated)
+    }
+}
+
+@Suite("LANRemotePairingPayload QR string codec")
+struct LANRemotePairingPayloadTests {
+
+    @Test("A payload with every field present round-trips through encode/decode unchanged")
+    func roundTripFullPayload() throws {
+        let original = LANRemotePairingPayload(
+            name: "iHymns TV — Fellowship Hall", host: "192.168.1.42", port: 7269,
+            fingerprintHex: String(repeating: "ab", count: 32), code: "042317"
+        )
+        let encoded = try #require(original.encodeToQRString())
+        #expect(encoded.hasPrefix("ihymns-lanpair:v1:"))
+
+        let decoded = try #require(LANRemotePairingPayload(qrString: encoded))
+        #expect(decoded == original)
+    }
+
+    @Test("The Settings 'standing' QR (code: nil, host/port absent) round-trips with those fields absent")
+    func roundTripStandingQR() throws {
+        let original = LANRemotePairingPayload(name: "iHymns TV", fingerprintHex: String(repeating: "cd", count: 32))
+        let encoded = try #require(original.encodeToQRString())
+        let decoded = try #require(LANRemotePairingPayload(qrString: encoded))
+
+        #expect(decoded.code == nil)
+        #expect(decoded.host == nil)
+        #expect(decoded.port == nil)
+        #expect(decoded == original)
+    }
+
+    @Test("A string missing the version prefix is rejected")
+    func rejectsMissingPrefix() {
+        #expect(LANRemotePairingPayload(qrString: "not-a-pairing-code") == nil)
+    }
+
+    @Test("A prefixed but non-base64 payload is rejected")
+    func rejectsGarbageAfterPrefix() {
+        #expect(LANRemotePairingPayload(qrString: "ihymns-lanpair:v1:!!!not-base64!!!") == nil)
+    }
+
+    @Test("A prefixed, valid-base64, but non-JSON payload is rejected")
+    func rejectsNonJSONPayload() {
+        let garbage = Data("not json".utf8).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        #expect(LANRemotePairingPayload(qrString: "ihymns-lanpair:v1:" + garbage) == nil)
+    }
+
+    @Test("An empty string is rejected")
+    func rejectsEmptyString() {
+        #expect(LANRemotePairingPayload(qrString: "") == nil)
+    }
+}

--- a/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/LANRemotePairingProofTests.swift
+++ b/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/LANRemotePairingProofTests.swift
@@ -1,0 +1,154 @@
+// LANRemotePairingProofTests.swift
+// IHLiveTests
+//
+// ELI5: Proves the pairing-proof math actually works the way
+// `LANRemotePairingProof.swift`'s header says it does — same inputs always
+// give the same answer, changing ANY one input changes the answer, a
+// frozen "known good" example never silently drifts, and a wrong/garbled
+// proof is always rejected.
+//
+// DETAILED: #1421 (`.claude/apple-phase2-pr6-spec.md` §7.1 — BINDING).
+// The GOLDEN VECTOR below was computed ONCE, offline, straight from the
+// production `HKDF<SHA256>`/`HMAC<SHA256>` construction this test also
+// exercises live (`compute(...)` against the same three inputs, asserted
+// equal) — so this test is both "does the code match a frozen answer" AND
+// "is the frozen answer even still reachable by the real code," the same
+// double-duty a golden-vector test always does. The constant-time property
+// of `verify(...)` is a STRUCTURAL guarantee (it routes through CryptoKit's
+// `HMAC.isValidAuthenticationCode`, which this repo's review process — not
+// a timing benchmark — is the gate for per spec §7.1: "a timing benchmark
+// in CI would be noise, not signal"); this file instead asserts the
+// BEHAVIOURAL surface — every class of malformed/wrong input is rejected.
+import Foundation
+import Testing
+@testable import IHLive
+
+@Suite("LANRemotePairingProof compute/verify")
+struct LANRemotePairingProofTests {
+
+    // MARK: - Shape / determinism
+
+    @Test("compute() returns 64 lowercase hex characters")
+    func computeShape() {
+        let proof = LANRemotePairingProof.compute(code: "042317", fingerprintHex: "ab", nonceHex: "cd")
+        #expect(proof.count == 64)
+        #expect(proof.allSatisfy { $0.isHexDigit && !$0.isUppercase })
+    }
+
+    @Test("compute() is deterministic — identical inputs always produce the identical proof")
+    func computeIsDeterministic() {
+        let first = LANRemotePairingProof.compute(code: "042317", fingerprintHex: "ab", nonceHex: "cd")
+        let second = LANRemotePairingProof.compute(code: "042317", fingerprintHex: "ab", nonceHex: "cd")
+        #expect(first == second)
+    }
+
+    @Test("compute() changes if the code, fingerprint, or nonce individually changes")
+    func computeDiffersOnAnySingleInputChange() {
+        let base = LANRemotePairingProof.compute(code: "042317", fingerprintHex: "ab", nonceHex: "cd")
+        #expect(LANRemotePairingProof.compute(code: "999999", fingerprintHex: "ab", nonceHex: "cd") != base)
+        #expect(LANRemotePairingProof.compute(code: "042317", fingerprintHex: "ff", nonceHex: "cd") != base)
+        #expect(LANRemotePairingProof.compute(code: "042317", fingerprintHex: "ab", nonceHex: "ff") != base)
+    }
+
+    // MARK: - Golden vector (spec §7.1 — BINDING)
+
+    /// **Freezes the HKDF+HMAC construction exactly as `LANRemotePairingProof
+    /// .swift`'s header documents it.** If this test fails, you changed the
+    /// crypto, which breaks every already-paired remote in the field —
+    /// bump the pairing sub-protocol's version instead of touching the
+    /// construction to make this pass.
+    @Test("GOLDEN VECTOR — a frozen, known-good (code, fingerprint, nonce) → proof")
+    func goldenVector() {
+        let code = "042317"
+        let fingerprintHex = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+        let nonceHex = "0123456789abcdef0123456789abcde0"
+        let expectedProofHex = "8b88b703f398bab753db30059cfde2c10d61b3a18d2cc9640c312f6a89b08847"
+
+        // The frozen expectation itself must be exactly 64 lowercase hex
+        // characters (a typo'd literal above would otherwise silently
+        // test against a truncated/garbled "golden" value).
+        #expect(expectedProofHex.count == 64)
+
+        let actual = LANRemotePairingProof.compute(code: code, fingerprintHex: fingerprintHex, nonceHex: nonceHex)
+        #expect(actual == expectedProofHex)
+        #expect(LANRemotePairingProof.verify(proofHex: expectedProofHex, code: code, fingerprintHex: fingerprintHex, nonceHex: nonceHex))
+    }
+
+    // MARK: - verify() — accepts its own compute(), rejects everything else
+
+    @Test("verify() accepts a proof compute() itself just produced")
+    func verifyAcceptsOwnCompute() {
+        let proof = LANRemotePairingProof.compute(code: "042317", fingerprintHex: "ab12", nonceHex: "cd34")
+        #expect(LANRemotePairingProof.verify(proofHex: proof, code: "042317", fingerprintHex: "ab12", nonceHex: "cd34"))
+    }
+
+    @Test("verify() rejects the wrong code")
+    func verifyRejectsWrongCode() {
+        let proof = LANRemotePairingProof.compute(code: "042317", fingerprintHex: "ab12", nonceHex: "cd34")
+        #expect(!LANRemotePairingProof.verify(proofHex: proof, code: "999999", fingerprintHex: "ab12", nonceHex: "cd34"))
+    }
+
+    @Test("verify() rejects the wrong fingerprint")
+    func verifyRejectsWrongFingerprint() {
+        let proof = LANRemotePairingProof.compute(code: "042317", fingerprintHex: "ab12", nonceHex: "cd34")
+        #expect(!LANRemotePairingProof.verify(proofHex: proof, code: "042317", fingerprintHex: "ffff", nonceHex: "cd34"))
+    }
+
+    @Test("verify() rejects the wrong nonce")
+    func verifyRejectsWrongNonce() {
+        let proof = LANRemotePairingProof.compute(code: "042317", fingerprintHex: "ab12", nonceHex: "cd34")
+        #expect(!LANRemotePairingProof.verify(proofHex: proof, code: "042317", fingerprintHex: "ab12", nonceHex: "ffff"))
+    }
+
+    @Test("verify() rejects a truncated proof")
+    func verifyRejectsTruncatedProof() {
+        let proof = LANRemotePairingProof.compute(code: "042317", fingerprintHex: "ab12", nonceHex: "cd34")
+        let truncated = String(proof.prefix(10))
+        #expect(!LANRemotePairingProof.verify(proofHex: truncated, code: "042317", fingerprintHex: "ab12", nonceHex: "cd34"))
+    }
+
+    @Test("verify() rejects odd-length hex — a non-secret-dependent format rejection")
+    func verifyRejectsOddLengthHex() {
+        #expect(!LANRemotePairingProof.verify(proofHex: "abc", code: "042317", fingerprintHex: "ab12", nonceHex: "cd34"))
+    }
+
+    @Test("verify() rejects non-hex characters")
+    func verifyRejectsNonHex() {
+        let notHex = String(repeating: "zz", count: 32)
+        #expect(!LANRemotePairingProof.verify(proofHex: notHex, code: "042317", fingerprintHex: "ab12", nonceHex: "cd34"))
+    }
+
+    @Test("verify() rejects an empty proof")
+    func verifyRejectsEmptyProof() {
+        #expect(!LANRemotePairingProof.verify(proofHex: "", code: "042317", fingerprintHex: "ab12", nonceHex: "cd34"))
+    }
+
+    // MARK: - LANRemotePairingSecrets minting
+
+    @Test("mintCode() is 6 digits, zero-padded, from the injected generator")
+    func mintCodeZeroPadded() {
+        #expect(LANRemotePairingSecrets.mintCode(random: { 7 }) == "000007")
+        #expect(LANRemotePairingSecrets.mintCode(random: { 999_999 }) == "999999")
+        #expect(LANRemotePairingSecrets.mintCode(random: { 0 }) == "000000")
+    }
+
+    @Test("mintToken() is 64 lowercase hex characters")
+    func mintTokenShape() {
+        let token = LANRemotePairingSecrets.mintToken()
+        #expect(token.count == 64)
+        #expect(token.allSatisfy { $0.isHexDigit && !$0.isUppercase })
+    }
+
+    @Test("mintNonce() is 32 lowercase hex characters")
+    func mintNonceShape() {
+        let nonce = LANRemotePairingSecrets.mintNonce()
+        #expect(nonce.count == 32)
+        #expect(nonce.allSatisfy { $0.isHexDigit && !$0.isUppercase })
+    }
+
+    @Test("Two mints of the same kind are never equal")
+    func mintsAreNeverEqual() {
+        #expect(LANRemotePairingSecrets.mintToken() != LANRemotePairingSecrets.mintToken())
+        #expect(LANRemotePairingSecrets.mintNonce() != LANRemotePairingSecrets.mintNonce())
+    }
+}

--- a/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/LANRemoteTestSupport.swift
+++ b/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/LANRemoteTestSupport.swift
@@ -125,3 +125,77 @@ func lanRemoteKeychainIdentityAvailable() -> Bool {
     identity.removeFromKeychain()
     return true
 }
+
+/// A process-wide mutex every REAL-Keychain-touching LANRemote test wraps
+/// its body in — `await KeychainTestSerialization.shared.run { ... }`.
+///
+/// ELI5: "Only one Keychain test gets to actually talk to the Keychain at a
+/// time — everyone else politely waits their turn," so a burst of tests
+/// from DIFFERENT files never all hammer `Security.framework` at once.
+///
+/// DETAILED: #1421. Empirically REQUIRED (not just a nice-to-have): Swift
+/// Testing runs different `@Suite` types concurrently with each other by
+/// default — a PER-SUITE `.serialized` trait (which `LANRemoteIdentityTests`/
+/// `LANRemoteIdentityStoreTests`/`KeychainPairingAuthorityTests` all also
+/// carry) only stops a suite's OWN tests from overlapping EACH OTHER, not
+/// from overlapping ANOTHER suite's tests. Once this file grew a SECOND
+/// (`LANRemoteIdentityStoreTests`) and THIRD (`KeychainPairingAuthorityTests`)
+/// suite that call the SAME `LANRemoteIdentityFactory`/real Keychain APIs
+/// PR-4's original `LANRemoteIdentityTests` already used, running a plain
+/// `swift test` reproducibly hit TRANSIENT `errSecItemNotFound`/"failed to
+/// generate CDSA key" failures under concurrent `SecKeyCreateRandomKey`/
+/// `SecItemAdd`/`SecItemCopyMatching` load — a genuine macOS Keychain-daemon
+/// contention artifact under heavy simultaneous access from multiple
+/// threads, not a logic bug (a bounded retry was ALSO added in
+/// `LANRemoteIdentityFactory.generatePermanentKey(attributes:)` for the
+/// identical reason production code faces the same theoretical, if far
+/// rarer, contention window — this lock additionally eliminates it for the
+/// test suite specifically, since a real tvOS app never runs 13 Keychain
+/// tests concurrently the way this local package's test binary does).
+///
+/// A true mutex (not merely `.serialized`): `run(_:)` suspends a caller
+/// until any IN-PROGRESS call — INCLUDING one currently suspended at an
+/// `await` inside its own body — has fully finished, unlike a naive
+/// `actor`-isolated method (which Swift's actor-reentrancy rules would
+/// allow a SECOND caller to enter the moment the first one hits its own
+/// first `await`, defeating the whole point here).
+actor KeychainTestSerialization {
+    static let shared = KeychainTestSerialization()
+    private init() {}
+
+    private var isBusy = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    /// Runs `body` with exclusive access — every other concurrent caller
+    /// (from ANY suite) waits until this call fully completes (success OR
+    /// throw) before its own `body` begins.
+    func run<T: Sendable>(_ body: () async throws -> T) async throws -> T {
+        await acquire()
+        do {
+            let result = try await body()
+            release()
+            return result
+        } catch {
+            release()
+            throw error
+        }
+    }
+
+    private func acquire() async {
+        if !isBusy {
+            isBusy = true
+            return
+        }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    private func release() {
+        if waiters.isEmpty {
+            isBusy = false
+        } else {
+            waiters.removeFirst().resume()
+        }
+    }
+}

--- a/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/TVListenerPairingLoopbackTests.swift
+++ b/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/TVListenerPairingLoopbackTests.swift
@@ -1,0 +1,350 @@
+// TVListenerPairingLoopbackTests.swift
+// IHLiveTests
+//
+// ELI5: The REAL end-to-end proof that the whole pairing ceremony works —
+// a real TV listener and a real remote connection over `127.0.0.1`, real
+// TLS 1.3, actually running the code-entry dance: the TV challenges, the
+// remote computes a proof and answers, and the TV either lets it in or
+// rejects it, exactly as a real phone and a real TV would.
+//
+// DETAILED: #1421 (`.claude/apple-phase2-pr6-spec.md` §7.5). Verbatim
+// posture from `LANRemoteLoopbackTests.swift` (PR-4/#1420): opt-in behind
+// `IHYMNS_LAN_LOOPBACK_TESTS=1` (macOS Local Network Privacy blocks an
+// unsigned headless `swift test` binary from completing a REAL
+// `127.0.0.1` handshake — that file's header comment is the full
+// explanation, unchanged here), `advertiseViaBonjour: false`, connect by
+// explicit `.hostPort(...)`, and a `ManualLANRemoteClock` injected into the
+// LISTENER's `Configuration` specifically so the TTL/rotation tests can
+// drive the ceremony's clock deterministically (no real sleeps).
+import Foundation
+import IHModels
+import Network
+import Testing
+@testable import IHLive
+
+/// A test-double remote that drives the REAL pairing wire ceremony against
+/// a real `RemoteSessionActor` — this IS the exact recipe PR-7's real
+/// client will use: `LANRemotePairingProof.compute(...)` is the SAME
+/// public function the TV's `handlePairConfirm` verifies against (one
+/// implementation, two callers, per this repo's modularity rule).
+///
+/// ELI5: A pretend phone that actually does the pairing dance for real —
+/// connects, waits for the code-challenge, computes (or, for the invalid-
+/// proof tests, fakes) the proof, and sends it back.
+private struct PairingTestRemote {
+    let remote: RemoteSessionActor
+
+    init(kind: IHRPRemoteKind = .phone) {
+        remote = RemoteSessionActor(configuration: .init(kind: kind))
+    }
+
+    /// Connects fresh (no saved token) and waits for the TV's
+    /// `.pairChallenge`, returning the nonce it carries.
+    func connectAndAwaitChallenge(to endpoint: NWEndpoint, expectedFingerprint: String) async throws -> String {
+        try await remote.connect(to: endpoint, expectedFingerprint: expectedFingerprint, token: nil)
+        let frame = try await waitFor(remote.incomingMessages) { if case .pairChallenge = $0.message { true } else { false } }
+        guard case .pairChallenge(let nonce) = frame.message else {
+            throw LANRemoteTestTimeoutError()
+        }
+        return nonce
+    }
+
+    /// Computes the real proof (or, `invalidProof: true`, substitutes
+    /// garbage) and sends `.pairConfirm`.
+    func sendPairConfirm(code: String, fingerprintHex: String, nonce: String, deviceName: String? = nil, invalidProof: Bool = false) async throws {
+        let proof = invalidProof
+            ? String(repeating: "0", count: 64)
+            : LANRemotePairingProof.compute(code: code, fingerprintHex: fingerprintHex, nonceHex: nonce)
+        try await remote.send(.pairConfirm(proof: proof, deviceName: deviceName))
+    }
+}
+
+@Suite(
+    "TVListenerActor pairing ceremony — TLS loopback integration",
+    .enabled(
+        if: ProcessInfo.processInfo.environment["IHYMNS_LAN_LOOPBACK_TESTS"] == "1",
+        "Live 127.0.0.1 TLS loopback needs macOS Local Network permission an unsigned headless `swift test` binary can't obtain — set IHYMNS_LAN_LOOPBACK_TESTS=1 on a Mac where iHymns has that grant. See LANRemoteLoopbackTests.swift's header comment."
+    )
+)
+struct TVListenerPairingLoopbackTests {
+
+    /// - Parameter clock: Injectable so a TTL/rotation test can keep its
+    ///   OWN reference to advance later (`expiredCodeNeverCountsTowardRotation`)
+    ///   — returning a 3-tuple here would trip SwiftLint's `large_tuple`
+    ///   rule, so the caller supplies (and keeps) the clock instead of
+    ///   receiving it back.
+    private func makeListener(
+        maxUnpaired: Int = 4,
+        pairingAuthority: any LANRemotePairingAuthority = InMemoryLANRemotePairingAuthority(),
+        clock: any LANRemoteClock = ManualLANRemoteClock()
+    ) async throws -> (TVListenerActor, LANRemoteIdentity) {
+        // `KeychainTestSerialization` (`LANRemoteTestSupport.swift`) — every
+        // test in this suite calls `generateSelfSigned()`, and this suite's
+        // 6 tests run CONCURRENTLY by default; wrapping just the identity
+        // generation (not the whole test body, which is mostly network
+        // I/O that doesn't touch the Keychain) is enough to eliminate the
+        // SAME transient contention documented there.
+        let identity = try await KeychainTestSerialization.shared.run {
+            try LANRemoteIdentityFactory.generateSelfSigned()
+        }
+        let config = TVListenerActor.Configuration(
+            port: .any,
+            advertiseViaBonjour: false,
+            maxUnpairedConnections: maxUnpaired,
+            pairingAuthority: pairingAuthority,
+            clock: clock
+        )
+        let listener = TVListenerActor(identity: identity, configuration: config)
+        try await listener.start()
+        try await listener.waitUntilReady()
+        return (listener, identity)
+    }
+
+    private func hostPortEndpoint(port: NWEndpoint.Port) -> NWEndpoint {
+        .hostPort(host: "127.0.0.1", port: port)
+    }
+
+    // MARK: - Happy path: full ceremony, then a token-based reconnect skips it
+
+    @Test("beginPairing() → a remote pairs via the ceremony and receives .pairSuccess + .capabilities; reconnecting with the saved token skips the ceremony")
+    func happyPathCeremonyThenReconnect() async throws {
+        let (listener, identity) = try await makeListener()
+        defer { identity.removeFromKeychain() }
+        guard let port = await listener.boundPort else {
+            Issue.record("listener never bound a port")
+            return
+        }
+
+        let code = await listener.beginPairing()
+        let remote = PairingTestRemote()
+        let nonce = try await remote.connectAndAwaitChallenge(to: hostPortEndpoint(port: port), expectedFingerprint: identity.fingerprint)
+        try await remote.sendPairConfirm(code: code, fingerprintHex: identity.fingerprint, nonce: nonce, deviceName: "Test Phone")
+
+        let successFrame = try await waitFor(remote.remote.incomingMessages) { if case .pairSuccess = $0.message { true } else { false } }
+        guard case .pairSuccess(let token) = successFrame.message else {
+            Issue.record("expected .pairSuccess")
+            return
+        }
+        _ = try await waitFor(remote.remote.phaseUpdates) { if case .controlling = $0 { true } else { false } }
+
+        #expect(await listener.pairedConnectionCount == 1)
+        #expect(await remote.remote.currentPairingToken == token)
+
+        await remote.remote.disconnect()
+
+        // Reconnect with the saved token — straight to `.controlling`, the
+        // ceremony never runs again.
+        let reconnected = RemoteSessionActor(configuration: .init(kind: .phone))
+        try await reconnected.connect(to: hostPortEndpoint(port: port), expectedFingerprint: identity.fingerprint, token: token)
+        _ = try await waitFor(reconnected.phaseUpdates) { if case .controlling = $0 { true } else { false } }
+        #expect(await listener.pairedConnectionCount == 1)
+
+        await reconnected.disconnect()
+        await listener.stop()
+    }
+
+    // MARK: - Wrong proof: rejected in place, then the per-connection cap tears down
+
+    @Test("A wrong proof is rejected but the connection stays open; exceeding the per-connection attempt cap tears it down")
+    func wrongProofRejectedThenCapTearsDown() async throws {
+        let (listener, identity) = try await makeListener()
+        defer { identity.removeFromKeychain() }
+        guard let port = await listener.boundPort else {
+            Issue.record("listener never bound a port")
+            return
+        }
+
+        let code = await listener.beginPairing()
+        let remote = PairingTestRemote()
+        let nonce = try await remote.connectAndAwaitChallenge(to: hostPortEndpoint(port: port), expectedFingerprint: identity.fingerprint)
+
+        // 3 wrong proofs (§3.4's algorithm: `pairingAttempts <=
+        // maxAttemptsPerConnection`, default 3, all three still proceed to
+        // verify) — each rejected via `.pairingRejected`, NOT `.unauthorized`
+        // (`RemoteSessionActor` only disconnects on the latter), so the
+        // connection stays open every time.
+        for attemptIndex in 0..<3 {
+            try await remote.sendPairConfirm(code: code, fingerprintHex: identity.fingerprint, nonce: nonce, invalidProof: true)
+            let reply = try await waitFor(remote.remote.incomingMessages) { if case .error = $0.message { true } else { false } }
+            guard case .error(let errorCode, _) = reply.message else {
+                Issue.record("attempt \(attemptIndex): expected .error")
+                return
+            }
+            #expect(errorCode == .pairingRejected)
+        }
+        #expect(await remote.remote.phase.isConnected)
+
+        // The 4th attempt exceeds the cap outright — the TV tears the
+        // connection down without even checking the proof this time.
+        try await remote.sendPairConfirm(code: code, fingerprintHex: identity.fingerprint, nonce: nonce, invalidProof: true)
+        try await waitForCondition { await listener.unpairedConnectionCount == 0 }
+
+        await listener.stop()
+    }
+
+    // MARK: - Rotation: enough global wrong proofs (across ≤2 connections) rotates the code
+
+    @Test("5 wrong proofs across 2 connections rotates the code; the OLD code is now rejected, the NEW code pairs")
+    func rotationAfterFiveGlobalWrongProofs() async throws {
+        let (listener, identity) = try await makeListener()
+        defer { identity.removeFromKeychain() }
+        guard let port = await listener.boundPort else {
+            Issue.record("listener never bound a port")
+            return
+        }
+
+        let oldCode = await listener.beginPairing()
+
+        let remoteA = PairingTestRemote()
+        let nonceA = try await remoteA.connectAndAwaitChallenge(to: hostPortEndpoint(port: port), expectedFingerprint: identity.fingerprint)
+        let remoteB = PairingTestRemote()
+        let nonceB = try await remoteB.connectAndAwaitChallenge(to: hostPortEndpoint(port: port), expectedFingerprint: identity.fingerprint)
+
+        // Connection A: 3 wrong attempts (global wrongAttempts 1, 2, 3) —
+        // exactly its own per-connection cap, never exceeding it.
+        for _ in 0..<3 {
+            try await remoteA.sendPairConfirm(code: oldCode, fingerprintHex: identity.fingerprint, nonce: nonceA, invalidProof: true)
+            _ = try await waitFor(remoteA.remote.incomingMessages) { if case .error = $0.message { true } else { false } }
+        }
+        // Connection B: 2 wrong attempts (global 4, then 5 — the 5th GLOBAL
+        // failure triggers rotation, spec §3.4/Configuration default).
+        for _ in 0..<2 {
+            try await remoteB.sendPairConfirm(code: oldCode, fingerprintHex: identity.fingerprint, nonce: nonceB, invalidProof: true)
+            _ = try await waitFor(remoteB.remote.incomingMessages) { if case .error = $0.message { true } else { false } }
+        }
+
+        _ = try await waitFor(listener.pairingEvents) { if case .codeRotated = $0 { true } else { false } }
+        let newCode = await listener.activePairingCode
+        #expect(newCode != nil)
+        #expect(newCode != oldCode)
+
+        // A FRESH connection using the OLD code is rejected (it no longer
+        // matches `pairingCeremony.activeCode`).
+        let remoteC = PairingTestRemote()
+        let nonceC = try await remoteC.connectAndAwaitChallenge(to: hostPortEndpoint(port: port), expectedFingerprint: identity.fingerprint)
+        try await remoteC.sendPairConfirm(code: oldCode, fingerprintHex: identity.fingerprint, nonce: nonceC)
+        let oldCodeReply = try await waitFor(remoteC.remote.incomingMessages) { if case .error = $0.message { true } else { false } }
+        guard case .error(let oldCodeErrorCode, _) = oldCodeReply.message else {
+            Issue.record("expected .error for the old code")
+            return
+        }
+        #expect(oldCodeErrorCode == .pairingRejected)
+
+        // The SAME connection, now trying the NEW code (its 2nd attempt,
+        // still within its own cap of 3), pairs successfully.
+        try await remoteC.sendPairConfirm(code: newCode ?? "", fingerprintHex: identity.fingerprint, nonce: nonceC)
+        _ = try await waitFor(remoteC.remote.incomingMessages) { if case .pairSuccess = $0.message { true } else { false } }
+
+        await remoteA.remote.disconnect()
+        await remoteB.remote.disconnect()
+        await remoteC.remote.disconnect()
+        await listener.stop()
+    }
+
+    // MARK: - Expired code: rejected, and never counts toward rotation
+
+    @Test("An expired code's rejections never count toward rotation, even repeated well past the threshold")
+    func expiredCodeNeverCountsTowardRotation() async throws {
+        let clock = ManualLANRemoteClock()
+        let (listener, identity) = try await makeListener(clock: clock)
+        defer { identity.removeFromKeychain() }
+        guard let port = await listener.boundPort else {
+            Issue.record("listener never bound a port")
+            return
+        }
+
+        let code = await listener.beginPairing()
+        clock.advance(by: 121) // past the 120s TTL (spec §3.3 default)
+
+        // 6 attempts (one more than `rotateAfterFailures`'s default of 5) —
+        // if an expired-code rejection counted toward rotation, this would
+        // have DEFINITELY rotated by now (spec Decision D-5: it must not).
+        for attemptIndex in 0..<6 {
+            let remote = PairingTestRemote()
+            let nonce = try await remote.connectAndAwaitChallenge(to: hostPortEndpoint(port: port), expectedFingerprint: identity.fingerprint)
+            try await remote.sendPairConfirm(code: code, fingerprintHex: identity.fingerprint, nonce: nonce)
+            let reply = try await waitFor(remote.remote.incomingMessages) { if case .error = $0.message { true } else { false } }
+            guard case .error(let errorCode, _) = reply.message else {
+                Issue.record("attempt \(attemptIndex): expected .error")
+                return
+            }
+            #expect(errorCode == .pairingRejected)
+            await remote.remote.disconnect()
+        }
+
+        await #expect(throws: LANRemoteTestTimeoutError.self) {
+            _ = try await waitFor(listener.pairingEvents, timeout: .milliseconds(300)) { if case .codeRotated = $0 { true } else { false } }
+        }
+        #expect(await listener.activePairingCode == code)
+
+        await listener.stop()
+    }
+
+    // MARK: - No ceremony running at all
+
+    @Test("A proof sent without ever calling beginPairing() is rejected; the connection survives")
+    func noCeremonyRunningRejectsProof() async throws {
+        let (listener, identity) = try await makeListener()
+        defer { identity.removeFromKeychain() }
+        guard let port = await listener.boundPort else {
+            Issue.record("listener never bound a port")
+            return
+        }
+
+        // Deliberately never call `beginPairing()`.
+        let remote = PairingTestRemote()
+        let nonce = try await remote.connectAndAwaitChallenge(to: hostPortEndpoint(port: port), expectedFingerprint: identity.fingerprint)
+        try await remote.sendPairConfirm(code: "000000", fingerprintHex: identity.fingerprint, nonce: nonce)
+
+        let reply = try await waitFor(remote.remote.incomingMessages) { if case .error = $0.message { true } else { false } }
+        guard case .error(let errorCode, _) = reply.message else {
+            Issue.record("expected .error")
+            return
+        }
+        #expect(errorCode == .pairingRejected)
+        #expect(await remote.remote.phase.isConnected)
+
+        await remote.remote.disconnect()
+        await listener.stop()
+    }
+
+    // MARK: - Paired-connection injection guard (the handlePaired reject-list)
+
+    @Test("A PAIRED connection sending .pairConfirm gets .error(.malformedRequest); no ControlEvent is ever yielded")
+    func pairedConnectionInjectingPairConfirmIsRejected() async throws {
+        let authority = InMemoryLANRemotePairingAuthority()
+        let (listener, identity) = try await makeListener(pairingAuthority: authority)
+        defer { identity.removeFromKeychain() }
+        guard let port = await listener.boundPort else {
+            Issue.record("listener never bound a port")
+            return
+        }
+
+        let token = "pretrusted-token-\(UUID().uuidString)"
+        await authority.registerPairedToken(token)
+        let remote = RemoteSessionActor(configuration: .init(kind: .phone))
+        try await remote.connect(to: hostPortEndpoint(port: port), expectedFingerprint: identity.fingerprint, token: token)
+        _ = try await waitFor(remote.phaseUpdates) { if case .controlling = $0 { true } else { false } }
+
+        // A PAIRED remote sending `.pairConfirm` directly — never reachable
+        // through a legitimate client (PR-7 only sends it pre-pairing) —
+        // is exactly the injection attempt `handlePaired`'s reject-list
+        // guards against.
+        try await remote.send(.pairConfirm(proof: "irrelevant", deviceName: nil))
+        let reply = try await waitFor(remote.incomingMessages) { if case .error = $0.message { true } else { false } }
+        guard case .error(let errorCode, _) = reply.message else {
+            Issue.record("expected .error")
+            return
+        }
+        #expect(errorCode == .malformedRequest)
+
+        // No `ControlEvent` ever surfaces — asserted via a short-timeout
+        // expectation that `controlEvents` stays silent.
+        await #expect(throws: LANRemoteTestTimeoutError.self) {
+            _ = try await waitFor(listener.controlEvents, timeout: .milliseconds(300)) { _ in true }
+        }
+
+        await remote.disconnect()
+        await listener.stop()
+    }
+}

--- a/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/TVListenerPairingLoopbackTests.swift
+++ b/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/TVListenerPairingLoopbackTests.swift
@@ -76,11 +76,12 @@ struct TVListenerPairingLoopbackTests {
     private func makeListener(
         maxUnpaired: Int = 4,
         pairingAuthority: any LANRemotePairingAuthority = InMemoryLANRemotePairingAuthority(),
-        clock: any LANRemoteClock = ManualLANRemoteClock()
+        clock: any LANRemoteClock = ManualLANRemoteClock(),
+        pairingConfiguration: LANRemotePairingCeremonyState.Configuration = .init()
     ) async throws -> (TVListenerActor, LANRemoteIdentity) {
         // `KeychainTestSerialization` (`LANRemoteTestSupport.swift`) — every
         // test in this suite calls `generateSelfSigned()`, and this suite's
-        // 6 tests run CONCURRENTLY by default; wrapping just the identity
+        // tests run CONCURRENTLY by default; wrapping just the identity
         // generation (not the whole test body, which is mostly network
         // I/O that doesn't touch the Keychain) is enough to eliminate the
         // SAME transient contention documented there.
@@ -92,7 +93,8 @@ struct TVListenerPairingLoopbackTests {
             advertiseViaBonjour: false,
             maxUnpairedConnections: maxUnpaired,
             pairingAuthority: pairingAuthority,
-            clock: clock
+            clock: clock,
+            pairingConfiguration: pairingConfiguration
         )
         let listener = TVListenerActor(identity: identity, configuration: config)
         try await listener.start()
@@ -305,6 +307,50 @@ struct TVListenerPairingLoopbackTests {
         #expect(await remote.remote.phase.isConnected)
 
         await remote.remote.disconnect()
+        await listener.stop()
+    }
+
+    // MARK: - Cumulative brute-force ceiling: the WHOLE ceremony disarms
+
+    // Post-#1421 adversarial-review brute-force fix (spec §8): a low ceiling
+    // (3), reachable inside ONE connection's own 3-attempt cap, proves the
+    // exhaustion path without staging 15 real guesses across many connections.
+    @Test("Reaching the cumulative per-ceremony failure ceiling disarms the ceremony (.ceremonyExhausted); even the correct code then fails")
+    func cumulativeCeilingDisarmsCeremony() async throws {
+        let (listener, identity) = try await makeListener(pairingConfiguration: .init(maxCeremonyFailures: 3))
+        defer { identity.removeFromKeychain() }
+        guard let port = await listener.boundPort else {
+            Issue.record("listener never bound a port")
+            return
+        }
+
+        let code = await listener.beginPairing()
+        let remote = PairingTestRemote()
+        let nonce = try await remote.connectAndAwaitChallenge(to: hostPortEndpoint(port: port), expectedFingerprint: identity.fingerprint)
+
+        // 3 wrong proofs on one connection — the 3rd reaches the cumulative
+        // ceiling and disarms the ENTIRE ceremony (all within the 3/connection cap).
+        for _ in 0..<3 {
+            try await remote.sendPairConfirm(code: code, fingerprintHex: identity.fingerprint, nonce: nonce, invalidProof: true)
+            let reply = try await waitFor(remote.remote.incomingMessages) { if case .error = $0.message { true } else { false } }
+            guard case .error(let errorCode, _) = reply.message else { Issue.record("expected .error"); return }
+            #expect(errorCode == .pairingRejected)
+        }
+
+        _ = try await waitFor(listener.pairingEvents) { if case .ceremonyExhausted = $0 { true } else { false } }
+        #expect(await listener.activePairingCode == nil)   // disarmed, not merely rotated
+
+        // A FRESH connection presenting the ORIGINAL code is now rejected too —
+        // the ceremony is DEAD until the operator re-opens pairing.
+        let remote2 = PairingTestRemote()
+        let nonce2 = try await remote2.connectAndAwaitChallenge(to: hostPortEndpoint(port: port), expectedFingerprint: identity.fingerprint)
+        try await remote2.sendPairConfirm(code: code, fingerprintHex: identity.fingerprint, nonce: nonce2)
+        let reply2 = try await waitFor(remote2.remote.incomingMessages) { if case .error = $0.message { true } else { false } }
+        guard case .error(let exhaustedCode, _) = reply2.message else { Issue.record("expected .error after exhaustion"); return }
+        #expect(exhaustedCode == .pairingRejected)
+
+        await remote.remote.disconnect()
+        await remote2.remote.disconnect()
         await listener.stop()
     }
 

--- a/appApple/project.yml
+++ b/appApple/project.yml
@@ -216,6 +216,16 @@ targets:
         # its own answer to the Export Compliance question, not just the
         # iOS target's.
         INFOPLIST_KEY_ITSAppUsesNonExemptEncryption: NO
+        # #1421 (PR-6 spec §6.4, Decision D-8) — belt-and-braces, NOT
+        # load-bearing: per Apple TN3179 (Local Network Privacy), LISTENING
+        # for incoming connections and ADVERTISING a Bonjour service (both
+        # of which `TVListenerActor`/`TVRemoteControlCoordinator` do) are
+        # NOT restricted operations that trigger the Local Network
+        # permission prompt — only BROWSING/outgoing local-network traffic
+        # does, which is PR-7's `NWBrowser`-side concern on the `iHymns`
+        # target, not this one. This key is added defensively in case
+        # on-device testing shows tvOS prompting anyway.
+        INFOPLIST_KEY_NSLocalNetworkUsageDescription: "iHymns uses your local network so iPhones and iPads you pair can act as remote controls for this TV."
     dependencies:
       - package: iHymnsKit
         products: [IHFeatures, IHDesign]


### PR DESCRIPTION
## Apple Phase-2 **PR-6** — tvOS listener wiring + LAN-remote **pairing ceremony** + trusted-remotes Settings

Closes #1421 (base: **`alpha`** — "Closes" won't auto-close since alpha isn't default; will close manually on merge). Built from the Fable-designed spec `.claude/apple-phase2-pr6-spec.md` (§9's 4-commit plan) + a 5th commit hardening a gap found in adversarial security review.

**This PR is the security boundary of the whole LAN remote.** The §8 threat model below is acceptance criteria, not commentary.

### What it adds
- **IHRP/1 pairing sub-protocol** — 3 new `IHRPMessage` cases (`pairChallenge`/`pairConfirm`/`pairSuccess`) + a NEW non-disconnecting `IHRPErrorCode.pairingRejected` (a mistyped code must be retryable in place; `.unauthorized` still tears the connection down).
- **The one proof function** `LANRemotePairingProof` (public — PR-7's phone UI calls the same `compute`): `HKDF<SHA256>(code) → HMAC<SHA256>` over `fingerprint.nonce`, **constant-time verify** via `HMAC.isValidAuthenticationCode`. Channel-binding = the TV's own cert fingerprint; per-connection nonce = replay freshness. Frozen by a **golden vector** (independently reproduced from an RFC 5869 reference implementation during review).
- **Pure ceremony state machine** `LANRemotePairingCeremonyState` (TTL / single-use / rotation / **cumulative brute-force ceiling**) — clock-injected, no I/O.
- **Persistent TV identity** `LANRemoteIdentityStore` (same fingerprint every relaunch — the load-bearing pin-stability property) + the real **`KeychainLANRemotePairingAuthority`** (stores `sha256(token)` only, `synchronizable:false` hard-coded, fail-closed trust reads).
- **`TVListenerActor` ceremony wiring** + `TVPairingEvent` stream; **tvOS pairing overlay** (giant code + QR + fingerprint), **trusted-remotes Settings tab** (revoke drops live connections), and the **listener ↔ `ProjectionViewModel` bridge** PR-5 reserved.
- **QR payload codec** `LANRemotePairingPayload` (`ihymns-lanpair:v1:` base64url — the shape PR-7's scanner decodes; the standing Settings QR never carries a code).

### 🔒 Security review (done in-flight, as required)
An independent fresh-context Opus review + an adversarial "try to break it" pass traced all 9 attack classes to code. **Confirmed SOUND:** auth-bypass (reject-lists exhaustive), constant-time verify, channel binding, replay defence, keychain hash-at-rest/fail-closed, the rewritten identity bridging, log hygiene (no code/token/proof/nonce ever interpolated into any log line — grep-clean), protocol confinement, scope tripwires (no `synchronizable:true`, no `import Network` in IHFeatures, no TOFU, no new dependency).

**One MEDIUM gap found AND FIXED in this PR (commit 5):** the original design's "≤5 guesses per ceremony" was unmet — `recordFailure()` only *rotated* to a fresh random code (zero benefit against uniform guessing) and never *ended* the ceremony, so a LAN attacker could cycle connections indefinitely while the overlay is open. Fixed with a **cumulative `maxCeremonyFailures` (15) ceiling** that disarms the whole ceremony (sticky counter survives TTL re-arms + successful pairs) — caps an attacker at ~15 guesses/ceremony (0.0015%). Also fixed (LOW): idempotent repeat-`.hello` (no nonce re-mint / count inflation) and a `.remoteLeftPairing` on promotion.

**Deferred to the Audit-B gate (LOW, filed separately):** a narrow reconnect/revoke concurrency race in PR-4's merged fast-path — too subtle to rush into a security PR.

### ⚠️ Notable deviation for the reviewer
Commit 2 **rewrites merged-PR-4 `LANRemoteIdentity.swift`** — it fixes two latent Keychain identity-bridging bugs that only surface with a *persistent, reused* label (which PR-6 introduces): (1) the private key must be `kSecAttrIsPermanent:true` inside `SecKeyCreateRandomKey` so `SecIdentityCreateWithCertificate` finds it by the cert's public-key hash; (2) cert DER goes in a generic-password item, not `kSecClassCertificate` (whose label `SecItemAdd` silently overwrites from the Subject CN). Validated by real keychain + loopback-TLS tests (a broken bridge would fail the handshake).

### Verification (local, on macOS 26 / Swift 6.3.3)
- `swift build` — clean · `swift test` — **627 tests / 93 suites green**
- `IHYMNS_LAN_LOOPBACK_TESTS=1 swift test --filter Pairing` — **46 tests green** (full ceremony over real 127.0.0.1 TLS, incl. exhaustion, rotation, expired-code, paired-injection guard)
- `swiftlint` — **0 violations** · `loc-budget` — OK · `xcodegen generate` — clean

⚠️ **Apple CI is not a required check (#1526)** — please check this PR's `build` job after merge and fix forward if red. Close #1421 manually on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
