### PR TITLE
fix(setlist): hide 'Import to My Set Lists' on your OWN shared set list (#1535)

### DIFF
--- a/appWeb/public_html/api.php
+++ b/appWeb/public_html/api.php
@@ -1842,22 +1842,40 @@ if ($action !== null) {
                 break;
             }
 
-            /* Raw snapshot — id / created / updated only (the resolver projects
-               name/songs/arrangements/live). Private owner keys are never read here. */
+            /* Raw snapshot — id / created / updated + the PRIVATE owner id (used
+               ONLY for the isOwner comparison below; never echoed). The resolver
+               projects name/songs/arrangements/live. */
             $meta = sharedSetlistGet($shareId);
 
             sharedSetlistMarkViewed($shareId);
 
+            /* #1535 — is the CURRENT authenticated viewer this share's OWNER? The
+               client suppresses the "shared with you" banner + the Import buttons
+               for the owner (importing your own set list into itself is
+               nonsensical) and shows an owner note instead. This is a BOOLEAN
+               ONLY — the owner's identity (_ownerUserId) is NEVER echoed, so the
+               public-safe allow-list below is unchanged. No auth, no live-link
+               owner, or a different user ⇒ false. */
+            $viewerIsOwner     = false;
+            $sharedOwnerUserId = $meta['_ownerUserId'] ?? null;
+            if ($sharedOwnerUserId !== null) {
+                $viewer = getAuthenticatedUser();
+                if ($viewer !== null && (int)($viewer['Id'] ?? 0) === (int)$sharedOwnerUserId) {
+                    $viewerIsOwner = true;
+                }
+            }
+
             /* PUBLIC-SAFE response — strict ALLOW-LIST. NEVER echo any of the
                owner-identifying fields: owner (anon UUID), _ownerUserId,
                _sourceSetlistId, CreatedBy, or any email. The only fields that
-               leave the server are: id, name, songs, live, created, updated, and
-               (optionally) arrangements. (#1380) */
+               leave the server are: id, name, songs, live, isOwner (a boolean),
+               created, updated, and (optionally) arrangements. (#1380 / #1535) */
             $response = [
                 'id'      => $meta['id'] ?? $shareId,
                 'name'    => $wire['name'],
                 'songs'   => $wire['songs'],
                 'live'    => $wire['live'],
+                'isOwner' => $viewerIsOwner,
                 'created' => $meta['created'] ?? null,
                 'updated' => $meta['updated'] ?? null,
             ];

--- a/appWeb/public_html/includes/pages/setlist-shared.php
+++ b/appWeb/public_html/includes/pages/setlist-shared.php
@@ -59,8 +59,9 @@ declare(strict_types=1);
     <!-- Shared set list content (hidden by default, populated by JS) -->
     <div id="shared-setlist-content" class="d-none">
 
-        <!-- Shared indicator banner -->
-        <div class="alert alert-info d-flex align-items-center gap-2 mb-3" role="status">
+        <!-- Shared indicator banner — hidden by JS for the OWNER (#1535), who
+             sees the owner note below instead of a "shared with you" message. -->
+        <div id="shared-setlist-banner" class="alert alert-info d-flex align-items-center gap-2 mb-3" role="status">
             <i class="fa-solid fa-share-nodes" aria-hidden="true"></i>
             <div>
                 <strong>Shared Set List</strong>
@@ -72,6 +73,18 @@ declare(strict_types=1);
                     <i class="fa-solid fa-rotate me-1" aria-hidden="true"></i>
                     This set list updates live — you&rsquo;ll always see the latest version.
                 </small>
+            </div>
+        </div>
+
+        <!-- #1535 — Owner-viewing-own-share note. Shown by JS only when the
+             server reports data.isOwner (the signed-in viewer IS this share's
+             owner), replacing the "shared with you" banner + Import buttons.
+             Also reinforces the #1380 live-share model for the owner. -->
+        <div id="shared-setlist-owner-note" class="alert alert-secondary d-flex align-items-center gap-2 mb-3 d-none" role="status">
+            <i class="fa-solid fa-user-check" aria-hidden="true"></i>
+            <div>
+                <strong>This is your set list</strong>
+                <small class="d-block">You&rsquo;re viewing your own shared link — there&rsquo;s nothing to import. Anyone you shared it with always sees your latest changes.</small>
             </div>
         </div>
 

--- a/appWeb/public_html/js/modules/setlist.js
+++ b/appWeb/public_html/js/modules/setlist.js
@@ -1481,7 +1481,14 @@ export class SetList {
         try {
             const url = `${this.app.config.apiUrl}?action=setlist_get&id=${encodeURIComponent(shareId)}`;
             const response = await fetch(url, {
-                headers: { 'X-Requested-With': 'XMLHttpRequest' },
+                headers: {
+                    'X-Requested-With': 'XMLHttpRequest',
+                    /* #1535 — send the bearer token when signed in so the server
+                       can tell whether the VIEWER is this share's OWNER. Anonymous
+                       viewers send no token and are never treated as the owner
+                       (they still see the share + Import normally). */
+                    ...(this.app?.userAuth?.authHeaders?.() || {}),
+                },
             });
 
             /* #1380 — 410 Gone: the share was a LIVE link to a setlist the owner
@@ -1504,6 +1511,9 @@ export class SetList {
                 /* #1380 — true when the server resolved the owner's CURRENT setlist
                    (a live link); the page can note "updates live" to the viewer. */
                 live: data.live === true,
+                /* #1535 — true when the signed-in viewer IS this share's owner, so
+                   the page hides the "shared with you" banner + Import buttons. */
+                isOwner: data.isOwner === true,
             };
         } catch {
             return null;
@@ -1625,6 +1635,17 @@ export class SetList {
             liveNoteEl.classList.toggle('d-none', !sharedData.live);
         }
 
+        /* #1535 — the OWNER viewing their OWN shared link shouldn't be told it was
+           "shared with you" nor offered to Import it into itself. Hide the shared
+           banner + both Import buttons and show the owner note instead; a non-owner
+           / anonymous viewer keeps the normal shared+import UI. (The live-link note
+           above stays useful — those are the owner's own edits flowing through.) */
+        const viewerIsOwner = sharedData.isOwner === true;
+        document.getElementById('shared-setlist-banner')?.classList.toggle('d-none', viewerIsOwner);
+        document.getElementById('shared-setlist-owner-note')?.classList.toggle('d-none', !viewerIsOwner);
+        document.getElementById('shared-setlist-import-btn')?.classList.toggle('d-none', viewerIsOwner);
+        document.getElementById('shared-setlist-import-btn-bottom')?.classList.toggle('d-none', viewerIsOwner);
+
         if (titleEl) titleEl.textContent = sharedData.name;
         if (countEl) countEl.textContent = sharedData.songIds.length;
         if (pluralEl) pluralEl.textContent = sharedData.songIds.length !== 1 ? 's' : '';
@@ -1653,19 +1674,22 @@ export class SetList {
         /* Enrich song items with metadata from the API */
         this.enrichSharedSongItems(sharedData.songIds);
 
-        /* Bind import buttons */
-        const importHandler = async () => {
-            const imported = await this.importSharedSetlist(sharedData);
-            if (imported) {
-                this.app.showToast(`Set list "${sharedData.name}" imported with ${imported.songs.length} songs`, 'success', 3000);
-                this.app.router.navigate('/setlist');
-            } else {
-                this.app.showToast('Failed to import set list', 'danger', 3000);
-            }
-        };
+        /* Bind import buttons — skipped entirely for the owner (#1535); their
+           buttons are hidden above, so there's nothing to import into itself. */
+        if (!viewerIsOwner) {
+            const importHandler = async () => {
+                const imported = await this.importSharedSetlist(sharedData);
+                if (imported) {
+                    this.app.showToast(`Set list "${sharedData.name}" imported with ${imported.songs.length} songs`, 'success', 3000);
+                    this.app.router.navigate('/setlist');
+                } else {
+                    this.app.showToast('Failed to import set list', 'danger', 3000);
+                }
+            };
 
-        document.getElementById('shared-setlist-import-btn')?.addEventListener('click', importHandler);
-        document.getElementById('shared-setlist-import-btn-bottom')?.addEventListener('click', importHandler);
+            document.getElementById('shared-setlist-import-btn')?.addEventListener('click', importHandler);
+            document.getElementById('shared-setlist-import-btn-bottom')?.addEventListener('click', importHandler);
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes the bug in your screenshot: opening the share link for a set list **you created** still showed the "shared with you" banner + both **Import to My Set Lists** buttons.

**Fix (server + client, no PII leak):**
- `setlist_get` compares the authenticated PWA viewer against the share's `_ownerUserId` (already stored for the #1380 live-link) and returns a **boolean `isOwner`** — the owner's identity is never echoed; the public-safe allow-list is unchanged.
- The shared-fetch now sends the bearer token (like `setlist_share` already does) so the server can identify the viewer. Anonymous viewers send no token → never treated as owner.
- Client hides the banner + both Import buttons for the owner and shows an **owner note** that also clarifies the live-share model ("anyone you shared it with always sees your latest changes") — directly addressing your #1534 question.

**Also answers #1534:** the live-ownership model already exists (#1380) — a shared set list resolves the owner's *current* set list at read time, so the owner's edits propagate to everyone it was shared with, even after they import. (A separate "Duplicate to a detached copy" affordance could be a follow-up if you want one.)

php -l + node --check clean; `setlist_get` is a read (no CSRF); no owner PII leaves the server. Closes #1535. Base: `alpha`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)