### PR TITLE
fix(apple): make iHymnsWatch compile for watchOS + re-enable app-scheme iOS CI build (#1549)

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -76,23 +76,34 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             build
 
-      # #1422 (PR-7) ships the first `#if os(iOS)`-only IHFeatures UI
-      # (`PairingScanView.swift`, AVFoundation camera) which the macOS build
-      # above never compiles. We verify it with a PACKAGE build cross-compiled
-      # for the iOS-Simulator SDK — deliberately NOT the full `iHymns` app
-      # scheme, because that scheme embeds `iHymnsWatch`, which imports
-      # IHFeatures and does NOT yet compile for watchOS (a pre-existing,
-      # never-CI-built gap — ~9 IHFeatures views use watchOS-unavailable
-      # SwiftUI APIs; tracked in #1549, which will re-enable the full
-      # app-scheme iOS build once the watch compiles). A `swift build`
-      # cross-compile needs only the iOS SDK (always present on the runner),
-      # so no `-downloadPlatform iOS` is required.
-      - name: Build iHymnsKit for iOS Simulator (proves the iOS-only remote UI, #1422)
-        working-directory: appApple/Packages/iHymnsKit
+      # #1422 (PR-7) shipped the first `#if os(iOS)`-only IHFeatures UI
+      # (`PairingScanView.swift`, AVFoundation camera), which the macOS build
+      # above never compiles. That PR verified it with a PACKAGE build
+      # cross-compiled for the iOS-Simulator SDK rather than the full `iHymns`
+      # app scheme, because that scheme embeds `iHymnsWatch` (`project.yml`
+      # `embed: true, destinationFilters: [iOS]`), which imports IHFeatures —
+      # and IHFeatures did NOT yet compile for watchOS (a pre-existing,
+      # never-CI-built gap: ~9 IHFeatures views used watchOS-unavailable
+      # SwiftUI APIs). **#1549 fixed that** (each usage now falls back to a
+      # watch-safe alternative under `#if os(watchOS)`/`#if !os(watchOS)`), so
+      # the full app-scheme build below now embeds AND compiles the watch app
+      # too — this replaces the old package-only interim build with the real
+      # thing. Needs the iOS Simulator platform installed first, same as the
+      # tvOS step below needs tvOS (`-destination 'generic/platform=...'`
+      # isn't the macOS SDK, which is the only one preinstalled on the
+      # macos-26 runner).
+      - name: Install iOS platform (runner ships without it, #1549)
+        run: sudo xcodebuild -downloadPlatform iOS
+
+      - name: Build (iOS Simulator destination — proves the full app + embedded watch, #1549)
+        working-directory: appApple
         run: |
-          swift build \
-            --sdk "$(xcrun --sdk iphonesimulator --show-sdk-path)" \
-            -Xswiftc -target -Xswiftc arm64-apple-ios26.0-simulator
+          xcodebuild \
+            -project iHymns.xcodeproj \
+            -scheme iHymns \
+            -destination 'generic/platform=iOS Simulator' \
+            CODE_SIGNING_ALLOWED=NO \
+            build
 
       # The generic tvOS-Simulator destination below needs the tvOS 26.0
       # platform, which is NOT preinstalled on the GitHub-hosted macos-26

--- a/appApple/Packages/iHymnsKit/Sources/IHFeatures/AccountDeleteView.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHFeatures/AccountDeleteView.swift
@@ -130,7 +130,16 @@ public struct AccountDeleteView: View {
                         Text(option.rawValue).tag(option)
                     }
                 }
+                // `.segmented` is UNAVAILABLE on watchOS (#1549) — this
+                // screen is never shown on the watch (`iHymnsWatch` links the
+                // whole IHFeatures target, so it must still COMPILE there);
+                // `.automatic` is a compile-only fallback, non-watch keeps
+                // `.segmented` unchanged.
+                #if os(watchOS)
+                .pickerStyle(.automatic)
+                #else
                 .pickerStyle(.segmented)
+                #endif
                 .onChange(of: reauthMode) { _, _ in errorMessage = nil }
             }
 

--- a/appApple/Packages/iHymnsKit/Sources/IHFeatures/CatalogueListView.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHFeatures/CatalogueListView.swift
@@ -174,6 +174,14 @@ public struct CatalogueListView: View {
     /// The button's own glyph fills in when a filter is active, so the
     /// affordance is visible without opening the menu at all.
     private var filterMenu: some View {
+        // `Menu` (incl. its nested submenus) is UNAVAILABLE on watchOS
+        // (#1549) — `CatalogueListView` is a full-app screen never shown on
+        // the watch (`iHymnsWatch` links the whole IHFeatures target, so it
+        // must still COMPILE there); `EmptyView` is a compile-only stub,
+        // non-watch keeps the real filter menu unchanged.
+        #if os(watchOS)
+        EmptyView()
+        #else
         Menu {
             if !viewModel.availableSongbookAbbreviations.isEmpty {
                 Menu("Songbook") {
@@ -220,5 +228,6 @@ public struct CatalogueListView: View {
                 systemImage: viewModel.hasActiveFilters ? "line.3.horizontal.decrease.circle.fill" : "line.3.horizontal.decrease.circle"
             )
         }
+        #endif
     }
 }

--- a/appApple/Packages/iHymnsKit/Sources/IHFeatures/LoginView.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHFeatures/LoginView.swift
@@ -79,7 +79,16 @@ public struct LoginView: View {
                             Text(option.rawValue).tag(option)
                         }
                     }
+                    // `.segmented` is UNAVAILABLE on watchOS (#1549) — this
+                    // screen is never shown on the watch (`iHymnsWatch` links
+                    // the whole IHFeatures target, so it must still COMPILE
+                    // there); `.automatic` is a compile-only fallback,
+                    // non-watch keeps `.segmented` unchanged.
+                    #if os(watchOS)
+                    .pickerStyle(.automatic)
+                    #else
                     .pickerStyle(.segmented)
+                    #endif
                     .onChange(of: mode) { _, _ in errorMessage = nil }
                 }
 

--- a/appApple/Packages/iHymnsKit/Sources/IHFeatures/RemoteControlSurfaceView.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHFeatures/RemoteControlSurfaceView.swift
@@ -145,7 +145,16 @@ public struct RemoteControlSurfaceView: View {
                 Text("Logo").tag(IHRPDisplayState.logo)
                 Text("Freeze").tag(IHRPDisplayState.frozen)
             }
+            // `.segmented` is UNAVAILABLE on watchOS (#1549) — this screen
+            // is never shown on the watch (`iHymnsWatch` links the whole
+            // IHFeatures target, so it must still COMPILE there);
+            // `.automatic` is a compile-only fallback, non-watch keeps
+            // `.segmented` unchanged.
+            #if os(watchOS)
+            .pickerStyle(.automatic)
+            #else
             .pickerStyle(.segmented)
+            #endif
         }
         .ihGlassCard()
     }
@@ -159,6 +168,14 @@ public struct RemoteControlSurfaceView: View {
     private var appearanceCard: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Appearance").font(.subheadline).foregroundStyle(.secondary)
+            // `Menu` is UNAVAILABLE on watchOS (#1549) — this screen is
+            // never shown on the watch (`iHymnsWatch` links the whole
+            // IHFeatures target, so it must still COMPILE there); `EmptyView`
+            // is a compile-only stub, non-watch keeps the real theme menu
+            // unchanged.
+            #if os(watchOS)
+            EmptyView()
+            #else
             Menu {
                 ForEach(Self.themeOptions, id: \.self) { theme in
                     Button(theme.capitalized) { onIntent(.setAppearance(theme: theme, textScale: nil)) }
@@ -166,6 +183,7 @@ public struct RemoteControlSurfaceView: View {
             } label: {
                 Label("Theme", systemImage: "paintbrush")
             }
+            #endif
             HStack {
                 Text("Text Size")
                 Spacer()

--- a/appApple/Packages/iHymnsKit/Sources/IHFeatures/SetlistCatalogueBrowserView.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHFeatures/SetlistCatalogueBrowserView.swift
@@ -100,8 +100,11 @@ public struct SetlistCatalogueBrowserView: View {
         // `.draggable` is UNAVAILABLE on tvOS (D-1, #1504's tvOS-build
         // gate) — no drag-and-drop concept there; the Button's own tap
         // action (`onAdd`) is already the tvOS-reachable "add to setlist"
-        // affordance regardless.
-        #if !os(tvOS)
+        // affordance regardless. Also UNAVAILABLE on watchOS (#1549, same
+        // "no drag-and-drop" reasoning) — this browser is never shown on
+        // the watch anyway (`iHymnsWatch` links the whole IHFeatures
+        // target, so it must still COMPILE there).
+        #if !os(tvOS) && !os(watchOS)
         .draggable(song.songId.rawValue)
         #endif
     }

--- a/appApple/Packages/iHymnsKit/Sources/IHFeatures/SetlistDetailView.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHFeatures/SetlistDetailView.swift
@@ -188,8 +188,11 @@ public struct SetlistDetailView: View {
             // `.dropDestination` is UNAVAILABLE on tvOS (D-1, #1504) — its
             // counterpart `.draggable` on `SetlistCatalogueBrowserView`'s row
             // is ALSO tvOS-omitted, so nothing would ever drag INTO this
-            // drop target there anyway.
-            #if !os(tvOS)
+            // drop target there anyway. Also UNAVAILABLE on watchOS (#1549,
+            // same reasoning) — this screen is never shown on the watch
+            // anyway (`iHymnsWatch` links the whole IHFeatures target, so it
+            // must still COMPILE there).
+            #if !os(tvOS) && !os(watchOS)
             .dropDestination(for: String.self) { droppedIds, _ in
                 return handleDrop(droppedIds, into: setlist)
             }

--- a/appApple/Packages/iHymnsKit/Sources/IHFeatures/SongComparisonView.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHFeatures/SongComparisonView.swift
@@ -139,7 +139,18 @@ public struct SongComparisonView: View {
                 Text(sideLabel(isPrimary: true)).tag(ComparisonSide.primary)
                 Text(sideLabel(isPrimary: false)).tag(ComparisonSide.secondary)
             }
+            // `.segmented` is UNAVAILABLE on watchOS (#1549) — `pagedContent`
+            // is never actually REACHED on watchOS at runtime (mirrors this
+            // file's own macOS `pagedTabViewStyle()` note below: `layout`
+            // always resolves `.sideBySide` off-iOS), but the file must
+            // still COMPILE for that platform since `iHymnsWatch` links the
+            // whole IHFeatures target; `.automatic` is a compile-only
+            // fallback, non-watch keeps `.segmented` unchanged.
+            #if os(watchOS)
+            .pickerStyle(.automatic)
+            #else
             .pickerStyle(.segmented)
+            #endif
             .padding([.horizontal, .top])
 
             TabView(selection: $selectedSide) {

--- a/appApple/Packages/iHymnsKit/Sources/IHFeatures/SongMetadataView.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHFeatures/SongMetadataView.swift
@@ -134,8 +134,10 @@ struct SongMetadataView: View {
             // `DisclosureGroup` is UNAVAILABLE on tvOS (D-1, #1504's
             // tvOS-build gate) — shown always-expanded there instead of
             // collapsible (a metadata footnote, not worth a bespoke
-            // expand/collapse affordance on a remote-driven focus UI).
-            #if os(tvOS)
+            // expand/collapse affordance on a remote-driven focus UI). Also
+            // UNAVAILABLE on watchOS (#1549) — same always-expanded
+            // fallback applies there too.
+            #if os(tvOS) || os(watchOS)
             VStack(alignment: .leading, spacing: 4) {
                 Text("Song Identifiers").font(.headline)
                 authorityIdsContent(royaltyIds: royaltyIds)

--- a/appApple/Packages/iHymnsKit/Sources/IHFeatures/SongPagerView.swift
+++ b/appApple/Packages/iHymnsKit/Sources/IHFeatures/SongPagerView.swift
@@ -168,7 +168,7 @@ public struct SongPagerView: View {
     /// from.
     @ToolbarContentBuilder
     private var pagerToolbar: some ToolbarContent {
-        ToolbarItemGroup(placement: .navigation) {
+        ToolbarItemGroup(placement: pagerToolbarPlacement) {
             Button {
                 goToPrevious()
             } label: {
@@ -177,8 +177,12 @@ public struct SongPagerView: View {
             .disabled(!hasPrevious)
             // `.keyboardShortcut` is UNAVAILABLE on tvOS (D-1, #1504) — no
             // physical keyboard concept there; the button itself stays
-            // focusable/selectable via the Siri Remote regardless.
-            #if !os(tvOS)
+            // focusable/selectable via the Siri Remote regardless. Also
+            // UNAVAILABLE on watchOS (#1549, same "no hardware keyboard"
+            // reasoning) — this screen is never shown on the watch anyway
+            // (`iHymnsWatch` links the whole IHFeatures target, so it must
+            // still COMPILE there).
+            #if !os(tvOS) && !os(watchOS)
             .keyboardShortcut(.leftArrow, modifiers: [])
             #endif
             .help("Previous Song")
@@ -189,11 +193,23 @@ public struct SongPagerView: View {
                 Label("Next Song", systemImage: "chevron.right")
             }
             .disabled(!hasNext)
-            #if !os(tvOS)
+            #if !os(tvOS) && !os(watchOS)
             .keyboardShortcut(.rightArrow, modifiers: [])
             #endif
             .help("Next Song")
         }
+    }
+
+    /// `.navigation` is UNAVAILABLE on watchOS (#1549) — this screen is
+    /// never shown on the watch anyway (`iHymnsWatch` links the whole
+    /// IHFeatures target, so it must still COMPILE there); `.automatic` is
+    /// a compile-only fallback, non-watch keeps `.navigation` unchanged.
+    private var pagerToolbarPlacement: ToolbarItemPlacement {
+        #if os(watchOS)
+        .automatic
+        #else
+        .navigation
+        #endif
     }
 }
 


### PR DESCRIPTION
Makes iHymnsWatch compile for watchOS by guarding ~9 IHFeatures views' watchOS-unavailable SwiftUI APIs (`.segmented`/`Menu`/`.draggable`/`.dropDestination`/`DisclosureGroup`/`.keyboardShortcut`/`ToolbarItemPlacement.navigation`) with minimal `#if !os(watchOS)` compile-only fallbacks — non-watch branches byte-identical. Re-enables the full app-scheme iOS build in apple.yml (embeds+compiles the watch). Verified: watchOS cross-compile 0 errors; full app-scheme iOS build BUILD SUCCEEDED with the watch embedded; swift test 747; SwiftLint 0/350. Unblocks Bundle D PR-11 (Watch relay). Closes #1549 (close manually — alpha ≠ default). Full detail was in the first (network-timed-out) attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)