### PR TITLE
fix(apple): tvOS-compatible LAN-remote identity bridging (fixes PR-6 #1529 red build, #1421)

### DIFF
--- a/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/LANRemoteIdentity.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/LANRemoteIdentity.swift
@@ -31,46 +31,43 @@
 // same identity back on every subsequent launch.
 //
 // **Why `SecItemAdd`/Keychain at all, if persistence is out of scope?**
-// Apple's `Security.framework` has no PUBLIC API to construct a `SecIdentity`
-// (the type `NWProtocolTLS.Options`' local-identity setter requires) purely
-// in-memory from a `SecCertificate` + a matching `SecKey` — the documented
-// route this file uses is `SecIdentityCreateWithCertificate`, which bridges
-// a certificate to its MATCHING private key already present in the
-// Keychain (found by the certificate's own embedded public-key hash).
-// Every item this file adds is tagged with a UUID-unique label (unless a
-// persistent one is supplied, #1421) and is meant to be removed via
-// `removeFromKeychain()` once no longer needed (`LANRemoteTests` does this
-// in a `defer`) — this is Keychain used as unavoidable OS PLUMBING to
-// bridge two in-memory objects into the shape TLS needs, not as the
-// "remember this across app launches" persistence PR-6 owns.
+// Apple's `Security.framework` has no PUBLIC, CROSS-PLATFORM API to build a
+// `SecIdentity` (the type `NWProtocolTLS.Options`' local-identity setter
+// requires) purely in-memory from a `SecCertificate` + a matching `SecKey`.
+// `SecIdentityCreateWithCertificate` does exactly that — but it is **macOS-
+// ONLY** (its use in PR #1529 compiled locally via `swift build` for macOS
+// yet BROKE the tvOS Simulator build: "cannot find 'SecIdentityCreateWith
+// Certificate' in scope"). The portable route (iOS/tvOS/macOS) is the one
+// this file now uses: put the matching PRIVATE KEY and the CERTIFICATE both
+// in the Keychain, let the OS AUTO-FORM the identity, then retrieve it with
+// a `kSecClassIdentity` query. Every item is tagged by a UUID-unique label
+// (or a persistent one, #1421) and removed via `removeFromKeychain()`.
 //
-// **#1421 FIX #1 — the private key MUST be generated with
+// **#1421 FIX #1 (kept) — the private key MUST be generated with
 // `kSecAttrIsPermanent: true` directly inside `SecKeyCreateRandomKey`'s OWN
 // attributes, never generated ephemeral-then-`SecItemAdd`-ed afterward.**
-// Empirically verified: an ephemeral key added via a SEPARATE
-// `SecItemAdd(kSecValueRef:)` is findable again by its own custom
-// `kSecAttrLabel`, but `SecIdentityCreateWithCertificate` silently FAILS
-// (`errSecItemNotFound`) to bridge it against ANY matching certificate —
-// that second-hand add never wires up the key's `kSecAttrApplicationLabel`
-// (its public-key hash), the ONLY thing identity-bridging matches on.
-// Apple's documented "generate a keychain-resident key" pattern
+// A second-hand `SecItemAdd(kSecValueRef:)` never wires up the key's
+// `kSecAttrApplicationLabel` (its public-key hash), the ONLY thing the OS
+// matches a certificate to its key on when forming a `SecIdentity`. Apple's
+// documented "generate a keychain-resident key" pattern
 // (https://developer.apple.com/documentation/security/certificate_key_and_trust_services/keys/generating_new_cryptographic_keys)
 // fixes this on the first try.
 //
-// **#1421 FIX #2 — never store or look up the certificate via
-// `kSecClassCertificate` + `kSecAttrLabel`.** Also empirically verified:
-// `SecItemAdd` silently OVERWRITES a certificate's requested `kSecAttrLabel`
-// with a value derived from its own Subject Common Name — a custom-label
-// lookup is unreliable the instant two self-signed identities share a
-// Common Name (every call with this factory's default `commonName`, for
-// instance). This file never stores the certificate as a
-// `kSecClassCertificate` item; its DER bytes go into a plain
-// `kSecClassGenericPassword` item instead (the same reliable pattern
-// `KeychainTokenStore`/`KeychainLANRemotePairingAuthority` already use),
-// keyed by the caller's own `label`, reconstructed via
-// `SecCertificateCreateWithData` whenever `queryIdentity(label:)` needs it —
-// `SecIdentityCreateWithCertificate` never requires the certificate itself
-// to be a stored item, only the matching PRIVATE KEY does.
+// **#1421 FIX #2 (revised for the tvOS-build fix) — the certificate IS stored
+// as a `kSecClassCertificate` item (the OS needs BOTH key + cert present to
+// form the identity on iOS/tvOS), but it is NEVER LOOKED UP by
+// `kSecAttrLabel`** — `SecItemAdd` silently overwrites a certificate item's
+// label with its Subject Common Name, so a label lookup is unreliable the
+// instant two self-signed identities share a CN. Instead `queryIdentity`
+// ENUMERATES every formed `SecIdentity` and returns the one whose certificate
+// DER is byte-identical to ours (kept in a stable `kSecClassGenericPassword`
+// blob keyed by our own `label`). That DER match is label-independent — it
+// can never silently return an UNRELATED identity (the wrong-identity hazard
+// PR #1529 rightly worried about) — AND uses no macOS-only API, so it both
+// compiles and runs on tvOS. Uses each platform's DEFAULT keychain (file on
+// macOS, data-protection on tvOS) — deliberately NOT `kSecUseDataProtection
+// Keychain`, which an unsigned headless `swift test` binary can't access
+// (it would make the whole gated suite un-runnable on the dev Mac).
 import Foundation
 import Network
 import Security
@@ -219,6 +216,7 @@ public enum LANRemoteIdentityFactory {
         )
 
         try persistCertificateDER(certificateDER, label: label)
+        try addCertificateItem(certificateDER)
         let secIdentityRef = try queryIdentity(label: label)
 
         return LANRemoteIdentity(
@@ -301,93 +299,6 @@ public enum LANRemoteIdentityFactory {
             tbsCertificate, signatureAlgorithm, LANRemoteDER.bitString(Array(signature))
         ])
         return Data(certificate)
-    }
-
-    /// The `kSecClassGenericPassword` namespace the certificate DER bytes
-    /// are persisted under (this file's #1421 header update explains why
-    /// NOT `kSecClassCertificate`) — `kSecAttrAccount` is the caller's own
-    /// `label`, so each identity's certificate is independently addressable
-    /// the same way its private key is.
-    private static let certificateDERService = "app.ihymns.lanremote.identitycert"
-
-    /// Persists `der` (replace semantics — matches `KeychainTokenStore
-    /// .save(_:)`'s identical "delete any existing item first" convention)
-    /// so `queryIdentity(label:)` can reconstruct the certificate again in
-    /// a LATER process launch.
-    private static func persistCertificateDER(_ der: Data, label: String) throws {
-        SecItemDelete(certificateDERQuery(label: label) as CFDictionary)
-        var query = certificateDERQuery(label: label)
-        query[kSecValueData as String] = der
-        let status = SecItemAdd(query as CFDictionary, nil)
-        guard status == errSecSuccess else {
-            throw LANRemoteIdentityError.keychainBridgeFailed(status: status)
-        }
-    }
-
-    private static func certificateDERQuery(label: String) -> [String: Any] {
-        [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: certificateDERService,
-            kSecAttrAccount as String: label,
-            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock
-        ]
-    }
-
-    /// Looks up the `SecIdentity` bridged under `label` — `internal` (not
-    /// `private`, #1421 PR-6 spec §5.1) so `LANRemoteIdentityStore.swift`
-    /// (a DIFFERENT file, same `IHLive` module) can reuse this EXACT lookup
-    /// rather than duplicating it — this repo's "extract first, use
-    /// second" modularity rule applied to a same-module, cross-file helper.
-    ///
-    /// **#1421 FIX — never a direct `kSecClassIdentity`+`kSecAttrLabel`
-    /// query, and never `kSecClassCertificate`+`kSecAttrLabel` either.**
-    /// Both were empirically verified broken (this file's header). This
-    /// instead (1) reads the certificate's raw DER bytes back from the
-    /// reliable `kSecClassGenericPassword` store
-    /// `persistCertificateDER(_:label:)` wrote, (2) reconstructs a
-    /// `SecCertificate` via `SecCertificateCreateWithData`, then (3)
-    /// bridges it to a `SecIdentity` via `SecIdentityCreateWithCertificate`
-    /// — which finds the matching PERMANENT private key by the
-    /// certificate's own embedded public-key hash, never by a label.
-    ///
-    /// SECURITY-RELEVANT, not cosmetic: the ORIGINAL broken lookup meant
-    /// `TVListenerActor.start()` could silently build its TLS options from
-    /// a WRONG `SecIdentity` (some unrelated cert+key already in the login
-    /// keychain) whose ACTUAL presented fingerprint would never match the
-    /// `LANRemoteIdentity.fingerprint` shown to/pinned by a remote — every
-    /// real connection would then fail `RemoteSessionActor`'s pin check.
-    /// Existing tests never caught this because CI/most dev runs start
-    /// from a keychain with NO other identity present, where the
-    /// (unfiltered) match happened to coincide with the only identity that
-    /// existed.
-    static func queryIdentity(label: String) throws -> SecIdentity {
-        var query = certificateDERQuery(label: label)
-        query[kSecReturnData as String] = true
-        query[kSecMatchLimit as String] = kSecMatchLimitOne
-
-        var result: CFTypeRef?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
-        guard status == errSecSuccess, let der = result as? Data else {
-            throw LANRemoteIdentityError.keychainBridgeFailed(status: status)
-        }
-        guard let certificate = SecCertificateCreateWithData(nil, der as CFData) else {
-            throw LANRemoteIdentityError.certificateCreationFailed
-        }
-
-        var identityRef: SecIdentity?
-        let identityStatus = SecIdentityCreateWithCertificate(nil, certificate, &identityRef)
-        guard identityStatus == errSecSuccess, let identityRef else {
-            throw LANRemoteIdentityError.keychainBridgeFailed(status: identityStatus)
-        }
-        return identityRef
-    }
-
-    /// Removes the Keychain items tagged with `label` — see
-    /// `LANRemoteIdentity.removeFromKeychain()`'s doc comment.
-    static func removeFromKeychain(label: String) {
-        let keyQuery: [String: Any] = [kSecClass as String: kSecClassKey, kSecAttrLabel as String: label]
-        SecItemDelete(keyQuery as CFDictionary)
-        SecItemDelete(certificateDERQuery(label: label) as CFDictionary)
     }
 
     private static func describe(_ error: Unmanaged<CFError>?) -> String {

--- a/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/LANRemoteIdentityKeychain.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/LANRemoteIdentityKeychain.swift
@@ -1,0 +1,153 @@
+// LANRemoteIdentityKeychain.swift
+// IHLive/LANRemote
+//
+// ELI5: The Keychain plumbing half of the TV's TLS identity — "write the
+// certificate + key into the Keychain so the OS can pair them into an
+// identity," "find OUR identity again later," and "forget it." Split out of
+// `LANRemoteIdentity.swift` purely for the 400-line file budget
+// (`appApple/Scripts/loc-budget.sh`); the WHY of every decision here lives
+// in that file's header comment (read it first).
+//
+// DETAILED: #1421 (PR-6) + the ★ CI fix (PR #1529 broke the tvOS build by
+// reaching for the macOS-only `SecIdentityCreateWithCertificate`). This
+// extension holds the cross-platform bridge: BOTH the permanent private key
+// (`LANRemoteIdentity.swift`) AND the certificate item below are placed in
+// the Keychain so iOS/tvOS/macOS AUTO-FORM the `SecIdentity`, then
+// `queryIdentity(label:)` retrieves OURS by matching the exact certificate
+// DER bytes — never the macOS-only creation API, and never an OS-overwritten
+// `kSecAttrLabel`. Uses each platform's DEFAULT keychain (file on macOS,
+// data-protection on tvOS) so an unsigned headless `swift test` binary can
+// still exercise the gated suites on the dev Mac.
+import Foundation
+import Security
+
+extension LANRemoteIdentityFactory {
+
+    /// The `kSecClassGenericPassword` namespace the certificate DER bytes are
+    /// persisted under — `kSecAttrAccount` is the caller's own `label`, so
+    /// each identity's certificate DER is independently addressable and acts
+    /// as the STABLE "which certificate is ours" record `queryIdentity` uses.
+    private static let certificateDERService = "app.ihymns.lanremote.identitycert"
+
+    /// Persists `der` in the label-keyed generic-password blob (replace
+    /// semantics — `KeychainTokenStore.save(_:)`'s "delete first" convention).
+    /// This blob is how `queryIdentity(label:)` picks OUR `SecIdentity` out of
+    /// a keychain that may hold others, without the OS-overwritten cert label.
+    static func persistCertificateDER(_ der: Data, label: String) throws {
+        SecItemDelete(certificateDERQuery(label: label) as CFDictionary)
+        var query = certificateDERQuery(label: label)
+        query[kSecValueData as String] = der
+        let status = SecItemAdd(query as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            throw LANRemoteIdentityError.keychainBridgeFailed(status: status)
+        }
+    }
+
+    private static func certificateDERQuery(label: String) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: certificateDERService,
+            kSecAttrAccount as String: label,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock
+        ]
+    }
+
+    /// Adds the certificate as a real `kSecClassCertificate` item so the OS
+    /// AUTO-FORMS a `SecIdentity` from it + the matching permanent private key
+    /// (the cross-platform bridge — `SecIdentityCreateWithCertificate` is
+    /// **macOS-only** and its use in PR #1529 broke the tvOS build). Delete-
+    /// then-add by the SPECIFIC certificate value (never by label — the OS
+    /// derives a cert item's label from its Subject CN, which two same-CN
+    /// identities would collide on) keeps regenerate idempotent.
+    static func addCertificateItem(_ der: Data) throws {
+        guard let certificate = SecCertificateCreateWithData(nil, der as CFData) else {
+            throw LANRemoteIdentityError.certificateCreationFailed
+        }
+        let base: [String: Any] = [
+            kSecClass as String: kSecClassCertificate,
+            kSecValueRef as String: certificate
+        ]
+        SecItemDelete(base as CFDictionary)
+        let status = SecItemAdd(base as CFDictionary, nil)
+        guard status == errSecSuccess || status == errSecDuplicateItem else {
+            throw LANRemoteIdentityError.keychainBridgeFailed(status: status)
+        }
+    }
+
+    /// Looks up the `SecIdentity` for `label` — `internal` (not `private`,
+    /// #1421 PR-6 spec §5.1) so `LANRemoteIdentityStore.swift` reuses this
+    /// EXACT lookup rather than duplicating it.
+    ///
+    /// **Cross-platform, label-independent** (the ★ CI-fix reconciliation of
+    /// two constraints): (1) reads OUR certificate's DER from the stable
+    /// generic-password blob; (2) enumerates EVERY `SecIdentity` the keychain
+    /// has formed and returns the one whose certificate DER is byte-identical
+    /// to ours. Never calls the macOS-only `SecIdentityCreateWithCertificate`
+    /// (so it compiles AND runs on tvOS), and never trusts a `kSecAttrLabel`
+    /// the OS may have overwritten (so it can't silently return an UNRELATED
+    /// identity — the wrong-identity hazard PR #1529 rightly worried about,
+    /// solved without the macOS-only API).
+    ///
+    /// SECURITY-RELEVANT: `TVListenerActor.start()` builds its TLS options
+    /// from whatever this returns; matching on the exact DER bytes guarantees
+    /// the presented fingerprint equals `LANRemoteIdentity.fingerprint` a
+    /// remote pins against.
+    static func queryIdentity(label: String) throws -> SecIdentity {
+        var derQuery = certificateDERQuery(label: label)
+        derQuery[kSecReturnData as String] = true
+        derQuery[kSecMatchLimit as String] = kSecMatchLimitOne
+        var derResult: CFTypeRef?
+        let derStatus = SecItemCopyMatching(derQuery as CFDictionary, &derResult)
+        guard derStatus == errSecSuccess, let ourDER = derResult as? Data else {
+            throw LANRemoteIdentityError.keychainBridgeFailed(status: derStatus)
+        }
+
+        let identityQuery: [String: Any] = [
+            kSecClass as String: kSecClassIdentity,
+            kSecReturnRef as String: true,
+            kSecMatchLimit as String: kSecMatchLimitAll
+        ]
+        var identitiesResult: CFTypeRef?
+        let identityStatus = SecItemCopyMatching(identityQuery as CFDictionary, &identitiesResult)
+        guard identityStatus == errSecSuccess, let identities = identitiesResult as? [SecIdentity] else {
+            // No identities at all ⇒ treat as "not found" so `loadOrCreate`
+            // regenerates, rather than surfacing a raw non-notFound status.
+            throw LANRemoteIdentityError.keychainBridgeFailed(status: errSecItemNotFound)
+        }
+        for identity in identities {
+            var certificateRef: SecCertificate?
+            guard SecIdentityCopyCertificate(identity, &certificateRef) == errSecSuccess,
+                  let certificateRef else { continue }
+            if (SecCertificateCopyData(certificateRef) as Data) == ourDER {
+                return identity
+            }
+        }
+        throw LANRemoteIdentityError.keychainBridgeFailed(status: errSecItemNotFound)
+    }
+
+    /// Removes every Keychain item this identity generated — the permanent
+    /// private key (by its application tag = `label`), the generic-password
+    /// DER blob, and the `kSecClassCertificate` item (deleted by its exact
+    /// value, reconstructed from the blob's DER, so a same-CN cert belonging
+    /// to something else is never touched).
+    static func removeFromKeychain(label: String) {
+        // Reconstruct + delete the specific certificate item first (best
+        // effort — if the blob is already gone, skip it).
+        var derQuery = certificateDERQuery(label: label)
+        derQuery[kSecReturnData as String] = true
+        derQuery[kSecMatchLimit as String] = kSecMatchLimitOne
+        var derResult: CFTypeRef?
+        if SecItemCopyMatching(derQuery as CFDictionary, &derResult) == errSecSuccess,
+           let der = derResult as? Data, let certificate = SecCertificateCreateWithData(nil, der as CFData) {
+            SecItemDelete([
+                kSecClass as String: kSecClassCertificate,
+                kSecValueRef as String: certificate
+            ] as CFDictionary)
+        }
+        SecItemDelete([
+            kSecClass as String: kSecClassKey,
+            kSecAttrApplicationTag as String: Data(label.utf8)
+        ] as CFDictionary)
+        SecItemDelete(certificateDERQuery(label: label) as CFDictionary)
+    }
+}


### PR DESCRIPTION
## Fix-forward: PR-6's tvOS build (broke on `alpha` after auto-merge)

Base: **`alpha`**. Follows **#1529** (PR-6), which auto-merged on the required PHP+Lint checks while its Apple `build` job was still pending — then went **red** (Apple CI isn't a required check, the #1526 trap).

### Root cause
PR-6's identity rewrite used **`SecIdentityCreateWithCertificate`**, which is **macOS-only**. It compiled under my local `swift build` (macOS) but failed the tvOS Simulator build (`cannot find 'SecIdentityCreateWithCertificate' in scope`). tvOS is the whole point of this feature (the TV listener), so this had to be a true cross-platform bridge.

### Fix
Cross-platform, **label-independent** identity bridging:
- Store the certificate as a `kSecClassCertificate` item next to the permanent private key → iOS/tvOS/macOS **auto-form** the `SecIdentity`.
- Retrieve OUR identity by **enumerating** formed identities and matching the **exact certificate DER bytes** (kept in a stable label-keyed generic-password blob). No macOS-only API; no reliance on an OS-overwritten cert label. This also *properly* closes the wrong-identity hazard the rewrite was chasing — a DER match can't return an unrelated identity.
- Use each platform's **default** keychain (file on macOS, data-protection on tvOS) — deliberately **not** `kSecUseDataProtectionKeychain`, which an unsigned headless `swift test` binary can't access (it would skip the whole gated suite on the dev Mac).
- Split the Keychain plumbing into `LANRemoteIdentityKeychain.swift` for the 400-line budget.

### Validated on BOTH platforms locally
- ✅ **tvOS Simulator `xcodebuild build` SUCCEEDED** (the exact CI command) — the failure is resolved
- ✅ macOS keychain-gated tests **run + pass**: same-fingerprint-across-loads, `makeServerTLSOptions()` on a **loaded** identity, two identities never collide (proves the DER match picks the right one)
- ✅ full macOS suite **627 green**; pairing loopback (real TLS) **46 green**; swiftlint **0**; loc-budget **OK**

⚠️ Apple CI still isn't a required check (#1526) — please verify this PR's `build` job goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
