### PR TITLE
fix(cutover-gate): emit failure samples on the web path (#1654)

### DIFF
--- a/appWeb/.sql/verify-lyrics-cutover.php
+++ b/appWeb/.sql/verify-lyrics-cutover.php
@@ -24,6 +24,14 @@ declare(strict_types=1);
  *   --emit-samples   print up to 20 example divergences per failing gate
  *   --json           machine-readable summary on stdout (NDJSON failures to stderr)
  *
+ * The WEB path always emits samples (there is no flag to turn them off). It used to
+ * hardcode $emitSamples = false, which made a RED run undiagnosable on the ONE
+ * environment this script actually runs in: DreamHost is web-only, so the operator
+ * got "[FAIL] G1 … (1 fail)" and no way to learn WHICH song — the samples were
+ * collected and then discarded unprinted, and the NDJSON stream that carries the
+ * same detail is fwrite(STDERR) which is undefined under PHP-FPM. Both diagnostic
+ * channels were switched off precisely where they were needed (#1654).
+ *
  * On an ALL-GREEN run it writes the sentinel row tblAppSettings['lyrics_cutover_gate']
  * = {phase, ranAt, result:'green', fingerprint:{songs,components,lines,corpusSha256}}.
  * The drop migration REFUSES to run unless that sentinel says phase=pre-drop/green and
@@ -161,14 +169,23 @@ if (!function_exists('logActivity')) {
     }
 }
 
-/* ---- args ---- (CLI: getopt; web: ?phase= only — the smoke/sample flags are CLI-only) */
+/* ---- args ---- (CLI: getopt; web: ?phase= + optional ?limit= only) */
 if ($LCV_WEB) {
     $phase       = (string)($_GET['phase'] ?? 'pre');
     /* Optional smoke limit (capped): a fast first-N-songs dry-run so the operator
        can confirm the web path works before the slow full-corpus run. limit>0 NEVER
        writes the sentinel (see the report tail), so a smoke run can't arm the drop. */
     $limit       = isset($_GET['limit']) ? max(0, min(5000, (int)$_GET['limit'])) : 0;
-    $emitSamples = false;
+    /* ALWAYS ON, and deliberately not a flag (#1654).
+       ELI5: if the check fails, it has to tell you which song — otherwise "it failed"
+       is all you ever get, and you cannot fix it.
+       Detail: this is the operator's ONLY path (DreamHost is web-only; the header's
+       CLI invocations are for CI and the local rehearsal). gfail() already caps
+       retained samples at 20 PER GATE, so the cost is bounded no matter how badly
+       the corpus fails — it is the printing that was missing, not the collecting.
+       Output is HTML-escaped by out() and the page is Global-Admin-only, so lyric
+       excerpts in a G2 cpDiff are no wider an exposure than the song editor. */
+    $emitSamples = true;
     $asJson      = false;
 } else {
     $opt         = getopt('', ['phase:', 'limit:', 'emit-samples', 'json']);
@@ -298,11 +315,19 @@ $gates = [];   // id => ['desc'=>, 'pass'=>bool, 'fails'=>int, 'samples'=>[]]
 function gate(string $id, string $desc): void { global $gates; $gates[$id] = ['desc' => $desc, 'pass' => true, 'fails' => 0, 'samples' => []]; }
 function gfail(string $id, array $detail): void
 {
-    global $gates, $failuresNdjson;
+    global $gates, $failuresNdjson, $LCV_WEB;
     $gates[$id]['pass'] = false;
     $gates[$id]['fails']++;
     if (count($gates[$id]['samples']) < 20) { $gates[$id]['samples'][] = $detail; }
-    $failuresNdjson[] = json_encode(['gate' => $id] + $detail, JSON_UNESCAPED_UNICODE);
+    /* NDJSON is the CLI's failure stream (fwrite(STDERR) at the report tail, guarded
+       by !$LCV_WEB because STDERR is undefined under PHP-FPM). Accumulating it on the
+       web therefore builds an array that is only ever discarded — and it is the ONE
+       unbounded structure here (samples cap at 20, this does not). A corpus-wide G2
+       failure would add ~292k json_encode'd entries for no reader, in a codebase that
+       has already OOM'd once on whole-corpus memory (#929). (#1654) */
+    if (!$LCV_WEB) {
+        $failuresNdjson[] = json_encode(['gate' => $id] + $detail, JSON_UNESCAPED_UNICODE);
+    }
 }
 
 out("== #1235 P4 lyrics-cutover gate — phase={$phase} ==");


### PR DESCRIPTION
Found by actually running the #1616 soak on dev. The gate went RED correctly — and then could not say what was wrong.

## The failure

```
[FAIL] G1   per-component LinesJson length == mirror line count  (1 fail)
```

That is the whole diagnostic. One component out of 70,129, unnamed.

## Cause

The detail was never missing. `gfail()` already collects up to 20 samples per gate, each with `songId` / `component` / `assembledLines` / `sourceLines`. They were collected and discarded, because the report tail prints them only behind `$emitSamples`, and the web branch hardcoded `false`.

The other channel fails identically: the NDJSON stream carries the same detail but is `fwrite(STDERR)`, correctly guarded `!$LCV_WEB` because `STDERR` is undefined under PHP-FPM.

**Both diagnostic channels are gated off exactly where the script runs.** The file header says it — *"web-only DreamHost; no CLI"*. The CLI invocations serve CI and a local rehearsal; the operator has no shell on the host.

## Why it's worth a PR of its own

This gate authorises an **irreversible drop**. A red verdict nobody can act on leaves two exits: abandon the drop, or decide the gate is noisy and force past it. The `[REFUSE]` strings in the drop migration exist to prevent the second — withholding the reason invites it straight back.

Same shape as #1565 and #1581: every component is implemented and correct, the boundary wiring is not, and the failure is silent. No error, no warning — just less information than the author intended.

## Changes

`appWeb/.sql/verify-lyrics-cutover.php`, three edits:

1. **`$emitSamples = true` on the web path** — unconditional, not a flag. A flag has an off position, and there is no case where an operator wants a red run with the reason withheld. Bounded by the existing 20-per-gate cap; `out()` HTML-escapes; the page is Global-Admin-only, so a G2 `cpDiff` lyric excerpt is no wider an exposure than the song editor.
2. **Skip `$failuresNdjson` accumulation under `$LCV_WEB`** — the one *unbounded* structure here (samples cap, this does not), with no reader on the web. A corpus-wide G2 failure would build ~292k `json_encode`d entries for nobody, in a codebase that has already OOM'd on whole-corpus memory (#929).
3. **Header doc** records why, so the next person doesn't re-disable it as "CLI-only debug output".

## Verification

- `php -l` clean.
- `php tools/run-php-tests.php` — **46 passed, 0 failed**.
- Behaviour on a green run is unchanged: the sample block only executes for a failing gate.

## Not fixed here

The G1 divergence itself is **#1655**. Note there that **G2's PASS does not clear it** — a G1 failure short-circuits the `else` block containing the whole G2 comparison, so the one divergence is precisely what G2 never examined. #1655 carries a SQL query that finds the component without waiting for this to deploy.

Base branch: `alpha`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNiDThGGEJujdRL9fNR2Bq)_