### PR TITLE
ci: fix 2 workflow-lint errors (empty option, injection) + add actionlint CI

### DIFF
--- a/.github/workflows/apple-deploy.yml
+++ b/.github/workflows/apple-deploy.yml
@@ -60,11 +60,11 @@ on:
   workflow_dispatch:
     inputs:
       lane:
-        description: 'Fastlane lane to run (overrides the branch->lane mapping below)'
+        description: "Fastlane lane to run — use 'auto' to follow the branch->lane mapping below"
         required: false
         type: choice
         options:
-          - ''
+          - auto
           - alpha
           - beta
           - release
@@ -148,7 +148,7 @@ jobs:
       - name: Determine Fastlane lane
         id: lane
         run: |
-          if [ -n "${{ github.event.inputs.lane }}" ]; then
+          if [ -n "${{ github.event.inputs.lane }}" ] && [ "${{ github.event.inputs.lane }}" != "auto" ]; then
             echo "lane=${{ github.event.inputs.lane }}" >> "$GITHUB_OUTPUT"
           elif [ "${{ github.ref }}" = "refs/heads/alpha" ]; then
             echo "lane=alpha" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,48 @@
+# Lint GitHub Actions workflow files with actionlint.
+#
+# Added org-wide to catch real workflow bugs early — undefined `needs:`
+# jobs, malformed `${{ }}` expressions, invalid `runs-on`, deprecated
+# syntax, and genuine shell errors inside `run:` blocks. It is tuned to be
+# non-disruptive: the embedded shellcheck runs at `--severity=error`, so
+# cosmetic style/info/warning lint (SC2129 "group your redirects", SC2086
+# quoting info, …) never fails the build — only genuine breakage does.
+#
+# Runs only when workflow files change, so it costs no CI minutes on
+# ordinary code pushes.
+name: Lint Workflows
+
+on:
+  push:
+    paths:
+      - '.github/workflows/**'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  workflow_dispatch:
+
+# Least-privilege: this job only reads the checked-out tree.
+permissions:
+  contents: read
+
+concurrency:
+  group: lint-workflows-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install actionlint (pinned, checksum-verified by the official script)
+        run: |
+          bash <(curl -sSfL "https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash") 1.7.12
+
+      - name: Lint workflow files
+        env:
+          # Suppress cosmetic shellcheck style/info/warning; fail only on
+          # genuine errors (plus all of actionlint's own native checks).
+          SHELLCHECK_OPTS: --severity=error
+        run: ./actionlint -color

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -90,8 +90,9 @@ jobs:
       # -----------------------------------------------------------------------
       - name: Determine bump type
         id: bump
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
-          COMMIT_MSG="${{ github.event.head_commit.message }}"
           echo "Commit message: $COMMIT_MSG"
 
           if echo "$COMMIT_MSG" | grep -qiE 'BREAKING CHANGE|!\:'; then


### PR DESCRIPTION
Closes #1563

Fixes the actionlint-flagged workflow errors and adds the `Lint Workflows` (actionlint) CI job. Verified green locally at `--severity=error` (cosmetic style/info is not failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)