### PR TITLE
fix(admin): readable contrast + plain-English wording on Credit People promote buttons (#1542/#1543)

### DIFF
--- a/appWeb/public_html/css/admin.css
+++ b/appWeb/public_html/css/admin.css
@@ -506,8 +506,18 @@ body:has(.navbar-admin) {
 
 .btn-amber-solid {
     color: #fff;
-    background: linear-gradient(135deg, var(--accent-start), var(--accent-end));
-    border: 1px solid var(--accent-solid);
+    /* A SOLID call-to-action with WHITE text needs a consistently dark-enough
+       background in EVERY theme. The theme's --accent-* are tuned for text/links
+       on a dark surface, so dark mode LIGHTENS them (indigo-400 #818cf8 →
+       violet-400 #a78bfa) — which drops white-on-button contrast to ~2:1, well
+       below WCAG 2.2 AA (the unreadable "Bulk promote" button, #1542). Pin a
+       fixed indigo-600 → violet-600 gradient here instead: white text scores
+       ≈6.7:1 / ≈5.2:1 (AA pass) in light, dark AND colour-blind modes, and it
+       stays visually on-brand. High-contrast mode re-pins to its own maximal
+       #0000cc token below. Systematic fix for every such reuse is tracked in
+       #1542. */
+    background: linear-gradient(135deg, #4f46e5, #7c3aed);
+    border: 1px solid #4f46e5;
     font-weight: 600;
     transition: filter var(--transition-fast),
                 transform var(--transition-fast);
@@ -521,6 +531,12 @@ body:has(.navbar-admin) {
 .btn-amber-solid:active {
     transform: translateY(1px);
     filter: brightness(0.95);
+}
+/* High-contrast theme re-pins this button to its maximal-contrast accent
+   (#0000cc) — white text on it is very high contrast (#1542). */
+[data-ihymns-theme="high-contrast"] .btn-amber-solid {
+    background: var(--accent-solid);
+    border-color: var(--accent-solid);
 }
 
 /* ==========================================================================

--- a/appWeb/public_html/manage/credit-people.php
+++ b/appWeb/public_html/manage/credit-people.php
@@ -1873,18 +1873,21 @@ $totalInUseUnregistered = count(array_filter($people, static fn($p) =>
                 <i class="bi bi-people" aria-hidden="true"></i>
                 <span>
                     <strong><?= number_format($totalInUseUnregistered) ?></strong>
-                    name<?= $totalInUseUnregistered === 1 ? '' : 's' ?> cited on at least one song
-                    <em>aren't</em> in the registry yet.
+                    <?= $totalInUseUnregistered === 1 ? 'person is' : 'people are' ?> credited on a song
+                    but <em><?= $totalInUseUnregistered === 1 ? "isn't" : "aren't" ?></em> saved to Credit People yet.
                 </span>
+                <!-- #1543 — plain-English CTA labels. The action still "promotes"
+                     (bulk_register_unregistered) internally; only the user-facing
+                     wording changed so non-technical admins understand it. -->
                 <a href="/manage/credit-people-bulk-promote" class="btn btn-sm btn-amber-solid ms-auto">
-                    <i class="bi bi-magic me-1"></i>Bulk promote with fuzzy-match
+                    <i class="bi bi-magic me-1"></i>Review &amp; add (checks for duplicates)
                 </a>
                 <form method="POST" class="d-inline"
-                      onsubmit="return confirm('Register all <?= (int)$totalInUseUnregistered ?> remaining cited-but-unregistered name(s) as new registry entries?\n\nThis skips the fuzzy-match duplicate review — use &quot;Bulk promote with fuzzy-match&quot; instead if you want to check for near-duplicates first.');">
+                      onsubmit="return confirm('Add all <?= (int)$totalInUseUnregistered ?> credited <?= $totalInUseUnregistered === 1 ? 'person' : 'people' ?> to Credit People as new entries?\n\nThis adds them straight away, without checking for possible duplicates first. Use &quot;Review &amp; add&quot; instead if you want to check for near-duplicates.');">
                     <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
                     <input type="hidden" name="action" value="bulk_register_unregistered">
                     <button type="submit" class="btn btn-sm btn-outline-info">
-                        <i class="bi bi-person-plus me-1"></i>Promote all remaining (<?= number_format($totalInUseUnregistered) ?>)
+                        <i class="bi bi-person-plus me-1"></i>Add all <?= number_format($totalInUseUnregistered) ?> now
                     </button>
                 </form>
             </div>


### PR DESCRIPTION
Fixes the two issues from your screenshot on the **Credit People** page.

**1. Contrast (#1542):** the "Bulk promote" button used **white text on the theme accent**, which dark mode lightens to `#818cf8→#a78bfa` — white-on-that is ~2:1, unreadable. A solid white-text CTA needs a dark-enough background in every mode, so it's now pinned to a fixed **indigo-600→violet-600** gradient (white ≈6.7:1 / ≈5.2:1 — **WCAG AA** in light, dark AND colour-blind modes), with a high-contrast override keeping its `#0000cc`.

**2. Wording (#1543):** the jargon ("promote", "registry", "fuzzy-match") → plain English:
- "Bulk promote with fuzzy-match" → **"Review & add (checks for duplicates)"**
- "Promote all remaining (N)" → **"Add all N now"**
- banner → **"N people are credited on a song but aren't saved to Credit People yet"**; confirm dialog matches.
- Internal action unchanged — user-facing copy only.

These are the **acute** fixes; the systematic **all-modes contrast + palette refresh (#1542)** and **product-wide de-jargon sweep (#1543)** are queued epics (with #1544 i18n + #1545 accessibility). `php -l` clean; CSS braces balanced. Base: `alpha`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)