### PR TITLE
docs: step-by-step runbooks for the two owner-gated migrations (#1621, #1616)

### DIFF
--- a/.claude/sessions/2026-07-28-HANDOFF.md
+++ b/.claude/sessions/2026-07-28-HANDOFF.md
@@ -25,8 +25,12 @@
 - **`beta` / `main`**: a month behind on an **unrelated history** (#1600). Two cherry-picks were
   pushed directly to both with owner approval: #1611 (migrate-json confirm gate) and #1622
   (version-bump script injection). **Nothing else.**
-- ⚠️ **The deploy has NOT been verified** as of writing. `[deploy all]` to alpha is the first owner
-  action below, and it is what actually puts #1650 and the migration script on the docroot.
+- ✅ **Deploy to dev succeeded** (`bc0eb52e`, "Deploy via SFTP" green). The docs follow-up #1652
+  (`46dee8fa`) deployed behind it — the per-branch concurrency group serialises them rather than
+  cancelling, so no half-mirrored docroot.
+- ⚠️ **`[deploy all]` may STILL be needed** for #1642: the normal deploy uses a 5-commit change-
+  detection window, and the missing `migrate-apple-phase2-live-schema.php` predates it. If
+  `/manage/setup-database` still says *Script not found*, force a full mirror.
 
 ## ⛔ Do NOT do these
 
@@ -46,9 +50,9 @@
 |---|---|---|
 | — | **Push `[deploy all]` to alpha** | Clears BOTH the blocked migration screen (#1642 — `migrate-apple-phase2-live-schema.php` is in git but not on the docroot) AND deploys the #1650 data-health fix |
 | — | Then hit **Disconnect legacy fallbacks** | #1650 fixed the circular gate; it should now show 0 blockers. Removes the server-side `songs.json` copies that #1617 could not reach |
-| **#1621** | Smoke-test the migration on alpha | 4 DDL behaviours reasoned from docs, never executed (no MySQL in the build container): the `ALTER` with a `GENERATED … STORED` column + `ADD UNIQUE KEY`, the correlated `EXISTS` inside `UPDATE`, `LIMIT` on an aliased single-table `UPDATE`, and whether `idx_Live_Expiry` is chosen |
+| **#1621** | Smoke-test the migration | **Step-by-step runbook is in the issue** (comment, 2026-07-29): which card, the exact expected output, and the failure signature of each of the 4 DDL behaviours that were reasoned from docs but never executed. ~2 min, non-destructive |
 | **#1649** | Confirm the fix approach | Changes sync semantics — see below |
-| **#1616** | Six runtime checks | Before the C6 drop |
+| **#1616** | Runtime checks before the C6 drop | **Full runbook is in the issue** (comment, 2026-07-29) — phased: OPcache/version check → smoke test → `--phase=pre` → ≥7-night soak → freeze + backup → `pre-drop` → drop → `post-drop`. Includes the verbatim `[REFUSE]` strings so a safe stop is distinguishable from a failure. **Not urgent — nothing depends on it** |
 | **#1600** | The promotion | Its own exercise; **verify `APPLE_DEPLOY_ENABLED` is off first** — an earlier audit reported it ON and I cannot verify it from here |
 
 ## What to do next (recommended order)


### PR DESCRIPTION
Docs-only follow-up to PR #1651 / #1652. No code, no schema, no behaviour change.

## What this adds

Two migrations are deliberately gated on an owner decision rather than being applied by "Apply all pending". Both were blocked on the same thing: nobody had written down *exactly* what to run, what a pass looks like, and what to do when it fails. This adds those runbooks as issue comments and points the handoff at them.

**#1621 — `migrate-service-code-uniqueness.php`** (join-code collision prevention)
A ~2-minute, non-destructive smoke test on a scratch database. It covers the four DDL behaviours that were designed against the MySQL manual but never executed on the live server version:

1. `CASE`-expression STORED generated column is accepted (a non-deterministic expression such as `UTC_TIMESTAMP()` would raise `ER_GENERATED_COLUMN_FUNCTION_IS_NOT_ALLOWED`);
2. multiple `NULL`s coexist under `UNIQUE KEY uq_ActiveCode` (the partial-unique idiom);
3. a genuine duplicate active code is rejected with `ER_DUP_ENTRY`;
4. the index is actually *used* — an `EXPLAIN` query is included, because a correct-but-unused index is a silent full scan on every join.

Each step lists the expected output verbatim (e.g. `[OK] Added ActiveCode (STORED generated) + UNIQUE uq_ActiveCode`) and the failure signature, plus a rollback.

**#1616 — `migrate-retire-component-lines-json.php`** (the destructive C6 drop)
A phased procedure rather than a single command, because this one is irreversible and the three docroots share one MySQL:

- OPcache / deployed-version check → smoke test → `--phase=pre` → **≥7-night soak** → freeze + backup → `pre-drop` → drop → `post-drop`.
- The seven `[REFUSE]` guard strings the script can emit are listed with what each one means, so a refusal is diagnosable without reading the source.
- Recovery path (`regenerate-lines-json-from-lines.php`) is named explicitly.

## Files changed

- `.claude/sessions/2026-07-28-HANDOFF.md` — links both runbooks; records that the PR #1651 deploy succeeded.

The runbooks themselves live as comments on #1621 and #1616 so they sit next to the issue an operator is already reading.

## Verification

Output strings were read from the migration scripts rather than written from memory — `_migSCU_output` in `appWeb/.sql/migrate-service-code-uniqueness.php` and the `[REFUSE]` branches in `appWeb/.sql/migrate-retire-component-lines-json.php`.

Base branch: `alpha`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNiDThGGEJujdRL9fNR2Bq)_