### PR TITLE
feat(pwa): show full Songbook NAME (not abbreviation) in list views (#1531 part 1)

### DIFF
--- a/appWeb/public_html/js/app.js
+++ b/appWeb/public_html/js/app.js
@@ -56,6 +56,7 @@ import {
     STORAGE_DEFAULT_SONGBOOK,
     STORAGE_DISCLAIMER_ACCEPTED,
     STORAGE_AUTO_UPDATE_SONGS,
+    loadSongbookRegistry,
 } from './constants.js';
 
 /**
@@ -166,6 +167,14 @@ class iHymnsApp {
              * are available immediately (#133, Layer 1). */
             this.subdomainSync = new SubdomainSync();
             this.subdomainSync.init();
+
+            /* #1531 — populate the client songbook registry (abbr → full name)
+               once, fire-and-forget, so every list view can show the full
+               Songbook NAME instead of the abbreviation. Best-effort and
+               non-blocking: songbookLabel() falls back to the abbreviation until
+               this resolves (list views are navigated to after init, by which
+               time it's ready). */
+            loadSongbookRegistry(this.config.apiUrl);
 
             /* Settings must be first — it sets theme, motion prefs, etc. */
             this.settings = new Settings(this);

--- a/appWeb/public_html/js/constants.js
+++ b/appWeb/public_html/js/constants.js
@@ -92,8 +92,61 @@ function _escSongbook(s) {
  * @returns {string} HTML with both spans
  */
 export function songbookLabel(abbr, fullName) {
-    const full = fullName || SONGBOOK_NAMES[abbr] || abbr;
+    /* #1531 — resolve order: an explicit override → the client songbook
+       registry (covers EVERY songbook, loaded once from /api?action=songbooks)
+       → the six hardcoded fallbacks → the abbreviation. This is what makes
+       list views (setlists, favourites, search, home) show the full Songbook
+       NAME rather than the abbreviation, for all songbooks not just the six. */
+    const full = fullName || songbookFullName(abbr) || SONGBOOK_NAMES[abbr] || abbr;
     const safeAbbr = _escSongbook(abbr);
     if (full === abbr) return safeAbbr; /* no full name available */
     return `<span class="songbook-name-full">${_escSongbook(full)}</span><span class="songbook-name-abbr">${safeAbbr}</span>`;
+}
+
+/* ── #1531 — Client songbook registry ──────────────────────────────────────
+   The ONE abbr → { name, isOfficial } source so every list view shows the full
+   Songbook NAME (not the abbreviation) for ALL songbooks — not just the six in
+   SONGBOOK_NAMES above. Populated once from /api?action=songbooks at app init
+   (App.init() calls loadSongbookRegistry); songbookLabel()/songbookFullName()
+   read it synchronously. Best-effort: if the fetch hasn't completed (or failed)
+   the resolvers fall back to SONGBOOK_NAMES / the abbreviation, so nothing
+   breaks — the name simply fills in once the registry loads. */
+const _SONGBOOK_REGISTRY = new Map();
+
+/** Load the songbook registry once. Fire-and-forget from App.init(). */
+export async function loadSongbookRegistry(apiUrl) {
+    if (!apiUrl) return;
+    try {
+        const res = await fetch(`${apiUrl}?action=songbooks`, {
+            headers: { 'X-Requested-With': 'XMLHttpRequest' },
+        });
+        if (!res.ok) return;
+        const data = await res.json();
+        for (const book of (data.songbooks || [])) {
+            if (book && book.id) {
+                _SONGBOOK_REGISTRY.set(book.id, {
+                    name: book.name || '',
+                    /* IsOfficial is a strict bool from the API (#502); default
+                       to true when a book is somehow absent so an unknown book
+                       is never mis-flagged as "unofficial". */
+                    isOfficial: book.isOfficial !== false,
+                });
+            }
+        }
+    } catch {
+        /* Best-effort — songbookLabel falls back to SONGBOOK_NAMES / abbr. */
+    }
+}
+
+/** Full name for a songbook abbreviation from the registry, or null. */
+export function songbookFullName(abbr) {
+    const entry = _SONGBOOK_REGISTRY.get(abbr);
+    return (entry && entry.name) || null;
+}
+
+/** Whether a songbook is official (registry), defaulting to true if unknown.
+   Enables the "Unofficial → show writing team" treatment (#1531 part 2). */
+export function songbookIsOfficial(abbr) {
+    const entry = _SONGBOOK_REGISTRY.get(abbr);
+    return entry ? entry.isOfficial : true;
 }

--- a/appWeb/public_html/js/modules/setlist.js
+++ b/appWeb/public_html/js/modules/setlist.js
@@ -20,7 +20,7 @@
 import { toTitleCase } from '../utils/text.js';
 import { escapeHtml, verifiedBadge } from '../utils/html.js';
 import { shortTag, fullLabel, typeColor, typeTextColor, COMPONENT_TYPES } from '../utils/components.js';
-import { STORAGE_SETLISTS, STORAGE_OWNER_ID, STORAGE_AUTH_TOKEN, songbookLabel, SONGBOOK_NAMES } from '../constants.js';
+import { STORAGE_SETLISTS, STORAGE_OWNER_ID, STORAGE_AUTH_TOKEN, songbookLabel, songbookFullName, SONGBOOK_NAMES } from '../constants.js';
 
 export class SetList {
     /**
@@ -1718,7 +1718,16 @@ export class SetList {
                     const badge = item.querySelector('.song-number-badge');
 
                     if (titleEl) titleEl.textContent = toTitleCase(json.song.title) || songId;
-                    if (metaEl) metaEl.textContent = json.song.songbook || '';
+                    /* #1531 — show the full Songbook NAME, not the abbreviation.
+                       textContent (not innerHTML) so the plain name is used:
+                       the song detail's own songbookName if present, else the
+                       client registry, else the six fallbacks, else the abbr. */
+                    if (metaEl) {
+                        metaEl.textContent = json.song.songbookName
+                            || songbookFullName(json.song.songbook)
+                            || SONGBOOK_NAMES[json.song.songbook]
+                            || json.song.songbook || '';
+                    }
                     if (badge) {
                         badge.textContent = json.song.number ?? '';
                         badge.dataset.songbook = json.song.songbook || '';


### PR DESCRIPTION
Fixes the abbreviation-only songbook sub-line in list views (your shared-setlist screenshot).

**Fix — one client songbook registry** (`constants.js`), fetched once at app init from `/api?action=songbooks` (`abbr → {name, isOfficial}`). `songbookLabel()` now resolves override → registry → hardcoded fallbacks → abbr. Because **setlist / favourites / search all call `songbookLabel(abbr)`, they now show the full name for EVERY songbook with no changes to those modules**; the shared-setlist enrich (which printed the raw abbr) now uses the full name too (textContent-safe).

- Best-effort/non-blocking: falls back to the abbreviation until the registry loads or if the fetch fails — nothing breaks.
- `songbookIsOfficial()` is exposed to enable **part 2** (Unofficial → italic writing-team credits) as a follow-up (needs a per-view credits source).
- Minor caveat: `action=songbooks` applies the viewer's language filter, so a non-preferred-language book falls back to the abbr (hardcoded fallbacks cover the common English books).

`node --check` clean (constants.js, app.js, setlist.js). ⚠️ This is a client JS render change — visual verification is on the alpha deploy (headless can't render). Part 1 of #1531. Base: `alpha`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)