### PR TITLE
docs(handoff): record the #1621 pass and the #1616 soak RED (#1655)

### DIFF
--- a/.claude/sessions/2026-07-28-HANDOFF.md
+++ b/.claude/sessions/2026-07-28-HANDOFF.md
@@ -25,9 +25,10 @@
 - **`beta` / `main`**: a month behind on an **unrelated history** (#1600). Two cherry-picks were
   pushed directly to both with owner approval: #1611 (migrate-json confirm gate) and #1622
   (version-bump script injection). **Nothing else.**
-- ✅ **Deploy to dev succeeded** (`bc0eb52e`, "Deploy via SFTP" green). The docs follow-up #1652
-  (`46dee8fa`) deployed behind it — the per-branch concurrency group serialises them rather than
-  cancelling, so no half-mirrored docroot.
+- ✅ **Deploy to dev succeeded** (`bc0eb52e`, "Deploy via SFTP" green). Three follow-ups landed and
+  deployed behind it — #1652 `46dee8fa` (handoff consolidation), #1653 `8e28179b` (the two
+  runbooks), #1654 `e80b8641` (cutover-gate diagnostics). The per-branch concurrency group
+  serialises deploys rather than cancelling them, so no half-mirrored docroot.
 - ⚠️ **`[deploy all]` may STILL be needed** for #1642: the normal deploy uses a 5-commit change-
   detection window, and the missing `migrate-apple-phase2-live-schema.php` predates it. If
   `/manage/setup-database` still says *Script not found*, force a full mirror.
@@ -40,8 +41,14 @@
    Sign-in-with-Apple on the public site. Needs the promotion first.
 2. **Do NOT run `retire-component-lines-json` (#1235 C6)** until the six runtime checks in **#1616**
    are done. Code is proven safe on all three branches; the preconditions are live state only.
-3. **Do NOT raise the setlist sync cap** as the fix for #1649 — that moves the cliff. See below.
-4. **Do NOT start a full docs sweep** before #1601 lands — the v2 cutover rewrites architecture and
+   **The first soak run (2026-07-29) was RED — see #1655.** The drop would `[REFUSE]` anyway (no
+   green `pre-drop` sentinel), so this is the guardrail working, not a new risk.
+3. **Do NOT read G2's PASS as clearing G1** in a cutover-gate report. A G1 failure short-circuits
+   the `else` block containing the entire G2 comparison, so the one thing G1 flagged is exactly
+   what G2 never examined. G2 green means *"everything I compared matched"*, not *"everything
+   matched"*. Reading it otherwise waves through the single divergence the gate exists to catch.
+4. **Do NOT raise the setlist sync cap** as the fix for #1649 — that moves the cliff. See below.
+5. **Do NOT start a full docs sweep** before #1601 lands — the v2 cutover rewrites architecture and
    API docs. The final docs pass is a **delta**.
 
 ## 🔴 Owner actions outstanding
@@ -50,12 +57,45 @@
 |---|---|---|
 | — | **Push `[deploy all]` to alpha** | Clears BOTH the blocked migration screen (#1642 — `migrate-apple-phase2-live-schema.php` is in git but not on the docroot) AND deploys the #1650 data-health fix |
 | — | Then hit **Disconnect legacy fallbacks** | #1650 fixed the circular gate; it should now show 0 blockers. Removes the server-side `songs.json` copies that #1617 could not reach |
-| **#1621** | Smoke-test the migration | **Step-by-step runbook is in the issue** (comment, 2026-07-29): which card, the exact expected output, and the failure signature of each of the 4 DDL behaviours that were reasoned from docs but never executed. ~2 min, non-destructive |
+| ~~#1621~~ | ✅ **DONE 2026-07-29 — CLOSED** | Ran clean on dev, all six `[OK]` lines. 3 of the 4 unverified DDL behaviours now proven on the live server (generated-STORED + UNIQUE in one `ALTER`; correlated `EXISTS` inside an `UPDATE`; `LIMIT` on an aliased `UPDATE`). Behaviour 4 (is `idx_Live_Expiry` actually chosen) left open **deliberately** — needs `EXPLAIN`, and a table-scan over a handful of live rows is a nit, not a correctness problem |
 | **#1649** | Confirm the fix approach | Changes sync semantics — see below |
-| **#1616** | Runtime checks before the C6 drop | **Full runbook is in the issue** (comment, 2026-07-29) — phased: OPcache/version check → smoke test → `--phase=pre` → ≥7-night soak → freeze + backup → `pre-drop` → drop → `post-drop`. Includes the verbatim `[REFUSE]` strings so a safe stop is distinguishable from a failure. **Not urgent — nothing depends on it** |
+| **#1616** | Runtime checks before the C6 drop | **Full runbook is in the issue** (comment, 2026-07-29) — phased. ⚠️ **Phase-1 soak RAN 2026-07-29 and came back RED** → **#1655**. The **≥7-night soak has NOT started** — it starts at the first GREEN run |
 | **#1600** | The promotion | Its own exercise; **verify `APPLE_DEPLOY_ENABLED` is off first** — an earlier audit reported it ON and I cannot verify it from here |
 
 ## What to do next (recommended order)
+
+### 0. #1655 — one component fails G1 (NEW 2026-07-29; blocks the whole #1616 programme)
+
+First real soak run on dev. **1 fail out of 70,129 components.** Everything else green — including
+G2 across 16,085 songs / 291,713 lines, and G12 on its first ever live execution.
+
+```
+[FAIL] G1   per-component LinesJson length == mirror line count  (1 fail)
+fingerprint: {"songs":16085,"components":70129,"lines":291713,
+              "corpusSha256":"bc51a3fcf2749d24f637da2ef4b387dd4f73d67da11f6c91722ecabf9d267f95"}
+```
+
+⚠️ **G2's PASS does not cover it** — see "Do NOT" #3 above.
+
+**#1654 is fixed and merged** (`e80b8641`), so a re-run now names the offending song. Until that
+deploy is confirmed, this finds it with no deploy at all:
+
+```sql
+SELECT sc.SongId, sc.Id AS ComponentId, sc.SortOrder, sc.Type, sc.Number,
+       JSON_LENGTH(sc.LinesJson) AS jsonLines, COUNT(ll.Id) AS mirrorLines
+  FROM tblSongComponents sc
+  LEFT JOIN tblLyricLines ll ON ll.ComponentId = sc.Id
+ GROUP BY sc.Id
+HAVING jsonLines <> mirrorLines
+ ORDER BY sc.SongId, sc.SortOrder;
+```
+
+`mirrorLines = 0` ⇒ the component-count branch; anything else ⇒ the per-component line-count branch.
+
+**The judgement to make once it's named:** one-off legacy row vs. a live writer bug. The mirror has
+a single write funnel (`lyricLinesWriteComponents()`, rule #25), so a systematic bug would not
+produce exactly one — but confirm rather than assume. A one-off is repairable; a writer bug is not,
+and at this resolution the two look identical.
 
 ### 1. #1649 — setlist data loss (HIGHEST — active, silent, permanent)
 


### PR DESCRIPTION
Docs-only. Both owner-gated migrations were actually run on dev today, so the handoff's "outstanding" table was wrong in both directions.

## Changes

**#1621 — passed, closed.** Ran clean, all six `[OK]` lines. Three of its four never-executed DDL behaviours are now proven against the live server. The fourth (is `idx_Live_Expiry` actually chosen) is deliberately left open rather than tracked: a table-scan over a handful of live rows is a performance nit, and holding an issue open for it would misrepresent the risk.

**#1616 — phase-1 soak came back RED.** One component out of 70,129 fails G1 → now **#1655**. Records plainly that the **≥7-night soak has not started**, since the runbook reads as though running the soak once begins the clock. It doesn't — it starts at the first green run.

**New "Do NOT" entry** for the trap this result sets. The report puts `[FAIL] G1` directly above `[PASS] G2`, which invites reading G2 as having cleared it:

```php
if (count($cmpNew) !== count($source)) {
    gfail('G1', [...]);
} else {                      // ← the entire G2 comparison lives in here
    foreach ($source as $i => $sc) {
        if (count($ac['lines']) !== count($sc['lines'])) {
            gfail('G1', [...]);
            continue;         // ← G2 skipped for this component
        }
```

G2 green means *"everything I compared matched"*, not *"everything matched"* — the one divergence is precisely what it never examined. Getting this backwards would wave through the single component the gate exists to catch, on the way to an irreversible drop.

**Plus** the SQL that finds the component without waiting for the #1654 deploy, and the judgement it leads to: one-off legacy row vs. live writer bug. Lines have a single write funnel (rule #25), so a systematic bug wouldn't produce exactly one — but a one-off is repairable and a writer bug is not, and at this resolution they're indistinguishable, so it's worth confirming rather than assuming.

Base branch: `alpha`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNiDThGGEJujdRL9fNR2Bq)_