### PR TITLE
feat(ops): log OPcache resets to the Activity Log (#1537, rebuilt from unmerged fb450d32)

### DIFF
--- a/appWeb/public_html/manage/setup-database.php
+++ b/appWeb/public_html/manage/setup-database.php
@@ -1586,6 +1586,30 @@ if ($action !== '') {
             echo "Log. If the 'Unknown column s.SongbookName' errors STOP, stale OPcache was the cause\n";
             echo "(the deployed code is already correct). If they persist, the deploy didn't upload the\n";
             echo "current SongData.php — tell me and we'll fix the deploy itself.\n";
+            /* #1290 — mirror opcache-bust.php's Activity-Log entry so a MANUAL
+               reset from this dashboard is auditable alongside the automated
+               cron busts: same action key + EntityType (trigger='manual').
+               This handler already runs authenticated as a global_admin with
+               the DB + app bootstrap loaded, so a direct call is safe — no
+               require/try-catch gymnastics needed, and logActivity() is itself
+               best-effort and never throws. Logs nothing derived from the
+               secret key or raw request input — only the reset outcome +
+               environment. (Rebuilt for current alpha in the 2026-07-11 branch
+               audit from the never-merged fb450d32; see #1537.) */
+            if (function_exists('logActivity')) {
+                logActivity(
+                    'ops.opcache_reset',
+                    'runtime',
+                    'opcache',
+                    [
+                        'trigger'           => 'manual',
+                        'reset'             => (bool) $reset,
+                        'opcache_available' => function_exists('opcache_reset'),
+                        'environment'       => function_exists('ihymns_environment') ? ihymns_environment() : null,
+                    ],
+                    $actionSuccess ? 'success' : 'error'
+                );
+            }
         }
     } elseif ($action === 'deploy-forensics') {
         /* #1295 — READ-ONLY deploy forensics. The live site INTERMITTENTLY throws

--- a/appWeb/public_html/opcache-bust.php
+++ b/appWeb/public_html/opcache-bust.php
@@ -113,8 +113,48 @@ $available = function_exists('opcache_reset');
 $reset     = $available ? @opcache_reset() : false;
 clearstatcache(true);
 
+/* ---- Best-effort Activity-Log entry (#1290). ----------------------------
+   The bust above has ALREADY run — logging here is observability only. We pull
+   in the long-lived DB + logging includes (present in every live docroot) via
+   the same __DIR__-relative convention as api.php / index.php. The ENTIRE
+   require + log is wrapped so a DB outage, a missing tblActivityLog, or ANY
+   throwable can never break or delay the reset response. We deliberately log
+   NOTHING derived from the secret key or any raw request input — only the reset
+   outcome + environment. Sits AFTER the 503-unconfigured / 403-token / rate-
+   limit guards above, so an unauthenticated caller can never cause a DB write.
+   (Rebuilt for current alpha in the 2026-07-11 branch audit from the never-
+   merged fb450d32; see #1537.) */
+$logged = false;
+try {
+    require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'db_mysql.php';
+    require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'activity_log.php';
+    /* Also load environment.php so the log's `environment` field is populated
+       even in this minimal standalone endpoint (an improvement over fb450d32,
+       whose auto-deploy log left it null); require_once is idempotent. */
+    require_once __DIR__ . DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'environment.php';
+    logActivity(
+        'ops.opcache_reset',
+        'runtime',
+        'opcache',
+        [
+            'trigger'           => 'auto-deploy',
+            'reset'             => (bool) $reset,
+            'opcache_available' => $available,
+            'environment'       => function_exists('ihymns_environment') ? ihymns_environment() : null,
+        ],
+        $reset ? 'success' : 'error'
+    );
+    $logged = true;
+} catch (\Throwable $e) {
+    /* Swallow — logging must NEVER break or delay the bust, especially if the
+       DB is down (getDbMysqli() runs under MYSQLI_REPORT_STRICT and throws).
+       One error_log line lets an operator spot a sustained logging outage. */
+    error_log('[opcache-bust] activity log failed: ' . $e->getMessage());
+}
+
 echo json_encode([
     'ok'                => true,
     'reset'             => (bool) $reset,
     'opcache_available' => $available,
+    'logged'            => $logged,
 ]);


### PR DESCRIPTION
Rebuilt cleanly against current alpha (not cherry-picked) — the only genuinely-unmerged feature found in the 2026-07-11 branch audit. Both the automated `opcache-bust.php` bust and the manual `setup-database.php` reset now log an `ops.opcache_reset` Activity-Log entry.

- **Best-effort + fail-safe**: the auto-deploy path wraps the whole require + log in `try/catch(\Throwable)` so a DB outage can never break/delay the bust; adds `logged` to the JSON.
- **Correctly placed**: the manual block sits in the opcache-reset handler (not the adjacent deploy-forensics handler #1295, where the abandoned auto-merge mis-placed it).
- **Improvement over the original fb450d32**: also loads `environment.php` so the `environment` field is populated (was null before).
- Reuses shared `logActivity()`; logs nothing from the secret key or raw input. `php -l` clean.

Closes #1537. Base: `alpha`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)