### PR TITLE
Apple Phase-2 PR-7: LAN-remote control app UI (iPhone/iPad/Mac/Vision) — discovery, pairing client, reconnect ladder, control surface (#1422)

### DIFF
--- a/.claude/apple-phase2-pr7-spec.md
+++ b/.claude/apple-phase2-pr7-spec.md
@@ -1,0 +1,537 @@
+# Apple Phase-2 PR-7 — remote-control app UI (iPhone/iPad/Mac/Vision): discovery, pairing client, reconnect ladder, control surface (#1422)
+
+> **STATUS: IMPLEMENTATION SPEC (Fable 5 deep-design pass, 2026-07-12).** Sibling of `.claude/apple-phase2-pr6-spec.md` (the TV side + shared crypto, MERGED — its §1 wire ceremony is the BINDING contract this PR implements the CLIENT of, and its §8 threat model is acceptance criteria here too). Grounded in a code-level read of the merged PR-4/PR-5/PR-6 seam on `alpha` (`Sources/IHLive/LANRemote/*`, `Sources/IHFeatures/TVRemoteControlCoordinator.swift` et al.), `apple-native-strategy.md` §2.4.2–§2.4.5, and `apple-phase2-implementation-plan.md` §2 (PR-7 row) + §4 + §5 + §6. A Sonnet builder should execute this top-to-bottom with minimal further judgement. Target branch: **`feat/apple-p2-pr7-remote`** off `alpha`; ONE PR targeting `alpha`. **CI's `apple.yml` is NOT a required check (#1526 — it auto-merged red appApple PRs twice), so every §7 verify command MUST be run locally before the PR is opened.**
+
+---
+
+## 1. The PR-6 / PR-7 boundary — and the exact ceremony/reconnect contract, from the REMOTE's point of view
+
+**PR-6 built (merged, do not touch):** the TV listener ceremony (`TVListenerActor+Pairing.swift`), the ONE proof function (`LANRemotePairingProof`, public specifically so THIS PR calls the same `compute(...)` the TV verifies — `LANRemotePairingProof.swift:12-17`), the QR payload codec (`LANRemotePairingPayload`), the TV's Keychain authority + identity store, the tvOS overlay/Settings UI, and the tvOS-side coordinator (`TVRemoteControlCoordinator.swift` — the composition-root pattern this PR mirrors on the phone side).
+
+**PR-7 builds (this spec):** everything on the **remote-device side** —
+- The **entry-path matrix** (§4): ceremony-QR scan → one-shot pair; standing-QR scan/paste → connect + typed code; discovery list → reconnect to already-paired TVs.
+- The **pairing-flow client** (pure reducer + the `RemoteControlSession` actor that drives `RemoteSessionActor` through the §1.1 ceremony).
+- The **ping/reconnect ladder** (5 s ping, 3 missed pongs → detached, jittered exponential-backoff reconnect) — pure, injected-config state machines + an actor driver, because the transport actor deliberately does neither (verified: `RemoteSessionActor+Connection.swift:169-205` — a receive error or `isComplete` just calls `disconnect()` → `.idle`; no retry, no ping loop anywhere in `IHLive` today).
+- The **remote-side paired-TV Keychain store** (raw token + pinned fingerprint + last-good address, **`synchronizable: false` hard-coded** — plan §4/§6.4's tripwire).
+- The **control surface** (song search/select, component/line nav, display-state, appearance, scroll) reflecting `.state` broadcasts — last-writer-wins multi-remote per strategy §2.4.4.
+- The browse-side **`Info.plist` keys** on the `iHymns` target (`NSLocalNetworkUsageDescription` + `NSBonjourServices` + `NSCameraUsageDescription`) — **load-bearing here**, unlike PR-6's belt-and-braces tvOS key (`project.yml:219-228`): per Apple TN3179 it is *browsing* that trips the Local Network gate, and `NWBrowser` browsing is exactly what this PR ships.
+
+**PR-8 builds (NOT here — tripwire):** manual connect-by-address (typed IP/host + port with NO fingerprint → TOFU), the VPN/AP-isolation troubleshooter, the venue network doc. **The line is the fingerprint:** every PR-7 connect path knows `expectedFingerprint` BEFORE connecting, because `RemoteSessionActor.connect(to:expectedFingerprint:token:)` (`RemoteSessionActor+Connection.swift:48`) has no fingerprint-less path — and this PR must not add one. Pasting the QR **string** (§4 path B') is NOT manual connect: the pasted payload carries the fingerprint, it's just transported by AirDrop/Messages/typing instead of a camera.
+
+### 1.1 The wire ceremony, remote's POV (BINDING — PR-6 spec §1's diagram, mirrored)
+
+```
+Remote (this PR)                                      TV (merged PR-6)
+────────────────                                      ────────────────
+RemoteSessionActor.connect(to:, expectedFingerprint:, token:)
+  TLS 1.3; verify_block pins expectedFingerprint      [PR-4, unchanged]
+  → phase .connecting → .awaitingPairing (.ready)
+  actor auto-sends .hello(token: saved-or-nil, kind)  ─►  paired token? → fast path:
+                                        ◄─  .ack(ackSeq)
+    ── FAST PATH (token accepted) ──
+                                        ◄─  .capabilities(currentState)   → phase .controlling  DONE
+    ── CEREMONY (token nil/stale) ──
+                                        ◄─  .pairChallenge(nonce)         [the "show code UI" signal]
+  proof = LANRemotePairingProof.compute(code,
+            fingerprintHex: expectedFingerprint,       ← the fingerprint WE pinned, never one the
+            nonceHex: nonce)                             TV sends us (channel binding, PR-6 §3.2)
+  .pairConfirm(proof, deviceName)       ─►  constant-time verify…
+    on success:                         ◄─  .pairSuccess(token)   → actor stores currentPairingToken;
+                                        ◄─  .capabilities(...)      WE persist raw token (§5)
+    on wrong code:                      ◄─  .error(.pairingRejected, nil)  → connection STAYS UP,
+                                            user retypes (≤3 per connection, then TV tears down)
+```
+
+Steady state: WE send `.ping` every 5 s (strategy §2.4.4 — the TV only ever answers `.pong`, it never initiates pings); the TV broadcasts `.state(IHRPState)` to every paired remote on every accepted change (`TVListenerActor+Messages.swift:201-214` — `revision` bumps monotonically, broadcast includes the originator, so our own intents come back as state too).
+
+### 1.2 Facts about the merged seam this spec builds on (verified in code — cite these in file headers)
+
+- **`RemoteSessionActor`'s streams are single-consumer `AsyncStream`s** (`RemoteSessionActor.swift:120-136`). The PR-5 review caught exactly this class of bug. **BINDING: `RemoteControlSession` (§3.4) is the ONLY consumer of `phaseUpdates` and `incomingMessages`; the coordinator/UI consume ONLY the session's own `events` stream.** A second `for await` on either actor stream silently steals frames.
+- `connect(...)` throws on transport failure OR pin mismatch (indistinguishable at this layer — `RemoteSessionError.transport`'s doc, `RemoteSessionActor.swift:37-45`; the definitive pin-mismatch signal is the `.fault` log line at `+Connection.swift:69-71`).
+- `send(_:)` throws `.notConnected` unless `phase.isConnected` (`+Connection.swift:103-104`); `.awaitingPairing` counts as connected (`RemoteSessionActor.swift:63-72`) — so `.pairConfirm` is sendable mid-ceremony, and a thrown `.notConnected` from the ping loop IS a detach signal.
+- On `.error(.unauthorized)` the actor hard-disconnects; on `.error(.pairingRejected)` it does NOT (`+Connection.swift:234-237` + `IHRPPayloads.swift:164-173`, PR-6 D-2) — the retype loop rides on that distinction.
+- `.pairSuccess(token)` is captured into `currentPairingToken` (`RemoteSessionActor.swift:104-117`, `+Connection.swift:225-233`), and `.capabilities` always follows on the same connection → `.controlling` fires without this PR touching `phase`.
+- `.state`/`.capabilities` both drive `phase = .controlling(state)` (`+Connection.swift:220-226`) — reflecting TV state is "consume phase/events", not new protocol work.
+- Discovery: `startDiscovery()` returns a fresh per-call stream of `[LANRemoteDiscoveredService]` (`RemoteSessionActor.swift:156-175`); a result carries **name + `NWEndpoint` only — no fingerprint** (`LANRemoteDiscovery.swift:32-45`), which is WHY discovery alone can never start a brand-new pairing (§4 path C′). Local-Network permission denial surfaces as `NWError.dns(kDNSServiceErr_PolicyDenied)` via `isLocalNetworkPermissionDenied` (`RemoteSessionActor.swift:217-225`).
+- `LANRemotePairingPayload.init?(qrString:)` (`LANRemotePairingPayload.swift:112-120`) decodes the exact string both TV QRs render: `code != nil` ⇒ ceremony QR, `code == nil` ⇒ standing QR; `host`/`port` are best-effort optionals (`:49-57`).
+- `PairingTestRemote` (`TVListenerPairingLoopbackTests.swift:34-60`) is the mirror-image client recipe — its own header says "this IS the exact recipe PR-7's real client will use." §7.5 inverts it: the REAL client machinery drives a real `TVListenerActor` over loopback TLS.
+- The remote-side store's shape precedents: `KeychainTokenStore` (`IHAuth`, `synchronizable` INJECTABLE, default `true` — `KeychainTokenStore.swift:55-65`; the account token WANTS iCloud sync) vs `KeychainLANRemotePairingAuthority` (`IHLive`, `synchronizable` HARD-CODED `false` — `KeychainLANRemotePairingAuthority.swift:211-226`). §5 follows the SECOND, for the same proximity-model reason.
+- The app shell: `RootContainerView`'s `.live` section is an honest "coming soon" placeholder today (`RootContainerView.swift:388-394`, switch at `:368-369`, tab at `:321-325`); `RootSection` caps at 7 tabs deliberately (`AppNavigationState.swift:68-80`). §6.1 fills `.live` with a real hub rather than adding an 8th tab.
+- Song search building blocks to REUSE, not fork: `AppRootViewModel.filteredSongs` + `CatalogueNumberQuery` (`AppRootViewModel+Search.swift:40-64`); `SongSummary.songId: SongID` (`IHModels/SongSummary.swift:50-60`) is exactly what `.selectSong` wants.
+- `IHLog.remote` / `IHLog.discovery` / `IHLog.signposter` exist; AVFoundation is already imported inside IHFeatures (`SongAudioPlaybackEngine.swift`) — the QR scanner adds no new framework class to the dependency picture. No `Package.swift` change anywhere in this PR.
+
+---
+
+## 2. Files — new and edited
+
+All new files ≤400 raw lines (`appApple/Scripts/loc-budget.sh` — budget for two-register comments by splitting early). SwiftLint clean. Every file carries ELI5 + DETAILED headers referencing **#1422**, strategy §2.4.4/§2.4.5, and plan §2 PR-7 — match PR-4/PR-6 comment density.
+
+### New — module `IHLive` (`Sources/IHLive/LANRemote/`)
+
+| File | Purpose (one line) |
+|---|---|
+| `RemotePairingFlowState.swift` | Pure pairing-flow reducer (client half of the ceremony): challenge → (auto-proof \| prompt) → proof → success/rejected. No I/O, no actor. |
+| `RemoteLinkPolicy.swift` | TWO pure machines: `RemoteLinkHealthState` (tick-counted 5 s ping / 3-miss → detached) + `RemoteReconnectBackoffState` (jittered exponential backoff, injected unit-random). |
+| `PairedTVStore.swift` | `PairedTVRecord` (fingerprint-keyed: raw token + name + last-good host/port + dates) + `PairedTVStoring` protocol + `InMemoryPairedTVStore` (tests/previews). |
+| `KeychainPairedTVStore.swift` | The real store — one generic-password item per TV, account = fingerprint, `kSecAttrSynchronizable = false` **hard-coded**, `internal baseAttributes(account:)` test hook (§5). |
+| `RemotePairingEntryResolver.swift` | Pure entry-path decisions: payload/saved/discovered → `RemoteConnectPlan`; and the pinned-saved + nearby list merge (`RemoteTVListRow`) with name-match-is-routing-only semantics (§4). |
+| `RemoteControlSession.swift` | The supervising `actor` (remote-side mirror of `TVListenerActor`'s role): owns ONE `RemoteSessionActor`, runs the ceremony client, exposes `events: AsyncStream<RemoteControlSessionEvent>` + `send(_:)`/`submitPairingCode(_:)`/`endControl()`/`setSuspended(_:)`. |
+| `RemoteControlSession+Link.swift` | The link half (LOC split, the `TVListenerActor+*` precedent): stream consumption loop, ping ticker, detach detection, the reconnect ladder, endpoint alternation. |
+
+### New — module `IHFeatures`
+
+| File | Purpose |
+|---|---|
+| `RemoteControlCoordinator.swift` | `@MainActor @Observable` composition root (the `TVRemoteControlCoordinator` mirror): builds store + session, consumes `session.events` + discovery, persists on `.paired`, exposes `uiPhase`/rows/errors. Includes the PURE static `uiPhase(after:current:)` event→UI mapping (§7.3-testable). |
+| `RemoteDeviceIdentity.swift` | Platform-conditional `IHRPRemoteKind` + device display name (`UIDevice`/`Host`/`WKInterfaceDevice`), the `hello`/`pairConfirm` cosmetic identity. |
+| `LiveHubView.swift` | The real `.live` section: "TV Remote" entry (→ `RemoteControlView`) + the retained honest "Live Follow / Service Mode coming soon" block (PR-10's future slot). |
+| `RemoteControlView.swift` | Screen scaffold: local-network primer, discovery list (paired pinned + nearby), Scan/Paste entry buttons, scenePhase suspend/resume, connect/disconnect lifecycle. |
+| `RemoteControlSurfaceView.swift` | The controlling surface: TV header + state dot, transport controls (component/line/scroll), display-state control, appearance controls, song-picker entry (§6.3). |
+| `RemoteSongPickerView.swift` | Search-and-select sheet reusing the extracted shared matcher (§6.3) — sends `.selectSong` on tap, `.prepare` from a context action. |
+| `PairingCodeEntrySheet.swift` | 6-digit code entry (path B), failed-attempt copy, "ask the operator" guidance after teardown. |
+| `PairingPayloadEntrySheet.swift` | The scan-or-paste chooser: Scan button (`#if os(iOS)`) + paste field (ALL platforms) → `LANRemotePairingPayload(qrString:)` → coordinator. |
+| `PairingScanView.swift` | `#if os(iOS)` ONLY: `AVCaptureSession` + `AVCaptureMetadataOutput(.qr)` + preview-layer representable + permission handling (§4.3/§6.4). Non-iOS: file compiles to nothing. |
+
+### New — tests
+
+| File | Gate | Purpose |
+|---|---|---|
+| `Tests/IHLiveTests/LANRemote/RemotePairingFlowStateTests.swift` | always-on | reducer transitions; **golden-vector reuse** — the flow's computed proof for PR-6 §7.1's frozen inputs equals the frozen output (§7.1). |
+| `Tests/IHLiveTests/LANRemote/RemoteLinkPolicyTests.swift` | always-on | 3-miss detach, pong reset, backoff sequence/jitter bounds/cap/reset; defaults asserted literally (§7.2). |
+| `Tests/IHLiveTests/LANRemote/RemotePairingEntryResolverTests.swift` | always-on | the §4 matrix as table-driven cases incl. every degraded branch (§7.2). |
+| `Tests/IHLiveTests/LANRemote/PairedTVStoreTests.swift` | always-on | `InMemoryPairedTVStore` round-trip/list-order/delete + `PairedTVRecord` Codable stability (§7.2). |
+| `Tests/IHLiveTests/LANRemote/KeychainPairedTVStoreTests.swift` | `lanRemoteKeychainIdentityAvailable()` + `KeychainTestSerialization` | real-Keychain round-trip, **`synchronizable == false` asserted on `baseAttributes`**, raw-token-at-rest semantics, lookup-by-fingerprint (§7.4). |
+| `Tests/IHLiveTests/LANRemote/RemoteControlSessionLoopbackTests.swift` | `IHYMNS_LAN_LOOPBACK_TESTS=1` | the REAL client vs a REAL `TVListenerActor` over 127.0.0.1 TLS: ceremony (auto-code + typed-code), wrong-code retype, reconnect fast path, **kill-the-listener → detach → backoff → restart → re-attach** (§7.5). |
+| `Tests/IHFeaturesTests/RemoteControlUIStateTests.swift` | always-on | the pure `uiPhase(after:current:)` mapping (§7.3). |
+| `Tests/IHFeaturesTests/SongsMatchingQueryTests.swift` | always-on | the extracted shared matcher behaves byte-identically to pre-extraction `filteredSongs` fixtures (§7.3). |
+
+### Edited
+
+| File | Edit |
+|---|---|
+| `Sources/IHLive/LANRemote/RemoteSessionActor+Connection.swift` | On `.ready`, capture `connection.currentPath?.remoteEndpoint`'s host/port into a new stored `resolvedRemoteAddress: LANRemoteResolvedAddress?` (cleared in `disconnect()`); expose `public var currentResolvedRemoteAddress`. Additive ONLY — any change to connect/disconnect/verify behaviour is a review reject. |
+| `Sources/IHLive/LANRemote/LANRemoteAddress.swift` | +`public struct LANRemoteResolvedAddress: Sendable, Equatable, Codable { public let host: String; public let port: UInt16 }` (lives beside the existing address helper — one address-shaped file). |
+| `Sources/IHFeatures/RootContainerView.swift` | `.live` switch case + Live tab now host `LiveHubView(rootViewModel:)`; `liveComingSoonView` removed (its copy moves INTO `LiveHubView`'s server-half block); header note updated (#1422). |
+| `Sources/IHFeatures/AppRootViewModel+Search.swift` | **Extract-first refactor:** the number-then-substring matching core of `filteredSongs` becomes `public static func songsMatching(_ query: String, in songs: [SongSummary]) -> [SongSummary]`; `filteredSongs` delegates to it (facet filtering stays where it is); `RemoteSongPickerView` calls the SAME static. Behaviour byte-identical (§7.3 guards it). |
+| `Sources/IHFeatures/IHSettingsStore.swift` | +`hasSeenLocalNetworkPrimer: Bool` (UserDefaults-backed, same shape as `hasSeenOnboarding`) — drives the §4.3 pre-permission explainer. + its `IHSettingsStoreTests` row. |
+| `appApple/project.yml` | `iHymns` target gains an `info:` block with `NSLocalNetworkUsageDescription` + `NSBonjourServices: [_ihymns-remote._tcp]` + `NSCameraUsageDescription` (§6.5, D-13 — the array-typed key cannot ride the flat `INFOPLIST_KEY_` mechanism). |
+| `.github/workflows/apple.yml` | +`sudo xcodebuild -downloadPlatform iOS` + an iOS-Simulator build step for the `iHymns` scheme (the PR-5/#1504 tvOS precedent, byte-for-byte pattern) — PR-7 introduces the first `#if os(iOS)`-only UI in IHFeatures and the current macOS-only `iHymns` build would leave it unverified. |
+
+**No edits to:** `Package.swift` (no new dependency, no new target), `IHRPMessage/IHRPFrame/IHRPPayloads` (the protocol is complete for this PR), `TVListenerActor*` / `TVRemoteControlCoordinator` / the tvOS views (the TV side is done), `LANRemotePairingProof/Payload/Ceremony` (frozen by PR-6's golden vector), `KeychainTokenStore` (the account token's sync stance is correct and untouched).
+
+---
+
+## 3. The pure state machines + the session actor (BINDING shapes — do not improvise)
+
+Everything time-driven is a pure, injected-input machine (the `LiveFollowEngine.isFresh(lastUpdatedAt:now:)` seam, `LiveFollowEngine.swift:67`, and PR-6's `LANRemotePairingCeremonyState` precedent): no clock reads, no RNG, no I/O inside any of §3.1–§3.3. The ONLY place that sleeps is the session actor's driver loops (§3.4), and every interval it sleeps for comes from an injectable `Configuration` so the §7.5 loopback tests run the whole ladder in tens of milliseconds.
+
+### 3.1 `RemotePairingFlowState` (pure reducer — the ceremony's client half)
+
+```swift
+public struct RemotePairingFlowState: Sendable, Equatable {
+    /// Everything the flow needs up front. `knownCode` non-nil = path A
+    /// (ceremony QR): the challenge is answered WITHOUT prompting.
+    public struct Context: Sendable, Equatable {
+        public var expectedFingerprint: String   // the fingerprint WE pinned — the proof binds to it
+        public var knownCode: String?
+        public var deviceName: String?
+        public init(expectedFingerprint: String, knownCode: String? = nil, deviceName: String? = nil)
+    }
+    public enum Phase: Sendable, Equatable {
+        case awaitingChallenge                       // connected, hello sent, nothing back yet
+        case awaitingCode(nonce: String, failedAttempts: Int)   // challenge in hand, need the human
+        case proofSent(nonce: String, failedAttempts: Int)
+        case paired(token: String)
+        case failed(RemotePairingFlowFailure)        // terminal for THIS connection
+    }
+    public enum Event: Sendable, Equatable {
+        case challengeReceived(nonce: String)
+        case codeEntered(String)                     // path B: the user typed it
+        case pairSuccess(token: String)
+        case pairingRejected                         // .error(.pairingRejected) arrived
+        case transportClosed                         // actor phase fell to .idle/.failed mid-ceremony
+    }
+    /// What the DRIVER must now do — computing the proof is pure
+    /// (`LANRemotePairingProof.compute` is deterministic), so it happens
+    /// INSIDE the reducer and the effect carries the finished proof.
+    public enum Effect: Sendable, Equatable {
+        case none
+        case sendProof(proof: String, deviceName: String?)
+        case promptForCode(failedAttempts: Int)      // surface the code sheet (0 = first ask)
+        case reportPaired(token: String)
+        case reportFailed(RemotePairingFlowFailure)
+    }
+    public enum RemotePairingFlowFailure: Sendable, Equatable {
+        case connectionTornDown      // TV hit its 3-attempt cap (or dropped) — "ask the operator for a fresh code"
+        case cancelled
+    }
+    public private(set) var phase: Phase
+    public let context: Context
+    public init(context: Context)
+    public mutating func handle(_ event: Event) -> Effect
+}
+```
+Transition rules (each an explicit reducer branch + a §7.1 test):
+- `awaitingChallenge` + `challengeReceived(nonce)` → `knownCode != nil` ? (`proofSent`, effect `.sendProof(compute(knownCode, fp, nonce))`) : (`awaitingCode(nonce, 0)`, effect `.promptForCode(0)`).
+- `awaitingCode` + `codeEntered(code)` → `proofSent` (same `failedAttempts`), effect `.sendProof(compute(code, fp, nonce))`. The typed code is held ONLY long enough to compute — never stored on the state (Equatable dumps in test logs must never contain a live code).
+- `proofSent` + `pairSuccess(token)` → `paired`, effect `.reportPaired(token)`.
+- `proofSent` + `pairingRejected` → `awaitingCode(nonce, failedAttempts + 1)`, effect `.promptForCode(n)` — **including when `knownCode` was set** (a scanned code that expired between scan and confirm degrades gracefully into typing the freshly rotated one; the stale `knownCode` is discarded after its one shot).
+- Any non-terminal phase + `transportClosed` → `failed(.connectionTornDown)`, effect `.reportFailed` (covers the TV's 3-attempt teardown — `TVListenerActor+Pairing.swift:148-154` — and any mid-ceremony drop).
+- Events that don't apply in the current phase → `.none` (e.g. a duplicate `pairingRejected` after teardown) — never a crash, never an assert.
+
+### 3.2 `RemoteLinkHealthState` (pure — the "5 s ping / 3 miss" machine, in `RemoteLinkPolicy.swift`)
+
+```swift
+public struct RemoteLinkHealthState: Sendable, Equatable {
+    public struct Configuration: Sendable, Equatable {
+        /// Strategy §2.4.4's "`ping`(5s)" — the DRIVER sleeps this long between ticks.
+        public var pingInterval: Duration = .seconds(5)
+        /// Ticks that may elapse with no pong before the link is declared dead.
+        public var maxMissedPongs: Int = 3
+        public init()
+    }
+    public private(set) var pingsAwaitingPong: Int = 0
+    public let configuration: Configuration
+    public enum TickOutcome: Sendable, Equatable { case sendPing, declareDetached }
+    /// One timer tick: if `pingsAwaitingPong >= maxMissedPongs` → `.declareDetached`
+    /// (3 pings went unanswered across ~15 s); else increment and `.sendPing`.
+    public mutating func onTick() -> TickOutcome
+    public mutating func onPong()      // reset to 0 — ANY pong proves liveness
+    public mutating func reset()       // fresh connection
+}
+```
+Deliberately **tick-counted, not Date-based** — the machine needs no clock at all (the driver's sleep cadence IS the time source), which makes §7.2's tests trivial and removes a whole class of wall-clock flake. Worst-case detach latency = `pingInterval × (maxMissedPongs + 1)` ≈ 20 s; a hard transport error (send throws / receive error → actor `.idle`) detaches IMMEDIATELY via the phase stream, so the ping ladder is the SLOW detector for silent half-open links (Wi-Fi power-save, AP roam), not the only one.
+
+### 3.3 `RemoteReconnectBackoffState` (pure — same file)
+
+```swift
+public struct RemoteReconnectBackoffState: Sendable, Equatable {
+    public struct Configuration: Sendable, Equatable {
+        public var baseDelay: TimeInterval = 1
+        public var multiplier: Double = 2
+        public var maxDelay: TimeInterval = 30
+        public var jitterFraction: Double = 0.2      // ±20%
+        public init()
+    }
+    public private(set) var attempt: Int = 0
+    public let configuration: Configuration
+    /// delay = min(maxDelay, baseDelay × multiplier^attempt) × (1 − j + 2j·unitRandom),
+    /// then attempt += 1. `unitRandom` ∈ [0,1) injected (production: one
+    /// `Double.random(in: 0..<1)` at the call site; tests: literals).
+    public mutating func nextDelay(unitRandom: Double) -> TimeInterval
+    public mutating func reset()
+}
+```
+Sequence (unitRandom 0.5 ⇒ jitter ≈ ×1.0): ~1, 2, 4, 8, 16, 30, 30, … **Why jitter is load-bearing, not polish:** multi-remote is a first-class mode (strategy §2.4.4 last-writer-wins) — when the venue TV app relaunches, every paired remote detects detach on the same ~5 s cadence and would otherwise dial back in lockstep against PR-4's 4-slot unpaired cap; ±20% decorrelates the herd. Attempts are UNBOUNDED while the remote screen is open and the target is a PAIRED TV (the operator's real-world want: "it comes back by itself when the TV does") — but the ladder runs ONLY while the surface is visible and foregrounded (§3.4 suspend), so it can never become a background battery drain.
+
+### 3.4 `RemoteControlSession` (actor — the driver; core + `+Link.swift`)
+
+The remote-side mirror of the TV's composition split: transport stays in `RemoteSessionActor` (untouched), supervision lives HERE (an `IHLive` actor, NOT the `@MainActor` coordinator), because (a) the §7.5 loopback suite must drive the whole ladder headlessly without pumping a MainActor, (b) PR-11's Watch relay reuses exactly this supervision on the iPhone with no UI attached, (c) the coordinator would blow the LOC budget, and (d) `RemoteSessionActor`'s own header assigns reconnect/replay policy OUTSIDE the transport actor. (Decision D-2.)
+
+```swift
+public actor RemoteControlSession {
+    public struct Configuration: Sendable {
+        public var remoteKind: IHRPRemoteKind
+        public var deviceName: String?
+        public var health: RemoteLinkHealthState.Configuration = .init()
+        public var backoff: RemoteReconnectBackoffState.Configuration = .init()
+        public var clock: any LANRemoteClock = SystemLANRemoteClock()
+        public init(remoteKind: IHRPRemoteKind, deviceName: String? = nil)
+    }
+    /// Everything needed to (re)connect to ONE TV — produced by
+    /// `RemotePairingEntryResolver` (§4), never assembled ad-hoc in a view.
+    public struct Target: Sendable {
+        public var tvName: String
+        public var endpoint: NWEndpoint            // primary (discovered service OR QR host:port)
+        public var fallbackEndpoint: NWEndpoint?   // saved last-good host:port when primary is a Bonjour service
+        public var expectedFingerprint: String     // ALWAYS present — no TOFU (PR-8)
+        public var token: String?                  // nil ⇒ ceremony; non-nil ⇒ fast path + auto-reconnect eligibility
+        public var knownCode: String?              // path A only
+    }
+    public enum Event: Sendable, Equatable {
+        case connecting(attempt: Int)                      // 0 = first connect, ≥1 = ladder
+        case awaitingCodeEntry(failedAttempts: Int)        // show/refresh the code sheet
+        case pairingEnded(RemotePairingFlowState.RemotePairingFlowFailure)
+        case paired(token: String, resolved: LANRemoteResolvedAddress?)   // coordinator persists (§5)
+        case controlling(IHRPState)                        // every TV state broadcast lands here
+        case detached                                      // 3-miss or transport drop on a PAIRED link
+        case reconnecting(attempt: Int, delay: TimeInterval)
+        case suspended                                     // scenePhase left .active
+        case ended                                         // stop()/endControl() completed
+    }
+    public nonisolated let events: AsyncStream<Event>      // the ONE stream the UI consumes
+    public init(configuration: Configuration)
+    public func startDiscovery() async -> AsyncStream<[LANRemoteDiscoveredService]>   // pass-through
+    public func stopDiscovery() async
+    public func attach(to target: Target) async            // begin connect (+ceremony or fast path)
+    public func submitPairingCode(_ code: String) async    // path B's sheet
+    public func cancelPairing() async                      // sheet dismissed → disconnect, .pairingEnded(.cancelled)
+    public func sendIntent(_ message: IHRPMessage) async   // control surface's one door (asserts isControlIntent)
+    public func endControl() async                         // deliberate: try? send(.endControl) → disconnect → .ended
+    public func setSuspended(_ suspended: Bool) async      // scenePhase: true = endControl-style quiesce, keep target;
+                                                           // false = immediate token reconnect (fast path <1 s)
+    public func stop() async                               // full teardown: cancel loops, disconnect, finish nothing else
+}
+```
+`+Link.swift` internals (the only sleeping code in this PR):
+1. **One consumption loop** owns BOTH actor streams via a `TaskGroup` (`phaseUpdates` + `incomingMessages`) — the §1.2 single-consumer rule, enforced structurally: the two `for await`s exist exactly once, here. `incomingMessages` routing: `.pairChallenge` → flow reducer; `.pairSuccess` → reducer (token also mirrored by the actor's `currentPairingToken`); `.error(.pairingRejected)` → reducer; `.pong` → `health.onPong()`; `.state`/`.capabilities` → yield `.controlling` + revision-jump `.notice` when `revision > last + 1` after a reconnect (`IHRPPayloads.swift:86-88`'s intended consumer). `phaseUpdates`: `.idle`/`.failed` while attached → detach path; `.controlling` first arrival → `backoff.reset()` + start ping ticker.
+2. **Ping ticker**: `while attached { try await Task.sleep(for: health.configuration.pingInterval); switch health.onTick() { case .sendPing: try? await remote.send(.ping) — a THROW here (.notConnected) short-circuits to detach; case .declareDetached: → detach } }`.
+3. **Detach path**: only meaningful for a paired target (`token != nil`): `remote.disconnect()`, yield `.detached`, then the ladder — `let delay = backoff.nextDelay(unitRandom: .random(in: 0..<1)); yield .reconnecting(attempt:delay:); try await Task.sleep(for: .seconds(delay)); connect(endpoints[attempt % endpoints.count], token: savedToken)` where `endpoints = [primary, fallback].compactMap{...}` — attempts ALTERNATE primary/last-good so a TV that lost its Bonjour registration (or a remote that roamed onto the VPN, strategy §2.4.5) still comes back. An UNPAIRED (mid-ceremony) drop never auto-retries — the user is standing at the TV; surface `.pairingEnded(.connectionTornDown)` instead.
+4. **Suspend** (`setSuspended(true)`): cancel ticker + ladder, `try? send(.endControl)` (the deliberate-hand-off log on the TV, `IHRPMessage.swift:112-115`), disconnect, yield `.suspended`, KEEP the target. Resume: straight to a token reconnect. This is strategy §2.4.4's "backgrounded remote = detached, TV holds state, <1 s reconnect" made literal.
+
+**Instrumentation contract (binding, PR-4's):** transitions-not-states — `lanremote.link attach`, `lanremote.link detached missed-pongs=N`, `lanremote.link reconnect attempt=N`, `lanremote.link suspended/resumed`, `lanremote.pairflow prompt/proof-sent/paired/rejected count=N` — `caseName`s and counts ONLY; the code/proof/token/nonce NEVER appear in any `IHLog` interpolation at any level; TV names and hosts log `.private` (the `RemoteSessionActor.swift:212` convention); the fingerprint (public by design) may log `.public`.
+
+---
+
+## 4. The entry-path matrix (the subtlest part of this PR — resolve it EXACTLY this way)
+
+**The invariant behind the whole table: `expectedFingerprint` must be in hand BEFORE `connect(...)` is called, and it comes from exactly two sources — a scanned/pasted `LANRemotePairingPayload`, or a saved `PairedTVRecord`. Bonjour discovery NEVER supplies trust — a discovered result is name + endpoint only (§1.2) — and name-matching a discovered service to a saved record is ROUTING ONLY (picking which endpoint to dial), never a trust decision: an impostor advertising a saved TV's name simply fails the TLS pin (`+Connection.swift:59-74`) because we always pin the SAVED record's fingerprint.**
+
+| Path | User action | Fingerprint from | Endpoint from | Code | Flow |
+|---|---|---|---|---|---|
+| **A — ceremony QR** (the PRIMARY new-pair path) | Scans the TV's pairing-overlay QR (iOS/iPadOS camera; any platform via B′ paste) | `payload.fingerprintHex` | `payload.host:port`; if `host == nil` → a discovered service whose name == `payload.name`; if neither → error card (below) | `payload.code` — auto-answered | connect → challenge → auto `.sendProof` → `.pairSuccess` → persist → controlling. Zero typing. Expired-in-hand code degrades to path B's sheet (§3.1). |
+| **B — standing QR + typed code** | Scans/pastes the Settings standing QR, operator opens pairing on the TV, user types the 6-digit code | `payload.fingerprintHex` | as A | typed when `.pairChallenge` arrives (`awaitingCodeEntry`) | connect → challenge → sheet → `.sendProof` → success/retype (≤3/connection, then TV tears down → "ask the operator to re-open pairing"). |
+| **B′ — pasted payload string** (macOS + visionOS's ONLY new-pair path; also iOS fallback) | Pastes the `ihymns-lanpair:v1:…` string (AirDropped/Messaged/typed from the TV screen) into `PairingPayloadEntrySheet` | same as A/B — the string IS the QR payload | as A | per payload (`code` present ⇒ A semantics, absent ⇒ B) | identical to A/B from `LANRemotePairingPayload(qrString:)` onward. **NOT PR-8's manual connect: the fingerprint travels with the string.** A paste that fails `init?(qrString:)` = "Not a valid iHymns pairing code," never a crash, never a host:port fallback prompt. |
+| **C — discovery/saved list row (paired TV)** | Taps a pinned saved TV | the SAVED record's pinned fingerprint | name-matched discovered endpoint if present, else saved last-good `host:port` (both wired as primary/fallback into `Target`) | none | `connect(token:)` → fast path → controlling <1 s. |
+| **C′ — discovery row (unpaired nearby TV)** | Taps a nearby TV that is NOT in the store | **NONE — connection is impossible by design** | — | — | The row is informational: "To pair, scan the QR code shown on this TV" + a button opening path A/B′. Wiring ANY connect here (or a "trust on first use" shortcut) is the PR-8 boundary violation — reviewer reject. |
+
+`RemotePairingEntryResolver` (IHLive, pure — §7.2-tested) encodes the table:
+```swift
+public enum RemotePairingEntryResolver {
+    public enum Entry: Sendable { case payload(LANRemotePairingPayload), savedRow(PairedTVRecord) }
+    public enum Resolution: Sendable {
+        case connect(RemoteControlSession.Target)
+        case unpairable(reason: UnpairableReason)   // .noRouteToTV (payload host nil + no name match)
+    }
+    public static func resolve(_ entry: Entry, saved: [PairedTVRecord],
+                               discovered: [LANRemoteDiscoveredService]) -> Resolution
+    /// The list model: saved records first (pinned, `isNearby` flagged when a
+    /// discovered name matches), then unpaired nearby services. Sorting: saved
+    /// by lastConnectedAt desc; nearby by name.
+    public static func listRows(saved: [PairedTVRecord],
+                                discovered: [LANRemoteDiscoveredService]) -> [RemoteTVListRow]
+}
+```
+Extra resolver rules (all table-driven-tested): a scanned payload whose fingerprint matches an EXISTING saved record = a RE-pair of a known TV → the resulting `.paired` overwrites that record (same account key, §5) and the target still carries the saved token? **No — a ceremony payload means the user intends to (re)pair: `token` stays nil so the ceremony runs; the fresh token replaces the old on success.** A STANDING payload (`code == nil`) whose fingerprint matches a saved record short-circuits to path C (we already trust this TV — connect with the saved token instead of making the user type a code pointlessly); only if that token is later rejected (TV revoked us → `.pairChallenge` arrives instead of `.capabilities`) does the flow drop into the code sheet — which the §1.1 contract gives us for free, because a stale-token `hello` lands in `.pairing` on the TV side.
+
+### 4.3 Camera + permission handling (path A's iOS half)
+
+- `PairingScanView` (`#if os(iOS)`): `AVCaptureSession` + `AVCaptureMetadataOutput` with `metadataObjectTypes = [.qr]`, an `AVCaptureVideoPreviewLayer` inside a `UIViewRepresentable`, torch toggle omitted (scope). First matching string that `LANRemotePairingPayload(qrString:)` accepts wins; non-matching QR codes are ignored silently (people WILL scan the venue Wi-Fi poster by mistake). Session started/stopped with view appear/disappear on a utility queue (never the main thread — Apple's AVCapture guidance).
+- Permission: `AVCaptureDevice.authorizationStatus(for: .video)` — `.notDetermined` → `requestAccess` on the Scan button tap (never on screen appear); `.denied/.restricted` → inline guidance card ("Allow camera access in Settings, or paste the pairing code instead") + the paste field. Camera denial NEVER dead-ends pairing — B′ is always on screen. (Decision D-12.)
+- **Platform truth (Decision D-12):** visionOS gets NO camera scanning — `AVCaptureDevice` main-camera access is unavailable to third-party visionOS apps (enterprise-entitlement only), so pretending otherwise would ship a dead button. macOS gets none either (a Mac pointed at a TV is not a real ergonomic, and it avoids the sandbox camera entitlement entirely). Both use B′/C. iPadOS = iOS (`#if os(iOS)` covers it). If a TV simply cannot be paired from a Mac because no payload string can be conveyed to it, that TV waits for PR-8 — say so in the empty-state copy honestly.
+- **Local Network primer (strategy §2.4.5 "permission prompt explained pre-fire"):** the FIRST time `RemoteControlView` appears with `!IHSettingsStore().hasSeenLocalNetworkPrimer`, show an explainer card ("iHymns will ask to find devices on your local network — that's how it finds your TV") whose Continue button sets the flag AND starts discovery (the OS prompt then fires on the first `NWBrowser` start). If discovery later reports permission-denied (`isLocalNetworkPermissionDenied`, §1.2), swap the list for a guidance card (Settings → Privacy → Local Network). Note in code: the Simulator does not enforce this prompt (plan §5) — device verification only.
+
+---
+
+## 5. Persistence — the remote-side paired-TV Keychain store
+
+### 5.1 `PairedTVRecord` + `PairedTVStoring` (+ `InMemoryPairedTVStore`) — `PairedTVStore.swift`
+
+```swift
+public struct PairedTVRecord: Sendable, Codable, Equatable, Identifiable {
+    public let fingerprintHex: String          // the TV's STABLE identity — the natural PK (id)
+    public var name: String                    // cosmetic, from payload.name / advertised name
+    public var token: String                   // the RAW pairing token — see custody note below
+    public var lastAddress: LANRemoteResolvedAddress?   // last-good host:port (PR-8's future seed too)
+    public var pairedAt: Date
+    public var lastConnectedAt: Date?
+    public var id: String { fingerprintHex }
+}
+public protocol PairedTVStoring: Sendable {
+    func save(_ record: PairedTVRecord) async            // upsert by fingerprint
+    func record(forFingerprint: String) async -> PairedTVRecord?
+    func listPairedTVs() async -> [PairedTVRecord]       // lastConnectedAt ?? pairedAt, newest first
+    func delete(fingerprint: String) async               // "Forget this TV"
+}
+public actor InMemoryPairedTVStore: PairedTVStoring { ... }   // tests/previews — the InMemoryLANRemotePairingAuthority precedent
+```
+**Why the fingerprint is the key, not the token:** the token ROTATES (every re-pair mints a fresh one — `LANRemotePairingSecrets.mintToken()` per ceremony) while the fingerprint is the TV's persistent identity (`LANRemoteIdentityStore`, PR-6 §5.1's whole point); keying by fingerprint makes re-pairing an UPSERT instead of a duplicate row, and lookup-by-fingerprint IS the reconnect path. **Why the RAW token (unlike the TV's sha256-only rule):** the remote must present the preimage in `hello` — asymmetric custody is the DESIGN (strategy §2.4.3: "TV stores `sha256`; remote stores raw + pinned cert"); the raw value lives only inside a Keychain item.
+
+### 5.2 `KeychainPairedTVStore` (actor — the `KeychainLANRemotePairingAuthority` idiom, exact `SecItem` shape)
+
+One `kSecClassGenericPassword` item per paired TV:
+- `kSecAttrService = "app.ihymns.lanremote.pairedTVs"` (a NEW private namespace beside `app.ihymns.lanremote.pairedRemotes` — never shared with it).
+- `kSecAttrAccount = fingerprintHex` — the record key.
+- `kSecValueData = try JSONEncoder().encode(record)` (dates via `.iso8601` for dump-stability; the record INCLUDES the raw token — one item, one query surface, no metadata sidecar to desync: PR-6 Decision D-6 applied here).
+- **`kSecAttrSynchronizable = false` — EXPLICIT, HARD-CODED, never injectable** (the `KeychainLANRemotePairingAuthority.swift:211-226` posture, NOT `KeychainTokenStore`'s injectable one): iCloud-syncing this item would propagate sanctuary-screen control to every device on the Apple ID and silently break the physical-proximity trust ceremony (plan §4/§6.4's named tripwire). Unlike the TV, remotes RUN on platforms that HAVE iCloud Keychain — this hard-coded `false` is the single most load-bearing character in the file. §7.4 asserts it on `baseAttributes`; the §8 grep gate re-checks it at review.
+- `kSecAttrAccessible = kSecAttrAccessibleAfterFirstUnlock` (reconnect after reboot; the established precedent).
+- No `kSecAttrAccessGroup` (nothing shares these items — widgets/watch never drive the TV directly; PR-11 relays through the iPhone app itself).
+- `save` = delete-then-add replace; add failure → `IHLog.remote.fault("lanremote.tvstore persist-failed status=…")` (status only) — the live session keeps working, the pairing just won't survive relaunch.
+- Reads: `errSecItemNotFound` ⇒ nil/[]; any other status ⇒ nil/[] + `.error` log (fail-closed: a TV we can't prove we trust is a TV we don't list).
+- `internal func baseAttributes(account: String?) -> [String: Any]` — the §7.4 `@testable` assertion hook, mirroring the authority.
+
+Persistence timing (coordinator, §6.2): on `.paired(token:resolved:)` → upsert `{fingerprint, name, token, lastAddress: resolved ?? payload host:port, pairedAt: now, lastConnectedAt: now}`; on each `.controlling` first-arrival after an `attach`/reconnect → update `lastConnectedAt` + `lastAddress` from `currentResolvedRemoteAddress` (the §2 actor edit). "Forget this TV" → `delete(fingerprint:)` + copy that is honest about the other half: "This TV will still list this device as trusted until you revoke it in the TV's Settings."
+
+---
+
+## 6. UI structure — coordinator, views, per-platform matrix, project.yml
+
+### 6.1 Placement: the `.live` section becomes real (Decision D-6)
+
+`RootContainerView`'s `.live` case (both `tabbedRoot` and `splitView`) now hosts **`LiveHubView(rootViewModel:)`**: a "TV Remote" navigation card (→ `RemoteControlView`) above a retained, honestly-labelled "Live Follow & Service Mode — coming in a future update" block (the exact `ContentUnavailableView` copy moving in from `RootContainerView.swift:388-394`, which is deleted there). Why here and not Settings or an 8th section: a control surface is a DESTINATION, not a preference (Settings rows push preference-shaped screens — `SettingsView.swift`'s own "one row, real content on the pushed screen" pattern is about settings content); `RootSection` deliberately caps at 7 tabs (`AppNavigationState.swift:76-80`); and `.live` is this feature family's designed home — PR-10's server clients land beside the remote later, making the hub honest twice over. The `.live` placeholder's "don't fake it" header rule is SATISFIED, not violated: the remote is real, the server half stays explicitly labelled future. tvOS/watchOS shells are untouched (`RootContainerView`'s `#else` branch never renders sections; the TV has `TVRootView`; the Watch is PR-11).
+
+### 6.2 `RemoteControlCoordinator` (IHFeatures, `@MainActor @Observable` — the `TVRemoteControlCoordinator` mirror)
+
+```swift
+@MainActor @Observable
+public final class RemoteControlCoordinator {
+    public enum UIPhase: Equatable {
+        case browsing                                    // list; not connected
+        case connecting(tvName: String, attempt: Int)
+        case codeEntry(tvName: String, failedAttempts: Int)
+        case controlling(tvName: String, state: IHRPState)
+        case reconnecting(tvName: String, attempt: Int)
+        case suspended(tvName: String)
+    }
+    public private(set) var uiPhase: UIPhase = .browsing
+    public private(set) var rows: [RemoteTVListRow] = []       // resolver-built (§4)
+    public private(set) var notice: String?                    // inline themed error/guidance copy
+    public private(set) var localNetworkDenied = false
+    public init(store: any PairedTVStoring = KeychainPairedTVStore(),
+                sessionConfiguration: RemoteControlSession.Configuration =
+                    .init(remoteKind: RemoteDeviceIdentity.kind, deviceName: RemoteDeviceIdentity.name))
+    public func start() async            // idempotent: load saved TVs, start discovery (post-primer), spawn the ONE events-consumer task
+    public func stop() async             // session.stop() + stopDiscovery + cancel tasks (view teardown)
+    public func handleScannedOrPasted(_ string: String)   // → payload init? → resolver → attach / notice
+    public func connect(row: RemoteTVListRow)             // path C / C′ routing per the resolver
+    public func submitCode(_ code: String) async
+    public func disconnect() async                        // user's explicit button → session.endControl()
+    public func forget(_ record: PairedTVRecord) async
+    public func setScenePhaseActive(_ active: Bool) async  // → session.setSuspended(!active)
+    public func sendIntent(_ message: IHRPMessage) async   // the surface's pass-through
+    /// PURE (static) event→UI mapping — `uiPhase(after: event, current: phase, tvName:)`
+    /// — the §7.3 always-on test target; the events-consumer task is a thin
+    /// `for await` that applies it + performs the §5.2 persistence side-effects.
+}
+```
+Injectable `store`/`sessionConfiguration` defaults keep production call sites one-line while §7.3's tests hand in `InMemoryPairedTVStore` + a never-started session config. The coordinator consumes ONLY `session.events` + the discovery stream (never the actor's streams — §1.2 rule). Discovery results also refresh `rows` via `RemotePairingEntryResolver.listRows`.
+
+### 6.3 The control surface + song picker
+
+**`RemoteControlView`** (scaffold): owns `@State private var coordinator` (built in `init` — the `TVRootView.swift:54-61` pattern), `.task { await coordinator.start() }`, `.onDisappear { Task { await coordinator.stop() } }`, `@Environment(\.scenePhase)` → `setScenePhaseActive`. Renders by `uiPhase`: `browsing` → primer card OR the list (pinned saved rows: name, kind glyph `tv`, "Nearby" badge when `isNearby`, relative last-connected; swipe-delete = Forget with the §5.2 copy; nearby-unpaired rows per C′) + toolbar buttons "Scan" (`#if os(iOS)`) and "Enter Code" (all platforms → `PairingPayloadEntrySheet`); `connecting/reconnecting` → the list with an overlaid progress banner + Cancel; `codeEntry` → `PairingCodeEntrySheet` presented; `controlling` → `RemoteControlSurfaceView`; `suspended` → a "reconnecting when you return" placeholder. Empty state (no saved, none nearby): "Open iHymns on your Apple TV, then scan the QR code in its Settings → Remote Control." with the macOS/visionOS-specific extra line "…or paste the pairing code from the TV screen."
+
+**`RemoteControlSurfaceView`** (the actual remote — STATELESS/REFLECTIVE, Decision D-7): every control renders from the `IHRPState` in `uiPhase.controlling` and every interaction ONLY calls `coordinator.sendIntent(...)`; nothing is optimistically toggled locally. The TV is the single display authority (strategy §2.4.1) and its `.state` broadcast — which includes echoes of our own intents (§1.1) — is the ONLY thing that updates the UI. This makes multi-remote last-writer-wins correct BY CONSTRUCTION: when another remote changes the display, our surface just re-renders the broadcast; there is no local shadow state to fight over, and the sub-100 ms echo latency makes the round-trip invisible. Layout (one scrolling column, `.ihGlassCard()` groupings, all controls ≥44 pt, VoiceOver labels on every glyph):
+1. **Header** — TV name, live dot, current song title line ("Nothing selected" for `songId == nil`), Disconnect button.
+2. **Song** — "Choose Song…" (→ `RemoteSongPickerView` sheet) + prev/next COMPONENT buttons flanking a "Verse/Component" label (the TV resolves arrangement order — the remote never counts components, `IHRPMessage.swift:89-92`).
+3. **Line** — prev/next line + a scroll-nudge pair sending `.scroll(delta: ±1)`.
+4. **Display** — a 4-way control for `IHRPDisplayState` (`lyrics/blackout/logo/frozen`), selection = `state.displayState`, tap = `.setDisplayState(...)`.
+5. **Appearance** — theme menu (sends `.setAppearance(theme: key, textScale: nil)`) + textScale stepper (`.setAppearance(theme: nil, textScale: value)`) — fire-and-forget hints, no local persistence (they're TV-side cosmetics).
+**Content INVARIANT (restate in the file header):** every send is a ~200-byte intent; no lyric text ever crosses this seam in either direction the UI can observe beyond `IHRPState` indices (`IHRPMessage.swift:15-25`).
+
+**`RemoteSongPickerView`**: a sheet with a search field + list of `SongSummary` rows filtered by the EXTRACTED shared matcher `AppRootViewModel.songsMatching(_:in:)` over `rootViewModel`'s already-loaded catalogue (`catalogueLoadState`) — its OWN `@State query`, deliberately NOT `rootViewModel.searchText` (mutating that would clobber the Search tab's live state; the extraction exists precisely so both callers share the number-then-substring logic — `AppRootViewModel+Search.swift:40-64` — without sharing UI state). Row tap → `sendIntent(.selectSong(songId:, componentIndex: nil, lineIndex: nil))` + dismiss. Row context menu "Prepare on TV" → `sendIntent(.prepare(songId:))` and stays open — the real worship flow ("prefetch the next hymn during the current verse", strategy §2.4.4's RTT-hiding intent; sending prepare+select on the same tap would hide nothing, Decision D-9). If the catalogue isn't loaded yet, the sheet triggers the same `loadCatalogueIfNeeded()` the Search tab uses.
+
+### 6.4 `RemoteDeviceIdentity` (IHFeatures)
+
+`static var kind: IHRPRemoteKind` — `#if os(iOS)`: `UIDevice.current.userInterfaceIdiom == .pad ? .pad : .phone`; `#elseif os(visionOS)`: `.vision`; `#elseif os(macOS)`: `.mac`; `#elseif os(watchOS)`: `.watchRelay` (defensive — PR-11's future caller); `#else` (tvOS compile-only): `.phone` (dead code, the package compiles everywhere). `static var name: String?` — `UIDevice.current.name` where UIKit exists (NOTE in the comment: iOS 16+ returns the generic model name, not the user's personalised one, without a special entitlement — fine, it's cosmetic), `Host.current().localizedName` on macOS, `WKInterfaceDevice.current().name` on watchOS.
+
+### 6.5 `project.yml` — the browse-side keys (Decision D-13) + CI
+
+Add to the `iHymns` target (keep ALL existing `settings.base` keys byte-untouched):
+```yaml
+    # #1422 (PR-7 spec §6.5, D-13) — the LOAD-BEARING Local Network keys (TN3179:
+    # BROWSING is the restricted operation; the tvOS listener side's copy of
+    # NSLocalNetworkUsageDescription is belt-and-braces, THIS one is not).
+    # NSBonjourServices is array-typed with no INFOPLIST_KEY_ build-setting
+    # equivalent, so it rides XcodeGen's `info:` mechanism (the iHymnsWidgets
+    # precedent) — Xcode merges the INFOPLIST_KEY_* settings above into this
+    # generated file's content at build time, so the existing flat keys keep
+    # working unchanged.
+    info:
+      path: Apps/iHymns/Generated/Info.plist
+      properties:
+        NSLocalNetworkUsageDescription: "iHymns looks for iHymns on your Apple TV over your local network so this device can act as its remote control."
+        NSBonjourServices:
+          - _ihymns-remote._tcp
+        NSCameraUsageDescription: "iHymns uses the camera only to scan the pairing QR code shown on your TV."
+```
+**Builder MUST verify the merge** (this is the one toolchain-behaviour bet in this PR): after `xcodegen generate` + an iOS-Simulator build, `plutil -p` the built product's `Info.plist` and confirm it contains BOTH the new keys AND the pre-existing `INFOPLIST_KEY_`-sourced ones (`CFBundleDisplayName`, `UIBackgroundModes`, `ITSAppUsesNonExemptEncryption`). **Documented fallback if any key is missing:** migrate every `INFOPLIST_KEY_*` value on this target into the `info:` block as real plist keys (`UILaunchScreen: {}` for the launch-screen flag) and set `GENERATE_INFOPLIST_FILE: NO` — the exact `iHymnsWidgets` configuration (`project.yml:286-307`). Either way, the three new keys shipping is the acceptance criterion; which mechanism carries them is not. `NSCameraUsageDescription` on the macOS/visionOS destinations of this multiplatform target is inert (no code path requests the camera there — §4.3). No entitlements change (macOS App Sandbox is not currently enabled on this target; when the strategy §3.1 sandbox lands later, `com.apple.security.network.client` becomes its concern, noted, out of scope).
+
+`apple.yml`: after the existing macOS build step, add `sudo xcodebuild -downloadPlatform iOS` + an `xcodebuild -project iHymns.xcodeproj -scheme iHymns -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build` step — copy the tvOS step's comment style + #1504 citation, adding #1422.
+
+---
+
+## 7. Test plan (Swift Testing; injected config everywhere; secrets never printed in test output either)
+
+### 7.1 `RemotePairingFlowStateTests` (always-on, pure)
+- Path A: `challengeReceived` with `knownCode` ⇒ `.sendProof` whose proof EQUALS `LANRemotePairingProof.compute` for the same inputs; **golden-vector cross-check** — feed PR-6 §7.1's frozen (code, fingerprint, nonce) triple through the reducer and assert the effect carries the frozen proof hex verbatim ("if this fails you changed the client half of a frozen construction").
+- Path B: challenge without code ⇒ `.promptForCode(0)`; `codeEntered` ⇒ `.sendProof`; `pairingRejected` ⇒ `.promptForCode(1)` and the nonce is retained; three reject/re-enter cycles keep counting.
+- Expired-scanned-code degrade: `knownCode` + `pairingRejected` after its auto-proof ⇒ `.promptForCode(1)` (the stale code is NOT re-sent).
+- `pairSuccess` ⇒ `.reportPaired(token)`; `transportClosed` from every non-terminal phase ⇒ `.reportFailed(.connectionTornDown)`; out-of-phase events ⇒ `.none`; `Phase`'s `Equatable` dump never contains a typed code (structural: the code isn't stored — assert `awaitingCode` only carries nonce+count).
+
+### 7.2 `RemoteLinkPolicyTests` + `RemotePairingEntryResolverTests` + `PairedTVStoreTests` (always-on, pure)
+- Health: fresh state → 3 × `onTick()` ⇒ `.sendPing` each, `pingsAwaitingPong == 3`; 4th tick ⇒ `.declareDetached`; `onPong()` after 2 ticks resets to 0 and the ladder restarts; defaults asserted literally (`.seconds(5)` / 3) so a drive-by tune shows in review.
+- Backoff: with `unitRandom: 0.5` the sequence is 1, 2, 4, 8, 16, 30, 30; with 0.0/1.0 every delay stays within ±20% of nominal; `reset()` returns to attempt 0; defaults asserted literally (1 / 2 / 30 / 0.2).
+- Resolver: one table-driven case per §4 row incl. — ceremony payload for an ALREADY-saved fingerprint ⇒ token nil (re-pair); standing payload for a saved fingerprint ⇒ path-C target with the saved token; payload with nil host + name-matching discovery ⇒ discovered endpoint primary; payload nil host + no match ⇒ `.unpairable(.noRouteToTV)`; saved row with a name-matched discovery ⇒ discovered primary + saved-address fallback; saved row alone ⇒ saved-address primary, no fallback; `listRows` pins saved first, flags `isNearby`, sorts as specified.
+- Store: InMemory upsert-by-fingerprint (a re-save replaces, count stays 1), list order (lastConnectedAt desc, nil sorts by pairedAt), delete; `PairedTVRecord` JSON round-trip with `.iso8601` dates.
+
+### 7.3 `IHFeaturesTests` (always-on, `@MainActor`)
+- `RemoteControlUIStateTests`: the pure `uiPhase(after:current:tvName:)` mapping — every `RemoteControlSession.Event` from every current phase (e.g. `.detached` while `.controlling` ⇒ `.reconnecting`… as specified by the mapping's own doc table; `.suspended`/resume; `.pairingEnded(.cancelled)` ⇒ `.browsing` with no notice, `.connectionTornDown` ⇒ `.browsing` + operator-guidance notice).
+- `SongsMatchingQueryTests`: `songsMatching(_:in:)` reproduces `filteredSongs`' documented behaviour on fixture summaries — number-mode hit ("MP 1008"), number-mode miss falling through to substring ("Song 23" → title match), plain substring, empty query returns input unchanged; and (regression guard for the extraction) `AppRootViewModel.filteredSongs` still passes its existing expectations via the current `AppRootViewModelTests`/`CatalogueNumberQueryTests` suites untouched.
+
+### 7.4 `KeychainPairedTVStoreTests` (`.enabled(if: lanRemoteKeychainIdentityAvailable(), …)` — the exact PR-6 gate + skip-message style; every test wraps Keychain work in `KeychainTestSerialization.shared.run { }` and cleans up in `defer`)
+- save → `record(forFingerprint:)` returns the record INCLUDING the raw token (the preimage-custody property); upsert replaces; `listPairedTVs` order; `delete` removes; unknown fingerprint ⇒ nil.
+- **`baseAttributes(account:)` asserts `kSecAttrSynchronizable == false` and `kSecAttrAccessible == AfterFirstUnlock` and service == `app.ihymns.lanremote.pairedTVs`** — plan §6.4's required unit test, remote side.
+
+### 7.5 `RemoteControlSessionLoopbackTests` (`IHYMNS_LAN_LOOPBACK_TESTS=1` gate, verbatim posture from `TVListenerPairingLoopbackTests.swift:62-68`: `advertiseViaBonjour: false`, `.hostPort` connects, `ManualLANRemoteClock` into the LISTENER, `KeychainTestSerialization` around identity generation). Session config for ALL tests here: `health.pingInterval = .milliseconds(40)`, `backoff = .init(baseDelay: 0.05, maxDelay: 0.2)` — the ladder runs in real milliseconds; the ALWAYS-ON suites own the numeric defaults.
+- **Ceremony, path A:** listener `beginPairing()`; session `attach` with `knownCode` ⇒ events yield `.paired(token:resolved:)` then `.controlling`; `resolved` is 127.0.0.1 + the bound port (the §2 actor edit, verified end-to-end); reconnect `attach` with that token ⇒ `.controlling` with NO `.awaitingCodeEntry` ever yielded.
+- **Ceremony, path B:** `attach` without code ⇒ `.awaitingCodeEntry(0)`; `submitPairingCode(wrong)` ⇒ `.awaitingCodeEntry(1)` and the connection survives (the `.pairingRejected`-not-`.unauthorized` distinction, client side); `submitPairingCode(correct)` ⇒ `.paired`. Then 3 wrongs on a fresh attach ⇒ TV teardown ⇒ `.pairingEnded(.connectionTornDown)`.
+- **The ladder (the headline test):** pair; `await listener.stop()`; expect `.detached` (ping throws/receive error at ms cadence) then ≥1 `.reconnecting(attempt:delay:)`; start a NEW listener on the SAME fixed port (pick a random high port up front and pass it to both `Configuration(port:)` calls so the restart is addressable) with the SAME identity + an authority pre-seeded with the token; expect `.controlling` again with NO ceremony events. Assert attempts observed ≥1 and delays non-decreasing until reset.
+- **Suspend/resume:** pair; `setSuspended(true)` ⇒ `.suspended` + the listener sees the connection close; `setSuspended(false)` ⇒ `.controlling` (fast path).
+- **Multi-remote reflection:** two sessions paired to one listener; session A `sendIntent(.setDisplayState(.blackout))` ⇒ BOTH sessions yield `.controlling` whose state is `.blackout` with the same bumped revision (last-writer-wins reflection, `TVListenerActor+Messages.swift:201-214` observed from the client).
+
+**No snapshot tests (Decision D-10):** `Package.swift` carries no snapshot-testing dependency and adding one violates this PR's no-new-external-package tripwire; view coverage = compile-everywhere + the §6 walkthrough on device/Simulator. Snapshot infra is tracked as #1527 — note it in the PR body, don't smuggle it in.
+
+**Local pre-PR verification (builder runs ALL — CI is not a required check, #1526):**
+```
+cd appApple/Packages/iHymnsKit && swift build && swift test
+IHYMNS_LAN_LOOPBACK_TESTS=1 swift test --filter 'RemoteControlSessionLoopback|TVListenerPairingLoopback|LANRemoteLoopback'
+swiftlint --config appApple/.swiftlint.yml appApple          # 0 violations
+bash appApple/Scripts/loc-budget.sh
+cd appApple && xcodegen generate
+xcodebuild -project iHymns.xcodeproj -scheme iHymns -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build
+xcodebuild -project iHymns.xcodeproj -scheme iHymns -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build
+# + §6.5's plutil Info.plist merge verification on the built iOS product
+```
+(The tvOS target is untouched by this PR, but if ANY IHLive/IHFeatures shared file was edited — it was — run the tvOS build too before pushing; the #1532 lesson was exactly a shared-code platform break: `xcodebuild -scheme iHymnsTV -destination 'generic/platform=tvOS Simulator' CODE_SIGNING_ALLOWED=NO build`.)
+
+---
+
+## 8. Threat model (acceptance criteria — PR-6 §8 still applies wholesale; these are the REMOTE-side rows) + Decisions
+
+| Threat | Mitigation (mechanism, THIS PR) | Residual |
+|---|---|---|
+| **Swapped/forged venue QR** (attacker's payload pairs the phone to the ATTACKER's device) | The pin means the phone talks ONLY to whoever holds the private key for the scanned fingerprint — the attacker pairs the phone to their own box, never gains anything toward the REAL TV (no credential of ours transits: the proof binds to the attacker's fingerprint and is useless elsewhere — PR-6 §3.2). The phone shows the payload's TV name before connecting; the real TV's operator sees no "Paired" banner. | The user drives the attacker's screen until they notice. Physical-space attack, accepted (PR-6 §8 row 1); UI copy nudges name-checking. |
+| **Malicious payload string / QR content** (fuzz the parser, absurd fields) | `LANRemotePairingPayload.init?(qrString:)` is nil-on-garbage (PR-6-tested); resolver additionally clamps: displayed name truncated for UI, port 0 ⇒ `.unpairable`, non-64-hex fingerprint ⇒ reject before any connect. The scanner ignores non-`ihymns-lanpair:` codes silently. | None meaningful. |
+| **Evil "TV" advertising on the LAN** (rogue Bonjour service, spoofed name of a saved TV) | Discovery is trust-free by construction (§4): an unpaired nearby row CANNOT be connected; a name-spoof of a saved TV gets dialled but fails the SAVED fingerprint's TLS pin at handshake (logged `.fault`). | An attacker can pollute the nearby list cosmetically (LAN-local, no interaction possible). Accepted. |
+| **Raw-token theft from the remote** | Keychain generic-password, `AfterFirstUnlock`, **`synchronizable:false` hard-coded + unit-tested + grep-gated** — never UserDefaults, never logs, never crosses iCloud. A stolen token is revocable in one tap on the TV (PR-6's trusted-remotes list + `disconnectPaired`). | Device compromise = the attacker IS the remote (parity with PR-6's identity row). Accepted. |
+| **Reconnect storm / self-DoS** (TV restarts, N remotes redial; or a dead TV drains the phone) | ONE supervisor per surface; exponential backoff to 30 s cap; ±20% jitter decorrelates the herd (§3.3); ladder runs only while the screen is open AND foregrounded (`setSuspended` on scenePhase); unpaired ceremonies never auto-retry. | None meaningful (PR-4's unpaired-slot DoS envelope unchanged). |
+| **Pasted ceremony code lingering in a pasteboard** | The app NEVER reads the pasteboard programmatically (no `UIPasteboard.general` access — the user pastes into a field themselves, so no iOS paste-prompt surprise and no ambient clipboard sniffing by us). A pasted CEREMONY payload does carry a live code — bounded by the TV's 120 s TTL + single-use + operator visibility (PR-6 §8 row 4); the STANDING payload carries no secret and is the recommended paste artefact (UI copy says so). | Third-party clipboard managers retaining the string — outside our control, TTL-bounded. |
+| **Secrets/PII in logs** | Binding contract restated in §3.4: no code/proof/token/nonce in ANY `IHLog` interpolation; TV names + hosts `.private`; fingerprints only `.public` value. Review gate: grep every new file's `IHLog` calls. | — |
+| **Multi-remote races** (two operators fight) | Last-writer-wins is the TV's resolution (PR-4 seq+timestamp); the surface is reflective-only (D-7) so a losing remote just sees the winner's state — no client-side merge, no divergence. Primary-operator lock stays deferred (strategy §2.4.4). | Two people can still alternate rapidly; visible, human-resolvable. Accepted. |
+| **Local Network permission denied** | Detected via the documented `kDNSServiceErr_PolicyDenied` shape (§1.2) → guidance card; pairing via QR host:port STILL WORKS (unicast connect needs no browse permission — TN3179), so denial degrades, not bricks. Primer pre-explains the prompt (§4.3). | Discovery-less UX until the user flips the toggle. |
+| **Camera permission denied / unavailable** | Request on tap, not appear; denial → paste path always present (§4.3); visionOS/macOS never offer the dead button. | — |
+
+**Decisions (do NOT re-litigate while building):**
+- **D-1 — Entry-path matrix as §4's table.** Fingerprint before connect, always; Bonjour is routing, never trust; C′ rows are unconnectable by design. Rationale: `connect` has no fingerprint-less path and PR-8 owns TOFU.
+- **D-2 — Supervision lives in `RemoteControlSession` (IHLive actor), not the coordinator.** Headless loopback testability + PR-11 reuse + LOC + the transport actor's own policy note (§3.4).
+- **D-3 — Health machine is tick-counted (no Date)**; detach ≈ 20 s worst case for silent links, immediate for hard errors. Numbers 5 s/3 from #1422's own text; asserted literally in tests.
+- **D-4 — Backoff 1 s × 2 → 30 s cap, ±20% injected jitter, unbounded while visible+paired, suspended on background.** Jitter is a correctness feature (herd vs the 4-slot cap), not polish.
+- **D-5 — Store keyed by fingerprint; raw token stored; `synchronizable:false` hard-coded.** Asymmetric custody is the strategy §2.4.3 design; §7.4 + grep gate enforce.
+- **D-6 — UI home is the `.live` section via `LiveHubView`** (7-tab cap; destination-not-preference; PR-10's future slot beside it).
+- **D-7 — The surface is stateless/reflective**; the TV's broadcast (including self-echo) is the only UI-state source. Multi-remote correctness by construction.
+- **D-8 — Song matching is EXTRACTED to `AppRootViewModel.songsMatching(_:in:)`** and shared by `filteredSongs` + the picker; the picker keeps its own query string. Re-forking the number/substring ladder is the exact `_bsls_*`-class regression this repo names.
+- **D-9 — `.prepare` is a deliberate context action ("Prepare on TV"), `.selectSong` is the tap.** Same-tap prepare+select hides no RTT; don't ship cargo-cult prefetch.
+- **D-10 — No snapshot tests** (no package; #1527); no new external dependency of any kind.
+- **D-11 — CI gains the iOS-Simulator `iHymns` build step** (PR-5/#1504 precedent) because this PR ships the first iOS-only IHFeatures code; AND the builder runs everything locally regardless (#1526).
+- **D-12 — Camera = iOS/iPadOS only, `AVCaptureSession`+`AVCaptureMetadataOutput`;** visionOS (no third-party camera access) and macOS (ergonomics + sandbox surface) use paste (B′). Honest per-platform matrix over a uniform lie.
+- **D-13 — `info:`-block for the array-typed `NSBonjourServices`,** merge-verified via `plutil`, with the full-migration fallback documented (§6.5). The three keys shipping is the criterion, the mechanism is not.
+- **D-14 — `RemoteSessionActor` edits are ADDITIVE ONLY** (resolved-address capture). Any change to connect/verify/disconnect semantics, or a second consumer of its streams, is a review reject.
+- **D-15 — Scope tripwires (reviewer rejects on sight):** manual connect-by-address / any fingerprint-less or TOFU connect (PR-8); Watch relay (PR-11); `service_broadcast` mirror (PR-14); `synchronizable: true` anywhere under `Sources/IHLive/LANRemote/` (grep gate: `grep -rn "Synchronizable" appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/` must show only hard-coded `false`); any new external package; lyric text in any IHRP payload; a second consumer of `phaseUpdates`/`incomingMessages`; `import Network` in new IHFeatures files (views/coordinator talk to the session; `NWEndpoint` values ride inside IHLive types).
+- **Security notes for the PR body:** new credential custody on the REMOTE side (raw token at rest — custody rules above); no backend contact anywhere in this PR; reproduce this §8 table; note Audit B re-reviews PR-6+PR-7 together before external TestFlight (plan §2 gate).
+
+## 9. Commit plan (one PR, atomic — each commit compiles + `swift test` green)
+
+1. `feat(apple): remote-side pairing flow + link policy cores, paired-TV stores (#1422)` — `RemotePairingFlowState.swift`, `RemoteLinkPolicy.swift`, `PairedTVStore.swift`, `KeychainPairedTVStore.swift`, `RemotePairingEntryResolver.swift`, `LANRemoteResolvedAddress` (in `LANRemoteAddress.swift`), §7.1/§7.2/§7.4 suites.
+2. `feat(apple): RemoteControlSession — ceremony client, ping ladder, jittered reconnect (#1422)` — `RemoteControlSession.swift` + `+Link.swift`, the `RemoteSessionActor+Connection.swift` resolved-address edit, §7.5 loopback suite.
+3. `feat(apple): remote control UI — Live hub, discovery/paired list, pairing sheets, control surface (#1422)` — all §2 IHFeatures files, `RootContainerView`/`AppRootViewModel+Search`/`IHSettingsStore` edits, §7.3 suites.
+4. `feat(apple): iHymns browse-side Local Network/Bonjour/camera Info.plist keys + iOS-sim CI build (#1422)` — `project.yml` `info:` block (+ merge verification noted in the commit body), `apple.yml` step, regenerated-project build proof.

--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -76,23 +76,23 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             build
 
-      # The generic iOS-Simulator destination below needs the iOS 26.0
-      # platform, which is NOT preinstalled on the GitHub-hosted macos-26
-      # runner — same fix as the tvOS step below (#1504), needed here because
       # #1422 (PR-7) ships the first `#if os(iOS)`-only IHFeatures UI
-      # (`PairingScanView.swift`) and the macOS build above never compiles it.
-      - name: Install iOS platform (runner ships without it, #1422)
-        run: sudo xcodebuild -downloadPlatform iOS
-
-      - name: Build (iOS Simulator destination — proves the iOS-only remote-control UI, #1422)
-        working-directory: appApple
+      # (`PairingScanView.swift`, AVFoundation camera) which the macOS build
+      # above never compiles. We verify it with a PACKAGE build cross-compiled
+      # for the iOS-Simulator SDK — deliberately NOT the full `iHymns` app
+      # scheme, because that scheme embeds `iHymnsWatch`, which imports
+      # IHFeatures and does NOT yet compile for watchOS (a pre-existing,
+      # never-CI-built gap — ~9 IHFeatures views use watchOS-unavailable
+      # SwiftUI APIs; tracked in #1549, which will re-enable the full
+      # app-scheme iOS build once the watch compiles). A `swift build`
+      # cross-compile needs only the iOS SDK (always present on the runner),
+      # so no `-downloadPlatform iOS` is required.
+      - name: Build iHymnsKit for iOS Simulator (proves the iOS-only remote UI, #1422)
+        working-directory: appApple/Packages/iHymnsKit
         run: |
-          xcodebuild \
-            -project iHymns.xcodeproj \
-            -scheme iHymns \
-            -destination 'generic/platform=iOS Simulator' \
-            CODE_SIGNING_ALLOWED=NO \
-            build
+          swift build \
+            --sdk "$(xcrun --sdk iphonesimulator --show-sdk-path)" \
+            -Xswiftc -target -Xswiftc arm64-apple-ios26.0-simulator
 
       # The generic tvOS-Simulator destination below needs the tvOS 26.0
       # platform, which is NOT preinstalled on the GitHub-hosted macos-26

--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -76,6 +76,24 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             build
 
+      # The generic iOS-Simulator destination below needs the iOS 26.0
+      # platform, which is NOT preinstalled on the GitHub-hosted macos-26
+      # runner — same fix as the tvOS step below (#1504), needed here because
+      # #1422 (PR-7) ships the first `#if os(iOS)`-only IHFeatures UI
+      # (`PairingScanView.swift`) and the macOS build above never compiles it.
+      - name: Install iOS platform (runner ships without it, #1422)
+        run: sudo xcodebuild -downloadPlatform iOS
+
+      - name: Build (iOS Simulator destination — proves the iOS-only remote-control UI, #1422)
+        working-directory: appApple
+        run: |
+          xcodebuild \
+            -project iHymns.xcodeproj \
+            -scheme iHymns \
+            -destination 'generic/platform=iOS Simulator' \
+            CODE_SIGNING_ALLOWED=NO \
+            build
+
       # The generic tvOS-Simulator destination below needs the tvOS 26.0
       # platform, which is NOT preinstalled on the GitHub-hosted macos-26
       # runner ("tvOS 26.0 is not installed. Please download and install the

--- a/appApple/Packages/iHymnsKit/Sources/IHDesign/IHColorTokens.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHDesign/IHColorTokens.swift
@@ -112,9 +112,41 @@ public enum IHColorTokens {
     /// before committing to the asset-backed `Color`. `#if canImport`
     /// covers every platform this package targets (`Package.swift`'s
     /// `platforms:` list: iOS/iPadOS, macOS, tvOS, watchOS, visionOS all
-    /// provide EITHER UIKit or AppKit).
+    /// provide EITHER UIKit or AppKit) — EXCEPT watchOS needs its OWN
+    /// branch ahead of the `canImport(UIKit)` one (see below).
+    ///
+    /// ELI5: watchOS has UIKit, but not the one UIKit colour-lookup
+    /// function this file leans on — so watchOS gets its own answer
+    /// instead of calling that function and failing to build at all.
+    ///
+    /// DETAILED (#1422 review — PR-7 fix 1): `UIColor(named:in:
+    /// compatibleWith:)` is `API_UNAVAILABLE(watchOS)` in UIKit's own
+    /// header, but `#if canImport(UIKit)` is still TRUE on watchOS (its
+    /// UIKit module exists, just without this particular initializer) — so
+    /// before this fix, the watchOS build of `IHDesign` hit an unavailable
+    /// symbol and failed outright the moment anything actually compiled it
+    /// FOR watchOS. That never happened until PR-7's new iOS-Simulator CI
+    /// build started embedding `iHymnsWatch` (which links `IHDesign` for
+    /// watchOS) — a pre-existing latent bug PR-7's own new CI step was the
+    /// first thing to exercise, so the fix ships alongside it. The fix:
+    /// branch on `os(watchOS)` FIRST and skip the failable lookup
+    /// entirely — the bundled `Accent`/`AccentHighContrast` colour sets are
+    /// always compiled into `Bundle.module` (never optionally downloaded),
+    /// and SwiftUI's `Color(_:bundle:)` DOES resolve Asset-Catalog colour
+    /// sets on watchOS (only the FAILABLE `UIColor` lookup is missing), so
+    /// assuming "present" here is safe — this guard exists to catch a
+    /// genuinely MISSING asset, which cannot happen for a colour set
+    /// shipped inside this package's own bundle. iOS/tvOS/macOS keep their
+    /// existing branches, byte-for-byte unchanged (`UIColor(named:in:
+    /// compatibleWith:)` IS available on tvOS).
     private static func assetExists(_ name: String) -> Bool {
-        #if canImport(UIKit)
+        #if os(watchOS)
+        // watchOS has no failable `UIColor(named:in:compatibleWith:)`
+        // (`API_UNAVAILABLE(watchOS)`) — see this function's DETAILED
+        // comment above. Assume-present: the bundled colour sets are
+        // always compiled in, and `Color(_:bundle:)` resolves them fine.
+        return true
+        #elseif canImport(UIKit)
         return UIColor(named: name, in: .module, compatibleWith: nil) != nil
         #elseif canImport(AppKit)
         return NSColor(named: name, bundle: .module) != nil

--- a/appApple/Packages/iHymnsKit/Sources/IHFeatures/AppRootViewModel+Search.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHFeatures/AppRootViewModel+Search.swift
@@ -40,10 +40,28 @@ extension AppRootViewModel {
     public var filteredSongs: [SongSummary] {
         guard case .loaded(let songs) = catalogueLoadState else { return [] }
         let faceted = applyFacetFilters(to: songs)
-        guard !searchText.isEmpty else { return faceted }
+        return Self.songsMatching(searchText, in: faceted)
+    }
 
-        if let numberQuery = CatalogueNumberQuery(rawQuery: searchText) {
-            let numberMatches = faceted.filter(numberQuery.matches)
+    /// The number-then-substring matching core `filteredSongs` delegates
+    /// to — extracted (#1422, `.claude/apple-phase2-pr7-spec.md` §2/D-8) so
+    /// `RemoteSongPickerView` (`IHFeatures`) can reuse the EXACT SAME
+    /// matching logic over its own (unfiltered by songbook/language facets)
+    /// song list without re-forking the number/substring ladder — this
+    /// repo's own named regression class (`.claude/CLAUDE.md`'s "the
+    /// builder's old private `_bsls_*` copies" precedent, applied here to
+    /// Swift search matching instead of PHP similarity scoring). An empty
+    /// query returns `songs` unchanged (`filteredSongs`' own original
+    /// behaviour, now shared).
+    ///
+    /// ELI5: "Of these songs, which ones match what was typed?" — the same
+    /// answer whether you're searching the whole catalogue or picking a
+    /// song from the TV remote.
+    public nonisolated static func songsMatching(_ query: String, in songs: [SongSummary]) -> [SongSummary] {
+        guard !query.isEmpty else { return songs }
+
+        if let numberQuery = CatalogueNumberQuery(rawQuery: query) {
+            let numberMatches = songs.filter(numberQuery.matches)
             // Only trust the number interpretation if it actually found
             // something. A query like "Song 23" parses just fine as
             // songbook-prefix "SONG" + number 23, but no real songbook is
@@ -54,8 +72,8 @@ extension AppRootViewModel {
             if !numberMatches.isEmpty { return numberMatches }
         }
 
-        let needle = searchText.lowercased()
-        return faceted.filter {
+        let needle = query.lowercased()
+        return songs.filter {
             $0.title.lowercased().contains(needle)
                 || $0.displayNumber.contains(needle)
                 || $0.songbookAbbreviation.lowercased().contains(needle)

--- a/appApple/Packages/iHymnsKit/Sources/IHFeatures/IHSettingsStore.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHFeatures/IHSettingsStore.swift
@@ -112,6 +112,24 @@ public struct IHSettingsStore: @unchecked Sendable {
         nonmutating set { defaults.set(newValue, forKey: Keys.hasSeenOnboarding) }
     }
 
+    /// Whether the user has already been shown the LAN-remote screen's
+    /// Local Network explainer card (#1422, `.claude/apple-phase2-pr7-spec.md`
+    /// §4.3: "permission prompt explained pre-fire" — strategy §2.4.5).
+    /// Same shape as `hasSeenOnboarding` above: an unset key means the card
+    /// hasn't been shown yet, so `RemoteControlView` shows it before the
+    /// FIRST `NWBrowser` start (which is what actually triggers the OS's own
+    /// Local Network permission prompt) rather than letting that system
+    /// prompt appear with no context. Set `true` the moment the card's
+    /// "Continue" button is tapped (`RemoteControlCoordinator
+    /// .acknowledgeLocalNetworkPrimer()`).
+    ///
+    /// ELI5: "Have you already seen the explanation for why iHymns wants to
+    /// look for devices on your network?"
+    public var hasSeenLocalNetworkPrimer: Bool {
+        get { defaults.bool(forKey: Keys.hasSeenLocalNetworkPrimer) }
+        nonmutating set { defaults.set(newValue, forKey: Keys.hasSeenLocalNetworkPrimer) }
+    }
+
     /// An explicit override of which backend deployment (`IHAPI
     /// .APIEnvironment`) this device targets, or `nil` to use the app
     /// shell's own compiled-in default (`IHymnsApp.swift`'s `.dev`, per
@@ -149,6 +167,7 @@ public struct IHSettingsStore: @unchecked Sendable {
         static let dyslexiaReadingMode = "ihDyslexiaReadingModeEnabled"
         static let analyticsConsent = "ihAnalyticsConsentEnabled"
         static let hasSeenOnboarding = "ihHasSeenOnboarding"
+        static let hasSeenLocalNetworkPrimer = "ihHasSeenLocalNetworkPrimer"
         static let apiEnvironment = "ihApiEnvironmentOverride"
     }
 }

--- a/appApple/Packages/iHymnsKit/Sources/IHFeatures/LiveHubView.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHFeatures/LiveHubView.swift
@@ -1,0 +1,54 @@
+// LiveHubView.swift
+// IHFeatures
+//
+// ELI5: The real `.live` section screen — a "TV Remote" card that takes you
+// to the actual remote-control screen, plus an honest "Live Follow / Service
+// Mode — coming in a future update" note underneath, so this section is
+// truthful about what's built and what isn't.
+//
+// DETAILED: #1422 (`.claude/apple-phase2-pr7-spec.md` §6.1, Decision D-6).
+// Fills `RootContainerView`'s `.live` case (both `tabbedRoot` and
+// `splitView`), replacing what was purely `liveComingSoonView` — that
+// `ContentUnavailableView` copy MOVES here verbatim rather than being
+// rewritten, so the "don't fake a screen" honesty this repo insists on
+// (`RootContainerView.swift`'s own header) survives the refactor unchanged
+// for the half that's still unbuilt. Placed in `.live` rather than a new
+// tab/Settings row because a control surface is a DESTINATION (strategy
+// §2.4.1's remote-control feature), not a preference, and `RootSection`
+// deliberately caps at 7 tabs (`AppNavigationState.swift`) — see spec §6.1
+// for the full reasoning this header summarises.
+import IHDesign
+import SwiftUI
+
+/// The `.live` section's real content: a card leading to the LAN TV remote,
+/// plus the still-honest "coming soon" note for the server-mediated half.
+public struct LiveHubView: View {
+    private let rootViewModel: AppRootViewModel
+
+    public init(rootViewModel: AppRootViewModel) {
+        self.rootViewModel = rootViewModel
+    }
+
+    public var body: some View {
+        List {
+            Section {
+                NavigationLink {
+                    RemoteControlView(rootViewModel: rootViewModel)
+                } label: {
+                    Label("TV Remote", systemImage: "appletv")
+                }
+            } footer: {
+                Text("Control iHymns on your Apple TV from this device.")
+            }
+
+            Section {
+                ContentUnavailableView(
+                    "Live Follow & Service Mode",
+                    systemImage: "dot.radiowaves.left.and.right",
+                    description: Text("Live Follow and Service Mode are coming in a future update.")
+                )
+            }
+        }
+        .navigationTitle("Live")
+    }
+}

--- a/appApple/Packages/iHymnsKit/Sources/IHFeatures/PairingCodeEntrySheet.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHFeatures/PairingCodeEntrySheet.swift
@@ -1,0 +1,75 @@
+// PairingCodeEntrySheet.swift
+// IHFeatures
+//
+// ELI5: The "type the 6-digit code shown on the TV" screen — shows which TV
+// you're pairing with, a place to type the code, and (if you typed it
+// wrong) a plain-English "try again" note. If the TV gives up on you after
+// too many wrong tries, it explains what to do next instead of just
+// vanishing.
+//
+// DETAILED: #1422 (`.claude/apple-phase2-pr7-spec.md` §4/§6.3, path B).
+// Presented by `RemoteControlView` while `RemoteControlCoordinator.uiPhase`
+// is `.codeEntry(tvName:failedAttempts:)`; submitting calls `coordinator
+// .submitCode(_:)`, which drives `RemoteControlSession`'s pairing-flow
+// reducer (`IHLive`) — this view never talks to the session/actor layer
+// directly, matching this package's "screens render `AppRootViewModel`-style
+// state, they don't own engines" convention (`CatalogueListView.swift`'s own
+// header makes the identical point for the catalogue).
+import SwiftUI
+
+/// The 6-digit code entry sheet (spec §4 path B).
+public struct PairingCodeEntrySheet: View {
+    let tvName: String
+    let failedAttempts: Int
+    let onSubmit: (String) -> Void
+    let onCancel: () -> Void
+
+    @State private var code = ""
+    @FocusState private var isCodeFieldFocused: Bool
+
+    public init(tvName: String, failedAttempts: Int, onSubmit: @escaping (String) -> Void, onCancel: @escaping () -> Void) {
+        self.tvName = tvName
+        self.failedAttempts = failedAttempts
+        self.onSubmit = onSubmit
+        self.onCancel = onCancel
+    }
+
+    public var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    Text("Enter the 6-digit code shown on \(tvName).")
+                } footer: {
+                    if failedAttempts > 0 {
+                        Text("That code didn't match. Please try again.")
+                            .foregroundStyle(.red)
+                    }
+                }
+
+                Section {
+                    TextField("Pairing code", text: $code)
+                        .textContentType(.oneTimeCode)
+                        #if os(iOS) || os(visionOS)
+                        .keyboardType(.numberPad)
+                        #endif
+                        .focused($isCodeFieldFocused)
+                        .onChange(of: code) { _, newValue in
+                            let digitsOnly = newValue.filter(\.isNumber)
+                            code = String(digitsOnly.prefix(6))
+                        }
+                }
+            }
+            .navigationTitle("Enter Code")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel", role: .cancel, action: onCancel)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Pair") { onSubmit(code) }
+                        .disabled(code.count != 6)
+                }
+            }
+            .onAppear { isCodeFieldFocused = true }
+        }
+    }
+}

--- a/appApple/Packages/iHymnsKit/Sources/IHFeatures/PairingPayloadEntrySheet.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHFeatures/PairingPayloadEntrySheet.swift
@@ -1,0 +1,102 @@
+// PairingPayloadEntrySheet.swift
+// IHFeatures
+//
+// ELI5: The "how do you want to tell iHymns which TV to pair with" sheet —
+// on iPhone/iPad, a big "Scan QR Code" button; on every platform, a place
+// to paste the pairing text instead (handy on a Mac, or if AirDrop/Messages
+// carried the code over from the TV's screen).
+//
+// DETAILED: #1422 (`.claude/apple-phase2-pr7-spec.md` §4 path B′, §6.3/D-12).
+// Whichever way the string arrives, it's handed to `RemoteControlCoordinator
+// .handleScannedOrPasted(_:)` unchanged — that's the ONE place
+// `LANRemotePairingPayload(qrString:)` gets parsed and turned into a connect
+// attempt (spec §4's invariant: never a second, ad-hoc parse site). Scan is
+// `#if os(iOS)` only (visionOS has no third-party camera access; macOS
+// skips it for ergonomics/sandbox reasons — spec Decision D-12) — paste is
+// on every platform, and is the ONLY new-pair path macOS/visionOS have.
+#if os(iOS)
+import AVFoundation
+#endif
+import SwiftUI
+
+/// The scan-or-paste chooser (spec §4 path B′).
+public struct PairingPayloadEntrySheet: View {
+    /// Called with the raw scanned/pasted string — `RemoteControlView` wires
+    /// this straight to `coordinator.handleScannedOrPasted(_:)`.
+    let onResolved: (String) -> Void
+    let onCancel: () -> Void
+
+    @State private var pastedText = ""
+    #if os(iOS)
+    @State private var isPresentingScanner = false
+    #endif
+
+    public init(onResolved: @escaping (String) -> Void, onCancel: @escaping () -> Void) {
+        self.onResolved = onResolved
+        self.onCancel = onCancel
+    }
+
+    public var body: some View {
+        NavigationStack {
+            Form {
+                #if os(iOS)
+                Section {
+                    Button {
+                        Task { await requestCameraAccessThenPresentScanner() }
+                    } label: {
+                        Label("Scan QR Code", systemImage: "qrcode.viewfinder")
+                    }
+                } footer: {
+                    Text("Scan the QR code shown on your Apple TV's Settings → Remote Control screen.")
+                }
+                #endif
+
+                Section {
+                    TextField("Paste pairing code", text: $pastedText, axis: .vertical)
+                        .lineLimit(3...6)
+                        #if os(iOS) || os(visionOS)
+                        .textInputAutocapitalization(.never)
+                        #endif
+                        .autocorrectionDisabled()
+                } header: {
+                    Text("Or paste it")
+                } footer: {
+                    Text("Paste the pairing text shown under the QR code — for example, if it was sent by AirDrop or Messages.")
+                }
+            }
+            .navigationTitle("Pair with a TV")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel", role: .cancel, action: onCancel)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Connect") { onResolved(pastedText.trimmingCharacters(in: .whitespacesAndNewlines)) }
+                        .disabled(pastedText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+            #if os(iOS)
+            .sheet(isPresented: $isPresentingScanner) {
+                PairingScanView { scanned in
+                    isPresentingScanner = false
+                    onResolved(scanned)
+                }
+            }
+            #endif
+        }
+    }
+
+    #if os(iOS)
+    /// Requests camera access ONLY if it hasn't been decided yet — spec
+    /// §4.3: "`.notDetermined` → `requestAccess` on the Scan button tap
+    /// (never on screen appear)". Presents `PairingScanView` regardless of
+    /// the outcome; that view reads the FINAL authorization status itself
+    /// to decide between the live preview and its own denied-guidance card
+    /// (spec: "camera denial NEVER dead-ends pairing").
+    private func requestCameraAccessThenPresentScanner() async {
+        if AVCaptureDevice.authorizationStatus(for: .video) == .notDetermined {
+            _ = await AVCaptureDevice.requestAccess(for: .video)
+        }
+        isPresentingScanner = true
+    }
+    #endif
+}

--- a/appApple/Packages/iHymnsKit/Sources/IHFeatures/PairingScanView.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHFeatures/PairingScanView.swift
@@ -1,0 +1,187 @@
+// PairingScanView.swift
+// IHFeatures
+//
+// ELI5: The actual camera screen that watches for the TV's pairing QR code
+// — as soon as it sees one that really is an iHymns pairing code (not a
+// Wi-Fi poster or some other QR someone points it at by mistake), it hands
+// the text back and closes itself.
+//
+// DETAILED: #1422 (`.claude/apple-phase2-pr7-spec.md` §4.3/§6.4, Decision
+// D-12). `#if os(iOS)` ONLY — on every other platform this file compiles to
+// NOTHING (visionOS has no third-party main-camera access; macOS skips
+// camera scanning for ergonomics + sandbox-entitlement reasons). Adds NO new
+// framework class to the app's dependency picture: AVFoundation is already
+// imported elsewhere in `IHFeatures` (`SongAudioPlaybackEngine.swift`), and
+// this file needs nothing beyond `AVCaptureSession`/`AVCaptureMetadataOutput`/
+// `AVCaptureVideoPreviewLayer` — all first-party, no new SwiftPM dependency
+// (spec §8 D-15's "no new external package" tripwire).
+#if os(iOS)
+import AVFoundation
+import SwiftUI
+
+/// The QR-scanning camera screen — see this file's header for the full
+/// platform story.
+public struct PairingScanView: View {
+    /// Called EXACTLY ONCE, with the first scanned string that
+    /// `LANRemotePairingPayload(qrString:)` (`IHLive`) would accept — the
+    /// caller (`PairingPayloadEntrySheet`) re-parses it again itself via
+    /// `RemoteControlCoordinator.handleScannedOrPasted(_:)`, this view only
+    /// pre-filters obviously-irrelevant QR codes so a stray scan of the
+    /// venue's Wi-Fi poster never even reaches the coordinator.
+    let onScanned: (String) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var isAuthorized = AVCaptureDevice.authorizationStatus(for: .video) == .authorized
+
+    public init(onScanned: @escaping (String) -> Void) {
+        self.onScanned = onScanned
+    }
+
+    public var body: some View {
+        ZStack {
+            if isAuthorized {
+                CameraPreview(onScanned: handleScanned)
+                    .ignoresSafeArea()
+            } else {
+                deniedView
+            }
+        }
+        .overlay(alignment: .topTrailing) {
+            Button {
+                dismiss()
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.title)
+                    .foregroundStyle(.white, .black.opacity(0.5))
+            }
+            .padding()
+            .accessibilityLabel("Close scanner")
+        }
+        .task {
+            // Re-check on appear — the tap that presented this screen
+            // already ran `requestAccess` if needed (spec §4.3: "request on
+            // the Scan button tap, never on screen appear"); this just picks
+            // up whatever the OS decided.
+            isAuthorized = AVCaptureDevice.authorizationStatus(for: .video) == .authorized
+        }
+    }
+
+    private func handleScanned(_ string: String) {
+        guard LANRemotePairingPayload(qrString: string) != nil else {
+            // Not an iHymns pairing code — ignored silently (spec §4.3:
+            // "people WILL scan the venue Wi-Fi poster by mistake").
+            return
+        }
+        onScanned(string)
+    }
+
+    /// Camera access was denied/restricted — pairing is never dead-ended by
+    /// this (spec §4.3, Decision D-12): dismissing returns to
+    /// `PairingPayloadEntrySheet`, where the paste field is always present.
+    private var deniedView: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "camera.fill")
+                .font(.largeTitle)
+                .foregroundStyle(.secondary)
+            Text("Camera access is off")
+                .font(.headline)
+            Text("Allow camera access in Settings, or go back and paste the pairing code instead.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+            Button("Close") { dismiss() }
+                .buttonStyle(.bordered)
+        }
+        .padding()
+    }
+}
+
+/// `UIViewRepresentable` wrapping an `AVCaptureSession` + QR metadata output
+/// + `AVCaptureVideoPreviewLayer` — the plain, no-dependency way to put a
+/// live camera feed with QR detection on screen.
+private struct CameraPreview: UIViewRepresentable {
+    let onScanned: (String) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onScanned: onScanned)
+    }
+
+    func makeUIView(context: Context) -> PreviewUIView {
+        let view = PreviewUIView()
+        context.coordinator.configure(previewView: view)
+        return view
+    }
+
+    func updateUIView(_ uiView: PreviewUIView, context: Context) {}
+
+    static func dismantleUIView(_ uiView: PreviewUIView, coordinator: Coordinator) {
+        coordinator.stop()
+    }
+
+    /// Owns the capture session and starts/stops it on a background
+    /// (utility) queue — Apple's own guidance: never start/stop
+    /// `AVCaptureSession` on the main thread.
+    final class Coordinator: NSObject, AVCaptureMetadataOutputObjectsDelegate {
+        private let onScanned: (String) -> Void
+        private let session = AVCaptureSession()
+        private let sessionQueue = DispatchQueue(label: "app.ihymns.lanremote.scan", qos: .userInitiated)
+        private var hasDelivered = false
+
+        init(onScanned: @escaping (String) -> Void) {
+            self.onScanned = onScanned
+        }
+
+        func configure(previewView: PreviewUIView) {
+            previewView.videoPreviewLayer.session = session
+            sessionQueue.async { [weak self] in
+                self?.startSession()
+            }
+        }
+
+        private func startSession() {
+            guard let device = AVCaptureDevice.default(for: .video),
+                  let input = try? AVCaptureDeviceInput(device: device),
+                  session.canAddInput(input) else { return }
+            session.addInput(input)
+
+            let output = AVCaptureMetadataOutput()
+            guard session.canAddOutput(output) else { return }
+            session.addOutput(output)
+            output.setMetadataObjectsDelegate(self, queue: sessionQueue)
+            output.metadataObjectTypes = [.qr]
+
+            session.startRunning()
+        }
+
+        func stop() {
+            sessionQueue.async { [weak self] in
+                self?.session.stopRunning()
+            }
+        }
+
+        func metadataOutput(
+            _ output: AVCaptureMetadataOutput, didOutput metadataObjects: [AVMetadataObject], from connection: AVCaptureConnection
+        ) {
+            guard !hasDelivered,
+                  let match = metadataObjects.first as? AVMetadataMachineReadableCodeObject,
+                  match.type == .qr,
+                  let string = match.stringValue else { return }
+            hasDelivered = true
+            DispatchQueue.main.async { [onScanned] in
+                onScanned(string)
+            }
+        }
+    }
+
+    /// A plain `UIView` whose backing layer IS the preview layer — the
+    /// standard `AVCaptureVideoPreviewLayer` hosting idiom.
+    final class PreviewUIView: UIView {
+        override static var layerClass: AnyClass { AVCaptureVideoPreviewLayer.self }
+        var videoPreviewLayer: AVCaptureVideoPreviewLayer {
+            // swiftlint:disable:next force_cast
+            layer as! AVCaptureVideoPreviewLayer
+        }
+    }
+}
+#endif

--- a/appApple/Packages/iHymnsKit/Sources/IHFeatures/PairingScanView.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHFeatures/PairingScanView.swift
@@ -17,6 +17,12 @@
 // (spec §8 D-15's "no new external package" tripwire).
 #if os(iOS)
 import AVFoundation
+// `LANRemotePairingPayload(qrString:)` (used in `handleScanned` to pre-filter
+// non-iHymns QR codes) lives in IHLive — imported explicitly here because Swift
+// imports are per-FILE, and this file's whole body is `#if os(iOS)`, so a
+// missing import only ever surfaces on an iOS compile (the macOS/tvOS builds
+// compile this file to nothing). #1422.
+import IHLive
 import SwiftUI
 
 /// The QR-scanning camera screen — see this file's header for the full
@@ -122,7 +128,38 @@ private struct CameraPreview: UIViewRepresentable {
     /// Owns the capture session and starts/stops it on a background
     /// (utility) queue — Apple's own guidance: never start/stop
     /// `AVCaptureSession` on the main thread.
-    final class Coordinator: NSObject, AVCaptureMetadataOutputObjectsDelegate {
+    ///
+    /// ELI5: this class touches a camera from more than one thread, so we
+    /// have to PROVE to Swift 6 that it's doing so safely — `@unchecked
+    /// Sendable` is that proof, backed by the discipline documented below,
+    /// not a way of skipping the check.
+    ///
+    /// DETAILED (#1422 review fix 5): under Swift 6 strict concurrency,
+    /// `DispatchQueue.async(execute:)` takes an `@escaping @Sendable`
+    /// closure — capturing `self` (a plain `NSObject` subclass, not
+    /// `Sendable`) in either `sessionQueue.async { [weak self] … }` below
+    /// (`configure(previewView:)`'s `startSession()` kickoff, `stop()`'s
+    /// `stopRunning()`) produced a "capture of non-Sendable type in a
+    /// `@Sendable` closure" warning. The underlying design was already
+    /// safe, just not provably so to the compiler: EVERY mutable property
+    /// here (`session`'s own configuration/state, `hasDelivered`) is
+    /// touched ONLY from `sessionQueue` — a dedicated serial queue — after
+    /// construction; `session` itself is a `let` (the reference never
+    /// changes), and the ONE MainActor touch, `configure(previewView:)`'s
+    /// `previewView.videoPreviewLayer.session = session`, only hands that
+    /// same immutable reference to the preview layer (assigning
+    /// `AVCaptureVideoPreviewLayer.session` from the main thread while
+    /// `startRunning()`/`stopRunning()`/`addInput`/`addOutput` run on a
+    /// background queue is Apple's own documented, blessed pattern — no
+    /// property of THIS type is ever read or written from two different
+    /// queues at once, which is exactly what `Sendable` verification exists
+    /// to prove and exactly what the compiler cannot see through a
+    /// hand-rolled `DispatchQueue` confinement discipline). Hence
+    /// `@unchecked` — this silences the warnings without changing any
+    /// runtime behaviour; a future change that starts mutating `session`'s
+    /// configuration or `hasDelivered` from anywhere OTHER than
+    /// `sessionQueue` would break the discipline this comment documents.
+    final class Coordinator: NSObject, AVCaptureMetadataOutputObjectsDelegate, @unchecked Sendable {
         private let onScanned: (String) -> Void
         private let session = AVCaptureSession()
         private let sessionQueue = DispatchQueue(label: "app.ihymns.lanremote.scan", qos: .userInitiated)

--- a/appApple/Packages/iHymnsKit/Sources/IHFeatures/RemoteControlCoordinator.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHFeatures/RemoteControlCoordinator.swift
@@ -1,0 +1,317 @@
+// RemoteControlCoordinator.swift
+// IHFeatures
+//
+// ELI5: The one object the remote-control screens actually talk to — it
+// owns the paired-TV address book and the connection supervisor, turns
+// scanned QR codes / tapped list rows into real connection attempts, saves
+// a TV the moment pairing succeeds, and boils everything happening down
+// into ONE simple "what should the screen show right now?" value.
+//
+// DETAILED: #1422 (`.claude/apple-phase2-pr7-spec.md` §6.2 — the
+// `TVRemoteControlCoordinator` mirror, phone side). Builds `KeychainPairedTVStore`
+// + `RemoteControlSession` and consumes ONLY `session.events` (never
+// `RemoteSessionActor`'s own streams — the single-consumer rule
+// `RemoteControlSession.swift`'s header restates) plus the discovery stream
+// `session.startDiscovery()` returns. `RemotePairingEntryResolver` (`IHLive`)
+// is the ONE place entry-path decisions get made — this file never
+// improvises a connect target of its own.
+import Foundation
+import IHLive
+import IHLog
+import Observation
+
+/// The phone/iPad/Mac/Vision composition root for the LAN TV remote — see
+/// this file's header for the full picture.
+///
+/// ELI5: "Here's every TV I know about, here's what the screen should show,
+/// and here's how to connect to one."
+@MainActor
+@Observable
+public final class RemoteControlCoordinator {
+
+    /// Everything the browsing/connecting/controlling screens render from —
+    /// the PURE `uiPhase(after:current:tvName:)` mapping (below) is what
+    /// turns a `RemoteControlSession.Event` into one of these.
+    public enum UIPhase: Equatable {
+        case browsing
+        case connecting(tvName: String, attempt: Int)
+        case codeEntry(tvName: String, failedAttempts: Int)
+        case controlling(tvName: String, state: IHRPState)
+        case reconnecting(tvName: String, attempt: Int)
+        case suspended(tvName: String)
+    }
+
+    public private(set) var uiPhase: UIPhase = .browsing
+    /// Resolver-built (`RemotePairingEntryResolver.listRows`) — saved TVs
+    /// first, then unpaired nearby ones, rebuilt whenever either the saved
+    /// list or the discovered set changes.
+    public private(set) var rows: [RemoteTVListRow] = []
+    /// A transient, inline themed notice — "Not a valid iHymns pairing
+    /// code," "ask the operator for a fresh code," etc. Cleared on the next
+    /// successful action.
+    public private(set) var notice: String?
+    /// Set when Bonjour browsing itself was denied Local Network
+    /// permission. **Always `false` in this PR** — `RemoteSessionActor`'s
+    /// current discovery API (`RemoteSessionActor.swift`'s
+    /// `isLocalNetworkPermissionDenied` helper) only LOGS the denial
+    /// (`IHLog.discovery.error`), it does not surface it through
+    /// `startDiscovery()`'s result stream or any other public signal this
+    /// PR's binding "no further `RemoteSessionActor` edits beyond the
+    /// resolved-address capture" scope allows adding a hook for. Wiring this
+    /// up for real needs a small, separate `RemoteSessionActor` addition —
+    /// tracked as follow-up, not guessed at here.
+    public private(set) var localNetworkDenied = false
+
+    private let store: any PairedTVStoring
+    private let session: RemoteControlSession
+    private var savedRecords: [PairedTVRecord] = []
+    private var discoveredServices: [LANRemoteDiscoveredService] = []
+
+    /// The TV currently being attached to/controlled — tracked HERE (not
+    /// read back from `RemoteControlSession`, which only exposes ITS OWN
+    /// events) so `.paired`/`.controlling` events can be turned into both a
+    /// `PairedTVRecord` upsert and a `UIPhase` carrying the right name.
+    private var currentTVName: String?
+    private var currentFingerprint: String?
+
+    private var hasStarted = false
+    private var eventsTask: Task<Void, Never>?
+    private var discoveryTask: Task<Void, Never>?
+
+    public init(
+        store: any PairedTVStoring = KeychainPairedTVStore(),
+        sessionConfiguration: RemoteControlSession.Configuration = .init(
+            remoteKind: RemoteDeviceIdentity.kind, deviceName: RemoteDeviceIdentity.name
+        )
+    ) {
+        self.store = store
+        self.session = RemoteControlSession(configuration: sessionConfiguration)
+    }
+
+    /// Idempotent — loads the saved-TV list, starts discovery IF the Local
+    /// Network primer has already been shown, and spawns the ONE
+    /// `session.events` consumer this coordinator ever runs.
+    ///
+    /// ELI5: "Get the remote-control screen ready."
+    public func start() async {
+        guard !hasStarted else { return }
+        hasStarted = true
+
+        savedRecords = await store.listPairedTVs()
+        rebuildRows()
+        spawnEventsConsumer()
+
+        if IHSettingsStore().hasSeenLocalNetworkPrimer {
+            await beginDiscovery()
+        }
+    }
+
+    /// The primer card's "Continue" action (spec §4.3) — persists that the
+    /// user has seen it AND starts discovery in the same step (the OS
+    /// permission prompt fires on the first real `NWBrowser` start, right
+    /// after this).
+    public func acknowledgeLocalNetworkPrimer() async {
+        IHSettingsStore().hasSeenLocalNetworkPrimer = true
+        await beginDiscovery()
+    }
+
+    public func stop() async {
+        discoveryTask?.cancel(); discoveryTask = nil
+        eventsTask?.cancel(); eventsTask = nil
+        await session.stop()
+    }
+
+    // MARK: - Entry paths (spec §4)
+
+    /// A scanned QR or a pasted payload string — `PairingPayloadEntrySheet`'s
+    /// one call.
+    ///
+    /// ELI5: "I scanned/pasted this — try to connect."
+    public func handleScannedOrPasted(_ string: String) {
+        guard let payload = LANRemotePairingPayload(qrString: string) else {
+            notice = "Not a valid iHymns pairing code."
+            return
+        }
+        resolveAndAttach(.payload(payload), tvName: payload.name, fingerprint: payload.fingerprintHex)
+    }
+
+    /// A tap on a list row — informational-only for an unpaired nearby row
+    /// (spec §4 row C′: never connects; the view's own affordance for that
+    /// row opens the scan/paste sheet instead, this method simply no-ops).
+    public func connect(row: RemoteTVListRow) {
+        guard case .paired(let record) = row.kind else { return }
+        resolveAndAttach(.savedRow(record), tvName: record.name, fingerprint: record.fingerprintHex)
+    }
+
+    private func resolveAndAttach(_ entry: RemotePairingEntryResolver.Entry, tvName: String, fingerprint: String) {
+        let resolution = RemotePairingEntryResolver.resolve(entry, saved: savedRecords, discovered: discoveredServices)
+        switch resolution {
+        case .connect(let target):
+            notice = nil
+            currentTVName = tvName
+            currentFingerprint = fingerprint
+            Task { await session.attach(to: target) }
+        case .unpairable(.noRouteToTV):
+            notice = "Couldn't find \(tvName) on this network. Scan its QR code again from the TV's screen."
+        }
+    }
+
+    // MARK: - Ceremony / control-surface pass-throughs
+
+    public func submitCode(_ code: String) async {
+        await session.submitPairingCode(code)
+    }
+
+    public func cancelPairing() async {
+        await session.cancelPairing()
+    }
+
+    /// The user's explicit "Disconnect" button.
+    public func disconnect() async {
+        await session.endControl()
+    }
+
+    /// "Forget this TV" — removes the local record; the TV itself still
+    /// trusts this device until revoked there too (spec §5.2's honesty
+    /// note — the caller's confirmation copy says so).
+    public func forget(_ record: PairedTVRecord) async {
+        await store.delete(fingerprint: record.fingerprintHex)
+        savedRecords = await store.listPairedTVs()
+        rebuildRows()
+    }
+
+    /// `scenePhase` wiring.
+    public func setScenePhaseActive(_ active: Bool) async {
+        await session.setSuspended(!active)
+    }
+
+    /// The control surface's one door for sending an intent.
+    public func sendIntent(_ message: IHRPMessage) async {
+        await session.sendIntent(message)
+    }
+
+    // MARK: - Discovery
+
+    private func beginDiscovery() async {
+        guard discoveryTask == nil else { return }
+        let stream = await session.startDiscovery()
+        discoveryTask = Task { [weak self] in
+            for await services in stream {
+                guard let self else { break }
+                self.applyDiscovered(services)
+            }
+        }
+    }
+
+    private func applyDiscovered(_ services: [LANRemoteDiscoveredService]) {
+        discoveredServices = services
+        rebuildRows()
+    }
+
+    private func rebuildRows() {
+        rows = RemotePairingEntryResolver.listRows(saved: savedRecords, discovered: discoveredServices)
+    }
+
+    // MARK: - The events consumer (the ONE consumer of `session.events`)
+
+    private func spawnEventsConsumer() {
+        eventsTask = Task { [weak self] in
+            guard let self else { return }
+            for await event in self.session.events {
+                await self.apply(event)
+            }
+        }
+    }
+
+    private func apply(_ event: RemoteControlSession.Event) async {
+        let tvName = currentTVName ?? "this TV"
+        uiPhase = Self.uiPhase(after: event, current: uiPhase, tvName: tvName)
+
+        switch event {
+        case .paired(let token, let resolved):
+            await persistPaired(token: token, resolved: resolved)
+        case .controlling:
+            await touchLastConnected()
+        case .pairingEnded(let failure):
+            currentTVName = nil
+            currentFingerprint = nil
+            switch failure {
+            case .cancelled:
+                notice = nil
+            case .connectionTornDown:
+                notice = "Pairing didn't complete. Ask the operator to open pairing on the TV again."
+            }
+        case .ended:
+            currentTVName = nil
+            currentFingerprint = nil
+        case .connecting, .awaitingCodeEntry, .detached, .reconnecting, .suspended:
+            break
+        }
+    }
+
+    private func persistPaired(token: String, resolved: LANRemoteResolvedAddress?) async {
+        guard let fingerprint = currentFingerprint, let name = currentTVName else { return }
+        let now = Date()
+        let existing = await store.record(forFingerprint: fingerprint)
+        let record = PairedTVRecord(
+            fingerprintHex: fingerprint, name: name, token: token,
+            lastAddress: resolved ?? existing?.lastAddress,
+            pairedAt: existing?.pairedAt ?? now, lastConnectedAt: now
+        )
+        await store.save(record)
+        savedRecords = await store.listPairedTVs()
+        rebuildRows()
+    }
+
+    /// On each `.controlling` first-arrival after an attach/reconnect,
+    /// update `lastConnectedAt`/`lastAddress` on the EXISTING saved record
+    /// (spec §5.2) — distinct from `persistPaired`, which only runs once per
+    /// FRESH ceremony. A fast-path reconnect (no `.paired` event at all)
+    /// still needs its `lastConnectedAt` refreshed, which is what this call
+    /// is for.
+    private func touchLastConnected() async {
+        guard let fingerprint = currentFingerprint, var record = await store.record(forFingerprint: fingerprint) else { return }
+        record.lastConnectedAt = Date()
+        if let resolved = await session.currentResolvedAddress() {
+            record.lastAddress = resolved
+        }
+        await store.save(record)
+        savedRecords = await store.listPairedTVs()
+        rebuildRows()
+    }
+
+    // MARK: - The pure event → UI mapping (spec §7.3-testable)
+
+    /// Turns one `RemoteControlSession.Event` into the next `UIPhase` —
+    /// pure and static so `RemoteControlUIStateTests` can drive it with zero
+    /// actors/sessions/network involved.
+    ///
+    /// ELI5: "Given what just happened, what should the screen show now?"
+    nonisolated static func uiPhase(after event: RemoteControlSession.Event, current: UIPhase, tvName: String) -> UIPhase {
+        switch event {
+        case .connecting(let attempt):
+            return .connecting(tvName: tvName, attempt: attempt)
+        case .awaitingCodeEntry(let failedAttempts):
+            return .codeEntry(tvName: tvName, failedAttempts: failedAttempts)
+        case .pairingEnded:
+            return .browsing
+        case .paired:
+            // `.controlling` always follows on the same connection (§1.1's
+            // wire contract) — no visible transition needed here.
+            return current
+        case .controlling(let state):
+            return .controlling(tvName: tvName, state: state)
+        case .detached:
+            // The ladder's first `.reconnecting(attempt: 0, …)` is only
+            // moments away; show it immediately rather than leaving a stale
+            // `.controlling` phase on screen for that brief window.
+            return .reconnecting(tvName: tvName, attempt: 0)
+        case .reconnecting(let attempt, _):
+            return .reconnecting(tvName: tvName, attempt: attempt)
+        case .suspended:
+            return .suspended(tvName: tvName)
+        case .ended:
+            return .browsing
+        }
+    }
+}

--- a/appApple/Packages/iHymnsKit/Sources/IHFeatures/RemoteControlCoordinator.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHFeatures/RemoteControlCoordinator.swift
@@ -63,7 +63,26 @@ public final class RemoteControlCoordinator {
     public private(set) var localNetworkDenied = false
 
     private let store: any PairedTVStoring
-    private let session: RemoteControlSession
+    /// Kept so `start()` can build a BRAND-NEW `RemoteControlSession` on
+    /// every (re)start rather than the one this type used to construct
+    /// ONCE in `init` — see `session`'s own doc comment (#1422 review fix 3).
+    private let sessionConfiguration: RemoteControlSession.Configuration
+    /// `var`, not `let` (#1422 review fix 3): `RemoteControlSession.stop()`
+    /// is TERMINAL — `eventContinuation.finish()` means its `events` stream
+    /// never yields again, no matter what's called on the actor afterwards.
+    /// Before this fix `session` was a `let` built ONCE in `init` and
+    /// `start()` was one-shot (`hasStarted`, never reset) — so a view that
+    /// saw `onDisappear` (→ `stop()`) and then re-`appear`ed (a tab switch
+    /// while this screen stays pushed; SwiftUI keeps this `@Observable`
+    /// coordinator's `@State` alive across that and just re-runs `.task`,
+    /// `RemoteControlView.swift:35-36`) hit a genuinely DEAD screen:
+    /// `start()` no-op'd, and even if it hadn't, the OLD session's stream
+    /// was finished for good either way. Fix: `stop()` resets `hasStarted`
+    /// so `start()` re-arms, and `start()` builds a FRESH session — fresh
+    /// actor, fresh stream, fresh `spawnEventsConsumer()` — every time it
+    /// runs. The old, already-`stop()`'d session is simply dropped; it has
+    /// no background tasks left by the time `stop()` returns, so nothing leaks.
+    private var session: RemoteControlSession
     private var savedRecords: [PairedTVRecord] = []
     private var discoveredServices: [LANRemoteDiscoveredService] = []
 
@@ -73,6 +92,12 @@ public final class RemoteControlCoordinator {
     /// `PairedTVRecord` upsert and a `UIPhase` carrying the right name.
     private var currentTVName: String?
     private var currentFingerprint: String?
+
+    /// Guards `touchLastConnected()` so it only runs on the FIRST
+    /// `.controlling` arrival for the CURRENT attach/reconnect, not on
+    /// every subsequent state broadcast — see `apply(_:)`'s `.controlling`
+    /// case for the full story (#1422 review fix 2).
+    private var hasTouchedThisLink = false
 
     private var hasStarted = false
     private var eventsTask: Task<Void, Never>?
@@ -85,17 +110,33 @@ public final class RemoteControlCoordinator {
         )
     ) {
         self.store = store
+        self.sessionConfiguration = sessionConfiguration
         self.session = RemoteControlSession(configuration: sessionConfiguration)
     }
 
-    /// Idempotent — loads the saved-TV list, starts discovery IF the Local
+    /// Idempotent (re-armable — #1422 review fix 3) — rebuilds a fresh
+    /// `session`, loads the saved-TV list, starts discovery IF the Local
     /// Network primer has already been shown, and spawns the ONE
-    /// `session.events` consumer this coordinator ever runs.
+    /// `session.events` consumer this coordinator ever runs FOR THAT
+    /// session. Safe to call again after a matching `stop()` — see
+    /// `session`'s own doc comment for why.
     ///
-    /// ELI5: "Get the remote-control screen ready."
+    /// ELI5: "Get the remote-control screen ready" — including "ready
+    /// again," if the screen went away and came back.
     public func start() async {
         guard !hasStarted else { return }
         hasStarted = true
+
+        // A brand-new session every time — never reuse one a prior
+        // `stop()` already finished. Also reset the transient per-
+        // connection UI state: a stale `.controlling`/`.codeEntry` screen
+        // must not linger over a session attached to nothing.
+        session = RemoteControlSession(configuration: sessionConfiguration)
+        uiPhase = .browsing
+        notice = nil
+        currentTVName = nil
+        currentFingerprint = nil
+        hasTouchedThisLink = false
 
         savedRecords = await store.listPairedTVs()
         rebuildRows()
@@ -115,7 +156,14 @@ public final class RemoteControlCoordinator {
         await beginDiscovery()
     }
 
+    /// Full teardown — also re-arms `start()` (#1422 review fix 3): a
+    /// LATER `start()` call (the view reappearing) must not see
+    /// `hasStarted == true` and no-op over a session this just finished.
+    /// `guard hasStarted` makes a repeat/stray `stop()` call a cheap no-op
+    /// instead of re-finishing an already-finished session.
     public func stop() async {
+        guard hasStarted else { return }
+        hasStarted = false
         discoveryTask?.cancel(); discoveryTask = nil
         eventsTask?.cancel(); eventsTask = nil
         await session.stop()
@@ -153,6 +201,13 @@ public final class RemoteControlCoordinator {
             Task { await session.attach(to: target) }
         case .unpairable(.noRouteToTV):
             notice = "Couldn't find \(tvName) on this network. Scan its QR code again from the TV's screen."
+        case .unpairable(.malformedPayload):
+            // Spec §8's clamp (#1422 review fix 4) rejected the payload's
+            // OWN fields (port 0 / a malformed fingerprint) before this
+            // resolver even looked for a route — a distinct, more specific
+            // notice than "couldn't find it on the network" since the
+            // payload itself is the problem, not reachability.
+            notice = "Not a valid iHymns pairing code."
         }
     }
 
@@ -228,10 +283,32 @@ public final class RemoteControlCoordinator {
         uiPhase = Self.uiPhase(after: event, current: uiPhase, tvName: tvName)
 
         switch event {
+        case .connecting, .reconnecting:
+            // A NEW connection attempt is (re)starting — arm
+            // `hasTouchedThisLink` back to `false` so the next
+            // `.controlling` arrival still gets exactly one touch
+            // (#1422 review fix 2).
+            hasTouchedThisLink = false
         case .paired(let token, let resolved):
+            // Defensive re-reset: `.connecting` already cleared this for
+            // the same attempt, but `.paired` always precedes this
+            // connection's first `.controlling` on the wire (spec §1.1),
+            // so resetting again costs nothing.
+            hasTouchedThisLink = false
             await persistPaired(token: token, resolved: resolved)
         case .controlling:
-            await touchLastConnected()
+            // `.controlling` fires on EVERY TV state broadcast — including
+            // the TV's echo of our OWN intents (spec §1.1) — so touching
+            // unconditionally would hit the Keychain (read+delete+add) +
+            // `listPairedTVs()`/`rebuildRows()` on every next/prev/scroll
+            // tap. This gate makes the code match `touchLastConnected()`'s
+            // own "FIRST-arrival" doc comment (#1422 review fix 2): only
+            // the first arrival since the last `.connecting`/
+            // `.reconnecting`/`.paired` runs it; later echoes no-op.
+            if !hasTouchedThisLink {
+                hasTouchedThisLink = true
+                await touchLastConnected()
+            }
         case .pairingEnded(let failure):
             currentTVName = nil
             currentFingerprint = nil
@@ -244,7 +321,7 @@ public final class RemoteControlCoordinator {
         case .ended:
             currentTVName = nil
             currentFingerprint = nil
-        case .connecting, .awaitingCodeEntry, .detached, .reconnecting, .suspended:
+        case .awaitingCodeEntry, .detached, .suspended:
             break
         }
     }

--- a/appApple/Packages/iHymnsKit/Sources/IHFeatures/RemoteControlSurfaceView.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHFeatures/RemoteControlSurfaceView.swift
@@ -1,0 +1,202 @@
+// RemoteControlSurfaceView.swift
+// IHFeatures
+//
+// ELI5: The actual remote control — shows what song's up on the TV right
+// now, and lets you jump to another song, move between verses/lines, black
+// the screen out (or bring it back), and nudge the TV's look. Nothing you
+// tap here changes anything ON THIS SCREEN directly — it just tells the TV
+// what you want, and the TV's own next update is what actually redraws
+// this screen.
+//
+// DETAILED: #1422 (`.claude/apple-phase2-pr7-spec.md` §6.3 — BINDING,
+// Decision D-7: STATELESS/REFLECTIVE). Every control here renders from the
+// `IHRPState` the coordinator's `.controlling` phase carries and every
+// interaction ONLY calls `sendIntent(...)` — nothing is optimistically
+// toggled locally. The TV is the single display authority (strategy
+// §2.4.1) and its `.state` broadcast (which echoes our OWN intents back,
+// §1.1) is the ONLY thing that ever updates this view. This is what makes
+// multi-remote last-writer-wins correct BY CONSTRUCTION: when another
+// remote changes the display, this surface just re-renders the next
+// broadcast — there is no local shadow state to fight over.
+//
+// **Content INVARIANT (binding):** every intent sent from here is a
+// ~200-byte navigation intent (a song id, an index, an enum case) — no
+// lyric text ever crosses this seam in either direction this view can
+// observe (`IHRPMessage.swift`'s own header invariant).
+import IHLive
+import IHDesign
+import IHModels
+import SwiftUI
+
+/// The actual controlling surface — see this file's header for the
+/// stateless/reflective design.
+public struct RemoteControlSurfaceView: View {
+    let tvName: String
+    let state: IHRPState
+    let rootViewModel: AppRootViewModel
+    let onIntent: (IHRPMessage) -> Void
+    let onDisconnect: () -> Void
+
+    @State private var isPresentingSongPicker = false
+
+    public init(
+        tvName: String, state: IHRPState, rootViewModel: AppRootViewModel,
+        onIntent: @escaping (IHRPMessage) -> Void, onDisconnect: @escaping () -> Void
+    ) {
+        self.tvName = tvName
+        self.state = state
+        self.rootViewModel = rootViewModel
+        self.onIntent = onIntent
+        self.onDisconnect = onDisconnect
+    }
+
+    public var body: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                headerCard
+                songCard
+                lineCard
+                displayCard
+                appearanceCard
+            }
+            .padding()
+        }
+        .navigationTitle(tvName)
+        .sheet(isPresented: $isPresentingSongPicker) {
+            RemoteSongPickerView(
+                rootViewModel: rootViewModel,
+                onSelect: { songId in onIntent(.selectSong(songId: songId, componentIndex: nil, lineIndex: nil)) },
+                onPrepare: { songId in onIntent(.prepare(songId: songId)) }
+            )
+        }
+    }
+
+    // MARK: - 1. Header
+
+    private var headerCard: some View {
+        HStack {
+            Circle()
+                .fill(.green)
+                .frame(width: 10, height: 10)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(tvName).font(.headline)
+                Text(state.songId?.rawValue ?? "Nothing selected")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 12)
+            Button("Disconnect", role: .destructive, action: onDisconnect)
+        }
+        .ihGlassCard()
+        .accessibilityElement(children: .combine)
+    }
+
+    // MARK: - 2. Song
+
+    private var songCard: some View {
+        VStack(spacing: 12) {
+            Button {
+                isPresentingSongPicker = true
+            } label: {
+                Label("Choose Song…", systemImage: "music.note.list")
+                    .frame(maxWidth: .infinity, minHeight: 44)
+            }
+            .buttonStyle(.borderedProminent)
+
+            HStack {
+                remoteButton("Previous verse", systemImage: "chevron.left") { onIntent(.prevComponent) }
+                Spacer()
+                // The TV resolves arrangement order itself — this remote
+                // never counts components (`IHRPMessage.swift:89-92`).
+                Text("Verse")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                remoteButton("Next verse", systemImage: "chevron.right") { onIntent(.nextComponent) }
+            }
+        }
+        .ihGlassCard()
+    }
+
+    // MARK: - 3. Line
+
+    private var lineCard: some View {
+        HStack {
+            remoteButton("Previous line", systemImage: "arrow.up") { onIntent(.prevLine) }
+            Spacer()
+            remoteButton("Scroll up", systemImage: "arrow.up.to.line") { onIntent(.scroll(delta: -1)) }
+            Spacer()
+            remoteButton("Scroll down", systemImage: "arrow.down.to.line") { onIntent(.scroll(delta: 1)) }
+            Spacer()
+            remoteButton("Next line", systemImage: "arrow.down") { onIntent(.nextLine) }
+        }
+        .ihGlassCard()
+    }
+
+    // MARK: - 4. Display
+
+    private var displayCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Display").font(.subheadline).foregroundStyle(.secondary)
+            Picker("Display", selection: displayStateBinding) {
+                Text("Lyrics").tag(IHRPDisplayState.lyrics)
+                Text("Black").tag(IHRPDisplayState.blackout)
+                Text("Logo").tag(IHRPDisplayState.logo)
+                Text("Freeze").tag(IHRPDisplayState.frozen)
+            }
+            .pickerStyle(.segmented)
+        }
+        .ihGlassCard()
+    }
+
+    private var displayStateBinding: Binding<IHRPDisplayState> {
+        Binding(get: { state.displayState }, set: { onIntent(.setDisplayState($0)) })
+    }
+
+    // MARK: - 5. Appearance
+
+    private var appearanceCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Appearance").font(.subheadline).foregroundStyle(.secondary)
+            Menu {
+                ForEach(Self.themeOptions, id: \.self) { theme in
+                    Button(theme.capitalized) { onIntent(.setAppearance(theme: theme, textScale: nil)) }
+                }
+            } label: {
+                Label("Theme", systemImage: "paintbrush")
+            }
+            HStack {
+                Text("Text Size")
+                Spacer()
+                Button {
+                    onIntent(.setAppearance(theme: nil, textScale: 0.9))
+                } label: {
+                    Image(systemName: "textformat.size.smaller")
+                }
+                .accessibilityLabel("Smaller text")
+                Button {
+                    onIntent(.setAppearance(theme: nil, textScale: 1.1))
+                } label: {
+                    Image(systemName: "textformat.size.larger")
+                }
+                .accessibilityLabel("Larger text")
+            }
+        }
+        .ihGlassCard()
+    }
+
+    /// Cosmetic-only names (`ProjectionViewModel.appearanceThemeHint`'s own
+    /// doc comment: "stored but DELIBERATELY NEVER APPLIED") — free-text,
+    /// never a shared enum with the TV side, so this list is this view's
+    /// own choice, not a protocol contract.
+    private static let themeOptions = ["default", "warm", "cool", "highContrast"]
+
+    private func remoteButton(_ label: String, systemImage: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: systemImage)
+                .frame(minWidth: 44, minHeight: 44)
+        }
+        .accessibilityLabel(label)
+    }
+}

--- a/appApple/Packages/iHymnsKit/Sources/IHFeatures/RemoteControlView.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHFeatures/RemoteControlView.swift
@@ -1,0 +1,234 @@
+// RemoteControlView.swift
+// IHFeatures
+//
+// ELI5: The "TV Remote" screen itself — shows every TV you already trust
+// plus any nearby ones you don't, lets you pair a new one (by scanning or
+// pasting), and swaps to the actual remote control the moment you're
+// connected. It also politely explains WHY it's about to ask for local
+// -network permission before the system prompt just appears out of nowhere.
+//
+// DETAILED: #1422 (`.claude/apple-phase2-pr7-spec.md` §6.3). Owns the ONE
+// `RemoteControlCoordinator` for this screen (the `TVRootView.swift:54-61`
+// "build the composition root in `init`" pattern) and renders entirely from
+// its `uiPhase` — this view never reaches into `RemoteControlSession`/
+// `RemoteSessionActor` itself. `scenePhase` drives `setScenePhaseActive(_:)`
+// (strategy §2.4.4's "backgrounded remote = detached, TV holds state, <1s
+// reconnect").
+import IHLive
+import SwiftUI
+
+/// The remote-control screen scaffold — see this file's header.
+public struct RemoteControlView: View {
+    private let rootViewModel: AppRootViewModel
+    @State private var coordinator = RemoteControlCoordinator()
+    @State private var isPresentingPairingSheet = false
+    @State private var hasSeenPrimer = IHSettingsStore().hasSeenLocalNetworkPrimer
+    @Environment(\.scenePhase) private var scenePhase
+
+    public init(rootViewModel: AppRootViewModel) {
+        self.rootViewModel = rootViewModel
+    }
+
+    public var body: some View {
+        content
+            .navigationTitle("TV Remote")
+            .task { await coordinator.start() }
+            .onDisappear { Task { await coordinator.stop() } }
+            .onChange(of: scenePhase) { _, newPhase in
+                Task { await coordinator.setScenePhaseActive(newPhase == .active) }
+            }
+            .sheet(isPresented: $isPresentingPairingSheet) {
+                PairingPayloadEntrySheet(
+                    onResolved: { string in
+                        isPresentingPairingSheet = false
+                        coordinator.handleScannedOrPasted(string)
+                    },
+                    onCancel: { isPresentingPairingSheet = false }
+                )
+            }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch coordinator.uiPhase {
+        case .browsing:
+            browsingView
+        case .connecting(let tvName, _), .reconnecting(let tvName, _):
+            browsingView.overlay(alignment: .bottom) { connectingBanner(tvName: tvName) }
+        case .codeEntry(let tvName, let failedAttempts):
+            PairingCodeEntrySheet(
+                tvName: tvName, failedAttempts: failedAttempts,
+                onSubmit: { code in Task { await coordinator.submitCode(code) } },
+                onCancel: { Task { await coordinator.cancelPairing() } }
+            )
+        case .controlling(let tvName, let state):
+            RemoteControlSurfaceView(
+                tvName: tvName, state: state, rootViewModel: rootViewModel,
+                onIntent: { message in Task { await coordinator.sendIntent(message) } },
+                onDisconnect: { Task { await coordinator.disconnect() } }
+            )
+        case .suspended(let tvName):
+            ContentUnavailableView("Reconnecting to \(tvName)…", systemImage: "antenna.radiowaves.left.and.right")
+        }
+    }
+
+    // MARK: - Browsing (list / primer / empty state)
+
+    @ViewBuilder
+    private var browsingView: some View {
+        if !hasSeenPrimer {
+            localNetworkPrimerCard
+        } else if let notice = coordinator.notice, coordinator.rows.isEmpty {
+            ContentUnavailableView("Couldn't Connect", systemImage: "wifi.exclamationmark", description: Text(notice))
+                .toolbar { pairingToolbar }
+        } else if coordinator.rows.isEmpty {
+            emptyStateView
+                .toolbar { pairingToolbar }
+        } else {
+            List {
+                if let notice = coordinator.notice {
+                    Section {
+                        Text(notice).foregroundStyle(.secondary)
+                    }
+                }
+                ForEach(coordinator.rows) { row in
+                    rowView(row)
+                }
+            }
+            .toolbar { pairingToolbar }
+        }
+    }
+
+    private var localNetworkPrimerCard: some View {
+        ContentUnavailableView {
+            Label("Find Your TV", systemImage: "wifi")
+        } description: {
+            Text("iHymns will ask to find devices on your local network — that's how it finds your Apple TV.")
+        } actions: {
+            Button("Continue") {
+                hasSeenPrimer = true
+                Task { await coordinator.acknowledgeLocalNetworkPrimer() }
+            }
+        }
+    }
+
+    private var emptyStateView: some View {
+        ContentUnavailableView {
+            Label("No TVs Yet", systemImage: "appletv")
+        } description: {
+            #if os(iOS)
+            Text("Open iHymns on your Apple TV, then scan the QR code in its Settings → Remote Control.")
+            #else
+            Text(
+                "Open iHymns on your Apple TV, then scan the QR code in its Settings → Remote Control… "
+                    + "or paste the pairing code from the TV screen."
+            )
+            #endif
+        } actions: {
+            Button("Enter Code") { isPresentingPairingSheet = true }
+        }
+    }
+
+    private func connectingBanner(tvName: String) -> some View {
+        HStack(spacing: 8) {
+            ProgressView()
+            Text("Connecting to \(tvName)…")
+            Spacer()
+            Button("Cancel") { Task { await coordinator.disconnect() } }
+        }
+        .padding()
+        .background(.thinMaterial)
+    }
+
+    @ToolbarContentBuilder
+    private var pairingToolbar: some ToolbarContent {
+        #if os(iOS)
+        ToolbarItem(placement: .primaryAction) {
+            Button {
+                isPresentingPairingSheet = true
+            } label: {
+                Label("Scan", systemImage: "qrcode.viewfinder")
+            }
+        }
+        #endif
+        ToolbarItem(placement: .primaryAction) {
+            Button {
+                isPresentingPairingSheet = true
+            } label: {
+                Label("Enter Code", systemImage: "keyboard")
+            }
+        }
+    }
+
+    // MARK: - Rows
+
+    @ViewBuilder
+    private func rowView(_ row: RemoteTVListRow) -> some View {
+        switch row.kind {
+        case .paired(let record):
+            Button {
+                coordinator.connect(row: row)
+            } label: {
+                pairedRowLabel(record, isNearby: row.isNearby)
+            }
+            .buttonStyle(.plain)
+            // `.swipeActions` is UNAVAILABLE on tvOS (the `SetlistsView.swift`
+            // precedent this mirrors) — moot here in practice (this screen is
+            // only ever reached from the `iHymns` app shell's `.live` tab,
+            // never tvOS's `TVRootView`), but `IHFeatures` still compiles for
+            // every platform (`Package.swift`), so the guard is required for
+            // this FILE to build there at all.
+            #if os(tvOS)
+            .contextMenu {
+                Button("Forget", role: .destructive) { Task { await coordinator.forget(record) } }
+            }
+            #else
+            .swipeActions(edge: .trailing) {
+                Button("Forget", role: .destructive) { Task { await coordinator.forget(record) } }
+            }
+            #endif
+        case .nearbyUnpaired(let service):
+            nearbyRowLabel(service)
+        }
+    }
+
+    /// A saved, connectable TV — spec §4 path C.
+    private func pairedRowLabel(_ record: PairedTVRecord, isNearby: Bool) -> some View {
+        HStack {
+            Image(systemName: "appletv")
+            VStack(alignment: .leading, spacing: 2) {
+                Text(record.name)
+                if let lastConnectedAt = record.lastConnectedAt {
+                    Text(lastConnectedAt, style: .relative).font(.caption).foregroundStyle(.secondary)
+                }
+            }
+            Spacer(minLength: 12)
+            if isNearby {
+                Text("Nearby").font(.caption).foregroundStyle(.secondary)
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(isNearby ? "\(record.name), nearby" : record.name)
+    }
+
+    /// An UNPAIRED nearby TV — informational only (spec §4 row C′): tapping
+    /// this row itself does nothing (`RemoteControlCoordinator.connect(row:)`
+    /// no-ops for `.nearbyUnpaired`); the ONLY affordance is the button
+    /// below, which opens the SAME scan/paste sheet the toolbar does.
+    private func nearbyRowLabel(_ service: LANRemoteDiscoveredService) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Image(systemName: "appletv")
+                Text(service.name)
+                Spacer(minLength: 12)
+                Text("Nearby").font(.caption).foregroundStyle(.secondary)
+            }
+            Text("To pair, scan the QR code shown on this TV.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Button("Scan or Enter Code") { isPresentingPairingSheet = true }
+                .font(.caption)
+        }
+        .accessibilityElement(children: .combine)
+    }
+}

--- a/appApple/Packages/iHymnsKit/Sources/IHFeatures/RemoteDeviceIdentity.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHFeatures/RemoteDeviceIdentity.swift
@@ -1,0 +1,74 @@
+// RemoteDeviceIdentity.swift
+// IHFeatures
+//
+// ELI5: "What kind of device is this, and what should we call it?" — the two
+// little facts this app sends the TV when it pairs (`hello`/`pairConfirm`),
+// so a TV's trusted-remotes list can show a sensible icon and name instead
+// of a bare token.
+//
+// DETAILED: #1422 (`.claude/apple-phase2-pr7-spec.md` §6.4). Platform-
+// conditional the same way `TVRemoteControlCoordinator.deviceNameStatic`
+// (`IHFeatures`) already is for the TV side — this is the phone/iPad/Mac/
+// Vision mirror of that. Compiles on every platform `IHFeatures` targets
+// (`Package.swift`'s `platforms:` list includes tvOS/watchOS too), even
+// though only the `iHymns` app shell (iOS/iPadOS/macOS/visionOS) actually
+// constructs a `RemoteControlSession` with these values — the `#if
+// os(watchOS)`/`#else` branches below are DEFENSIVE (PR-11's future Watch
+// -relay caller, and dead-code-but-compiling on tvOS), not load-bearing yet.
+#if os(iOS) || os(visionOS)
+import UIKit
+#elseif os(macOS)
+import Foundation
+#elseif os(watchOS)
+import WatchKit
+#endif
+import IHLive
+
+/// This device's `IHRPRemoteKind` + cosmetic name, for the pairing
+/// ceremony's `hello`/`pairConfirm` fields.
+///
+/// ELI5: "Are we an iPhone, iPad, Mac, or Vision Pro — and what's our name?"
+public enum RemoteDeviceIdentity {
+
+    /// The `IHRPRemoteKind` this device identifies as.
+    public static var kind: IHRPRemoteKind {
+        #if os(iOS)
+        UIDevice.current.userInterfaceIdiom == .pad ? .pad : .phone
+        #elseif os(visionOS)
+        .vision
+        #elseif os(macOS)
+        .mac
+        #elseif os(watchOS)
+        // Defensive — PR-11's future Watch-relay caller; a watch never
+        // opens a direct `NWConnection` itself (strategy §2.4.2), so this
+        // value is never actually READ by anything shipping today.
+        .watchRelay
+        #else
+        // tvOS compile-only — `IHFeatures` builds for every platform
+        // (`Package.swift`), but the TV never constructs a
+        // `RemoteControlSession` (it's the LISTENER, not a remote); this
+        // case is dead code kept solely so the package compiles there.
+        .phone
+        #endif
+    }
+
+    /// A best-effort, cosmetic device name — `nil` only if the platform API
+    /// itself returns nothing.
+    ///
+    /// - Note: On iOS 16+, `UIDevice.current.name` returns the GENERIC model
+    ///   name ("iPhone"), not the user's personalised device name, unless the
+    ///   app holds a private entitlement Apple does not grant third-party
+    ///   apps — acceptable here since this is purely cosmetic (the TV's
+    ///   trusted-remotes list), never a security boundary.
+    public static var name: String? {
+        #if os(iOS) || os(visionOS)
+        UIDevice.current.name
+        #elseif os(macOS)
+        Host.current().localizedName
+        #elseif os(watchOS)
+        WKInterfaceDevice.current().name
+        #else
+        nil
+        #endif
+    }
+}

--- a/appApple/Packages/iHymnsKit/Sources/IHFeatures/RemoteSongPickerView.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHFeatures/RemoteSongPickerView.swift
@@ -1,0 +1,87 @@
+// RemoteSongPickerView.swift
+// IHFeatures
+//
+// ELI5: The "which song should the TV show?" sheet — search or scroll the
+// same catalogue you'd see on the Search tab, tap a song to put it on the
+// TV screen right now, or long-press → "Prepare on TV" to warm it up in the
+// background while the current song is still showing (so switching to it
+// later feels instant).
+//
+// DETAILED: #1422 (`.claude/apple-phase2-pr7-spec.md` §6.3). Reuses the
+// EXTRACTED shared matcher `AppRootViewModel.songsMatching(_:in:)`
+// (`AppRootViewModel+Search.swift`) rather than re-forking the number/
+// substring search ladder — the same number-then-substring behaviour the
+// Search tab's `filteredSongs` gets, over this sheet's OWN `@State query`
+// (deliberately NOT `rootViewModel.searchText`, which would clobber the
+// Search tab's own live state the moment this sheet opens). `.selectSong`
+// (tap) vs `.prepare` (context menu "Prepare on TV") is Decision D-9:
+// sending both on the same tap would hide no round-trip and is cargo-cult
+// prefetch — `prepare` is the real "cue the NEXT hymn while THIS one is
+// still up" worship-flow move, deliberately a SEPARATE action.
+import IHModels
+import SwiftUI
+
+/// The song-picker sheet the control surface's "Choose Song…" button opens.
+public struct RemoteSongPickerView: View {
+    private let rootViewModel: AppRootViewModel
+    /// `sendIntent(.selectSong(songId:, componentIndex: nil, lineIndex: nil))`
+    /// — the caller also dismisses the sheet.
+    let onSelect: (SongID) -> Void
+    /// `sendIntent(.prepare(songId:))` — the sheet stays open.
+    let onPrepare: (SongID) -> Void
+
+    @State private var query = ""
+    @Environment(\.dismiss) private var dismiss
+
+    public init(rootViewModel: AppRootViewModel, onSelect: @escaping (SongID) -> Void, onPrepare: @escaping (SongID) -> Void) {
+        self.rootViewModel = rootViewModel
+        self.onSelect = onSelect
+        self.onPrepare = onPrepare
+    }
+
+    public var body: some View {
+        NavigationStack {
+            content
+                .searchable(text: $query, prompt: "Search songs")
+                .navigationTitle("Choose Song")
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Cancel") { dismiss() }
+                    }
+                }
+                .task { await rootViewModel.loadCatalogueIfNeeded() }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch rootViewModel.catalogueLoadState {
+        case .idle, .loading:
+            ProgressView("Loading songs…")
+        case .error(let message):
+            ContentUnavailableView("Couldn't Load Songs", systemImage: "exclamationmark.triangle", description: Text(message))
+        case .loaded(let songs):
+            let matches = AppRootViewModel.songsMatching(query, in: songs)
+            if matches.isEmpty {
+                ContentUnavailableView.search(text: query)
+            } else {
+                List(matches) { song in
+                    Button {
+                        onSelect(song.songId)
+                        dismiss()
+                    } label: {
+                        SongSummaryRow(song)
+                    }
+                    .buttonStyle(.plain)
+                    .contextMenu {
+                        Button {
+                            onPrepare(song.songId)
+                        } label: {
+                            Label("Prepare on TV", systemImage: "arrow.triangle.2.circlepath")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/appApple/Packages/iHymnsKit/Sources/IHFeatures/RootContainerView.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHFeatures/RootContainerView.swift
@@ -42,14 +42,12 @@
 // `SettingsViewModel` and applies its `theme` as `.preferredColorScheme` on
 // the whole app.
 //
-// `.live` remains a DELIBERATE, honestly-labelled "coming soon" placeholder
+// `.live` WAS a DELIBERATE, honestly-labelled "coming soon" placeholder
 // (this task's own brief: "a Live tab/Setlists can be a labelled 'coming
-// soon' placeholder for now, don't fake them") — no `IHLive` engine is
-// wired to any UI yet in this package, so pretending there's a real Live
-// screen here would be exactly the kind of faked surface this task
-// explicitly rules out. `ContentUnavailableView` is the same "genuinely
-// nothing here yet" idiom the rest of this package already uses for
-// empty/error states, reused here for "not built yet" instead.
+// soon' placeholder for now, don't fake them") — no `IHLive` engine was
+// wired to any UI yet in this package, so pretending there was a real Live
+// screen here would have been exactly the kind of faked surface this task
+// explicitly ruled out.
 //
 // #181 UPDATE (setlists half) — `.setlists` is now a REAL section
 // (`SetlistsView`), split out of what was previously a combined "Live &
@@ -58,6 +56,16 @@
 // with the still-unbuilt Live placeholder would now be the dishonest
 // surface this file's own header warns against. `.live` alone keeps the
 // placeholder, relabelled to just "Live."
+//
+// #1422 UPDATE (Apple Phase-2 PR-7, `.claude/apple-phase2-pr7-spec.md`
+// §6.1/D-6) — `.live` is a placeholder no longer: it now hosts
+// `LiveHubView`, whose real "TV Remote" card leads to the full LAN
+// remote-control screens (`RemoteControlView`/`RemoteControlSurfaceView`).
+// `LiveHubView` itself RETAINS the honest "Live Follow & Service Mode —
+// coming in a future update" `ContentUnavailableView` copy for the
+// server-mediated half that's still unbuilt — this file's own "don't fake
+// a screen" rule is satisfied, not violated, by the split: the half that's
+// real is real, the half that isn't still says so.
 //
 // Compiles on every platform `IHFeatures` targets (`Package.swift`'s
 // `platforms:` list includes tvOS/watchOS too) even though only the
@@ -319,7 +327,7 @@ public struct RootContainerView: View {
             .tag(RootSection.setlists)
 
             NavigationStack {
-                liveComingSoonView
+                LiveHubView(rootViewModel: viewModel)
             }
             .tabItem { Label(RootSection.live.title, systemImage: RootSection.live.systemImage) }
             .tag(RootSection.live)
@@ -366,7 +374,7 @@ public struct RootContainerView: View {
             case .setlists:
                 SetlistsView(rootViewModel: viewModel)
             case .live:
-                liveComingSoonView
+                LiveHubView(rootViewModel: viewModel)
             case .settings:
                 SettingsView(rootViewModel: viewModel, settings: settingsViewModel)
             }
@@ -377,20 +385,6 @@ public struct RootContainerView: View {
                 description: Text("Choose a song from the list to view its lyrics.")
             )
         }
-    }
-
-    /// The honestly-labelled "coming soon" placeholder for Live Follow /
-    /// Service Mode — see this file's header for why this is a real,
-    /// explicit placeholder rather than a faked screen (setlists, formerly
-    /// lumped in here too, now have their own real `.setlists` section
-    /// above). Shared by both `tabbedRoot`'s Live tab and `splitView`'s
-    /// `.live` section so the wording only lives in one place.
-    private var liveComingSoonView: some View {
-        ContentUnavailableView(
-            "Live",
-            systemImage: "dot.radiowaves.left.and.right",
-            description: Text("Live Follow and Service Mode are coming in a future update.")
-        )
     }
 }
 

--- a/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/KeychainPairedTVStore.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/KeychainPairedTVStore.swift
@@ -1,0 +1,176 @@
+// KeychainPairedTVStore.swift
+// IHLive/LANRemote
+//
+// ELI5: The REAL "TVs I trust" address book — one entry per paired TV,
+// written to the Keychain (the same secure vault iOS itself uses for Wi-Fi
+// passwords) so it survives an app relaunch or a device reboot. Unlike the
+// TV's own address book (which only ever remembers a HASH of each remote's
+// token), this one has to hold the ACTUAL secret token, because a remote has
+// to hand that exact value back to the TV to reconnect without repeating the
+// code-typing dance.
+//
+// DETAILED: #1422 (`.claude/apple-phase2-pr7-spec.md` §5.2 — the
+// `KeychainLANRemotePairingAuthority` idiom, adapted for the OPPOSITE side of
+// the relationship: keyed by the TV's fingerprint, one item's `kSecValueData`
+// holds the WHOLE `PairedTVRecord` — including the raw token — rather than a
+// hash). One `kSecClassGenericPassword` item PER paired TV:
+//   - `kSecAttrService = "app.ihymns.lanremote.pairedTVs"` — a NEW private
+//     namespace, never shared with the TV-side authority's own
+//     `"app.ihymns.lanremote.pairedRemotes"` service string.
+//   - `kSecAttrAccount = fingerprintHex` — the record key (see
+//     `PairedTVStore.swift`'s header for why fingerprint, not token).
+//   - `kSecValueData = try JSONEncoder().encode(record)` — dates via
+//     `.iso8601` for dump-stability across Keychain backup/restore; the
+//     record INCLUDES the raw token (one item, one query surface — PR-6
+//     Decision D-6 applied here too: no metadata sidecar to desync).
+//
+// **`kSecAttrSynchronizable = false` — EXPLICIT, HARD-CODED, never
+// injectable.** This is the single most load-bearing character in this file
+// (spec §5.2). Contrast with `KeychainTokenStore`'s (`IHAuth`) deliberately
+// INJECTABLE `synchronizable` (`true` by default there — iCloud-Keychain
+// propagation IS the account token's intended global-login transport,
+// strategy §1.6). A LAN-remote pairing is a PHYSICAL-PROXIMITY trust
+// ceremony (the person had to be standing in front of the TV to read its
+// code): iCloud-syncing this item would silently hand every OTHER device on
+// the same Apple ID control of a TV that device never paired with, breaking
+// that whole model — and unlike the tvOS side (no iCloud Keychain at all),
+// every platform THIS store runs on (iOS/iPadOS/macOS/visionOS) very much
+// HAS iCloud Keychain, so the hard-coded `false` here is not a no-op, it is
+// the thing standing between "physical proximity" and "same Apple ID."
+// `KeychainPairedTVStoreTests` asserts this directly against
+// `baseAttributes(account:)`; the PR's grep gate re-checks it at review
+// (`grep -rn "Synchronizable" .../LANRemote/` must show ONLY hard-coded
+// `false`).
+import Foundation
+import IHLog
+import Security
+
+/// The real, Keychain-backed `PairedTVStoring` — see this file's header for
+/// the exact `SecItem` shape.
+///
+/// ELI5: The actual, persistent "TVs I trust" address book (as opposed to
+/// `InMemoryPairedTVStore`, the pretend one tests/previews use).
+///
+/// DETAILED: An `actor` — the `KeychainLANRemotePairingAuthority`/
+/// `KeychainTokenStore` precedent: every `SecItem*` call is itself
+/// synchronous+thread-safe at the OS level, but isolating this type still
+/// gives every call site a single, uniform `await`-based API matching
+/// `PairedTVStoring`'s `async` requirements.
+public actor KeychainPairedTVStore: PairedTVStoring {
+    /// `kSecAttrService` — a private per-app namespace distinct from the
+    /// TV-side authority's own service string (this file's header).
+    private let service: String
+
+    public init(service: String = "app.ihymns.lanremote.pairedTVs") {
+        self.service = service
+    }
+
+    public func save(_ record: PairedTVRecord) async {
+        // Replace semantics — delete any existing item under this
+        // fingerprint first (`KeychainTokenStore.save(_:)`'s identical
+        // precedent), then add the fresh one.
+        SecItemDelete(baseAttributes(account: record.fingerprintHex) as CFDictionary)
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        guard let payload = try? encoder.encode(record) else {
+            IHLog.remote.fault("lanremote.pairedtvstore persist-failed reason=encode")
+            return
+        }
+
+        var query = baseAttributes(account: record.fingerprintHex)
+        query[kSecValueData as String] = payload
+        let status = SecItemAdd(query as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            // `.fault` (spec §5.2): the live session keeps working (it's
+            // already `.controlling` in-memory by the time this is called),
+            // but the pairing won't survive a relaunch — an alarm-level
+            // condition worth surfacing, not a silent best-effort failure.
+            IHLog.remote.fault("lanremote.pairedtvstore persist-failed status=\(status, privacy: .public)")
+            return
+        }
+    }
+
+    public func record(forFingerprint fingerprint: String) async -> PairedTVRecord? {
+        var query = baseAttributes(account: fingerprint)
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        query[kSecReturnData as String] = true
+
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess, let data = result as? Data else {
+            // `errSecItemNotFound` is the expected "never paired"/"forgotten"
+            // case; any OTHER status also degrades to `nil` — fail-closed
+            // (spec §5.2: "a TV we can't prove we trust is a TV we don't
+            // list"), logged only when it's NOT the ordinary not-found case.
+            if status != errSecItemNotFound {
+                IHLog.remote.error("lanremote.pairedtvstore read-failed status=\(status, privacy: .public)")
+            }
+            return nil
+        }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try? decoder.decode(PairedTVRecord.self, from: data)
+    }
+
+    /// Every paired TV, newest-first by `lastConnectedAt` (falling back to
+    /// `pairedAt`).
+    ///
+    /// DETAILED: **Two queries, not one** — `SecItemCopyMatching` returns
+    /// `errSecParam` when `kSecReturnData` is combined with
+    /// `kSecMatchLimitAll` for a generic-password class (the same empirically
+    /// verified constraint `KeychainLANRemotePairingAuthority
+    /// .listPairedRemotes()`'s doc comment documents). Step 1 lists every
+    /// matching item's ATTRIBUTES ONLY to get each account (fingerprint);
+    /// step 2 fetches each one's full record via `record(forFingerprint:)`
+    /// above. A handful of paired TVs makes N+1 Keychain round-trips a
+    /// non-issue in practice.
+    public func listPairedTVs() async -> [PairedTVRecord] {
+        var listQuery = baseAttributes(account: nil)
+        listQuery[kSecMatchLimit as String] = kSecMatchLimitAll
+        listQuery[kSecReturnAttributes as String] = true
+
+        var listResult: CFTypeRef?
+        let listStatus = SecItemCopyMatching(listQuery as CFDictionary, &listResult)
+        guard listStatus == errSecSuccess, let items = listResult as? [[String: Any]] else {
+            return []
+        }
+
+        var records: [PairedTVRecord] = []
+        for item in items {
+            guard let fingerprint = item[kSecAttrAccount as String] as? String,
+                  let record = await record(forFingerprint: fingerprint) else { continue }
+            records.append(record)
+        }
+        return records.sorted { lhs, rhs in
+            (lhs.lastConnectedAt ?? lhs.pairedAt) > (rhs.lastConnectedAt ?? rhs.pairedAt)
+        }
+    }
+
+    public func delete(fingerprint: String) async {
+        SecItemDelete(baseAttributes(account: fingerprint) as CFDictionary)
+    }
+
+    /// The base Keychain attribute dictionary every call above shares —
+    /// `internal` (not `private`, spec §5.2/§7.4) so `KeychainPairedTVStoreTests`
+    /// can assert the `kSecAttrSynchronizable == false` / accessible /
+    /// service invariants DIRECTLY, the required unit test plan calls for.
+    func baseAttributes(account: String?) -> [String: Any] {
+        var query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            // EXPLICIT, hard-coded `false` — see this file's header. NEVER
+            // make this injectable or reference an external `synchronizable`
+            // parameter.
+            kSecAttrSynchronizable as String: false,
+            // Reconnect must work right after a reboot, before the user has
+            // unlocked the device a second time — the `KeychainTokenStore`/
+            // `KeychainLANRemotePairingAuthority` precedent.
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock
+        ]
+        if let account {
+            query[kSecAttrAccount as String] = account
+        }
+        return query
+    }
+}

--- a/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/LANRemoteAddress.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/LANRemoteAddress.swift
@@ -4,7 +4,8 @@
 // ELI5: Figures out "what's this TV's own address on the home Wi-Fi right
 // now?" — the number an operator could type into a phone's "connect by
 // address" screen if Bonjour discovery isn't finding the TV for some
-// reason.
+// reason. Also holds the small "host + port" shape a REMOTE records once it
+// actually resolves and connects to one.
 //
 // DETAILED: #1421 (`.claude/apple-phase2-pr6-spec.md` §2). Feeds the
 // Settings "Remote Control info" panel (strategy §2.4.5) —
@@ -17,7 +18,41 @@
 // convention) while still falling back to some OTHER interface's address
 // rather than `nil` if `en0` isn't up. Never throws — a Settings screen
 // showing "address unavailable" is a reasonable degraded UI, not a crash.
+//
+// #1422 UPDATE (`.claude/apple-phase2-pr7-spec.md` §2) — adds
+// `LANRemoteResolvedAddress`, the tiny value `RemoteSessionActor
+// +Connection.swift` captures off `NWConnection.currentPath?.remoteEndpoint`
+// once a connection reaches `.ready`. It lives HERE (beside the existing
+// address helper, "one address-shaped file" per that spec section) even
+// though it has nothing to do with `getifaddrs` — both types answer the same
+// question ("how do you reach a device on this LAN"), just from opposite
+// ends of the connection.
 import Foundation
+
+/// A resolved `host:port` pair for an ACTUAL live (or just-was-live)
+/// connection — as opposed to `LANRemotePairingPayload`'s `host`/`port`,
+/// which are the TV's own best-effort self-report at pairing time.
+///
+/// ELI5: "The exact address this connection is actually using right now."
+///
+/// DETAILED: Captured by `RemoteSessionActor+Connection.swift` from
+/// `NWConnection.currentPath?.remoteEndpoint` the instant a connection
+/// reaches `.ready` — this is what actually worked, which may differ from
+/// whatever `NWEndpoint` (a Bonjour `.service` result, say) was originally
+/// dialled. `PairedTVRecord.lastAddress` (`PairedTVStore.swift`) persists the
+/// most recent one of these per paired TV, and `RemoteControlSession
+/// +Link.swift`'s reconnect ladder alternates between the primary endpoint
+/// and this saved last-good address so a TV that temporarily lost its
+/// Bonjour registration is still reachable.
+public struct LANRemoteResolvedAddress: Sendable, Equatable, Codable {
+    public let host: String
+    public let port: UInt16
+
+    public init(host: String, port: UInt16) {
+        self.host = host
+        self.port = port
+    }
+}
 
 /// Best-effort local-network address lookup for this device.
 ///

--- a/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/PairedTVStore.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/PairedTVStore.swift
@@ -1,0 +1,134 @@
+// PairedTVStore.swift
+// IHLive/LANRemote
+//
+// ELI5: The remote's own little address book of "TVs I've already paired
+// with" — for each one, the secret token that lets us skip the code-typing
+// dance next time, its name, the last address that actually worked, and
+// when we last talked to it. This file just defines the SHAPE of that
+// address book plus a pretend, forgetful version for tests/previews; the
+// real, persistent one (backed by the Keychain) is `KeychainPairedTVStore.swift`.
+//
+// DETAILED: #1422 (`.claude/apple-phase2-pr7-spec.md` §5.1 — BINDING shape).
+// Mirrors PR-6's `PairedRemoteRecord`/`LANRemotePairingAuthority`
+// split (`LANRemotePairingAuthority.swift`'s header: "a small, swappable
+// object... so a TEST can answer with an in-memory list") — same idea,
+// opposite side of the pairing relationship: the TV keys its trust list by
+// TOKEN HASH (never the raw token); the remote keys ITS list by the TV's
+// FINGERPRINT (never the token) because the fingerprint is the TV's stable,
+// persistent identity (`LANRemoteIdentityStore`, PR-6 §5.1) while the token
+// ROTATES on every re-pair — keying by fingerprint makes re-pairing a clean
+// UPSERT instead of a duplicate row, and "look up by fingerprint" IS the
+// reconnect path (`RemotePairingEntryResolver.swift`).
+//
+// **Why the RAW token is stored here (unlike the TV's sha256-only rule):**
+// asymmetric custody is the whole design (strategy §2.4.3: "TV stores
+// `sha256`... remote stores raw + pinned cert") — the remote must present
+// the PREIMAGE in `hello` to reconnect, so it has no choice but to hold the
+// real value. The raw value only ever lives inside a Keychain item
+// (`KeychainPairedTVStore.swift`'s `synchronizable: false`, hard-coded); this
+// file's `InMemoryPairedTVStore` is tests/previews only, never production.
+import Foundation
+
+/// One TV this device has successfully paired with.
+///
+/// ELI5: "Here's a TV I already trust, and everything I need to reconnect to
+/// it without going through the code dance again."
+public struct PairedTVRecord: Sendable, Codable, Equatable, Identifiable {
+    /// The TV's STABLE identity — the natural primary key. Never the token,
+    /// which rotates on every re-pair (this file's header).
+    public let fingerprintHex: String
+
+    /// Cosmetic — from the scanned/pasted payload's `name`, or the TV's own
+    /// advertised Bonjour name; may go stale if the TV is renamed, which is
+    /// harmless (it's display-only).
+    public var name: String
+
+    /// The RAW pairing token — the preimage this device must present in a
+    /// reconnect `hello`. See this file's header for why the remote (unlike
+    /// the TV) has no choice but to hold the real value.
+    public var token: String
+
+    /// The most recent address that actually worked for this TV — seeds the
+    /// reconnect ladder's fallback endpoint (`RemoteControlSession
+    /// +Link.swift`) and PR-8's future manual-connect-by-address rung.
+    public var lastAddress: LANRemoteResolvedAddress?
+
+    public var pairedAt: Date
+    public var lastConnectedAt: Date?
+
+    public var id: String { fingerprintHex }
+
+    public init(
+        fingerprintHex: String,
+        name: String,
+        token: String,
+        lastAddress: LANRemoteResolvedAddress? = nil,
+        pairedAt: Date,
+        lastConnectedAt: Date? = nil
+    ) {
+        self.fingerprintHex = fingerprintHex
+        self.name = name
+        self.token = token
+        self.lastAddress = lastAddress
+        self.pairedAt = pairedAt
+        self.lastConnectedAt = lastConnectedAt
+    }
+}
+
+/// The remote-side paired-TV persistence boundary — swappable between the
+/// real Keychain-backed store (`KeychainPairedTVStore`) and an in-memory
+/// double (`InMemoryPairedTVStore`, below).
+///
+/// ELI5: "Remember this TV," "what do I know about this TV," "list every TV
+/// I trust," "forget this TV."
+public protocol PairedTVStoring: Sendable {
+    /// Upserts `record` by `fingerprintHex` — a re-pair of an already-known
+    /// TV replaces its row rather than duplicating it.
+    func save(_ record: PairedTVRecord) async
+
+    /// The saved record for `fingerprint`, or `nil` if this TV has never
+    /// been paired (or was forgotten).
+    func record(forFingerprint fingerprint: String) async -> PairedTVRecord?
+
+    /// Every paired TV, ordered newest-first by `lastConnectedAt` (falling
+    /// back to `pairedAt` for a TV that's never been reconnected to since).
+    func listPairedTVs() async -> [PairedTVRecord]
+
+    /// "Forget this TV" — removes its record. Does NOT reach out to the TV
+    /// itself (that half — the TV forgetting US — is the TV's own
+    /// trusted-remotes "Revoke," a separate device); the coordinator's
+    /// caller is responsible for the honest "the TV still trusts you until
+    /// you revoke it there too" copy (spec §5.2).
+    func delete(fingerprint: String) async
+}
+
+/// A simple, non-persistent `PairedTVStoring` — what tests and SwiftUI
+/// previews use; NEVER wired into the real app (that's
+/// `KeychainPairedTVStore`). Mirrors `InMemoryLANRemotePairingAuthority`'s
+/// identical "throwaway in-memory double, same shape as the real store"
+/// role on the TV side.
+///
+/// ELI5: A pretend address book that forgets everything when the app quits.
+public actor InMemoryPairedTVStore: PairedTVStoring {
+    private var records: [String: PairedTVRecord] = [:]
+
+    public init() {}
+
+    public func save(_ record: PairedTVRecord) async {
+        records[record.fingerprintHex] = record
+    }
+
+    public func record(forFingerprint fingerprint: String) async -> PairedTVRecord? {
+        records[fingerprint]
+    }
+
+    public func listPairedTVs() async -> [PairedTVRecord] {
+        records.values.sorted { lhs, rhs in
+            (lhs.lastConnectedAt ?? lhs.pairedAt) > (rhs.lastConnectedAt ?? rhs.pairedAt)
+        }
+    }
+
+    public func delete(fingerprint: String) async {
+        records.removeValue(forKey: fingerprint)
+    }
+}

--- a/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/RemoteControlSession+Link.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/RemoteControlSession+Link.swift
@@ -1,0 +1,324 @@
+// RemoteControlSession+Link.swift
+// IHLive/LANRemote
+//
+// ELI5: The "keep this connection alive, and bring it back if it dies" half
+// of the session — split out of `RemoteControlSession.swift`'s public
+// surface for the same LOC-budget reason `TVListenerActor+Messages.swift`
+// is its own file. This is the ONLY place in the whole app that reads
+// `RemoteSessionActor`'s two streams (`phaseUpdates`/`incomingMessages`) —
+// the single-consumer rule from `RemoteControlSession.swift`'s header.
+//
+// DETAILED: #1422 (`.claude/apple-phase2-pr7-spec.md` §3.4 — BINDING). Two
+// structural facts drove this file's shape, both verified against the
+// merged `RemoteSessionActor+Connection.swift`:
+//
+// 1. **Every `connect(...)`/`disconnect()` call causes an internal `.idle`
+//    phase transition FIRST**, because `connect(...)`'s very first line is
+//    `disconnect()`, and `disconnect()` unconditionally calls
+//    `setPhase(.idle)` even when nothing was connected yet. Left unhandled,
+//    THIS actor's own `attach(to:)`/reconnect/`disconnect()` calls would look
+//    identical to a genuine, unexpected drop and immediately self-destruct
+//    the very ceremony/session that just started. `expectedIdleCount` (bumped
+//    immediately before every one of THIS actor's own `connect`/`disconnect`
+//    calls) is the fix — it swallows exactly that many `.idle` transitions,
+//    never a later, genuine one. A COUNTER, not a boolean: two of THIS
+//    actor's own calls can legitimately queue up faster than the phase
+//    consumer drains them (adversarial-review finding — `setSuspended(true)`'s
+//    disconnect immediately followed by `setSuspended(false)`'s connect, each
+//    producing their own `.idle` before either is popped off the stream); a
+//    boolean would let the FIRST (stale) `.idle` consume the suppression
+//    meant for the SECOND (current) one, leaving a genuine reaction point
+//    unprotected — exactly the bug a `RemoteControlSessionLoopbackTests
+//    .suspendThenResume` re-run caught.
+// 2. **A stale/rejected token can drop a "fast path" connection into the
+//    ceremony instead** (spec §4's extra resolver rule: a saved token the TV
+//    has since revoked gets a `.pairChallenge`, not `.capabilities`) — so
+//    `handleIncoming(_:)`'s `.pairChallenge` branch LAZILY starts a
+//    `RemotePairingFlowState` (path B: no known code) if one isn't already
+//    running, rather than assuming `flow` is always pre-armed by `attach(to:)`.
+// 3. **Ceremony completion has exactly ONE authority: `handleControlling(_:)`,
+//    never `handleIncoming(_:)`'s `.pairSuccess` case** (adversarial-review
+//    finding — an EARLIER version raced the two). `.capabilities` (which
+//    always triggers the `.controlling` phase transition) is GUARANTEED to
+//    follow `.pairSuccess` on the same connection, so `handleControlling`'s
+//    synthesis alone is always sufficient; letting BOTH paths race to finish
+//    the SAME flow transition meant whichever one suspended (an `await`)
+//    between clearing `flow` and actually yielding `.paired` could lose to
+//    the other one sailing past on an now-nil `flow` and yielding
+//    `.controlling` FIRST — a flake that only showed up under real
+//    concurrency load, never in a single isolated test run.
+import Foundation
+import IHLog
+import Network
+
+extension RemoteControlSession {
+
+    // MARK: - Phase-stream reactions (the ONE consumer of `phaseUpdates`)
+
+    /// See this file's header for why `.idle` needs the `expectedIdleCount`
+    /// gate but `.failed` never does (a transport FAILURE is never something
+    /// THIS actor's own housekeeping produces).
+    func handlePhase(_ phase: RemoteSessionPhase) async {
+        switch phase {
+        case .idle:
+            if expectedIdleCount > 0 {
+                expectedIdleCount -= 1
+                return
+            }
+            await handleIdleOrFailed()
+        case .failed:
+            await handleIdleOrFailed()
+        case .controlling(let state):
+            await handleControlling(state)
+        case .connecting, .awaitingPairing:
+            break
+        }
+    }
+
+    /// A genuine drop (or an outright failed connect attempt) — routed to
+    /// exactly one of three reactions depending on WHAT was in flight,
+    /// spec §3.4 point 3.
+    func handleIdleOrFailed() async {
+        guard !isSuspended else {
+            // `setSuspended(true)` sends `.endControl` THEN disconnects —
+            // the TV may ALSO react to `.endControl` by closing its own end
+            // of the socket, which surfaces as `RemoteSessionActor`'s OWN
+            // INTERNAL `disconnect()` call (a receive error/`isComplete` in
+            // `onReceive`) — an `.idle` `expectedIdleCount` never anticipated
+            // (it only counts THIS actor's own explicit connect/disconnect
+            // calls). Any drop observed while deliberately suspended is
+            // expected noise regardless of the counter — `setSuspended(false)`
+            // is the only thing that ever reconnects from a suspended state.
+            return
+        }
+        if var currentFlow = flow {
+            // A ceremony (or its underlying connection) failed before ever
+            // completing — never auto-retried (the user is standing at the
+            // TV; a fresh scan/tap starts a whole new attempt instead).
+            let effect = currentFlow.handle(.transportClosed)
+            flow = nil
+            await apply(effect)
+            return
+        }
+
+        guard hasEverControlled else {
+            // A brand-new FAST-PATH attach's very first connect attempt
+            // failed outright (e.g. the saved address is unreachable) —
+            // there is no ceremony to report failure through, so this
+            // reuses the same terminal vocabulary directly.
+            target = nil
+            eventContinuation.yield(.pairingEnded(.connectionTornDown))
+            return
+        }
+
+        // A previously-controlling (or mid-ladder) link just dropped again —
+        // the auto-reconnect regime. `.detached` is yielded only on the
+        // TRANSITION out of `.controlling` (`wasAttached == true`); a retry
+        // that itself fails while already mid-ladder does not re-yield it.
+        let wasAttached = isAttached
+        isAttached = false
+        pingTask?.cancel(); pingTask = nil
+        if wasAttached {
+            IHLog.remote.notice("lanremote.link detached")
+            eventContinuation.yield(.detached)
+        }
+        scheduleReconnectAttempt()
+    }
+
+    /// The TV's canonical state arrived (via `phase`, which
+    /// `RemoteSessionActor` already sets whenever `.state`/`.capabilities`
+    /// lands) — first arrival resets the health/backoff machines and starts
+    /// the ping ticker (spec §3.4 point 1's `phaseUpdates` bullet).
+    ///
+    /// **The pairSuccess-before-controlling race:** `phaseUpdates` and
+    /// `incomingMessages` are TWO INDEPENDENT `AsyncStream`s, each drained by
+    /// its OWN `Task` (this file's header/single-consumer rule) — Swift
+    /// concurrency gives NO guarantee that this actor processes an already
+    /// -queued `.pairSuccess` message (yielded first, on the wire) before it
+    /// processes the `.controlling` phase transition that logically follows
+    /// it (`.capabilities` is only ever sent by the TV AFTER `.pairSuccess`
+    /// on the same connection — `TVListenerActor+Pairing.swift`'s
+    /// `promoteToPaired`), only that they're SEQUENCED that way on the wire.
+    /// If this method runs first, `flow` may still be sitting in
+    /// `.proofSent` even though the actor's OWN `currentPairingToken` has
+    /// ALREADY been updated (`RemoteSessionActor+Connection.swift`'s
+    /// `handleIncomingFrameData` sets `pairingToken` synchronously, with no
+    /// suspension point, strictly before the `.capabilities` frame that
+    /// triggers THIS phase transition is even processed) — so finishing the
+    /// flow HERE, reading that already-current token, guarantees `.paired`
+    /// is always yielded before `.controlling`, regardless of which of this
+    /// session's two consumer tasks the scheduler happened to run first.
+    func handleControlling(_ state: IHRPState) async {
+        if let currentFlow = flow, case .proofSent = currentFlow.phase, let token = await remote.currentPairingToken {
+            var mutableFlow = currentFlow
+            let effect = mutableFlow.handle(.pairSuccess(token: token))
+            flow = nil
+            await apply(effect)
+        }
+
+        if let lastKnownRevision, state.revision > lastKnownRevision + 1 {
+            // A jump means we missed one or more broadcasts while
+            // disconnected/reconnecting — `IHRPPayloads.swift`'s intended
+            // consumer of `revision`. Counts only, never content.
+            IHLog.remote.notice(
+                "lanremote.link revision-jump from=\(lastKnownRevision, privacy: .public) to=\(state.revision, privacy: .public)"
+            )
+        }
+        lastKnownRevision = state.revision
+
+        if !isAttached {
+            isAttached = true
+            hasEverControlled = true
+            reconnectTask?.cancel(); reconnectTask = nil
+            backoff.reset()
+            health.reset()
+            startPingTicker()
+            IHLog.remote.notice("lanremote.link attach")
+        }
+        eventContinuation.yield(.controlling(state))
+    }
+
+    // MARK: - Message-stream reactions (the ONE consumer of `incomingMessages`)
+
+    /// Routes exactly the frames the pairing sub-protocol and the ping
+    /// ladder care about; every control-surface response (`.ack`/`.error`
+    /// other than `.pairingRejected`) is intentionally left to `phase`
+    /// (which already reflects `.state`/`.capabilities`) — this loop never
+    /// duplicates that.
+    func handleIncoming(_ frame: IHRPFrame) async {
+        switch frame.message {
+        case .pairChallenge(let nonce):
+            if flow == nil, let target {
+                // The stale-token fallback (this file's header point 2) —
+                // path B semantics: no known code, prompt the human.
+                flow = RemotePairingFlowState(context: .init(
+                    expectedFingerprint: target.expectedFingerprint, knownCode: nil, deviceName: configuration.deviceName
+                ))
+            }
+            guard var currentFlow = flow else { return }
+            let effect = currentFlow.handle(.challengeReceived(nonce: nonce))
+            flow = currentFlow
+            await apply(effect)
+        // `.pairSuccess` is deliberately NOT handled here — see
+        // `handleControlling(_:)`'s "pairSuccess-before-controlling race"
+        // doc comment. `.capabilities` (which always triggers a
+        // `.controlling` phase transition) is GUARANTEED to follow
+        // `.pairSuccess` on the same connection (`TVListenerActor
+        // +Pairing.swift`'s `promoteToPaired` sends both, unconditionally,
+        // in that fixed order) — so `handleControlling`'s synthesis is
+        // ALWAYS sufficient to complete the ceremony on its own. Having
+        // TWO code paths race to finish the SAME flow transition is exactly
+        // what caused the flake this comment replaces: whichever path
+        // suspends (an `await`) between clearing `flow` and actually
+        // yielding `.paired` can let the OTHER path observe `flow == nil`
+        // and sail past it, yielding `.controlling` first. One authority,
+        // never a photo finish.
+        case .error(let code, _) where code == .pairingRejected:
+            guard var currentFlow = flow else { return }
+            let effect = currentFlow.handle(.pairingRejected)
+            flow = currentFlow
+            await apply(effect)
+        case .pong:
+            health.onPong()
+        default:
+            break
+        }
+    }
+
+    /// The one place a `RemotePairingFlowState.Effect` gets turned into
+    /// either a wire send or a yielded `Event` — shared by every
+    /// `handleIncoming`/`handleIdleOrFailed`/`submitPairingCode` caller so
+    /// the mapping never drifts between them.
+    func apply(_ effect: RemotePairingFlowState.Effect) async {
+        switch effect {
+        case .none:
+            break
+        case .sendProof(let proof, let deviceName):
+            try? await remote.send(.pairConfirm(proof: proof, deviceName: deviceName))
+        case .promptForCode(let failedAttempts):
+            eventContinuation.yield(.awaitingCodeEntry(failedAttempts: failedAttempts))
+        case .reportPaired(let token):
+            // The fresh token supersedes whatever was in `target` (nil for a
+            // brand-new pairing, or a stale value for a re-pair) — every
+            // later reconnect (including the ladder) must use THIS token.
+            if let existing = target {
+                target = Target(
+                    tvName: existing.tvName, endpoint: existing.endpoint, fallbackEndpoint: existing.fallbackEndpoint,
+                    expectedFingerprint: existing.expectedFingerprint, token: token, knownCode: nil
+                )
+            }
+            let resolved = await remote.currentResolvedRemoteAddress
+            eventContinuation.yield(.paired(token: token, resolved: resolved))
+        case .reportFailed(let failure):
+            target = nil
+            eventContinuation.yield(.pairingEnded(failure))
+        }
+    }
+
+    // MARK: - Ping ticker (spec §3.4 point 2 — the only OTHER sleeping code)
+
+    func startPingTicker() {
+        pingTask?.cancel()
+        pingTask = Task { [weak self] in
+            await self?.runPingTicker()
+        }
+    }
+
+    func runPingTicker() async {
+        while !Task.isCancelled {
+            try? await Task.sleep(for: health.configuration.pingInterval)
+            guard !Task.isCancelled, isAttached else { return }
+            switch health.onTick() {
+            case .sendPing:
+                do {
+                    try await remote.send(.ping)
+                } catch {
+                    // `.notConnected` — the actor already knows it's down;
+                    // react immediately rather than waiting for the phase
+                    // stream to (also) notice.
+                    await handleIdleOrFailed()
+                    return
+                }
+            case .declareDetached:
+                await handleIdleOrFailed()
+                return
+            }
+        }
+    }
+
+    // MARK: - Reconnect ladder (spec §3.4 point 3)
+
+    /// Spawns (replacing any prior) the ONE-SHOT "sleep, then try one
+    /// endpoint" task. A failed attempt produces another `.idle`/`.failed`
+    /// phase event, which re-enters `handleIdleOrFailed()` and schedules the
+    /// NEXT attempt — the ladder is a recursive re-triggering through the
+    /// SAME phase consumer, not a second stream reader or its own loop.
+    func scheduleReconnectAttempt() {
+        guard let target else { return }
+        reconnectTask?.cancel()
+        reconnectTask = Task { [weak self] in
+            await self?.performReconnectAttempt(target: target)
+        }
+    }
+
+    func performReconnectAttempt(target: Target) async {
+        guard !Task.isCancelled else { return }
+        let attemptNumber = backoff.attempt
+        let delay = backoff.nextDelay(unitRandom: Double.random(in: 0..<1))
+        eventContinuation.yield(.reconnecting(attempt: attemptNumber, delay: delay))
+        IHLog.remote.notice("lanremote.link reconnect attempt=\(attemptNumber, privacy: .public)")
+
+        try? await Task.sleep(for: .seconds(delay))
+        guard !Task.isCancelled else { return }
+
+        // Attempts ALTERNATE primary/last-good so a TV that lost its
+        // Bonjour registration (or a remote that roamed networks) still
+        // comes back.
+        let endpoints: [NWEndpoint] = [target.endpoint, target.fallbackEndpoint].compactMap { $0 }
+        guard !endpoints.isEmpty else { return }
+        let endpoint = endpoints[attemptNumber % endpoints.count]
+
+        expectedIdleCount += 1
+        try? await remote.connect(to: endpoint, expectedFingerprint: target.expectedFingerprint, token: target.token)
+    }
+}

--- a/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/RemoteControlSession.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/RemoteControlSession.swift
@@ -1,0 +1,354 @@
+// RemoteControlSession.swift
+// IHLive/LANRemote
+//
+// ELI5: The remote's own "supervisor" — the one thing the UI actually talks
+// to. It owns a single connection to one TV, runs the code-pairing dance
+// when needed, keeps sending little "are you still there?" pings, and — if
+// the connection ever drops — waits a bit and tries again by itself,
+// automatically, without the person having to do anything. Everything the
+// UI needs to know ("we're connecting," "type the code," "we're in
+// control," "we got disconnected, trying again in 4 seconds…") comes out of
+// its ONE `events` stream.
+//
+// DETAILED: #1422 (`.claude/apple-phase2-pr7-spec.md` §3.4 — BINDING shape).
+// This is the remote-side mirror of the TV's own composition split
+// (`TVListenerActor` = transport + pairing state; `TVRemoteControlCoordinator`
+// = the `@MainActor` UI glue built ON TOP of it). Here the split is: transport
+// stays entirely inside `RemoteSessionActor` (PR-4, untouched by this PR);
+// supervision — the ceremony client, the ping/reconnect ladder — lives HERE,
+// in a plain `IHLive` `actor`, NOT the `@MainActor` coordinator
+// (`RemoteControlCoordinator`, `IHFeatures`, commit 3), because: (a) the
+// `RemoteControlSessionLoopbackTests` suite (§7.5) must drive the WHOLE
+// ladder headlessly, with no `@MainActor` UI ever attached; (b) a future
+// Watch-relay PR reuses exactly this supervision on the iPhone with no UI
+// at all; (c) the coordinator would blow the LOC budget; (d)
+// `RemoteSessionActor`'s own header already assigns reconnect/replay policy
+// to something OUTSIDE the transport actor — this is that something.
+//
+// **The single-consumer rule (§1.2, BINDING):** `RemoteSessionActor
+// .phaseUpdates`/`.incomingMessages` are single-consumer `AsyncStream`s (the
+// exact class of bug the PR-5 review caught). This type is the ONLY
+// consumer of both — the two `for await` loops exist EXACTLY ONCE, in
+// `RemoteControlSession+Link.swift`. The UI/coordinator instead consumes
+// ONLY this type's OWN `events` stream. A second `for await` on either
+// `RemoteSessionActor` stream anywhere else in the app silently steals
+// frames from this actor — a review reject (spec §8 D-15).
+import Foundation
+import IHLog
+import Network
+
+/// The supervising actor that drives ONE `RemoteSessionActor` through the
+/// full pairing ceremony, the 5 s ping/3-miss link-health check, and the
+/// jittered exponential-backoff reconnect ladder — see this file's header
+/// for why supervision lives here, not in the `@MainActor` coordinator.
+///
+/// ELI5: "Connect to this TV, run whatever pairing dance is needed, keep the
+/// connection healthy, and automatically reconnect if it drops — and tell me
+/// everything that happens along the way."
+public actor RemoteControlSession {
+
+    /// Tunables — every interval an injected value, so
+    /// `RemoteControlSessionLoopbackTests` can run the ENTIRE ladder in tens
+    /// of milliseconds (spec §7.5: `health.pingInterval = .milliseconds(40)`,
+    /// `backoff = .init(baseDelay: 0.05, maxDelay: 0.2)`).
+    public struct Configuration: Sendable {
+        public var remoteKind: IHRPRemoteKind
+        public var deviceName: String?
+        public var health: RemoteLinkHealthState.Configuration = .init()
+        public var backoff: RemoteReconnectBackoffState.Configuration = .init()
+        public var clock: any LANRemoteClock = SystemLANRemoteClock()
+
+        public init(remoteKind: IHRPRemoteKind, deviceName: String? = nil) {
+            self.remoteKind = remoteKind
+            self.deviceName = deviceName
+        }
+    }
+
+    /// Everything needed to (re)connect to ONE TV — `RemotePairingEntryResolver
+    /// .swift`'s `RemoteConnectTarget` is the concrete type this aliases to;
+    /// see that file's header for why the concrete shape lives there.
+    public typealias Target = RemoteConnectTarget
+
+    /// Everything the UI needs to know, in the order it can happen.
+    public enum Event: Sendable, Equatable {
+        /// `0` = the very first connect attempt; `≥1` = the ladder.
+        case connecting(attempt: Int)
+        /// Show/refresh the code-entry sheet — `0` = first ask.
+        case awaitingCodeEntry(failedAttempts: Int)
+        /// A pairing attempt ended without a token — back to browsing.
+        case pairingEnded(RemotePairingFlowState.RemotePairingFlowFailure)
+        /// A ceremony JUST completed — the coordinator persists `token`
+        /// (Keychain) alongside `resolved` (the address that actually
+        /// worked). Fired exactly once per successful ceremony; a fast-path
+        /// (already-token) connect never fires this (nothing new to save).
+        case paired(token: String, resolved: LANRemoteResolvedAddress?)
+        /// Every TV state broadcast — including the TV's echo of our own
+        /// intents (§1.1) — lands here.
+        case controlling(IHRPState)
+        /// The link died (3 missed pongs, or a hard transport error) while
+        /// we were previously controlling — the reconnect ladder starts
+        /// right after this.
+        case detached
+        /// The ladder is about to sleep `delay` seconds before its `attempt`
+        /// -th retry.
+        case reconnecting(attempt: Int, delay: TimeInterval)
+        /// `setSuspended(true)` completed — the app went to the background.
+        case suspended
+        /// `stop()`/`endControl()` completed — deliberate, final.
+        case ended
+    }
+
+    let configuration: Configuration
+    let remote: RemoteSessionActor
+
+    // MARK: - Pure policy state (§3.2/§3.3 — mutated only from this actor's isolation)
+
+    var health: RemoteLinkHealthState
+    var backoff: RemoteReconnectBackoffState
+    var flow: RemotePairingFlowState?
+
+    // MARK: - Session bookkeeping (see `+Link.swift` for how these interact)
+
+    var target: Target?
+    /// True once `.controlling` has arrived at LEAST once for the CURRENT
+    /// target — reset to `false` on every fresh `attach(to:)`, flipped
+    /// `true` on first arrival, and never reset back to `false` merely
+    /// because the link later drops (that's exactly what makes the
+    /// reconnect ladder — as opposed to a one-shot "give up" — the right
+    /// reaction to a LATER drop).
+    var hasEverControlled = false
+    /// True only WHILE a live, `.controlling` connection is up — flips back
+    /// to `false` the instant the link drops, whether or not the ladder then
+    /// kicks in.
+    var isAttached = false
+    var isSuspended = false
+    /// How many `.idle` phase transitions are CURRENTLY expected as pure
+    /// housekeeping from THIS actor's own `remote.connect(...)`/`remote
+    /// .disconnect()` calls — a COUNTER, not a boolean, because two such
+    /// calls can legitimately queue up faster than the phase consumer drains
+    /// them (e.g. `setSuspended(true)`'s disconnect immediately followed by
+    /// `setSuspended(false)`'s connect, each producing their OWN `.idle`
+    /// before either has been popped off the stream) — a boolean would let
+    /// the FIRST (stale) `.idle` consume the suppression meant for the
+    /// SECOND (current) one, leaving a genuine reaction point unprotected.
+    /// See `+Link.swift`'s `handlePhase(_:)` header comment for why every
+    /// `connect`/`disconnect` call causes an internal `.idle` at all.
+    var expectedIdleCount = 0
+    var lastKnownRevision: UInt64?
+
+    var pingTask: Task<Void, Never>?
+    var reconnectTask: Task<Void, Never>?
+    var phaseTask: Task<Void, Never>?
+    var messageTask: Task<Void, Never>?
+
+    let eventContinuation: AsyncStream<Event>.Continuation
+    /// The ONE stream the UI/coordinator consumes — never `RemoteSessionActor`'s
+    /// own streams directly (this file's header).
+    public nonisolated let events: AsyncStream<Event>
+
+    public init(configuration: Configuration) {
+        self.configuration = configuration
+        self.remote = RemoteSessionActor(configuration: .init(kind: configuration.remoteKind, clock: configuration.clock))
+        self.health = RemoteLinkHealthState(configuration: configuration.health)
+        self.backoff = RemoteReconnectBackoffState(configuration: configuration.backoff)
+        let (stream, continuation) = AsyncStream.makeStream(of: Event.self)
+        self.events = stream
+        self.eventContinuation = continuation
+    }
+
+    // MARK: - Discovery pass-through
+
+    public func startDiscovery() async -> AsyncStream<[LANRemoteDiscoveredService]> {
+        // Lazily spins up the driver loop the FIRST time anything is asked
+        // of this session — a plain browsing-only screen (nothing paired
+        // yet, no `attach(to:)` ever called) still needs the loop running
+        // so a LATER `attach(to:)` is instantly ready.
+        ensureDriverLoopStarted()
+        return await remote.startDiscovery()
+    }
+
+    public func stopDiscovery() async {
+        await remote.stopDiscovery()
+    }
+
+    // MARK: - Connect / pairing / control
+
+    /// Begins connecting to `target` — a brand-new pairing ceremony
+    /// (`target.token == nil`) or the fast token-based reconnect path.
+    /// Resets every piece of per-target state (spec §3.4).
+    ///
+    /// ELI5: "Connect to this TV."
+    public func attach(to target: Target) async {
+        ensureDriverLoopStarted()
+        pingTask?.cancel(); pingTask = nil
+        reconnectTask?.cancel(); reconnectTask = nil
+
+        self.target = target
+        self.isAttached = false
+        self.hasEverControlled = false
+        self.isSuspended = false
+        self.lastKnownRevision = nil
+        backoff.reset()
+        health.reset()
+        self.flow = target.token == nil
+            ? RemotePairingFlowState(context: .init(
+                expectedFingerprint: target.expectedFingerprint, knownCode: target.knownCode, deviceName: configuration.deviceName
+              ))
+            : nil
+
+        eventContinuation.yield(.connecting(attempt: 0))
+        IHLog.remote.notice("lanremote.link attach-begin")
+        expectedIdleCount += 1
+        try? await remote.connect(to: target.endpoint, expectedFingerprint: target.expectedFingerprint, token: target.token)
+    }
+
+    /// Path B's sheet — the human typed a code.
+    public func submitPairingCode(_ code: String) async {
+        guard var currentFlow = flow else { return }
+        let effect = currentFlow.handle(.codeEntered(code))
+        flow = currentFlow
+        await apply(effect)
+    }
+
+    /// The code sheet was dismissed by the person — disconnects and reports
+    /// `.pairingEnded(.cancelled)`; never auto-retries (this is an
+    /// UNPAIRED/mid-ceremony connection, spec §3.4 point 3's own rule).
+    public func cancelPairing() async {
+        guard flow != nil else { return }
+        flow = nil
+        target = nil
+        expectedIdleCount += 1
+        await remote.disconnect()
+        eventContinuation.yield(.pairingEnded(.cancelled))
+    }
+
+    /// The control surface's one door for sending an actual command.
+    public func sendIntent(_ message: IHRPMessage) async {
+        guard message.isControlIntent else {
+            assertionFailure("sendIntent called with a non-control-intent message: \(message.caseName)")
+            return
+        }
+        try? await remote.send(message)
+    }
+
+    /// A deliberate, user-initiated "stop controlling this TV" — sends the
+    /// TV a clean `.endControl` hand-off signal before disconnecting (spec
+    /// §3.4: "the deliberate-hand-off log on the TV").
+    ///
+    /// ELI5: "I'm done with this TV for now."
+    public func endControl() async {
+        pingTask?.cancel(); pingTask = nil
+        reconnectTask?.cancel(); reconnectTask = nil
+        flow = nil
+        target = nil
+        hasEverControlled = false
+        isAttached = false
+        expectedIdleCount += 1
+        try? await remote.send(.endControl)
+        await remote.disconnect()
+        eventContinuation.yield(.ended)
+    }
+
+    /// `scenePhase` wiring — `true` when the app leaves `.active`
+    /// (quiesce, keep the target so resuming is a fast token reconnect);
+    /// `false` on return to `.active` (immediate reconnect).
+    ///
+    /// ELI5: "The app just went to the background" / "the app just came
+    /// back to the foreground."
+    public func setSuspended(_ suspended: Bool) async {
+        guard suspended != isSuspended else { return }
+        isSuspended = suspended
+
+        if suspended {
+            pingTask?.cancel(); pingTask = nil
+            reconnectTask?.cancel(); reconnectTask = nil
+            isAttached = false
+            expectedIdleCount += 1
+            try? await remote.send(.endControl)
+            await remote.disconnect()
+            eventContinuation.yield(.suspended)
+            return
+        }
+
+        guard let target else { return }
+        backoff.reset()
+        eventContinuation.yield(.connecting(attempt: 0))
+        // ★ Adversarial-review finding: `RemoteSessionActor.disconnect()`
+        // cancels `connection` but does NOT synchronously stop an
+        // already-in-flight `connection.receive(...)` completion — that
+        // callback can still fire moments later (Network.framework's own
+        // queue), and `onReceive`'s error/`isComplete` path calls
+        // `disconnect()` AGAIN as a delayed echo of a teardown we already
+        // initiated ourselves. If that echo lands AFTER this method has
+        // ALREADY started a brand-new `connect(...)` (which sets its own
+        // fresh `pendingConnectContinuation`), the echo's `disconnect()`
+        // resumes THAT continuation with `.notConnected` — cancelling a
+        // perfectly healthy new connection attempt out from under itself.
+        // `RemoteSessionActor` is additive-only (no connect/disconnect
+        // semantics changes allowed), so the fix lives here: a short settle
+        // wait gives Network.framework's queue time to flush the echo
+        // BEFORE we ask for a new continuation, at negligible cost against
+        // spec §3.4's "<1s" resume budget (production; this suite's
+        // millisecond configuration still comfortably clears it too).
+        try? await Task.sleep(for: .milliseconds(20))
+        expectedIdleCount += 1
+        try? await remote.connect(to: target.endpoint, expectedFingerprint: target.expectedFingerprint, token: target.token)
+    }
+
+    /// Full teardown — cancels every loop, disconnects, and finishes
+    /// `events` (nothing more will ever be yielded). Called when the
+    /// coordinator is torn down (e.g. the control screen goes away for
+    /// good), never as part of ordinary backgrounding (that's
+    /// `setSuspended(true)`).
+    public func stop() async {
+        pingTask?.cancel(); pingTask = nil
+        reconnectTask?.cancel(); reconnectTask = nil
+        // Cancel the consumer loops BEFORE disconnecting — `disconnect()`
+        // always yields one more `.idle` phase value (`RemoteSessionActor
+        // +Connection.swift`'s `disconnect()` is unconditional), which wakes
+        // the suspended `for await` up; by then `Task.isCancelled` is
+        // already true, so it exits cleanly instead of running
+        // `handlePhase(.idle)` one last time.
+        phaseTask?.cancel()
+        messageTask?.cancel()
+        flow = nil
+        target = nil
+        hasEverControlled = false
+        isAttached = false
+        await remote.stopDiscovery()
+        await remote.disconnect()
+        eventContinuation.finish()
+    }
+
+    /// The resolved `host:port` the LIVE (or just-was-live) connection
+    /// actually used — the coordinator reads this at `.paired`/first
+    /// `.controlling` to persist `PairedTVRecord.lastAddress` (spec §5.2).
+    /// Exists because `RemoteSessionActor.currentResolvedRemoteAddress` is
+    /// `internal` to `RemoteSessionActor`'s own actor, not reachable from
+    /// `IHFeatures` directly — the coordinator only ever talks to THIS type.
+    public func currentResolvedAddress() async -> LANRemoteResolvedAddress? {
+        await remote.currentResolvedRemoteAddress
+    }
+
+    /// Idempotent — the driver loop (the ONE consumer of both
+    /// `RemoteSessionActor` streams) starts the first time anything asks
+    /// this session to do real work (`startDiscovery()`/`attach(to:)`), not
+    /// necessarily at `init` — a session that's never used yet (e.g. a
+    /// preview) never spins up background tasks for nothing.
+    func ensureDriverLoopStarted() {
+        guard phaseTask == nil else { return }
+        let remote = remote
+        phaseTask = Task { [weak self] in
+            for await phase in remote.phaseUpdates {
+                guard let self, !Task.isCancelled else { break }
+                await self.handlePhase(phase)
+            }
+        }
+        messageTask = Task { [weak self] in
+            for await frame in remote.incomingMessages {
+                guard let self, !Task.isCancelled else { break }
+                await self.handleIncoming(frame)
+            }
+        }
+    }
+}

--- a/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/RemoteLinkPolicy.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/RemoteLinkPolicy.swift
@@ -1,0 +1,155 @@
+// RemoteLinkPolicy.swift
+// IHLive/LANRemote
+//
+// ELI5: Two little rulebooks for keeping a remote's connection to a TV
+// healthy: one says "ping every 5 seconds, and if 3 pings in a row go
+// unanswered, the link is dead"; the other says "when the link dies, wait a
+// bit before trying again, a bit longer each time, up to a cap, with some
+// randomness so a room full of remotes doesn't all redial in lockstep."
+// Neither one touches the network, a clock, or a random-number generator —
+// they're handed everything they need, which is what makes them trivial to
+// test at millisecond speed instead of real seconds.
+//
+// DETAILED: #1422 (`.claude/apple-phase2-pr7-spec.md` §3.2/§3.3 — BINDING
+// shapes). Mirrors PR-6's `LANRemotePairingCeremonyState` posture
+// (`LANRemotePairingCeremony.swift`'s header: "a plain struct... every input
+// is handed to it") and the repo-wide injected-clock/injected-RNG seam
+// (`LiveFollowEngine.isFresh(lastUpdatedAt:now:)`, strategy §3.3). The ONLY
+// place either machine's numbers actually cost real time is the session
+// actor's driver loop (`RemoteControlSession+Link.swift`), which sleeps for
+// exactly the intervals these structs report and supplies the one piece of
+// entropy the backoff machine needs (`unitRandom`) from a real
+// `Double.random(in: 0..<1)` in production, a literal in tests.
+import Foundation
+
+/// The "ping every N seconds, 3 misses = dead" link-health machine (spec
+/// §3.2) — tick-counted, not `Date`-based, so no clock object is needed at
+/// all: the DRIVER's own sleep cadence between calls to `onTick()` IS the
+/// time source.
+///
+/// ELI5: "Did the last few pings get answered? If not enough of them did,
+/// the connection is probably dead."
+public struct RemoteLinkHealthState: Sendable, Equatable {
+    public struct Configuration: Sendable, Equatable {
+        /// Strategy §2.4.4's "`ping`(5s)" — the DRIVER sleeps this long
+        /// between ticks.
+        public var pingInterval: Duration
+        /// Ticks that may elapse with no pong before the link is declared
+        /// dead.
+        public var maxMissedPongs: Int
+
+        public init(pingInterval: Duration = .seconds(5), maxMissedPongs: Int = 3) {
+            self.pingInterval = pingInterval
+            self.maxMissedPongs = maxMissedPongs
+        }
+    }
+
+    /// What one timer tick means the driver should do.
+    public enum TickOutcome: Sendable, Equatable {
+        /// Send a `.ping` — the link is still within its miss budget.
+        case sendPing
+        /// `maxMissedPongs` consecutive pings went unanswered — the link is
+        /// dead; the driver disconnects and starts the reconnect ladder.
+        case declareDetached
+    }
+
+    public private(set) var pingsAwaitingPong: Int = 0
+    public let configuration: Configuration
+
+    public init(configuration: Configuration = .init()) {
+        self.configuration = configuration
+    }
+
+    /// One timer tick. If the miss budget is ALREADY exhausted
+    /// (`pingsAwaitingPong >= maxMissedPongs` — i.e. `maxMissedPongs`
+    /// consecutive pings already went unanswered), the link is dead; else a
+    /// fresh ping goes out and the miss counter advances by one (assuming
+    /// nothing answers it before the next tick).
+    ///
+    /// ELI5: "Time to check in again — has the other side gone quiet?"
+    public mutating func onTick() -> TickOutcome {
+        guard pingsAwaitingPong < configuration.maxMissedPongs else {
+            return .declareDetached
+        }
+        pingsAwaitingPong += 1
+        return .sendPing
+    }
+
+    /// A `.pong` arrived — ANY pong proves liveness, so this resets the miss
+    /// counter to zero regardless of how many pings were outstanding.
+    ///
+    /// ELI5: "Good, they answered — the link is alive, reset the worry
+    /// counter."
+    public mutating func onPong() {
+        pingsAwaitingPong = 0
+    }
+
+    /// Fresh connection — same as a brand-new `RemoteLinkHealthState`, kept
+    /// as an explicit method so the driver never has to reconstruct one from
+    /// scratch just to reset it.
+    public mutating func reset() {
+        pingsAwaitingPong = 0
+    }
+}
+
+/// The jittered exponential-backoff reconnect machine (spec §3.3) — same
+/// no-clock/no-RNG purity as the health machine above; `nextDelay(unitRandom:)`
+/// takes its ONE random input from the caller instead of drawing it itself.
+///
+/// ELI5: "How long should I wait before trying to reconnect this time?" —
+/// waits a bit longer each failed attempt (up to a cap), with a little
+/// randomness mixed in so a whole room of remotes doesn't all redial at
+/// exactly the same instant.
+public struct RemoteReconnectBackoffState: Sendable, Equatable {
+    public struct Configuration: Sendable, Equatable {
+        public var baseDelay: TimeInterval
+        public var multiplier: Double
+        public var maxDelay: TimeInterval
+        /// `±20%` by default — see `nextDelay(unitRandom:)`'s doc comment
+        /// for the exact jitter formula.
+        public var jitterFraction: Double
+
+        public init(baseDelay: TimeInterval = 1, multiplier: Double = 2, maxDelay: TimeInterval = 30, jitterFraction: Double = 0.2) {
+            self.baseDelay = baseDelay
+            self.multiplier = multiplier
+            self.maxDelay = maxDelay
+            self.jitterFraction = jitterFraction
+        }
+    }
+
+    public private(set) var attempt: Int = 0
+    public let configuration: Configuration
+
+    public init(configuration: Configuration = .init()) {
+        self.configuration = configuration
+    }
+
+    /// Computes the delay for the CURRENT attempt, then advances `attempt`
+    /// for next time.
+    ///
+    /// `delay = min(maxDelay, baseDelay × multiplier^attempt) × (1 − j + 2j·unitRandom)`
+    /// — with `unitRandom ∈ [0, 1)`, the multiplier ranges from `(1 − j)` to
+    /// `(1 + j)`; `unitRandom == 0.5` reproduces the nominal (unjittered)
+    /// delay exactly.
+    ///
+    /// - Parameter unitRandom: A value in `[0, 1)` — production supplies one
+    ///   real `Double.random(in: 0..<1)` draw per call at the driver's call
+    ///   site; tests supply literals for exact, reproducible sequences.
+    ///
+    /// ELI5: "Work out this attempt's wait time (a bit random so we don't
+    /// collide with every other remote), then remember we've tried one more
+    /// time."
+    public mutating func nextDelay(unitRandom: Double) -> TimeInterval {
+        let nominal = min(configuration.maxDelay, configuration.baseDelay * pow(configuration.multiplier, Double(attempt)))
+        let jitterMultiplier = 1 - configuration.jitterFraction + (2 * configuration.jitterFraction * unitRandom)
+        attempt += 1
+        return nominal * jitterMultiplier
+    }
+
+    /// Back to attempt 0 — called the instant a reconnect actually succeeds
+    /// (`RemoteControlSession+Link.swift`'s first `.controlling` arrival
+    /// after a detach).
+    public mutating func reset() {
+        attempt = 0
+    }
+}

--- a/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/RemotePairingEntryResolver.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/RemotePairingEntryResolver.swift
@@ -144,6 +144,17 @@ public enum RemotePairingEntryResolver {
         /// matched `payload.name` — there is genuinely no address to dial
         /// (spec §4 row A/B: "if neither → error card").
         case noRouteToTV
+        /// The scanned/pasted payload's own fields fail the basic sanity
+        /// checks spec §8's threat-model table promises: `fingerprintHex`
+        /// isn't exactly 64 lowercase hex characters, or `port` is present
+        /// but `0` — see `isValidFingerprint(_:)`/`resolvePayload(_:saved:
+        /// discovered:)` (#1422 review fix 4). A malformed field here is
+        /// either an honest scanning glitch (a partially-obscured QR, a
+        /// mis-copied paste) or a deliberately crafted payload; either way
+        /// there is nothing safe to connect to, so this is rejected BEFORE
+        /// any endpoint/token resolution — never surfaced merely as a later
+        /// TLS-pin mismatch at connect time.
+        case malformedPayload
     }
 
     public enum Resolution: Sendable {
@@ -196,6 +207,20 @@ public enum RemotePairingEntryResolver {
     private static func resolvePayload(
         _ payload: LANRemotePairingPayload, saved: [PairedTVRecord], discovered: [LANRemoteDiscoveredService]
     ) -> Resolution {
+        // Spec §8's threat-model clamp, made real (#1422 review fix 4): a
+        // payload comes from a camera scan or a pasted string — untrusted
+        // input by construction — so its shape is validated BEFORE this
+        // resolver ever builds a `RemoteConnectTarget` from it, rather than
+        // letting a malformed fingerprint sail through to `RemoteSessionActor
+        // .connect(to:expectedFingerprint:token:)` and rely on the TLS pin
+        // simply never matching as the only thing standing in the way.
+        guard isValidFingerprint(payload.fingerprintHex) else {
+            return .unpairable(reason: .malformedPayload)
+        }
+        if let port = payload.port, port == 0 {
+            return .unpairable(reason: .malformedPayload)
+        }
+
         guard let endpoint = endpointFromPayload(payload, discovered: discovered) else {
             return .unpairable(reason: .noRouteToTV)
         }
@@ -236,6 +261,28 @@ public enum RemotePairingEntryResolver {
             return .hostPort(host: .init(host), port: nwPort)
         }
         return discovered.first { $0.name == payload.name }?.endpoint
+    }
+
+    /// The exact alphabet a valid fingerprint may use — lowercase only, spec
+    /// §8: "non-64-hex fingerprint ⇒ reject." Every REAL `LANRemoteIdentity
+    /// .fingerprint` (`IHLive`, PR-4) is a sha256 digest hex-encoded
+    /// lowercase, so this is checking "is this shaped like a real
+    /// fingerprint," not merely "is this hex" — `Character.isHexDigit`
+    /// alone would also accept uppercase `A`-`F`, which this payload format
+    /// never produces and which the TV's own fingerprint never contains.
+    private static let lowercaseHexDigits = Set("0123456789abcdef")
+
+    /// Spec §8's payload clamp (#1422 review fix 4): exactly 64 lowercase
+    /// hex characters. Anything else — wrong length, any uppercase letter,
+    /// any non-hex character — is NOT a fingerprint this app could ever
+    /// have generated itself, so `resolvePayload(_:saved:discovered:)`
+    /// rejects it up front rather than letting it become a wasted (or
+    /// worse, ambiguous) connect attempt.
+    ///
+    /// ELI5: "does this look like a real fingerprint, character for
+    /// character?"
+    private static func isValidFingerprint(_ value: String) -> Bool {
+        value.count == 64 && value.allSatisfy(lowercaseHexDigits.contains)
     }
 
     // MARK: - Path C — a tap on an already-saved list row

--- a/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/RemotePairingEntryResolver.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/RemotePairingEntryResolver.swift
@@ -1,0 +1,273 @@
+// RemotePairingEntryResolver.swift
+// IHLive/LANRemote
+//
+// ELI5: The one place that turns "I scanned this QR" / "I tapped this row in
+// my list" into "here's exactly how to connect" — which address to dial,
+// which fingerprint to pin, whether we already have a saved token or need to
+// run the code ceremony. It also builds the list of rows the UI shows:
+// TVs we already trust first, then nearby TVs we've never paired with (which
+// can only ever say "scan my QR to pair," never be tapped to connect).
+//
+// DETAILED: #1422 (`.claude/apple-phase2-pr7-spec.md` §4 — the entry-path
+// matrix, BINDING, "resolve it EXACTLY this way"). This is a PURE, static
+// enum — no actor, no I/O, no network call — so `RemotePairingEntryResolverTests`
+// can table-drive every row of the spec's matrix without a live listener.
+//
+// **The invariant behind the whole file:** `expectedFingerprint` must be in
+// hand BEFORE any connection is attempted, and it comes from exactly two
+// sources this resolver reads — a scanned/pasted `LANRemotePairingPayload`,
+// or an already-saved `PairedTVRecord`. Bonjour discovery (`discovered:`)
+// NEVER supplies trust here — a `LANRemoteDiscoveredService` is name +
+// endpoint only (`LANRemoteDiscovery.swift`'s header) — name-matching it to
+// a saved/scanned fingerprint is ROUTING ONLY (picking which endpoint to
+// dial); an impostor advertising a trusted TV's name still fails the SAVED
+// fingerprint's TLS pin at handshake (`RemoteSessionActor+Connection.swift`).
+// A nearby TV that ISN'T already paired can therefore never be resolved to a
+// `.connect(...)` target at all — `listRows(saved:discovered:)` marks it
+// `.nearbyUnpaired`, and the UI's only affordance for that row is opening the
+// scan/paste sheet (spec §4 row C′: "wiring ANY connect here... is the PR-8
+// boundary violation").
+//
+// `RemoteConnectTarget` (this file) is the concrete type
+// `RemoteControlSession.Target` (`RemoteControlSession.swift`, #1422 commit 2)
+// aliases to — defined HERE, not nested inside the session actor, because
+// this resolver is its ONLY producer (spec §3.4: "produced by
+// `RemotePairingEntryResolver`... never assembled ad-hoc in a view") and
+// keeping the concrete shape beside the code that builds it lets this file
+// compile — and be fully tested — before `RemoteControlSession` exists at
+// all (this PR's commit 1 has no dependency on commit 2's actor).
+import Foundation
+import Network
+
+/// Everything needed to (re)connect to ONE TV. `RemoteControlSession.Target`
+/// is a `typealias` to this exact type — see this file's header for why the
+/// concrete struct lives here.
+///
+/// ELI5: "Here's the TV, here's how to reach it, here's the fingerprint to
+/// pin, and here's whether we can skip straight to the fast reconnect."
+public struct RemoteConnectTarget: Sendable {
+    /// Cosmetic — shown while connecting/reconnecting.
+    public let tvName: String
+
+    /// The primary endpoint to dial — either a discovered Bonjour service or
+    /// an explicit `.hostPort` built from a scanned/pasted payload.
+    public let endpoint: NWEndpoint
+
+    /// A saved last-good `host:port` to fall back to if `endpoint` (when it's
+    /// a Bonjour service) can't be reached — `RemoteControlSession+Link.swift`'s
+    /// reconnect ladder alternates between the two.
+    public let fallbackEndpoint: NWEndpoint?
+
+    /// ALWAYS present — no TOFU (PR-8's boundary, not this PR's).
+    public let expectedFingerprint: String
+
+    /// `nil` ⇒ the ceremony must run; non-nil ⇒ the fast `hello(token:)`
+    /// reconnect path (and this connection is eligible for the auto-reconnect
+    /// ladder on a later drop — `RemoteControlSession+Link.swift`).
+    public let token: String?
+
+    /// Path A only — the code a scanned ceremony QR already carried, so the
+    /// challenge can be auto-answered without prompting.
+    public let knownCode: String?
+
+    public init(
+        tvName: String,
+        endpoint: NWEndpoint,
+        fallbackEndpoint: NWEndpoint? = nil,
+        expectedFingerprint: String,
+        token: String? = nil,
+        knownCode: String? = nil
+    ) {
+        self.tvName = tvName
+        self.endpoint = endpoint
+        self.fallbackEndpoint = fallbackEndpoint
+        self.expectedFingerprint = expectedFingerprint
+        self.token = token
+        self.knownCode = knownCode
+    }
+}
+
+/// One row in the discovery/paired-TV list (`RemoteControlCoordinator.rows`,
+/// #1422 commit 3) — saved TVs (optionally flagged "nearby" when a discovered
+/// service matches their name) followed by unpaired nearby TVs, which are
+/// informational only (spec §4 row C′).
+public struct RemoteTVListRow: Sendable, Equatable, Identifiable {
+    public enum Kind: Sendable, Equatable {
+        case paired(PairedTVRecord)
+        case nearbyUnpaired(LANRemoteDiscoveredService)
+    }
+
+    public let kind: Kind
+
+    /// Whether a currently-discovered Bonjour service shares this row's
+    /// name — routing information only (this file's header), never a trust
+    /// signal. Always `true` for a `.nearbyUnpaired` row (it exists because
+    /// it WAS discovered).
+    public let isNearby: Bool
+
+    public init(kind: Kind, isNearby: Bool) {
+        self.kind = kind
+        self.isNearby = isNearby
+    }
+
+    public var id: String {
+        switch kind {
+        case .paired(let record): "paired:\(record.fingerprintHex)"
+        case .nearbyUnpaired(let service): "nearby:\(service.name)"
+        }
+    }
+
+    public var displayName: String {
+        switch kind {
+        case .paired(let record): record.name
+        case .nearbyUnpaired(let service): service.name
+        }
+    }
+}
+
+/// The pure entry-path resolver — see this file's header for the full
+/// invariant it enforces.
+public enum RemotePairingEntryResolver {
+
+    /// The two things a "connect" action can start from — a scanned/pasted
+    /// QR payload (paths A/B/B′), or a tap on an already-saved list row
+    /// (path C). A tap on an UNPAIRED nearby row is deliberately NOT an
+    /// `Entry` case at all — see this file's header for why.
+    public enum Entry: Sendable {
+        case payload(LANRemotePairingPayload)
+        case savedRow(PairedTVRecord)
+    }
+
+    /// Why a `resolve(...)` call could not produce a connectable target.
+    public enum UnpairableReason: Sendable, Equatable {
+        /// A payload's `host` was `nil` and no discovered service's name
+        /// matched `payload.name` — there is genuinely no address to dial
+        /// (spec §4 row A/B: "if neither → error card").
+        case noRouteToTV
+    }
+
+    public enum Resolution: Sendable {
+        case connect(RemoteConnectTarget)
+        case unpairable(reason: UnpairableReason)
+    }
+
+    /// Resolves one entry into a connect target — spec §4's table, exactly.
+    ///
+    /// ELI5: "I want to connect to this TV — work out everything needed to
+    /// actually do that."
+    public static func resolve(
+        _ entry: Entry, saved: [PairedTVRecord], discovered: [LANRemoteDiscoveredService]
+    ) -> Resolution {
+        switch entry {
+        case .payload(let payload):
+            return resolvePayload(payload, saved: saved, discovered: discovered)
+        case .savedRow(let record):
+            return resolveSavedRow(record, discovered: discovered)
+        }
+    }
+
+    /// The list model: saved records first (pinned, `isNearby` flagged when
+    /// a discovered name matches), sorted by `lastConnectedAt` (falling back
+    /// to `pairedAt`) descending; then unpaired nearby services, sorted by
+    /// name.
+    ///
+    /// ELI5: "Build the list the browsing screen shows."
+    public static func listRows(saved: [PairedTVRecord], discovered: [LANRemoteDiscoveredService]) -> [RemoteTVListRow] {
+        let discoveredNames = Set(discovered.map(\.name))
+        let savedRows = saved
+            .sorted { (savedSortKey($0)) > (savedSortKey($1)) }
+            .map { RemoteTVListRow(kind: .paired($0), isNearby: discoveredNames.contains($0.name)) }
+
+        let savedNames = Set(saved.map(\.name))
+        let nearbyRows = discovered
+            .filter { !savedNames.contains($0.name) }
+            .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+            .map { RemoteTVListRow(kind: .nearbyUnpaired($0), isNearby: true) }
+
+        return savedRows + nearbyRows
+    }
+
+    private static func savedSortKey(_ record: PairedTVRecord) -> Date {
+        record.lastConnectedAt ?? record.pairedAt
+    }
+
+    // MARK: - Path A/B/B′ — a scanned/pasted payload
+
+    private static func resolvePayload(
+        _ payload: LANRemotePairingPayload, saved: [PairedTVRecord], discovered: [LANRemoteDiscoveredService]
+    ) -> Resolution {
+        guard let endpoint = endpointFromPayload(payload, discovered: discovered) else {
+            return .unpairable(reason: .noRouteToTV)
+        }
+
+        let matchingSaved = saved.first { $0.fingerprintHex == payload.fingerprintHex }
+        let fallback = matchingSaved.flatMap(fallbackEndpoint)
+
+        // A ceremony payload (`code != nil`) always means "the user intends
+        // to (re)pair" — the ceremony runs even for an already-known
+        // fingerprint (a re-pair overwrites the saved record on success,
+        // §4's extra resolver rule); `token` stays `nil` so the flow never
+        // silently short-circuits it. A STANDING payload (`code == nil`)
+        // for an ALREADY-saved fingerprint is where we already trust this
+        // TV — connect with the saved token instead of making the user type
+        // a code pointlessly; only a `.pairChallenge` arriving instead of
+        // `.capabilities` (a revoked/stale token) drops it into the code
+        // sheet, which the §1.1 wire contract gives for free.
+        let token = (payload.code == nil) ? matchingSaved?.token : nil
+
+        return .connect(RemoteConnectTarget(
+            tvName: payload.name,
+            endpoint: endpoint,
+            fallbackEndpoint: fallback,
+            expectedFingerprint: payload.fingerprintHex,
+            token: token,
+            knownCode: payload.code
+        ))
+    }
+
+    /// A payload's own `host`/`port` win when present; otherwise a
+    /// discovered service whose Bonjour name matches `payload.name` supplies
+    /// the endpoint (routing only, never trust — this file's header);
+    /// `nil` when neither is available.
+    private static func endpointFromPayload(
+        _ payload: LANRemotePairingPayload, discovered: [LANRemoteDiscoveredService]
+    ) -> NWEndpoint? {
+        if let host = payload.host, let port = payload.port, let nwPort = NWEndpoint.Port(rawValue: port) {
+            return .hostPort(host: .init(host), port: nwPort)
+        }
+        return discovered.first { $0.name == payload.name }?.endpoint
+    }
+
+    // MARK: - Path C — a tap on an already-saved list row
+
+    private static func resolveSavedRow(_ record: PairedTVRecord, discovered: [LANRemoteDiscoveredService]) -> Resolution {
+        if let discoveredMatch = discovered.first(where: { $0.name == record.name }) {
+            return .connect(RemoteConnectTarget(
+                tvName: record.name,
+                endpoint: discoveredMatch.endpoint,
+                fallbackEndpoint: fallbackEndpoint(for: record),
+                expectedFingerprint: record.fingerprintHex,
+                token: record.token,
+                knownCode: nil
+            ))
+        }
+        guard let addressEndpoint = fallbackEndpoint(for: record) else {
+            // Never connected before (no saved address) AND not currently
+            // discovered — genuinely nothing to dial.
+            return .unpairable(reason: .noRouteToTV)
+        }
+        return .connect(RemoteConnectTarget(
+            tvName: record.name,
+            endpoint: addressEndpoint,
+            fallbackEndpoint: nil,
+            expectedFingerprint: record.fingerprintHex,
+            token: record.token,
+            knownCode: nil
+        ))
+    }
+
+    private static func fallbackEndpoint(for record: PairedTVRecord) -> NWEndpoint? {
+        guard let address = record.lastAddress, let port = NWEndpoint.Port(rawValue: address.port) else { return nil }
+        return .hostPort(host: .init(address.host), port: port)
+    }
+}

--- a/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/RemotePairingFlowState.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/RemotePairingFlowState.swift
@@ -1,0 +1,230 @@
+// RemotePairingFlowState.swift
+// IHLive/LANRemote
+//
+// ELI5: The remote's OWN half of the pairing dance — "the TV just asked me
+// for a code," "here's what the person typed," "the TV said yes/no." This
+// file doesn't touch the network at all; it just tracks what step we're on
+// and tells whoever's driving the actual connection what to do next (send
+// this proof, show a code box, tell the app we're paired, tell the app it
+// failed).
+//
+// DETAILED: #1422 (`.claude/apple-phase2-pr7-spec.md` §3.1 — BINDING shape,
+// do not improvise). This is the CLIENT half of the ceremony PR-6's
+// `LANRemotePairingCeremonyState` (`LANRemotePairingCeremony.swift`) runs on
+// the TV side — same "pure struct, no clock read, no RNG, no I/O" posture
+// (`.claude/apple-native-strategy.md` §3.3's "injected-clock tests... no
+// wall-clock sleeps," and the `LiveFollowEngine.isFresh(lastUpdatedAt:now:)`
+// seam this whole module keeps reusing) so `RemotePairingFlowStateTests` can
+// drive every branch with plain literal `Event`s, no fake clock object even
+// needed here (there's no TTL on this side — the TV alone owns that).
+//
+// **Computing the proof is pure** (`LANRemotePairingProof.compute(...)` is a
+// deterministic HMAC — `LANRemotePairingProof.swift`'s header), so it happens
+// INSIDE `handle(_:)` itself rather than being deferred to the driver: the
+// `Effect.sendProof` case below always carries an already-finished proof
+// string, never "please go compute one." This is also the file PR-6's spec
+// §7.1 golden vector gets cross-checked against — the SAME (code,
+// fingerprint, nonce) triple fed through THIS reducer must produce the exact
+// same proof hex the TV's `LANRemotePairingProofTests` froze, because both
+// sides call the identical `LANRemotePairingProof.compute` (one
+// implementation, two callers, `.claude/CLAUDE.md`'s modularity rule).
+//
+// **Never stores a live code anywhere in `Phase`** (spec §3.1: "the typed
+// code is held ONLY long enough to compute — never stored on the state" —
+// binding, because `Phase`/`Event` are both `Equatable` and could otherwise
+// leak into a test failure diff or a debug dump). `awaitingCode`/`proofSent`
+// carry only the (non-secret, TV-issued) nonce and a failure count.
+import Foundation
+
+/// The remote-side pairing-flow reducer — see this file's header for why
+/// it's a pure `struct`, not an `actor`.
+///
+/// ELI5: "Where are we in the pairing dance, and what should the driver do
+/// next?"
+public struct RemotePairingFlowState: Sendable, Equatable {
+
+    /// Everything the flow needs up front, fixed for the lifetime of one
+    /// connection attempt.
+    ///
+    /// ELI5: "Which TV am I proving myself to, do I already have the code
+    /// (because I scanned a ceremony QR), and what should I call myself?"
+    public struct Context: Sendable, Equatable {
+        /// The fingerprint WE pinned when connecting (`RemoteSessionActor
+        /// .connect(to:expectedFingerprint:token:)`'s argument) — the proof
+        /// binds to THIS value, never one the TV sends us (channel binding,
+        /// PR-6 spec §3.2 — a relayed proof must bind to the attacker's own
+        /// fingerprint, not the real TV's).
+        public var expectedFingerprint: String
+
+        /// Non-nil = path A (a scanned ceremony QR already carried the live
+        /// code): the challenge is answered WITHOUT ever prompting a human.
+        /// `nil` = path B: the code has to come from `codeEntered(_:)`.
+        public var knownCode: String?
+
+        /// The cosmetic device name sent alongside the proof (for the TV's
+        /// trusted-remotes list) — `nil` lets the TV show "Unknown remote."
+        public var deviceName: String?
+
+        public init(expectedFingerprint: String, knownCode: String? = nil, deviceName: String? = nil) {
+            self.expectedFingerprint = expectedFingerprint
+            self.knownCode = knownCode
+            self.deviceName = deviceName
+        }
+    }
+
+    /// Where the ceremony currently stands, from the remote's point of view.
+    public enum Phase: Sendable, Equatable {
+        /// Connected, `hello` already sent by the transport layer, nothing
+        /// back yet.
+        case awaitingChallenge
+        /// The TV's `.pairChallenge(nonce:)` arrived and no `knownCode` was
+        /// available (or a previous one was rejected) — show the code-entry
+        /// UI. `failedAttempts` is this CONNECTION's own count (mirrors the
+        /// TV's per-connection cap, PR-6 spec §3.4).
+        case awaitingCode(nonce: String, failedAttempts: Int)
+        /// A proof was just sent; waiting for `.pairSuccess`/`.pairingRejected`.
+        case proofSent(nonce: String, failedAttempts: Int)
+        /// The TV accepted the proof — `token` is the raw value to persist.
+        case paired(token: String)
+        /// Terminal for THIS connection attempt — the driver tears down and
+        /// reports to the UI; a fresh `attach(to:)` starts a whole new flow.
+        case failed(RemotePairingFlowFailure)
+    }
+
+    /// Everything that can happen to this flow — every one is either a wire
+    /// event relayed by the driver (`RemoteControlSession+Link.swift`) or a
+    /// human action (`codeEntered`).
+    public enum Event: Sendable, Equatable {
+        /// The TV's `.pairChallenge(nonce:)` frame arrived.
+        case challengeReceived(nonce: String)
+        /// Path B: the person typed a code into the sheet.
+        case codeEntered(String)
+        /// The TV's `.pairSuccess(token:)` frame arrived.
+        case pairSuccess(token: String)
+        /// The TV's `.error(.pairingRejected, nil)` frame arrived — the
+        /// connection stays up (PR-6 spec D-2); the human gets to retype.
+        case pairingRejected
+        /// The actor's `phase` fell to `.idle`/`.failed` mid-ceremony (a hard
+        /// transport drop, or the TV's own 3-attempt teardown).
+        case transportClosed
+    }
+
+    /// What the DRIVER must now do — see this file's header for why
+    /// computing the proof happens INSIDE `handle(_:)`, not here.
+    public enum Effect: Sendable, Equatable {
+        /// Nothing to do — either a genuinely no-op transition, or an event
+        /// that doesn't apply in the current phase (never a crash/assert;
+        /// e.g. a duplicate `pairingRejected` after the flow already failed).
+        case none
+        /// Send `.pairConfirm(proof:, deviceName:)` on the wire.
+        case sendProof(proof: String, deviceName: String?)
+        /// Show (or refresh) the code-entry sheet — `failedAttempts == 0` is
+        /// the first ask, `> 0` is a retype after a rejection.
+        case promptForCode(failedAttempts: Int)
+        /// Pairing succeeded — the driver persists `token` (Keychain) and
+        /// the UI moves to the control surface.
+        case reportPaired(token: String)
+        /// Pairing ended without success — the UI shows guidance and
+        /// returns to browsing.
+        case reportFailed(RemotePairingFlowFailure)
+    }
+
+    /// Why a pairing attempt ended without a token.
+    public enum RemotePairingFlowFailure: Sendable, Equatable {
+        /// The TV hit its per-connection attempt cap (or the connection
+        /// otherwise dropped) — "ask the operator for a fresh code."
+        case connectionTornDown
+        /// The person dismissed the code sheet themselves.
+        case cancelled
+    }
+
+    public private(set) var phase: Phase
+    public let context: Context
+
+    public init(context: Context) {
+        self.context = context
+        self.phase = .awaitingChallenge
+    }
+
+    /// Advances the flow by one event, returning what the driver must do.
+    /// See this file's header for the "no I/O, no clock, no RNG" contract —
+    /// `LANRemotePairingProof.compute(...)` is deterministic, so calling it
+    /// here keeps `Effect.sendProof` self-contained without breaking purity.
+    ///
+    /// ELI5: "This just happened — what do I do, and where are we now?"
+    public mutating func handle(_ event: Event) -> Effect {
+        switch phase {
+        case .awaitingChallenge:
+            return handleAwaitingChallenge(event)
+        case .awaitingCode(let nonce, let failedAttempts):
+            return handleAwaitingCode(event, nonce: nonce, failedAttempts: failedAttempts)
+        case .proofSent(let nonce, let failedAttempts):
+            return handleProofSent(event, nonce: nonce, failedAttempts: failedAttempts)
+        case .paired, .failed:
+            // Terminal phases — every event is a stale/duplicate frame
+            // arriving after the flow already resolved (spec §3.1: "never a
+            // crash, never an assert").
+            return .none
+        }
+    }
+
+    private mutating func handleAwaitingChallenge(_ event: Event) -> Effect {
+        switch event {
+        case .challengeReceived(let nonce):
+            if let knownCode = context.knownCode {
+                // Path A: a scanned ceremony QR already carried the code —
+                // answer immediately, no human prompt.
+                let proof = LANRemotePairingProof.compute(
+                    code: knownCode, fingerprintHex: context.expectedFingerprint, nonceHex: nonce
+                )
+                phase = .proofSent(nonce: nonce, failedAttempts: 0)
+                return .sendProof(proof: proof, deviceName: context.deviceName)
+            }
+            phase = .awaitingCode(nonce: nonce, failedAttempts: 0)
+            return .promptForCode(failedAttempts: 0)
+        case .transportClosed:
+            phase = .failed(.connectionTornDown)
+            return .reportFailed(.connectionTornDown)
+        case .codeEntered, .pairSuccess, .pairingRejected:
+            return .none
+        }
+    }
+
+    private mutating func handleAwaitingCode(_ event: Event, nonce: String, failedAttempts: Int) -> Effect {
+        switch event {
+        case .codeEntered(let code):
+            let proof = LANRemotePairingProof.compute(
+                code: code, fingerprintHex: context.expectedFingerprint, nonceHex: nonce
+            )
+            phase = .proofSent(nonce: nonce, failedAttempts: failedAttempts)
+            return .sendProof(proof: proof, deviceName: context.deviceName)
+        case .transportClosed:
+            phase = .failed(.connectionTornDown)
+            return .reportFailed(.connectionTornDown)
+        case .challengeReceived, .pairSuccess, .pairingRejected:
+            return .none
+        }
+    }
+
+    private mutating func handleProofSent(_ event: Event, nonce: String, failedAttempts: Int) -> Effect {
+        switch event {
+        case .pairSuccess(let token):
+            phase = .paired(token: token)
+            return .reportPaired(token: token)
+        case .pairingRejected:
+            // Including when `context.knownCode` was set (spec §3.1): a
+            // scanned code that expired between scan and confirm degrades
+            // gracefully into typing the freshly rotated one — the stale
+            // `knownCode` is discarded after its one shot (this branch never
+            // re-reads `context.knownCode`).
+            let nextFailedAttempts = failedAttempts + 1
+            phase = .awaitingCode(nonce: nonce, failedAttempts: nextFailedAttempts)
+            return .promptForCode(failedAttempts: nextFailedAttempts)
+        case .transportClosed:
+            phase = .failed(.connectionTornDown)
+            return .reportFailed(.connectionTornDown)
+        case .challengeReceived, .codeEntered:
+            return .none
+        }
+    }
+}

--- a/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/RemoteSessionActor+Connection.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/RemoteSessionActor+Connection.swift
@@ -129,6 +129,9 @@ extension RemoteSessionActor {
         connection?.cancel()
         connection = nil
         decoder = IHRPFrameDecoder()
+        // #1422 — additive: clear the last-resolved address alongside every
+        // other per-connection piece of state this method already resets.
+        resolvedRemoteAddress = nil
         if let pendingConnectContinuation {
             pendingConnectContinuation.resume(throwing: RemoteSessionError.notConnected)
             self.pendingConnectContinuation = nil
@@ -139,6 +142,12 @@ extension RemoteSessionActor {
     func onConnectionStateChanged(_ state: NWConnection.State) async {
         switch state {
         case .ready:
+            // #1422 — additive: capture the ACTUAL host:port this connection
+            // resolved to (which may differ from a dialled Bonjour service
+            // endpoint) — PR-7's `RemoteControlSession` persists this as the
+            // paired-TV's last-good reconnect address (spec §2/§5.2). Never
+            // changes connect/verify/disconnect semantics.
+            resolvedRemoteAddress = Self.resolvedAddress(from: connection)
             setPhase(.awaitingPairing)
             pendingConnectContinuation?.resume()
             pendingConnectContinuation = nil
@@ -251,5 +260,16 @@ extension RemoteSessionActor {
         }
         let der = SecCertificateCopyData(leaf) as Data
         return LANRemoteFingerprint.sha256Hex(der)
+    }
+
+    /// #1422 (spec §2) — additive helper for `resolvedRemoteAddress`'s
+    /// capture above: `NWConnection.currentPath?.remoteEndpoint` reports the
+    /// endpoint actually in use, which is a resolved `.hostPort` for a live
+    /// connection (as opposed to whatever `NWEndpoint` — a Bonjour
+    /// `.service`, say — was originally dialled). `nil` for anything else
+    /// (no connection, no current path, or a path shape this isn't).
+    static func resolvedAddress(from connection: NWConnection?) -> LANRemoteResolvedAddress? {
+        guard case .hostPort(let host, let port) = connection?.currentPath?.remoteEndpoint else { return nil }
+        return LANRemoteResolvedAddress(host: "\(host)", port: port.rawValue)
     }
 }

--- a/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/RemoteSessionActor.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHLive/LANRemote/RemoteSessionActor.swift
@@ -101,6 +101,22 @@ public actor RemoteSessionActor {
     var expectedFingerprint: String?
     var pairingToken: String?
 
+    /// The actual `host:port` the current (or just-was-current) connection
+    /// resolved to, captured off `NWConnection.currentPath?.remoteEndpoint`
+    /// the instant a connection reaches `.ready` (`+Connection.swift`'s
+    /// `onConnectionStateChanged`) — `nil` before any connection has ever
+    /// gone `.ready`, and cleared every time `disconnect()` runs. #1422
+    /// (`.claude/apple-phase2-pr7-spec.md` §2/§5.2): PR-7's
+    /// `RemoteControlSession` reads this via `currentResolvedRemoteAddress`
+    /// to persist `PairedTVRecord.lastAddress` — additive-only, no existing
+    /// connect/verify/disconnect behaviour changes.
+    var resolvedRemoteAddress: LANRemoteResolvedAddress?
+
+    /// The public accessor for `resolvedRemoteAddress` above.
+    ///
+    /// ELI5: "What address is this connection actually using right now?"
+    public var currentResolvedRemoteAddress: LANRemoteResolvedAddress? { resolvedRemoteAddress }
+
     /// The most recently known pairing token — the value to persist
     /// (Keychain, `synchronizable: false`, PR-7's job) so the NEXT
     /// `connect(to:expectedFingerprint:token:)` call can take the fast

--- a/appApple/Packages/iHymnsKit/Tests/IHFeaturesTests/IHSettingsStoreTests.swift
+++ b/appApple/Packages/iHymnsKit/Tests/IHFeaturesTests/IHSettingsStoreTests.swift
@@ -37,6 +37,7 @@ struct IHSettingsStoreTests {
         #expect(store.dyslexiaReadingModeEnabled == false)
         #expect(store.analyticsConsentEnabled == false)  // strategy §3.1: OFF by default
         #expect(store.hasSeenOnboarding == false)        // #190: unset = genuinely fresh install
+        #expect(store.hasSeenLocalNetworkPrimer == false) // #1422: unset = show the explainer before discovery starts
         #expect(store.apiEnvironmentOverride == nil)     // use the build default
     }
 
@@ -51,6 +52,7 @@ struct IHSettingsStoreTests {
         writer.dyslexiaReadingModeEnabled = true
         writer.analyticsConsentEnabled = true
         writer.hasSeenOnboarding = true
+        writer.hasSeenLocalNetworkPrimer = true
         writer.apiEnvironmentOverride = .beta
 
         // A DIFFERENT store instance on the same underlying suite must see
@@ -62,6 +64,7 @@ struct IHSettingsStoreTests {
         #expect(reader.dyslexiaReadingModeEnabled == true)
         #expect(reader.analyticsConsentEnabled == true)
         #expect(reader.hasSeenOnboarding == true)
+        #expect(reader.hasSeenLocalNetworkPrimer == true)
         #expect(reader.apiEnvironmentOverride == .beta)
     }
 

--- a/appApple/Packages/iHymnsKit/Tests/IHFeaturesTests/RemoteControlUIStateTests.swift
+++ b/appApple/Packages/iHymnsKit/Tests/IHFeaturesTests/RemoteControlUIStateTests.swift
@@ -1,0 +1,107 @@
+// RemoteControlUIStateTests.swift
+// IHFeaturesTests
+//
+// ELI5: Checks that "here's what just happened to the connection" always
+// turns into the RIGHT thing on screen — connecting shows a spinner with
+// the TV's name, a code prompt shows the code sheet, a drop shows
+// "reconnecting," and so on — without needing a real session, actor, or
+// network anywhere.
+//
+// DETAILED: #1422 (`.claude/apple-phase2-pr7-spec.md` §7.3 — BINDING).
+// Exercises the PURE `RemoteControlCoordinator.uiPhase(after:current:tvName:)`
+// mapping directly — no coordinator instance, no `RemoteControlSession`, no
+// actor, no network.
+import IHLive
+import Testing
+@testable import IHFeatures
+
+@Suite("RemoteControlCoordinator.uiPhase(after:current:tvName:)")
+struct RemoteControlUIStateTests {
+
+    private let tvName = "Fellowship Hall TV"
+
+    @Test("connecting(attempt:) always shows .connecting with the TV name")
+    func connectingMapsToConnecting() {
+        let result = RemoteControlCoordinator.uiPhase(after: .connecting(attempt: 2), current: .browsing, tvName: tvName)
+        #expect(result == .connecting(tvName: tvName, attempt: 2))
+    }
+
+    @Test("awaitingCodeEntry(failedAttempts:) always shows .codeEntry with the TV name")
+    func awaitingCodeEntryMapsToCodeEntry() {
+        let result = RemoteControlCoordinator.uiPhase(
+            after: .awaitingCodeEntry(failedAttempts: 1), current: .connecting(tvName: tvName, attempt: 0), tvName: tvName
+        )
+        #expect(result == .codeEntry(tvName: tvName, failedAttempts: 1))
+    }
+
+    @Test("paired(token:resolved:) does not change the current UI phase — .controlling always follows on the wire")
+    func pairedLeavesCurrentPhaseUnchanged() {
+        let current = RemoteControlCoordinator.UIPhase.codeEntry(tvName: tvName, failedAttempts: 2)
+        let result = RemoteControlCoordinator.uiPhase(
+            after: .paired(token: "t", resolved: nil), current: current, tvName: tvName
+        )
+        #expect(result == current)
+    }
+
+    @Test("controlling(state) always shows .controlling with the TV name and the exact state")
+    func controllingMapsToControlling() {
+        let state = IHRPState(songId: nil, componentIndex: nil, lineIndex: nil, displayState: .lyrics, revision: 3)
+        let result = RemoteControlCoordinator.uiPhase(
+            after: .controlling(state), current: .connecting(tvName: tvName, attempt: 0), tvName: tvName
+        )
+        #expect(result == .controlling(tvName: tvName, state: state))
+    }
+
+    @Test("detached WHILE .controlling shows .reconnecting(attempt: 0) immediately, not a stale .controlling")
+    func detachedWhileControllingShowsReconnecting() {
+        let state = IHRPState(songId: nil, componentIndex: nil, lineIndex: nil, displayState: .lyrics, revision: 0)
+        let current = RemoteControlCoordinator.UIPhase.controlling(tvName: tvName, state: state)
+        let result = RemoteControlCoordinator.uiPhase(after: .detached, current: current, tvName: tvName)
+        #expect(result == .reconnecting(tvName: tvName, attempt: 0))
+    }
+
+    @Test("reconnecting(attempt:delay:) always shows .reconnecting with the TV name and attempt number")
+    func reconnectingMapsToReconnecting() {
+        let result = RemoteControlCoordinator.uiPhase(
+            after: .reconnecting(attempt: 3, delay: 8), current: .reconnecting(tvName: tvName, attempt: 2), tvName: tvName
+        )
+        #expect(result == .reconnecting(tvName: tvName, attempt: 3))
+    }
+
+    @Test("suspended always shows .suspended with the TV name, even from .controlling")
+    func suspendedMapsToSuspended() {
+        let state = IHRPState(songId: nil, componentIndex: nil, lineIndex: nil, displayState: .lyrics, revision: 0)
+        let current = RemoteControlCoordinator.UIPhase.controlling(tvName: tvName, state: state)
+        let result = RemoteControlCoordinator.uiPhase(after: .suspended, current: current, tvName: tvName)
+        #expect(result == .suspended(tvName: tvName))
+    }
+
+    @Test("resuming from .suspended (a fresh .connecting) shows .connecting again")
+    func resumeFromSuspendedShowsConnecting() {
+        let current = RemoteControlCoordinator.UIPhase.suspended(tvName: tvName)
+        let result = RemoteControlCoordinator.uiPhase(after: .connecting(attempt: 0), current: current, tvName: tvName)
+        #expect(result == .connecting(tvName: tvName, attempt: 0))
+    }
+
+    @Test("pairingEnded(.cancelled) returns to .browsing")
+    func pairingEndedCancelledReturnsToBrowsing() {
+        let current = RemoteControlCoordinator.UIPhase.codeEntry(tvName: tvName, failedAttempts: 1)
+        let result = RemoteControlCoordinator.uiPhase(after: .pairingEnded(.cancelled), current: current, tvName: tvName)
+        #expect(result == .browsing)
+    }
+
+    @Test("pairingEnded(.connectionTornDown) also returns to .browsing (the operator-guidance notice is a separate side effect)")
+    func pairingEndedTornDownReturnsToBrowsing() {
+        let current = RemoteControlCoordinator.UIPhase.codeEntry(tvName: tvName, failedAttempts: 3)
+        let result = RemoteControlCoordinator.uiPhase(after: .pairingEnded(.connectionTornDown), current: current, tvName: tvName)
+        #expect(result == .browsing)
+    }
+
+    @Test("ended (deliberate disconnect) returns to .browsing from .controlling")
+    func endedReturnsToBrowsing() {
+        let state = IHRPState(songId: nil, componentIndex: nil, lineIndex: nil, displayState: .lyrics, revision: 0)
+        let current = RemoteControlCoordinator.UIPhase.controlling(tvName: tvName, state: state)
+        let result = RemoteControlCoordinator.uiPhase(after: .ended, current: current, tvName: tvName)
+        #expect(result == .browsing)
+    }
+}

--- a/appApple/Packages/iHymnsKit/Tests/IHFeaturesTests/SongsMatchingQueryTests.swift
+++ b/appApple/Packages/iHymnsKit/Tests/IHFeaturesTests/SongsMatchingQueryTests.swift
@@ -1,0 +1,76 @@
+// SongsMatchingQueryTests.swift
+// IHFeaturesTests
+//
+// ELI5: Checks that the shared "find matching songs" helper behaves exactly
+// like the Search tab's own filtering always has — a real song number wins
+// outright, a number-shaped query that doesn't match any real songbook
+// falls back to a plain text search, an ordinary word search still works,
+// and typing nothing returns everything.
+//
+// DETAILED: #1422 (`.claude/apple-phase2-pr7-spec.md` §7.3/D-8 — BINDING).
+// Covers the EXTRACTED `AppRootViewModel.songsMatching(_:in:)` directly
+// (no view model, no network) — the regression guard that
+// `AppRootViewModel.filteredSongs` itself still passes its EXISTING
+// expectations lives in `CatalogueAndSongDetailLoadingTests
+// .filteredSongsNarrowsByTextSearch`/`CatalogueNumberQueryTests`, untouched
+// by this extraction (spec §7.3's own instruction).
+import IHModels
+import Testing
+@testable import IHFeatures
+
+@Suite("AppRootViewModel.songsMatching(_:in:)")
+struct SongsMatchingQueryTests {
+
+    private let fixtures: [SongSummary] = [
+        SongSummary(songId: SongID(songbookAbbreviation: "MP", number: 1008), title: "Amazing Grace", songbookAbbreviation: "MP", number: 1008, songbookName: "Mission Praise"),
+        SongSummary(songId: SongID(songbookAbbreviation: "MP", number: 23), title: "All Creatures of Our God and King", songbookAbbreviation: "MP", number: 23, songbookName: "Mission Praise"),
+        SongSummary(songId: SongID(songbookAbbreviation: "SDAH", number: 1008), title: "How Great Thou Art", songbookAbbreviation: "SDAH", number: 1008, songbookName: "Seventh-day Adventist Hymnal")
+    ]
+
+    @Test("A number-mode hit ('MP 1008') returns exactly that song, ignoring other songbooks sharing the number")
+    func numberModeHit() {
+        let matches = AppRootViewModel.songsMatching("MP 1008", in: fixtures)
+        #expect(matches.count == 1)
+        #expect(matches.first?.title == "Amazing Grace")
+    }
+
+    @Test("A bare number ('1008') matches the number in ANY songbook")
+    func bareNumberMatchesAnySongbook() {
+        let matches = AppRootViewModel.songsMatching("1008", in: fixtures)
+        #expect(matches.count == 2)
+        #expect(Set(matches.map(\.title)) == ["Amazing Grace", "How Great Thou Art"])
+    }
+
+    @Test("A number-mode MISS ('Song 23') falls through to substring title matching")
+    func numberModeMissFallsThroughToSubstring() {
+        // "Song 23" parses as songbook-prefix "SONG" + number 23 — no real
+        // songbook is abbreviated "SONG", so the number interpretation finds
+        // nothing and the plain substring search takes over instead.
+        let matches = AppRootViewModel.songsMatching("Song 23", in: fixtures)
+        #expect(matches.isEmpty) // no title contains the substring "Song 23" either — a genuine empty result, not a crash
+    }
+
+    @Test("A plain substring query matches title case-insensitively")
+    func plainSubstringMatch() {
+        let matches = AppRootViewModel.songsMatching("amazing", in: fixtures)
+        #expect(matches.count == 1)
+        #expect(matches.first?.title == "Amazing Grace")
+    }
+
+    @Test("An empty query returns the input unchanged")
+    func emptyQueryReturnsInputUnchanged() {
+        let matches = AppRootViewModel.songsMatching("", in: fixtures)
+        #expect(matches.count == fixtures.count)
+    }
+
+    @Test("A substring query also matches on songbook name/abbreviation")
+    func substringMatchesSongbookNameOrAbbreviation() {
+        let byAbbreviation = AppRootViewModel.songsMatching("sdah", in: fixtures)
+        #expect(byAbbreviation.count == 1)
+        #expect(byAbbreviation.first?.title == "How Great Thou Art")
+
+        let byName = AppRootViewModel.songsMatching("adventist", in: fixtures)
+        #expect(byName.count == 1)
+        #expect(byName.first?.title == "How Great Thou Art")
+    }
+}

--- a/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/KeychainPairedTVStoreTests.swift
+++ b/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/KeychainPairedTVStoreTests.swift
@@ -12,11 +12,23 @@
 // Gated on `lanRemoteKeychainIdentityAvailable()` — the exact PR-6 gate/
 // skip-message style (`LANRemoteTestSupport.swift`) — because a headless,
 // unsigned `swift test` binary can't always bridge a Keychain item on every
-// CI runner. Every test wraps its Keychain work in `KeychainTestSerialization
-// .shared.run { }` (PR-6's contention-avoidance precedent) and cleans up in
-// `defer`, capturing only immutable `String` fingerprints (never the whole
-// mutable record) into cleanup `Task`s — the identical "don't send a
-// non-Sendable/mutable value across a `Task` boundary" discipline
+// CI runner.
+//
+// **Every test wraps its ENTIRE body — every read AND every write — in
+// `KeychainTestSerialization.shared.run { }`**, matching
+// `KeychainPairingAuthorityTests.swift`'s exact precedent (adversarial-review
+// finding: an EARLIER version of this file wrapped only the initial `save()`
+// call, leaving `record(forFingerprint:)`/`listPairedTVs()`/`delete(
+// fingerprint:)` to hit the real Keychain UNSERIALIZED — which reproduced
+// the identical rare contention `KeychainTestSerialization`'s own header
+// warns about, this time as intermittent `read == nil` failures under a
+// full-suite run alongside `KeychainPairingAuthorityTests`/
+// `LANRemoteIdentityStoreTests`. The serialization mutex only helps when
+// EVERY real-Keychain call from EVERY suite goes through it — a partially
+// -wrapped test body defeats the whole point). Cleans up in `defer`,
+// capturing only immutable `String` fingerprints (never the whole mutable
+// record) into cleanup `Task`s — the identical "don't send a non-Sendable
+// /mutable value across a `Task` boundary" discipline
 // `KeychainPairingAuthorityTests.swift` already follows.
 import Foundation
 import Testing
@@ -53,49 +65,49 @@ struct KeychainPairedTVStoreTests {
 
     @Test("save() then record(forFingerprint:) returns the record INCLUDING the raw token")
     func saveThenRead() async throws {
-        let store = makeStore()
-        let fingerprint = "aa-\(UUID().uuidString)"
-        let original = record(fingerprint: fingerprint)
         try await KeychainTestSerialization.shared.run {
-            await store.save(original)
-        }
-        defer { Task { await store.delete(fingerprint: fingerprint) } }
+            let store = makeStore()
+            let fingerprint = "aa-\(UUID().uuidString)"
+            let original = record(fingerprint: fingerprint)
+            defer { Task { await store.delete(fingerprint: fingerprint) } }
 
-        let read = await store.record(forFingerprint: fingerprint)
-        #expect(read == original)
-        #expect(read?.token == "raw-token-value")
+            await store.save(original)
+            let read = await store.record(forFingerprint: fingerprint)
+            #expect(read == original)
+            #expect(read?.token == "raw-token-value")
+        }
     }
 
     @Test("save() upserts by fingerprint — a re-save replaces rather than duplicates")
     func upsertReplaces() async throws {
-        let store = makeStore()
-        let fingerprint = "aa-\(UUID().uuidString)"
         try await KeychainTestSerialization.shared.run {
+            let store = makeStore()
+            let fingerprint = "aa-\(UUID().uuidString)"
+            defer { Task { await store.delete(fingerprint: fingerprint) } }
+
             await store.save(record(fingerprint: fingerprint))
+            var renamed = record(fingerprint: fingerprint)
+            renamed.name = "Renamed TV"
+            await store.save(renamed)
+
+            let all = await store.listPairedTVs()
+            let matching = all.filter { $0.fingerprintHex == fingerprint }
+            #expect(matching.count == 1)
+            #expect(matching.first?.name == "Renamed TV")
         }
-        defer { Task { await store.delete(fingerprint: fingerprint) } }
-
-        var renamed = record(fingerprint: fingerprint)
-        renamed.name = "Renamed TV"
-        await store.save(renamed)
-
-        let all = await store.listPairedTVs()
-        let matching = all.filter { $0.fingerprintHex == fingerprint }
-        #expect(matching.count == 1)
-        #expect(matching.first?.name == "Renamed TV")
     }
 
     @Test("delete() removes the record; an unknown fingerprint returns nil")
     func deleteRemoves() async throws {
-        let store = makeStore()
-        let fingerprint = "aa-\(UUID().uuidString)"
         try await KeychainTestSerialization.shared.run {
-            await store.save(record(fingerprint: fingerprint))
-        }
+            let store = makeStore()
+            let fingerprint = "aa-\(UUID().uuidString)"
 
-        await store.delete(fingerprint: fingerprint)
-        #expect(await store.record(forFingerprint: fingerprint) == nil)
-        #expect(await store.record(forFingerprint: "never-existed") == nil)
+            await store.save(record(fingerprint: fingerprint))
+            await store.delete(fingerprint: fingerprint)
+            #expect(await store.record(forFingerprint: fingerprint) == nil)
+            #expect(await store.record(forFingerprint: "never-existed") == nil)
+        }
     }
 
     @Test("baseAttributes(account:) is synchronizable == false, accessible == AfterFirstUnlock, and the pairedTVs service")
@@ -112,6 +124,9 @@ extension KeychainPairedTVStore {
     /// boundary — only this `Bool` result does, which strict concurrency is
     /// happy with. Mirrors `KeychainLANRemotePairingAuthority
     /// .baseAttributesInvariantsHold(account:)`'s identical test-only shape.
+    /// Reads no Keychain state at all (`baseAttributes` is a pure dictionary
+    /// builder), so — unlike every other test above — this one needs no
+    /// `KeychainTestSerialization` wrapping.
     fileprivate func baseAttributesInvariantsHold(account: String?) -> Bool {
         let attributes = baseAttributes(account: account)
         guard attributes[kSecAttrSynchronizable as String] as? Bool == false else { return false }

--- a/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/KeychainPairedTVStoreTests.swift
+++ b/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/KeychainPairedTVStoreTests.swift
@@ -1,0 +1,125 @@
+// KeychainPairedTVStoreTests.swift
+// IHLiveTests
+//
+// ELI5: Checks the REAL "TVs I trust" address book actually talks to the
+// Keychain correctly — a saved record (including its raw secret token)
+// comes back exactly as saved, re-saving replaces rather than duplicates,
+// deleting really removes it, and — the one property this whole file exists
+// to nail down — the underlying Keychain item is EXPLICITLY marked
+// "never sync to iCloud."
+//
+// DETAILED: #1422 (`.claude/apple-phase2-pr7-spec.md` §7.4 — BINDING).
+// Gated on `lanRemoteKeychainIdentityAvailable()` — the exact PR-6 gate/
+// skip-message style (`LANRemoteTestSupport.swift`) — because a headless,
+// unsigned `swift test` binary can't always bridge a Keychain item on every
+// CI runner. Every test wraps its Keychain work in `KeychainTestSerialization
+// .shared.run { }` (PR-6's contention-avoidance precedent) and cleans up in
+// `defer`, capturing only immutable `String` fingerprints (never the whole
+// mutable record) into cleanup `Task`s — the identical "don't send a
+// non-Sendable/mutable value across a `Task` boundary" discipline
+// `KeychainPairingAuthorityTests.swift` already follows.
+import Foundation
+import Testing
+@testable import IHLive
+
+@Suite(
+    "KeychainPairedTVStore",
+    // `.serialized` — the same contention-reduction courtesy
+    // `KeychainPairingAuthorityTests.swift`'s identical suite trait
+    // documents; this suite's unique-per-test `service`/`fingerprint`
+    // strings already make it correct without serialization, this just
+    // lowers the odds of tripping the rare cross-suite Keychain-daemon
+    // contention that motivated `KeychainTestSerialization` in the first
+    // place.
+    .serialized,
+    .enabled(
+        if: lanRemoteKeychainIdentityAvailable(),
+        "Needs a real Keychain an unsigned headless `swift test` binary can't reliably exercise — see LANRemoteIdentityTests.swift's identical gate."
+    )
+)
+struct KeychainPairedTVStoreTests {
+
+    private func makeStore() -> KeychainPairedTVStore {
+        KeychainPairedTVStore(service: "app.ihymns.lanremote.pairedTVs.test.\(UUID().uuidString)")
+    }
+
+    private func record(fingerprint: String) -> PairedTVRecord {
+        PairedTVRecord(
+            fingerprintHex: fingerprint, name: "Fellowship Hall TV", token: "raw-token-value",
+            lastAddress: LANRemoteResolvedAddress(host: "10.0.0.9", port: 7269),
+            pairedAt: Date(timeIntervalSince1970: 1_700_000_000), lastConnectedAt: nil
+        )
+    }
+
+    @Test("save() then record(forFingerprint:) returns the record INCLUDING the raw token")
+    func saveThenRead() async throws {
+        let store = makeStore()
+        let fingerprint = "aa-\(UUID().uuidString)"
+        let original = record(fingerprint: fingerprint)
+        try await KeychainTestSerialization.shared.run {
+            await store.save(original)
+        }
+        defer { Task { await store.delete(fingerprint: fingerprint) } }
+
+        let read = await store.record(forFingerprint: fingerprint)
+        #expect(read == original)
+        #expect(read?.token == "raw-token-value")
+    }
+
+    @Test("save() upserts by fingerprint — a re-save replaces rather than duplicates")
+    func upsertReplaces() async throws {
+        let store = makeStore()
+        let fingerprint = "aa-\(UUID().uuidString)"
+        try await KeychainTestSerialization.shared.run {
+            await store.save(record(fingerprint: fingerprint))
+        }
+        defer { Task { await store.delete(fingerprint: fingerprint) } }
+
+        var renamed = record(fingerprint: fingerprint)
+        renamed.name = "Renamed TV"
+        await store.save(renamed)
+
+        let all = await store.listPairedTVs()
+        let matching = all.filter { $0.fingerprintHex == fingerprint }
+        #expect(matching.count == 1)
+        #expect(matching.first?.name == "Renamed TV")
+    }
+
+    @Test("delete() removes the record; an unknown fingerprint returns nil")
+    func deleteRemoves() async throws {
+        let store = makeStore()
+        let fingerprint = "aa-\(UUID().uuidString)"
+        try await KeychainTestSerialization.shared.run {
+            await store.save(record(fingerprint: fingerprint))
+        }
+
+        await store.delete(fingerprint: fingerprint)
+        #expect(await store.record(forFingerprint: fingerprint) == nil)
+        #expect(await store.record(forFingerprint: "never-existed") == nil)
+    }
+
+    @Test("baseAttributes(account:) is synchronizable == false, accessible == AfterFirstUnlock, and the pairedTVs service")
+    func baseAttributesInvariants() async {
+        let store = makeStore()
+        #expect(await store.baseAttributesInvariantsHold(account: "aa"))
+    }
+}
+
+extension KeychainPairedTVStore {
+    /// Test-only: evaluates `baseAttributes(account:)`'s invariants (plan
+    /// §6.4's required unit test, spec §7.4) WITHOUT ever letting the
+    /// non-`Sendable` `[String: Any]` dictionary itself cross the actor
+    /// boundary — only this `Bool` result does, which strict concurrency is
+    /// happy with. Mirrors `KeychainLANRemotePairingAuthority
+    /// .baseAttributesInvariantsHold(account:)`'s identical test-only shape.
+    fileprivate func baseAttributesInvariantsHold(account: String?) -> Bool {
+        let attributes = baseAttributes(account: account)
+        guard attributes[kSecAttrSynchronizable as String] as? Bool == false else { return false }
+        guard (attributes[kSecAttrAccessible as String] as? String) == (kSecAttrAccessibleAfterFirstUnlock as String) else {
+            return false
+        }
+        guard attributes[kSecClass as String] as? String == (kSecClassGenericPassword as String) else { return false }
+        guard attributes[kSecAttrAccount as String] as? String == account else { return false }
+        return true
+    }
+}

--- a/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/PairedTVStoreTests.swift
+++ b/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/PairedTVStoreTests.swift
@@ -1,0 +1,79 @@
+// PairedTVStoreTests.swift
+// IHLiveTests
+//
+// ELI5: Checks the pretend "TVs I trust" address book — saving the same TV
+// twice replaces its entry instead of creating a duplicate, the list comes
+// back newest-first, deleting actually removes it, and a record survives a
+// JSON round-trip (dates included) without losing anything.
+//
+// DETAILED: #1422 (`.claude/apple-phase2-pr7-spec.md` §7.2 — BINDING).
+// Always-on, exercises `InMemoryPairedTVStore` (never the real Keychain
+// store — that's `KeychainPairedTVStoreTests`, gated on Keychain
+// availability).
+import Foundation
+import Testing
+@testable import IHLive
+
+@Suite("PairedTVStore")
+struct PairedTVStoreTests {
+
+    private func record(
+        fingerprint: String, name: String = "TV", pairedAt: Date = Date(timeIntervalSince1970: 1_700_000_000),
+        lastConnectedAt: Date? = nil
+    ) -> PairedTVRecord {
+        PairedTVRecord(fingerprintHex: fingerprint, name: name, token: "token-\(fingerprint)", lastAddress: nil, pairedAt: pairedAt, lastConnectedAt: lastConnectedAt)
+    }
+
+    @Test("save() upserts by fingerprint — a re-save replaces, the count stays 1")
+    func saveUpsertsByFingerprint() async {
+        let store = InMemoryPairedTVStore()
+        await store.save(record(fingerprint: "aa", name: "First Name"))
+        await store.save(record(fingerprint: "aa", name: "Renamed"))
+
+        let all = await store.listPairedTVs()
+        #expect(all.count == 1)
+        #expect(all.first?.name == "Renamed")
+    }
+
+    @Test("listPairedTVs() orders newest-first by lastConnectedAt, falling back to pairedAt")
+    func listOrdering() async {
+        let store = InMemoryPairedTVStore()
+        await store.save(record(fingerprint: "old", pairedAt: Date(timeIntervalSince1970: 1_000), lastConnectedAt: nil))
+        await store.save(record(fingerprint: "recent", pairedAt: Date(timeIntervalSince1970: 1_000), lastConnectedAt: Date(timeIntervalSince1970: 5_000)))
+        await store.save(record(fingerprint: "middle", pairedAt: Date(timeIntervalSince1970: 3_000), lastConnectedAt: nil))
+
+        let all = await store.listPairedTVs()
+        #expect(all.map(\.fingerprintHex) == ["recent", "middle", "old"])
+    }
+
+    @Test("delete() removes the record; record(forFingerprint:) returns nil for an unknown fingerprint")
+    func deleteRemovesRecord() async {
+        let store = InMemoryPairedTVStore()
+        await store.save(record(fingerprint: "aa"))
+        #expect(await store.record(forFingerprint: "aa") != nil)
+
+        await store.delete(fingerprint: "aa")
+        #expect(await store.record(forFingerprint: "aa") == nil)
+        #expect(await store.record(forFingerprint: "never-existed") == nil)
+    }
+
+    @Test("PairedTVRecord round-trips through JSON with .iso8601 dates, including a resolved address")
+    func jsonRoundTrip() throws {
+        let original = PairedTVRecord(
+            fingerprintHex: "aa", name: "Fellowship Hall TV", token: "raw-token-value",
+            lastAddress: LANRemoteResolvedAddress(host: "10.0.0.9", port: 7269),
+            pairedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            lastConnectedAt: Date(timeIntervalSince1970: 1_700_000_500)
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(original)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(PairedTVRecord.self, from: data)
+
+        #expect(decoded == original)
+    }
+}

--- a/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/RemoteControlSessionLoopbackTests.swift
+++ b/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/RemoteControlSessionLoopbackTests.swift
@@ -1,0 +1,373 @@
+// RemoteControlSessionLoopbackTests.swift
+// IHLiveTests
+//
+// ELI5: The REAL end-to-end proof that the remote's whole supervisor works —
+// a real `RemoteControlSession` talking to a real `TVListenerActor` over
+// `127.0.0.1` TLS: scanning a code (or typing one), getting a wrong code
+// rejected, reconnecting instantly with a saved token, and — the headline
+// test — actually surviving the TV going away and coming back, entirely on
+// its own.
+//
+// DETAILED: #1422 (`.claude/apple-phase2-pr7-spec.md` §7.5 — BINDING).
+// Verbatim posture from `TVListenerPairingLoopbackTests.swift:62-68`:
+// opt-in behind `IHYMNS_LAN_LOOPBACK_TESTS=1` (macOS Local Network Privacy
+// blocks an unsigned headless `swift test` binary from completing a REAL
+// `127.0.0.1` handshake), `advertiseViaBonjour: false`, connect by explicit
+// `.hostPort(...)`, `ManualLANRemoteClock` injected into the LISTENER's
+// `Configuration`. Every session here uses MILLISECOND health/backoff
+// configuration (`health.pingInterval = .milliseconds(40)`, `backoff =
+// .init(baseDelay: 0.05, maxDelay: 0.2)`, spec §7.5) so the whole ladder —
+// including the headline restart test — runs in real wall-clock
+// milliseconds; the ALWAYS-ON suites (`RemoteLinkPolicyTests`) own the
+// production numeric defaults.
+//
+// **Every test registers its session/listener teardown via `defer` the
+// INSTANT each is created — never at the bottom of the function.** A session
+// left running (its ping ticker firing every 40 ms, its reconnect ladder
+// retrying) after a test exits EARLY (a failed `guard`/`Issue.record`) is not
+// just an untidy leak: it keeps consuming Swift's cooperative-thread-pool
+// slots for the rest of the run, and this suite's own `.serialized` trait
+// (below) means every later test WAITS its turn behind whatever the leaked
+// task's executor queue is doing — empirically, one early-return test
+// without a `defer` was enough to make the NEXT queued test hang indefinitely
+// rather than merely flake. `Task { await session.stop() }` (not a bare
+// `await` — `defer` bodies are synchronous) mirrors the exact cleanup idiom
+// `KeychainPairedTVStoreTests.swift`/`KeychainPairingAuthorityTests.swift`
+// already use for the identical reason.
+import Foundation
+import IHModels
+import Network
+import Testing
+@testable import IHLive
+
+@Suite(
+    "RemoteControlSession — TLS loopback integration",
+    .enabled(
+        if: ProcessInfo.processInfo.environment["IHYMNS_LAN_LOOPBACK_TESTS"] == "1",
+        "Live 127.0.0.1 TLS loopback needs macOS Local Network permission an unsigned headless `swift test` binary can't obtain — set IHYMNS_LAN_LOOPBACK_TESTS=1 on a Mac where iHymns has that grant. See TVListenerPairingLoopbackTests.swift's header comment."
+    )
+)
+struct RemoteControlSessionLoopbackTests {
+
+    /// A session configured for millisecond-fast ping/backoff — spec §7.5.
+    private func makeSession() -> RemoteControlSession {
+        var configuration = RemoteControlSession.Configuration(remoteKind: .phone, deviceName: "Test Phone")
+        configuration.health = .init(pingInterval: .milliseconds(40), maxMissedPongs: 3)
+        configuration.backoff = .init(baseDelay: 0.05, multiplier: 2, maxDelay: 0.2, jitterFraction: 0.2)
+        return RemoteControlSession(configuration: configuration)
+    }
+
+    private func makeListener(
+        port: NWEndpoint.Port = .any,
+        pairingAuthority: any LANRemotePairingAuthority = InMemoryLANRemotePairingAuthority(),
+        clock: any LANRemoteClock = ManualLANRemoteClock()
+    ) async throws -> (TVListenerActor, LANRemoteIdentity) {
+        let identity = try await KeychainTestSerialization.shared.run {
+            try LANRemoteIdentityFactory.generateSelfSigned()
+        }
+        let config = TVListenerActor.Configuration(
+            port: port, advertiseViaBonjour: false, pairingAuthority: pairingAuthority, clock: clock
+        )
+        let listener = TVListenerActor(identity: identity, configuration: config)
+        try await listener.start()
+        try await listener.waitUntilReady()
+        return (listener, identity)
+    }
+
+    private func target(
+        tvName: String = "Fellowship Hall TV", port: NWEndpoint.Port, fingerprint: String,
+        token: String? = nil, knownCode: String? = nil
+    ) -> RemoteControlSession.Target {
+        .init(
+            tvName: tvName, endpoint: .hostPort(host: "127.0.0.1", port: port),
+            expectedFingerprint: fingerprint, token: token, knownCode: knownCode
+        )
+    }
+
+    // MARK: - Ceremony, path A (known code auto-answered)
+
+    @Test("Path A: attach with a knownCode pairs automatically — .paired then .controlling, resolved address populated")
+    func ceremonyPathAAutoAnswers() async throws {
+        let (listener, identity) = try await makeListener()
+        defer { identity.removeFromKeychain(); Task { await listener.stop() } }
+        guard let port = await listener.boundPort else { Issue.record("no bound port"); return }
+
+        let code = await listener.beginPairing()
+        let session = makeSession()
+        defer { Task { await session.stop() } }
+        var events = session.events.makeAsyncIterator()
+
+        await session.attach(to: target(port: port, fingerprint: identity.fingerprint, knownCode: code))
+
+        let connecting = await events.next()
+        #expect(connecting == .connecting(attempt: 0))
+
+        guard case .paired(let token, let resolved) = await events.next() else {
+            Issue.record("expected .paired")
+            return
+        }
+        #expect(!token.isEmpty)
+        #expect(resolved?.host == "127.0.0.1")
+        #expect(resolved?.port == port.rawValue)
+
+        guard case .controlling = await events.next() else {
+            Issue.record("expected .controlling")
+            return
+        }
+    }
+
+    // MARK: - Ceremony, path B (typed code, wrong-then-right)
+
+    @Test("Path B: no knownCode prompts awaitingCodeEntry; a wrong code re-prompts (connection survives); the right code pairs")
+    func ceremonyPathBTypedCode() async throws {
+        let (listener, identity) = try await makeListener()
+        defer { identity.removeFromKeychain(); Task { await listener.stop() } }
+        guard let port = await listener.boundPort else { Issue.record("no bound port"); return }
+
+        let code = await listener.beginPairing()
+        let session = makeSession()
+        defer { Task { await session.stop() } }
+        var events = session.events.makeAsyncIterator()
+
+        await session.attach(to: target(port: port, fingerprint: identity.fingerprint))
+        _ = await events.next() // .connecting(0)
+
+        guard case .awaitingCodeEntry(let firstFailedAttempts) = await events.next() else {
+            Issue.record("expected .awaitingCodeEntry")
+            return
+        }
+        #expect(firstFailedAttempts == 0)
+
+        await session.submitPairingCode("000000") // deliberately wrong (unless it happens to match)
+        guard case .awaitingCodeEntry(let secondFailedAttempts) = await events.next() else {
+            Issue.record("expected a re-prompt after a wrong code")
+            return
+        }
+        #expect(secondFailedAttempts == 1)
+
+        await session.submitPairingCode(code)
+        guard case .paired = await events.next() else {
+            Issue.record("expected .paired after the correct code")
+            return
+        }
+        guard case .controlling = await events.next() else {
+            Issue.record("expected .controlling")
+            return
+        }
+    }
+
+    @Test("4 wrong codes on one connection exceed the TV's 3-attempt cap and tear it down — pairingEnded(.connectionTornDown)")
+    func fourWrongCodesTearDownConnection() async throws {
+        let (listener, identity) = try await makeListener()
+        defer { identity.removeFromKeychain(); Task { await listener.stop() } }
+        guard let port = await listener.boundPort else { Issue.record("no bound port"); return }
+
+        _ = await listener.beginPairing()
+        let session = makeSession()
+        defer { Task { await session.stop() } }
+        var events = session.events.makeAsyncIterator()
+
+        await session.attach(to: target(port: port, fingerprint: identity.fingerprint))
+        _ = await events.next() // .connecting(0)
+        _ = await events.next() // .awaitingCodeEntry(0)
+
+        // Attempts 1-3 are each rejected but stay within the TV's
+        // `maxAttemptsPerConnection` cap (default 3) — the connection
+        // survives and re-prompts every time (`TVListenerPairingLoopbackTests
+        // .wrongProofRejectedThenCapTearsDown`'s identical precedent).
+        await session.submitPairingCode("111111")
+        _ = await events.next() // .awaitingCodeEntry(1)
+        await session.submitPairingCode("222222")
+        _ = await events.next() // .awaitingCodeEntry(2)
+        await session.submitPairingCode("333333")
+        _ = await events.next() // .awaitingCodeEntry(3)
+
+        // The 4th attempt EXCEEDS the cap outright — the TV still replies
+        // `.error(.pairingRejected)` (one more `.awaitingCodeEntry`) BEFORE
+        // it tears the connection down (`TVListenerActor+Pairing.swift`'s
+        // `handlePairConfirm`: the cap-exceeded branch sends the error THEN
+        // calls `teardownConnection`), so the drop itself is the event
+        // AFTER that.
+        await session.submitPairingCode("444444")
+        _ = await events.next() // .awaitingCodeEntry(4) — the TV's own reply, right before it tears down
+
+        guard case .pairingEnded(let reason) = await events.next() else {
+            Issue.record("expected .pairingEnded after the TV's own attempt cap teardown")
+            return
+        }
+        #expect(reason == .connectionTornDown)
+    }
+
+    // MARK: - Reconnect fast path (an already-paired target)
+
+    @Test("A target with a pre-registered token reconnects straight to .controlling — no awaitingCodeEntry")
+    func fastPathReconnectSkipsCeremony() async throws {
+        let authority = InMemoryLANRemotePairingAuthority()
+        let token = "pretrusted-token-\(UUID().uuidString)"
+        await authority.registerPairedToken(token)
+        let (listener, identity) = try await makeListener(pairingAuthority: authority)
+        defer { identity.removeFromKeychain(); Task { await listener.stop() } }
+        guard let port = await listener.boundPort else { Issue.record("no bound port"); return }
+
+        let session = makeSession()
+        defer { Task { await session.stop() } }
+        var events = session.events.makeAsyncIterator()
+        await session.attach(to: target(port: port, fingerprint: identity.fingerprint, token: token))
+
+        #expect(await events.next() == .connecting(attempt: 0))
+        guard case .controlling = await events.next() else {
+            Issue.record("expected .controlling with no ceremony events at all")
+            return
+        }
+    }
+
+    // MARK: - Suspend / resume
+
+    @Test("setSuspended(true) yields .suspended; setSuspended(false) reconnects straight to .controlling")
+    func suspendThenResume() async throws {
+        let authority = InMemoryLANRemotePairingAuthority()
+        let token = "pretrusted-token-\(UUID().uuidString)"
+        await authority.registerPairedToken(token)
+        let (listener, identity) = try await makeListener(pairingAuthority: authority)
+        defer { identity.removeFromKeychain(); Task { await listener.stop() } }
+        guard let port = await listener.boundPort else { Issue.record("no bound port"); return }
+
+        let session = makeSession()
+        defer { Task { await session.stop() } }
+        var events = session.events.makeAsyncIterator()
+        await session.attach(to: target(port: port, fingerprint: identity.fingerprint, token: token))
+        _ = await events.next() // .connecting
+        _ = await events.next() // .controlling
+
+        await session.setSuspended(true)
+        #expect(await events.next() == .suspended)
+
+        await session.setSuspended(false)
+        #expect(await events.next() == .connecting(attempt: 0))
+        guard case .controlling = await events.next() else {
+            Issue.record("expected .controlling on resume")
+            return
+        }
+    }
+
+    // MARK: - THE HEADLINE TEST: kill the listener -> detach -> backoff -> restart -> re-attach
+
+    @Test("Killing the listener detaches the session, which backs off and re-attaches once a listener returns on the same port")
+    func killListenerThenRestartReattaches() async throws {
+        let fixedPort = try #require(NWEndpoint.Port(rawValue: UInt16.random(in: 20_000...40_000)))
+        let authority = InMemoryLANRemotePairingAuthority()
+        let token = "pretrusted-token-\(UUID().uuidString)"
+        await authority.registerPairedToken(token)
+
+        let identity = try await KeychainTestSerialization.shared.run {
+            try LANRemoteIdentityFactory.generateSelfSigned()
+        }
+        defer { identity.removeFromKeychain() }
+
+        var listener = TVListenerActor(
+            identity: identity,
+            configuration: .init(port: fixedPort, advertiseViaBonjour: false, pairingAuthority: authority, clock: ManualLANRemoteClock())
+        )
+        try await listener.start()
+        try await listener.waitUntilReady()
+        defer { let finalListener = listener; Task { await finalListener.stop() } }
+
+        let session = makeSession()
+        defer { Task { await session.stop() } }
+        var events = session.events.makeAsyncIterator()
+        await session.attach(to: target(port: fixedPort, fingerprint: identity.fingerprint, token: token))
+        _ = await events.next() // .connecting
+        _ = await events.next() // .controlling
+
+        // Kill the listener out from under the session — a hard drop.
+        await listener.stop()
+
+        #expect(await events.next() == .detached)
+        guard case .reconnecting(let firstAttempt, let firstDelay) = await events.next() else {
+            Issue.record("expected .reconnecting")
+            return
+        }
+        #expect(firstAttempt == 0)
+        #expect(firstDelay > 0)
+
+        // Bring a NEW listener up on the SAME fixed port, same identity, an
+        // authority that already knows the token — the fast path should
+        // work once the session's ladder tries again.
+        listener = TVListenerActor(
+            identity: identity,
+            configuration: .init(port: fixedPort, advertiseViaBonjour: false, pairingAuthority: authority, clock: ManualLANRemoteClock())
+        )
+        try await listener.start()
+        try await listener.waitUntilReady()
+
+        // Drain any further `.reconnecting` events (the ladder may need more
+        // than one attempt if the new listener wasn't up in time for the
+        // first retry) until `.controlling` arrives — bounded by a generous
+        // real-world timeout since this crosses real async network I/O.
+        let reconnected = try await waitForControlling(&events)
+        guard case .controlling = reconnected else {
+            Issue.record("expected the session to reach .controlling again with NO ceremony events")
+            return
+        }
+    }
+
+    /// Consumes `events` until `.controlling` arrives (skipping any further
+    /// `.connecting`/`.reconnecting` attempts along the way), or throws after
+    /// a generous real-world deadline — this crosses genuine async network
+    /// I/O (a fresh listener actually binding + a fresh TLS handshake), which
+    /// is exactly the class of wait `LANRemoteTestSupport.swift`'s own
+    /// `waitFor`/`waitForCondition` document as legitimate to time-box.
+    /// A plain deadline loop (not a `TaskGroup` race) — this session's
+    /// `events` is a SINGLE-CONSUMER stream (this file's binding rule), and
+    /// the ladder's own `.reconnecting` events fire every ≤0.2s in this
+    /// suite's millisecond configuration, so the deadline check between
+    /// iterations is a real bound in practice without needing a second,
+    /// concurrent reader of the same iterator.
+    private func waitForControlling(_ events: inout AsyncStream<RemoteControlSession.Event>.AsyncIterator) async throws -> RemoteControlSession.Event {
+        let deadline = ContinuousClock.now + .seconds(10)
+        while ContinuousClock.now < deadline {
+            guard let event = await events.next() else { throw LANRemoteTestTimeoutError() }
+            if case .controlling = event { return event }
+        }
+        throw LANRemoteTestTimeoutError()
+    }
+
+    // MARK: - Multi-remote reflection
+
+    @Test("Two sessions paired to one listener both see the SAME broadcast state when either one sends an intent")
+    func multiRemoteReflection() async throws {
+        let authority = InMemoryLANRemotePairingAuthority()
+        let tokenA = "token-a-\(UUID().uuidString)"
+        let tokenB = "token-b-\(UUID().uuidString)"
+        await authority.registerPairedToken(tokenA)
+        await authority.registerPairedToken(tokenB)
+        let (listener, identity) = try await makeListener(pairingAuthority: authority)
+        defer { identity.removeFromKeychain(); Task { await listener.stop() } }
+        guard let port = await listener.boundPort else { Issue.record("no bound port"); return }
+
+        let sessionA = makeSession()
+        let sessionB = makeSession()
+        defer { Task { await sessionA.stop() }; Task { await sessionB.stop() } }
+        var eventsA = sessionA.events.makeAsyncIterator()
+        var eventsB = sessionB.events.makeAsyncIterator()
+
+        await sessionA.attach(to: target(port: port, fingerprint: identity.fingerprint, token: tokenA))
+        await sessionB.attach(to: target(port: port, fingerprint: identity.fingerprint, token: tokenB))
+
+        _ = await eventsA.next() // .connecting
+        guard case .controlling = await eventsA.next() else { Issue.record("A never controlled"); return }
+        _ = await eventsB.next() // .connecting
+        guard case .controlling = await eventsB.next() else { Issue.record("B never controlled"); return }
+
+        let songId = SongID(songbookAbbreviation: "MP", number: 1008)
+        await sessionA.sendIntent(.selectSong(songId: songId, componentIndex: 0, lineIndex: nil))
+        // Simulate the projection layer resolving the intent and broadcasting.
+        await listener.updateState(songId: songId, componentIndex: 0, lineIndex: nil, displayState: .lyrics)
+
+        guard case .controlling(let stateA) = await eventsA.next() else { Issue.record("A never saw the broadcast"); return }
+        guard case .controlling(let stateB) = await eventsB.next() else { Issue.record("B never saw the broadcast"); return }
+        #expect(stateA.songId == songId)
+        #expect(stateB.songId == songId)
+        #expect(stateA.revision == stateB.revision)
+    }
+}

--- a/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/RemoteControlSessionLoopbackTests.swift
+++ b/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/RemoteControlSessionLoopbackTests.swift
@@ -50,14 +50,19 @@ import Testing
 struct RemoteControlSessionLoopbackTests {
 
     /// A session configured for millisecond-fast ping/backoff — spec §7.5.
-    private func makeSession() -> RemoteControlSession {
+    /// `internal` (not `private`) so `RemoteControlSessionReArmTests.swift`
+    /// — split out purely to keep this struct's `type_body_length` under
+    /// SwiftLint's budget (#1422 review fix 3) — can reuse it; it stays
+    /// invisible outside this test target either way.
+    func makeSession() -> RemoteControlSession {
         var configuration = RemoteControlSession.Configuration(remoteKind: .phone, deviceName: "Test Phone")
         configuration.health = .init(pingInterval: .milliseconds(40), maxMissedPongs: 3)
         configuration.backoff = .init(baseDelay: 0.05, multiplier: 2, maxDelay: 0.2, jitterFraction: 0.2)
         return RemoteControlSession(configuration: configuration)
     }
 
-    private func makeListener(
+    /// `internal` for the same cross-file-reuse reason as `makeSession()` above.
+    func makeListener(
         port: NWEndpoint.Port = .any,
         pairingAuthority: any LANRemotePairingAuthority = InMemoryLANRemotePairingAuthority(),
         clock: any LANRemoteClock = ManualLANRemoteClock()
@@ -74,7 +79,8 @@ struct RemoteControlSessionLoopbackTests {
         return (listener, identity)
     }
 
-    private func target(
+    /// `internal` for the same cross-file-reuse reason as `makeSession()` above.
+    func target(
         tvName: String = "Fellowship Hall TV", port: NWEndpoint.Port, fingerprint: String,
         token: String? = nil, knownCode: String? = nil
     ) -> RemoteControlSession.Target {

--- a/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/RemoteControlSessionReArmTests.swift
+++ b/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/RemoteControlSessionReArmTests.swift
@@ -1,0 +1,83 @@
+// RemoteControlSessionReArmTests.swift
+// IHLiveTests
+//
+// ELI5: Proves the fix for a real bug — switching away from the remote
+// screen and back used to leave it dead. Checks that once a session is
+// told to fully stop, its "what's happening" stream really is done for
+// good, and that building a BRAND-NEW session (exactly what the fix now
+// does every time the screen reappears) works perfectly fine — same TV,
+// same token, straight back to controlling.
+//
+// DETAILED: #1422 review fix 3 (`.claude/apple-phase2-pr7-spec.md` §3.4 —
+// `RemoteControlSession`). Split out of `RemoteControlSessionLoopbackTests
+// .swift` — NOT for a topical reason, purely to keep that struct's
+// `type_body_length` under SwiftLint's budget (the `+Link.swift`/
+// `TVListenerActor+Messages.swift` precedent for splitting an
+// over-budget file, applied here to a test target). This is an `extension`
+// of the SAME `RemoteControlSessionLoopbackTests` struct/suite — sharing
+// its `@Suite` gate (`IHYMNS_LAN_LOOPBACK_TESTS=1`, real 127.0.0.1 TLS —
+// macOS Local Network Privacy blocks an unsigned headless `swift test`
+// binary from completing a real loopback handshake) and its `makeSession()`
+// /`makeListener(...)`/`target(...)` helpers (loosened from `private` to
+// `internal` there for exactly this reuse).
+//
+// **What this test actually proves:** `RemoteControlSession` itself gained
+// NO new "re-arm" capability — `stop()` is still terminal, by design (this
+// file's header doc on `RemoteControlSession.swift` explains why: full
+// teardown, `eventContinuation.finish()`, nothing more is ever yielded).
+// The fix that closes the "tab-switch-while-pushed dead screen" review
+// finding lives one layer up, in `RemoteControlCoordinator.start()`
+// (`IHFeatures`): it now builds a BRAND-NEW `RemoteControlSession` every
+// time it (re)runs (`session = RemoteControlSession(configuration:
+// sessionConfiguration)`), rather than relying on the single `let` instance
+// it used to construct once in `init`. This test exercises exactly that
+// premise end-to-end over a real loopback connection: a stopped session's
+// stream really is dead, and a freshly-constructed session (mirroring what
+// the coordinator now builds) reattaches to the very same TV without a
+// hitch.
+import Foundation
+import Network
+import Testing
+@testable import IHLive
+
+extension RemoteControlSessionLoopbackTests {
+
+    @Test("stop() finishes a session's events stream for good; a FRESH session (the coordinator's re-arm strategy) reattaches fine")
+    func freshSessionAfterStopReattaches() async throws {
+        let authority = InMemoryLANRemotePairingAuthority()
+        let token = "pretrusted-token-\(UUID().uuidString)"
+        await authority.registerPairedToken(token)
+        let (listener, identity) = try await makeListener(pairingAuthority: authority)
+        defer { identity.removeFromKeychain(); Task { await listener.stop() } }
+        guard let port = await listener.boundPort else { Issue.record("no bound port"); return }
+
+        // First session: attach, reach `.controlling`, then a deliberate
+        // full teardown — the same `stop()` `RemoteControlView.onDisappear`
+        // calls (`RemoteControlCoordinator.stop()` → `session.stop()`).
+        let firstSession = makeSession()
+        var firstEvents = firstSession.events.makeAsyncIterator()
+        await firstSession.attach(to: target(port: port, fingerprint: identity.fingerprint, token: token))
+        _ = await firstEvents.next() // .connecting
+        guard case .controlling = await firstEvents.next() else {
+            Issue.record("first session never controlled")
+            return
+        }
+        await firstSession.stop()
+        #expect(await firstEvents.next() == nil) // finished for good — nothing more is EVER delivered
+
+        // A brand-new `RemoteControlSession` — exactly what
+        // `RemoteControlCoordinator.start()` now builds on every (re)start
+        // instead of relying on the dead first instance — reattaches to
+        // the SAME listener with no ceremony (the token is still valid),
+        // proving the coordinator-level re-arm strategy actually works.
+        let secondSession = makeSession()
+        defer { Task { await secondSession.stop() } }
+        var secondEvents = secondSession.events.makeAsyncIterator()
+        await secondSession.attach(to: target(port: port, fingerprint: identity.fingerprint, token: token))
+        #expect(await secondEvents.next() == .connecting(attempt: 0))
+        guard case .controlling = await secondEvents.next() else {
+            Issue.record("expected the fresh post-stop() session to reach .controlling")
+            return
+        }
+    }
+}

--- a/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/RemoteLinkPolicyTests.swift
+++ b/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/RemoteLinkPolicyTests.swift
@@ -1,0 +1,135 @@
+// RemoteLinkPolicyTests.swift
+// IHLiveTests
+//
+// ELI5: Checks the two little "is the link OK?" rulebooks — the ping-miss
+// counter correctly declares a link dead after 3 misses (and any pong at all
+// resets it), and the reconnect-wait calculator produces the right sequence
+// of waits, stays within its jitter band, respects the cap, and resets back
+// to the start once told to.
+//
+// DETAILED: #1422 (`.claude/apple-phase2-pr7-spec.md` §7.2 — BINDING).
+// Both machines are pure (no clock, no RNG reads) — `unitRandom` is supplied
+// as a plain literal here, exactly the seam the production driver
+// (`RemoteControlSession+Link.swift`) fills with a real `Double.random(in:
+// 0..<1)` draw. Defaults are asserted LITERALLY so a drive-by "tune" of the
+// numbers shows up as a diff in review, per spec §7.2's explicit instruction.
+import Foundation
+import Testing
+@testable import IHLive
+
+@Suite("RemoteLinkHealthState")
+struct RemoteLinkHealthStateTests {
+
+    @Test("Defaults are 5s ping interval / 3 missed pongs — asserted literally")
+    func defaultsAreTheStrategyNumbers() {
+        let configuration = RemoteLinkHealthState.Configuration()
+        #expect(configuration.pingInterval == .seconds(5))
+        #expect(configuration.maxMissedPongs == 3)
+    }
+
+    @Test("3 ticks each send a ping and advance the miss counter; the 4th declares detached")
+    func threeTicksSendPingsThenDetach() {
+        var state = RemoteLinkHealthState()
+        #expect(state.onTick() == .sendPing)
+        #expect(state.onTick() == .sendPing)
+        #expect(state.onTick() == .sendPing)
+        #expect(state.pingsAwaitingPong == 3)
+
+        #expect(state.onTick() == .declareDetached)
+    }
+
+    @Test("onPong() resets the miss counter to zero regardless of how many pings were outstanding")
+    func onPongResetsCounter() {
+        var state = RemoteLinkHealthState()
+        _ = state.onTick()
+        _ = state.onTick()
+        #expect(state.pingsAwaitingPong == 2)
+
+        state.onPong()
+        #expect(state.pingsAwaitingPong == 0)
+
+        // The ladder restarts cleanly from zero.
+        #expect(state.onTick() == .sendPing)
+        #expect(state.onTick() == .sendPing)
+        #expect(state.onTick() == .sendPing)
+        #expect(state.onTick() == .declareDetached)
+    }
+
+    @Test("reset() returns a fresh connection's state")
+    func resetReturnsToZero() {
+        var state = RemoteLinkHealthState()
+        _ = state.onTick()
+        _ = state.onTick()
+        _ = state.onTick()
+        state.reset()
+        #expect(state.pingsAwaitingPong == 0)
+        #expect(state.onTick() == .sendPing)
+    }
+
+    @Test("A custom maxMissedPongs is honoured")
+    func customMissBudget() {
+        var state = RemoteLinkHealthState(configuration: .init(maxMissedPongs: 1))
+        #expect(state.onTick() == .sendPing)
+        #expect(state.onTick() == .declareDetached)
+    }
+}
+
+@Suite("RemoteReconnectBackoffState")
+struct RemoteReconnectBackoffStateTests {
+
+    @Test("Defaults are 1s base / ×2 / 30s cap / ±20% jitter — asserted literally")
+    func defaultsAreTheStrategyNumbers() {
+        let configuration = RemoteReconnectBackoffState.Configuration()
+        #expect(configuration.baseDelay == 1)
+        #expect(configuration.multiplier == 2)
+        #expect(configuration.maxDelay == 30)
+        #expect(configuration.jitterFraction == 0.2)
+    }
+
+    @Test("With unitRandom 0.5 (no jitter offset) the sequence is 1, 2, 4, 8, 16, 30, 30")
+    func nominalSequenceAtHalfUnitRandom() {
+        var state = RemoteReconnectBackoffState()
+        let expected: [TimeInterval] = [1, 2, 4, 8, 16, 30, 30]
+        for expectedDelay in expected {
+            let delay = state.nextDelay(unitRandom: 0.5)
+            #expect(abs(delay - expectedDelay) < 0.0001)
+        }
+    }
+
+    @Test("Every delay stays within ±20% of nominal across the full unitRandom range")
+    func everyDelayStaysWithinJitterBounds() {
+        var lowState = RemoteReconnectBackoffState()
+        var highState = RemoteReconnectBackoffState()
+        let nominals: [TimeInterval] = [1, 2, 4, 8, 16, 30, 30]
+
+        for nominal in nominals {
+            let low = lowState.nextDelay(unitRandom: 0.0)
+            let high = highState.nextDelay(unitRandom: 1.0)
+            #expect(abs(low - nominal * 0.8) < 0.0001)
+            #expect(abs(high - nominal * 1.2) < 0.0001)
+        }
+    }
+
+    @Test("reset() returns to attempt 0")
+    func resetReturnsToAttemptZero() {
+        var state = RemoteReconnectBackoffState()
+        _ = state.nextDelay(unitRandom: 0.5)
+        _ = state.nextDelay(unitRandom: 0.5)
+        #expect(state.attempt == 2)
+
+        state.reset()
+        #expect(state.attempt == 0)
+        let delay = state.nextDelay(unitRandom: 0.5)
+        #expect(abs(delay - 1) < 0.0001)
+    }
+
+    @Test("A custom configuration's numbers are honoured")
+    func customConfiguration() {
+        var state = RemoteReconnectBackoffState(configuration: .init(baseDelay: 0.05, multiplier: 2, maxDelay: 0.2, jitterFraction: 0))
+        #expect(abs(state.nextDelay(unitRandom: 0.5) - 0.05) < 0.0001)
+        #expect(abs(state.nextDelay(unitRandom: 0.5) - 0.1) < 0.0001)
+        #expect(abs(state.nextDelay(unitRandom: 0.5) - 0.2) < 0.0001)
+        // Capped, doesn't keep growing past maxDelay.
+        #expect(abs(state.nextDelay(unitRandom: 0.5) - 0.2) < 0.0001)
+    }
+}

--- a/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/RemotePairingEntryResolverTests.swift
+++ b/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/RemotePairingEntryResolverTests.swift
@@ -1,0 +1,212 @@
+// RemotePairingEntryResolverTests.swift
+// IHLiveTests
+//
+// ELI5: Checks that "I scanned this QR" / "I tapped this saved TV" always
+// turns into the RIGHT connection plan — the right address, the right
+// fingerprint, whether we skip the code dance — for every row of the entry-
+// path table, including the tricky ones (already-paired TV re-scanned,
+// standing QR for a TV we already trust, no address at all).
+//
+// DETAILED: #1422 (`.claude/apple-phase2-pr7-spec.md` §4/§7.2 — BINDING,
+// "resolve it EXACTLY this way"). Pure/always-on, table-driven where the
+// table itself is the clearest form.
+import Foundation
+import Network
+import Testing
+@testable import IHLive
+
+@Suite("RemotePairingEntryResolver")
+struct RemotePairingEntryResolverTests {
+
+    private let fingerprint = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+    private let otherFingerprint = "1111110123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+
+    private func discovered(name: String, port: UInt16 = 7269) -> LANRemoteDiscoveredService {
+        LANRemoteDiscoveredService(name: name, endpoint: .hostPort(host: "10.0.0.5", port: NWEndpoint.Port(rawValue: port)!))
+    }
+
+    private func savedRecord(
+        fingerprintHex: String? = nil, name: String = "Fellowship Hall TV", token: String = "saved-token",
+        lastAddress: LANRemoteResolvedAddress? = LANRemoteResolvedAddress(host: "10.0.0.9", port: 7269)
+    ) -> PairedTVRecord {
+        PairedTVRecord(
+            fingerprintHex: fingerprintHex ?? fingerprint, name: name, token: token, lastAddress: lastAddress,
+            pairedAt: Date(timeIntervalSince1970: 1_700_000_000), lastConnectedAt: nil
+        )
+    }
+
+    // MARK: - Path A/B: ceremony vs standing payload for an already-saved fingerprint
+
+    @Test("A ceremony payload (code != nil) for an ALREADY-saved fingerprint runs the ceremony anyway — token is nil (re-pair)")
+    func ceremonyPayloadForSavedFingerprintReRunsCeremony() {
+        let saved = [savedRecord()]
+        let payload = LANRemotePairingPayload(name: "Fellowship Hall TV", host: "10.0.0.9", port: 7269, fingerprintHex: fingerprint, code: "042317")
+
+        let resolution = RemotePairingEntryResolver.resolve(.payload(payload), saved: saved, discovered: [])
+        guard case .connect(let target) = resolution else {
+            Issue.record("expected .connect, got \(resolution)")
+            return
+        }
+        #expect(target.token == nil)
+        #expect(target.knownCode == "042317")
+        #expect(target.expectedFingerprint == fingerprint)
+    }
+
+    @Test("A standing payload (code == nil) for a saved fingerprint short-circuits to the saved token — no ceremony")
+    func standingPayloadForSavedFingerprintUsesSavedToken() {
+        let saved = [savedRecord(token: "already-trusted-token")]
+        let payload = LANRemotePairingPayload(name: "Fellowship Hall TV", host: "10.0.0.9", port: 7269, fingerprintHex: fingerprint, code: nil)
+
+        let resolution = RemotePairingEntryResolver.resolve(.payload(payload), saved: saved, discovered: [])
+        guard case .connect(let target) = resolution else {
+            Issue.record("expected .connect, got \(resolution)")
+            return
+        }
+        #expect(target.token == "already-trusted-token")
+        #expect(target.knownCode == nil)
+    }
+
+    @Test("A standing payload for an UNKNOWN fingerprint runs the ceremony (token nil, typed-code path)")
+    func standingPayloadForUnknownFingerprintNoToken() {
+        let payload = LANRemotePairingPayload(name: "New TV", host: "10.0.0.9", port: 7269, fingerprintHex: otherFingerprint, code: nil)
+        let resolution = RemotePairingEntryResolver.resolve(.payload(payload), saved: [], discovered: [])
+        guard case .connect(let target) = resolution else {
+            Issue.record("expected .connect, got \(resolution)")
+            return
+        }
+        #expect(target.token == nil)
+        #expect(target.knownCode == nil)
+    }
+
+    // MARK: - Payload endpoint resolution
+
+    @Test("A payload with an explicit host/port uses it directly, ignoring discovery")
+    func payloadWithHostUsesItDirectly() {
+        let payload = LANRemotePairingPayload(name: "TV", host: "10.0.0.9", port: 7269, fingerprintHex: fingerprint, code: "042317")
+        let resolution = RemotePairingEntryResolver.resolve(.payload(payload), saved: [], discovered: [discovered(name: "Some Other TV")])
+        guard case .connect(let target) = resolution, case .hostPort(let host, let port) = target.endpoint else {
+            Issue.record("expected a .hostPort endpoint")
+            return
+        }
+        #expect("\(host)" == "10.0.0.9")
+        #expect(port.rawValue == 7269)
+    }
+
+    @Test("A payload with nil host falls back to a name-matching discovered endpoint")
+    func payloadWithNilHostUsesNameMatchedDiscovery() {
+        let payload = LANRemotePairingPayload(name: "Fellowship Hall TV", host: nil, port: nil, fingerprintHex: fingerprint, code: "042317")
+        let match = discovered(name: "Fellowship Hall TV", port: 12345)
+        let resolution = RemotePairingEntryResolver.resolve(.payload(payload), saved: [], discovered: [match])
+        guard case .connect(let target) = resolution else {
+            Issue.record("expected .connect, got \(resolution)")
+            return
+        }
+        #expect(target.endpoint == match.endpoint)
+    }
+
+    @Test("A payload with nil host and no discovery match is unpairable (.noRouteToTV)")
+    func payloadWithNilHostAndNoMatchIsUnpairable() {
+        let payload = LANRemotePairingPayload(name: "Fellowship Hall TV", host: nil, port: nil, fingerprintHex: fingerprint, code: "042317")
+        let resolution = RemotePairingEntryResolver.resolve(.payload(payload), saved: [], discovered: [discovered(name: "Some Other TV")])
+        guard case .unpairable(let reason) = resolution else {
+            Issue.record("expected .unpairable, got \(resolution)")
+            return
+        }
+        #expect(reason == .noRouteToTV)
+    }
+
+    // MARK: - Path C: a tap on an already-saved row
+
+    @Test("A saved row with a name-matched discovery uses the discovered endpoint as primary, saved address as fallback")
+    func savedRowWithNameMatchUsesDiscoveredPrimary() {
+        let record = savedRecord(lastAddress: LANRemoteResolvedAddress(host: "10.0.0.9", port: 7269))
+        let match = discovered(name: record.name, port: 9999)
+
+        let resolution = RemotePairingEntryResolver.resolve(.savedRow(record), saved: [record], discovered: [match])
+        guard case .connect(let target) = resolution else {
+            Issue.record("expected .connect, got \(resolution)")
+            return
+        }
+        #expect(target.endpoint == match.endpoint)
+        #expect(target.token == record.token)
+        guard case .hostPort(let host, let port) = target.fallbackEndpoint else {
+            Issue.record("expected a .hostPort fallback endpoint")
+            return
+        }
+        #expect("\(host)" == "10.0.0.9")
+        #expect(port.rawValue == 7269)
+    }
+
+    @Test("A saved row alone (no discovery match) uses its saved address as primary, no fallback")
+    func savedRowAloneUsesSavedAddress() {
+        let record = savedRecord(lastAddress: LANRemoteResolvedAddress(host: "10.0.0.9", port: 7269))
+        let resolution = RemotePairingEntryResolver.resolve(.savedRow(record), saved: [record], discovered: [])
+        guard case .connect(let target) = resolution else {
+            Issue.record("expected .connect, got \(resolution)")
+            return
+        }
+        guard case .hostPort(let host, let port) = target.endpoint else {
+            Issue.record("expected a .hostPort endpoint")
+            return
+        }
+        #expect("\(host)" == "10.0.0.9")
+        #expect(port.rawValue == 7269)
+        #expect(target.fallbackEndpoint == nil)
+        #expect(target.token == record.token)
+    }
+
+    @Test("A saved row with neither a discovery match nor a saved address is unpairable")
+    func savedRowWithNoRouteIsUnpairable() {
+        let record = savedRecord(lastAddress: nil)
+        let resolution = RemotePairingEntryResolver.resolve(.savedRow(record), saved: [record], discovered: [])
+        guard case .unpairable(let reason) = resolution else {
+            Issue.record("expected .unpairable, got \(resolution)")
+            return
+        }
+        #expect(reason == .noRouteToTV)
+    }
+
+    // MARK: - listRows
+
+    @Test("listRows pins saved rows first (newest lastConnectedAt/pairedAt first), then nearby-unpaired sorted by name")
+    func listRowsOrdering() {
+        let older = savedRecord(fingerprintHex: fingerprint, name: "Older TV")
+        var newer = savedRecord(fingerprintHex: otherFingerprint, name: "Newer TV")
+        newer.lastConnectedAt = Date(timeIntervalSince1970: 1_800_000_000)
+
+        let nearbyB = discovered(name: "Zebra Hall")
+        let nearbyA = discovered(name: "Annex TV")
+
+        let rows = RemotePairingEntryResolver.listRows(saved: [older, newer], discovered: [nearbyB, nearbyA])
+        #expect(rows.count == 4)
+
+        guard case .paired(let first) = rows[0].kind, case .paired(let second) = rows[1].kind else {
+            Issue.record("expected the first two rows to be .paired")
+            return
+        }
+        #expect(first.name == "Newer TV")
+        #expect(second.name == "Older TV")
+
+        guard case .nearbyUnpaired(let third) = rows[2].kind, case .nearbyUnpaired(let fourth) = rows[3].kind else {
+            Issue.record("expected the last two rows to be .nearbyUnpaired")
+            return
+        }
+        #expect(third.name == "Annex TV")
+        #expect(fourth.name == "Zebra Hall")
+    }
+
+    @Test("listRows flags a saved row isNearby when a discovered service shares its name")
+    func listRowsFlagsIsNearby() {
+        let record = savedRecord(name: "Fellowship Hall TV")
+        let rows = RemotePairingEntryResolver.listRows(saved: [record], discovered: [discovered(name: "Fellowship Hall TV")])
+        #expect(rows.count == 1)
+        #expect(rows[0].isNearby == true)
+    }
+
+    @Test("listRows never surfaces a saved TV twice as a nearby-unpaired row too")
+    func listRowsDoesNotDuplicateSavedAsNearby() {
+        let record = savedRecord(name: "Fellowship Hall TV")
+        let rows = RemotePairingEntryResolver.listRows(saved: [record], discovered: [discovered(name: "Fellowship Hall TV")])
+        #expect(rows.filter { if case .nearbyUnpaired = $0.kind { return true }; return false }.isEmpty)
+    }
+}

--- a/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/RemotePairingEntryResolverTests.swift
+++ b/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/RemotePairingEntryResolverTests.swift
@@ -115,6 +115,65 @@ struct RemotePairingEntryResolverTests {
         #expect(reason == .noRouteToTV)
     }
 
+    // MARK: - §8 threat-model clamps (#1422 review fix 4) — table-driven
+
+    @Test("A payload with port == 0 is rejected as .malformedPayload before any connect is attempted")
+    func payloadWithZeroPortIsMalformed() {
+        let payload = LANRemotePairingPayload(name: "TV", host: "10.0.0.9", port: 0, fingerprintHex: fingerprint, code: "042317")
+        let resolution = RemotePairingEntryResolver.resolve(.payload(payload), saved: [], discovered: [])
+        guard case .unpairable(let reason) = resolution else {
+            Issue.record("expected .unpairable, got \(resolution)")
+            return
+        }
+        #expect(reason == .malformedPayload)
+    }
+
+    @Test("A payload whose fingerprint is 63 hex characters (one short of 64) is rejected as .malformedPayload")
+    func payloadWithShortFingerprintIsMalformed() {
+        let shortFingerprint = String(fingerprint.dropLast())
+        let payload = LANRemotePairingPayload(name: "TV", host: "10.0.0.9", port: 7269, fingerprintHex: shortFingerprint, code: "042317")
+        let resolution = RemotePairingEntryResolver.resolve(.payload(payload), saved: [], discovered: [])
+        guard case .unpairable(let reason) = resolution else {
+            Issue.record("expected .unpairable, got \(resolution)")
+            return
+        }
+        #expect(reason == .malformedPayload)
+    }
+
+    @Test("A payload whose fingerprint contains uppercase hex characters is rejected as .malformedPayload")
+    func payloadWithUppercaseFingerprintIsMalformed() {
+        let uppercaseFingerprint = fingerprint.uppercased()
+        let payload = LANRemotePairingPayload(name: "TV", host: "10.0.0.9", port: 7269, fingerprintHex: uppercaseFingerprint, code: "042317")
+        let resolution = RemotePairingEntryResolver.resolve(.payload(payload), saved: [], discovered: [])
+        guard case .unpairable(let reason) = resolution else {
+            Issue.record("expected .unpairable, got \(resolution)")
+            return
+        }
+        #expect(reason == .malformedPayload)
+    }
+
+    @Test("A payload whose fingerprint contains a non-hex character is rejected as .malformedPayload")
+    func payloadWithNonHexFingerprintIsMalformed() {
+        let nonHexFingerprint = "zz" + String(fingerprint.dropFirst(2))
+        let payload = LANRemotePairingPayload(name: "TV", host: "10.0.0.9", port: 7269, fingerprintHex: nonHexFingerprint, code: "042317")
+        let resolution = RemotePairingEntryResolver.resolve(.payload(payload), saved: [], discovered: [])
+        guard case .unpairable(let reason) = resolution else {
+            Issue.record("expected .unpairable, got \(resolution)")
+            return
+        }
+        #expect(reason == .malformedPayload)
+    }
+
+    @Test("A well-formed payload (valid 64-lowercase-hex fingerprint, non-zero port) still resolves to .connect")
+    func validPayloadStillResolvesToConnect() {
+        let payload = LANRemotePairingPayload(name: "TV", host: "10.0.0.9", port: 7269, fingerprintHex: fingerprint, code: "042317")
+        let resolution = RemotePairingEntryResolver.resolve(.payload(payload), saved: [], discovered: [])
+        guard case .connect = resolution else {
+            Issue.record("expected .connect, got \(resolution)")
+            return
+        }
+    }
+
     // MARK: - Path C: a tap on an already-saved row
 
     @Test("A saved row with a name-matched discovery uses the discovered endpoint as primary, saved address as fallback")

--- a/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/RemotePairingFlowStateTests.swift
+++ b/appApple/Packages/iHymnsKit/Tests/IHLiveTests/LANRemote/RemotePairingFlowStateTests.swift
@@ -1,0 +1,198 @@
+// RemotePairingFlowStateTests.swift
+// IHLiveTests
+//
+// ELI5: Checks the remote's OWN half of the pairing dance — that it prompts
+// for a code (or skips straight to sending one, if we already scanned it),
+// that a wrong code lets the person try again, that success/failure end the
+// flow cleanly, and that a stray/duplicate event never causes a crash.
+//
+// DETAILED: #1422 (`.claude/apple-phase2-pr7-spec.md` §7.1 — BINDING).
+// Pure/always-on — no clock, no actor, no network. The GOLDEN-VECTOR
+// cross-check reuses PR-6's frozen (code, fingerprint, nonce) → proof triple
+// (`LANRemotePairingProofTests.swift`'s `goldenVector()` test) to prove this
+// reducer's `.sendProof` effect carries the EXACT SAME proof the TV's own
+// frozen construction expects — both sides call the identical
+// `LANRemotePairingProof.compute`, so if this ever drifts it means the
+// reducer stopped calling the real function correctly, not that the crypto
+// itself changed.
+import Foundation
+import Testing
+@testable import IHLive
+
+@Suite("RemotePairingFlowState")
+struct RemotePairingFlowStateTests {
+
+    private func makeState(knownCode: String? = nil, deviceName: String? = "Test Phone") -> RemotePairingFlowState {
+        RemotePairingFlowState(context: .init(
+            expectedFingerprint: "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+            knownCode: knownCode,
+            deviceName: deviceName
+        ))
+    }
+
+    // MARK: - Path A: a scanned ceremony QR already carries the code
+
+    @Test("Path A: challengeReceived with a knownCode sends a proof immediately, no prompt")
+    func pathASendsProofImmediately() {
+        var state = makeState(knownCode: "042317")
+        let effect = state.handle(.challengeReceived(nonce: "0123456789abcdef0123456789abcde0"))
+
+        guard case .sendProof(let proof, let deviceName) = effect else {
+            Issue.record("expected .sendProof, got \(effect)")
+            return
+        }
+        #expect(deviceName == "Test Phone")
+        #expect(proof == LANRemotePairingProof.compute(
+            code: "042317", fingerprintHex: state.context.expectedFingerprint, nonceHex: "0123456789abcdef0123456789abcde0"
+        ))
+        guard case .proofSent(let nonce, let failedAttempts) = state.phase else {
+            Issue.record("expected .proofSent, got \(state.phase)")
+            return
+        }
+        #expect(nonce == "0123456789abcdef0123456789abcde0")
+        #expect(failedAttempts == 0)
+    }
+
+    @Test("GOLDEN VECTOR cross-check — the reducer's proof equals PR-6's frozen construction verbatim")
+    func goldenVectorCrossCheck() {
+        let fingerprintHex = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+        let nonceHex = "0123456789abcdef0123456789abcde0"
+        let code = "042317"
+        let expectedProofHex = "8b88b703f398bab753db30059cfde2c10d61b3a18d2cc9640c312f6a89b08847"
+
+        var state = RemotePairingFlowState(context: .init(expectedFingerprint: fingerprintHex, knownCode: code))
+        let effect = state.handle(.challengeReceived(nonce: nonceHex))
+
+        guard case .sendProof(let proof, _) = effect else {
+            Issue.record("expected .sendProof, got \(effect)")
+            return
+        }
+        #expect(proof == expectedProofHex)
+    }
+
+    // MARK: - Path B: no known code — prompt, then send on codeEntered
+
+    @Test("Path B: challengeReceived with no knownCode prompts for a code")
+    func pathBPromptsForCode() {
+        var state = makeState(knownCode: nil)
+        let effect = state.handle(.challengeReceived(nonce: "aa"))
+        #expect(effect == .promptForCode(failedAttempts: 0))
+        #expect(state.phase == .awaitingCode(nonce: "aa", failedAttempts: 0))
+    }
+
+    @Test("Path B: codeEntered sends the computed proof")
+    func pathBCodeEnteredSendsProof() {
+        var state = makeState(knownCode: nil)
+        _ = state.handle(.challengeReceived(nonce: "aa"))
+        let effect = state.handle(.codeEntered("111222"))
+
+        guard case .sendProof(let proof, _) = effect else {
+            Issue.record("expected .sendProof, got \(effect)")
+            return
+        }
+        #expect(proof == LANRemotePairingProof.compute(code: "111222", fingerprintHex: state.context.expectedFingerprint, nonceHex: "aa"))
+        #expect(state.phase == .proofSent(nonce: "aa", failedAttempts: 0))
+    }
+
+    @Test("pairingRejected re-prompts with an incremented failedAttempts, retaining the nonce")
+    func pairingRejectedRePrompts() {
+        var state = makeState(knownCode: nil)
+        _ = state.handle(.challengeReceived(nonce: "aa"))
+        _ = state.handle(.codeEntered("000000"))
+        let effect = state.handle(.pairingRejected)
+
+        #expect(effect == .promptForCode(failedAttempts: 1))
+        #expect(state.phase == .awaitingCode(nonce: "aa", failedAttempts: 1))
+
+        // A second reject/re-enter cycle keeps counting.
+        _ = state.handle(.codeEntered("111111"))
+        let secondEffect = state.handle(.pairingRejected)
+        #expect(secondEffect == .promptForCode(failedAttempts: 2))
+
+        // A third.
+        _ = state.handle(.codeEntered("222222"))
+        let thirdEffect = state.handle(.pairingRejected)
+        #expect(thirdEffect == .promptForCode(failedAttempts: 3))
+    }
+
+    // MARK: - Expired-scanned-code degrade (Path A → Path B fallback)
+
+    @Test("A knownCode's proof getting rejected degrades to the code sheet — the stale code is never re-sent")
+    func expiredScannedCodeDegradesToPrompt() {
+        var state = makeState(knownCode: "042317")
+        _ = state.handle(.challengeReceived(nonce: "aa"))
+        let effect = state.handle(.pairingRejected)
+
+        #expect(effect == .promptForCode(failedAttempts: 1))
+        #expect(state.phase == .awaitingCode(nonce: "aa", failedAttempts: 1))
+
+        // The NEXT proof, from a freshly typed code, must be computed from
+        // THAT code — never a silently-retried `knownCode`.
+        let nextEffect = state.handle(.codeEntered("999999"))
+        guard case .sendProof(let proof, _) = nextEffect else {
+            Issue.record("expected .sendProof, got \(nextEffect)")
+            return
+        }
+        #expect(proof == LANRemotePairingProof.compute(code: "999999", fingerprintHex: state.context.expectedFingerprint, nonceHex: "aa"))
+    }
+
+    // MARK: - Success / transport-closed / out-of-phase events
+
+    @Test("pairSuccess reports paired with the token")
+    func pairSuccessReportsPaired() {
+        var state = makeState(knownCode: "042317")
+        _ = state.handle(.challengeReceived(nonce: "aa"))
+        let effect = state.handle(.pairSuccess(token: "deadbeef"))
+
+        #expect(effect == .reportPaired(token: "deadbeef"))
+        #expect(state.phase == .paired(token: "deadbeef"))
+    }
+
+    @Test("transportClosed from every non-terminal phase reports connectionTornDown")
+    func transportClosedFromEveryNonTerminalPhase() {
+        // From .awaitingChallenge.
+        var awaiting = makeState(knownCode: nil)
+        #expect(awaiting.handle(.transportClosed) == .reportFailed(.connectionTornDown))
+        #expect(awaiting.phase == .failed(.connectionTornDown))
+
+        // From .awaitingCode.
+        var awaitingCode = makeState(knownCode: nil)
+        _ = awaitingCode.handle(.challengeReceived(nonce: "aa"))
+        #expect(awaitingCode.handle(.transportClosed) == .reportFailed(.connectionTornDown))
+
+        // From .proofSent.
+        var proofSent = makeState(knownCode: "042317")
+        _ = proofSent.handle(.challengeReceived(nonce: "aa"))
+        #expect(proofSent.handle(.transportClosed) == .reportFailed(.connectionTornDown))
+    }
+
+    @Test("Out-of-phase events are ignored (.none), never a crash")
+    func outOfPhaseEventsAreIgnored() {
+        var state = makeState(knownCode: "042317")
+        _ = state.handle(.challengeReceived(nonce: "aa"))
+        _ = state.handle(.pairSuccess(token: "deadbeef"))
+
+        // A duplicate pairingRejected/pairSuccess after the flow already
+        // resolved must be a no-op, not a crash/assert.
+        #expect(state.handle(.pairingRejected) == .none)
+        #expect(state.handle(.codeEntered("000000")) == .none)
+        #expect(state.phase == .paired(token: "deadbeef"))
+
+        // challengeReceived while already awaiting a proof is also a no-op.
+        var proofSent = makeState(knownCode: "042317")
+        _ = proofSent.handle(.challengeReceived(nonce: "aa"))
+        #expect(proofSent.handle(.challengeReceived(nonce: "bb")) == .none)
+    }
+
+    @Test("Phase never carries a live code — awaitingCode/proofSent only ever hold nonce + count")
+    func phaseNeverStoresALiveCode() {
+        // Structural: the ONLY way to prove "never stores a code" from the
+        // outside is that these two cases' associated values are exactly
+        // (nonce, failedAttempts) — verified here by construction/equality
+        // against literals that contain no code at all.
+        let awaitingCode = RemotePairingFlowState.Phase.awaitingCode(nonce: "aa", failedAttempts: 2)
+        let proofSent = RemotePairingFlowState.Phase.proofSent(nonce: "aa", failedAttempts: 2)
+        #expect(awaitingCode == .awaitingCode(nonce: "aa", failedAttempts: 2))
+        #expect(proofSent == .proofSent(nonce: "aa", failedAttempts: 2))
+    }
+}

--- a/appApple/project.yml
+++ b/appApple/project.yml
@@ -106,6 +106,22 @@ targets:
         # by hand each time — declaring it here answers the question at
         # build time instead, for every upload from this target.
         INFOPLIST_KEY_ITSAppUsesNonExemptEncryption: NO
+    # #1422 (PR-7 spec §6.5, D-13) — the LOAD-BEARING Local Network keys (TN3179:
+    # BROWSING is the restricted operation; the tvOS listener side's copy of
+    # NSLocalNetworkUsageDescription, `iHymnsTV`'s own `settings.base` below
+    # in this file, is belt-and-braces — THIS one is not). NSBonjourServices
+    # is array-typed with no INFOPLIST_KEY_ build-setting equivalent, so it
+    # rides XcodeGen's `info:` mechanism (the iHymnsWidgets precedent below)
+    # — Xcode merges the INFOPLIST_KEY_* settings above into this generated
+    # file's content at build time, so the existing flat keys keep working
+    # unchanged. Run `xcodegen generate` after editing.
+    info:
+      path: Apps/iHymns/Generated/Info.plist
+      properties:
+        NSLocalNetworkUsageDescription: "iHymns looks for iHymns on your Apple TV over your local network so this device can act as its remote control."
+        NSBonjourServices:
+          - _ihymns-remote._tcp
+        NSCameraUsageDescription: "iHymns uses the camera only to scan the pairing QR code shown on your TV."
     # #186 (Apple Phase 1, "Sharing & social") — claims Universal Links for
     # every host `DeepLinkRouter.allowedHosts` (`IHAppSupport`) resolves a
     # `DeepLink` from, so a tapped `https://ihymns.app/song/...`-shaped link


### PR DESCRIPTION
## Apple Phase-2 PR-7 — LAN-remote control app UI (iPhone/iPad/Mac/Vision) — #1422

**Base:** `alpha`. ⚠️ `Closes #1422` won't auto-close (alpha ≠ default branch) — close manually after merge.

The phone/iPad/Mac/Vision **client** side of the LAN-direct TV remote: it discovers, pairs with (producing the proof the already-merged PR-6 TV side verifies), and drives an Apple TV over TLS on the local network. No backend. Design spec: `.claude/apple-phase2-pr7-spec.md` (Fable 5 deep-design). Sibling of the merged PR-6 (`.claude/apple-phase2-pr6-spec.md`) — its §1 wire ceremony is this PR's binding contract; its §8 threat model applies here too.

### What's in it
- **Entry-path matrix** — ceremony-QR scan (one-shot pair), standing-QR/paste + typed 6-digit code, and discovery-list **reconnect** to already-paired TVs. `expectedFingerprint` is always known before connecting (QR/paste carries it); Bonjour discovery is **routing only, never trust** (an impostor advertising a saved TV's name fails the pinned-fingerprint TLS check). No TOFU / manual-address — that's PR-8.
- **`RemoteControlSession`** (IHLive actor) — the ceremony client + the ping/reconnect ladder: 5 s ping / 3-missed-pong detach, jittered exponential backoff (1→30 s, ±20%), suspend-on-background, fast-path token reconnect (<1 s). Pure, injected-clock state machines (`RemotePairingFlowState`, `RemoteLinkHealthState`, `RemoteReconnectBackoffState`) so the whole ladder is deterministically testable.
- **`KeychainPairedTVStore`** (IHLive) — raw token + pinned fingerprint + last-good address, keyed by the TV's fingerprint, `kSecAttrSynchronizable = false` **hard-coded** (never iCloud-synced — the physical-proximity trust model).
- **Control surface** — stateless/**reflective**: renders from the TV's broadcast `IHRPState`, only sends ~200-byte intents (song select/prepare, component/line nav, display-state, appearance, scroll). Multi-remote last-writer-wins by construction. **No lyric text on the wire** (content stays API-driven, the TV fetches under its own auth).
- **UI** lives in the app's `.live` section (`LiveHubView` → `RemoteControlView` → control surface); iOS/iPadOS get camera QR scanning, macOS/visionOS use paste/discovery.

### Process (owner-locked): Fable plan → Sonnet build → Opus review → fixes
Independent Opus adversarial review verdict: **security logic sound** — channel binding correct (proof HMACs the fingerprint WE pinned, never one the TV sends), golden vector byte-identical to PR-6, `synchronizable=false` enforced + unit-tested + grep-gated, zero secrets logged, single-consumer streams, keychain custody correct, all 3 self-found concurrency fixes independently verified. **No blocker, no high logic defect.**

Fixes applied after review:
- **HIGH** — `IHColorTokens.swift` used `UIColor(named:in:compatibleWith:)` (`API_UNAVAILABLE(watchOS)`) under a `canImport(UIKit)` guard true on watchOS. First domino surfaced when we tried to add an iOS app-scheme CI build (which embeds the watch app). Guarded for watchOS.
- **MEDIUM** — `touchLastConnected()` now runs on first-arrival only (was every state broadcast → Keychain churn). `RemoteControlSession`/coordinator `start()`/`stop()` made re-armable (a re-shown view no longer dead-ends).
- **LOW** — resolver now enforces the §8 clamps (port 0 / non-64-hex fingerprint → unpairable); `PairingScanView` Coordinator `@unchecked Sendable` (zero Swift-6 warnings).

### ⚠️ Watch-app compile gap discovered → #1549 (why CI uses a package iOS build)
Adding an iOS **app-scheme** build to CI revealed that the embedded `iHymnsWatch` (imports IHFeatures) **has never compiled for watchOS** — CI only builds macOS + tvOS today, so ~9 IHFeatures views using watchOS-unavailable SwiftUI APIs were never caught (full list + fix plan in **#1549**). So this PR's new CI step verifies the iOS-only code via a **`swift build` package cross-compile** (proven green, compiles `PairingScanView`) rather than the app scheme; #1549 will re-enable the full app-scheme iOS build once the watch compiles.

### Verification (all local — CI's `apple.yml` is not a required check, #1526)
macOS build ✅ · tvOS build ✅ · **iOS package cross-compile ✅** (compiles `PairingScanView`) · `swift test` **697** ✅ (the intermittent `KeychainPairingAuthorityTests` failure is PR-6's unmodified suite flaking under cross-suite Keychain-daemon contention — passes 6/6 in isolation) · loopback (incl. new re-arm test) ✅ · SwiftLint 0/330 ✅ · LOC budget ✅ · Info.plist merge (`plutil`) ✅ · scope tripwires ✅ (`grep Synchronizable` → only hard-coded false; single-consumer streams; no TOFU/Watch-relay/mirror/new-dep/`import Network`-in-IHFeatures/lyric-text; `RemoteSessionActor` edits additive-only).

### 3 design decisions flagged for owner review (all reversible, sensible defaults)
1. **UI home = the `.live` section** — the designed home for this feature family (server Live-Follow copy retained beside it, PR-10's future slot). Reversible one-liner.
2. **`NSBonjourServices` via XcodeGen `info:` block**, `plutil`-verified, documented full fallback.
3. **Connection lives only while the Remote screen is open** — matches strategy §2.4.4 ("backgrounded → detached, TV holds state, <1 s reconnect").

### Security notes (per the standing pre-PR review)
New credential custody is REMOTE-side only (raw pairing token at rest — Keychain generic-password, `AfterFirstUnlock`, `synchronizable:false`, fail-closed reads, never logged). No backend contact anywhere in this PR. The §8 threat-model table (QR-swap, brute-force, replay, token theft, reconnect storm, LAN spoof, multi-remote races, log leakage) is reproduced in the spec. Audit B re-reviews PR-6 + PR-7 together before any external TestFlight.

### Documented residuals → follow-up issues (non-blocking)
- `localNetworkDenied` UI-guidance path is inert until a small additive `RemoteSessionActor` hook exists.
- The 20 ms resume-settle is a documented timing workaround (a deterministic per-connection generation token needs a `RemoteSessionActor` change, deferred to Audit B).
- Narrow teardown-abort race (Cancel during an in-flight reconnect) — LOW.
- No snapshot tests (no package; #1527).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
