### PR TITLE
chore(release): bump minor version to 0.4001.0

### DIFF
--- a/appWeb/public_html/includes/infoAppVer.php
+++ b/appWeb/public_html/includes/infoAppVer.php
@@ -79,7 +79,7 @@ $app["Application"]["Description"]["Keywords"] = "hymns, worship, lyrics, songbo
 /* Semantic version number (MAJOR.MINOR.PATCH) */
 /* Auto-bumped by the version-bump GitHub Action on push to beta */
 /* v1.x.x = Phase 1 (local JSON data), v2.x.x = Phase 2 (iLyrics dB) */
-$app["Application"]["Version"]["Number"] = "0.4000.0";
+$app["Application"]["Version"]["Number"] = "0.4001.0";
 
 /* Version name: human-readable release name (e.g., "Hymnal", NULL if unused) */
 $app["Application"]["Version"]["Name"] = NULL;


### PR DESCRIPTION
The consolidated batch merged to `alpha` as `887bcd2f` (PR #1585) — 98 commits, 228 files — **without a version bump**, so everything since has shipped under `0.4000.0`.

That is not a slip in the merge; it is how the automation is wired. `version-bump.yml` triggers only on a push to **`beta`**:

```yaml
on:
  push:
    branches:
      - beta
```

An `alpha` merge never bumps, by design. Since most work targets `alpha`, the version sits still for long stretches — which is what happened here.

## Why MINOR

The batch is feature work, not fixes alone:

- the public **Export** repair across both surfaces (#1565–#1570) — no format had ever worked on a public page
- **Present** mode (#1568)
- the observability trio — event-name constants (#1581), client error surfacing (#1582), the What's New page (#1583)
- **Swagger UI** hardening (#1587)
- **Apple Phase-2 / 1.5** — App Intents (#1415), watch relay (#1423), Service-Mode mirror (#1425), tvOS projector (#1428), Live Activities (#1429)

## Why `0.4001.0` and not something rounder

It follows `version-bump.yml`'s own arithmetic exactly:

```bash
minor)
  MINOR=$((MINOR + 1))
  PATCH=0
  ;;
```

`0.4000.0` → `0.4001.0`. Picking a different number by hand would mean this file and the workflow disagree about what a minor bump is, and the next `beta` push would compute its bump from a base nobody expected.

## Blast radius — one line, several derived values

`infoAppVer.php` is the single source. Changing it also changes:

| Consumer | Effect |
|---|---|
| `index.php` `?v=` on app.css / accessibility.css / print.css | cache-bust |
| the JS bundle version | cache-bust |
| `service-worker.js.php:37` cache version (#81) | SW cache invalidated |

**That last one is wanted here, not merely tolerated.** The export fix and Present mode ship as *new* ES modules. A client still holding the previous service-worker cache would keep serving the old bundle — which is precisely the "looks alive, does nothing" failure #1565 was about. The bump forces those clients onto the fixed code.

## Not touched

- **`package.json`** stays at `1.0.0-alpha.1` — a separate npm version, out of scope.
- **No changelog version section cut by hand.** `changelog.yml` regenerates those from conventional commits on the next `beta` push; hand-cutting would fight it.

## Verification

```
php -l appWeb/public_html/includes/infoAppVer.php     No syntax errors
resolved Version.Number                                0.4001.0
version-bump.yml's own parser regex                    0.4001.0
```

Base branch: `alpha`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DNiDThGGEJujdRL9fNR2Bq

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNiDThGGEJujdRL9fNR2Bq)_